### PR TITLE
feat(feed-item-row): add gap instead of padding and label field

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -46,6 +46,10 @@
         >
           {{ time }}
         </time>
+        <dt-badge
+          v-if="labelText"
+          :text="labelText"
+        />
       </div>
       <!-- @slot Default content slot for feed item row -->
       <span
@@ -95,6 +99,7 @@ import { DEFAULT_FEED_ROW_STATE, FEED_ROW_STATE_BACKGROUND_COLOR } from './feed_
 import { DtAvatar } from '@/components/avatar';
 import { DtLazyShow } from '@/components/lazy_show';
 import { DtListItem } from '@/components/list_item';
+import { DtBadge } from '@/components/badge';
 import Modal from '@/common/mixins/modal';
 
 export default {
@@ -104,6 +109,7 @@ export default {
     DtAvatar,
     DtLazyShow,
     DtListItem,
+    DtBadge,
   },
 
   mixins: [Modal],
@@ -162,6 +168,14 @@ export default {
     },
 
     /**
+     * A label displayed next to the displayName. Will not show if empty.
+     */
+    labelText: {
+      type: String,
+      default: '',
+    },
+
+    /**
      * displays a darkened background on the row.
      */
     isActive: {
@@ -202,7 +216,7 @@ export default {
      * @event keydown
      * @type {KeyboardEvent}
      */
-    'keydown',
+     'keydown',
   ],
 
   data () {
@@ -272,16 +286,13 @@ export default {
 </script>
 
 <style lang="less" scoped>
-.dt-feed-item-row :deep(.dt-item-layout--left) {
-  align-self: baseline;
-}
-
 .dt-feed-item-row {
   transition-duration: 2s !important;
 
   &__header {
     display: flex;
     align-items: center;
+    gap: var(--dt-space-300);
 
     &__name {
       font-size: var(--dt-font-size-200);
@@ -304,8 +315,6 @@ export default {
   }
 
   &__reactions {
-    padding-top: var(--dt-space-200);
-    padding-bottom: var(--dt-space-200);
     display: flex;
     flex-wrap: wrap;
   }
@@ -335,10 +344,17 @@ export default {
   }
 
   &:deep(.dt-item-layout--left) {
+    align-self: baseline;
     .d-avatar {
       align-self: flex-start;
       margin-top: var(--dt-space-300);
     }
+  }
+
+  &:deep(.dt-item-layout--bottom) {
+    display: flex;
+    flex-direction: column;
+    gap: var(--dt-space-200);
   }
 }
 </style>

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -46,6 +46,10 @@
         >
           {{ time }}
         </time>
+        <dt-badge
+          v-if="labelText"
+          :text="labelText"
+        />
       </div>
       <!-- @slot Default content slot for feed item row -->
       <span
@@ -95,6 +99,7 @@ import { DEFAULT_FEED_ROW_STATE, FEED_ROW_STATE_BACKGROUND_COLOR } from './feed_
 import { DtAvatar } from '@/components/avatar';
 import { DtLazyShow } from '@/components/lazy_show';
 import { DtListItem } from '@/components/list_item';
+import { DtBadge } from '@/components/badge';
 import Modal from '@/common/mixins/modal';
 
 export default {
@@ -104,6 +109,7 @@ export default {
     DtAvatar,
     DtLazyShow,
     DtListItem,
+    DtBadge,
   },
 
   mixins: [Modal],
@@ -157,6 +163,14 @@ export default {
      * Shown on the left of feed item when showHeader is false and isActive is true
      */
     shortTime: {
+      type: String,
+      default: '',
+    },
+
+    /**
+     * A label displayed next to the displayName. Will not show if empty.
+     */
+     labelText: {
       type: String,
       default: '',
     },
@@ -281,6 +295,7 @@ export default {
   &__header {
     display: flex;
     align-items: center;
+    gap: var(--dt-space-300);
 
     &__name {
       font-size: var(--dt-font-size-200);
@@ -303,15 +318,8 @@ export default {
   }
 
   &__reactions {
-    padding-top: var(--dt-space-200);
-    padding-bottom: var(--dt-space-200);
     display: flex;
     flex-wrap: wrap;
-  }
-
-  &__threading {
-    padding-top: var(--dt-space-200);
-    padding-bottom: var(--dt-space-200);
   }
 
   &__left-time {
@@ -334,10 +342,17 @@ export default {
   }
 
   &:deep(.dt-item-layout--left) {
+    align-self: baseline;
     .d-avatar {
       align-self: flex-start;
       margin-top: var(--dt-space-300);
     }
+  }
+
+  &:deep(.dt-item-layout--bottom) {
+    display: flex;
+    flex-direction: column;
+    gap: var(--dt-space-200);
   }
 }
 </style>

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -285,9 +285,6 @@ export default {
 </script>
 
 <style lang="less" scoped>
-.dt-feed-item-row :deep(.dt-item-layout--left) {
-  align-self: baseline;
-}
 
 .dt-feed-item-row {
   transition-duration: 2s !important;


### PR DESCRIPTION
## Description
Found a case where the feed items have an "external" label that wasn't represented in the component, so added support for this case and changed spacing to use gap instead of padding so it does not take up extra space if either of the threading / emoji slots don't exist. I think there is some re-thinking that needs to be done with the item layout and list item components, and also the use of dt-stack, but the scope of that is bigger than this PR, to be discussed at next grooming.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/gJ4fi0dgBLjvq/giphy.gif)
