### PR TITLE
docs: remove non existing utility classes from documentation

### DIFF
--- a/apps/dialtone-documentation/docs/_data/auto-spacing.json
+++ b/apps/dialtone-documentation/docs/_data/auto-spacing.json
@@ -1,0 +1,76 @@
+{
+  "values": [
+    {
+      "value": "0",
+      "output": "0"
+    },
+    {
+      "value": "1",
+      "output": ".1rem"
+    },
+    {
+      "value": "2",
+      "output": ".2rem"
+    },
+    {
+      "value": "4",
+      "output": ".4rem"
+    },
+    {
+      "value": "6",
+      "output": ".6rem"
+    },
+    {
+      "value": "8",
+      "output": ".8rem"
+    },
+    {
+      "value": "12",
+      "output": "1.2rem"
+    },
+    {
+      "value": "16",
+      "output": "1.6rem"
+    },
+    {
+      "value": "24",
+      "output": "2.4rem"
+    },
+    {
+      "value": "32",
+      "output": "3.2rem"
+    },
+    {
+      "value": "48",
+      "output": "4.8rem"
+    },
+    {
+      "value": "64",
+      "output": "6.4rem"
+    },
+    {
+      "value": "72",
+      "output": "7.2rem"
+    },
+    {
+      "value": "84",
+      "output": "8.4rem"
+    },
+    {
+      "value": "96",
+      "output": "9.6rem"
+    },
+    {
+      "value": "102",
+      "output": "10.2rem"
+    },
+    {
+      "value": "114",
+      "output": "11.4rem"
+    },
+    {
+      "value": "128",
+      "output": "12.8rem"
+    }
+  ]
+}

--- a/apps/dialtone-documentation/docs/_data/gap.json
+++ b/apps/dialtone-documentation/docs/_data/gap.json
@@ -1,0 +1,52 @@
+{
+  "values": [
+    {
+      "value": "0",
+      "output": "0"
+    },
+    {
+      "value": "1",
+      "output": ".1rem"
+    },
+    {
+      "value": "2",
+      "output": ".2rem"
+    },
+    {
+      "value": "4",
+      "output": ".4rem"
+    },
+    {
+      "value": "6",
+      "output": ".6rem"
+    },
+    {
+      "value": "8",
+      "output": ".8rem"
+    },
+    {
+      "value": "12",
+      "output": "1.2rem"
+    },
+    {
+      "value": "16",
+      "output": "1.6rem"
+    },
+    {
+      "value": "24",
+      "output": "2.4rem"
+    },
+    {
+      "value": "32",
+      "output": "3.2rem"
+    },
+    {
+      "value": "48",
+      "output": "4.8rem"
+    },
+    {
+      "value": "64",
+      "output": "6.4rem"
+    }
+  ]
+}

--- a/apps/dialtone-documentation/docs/_data/spacing.json
+++ b/apps/dialtone-documentation/docs/_data/spacing.json
@@ -50,24 +50,8 @@
       "output": "6.4rem"
     },
     {
-      "value": "72",
-      "output": "7.2rem"
-    },
-    {
-      "value": "84",
-      "output": "8.4rem"
-    },
-    {
       "value": "96",
       "output": "9.6rem"
-    },
-    {
-      "value": "102",
-      "output": "10.2rem"
-    },
-    {
-      "value": "114",
-      "output": "11.4rem"
     },
     {
       "value": "128",

--- a/apps/dialtone-documentation/docs/utilities/grid/gap.md
+++ b/apps/dialtone-documentation/docs/utilities/grid/gap.md
@@ -59,7 +59,7 @@ Use `d-gcg{#}` or `d-grg{#}` to independently change the row and column gap spac
 
 <script setup>
   import { gap } from '@data/grid.json';
-  import { values } from '@data/spacing.json';
+  import { values } from '@data/gap.json';
 </script>
 
 ## Classes

--- a/apps/dialtone-documentation/docs/utilities/spacing/auto-spacing.md
+++ b/apps/dialtone-documentation/docs/utilities/spacing/auto-spacing.md
@@ -40,7 +40,7 @@ description: Utilities for controlling the space between child elements.
 ```
 
 <script setup>
-  import { values } from '@data/spacing.json';
+  import { values } from '@data/auto-spacing.json';
 </script>
 
 ## Classes


### PR DESCRIPTION
## Description
Jira ticket: https://dialpad.atlassian.net/browse/DLT-1368

Affects the utility classes docs that where using `apps/dialtone-documentation/docs/_data/spacing.json` to obtain the values, these are: `margin`, `padding`, `auto-spacing` and `gap`. 
`margin` and `padding` have the same values, but `gap` and `auto-spacing` have other ones.
Check that the shown values are the same as the generated ones in `dialtone.css`

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
<img width="1792" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/b1494ab6-9e52-4db1-812e-29c4cd2818cb">
