### PR TITLE
docs(date-picker): added link to figma component

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/views/Overview.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/views/Overview.vue
@@ -48,6 +48,8 @@ const badgeKindClass = (status) => {
       return 'd-badge--bulletin';
     case 'ready':
       return 'd-badge--success';
+    case 'beta':
+      return 'd-badge--info';
     default:
       return '';
   }

--- a/apps/dialtone-documentation/docs/components/datepicker.md
+++ b/apps/dialtone-documentation/docs/components/datepicker.md
@@ -5,8 +5,9 @@ image: assets/images/components/datepicker.png
 description: Datepicker component will provide a calendar to select a date.
 status: beta
 storybook: https://vue.dialpad.design/?path=/story/components-datepicker--default
-figma: planned
+figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT8-Component-Library?type=design&node-id=13998-87&mode=design&t=k5q7YXo32w6HoOmK-11
 ---
+
 <code-well-header>
   <dt-datepicker
     prev-month-label="Previous month"

--- a/apps/dialtone-documentation/docs/components/icon.md
+++ b/apps/dialtone-documentation/docs/components/icon.md
@@ -1,7 +1,7 @@
 ---
 title: Icon
 description: An icon is used to visually communicate commands, meaning, status, feedback, or common actions.
-status: new
+status: ready
 thumb: true
 image: assets/images/components/icon.png
 storybook: https://vue.dialpad.design/?path=/docs/components-icon--default

--- a/apps/dialtone-documentation/docs/components/list-item.md
+++ b/apps/dialtone-documentation/docs/components/list-item.md
@@ -1,7 +1,7 @@
 ---
 title: List item
 description: A list item is an element that can be used to represent individual items in a list.
-status: planned
+status: ready
 thumb: true
 image: assets/images/components/list-item.png
 storybook: https://vue.dialpad.design/?path=/story/components-list-item--default

--- a/apps/dialtone-documentation/docs/components/presence.md
+++ b/apps/dialtone-documentation/docs/components/presence.md
@@ -1,7 +1,7 @@
 ---
 title: Presence
 description: A visual control element indicating the current status of a user.
-status: new
+status: ready
 thumb: true
 image: assets/images/components/presence.png
 storybook: https://vue.dialpad.design/?path=/docs/components-presence--default


### PR DESCRIPTION
## Description

* Datepicker's Figma component now available, link to it.
* Adjusted status of several components, e.g. `icon`: `new` → `ready`.

## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [ ] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](path/to/gif)
