### PR TITLE
chore(emoji-picker): keyboard navigation updates

### DIFF
--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
@@ -11,6 +11,7 @@
         :tab-set-labels="tabSetLabels"
         :is-scrolling="isScrolling"
         @focus-search-input="$refs.searchInputRef.focusSearchInput()"
+        @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
         @selected-tabset="scrollToSelectedTabset"
         @keydown.esc.native="$emit('close')"
       />
@@ -53,6 +54,7 @@
         :skin-tone="skinTone"
         @skin-tone="$emit('skin-tone', $event)"
         @focus-tabset="$refs.tabsetRef.focusTabset()"
+        @focus-last-emoji="$refs.emojiSelectorRef.focusLastEmoji()"
         @keydown.esc.native="$emit('close')"
       />
     </div>

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -284,7 +284,7 @@ export default {
       }
     },
 
-    searchByNameAndKeywords() {
+    searchByNameAndKeywords () {
       const searchStr = this.emojiFilter.toLowerCase();
       this.filteredEmojis = this.currentEmojis.filter(function (obj) {
         const nameIncludesSearchStr = obj.name.toLowerCase().includes(searchStr);
@@ -608,6 +608,10 @@ export default {
         child.dataset.index = index;
       });
     },
+
+    focusLastEmoji () {
+      this.focusEmoji(this.tabs.length - 1, 0);
+    }
 
   },
 

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_skin_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_skin_selector.vue
@@ -201,7 +201,11 @@ export default {
       }
 
       if (event.key === 'Tab') {
-        this.$emit('focus-tabset');
+        if (event.shiftKey) {
+          this.$emit('focus-last-emoji');
+        } else {
+          this.$emit('focus-tabset');
+        }
       }
     },
 

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
@@ -156,7 +156,11 @@ export default {
 
       if (event.key === 'Tab') {
         event.preventDefault();
-        this.$emit('focus-search-input');
+        if (event.shiftKey) {
+          this.$emit('focus-skin-selector');
+        } else {
+          this.$emit('focus-search-input');
+        }
       }
 
       if (event.key === 'ArrowDown') {

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
@@ -11,6 +11,7 @@
         :tabset-labels="tabSetLabels"
         :is-scrolling="isScrolling"
         @focus-search-input="$refs.searchInputRef.focusSearchInput()"
+        @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
         @selected-tabset="scrollToSelectedTabset"
         @keydown.esc="emits('close')"
       />
@@ -52,6 +53,7 @@
         :skin-tone="skinTone"
         @skin-tone="emits('skin-tone', $event)"
         @focus-tabset="$refs.tabsetRef.focusTabset()"
+        @focus-last-emoji="$refs.emojiSelectorRef.focusLastEmoji()"
         @keydown.esc="emits('close')"
       />
     </div>

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
@@ -574,6 +574,10 @@ function focusEmojiSelector () {
   focusEmoji(0, 0);
 }
 
+function focusLastEmoji () {
+  focusEmoji(tabs.value.length - 1, 0);
+}
+
 onMounted(() => {
   setTabLabelObserver();
 });
@@ -584,5 +588,6 @@ onUnmounted(() => {
 
 defineExpose({
   focusEmojiSelector,
+  focusLastEmoji,
 });
 </script>

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_skin_selector.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_skin_selector.vue
@@ -86,6 +86,7 @@ const emits = defineEmits([
    */
   'skin-tone',
   'focus-tabset',
+  'focus-last-emoji',
 ]);
 
 const skinList = [
@@ -181,7 +182,11 @@ const handleKeyDown = (event, skin, index) => {
   }
 
   if (event.key === 'Tab') {
-    emits('focus-tabset');
+    if (event.shiftKey) {
+      emits('focus-last-emoji');
+    } else {
+      emits('focus-tabset');
+    }
   }
 };
 

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
@@ -79,6 +79,7 @@ const emits = defineEmits([
   'selected-tabset',
 
   'focus-search-input',
+  'focus-skin-selector',
 ]);
 
 const TABS_DATA = [
@@ -157,7 +158,11 @@ function handleKeyDown (event, tabId) {
 
   if (event.key === 'Tab') {
     event.preventDefault();
-    emits('focus-search-input');
+    if (event.shiftKey) {
+      emits('focus-skin-selector');
+    } else {
+      emits('focus-search-input');
+    }
   }
 
   if (event.key === 'ArrowDown') {

--- a/packages/dialtone/lib/build/less/components/emoji-picker.less
+++ b/packages/dialtone/lib/build/less/components/emoji-picker.less
@@ -135,8 +135,9 @@
     position: sticky;
     top: 0;
     width: 100%;
-    padding-top: var(--dt-space-525);
     background: var(--dt-color-surface-primary);
+    padding: var(--dt-space-525) var(--dt-space-500) 0 var(--dt-space-500);
+    margin: 0;
   }
 
   &__list {


### PR DESCRIPTION
## Description
Few updates to emoji picker keyboard navigation:

Fix:

- The emojis are getting hidden behind the category header

Changes:

- From emoji skin selector with `shift+tab` key would jump to previous focus. (first emoji of last label on emoji selector).
- From tabset with `shift+tab` key would jump to emoji skin selector

Modified packages:

- Dialtone
- Dialtone-vue2
- Dialtone-vue3
