### PR TITLE
docs: update codepen template

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Navbar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Navbar.vue
@@ -99,7 +99,7 @@
         <template #anchor>
           <a
             class="d-btn d-btn--muted d-btn--circle"
-            href="https://codepen.io/pen/?template=BajJpwW"
+            href="https://codepen.io/pen?template=oNmoRqO"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/packages/dialtone-tokens/.github/workflows/release.yml
+++ b/packages/dialtone-tokens/.github/workflows/release.yml
@@ -52,6 +52,11 @@ jobs:
         run: npm publish --tag ${{ steps.branch.outputs.BRANCH }}
         continue-on-error: true
 
+      - name: Build external packages (android, ios)
+        if: ${{ github.ref == 'refs/heads/production' }}
+        run: npm run publish:external-packages
+        continue-on-error: true
+
       - name: Deploy production - Gradle
         if: ${{ github.ref == 'refs/heads/production' }}
         run: ./gradlew publish

--- a/packages/dialtone-tokens/package.json
+++ b/packages/dialtone-tokens/package.json
@@ -9,9 +9,11 @@
     "build:token-transformer": "npm run build:token-transformer:light && npm run build:token-transformer:dark",
     "build:token-transformer:light": "token-transformer tokens token_transformer/tokens-light.json root,base/default,semantic/dp/default,components/checkbox,components/avatar/default,components/badge/default,components/checkbox/default,components/icon/default,components/radio/default root --expandTypography=true --expandShadow=true",
     "build:token-transformer:dark": "token-transformer tokens token_transformer/tokens-dark.json root,base/default,base/dark,semantic/dp/default,semantic/dp/dark,components/avatar/default,components/badge/default,components/checkbox/default,components/checkbox/dark,components/icon/default,components/radio/default,components/radio/dark root --expandTypography=true --expandShadow=true",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build && npm run publish:external-packages",
     "release": "semantic-release --no-ci --extends ./release-local.config.cjs",
-    "build:all-platforms": "npm run build:token-transformer && node ./build.js && cp ./AndroidManifest.xml dist/android && ./gradlew publishToMavenLocal -Pversion=$npm_package_version && ./build-ios.js"
+    "publish:external-packages": "npm run build:android-package && npm run build:ios-package",
+    "publish:android-package": "cp ./AndroidManifest.xml dist/android && ./gradlew publishToMavenLocal -Pversion=$npm_package_version",
+    "publish:ios-package": "./build-ios.js"
   },
   "files": [
     "dist"

--- a/packages/dialtone-tokens/package.json
+++ b/packages/dialtone-tokens/package.json
@@ -9,9 +9,9 @@
     "build:token-transformer": "npm run build:token-transformer:light && npm run build:token-transformer:dark",
     "build:token-transformer:light": "token-transformer tokens token_transformer/tokens-light.json root,base/default,semantic/dp/default,components/checkbox,components/avatar/default,components/badge/default,components/checkbox/default,components/icon/default,components/radio/default root --expandTypography=true --expandShadow=true",
     "build:token-transformer:dark": "token-transformer tokens token_transformer/tokens-dark.json root,base/default,base/dark,semantic/dp/default,semantic/dp/dark,components/avatar/default,components/badge/default,components/checkbox/default,components/checkbox/dark,components/icon/default,components/radio/default,components/radio/dark root --expandTypography=true --expandShadow=true",
-    "prepublishOnly": "npm run build && npm run publish:external-packages",
+    "prepublishOnly": "npm run build",
     "release": "semantic-release --no-ci --extends ./release-local.config.cjs",
-    "publish:external-packages": "npm run build:android-package && npm run build:ios-package",
+    "publish:external-packages": "npm run publish:android-package && npm run publish:ios-package",
     "publish:android-package": "cp ./AndroidManifest.xml dist/android && ./gradlew publishToMavenLocal -Pversion=$npm_package_version",
     "publish:ios-package": "./build-ios.js"
   },

--- a/packages/dialtone-tokens/package.json
+++ b/packages/dialtone-tokens/package.json
@@ -5,12 +5,13 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "build": "npm run build:token-transformer && node ./build.js && cp ./AndroidManifest.xml dist/android && ./gradlew publishToMavenLocal -Pversion=$npm_package_version && ./build-ios.js",
+    "build": "npm run build:token-transformer && node ./build.js",
     "build:token-transformer": "npm run build:token-transformer:light && npm run build:token-transformer:dark",
     "build:token-transformer:light": "token-transformer tokens token_transformer/tokens-light.json root,base/default,semantic/dp/default,components/checkbox,components/avatar/default,components/badge/default,components/checkbox/default,components/icon/default,components/radio/default root --expandTypography=true --expandShadow=true",
     "build:token-transformer:dark": "token-transformer tokens token_transformer/tokens-dark.json root,base/default,base/dark,semantic/dp/default,semantic/dp/dark,components/avatar/default,components/badge/default,components/checkbox/default,components/checkbox/dark,components/icon/default,components/radio/default,components/radio/dark root --expandTypography=true --expandShadow=true",
     "prepublishOnly": "npm run build",
-    "release": "semantic-release --no-ci --extends ./release-local.config.cjs"
+    "release": "semantic-release --no-ci --extends ./release-local.config.cjs",
+    "build:all-platforms": "npm run build:token-transformer && node ./build.js && cp ./AndroidManifest.xml dist/android && ./gradlew publishToMavenLocal -Pversion=$npm_package_version && ./build-ios.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Update Codepen Template

1. Linked header's Codepen link to [new Codepen Template](https://codepen.io/pen?template=oNmoRqO), which is now hosted at our newly-owned [Dialpad Codepen Account](https://codepen.io/dialpad).
2. Update default `build` script to bypass Android design token transforms as they are not necessary for a build of the doc site or (web) library.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

<img width="454" alt="image" src="https://github.com/dialpad/dialtone/assets/1165933/75987e9a-33d0-4e44-8b94-1c0684bdec3c">
