### PR TITLE
fix: skeleton paragraph styles

### DIFF
--- a/packages/dialtone/lib/build/less/components/skeleton.less
+++ b/packages/dialtone/lib/build/less/components/skeleton.less
@@ -78,10 +78,13 @@
 //  ----------------------------------------------------------------------------
 .d-skeleton-paragraph {
   width: 100%;
-  margin-bottom: var(--dt-space-450);
 
-  &:last-child {
-    margin-bottom: var(--dt-space-0);
+  .d-skeleton-text {
+    margin-bottom: var(--dt-space-450);
+
+    &:last-child {
+      margin-bottom: var(--dt-space-0);
+    }
   }
 }
 


### PR DESCRIPTION
## Description
The `:last-child` was applied to `d-skeleton-paragraph` instead of its children, causing a visual bug in https://github.com/dialpad/dialtone-vue/pull/1314. These styles are not being used in production yet.

| Before | After |
|------|------|
| <img width="426" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/60bb7e30-3bed-43d8-b267-31575e7b00cf"> | <img width="392" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/c5298fb0-5d4f-4e72-9341-322056282aab"> |



## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](path/to/gif)
