### PR TITLE
fix(toast): remove margin

### DIFF
--- a/packages/dialtone/lib/build/less/components/toast.less
+++ b/packages/dialtone/lib/build/less/components/toast.less
@@ -59,6 +59,11 @@
     position: relative;
     display: flex;
     align-items: center;
+
+
+    .d-notice__actions button:first-child {
+        margin-left: var(--dt-space-600); // 32
+    }
 }
 
 //  ============================================================================

--- a/packages/dialtone/lib/build/less/components/toast.less
+++ b/packages/dialtone/lib/build/less/components/toast.less
@@ -59,10 +59,6 @@
     position: relative;
     display: flex;
     align-items: center;
-
-    .d-notice__actions {
-        margin-left: var(--dt-space-600); // 32
-    }
 }
 
 //  ============================================================================


### PR DESCRIPTION
## Description
Removed unnecessary left margin on toast. It is not needed as gap is being used.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNXgyMHNkc3VnZ2wxY3RqMzZtajN0NTR2enIxMzlmMjRuMDVucjFhdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/a5llhdWKMOIfneMCpB/giphy.gif)
