### PR TITLE
chore: remove utility classes from components

### DIFF
--- a/packages/dialtone/lib/build/less/components/avatar.less
+++ b/packages/dialtone/lib/build/less/components/avatar.less
@@ -75,10 +75,13 @@
   }
 
   &__initials {
+    position: absolute;
+    z-index: var(--zi-base);
     font-weight: var(--dt-font-weight-bold);
     font-size: var(--avatar-size-text);
     line-height: var(--dt-font-line-height-100);
     text-transform: uppercase;
+    user-select: none;
   }
 
   &__icon {

--- a/packages/dialtone/lib/build/less/components/chip.less
+++ b/packages/dialtone/lib/build/less/components/chip.less
@@ -128,6 +128,12 @@
   background-color: var(--dt-color-black-400);
 }
 
+.d-chip__text {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 //  ============================================================================
 //  $   SIZES
 //  ----------------------------------------------------------------------------

--- a/packages/dialtone/lib/build/less/components/codeblock.less
+++ b/packages/dialtone/lib/build/less/components/codeblock.less
@@ -1,0 +1,26 @@
+//
+//  DIALTONE
+//  COMPONENTS: Codeblock
+//
+//  These are the styles for codeblock component.
+//
+//  TABLE OF CONTENTS
+//  • BASE STYLE
+//
+//  ============================================================================
+//  $   BASE STYLE
+//  ----------------------------------------------------------------------------
+
+.d-codeblock {
+    display: block;
+    padding: var(--dt-space-400);
+    color: var(--dt-color-foreground-secondary);
+    font-size: var(--dt-font-size-200);
+    font-family: var(--dt-font-family-mono);
+    line-height: var(--dt-font-line-height-400);
+    white-space: pre-wrap;
+    background-color: var(--dt-color-surface-secondary);
+    border: var(--dt-size-100) solid;
+    border-color: var(--dt-color-border-subtle);
+    border-radius: var(--dt-size-radius-400);
+}

--- a/packages/dialtone/lib/build/less/components/collapsible.less
+++ b/packages/dialtone/lib/build/less/components/collapsible.less
@@ -1,0 +1,33 @@
+//
+//  DIALTONE
+//  COMPONENTS: COLLAPSIBLE
+//
+//  These are collapsible classes for Dialpad's design system Dialtone.
+//  For further documentation of these and other classes,
+//  visit https://dialpad.design/components/collapsible
+//
+//  TABLE OF CONTENTS
+//  • BASE STYLE
+//
+//  ============================================================================
+//  $   BASE STYLE
+//  ----------------------------------------------------------------------------
+.d-collapsible__icon {
+  --icon-base-scale: var(--dt-size-400);
+  --icon-size-300: calc(var(--icon-base-scale) * 2.25);
+  --icon-size: var(--icon-size-300);
+
+  flex: none;
+  flex-shrink: 0;
+  width: var(--icon-size);
+  height: var(--icon-size);
+  margin-right: var(--dt-space-400);
+  fill: currentColor;
+}
+
+.d-collapsible__anchor-text {
+  margin-right: auto;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/packages/dialtone/lib/build/less/components/combobox.less
+++ b/packages/dialtone/lib/build/less/components/combobox.less
@@ -1,0 +1,28 @@
+//
+//  DIALTONE
+//  COMPONENTS: COMBOBOX
+//
+//  These are combobox classes for Dialpad's design system Dialtone.
+//  For further documentation of these and other classes,
+//  visit https://dialpad.design/components/combobox
+//
+//  TABLE OF CONTENTS
+//  • EMPTY LIST
+//  • LOADING LIST LIST
+//
+//  ============================================================================
+//  $   EMPTY LIST
+//  ----------------------------------------------------------------------------
+.d-combobox__empty-list {
+  padding: var(--dt-space-0);
+}
+
+//  ============================================================================
+//  $   LOADING LIST
+//  ----------------------------------------------------------------------------
+.d-combobox__loading-list {
+  max-height: var(--dt-size-925);
+  margin-top: var(--dt-space-400);
+  padding: var(--dt-space-0);
+  overflow-y: auto;
+}

--- a/packages/dialtone/lib/build/less/components/image-viewer.less
+++ b/packages/dialtone/lib/build/less/components/image-viewer.less
@@ -1,0 +1,35 @@
+//
+//  DIALTONE
+//  COMPONENTS: Image Viewer
+//
+//  These are the styles for Image Viewer component.
+//
+//  TABLE OF CONTENTS
+//  • BASE STYLE
+//
+//  ============================================================================
+//  $   BASE STYLE
+//  ----------------------------------------------------------------------------
+.d-image-viewer__preview-button {
+  padding: var(--dt-space-0);
+  cursor: -webkit-zoom-in;
+  cursor: zoom-in;
+}
+
+.d-image-viewer__full {
+  max-width: 80%;
+  max-height: 80%;
+  padding: var(--dt-space-0);
+  border-radius: var(--dt-size-radius-0);
+
+  &__image {
+    max-width: 100%;
+    max-height: 100%;
+  }
+}
+
+.d-image-viewer__close-button {
+  --fco: 100%;
+
+  color: hsla(var(--dt-color-neutral-white-h) var(--dt-color-neutral-white-s) var(--dt-color-neutral-white-l) / var(--fco));
+}

--- a/packages/dialtone/lib/build/less/components/input.less
+++ b/packages/dialtone/lib/build/less/components/input.less
@@ -114,6 +114,37 @@
     }
 }
 
+.d-input__label-text {
+    display: flex;
+    flex: 1 0%;
+    align-items: baseline;
+    justify-content: space-between;
+    box-sizing: border-box;
+    margin-bottom: var(--dt-space-300);
+    color: var(--dt-color-foreground-secondary);
+    font-weight: var(--dt-font-weight-semi-bold);
+    font-size: var(--dt-font-size-200);
+    font-family: inherit;
+    line-height: var(--dt-font-line-height-300);
+    word-break: break-word;
+    overflow-wrap: break-word;
+}
+
+.d-input__description {
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    color: var(--dt-color-foreground-tertiary);
+    font-size: var(--dt-font-size-100);
+    font-family: inherit;
+    line-height: var(--dt-font-line-height-400);
+    fill: currentColor;
+}
+
+.d-input__length-description {
+    margin-bottom: var(--dt-space-200);
+}
+
 //  $$  INPUT WRAPPER
 //  ----------------------------------------------------------------------------
 .d-input__wrapper {

--- a/packages/dialtone/lib/build/less/components/keyboard-shortcut.less
+++ b/packages/dialtone/lib/build/less/components/keyboard-shortcut.less
@@ -1,0 +1,39 @@
+//
+//  DIALTONE
+//  COMPONENTS: Keyboard Shortcut
+//
+//  These are the styles for Keyboard Shortcut component.
+//
+//  TABLE OF CONTENTS
+//  • BASE STYLE
+//
+//  ============================================================================
+//  $   BASE STYLE
+//  ----------------------------------------------------------------------------
+.d-keyboard-shortcut {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  padding-right: var(--dt-space-300);
+  padding-left: var(--dt-space-300);
+  font-size: var(--dt-font-size-100);
+  font-family: var(--dt-font-family-body);
+  border: var(--dt-size-100) solid;
+  border-color: var(--dt-color-border-default);
+  border-radius: var(--dt-size-radius-300);
+
+  &--inverted {
+    border-color: var(--dt-color-border-moderate-inverted);
+  }
+
+  &__icon,
+  &__item {
+    margin-right: var(--dt-space-200);
+    color: var(--dt-color-foreground-tertiary);
+
+    &--inverted {
+      color: var(--dt-color-foreground-secondary-inverted);
+    }
+  }
+}

--- a/packages/dialtone/lib/build/less/components/list-item-group.less
+++ b/packages/dialtone/lib/build/less/components/list-item-group.less
@@ -1,0 +1,17 @@
+//
+//  DIALTONE
+//  COMPONENTS: List Item Group
+//
+//  These are the styles for List Item Group component.
+//
+//  TABLE OF CONTENTS
+//  • BASE STYLE
+//
+//  ============================================================================
+//  $   BASE STYLE
+//  ----------------------------------------------------------------------------
+.d-list-item-group {
+  position: relative;
+  padding-right: var(--dt-space-0);
+  padding-left: var(--dt-space-0);
+}

--- a/packages/dialtone/lib/build/less/components/radio-checkbox.less
+++ b/packages/dialtone/lib/build/less/components/radio-checkbox.less
@@ -107,6 +107,22 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+
+    &__label {
+        display: flex;
+        flex: 1 0%;
+        align-items: baseline;
+        justify-content: space-between;
+        box-sizing: border-box;
+        margin-bottom: var(--dt-space-300);
+        color: var(--dt-color-foreground-secondary);
+        font-weight: var(--dt-font-weight-semi-bold);
+        font-size: var(--dt-font-size-200);
+        font-family: inherit;
+        line-height: var(--dt-font-line-height-300);
+        word-break: break-word;
+        overflow-wrap: break-word;
+    }
 }
 
 

--- a/packages/dialtone/lib/build/less/components/radio-checkbox.less
+++ b/packages/dialtone/lib/build/less/components/radio-checkbox.less
@@ -145,6 +145,16 @@
     cursor: pointer;
 }
 
+.d-checkbox__description {
+    display: flex;
+    box-sizing: border-box;
+    color: var(--dt-color-foreground-tertiary);
+    font-size: var(--dt-font-size-100);
+    font-family: inherit;
+    line-height: var(--dt-font-line-height-400);
+    fill: currentColor;
+  }
+
 //  ============================================================================
 //  $   CHECKBOXES
 //  ----------------------------------------------------------------------------

--- a/packages/dialtone/lib/build/less/dialtone.less
+++ b/packages/dialtone/lib/build/less/dialtone.less
@@ -23,9 +23,12 @@
 @import 'components/datepicker';
 @import 'components/emoji-picker';
 @import 'components/forms';
+@import 'components/image-viewer';
 @import 'components/input';
+@import 'components/keyboard-shortcut';
 @import 'components/link';
 @import 'components/list-group'; // Dialtone 5 shim
+@import 'components/list-item-group';
 @import 'components/modal';
 @import 'components/notice';
 @import 'components/toast';

--- a/packages/dialtone/lib/build/less/dialtone.less
+++ b/packages/dialtone/lib/build/less/dialtone.less
@@ -17,6 +17,7 @@
 @import 'components/button';
 @import 'components/card';
 @import 'components/chip';
+@import 'components/codeblock';
 @import 'components/datepicker';
 @import 'components/emoji-picker';
 @import 'components/forms';

--- a/packages/dialtone/lib/build/less/dialtone.less
+++ b/packages/dialtone/lib/build/less/dialtone.less
@@ -18,6 +18,8 @@
 @import 'components/card';
 @import 'components/chip';
 @import 'components/codeblock';
+@import 'components/collapsible';
+@import 'components/combobox';
 @import 'components/datepicker';
 @import 'components/emoji-picker';
 @import 'components/forms';


### PR DESCRIPTION
Jira: https://dialpad.atlassian.net/browse/DLT-1125
Subtask: https://dialpad.atlassian.net/browse/DLT-1385
Dialtone vue: https://github.com/dialpad/dialtone-vue/pull/1314

## Description
Adds styles for the following components in dialtone library: 

Avatar
Chip
Codeblock
Checkbox

Collapsible
Combobox
Input
Input Group

Image Viewer
Keyboard Shortcut
List Item Group

For now I am going to leave this PR as is so it doesn't grow that much. The idea is to merge batches of components and release to progressively incorporate and test these changes in the Dialtone Vue PR.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](path/to/gif)
