### PR TITLE
feat: refactor message input vue3

### DIFF
--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -3,8 +3,6 @@ import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import DtRecipeMessageInput from './message_input.vue';
 import DtRecipeMessageInputDefaultTemplate from './message_input_default.story.vue';
 
-import { NOTICE_KINDS } from '@/components/notice/notice_constants';
-
 /*
   Controls
   ========
@@ -22,13 +20,6 @@ import { NOTICE_KINDS } from '@/components/notice/notice_constants';
 */
 
 export const argTypesData = {
-  // Props
-  noticeKind: {
-    options: NOTICE_KINDS,
-    control: {
-      type: 'select',
-    },
-  },
   // Events
   onSubmit: {
     table: {
@@ -96,10 +87,7 @@ export const argsData = {
   modelValue: 'Always the Padawan, never the Jedi.',
   placeholder: 'New message',
   inputAriaLabel: 'Input text field',
-  noticeMessage: 'Files must be less than 32 MB to be sent as Dialpad messages.',
   maxHeight: '40vh',
-  characterLimitWarningMessage: 'You have reached the character limit.',
-  isEdit: false,
   emojiPickerProps: {
     searchNoResultsLabel: 'No results',
     searchResultsLabel: 'Search results',
@@ -117,6 +105,11 @@ export const argsData = {
       'Flags',
     ],
     skinTone: 'Default',
+  },
+  showCharacterLimit: {
+    count: 1000,
+    warning: 500,
+    message: 'You have exceeded the character limit',
   },
   onSubmit: action('submit'),
   onFocus: action('focus'),

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.test.js
@@ -14,9 +14,6 @@ let imageBtn;
 let emojiPickerBtn;
 let sendBtn;
 
-let footerLeftSlot;
-let footerRightSlot;
-
 // Test Environment
 let props;
 let attrs;
@@ -37,8 +34,6 @@ const randoText = 'ricketyrick';
 
 const baseSlots = {
   middle: 'image carousel',
-  footerLeft: 'footer left',
-  footerRight: 'footer right',
 };
 
 // Helpers
@@ -55,10 +50,6 @@ const _setChildWrappers = () => {
   messageInputEl = wrapper.find('[data-qa="dt-message-input"]');
   characterLimitEl = wrapper.find('[data-qa="dt-message-input-character-limit"]');
   errorNoticeEl = wrapper.find('[data-qa="dt-message-input-error-notice"]');
-
-  // slot divs
-  footerLeftSlot = wrapper.find('[data-qa="dt-message-input-footer-left"]');
-  footerRightSlot = wrapper.find('[data-qa="dt-message-input-footer-right"]');
 };
 
 const _mountWrapper = () => {
@@ -113,14 +104,6 @@ describe('DtRecipeMessageInput tests', () => {
 
     it('should contain send button', function () {
       expect(sendBtn.exists()).toBe(true);
-    });
-
-    it('should contain left footer slot', function () {
-      expect(footerLeftSlot.text()).toBe(baseSlots.footerLeft);
-    });
-
-    it('should contain right footer slot', function () {
-      expect(footerRightSlot.text()).toBe(baseSlots.footerRight);
     });
 
     it('should not have border applied on message-input when not focused', () => {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -3,8 +3,8 @@
   <div
     data-qa="dt-message-input"
     role="presentation"
-    class="d-d-flex d-fd-column d-bar8 d-baw1 d-ba d-c-text"
-    :class="{ 'd-bc-black-500 d-bs-sm': hasFocus, 'd-bc-default': !hasFocus }"
+    :class="['d-d-flex', 'd-fd-column', 'd-bar8', 'd-baw1', 'd-ba', 'd-c-text',
+             { 'd-bc-black-500 d-bs-sm': hasFocus, 'd-bc-default': !hasFocus }]"
     @click="$refs.richTextEditor.focusEditor()"
     @drag-enter="onDrag"
     @drag-over="onDrag"

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -1,244 +1,210 @@
 <!-- eslint-disable vue/no-restricted-class -->
 <template>
-  <dt-notice
-    v-if="showNotice"
-    data-qa="dt-message-input-error-notice"
-    :class="noticeClasses"
-    :kind="noticeKind"
-    :close-button-props="computedCloseButtonProps"
-    @close="noticeClose"
-  >
-    {{ noticeMessage }}
-    <template #icon>
-      <dt-icon
-        size="300"
-        name="alert-circle"
-      />
-    </template>
-  </dt-notice>
   <div
-    class="d-ps-relative d-bar8 d-bgc-white"
+    data-qa="dt-message-input"
+    role="presentation"
+    class="d-d-flex d-fd-column d-bar8 d-baw1 d-ba d-c-text"
+    :class="{ 'd-bc-black-500 d-bs-sm': hasFocus, 'd-bc-default': !hasFocus }"
+    @click="$refs.richTextEditor.focusEditor()"
+    @drag-enter="onDrag"
+    @drag-over="onDrag"
+    @drop="onDrop"
+    @keydown.enter.exact="onSend"
+    @focusin="hasFocus = true"
+    @focusout="hasFocus = false"
   >
+    <!-- Some wrapper to restrict the height and show the scrollbar -->
     <div
-      data-qa="dt-message-input"
-      role="presentation"
-      class="d-d-flex d-fd-column d-bar8 d-baw1 d-ba d-c-text"
-      :class="{ 'd-bc-black-500 d-bs-sm': hasFocus, 'd-bc-default': !hasFocus }"
-      @click="$refs.richTextEditor.focusEditor()"
-      @drag-enter="onDrag"
-      @drag-over="onDrag"
-      @drop="onDrop"
-      @keydown.enter.exact="onSend"
-      @focusin="hasFocus = true"
-      @focusout="hasFocus = false"
+      class="d-of-auto d-mx16 d-mt8 d-mb4"
+      :style="{ 'max-height': maxHeight }"
     >
-      <!-- Some wrapper to restrict the height and show the scrollbar -->
-      <div
-        class="d-of-auto d-mx16 d-mt8 d-mb4"
-        :style="{ 'max-height': maxHeight }"
-      >
-        <dt-rich-text-editor
-          ref="richTextEditor"
-          v-model="internalInputValue"
-          :editable="editable"
-          :input-aria-label="inputAriaLabel"
-          :input-class="inputClass"
-          :output-format="outputFormat"
-          :auto-focus="autoFocus"
-          :link="link"
-          :placeholder="placeholder"
-          v-bind="$attrs"
-          @focus="hasFocus = true"
-          @blur="hasFocus = false"
-        />
-      </div>
-      <!-- @slot Slot for attachment carousel -->
-      <slot name="middle" />
-      <!-- Section for the bottom UI -->
-      <section class="d-d-flex d-jc-space-between d-mx8 d-my4">
-        <!-- Left content -->
-        <div class="d-d-flex">
-          <dt-tooltip
-            v-if="!isEdit"
-            placement="top-start"
-            :message="imageTooltipLabel"
-            :offset="[-4, -4]"
-          >
-            <template #anchor>
-              <dt-button
-                data-qa="dt-message-input-image-btn"
-                size="sm"
-                circle
-                :kind="imagePickerFocus ? 'default' : 'muted'"
-                importance="clear"
-                :aria-label="imageButtonAriaLabel"
-                @click="onSelectImage"
-                @mouseenter="imagePickerFocus = true"
-                @mouseleave="imagePickerFocus = false"
-                @focusin="imagePickerFocus = true"
-                @focusout="imagePickerFocus = false"
-              >
-                <template #icon>
-                  <dt-icon
-                    name="image"
-                    size="300"
-                  />
-                </template>
-              </dt-button>
-              <dt-input
-                ref="messageInputImageUpload"
-                data-qa="dt-message-input-image-input"
-                type="file"
-                class="d-ps-absolute"
-                multiple
-                hidden
-                @input="onImageUpload"
-              />
-            </template>
-          </dt-tooltip>
-          <dt-popover
-            data-qa="dt-message-input-emoji-picker-popover"
-            :open="emojiPickerOpened"
-            initial-focus-element="#searchInput"
-            padding="none"
-            @opened="(open) => { emojiPickerOpened = open }"
-          >
-            <template #anchor>
-              <dt-tooltip
-                :message="emojiTooltipMessage"
-                :offset="[0, -4]"
-              >
-                <template #anchor>
-                  <dt-button
-                    data-qa="dt-message-input-emoji-picker-btn"
-                    size="sm"
-                    circle
-                    :kind="emojiPickerHovered ? 'default' : 'muted'"
-                    importance="clear"
-                    :aria-label="emojiButtonAriaLabel"
-                    :offset="[0, 0]"
-                    @click="toggleEmojiPicker"
-                    @mouseenter="emojiPickerFocus = true"
-                    @mouseleave="emojiPickerFocus = false"
-                    @focusin="emojiPickerFocus = true"
-                    @focusout="emojiPickerFocus = false"
-                  >
-                    <template #icon>
-                      <dt-icon
-                        :name="!emojiPickerHovered ? 'satisfied' : 'very-satisfied'"
-                        size="300"
-                      />
-                    </template>
-                  </dt-button>
-                </template>
-              </dt-tooltip>
-            </template>
-            <template #content>
-              <dt-emoji-picker
-                v-bind="emojiPickerProps"
-                @skin-tone="onSkinTone"
-                @selected-emoji="onSelectEmoji"
-              />
-            </template>
-          </dt-popover>
-        </div>
-        <!-- Right content -->
-        <div class="d-d-flex">
-          <!-- Optionally displayed remaining character counter -->
-          <dt-tooltip
-            v-if="displayCharacterLimitWarning"
-            :enabled="characterLimitWarningMessage && (characterLimitCount - inputLength < 0)"
-            placement="top-end"
-            :message="characterLimitWarningMessage"
-            :offset="[10, -8]"
-          >
-            <template #anchor>
-              <p
-                v-if="displayCharacterLimitWarning"
-                class="d-fc-error d-mr16 d-as-center dt-message-input--remaining-char"
-                data-qa="dt-message-input-character-limit"
-              >
-                {{ characterLimitCount - inputLength }}
-              </p>
-            </template>
-          </dt-tooltip>
-
-          <!-- Cancel button for edit mode -->
-          <dt-button
-            v-if="isEdit"
-            data-qa="dt-message-input-cancel-button"
-            class="dt-message-input--cancel-button"
-            size="sm"
-            kind="muted"
-            importance="clear"
-            :aria-label="cancelButtonAriaLabel"
-            @click="onCancel"
-          >
-            <p>{{ cancelButtonText }}</p>
-          </dt-button>
-
-          <!-- Send button -->
-          <dt-tooltip
-            placement="top-end"
-            :enabled="!isEdit"
-            :message="sendTooltipLabel"
-            :show="!isSendDisabled && sendButtonFocus"
-            :offset="[6, -8]"
-          >
-            <template #anchor>
-              <!-- Right positioned UI - send button -->
-              <dt-button
-                data-qa="dt-message-input-send-btn"
-                size="sm"
-                :kind="sendButtonKind"
-                :circle="!isEdit"
-                importance="primary"
-                :class="{
-                  'message-input-button__disabled d-fc-muted': isSendDisabled,
-                }"
-                :aria-label="sendButtonAriaLabel"
-                :aria-disabled="isSendDisabled"
-                @click="onSend"
-                @mouseenter="sendButtonFocus = true"
-                @mouseleave="sendButtonFocus = false"
-                @focusin="sendButtonFocus = true"
-                @focusout="sendButtonFocus = false"
-              >
-                <template
-                  v-if="!isEdit"
-                  #icon
-                >
-                  <dt-icon
-                    name="send"
-                    size="300"
-                  />
-                </template>
-                <template
-                  v-if="isEdit"
-                >
-                  <p>{{ saveChangesButtonText }}</p>
-                </template>
-              </dt-button>
-            </template>
-          </dt-tooltip>
-        </div>
-      </section>
+      <dt-rich-text-editor
+        ref="richTextEditor"
+        v-model="internalInputValue"
+        :editable="editable"
+        :input-aria-label="inputAriaLabel"
+        :input-class="inputClass"
+        :output-format="outputFormat"
+        :auto-focus="autoFocus"
+        :link="link"
+        :placeholder="placeholder"
+        v-bind="$attrs"
+        @focus="hasFocus = true"
+        @blur="hasFocus = false"
+      />
     </div>
-    <section
-      v-if="!isEdit"
-      class="d-d-flex d-jc-space-between d-h24 d-ai-center"
-    >
-      <div
-        data-qa="dt-message-input-footer-left"
-      >
-        <!-- @slot Slot for helper text. Who is typing can go here -->
-        <slot name="footerLeft" />
+    <!-- @slot Slot for attachment carousel -->
+    <slot name="middle" />
+    <!-- Section for the bottom UI -->
+    <section class="d-d-flex d-jc-space-between d-mx8 d-my4">
+      <!-- Left content -->
+      <div class="d-d-flex">
+        <dt-tooltip
+          v-if="showImagePicker"
+          placement="top-start"
+          :message="showImagePicker.tooltipLabel"
+          :offset="[-4, -4]"
+        >
+          <template #anchor>
+            <dt-button
+              data-qa="dt-message-input-image-btn"
+              size="sm"
+              circle
+              :kind="imagePickerFocus ? 'default' : 'muted'"
+              importance="clear"
+              :aria-label="showImagePicker.ariaLabel"
+              @click="onSelectImage"
+              @mouseenter="imagePickerFocus = true"
+              @mouseleave="imagePickerFocus = false"
+              @focusin="imagePickerFocus = true"
+              @focusout="imagePickerFocus = false"
+            >
+              <template #icon>
+                <dt-icon
+                  name="image"
+                  size="300"
+                />
+              </template>
+            </dt-button>
+            <dt-input
+              ref="messageInputImageUpload"
+              data-qa="dt-message-input-image-input"
+              type="file"
+              class="d-ps-absolute"
+              multiple
+              hidden
+              @input="onImageUpload"
+            />
+          </template>
+        </dt-tooltip>
+        <dt-popover
+          v-if="showEmojiPicker"
+          data-qa="dt-message-input-emoji-picker-popover"
+          :open="emojiPickerOpened"
+          initial-focus-element="#searchInput"
+          padding="none"
+          @opened="(open) => { emojiPickerOpened = open }"
+        >
+          <template #anchor>
+            <dt-tooltip
+              :message="emojiTooltipMessage"
+              :offset="[0, -4]"
+            >
+              <template #anchor>
+                <dt-button
+                  data-qa="dt-message-input-emoji-picker-btn"
+                  size="sm"
+                  circle
+                  :kind="emojiPickerHovered ? 'default' : 'muted'"
+                  importance="clear"
+                  :aria-label="emojiButtonAriaLabel"
+                  :offset="[0, 0]"
+                  @click="toggleEmojiPicker"
+                  @mouseenter="emojiPickerFocus = true"
+                  @mouseleave="emojiPickerFocus = false"
+                  @focusin="emojiPickerFocus = true"
+                  @focusout="emojiPickerFocus = false"
+                >
+                  <template #icon>
+                    <dt-icon
+                      :name="!emojiPickerHovered ? 'satisfied' : 'very-satisfied'"
+                      size="300"
+                    />
+                  </template>
+                </dt-button>
+              </template>
+            </dt-tooltip>
+          </template>
+          <template #content>
+            <dt-emoji-picker
+              v-bind="emojiPickerProps"
+              @skin-tone="onSkinTone"
+              @selected-emoji="onSelectEmoji"
+            />
+          </template>
+        </dt-popover>
       </div>
-      <div
-        data-qa="dt-message-input-footer-right"
-      >
-        <!-- @slot helper text for the input. Shift + enter for new line -->
-        <slot name="footerRight" />
+      <!-- Right content -->
+      <div class="d-d-flex">
+        <!-- Optionally displayed remaining character counter -->
+        <dt-tooltip
+          v-if="Boolean(showCharacterLimit)"
+          class="dt-message-input--remaining-char-tooltip"
+          placement="top-end"
+          :enabled="characterLimitTooltipEnabled"
+          :message="showCharacterLimit.message"
+          :offset="[10, -8]"
+        >
+          <template #anchor>
+            <p
+              v-show="displayCharacterLimitWarning"
+              class="d-fc-error d-mr16 dt-message-input--remaining-char"
+              data-qa="dt-message-input-character-limit"
+            >
+              {{ showCharacterLimit.count - inputLength }}
+            </p>
+          </template>
+        </dt-tooltip>
+
+        <!-- Cancel button for edit mode -->
+        <dt-button
+          v-if="showCancel"
+          data-qa="dt-message-input-cancel-button"
+          class="dt-message-input--cancel-button"
+          size="sm"
+          kind="muted"
+          importance="clear"
+          :aria-label="showCancel.ariaLabel"
+          @click="onCancel"
+        >
+          <p>{{ showCancel.text }}</p>
+        </dt-button>
+
+        <!-- Send button -->
+        <dt-tooltip
+          v-if="showSend"
+          placement="top-end"
+          :enabled="!showSend"
+          :message="showSend.tooltipLabel"
+          :show="!isSendDisabled && sendButtonFocus"
+          :offset="[6, -8]"
+        >
+          <template #anchor>
+            <!-- Right positioned UI - send button -->
+            <dt-button
+              data-qa="dt-message-input-send-btn"
+              size="sm"
+              :kind="sendButtonKind"
+              :circle="Boolean(showSend.icon)"
+              importance="primary"
+              :class="{
+                'message-input-button__disabled d-fc-muted': isSendDisabled,
+              }"
+              :aria-label="showSend.ariaLabel"
+              :aria-disabled="isSendDisabled"
+              @click="onSend"
+              @mouseenter="sendButtonFocus = true"
+              @mouseleave="sendButtonFocus = false"
+              @focusin="sendButtonFocus = true"
+              @focusout="sendButtonFocus = false"
+            >
+              <template
+                v-if="showSend.icon"
+                #icon
+              >
+                <dt-icon
+                  :name="showSend.icon"
+                  size="300"
+                />
+              </template>
+              <template
+                v-if="showSend.text"
+              >
+                <p>{{ showSend.text }}</p>
+              </template>
+            </dt-button>
+          </template>
+        </dt-tooltip>
       </div>
     </section>
   </div>
@@ -256,7 +222,6 @@ import { DtIcon } from '@/components/icon';
 import { DtEmojiPicker } from '@/components/emoji_picker';
 import { DtPopover } from '@/components/popover';
 import { DtInput } from '@/components/input';
-import { DtNotice, NOTICE_KINDS } from '@/components/notice';
 import { DtTooltip } from '@/components/tooltip';
 
 export default {
@@ -267,7 +232,6 @@ export default {
     DtEmojiPicker,
     DtIcon,
     DtInput,
-    DtNotice,
     DtPopover,
     DtRichTextEditor,
     DtTooltip,
@@ -374,71 +338,6 @@ export default {
       default: false,
     },
 
-    // Character limit props
-
-    /**
-     * Enable character Limit warning
-     */
-    hasCharacterLimit: {
-      type: Boolean,
-      default: true,
-    },
-
-    /**
-     * Max number of characters allowed
-     */
-    characterLimitCount: {
-      type: Number,
-      default: 1500,
-    },
-
-    /**
-     * Number after which warning for max limit appears
-     */
-    characterLimitWarning: {
-      type: Number,
-      default: 500,
-    },
-
-    /**
-     * Character limit warning message
-     */
-    characterLimitWarningMessage: {
-      type: String,
-      default: '',
-    },
-
-    // Error related props
-
-    /**
-     * Show error notice
-     * This should be turned to false after notice-close event is fired.
-     */
-    showNotice: {
-      type: Boolean,
-      default: false,
-    },
-
-    /**
-     * message in the notice
-     */
-    noticeMessage: {
-      type: String,
-      default: '',
-    },
-
-    /**
-     * kind of notice to manage color
-     * @values base, error, info, success, warning
-     */
-    noticeKind: {
-      type: String,
-      default: 'error',
-      validate (kind) {
-        return NOTICE_KINDS.includes(kind);
-      },
-    },
-
     /**
      * Content area needs to dynamically adjust height based on the conversation area height.
      * can be vh|px|rem|em|%
@@ -449,6 +348,10 @@ export default {
     },
 
     // Emoji picker props
+    showEmojiPicker: {
+      type: Boolean,
+      default: true,
+    },
 
     /**
      * Props to pass into the emoji picker.
@@ -476,7 +379,6 @@ export default {
     },
 
     // Aria label for buttons
-
     /**
      * Emoji button aria label
      */
@@ -485,62 +387,33 @@ export default {
       default: 'emoji button',
     },
 
-    imageButtonAriaLabel: {
-      type: String,
-      default: 'image button',
-    },
-
     /**
-     * Image button tooltip label
+     * Enable character Limit warning
      */
-    imageTooltipLabel: {
-      type: String,
-      default: 'Attach Image',
+    showCharacterLimit: {
+      type: [Boolean, Object],
+      default: () => ({ count: 1500, warning: 500, message: '' }),
     },
 
-    sendButtonAriaLabel: {
-      type: String,
-      default: 'send button',
+    showImagePicker: {
+      type: [Boolean, Object],
+      default: () => ({ tooltipLabel: 'Attach Image', ariaLabel: 'image button' }),
     },
 
     /**
-     * Send button tooltip label
+     * Send button defaults.
      */
-    sendTooltipLabel: {
-      type: String,
-      default: 'Send',
+    showSend: {
+      type: [Boolean, Object],
+      default: () => ({ icon: 'send' }),
     },
 
     /**
-     * isEdit
+     * Cancel button defaults.
      */
-    isEdit: {
-      type: Boolean,
-      default: false,
-    },
-
-    /**
-     * i18n Save changes button text
-    */
-    saveChangesButtonText: {
-      type: String,
-      default: 'Save changes',
-    },
-
-    /**
-     * Cancel aria label
-     */
-    cancelButtonAriaLabel: {
-      type: String,
-      default: 'Cancel button',
-    },
-
-    /**
-     * Cancel button i18n text
-    */
-    cancelButtonText: {
-      type: String,
-      default: 'Cancel',
+    showCancel: {
+      type: [Boolean, Object],
+      default: () => ({ text: 'Cancel' }),
     },
   },
 
@@ -568,15 +441,6 @@ export default {
      * @type {Array}
      */
     'add-media',
-
-    /**
-     * Fires when notice is closed by user.
-     * Listen to this event to toggle showNotice on usage.
-     *
-     * @event notice-close
-     * @type {Boolean}
-     */
-    'notice-close',
 
     /**
      * Fires when cancel button is pressed (only on edit mode)
@@ -620,36 +484,24 @@ export default {
     },
 
     displayCharacterLimitWarning () {
-      return this.hasCharacterLimit &&
-        (this.characterLimitCount - this.inputLength) <= this.characterLimitWarning;
+      return Boolean(this.showCharacterLimit) &&
+        ((this.showCharacterLimit.count - this.inputLength) <= this.showCharacterLimit.warning);
+    },
+
+    characterLimitTooltipEnabled () {
+      return this.showCharacterLimit.message && (this.showCharacterLimit.count - this.inputLength < 0);
     },
 
     isSendDisabled () {
       return this.inputLength === 0 ||
       this.disableSend ||
-      (this.hasCharacterLimit && this.inputLength > this.characterLimitCount);
+      (this.showCharacterLimit && this.inputLength > this.showCharacterLimit.count);
     },
 
     computedCloseButtonProps () {
       return {
         ariaLabel: 'Close',
       };
-    },
-
-    noticeClasses () {
-      return [
-        'dt-message-input-notice',
-        'd-ps-relative',
-        'd-t8',
-        'd-bbr0',
-        'd-pt4',
-        'd-pb8',
-        'd-pr12',
-        'd-pl16',
-        'd-bs-none',
-        'd-fs-100',
-        'd-wmx-unset',
-      ];
     },
 
     emojiPickerHovered () {
@@ -727,10 +579,6 @@ export default {
       this.$emit('cancel');
     },
 
-    noticeClose () {
-      this.$emit('notice-close', true);
-    },
-
     focus () {
       this.$refs.richTextEditor.focusEditor();
       this.hasFocus = true;
@@ -740,6 +588,10 @@ export default {
 </script>
 
 <style lang="less">
+.dt-message-input--remaining-char-tooltip {
+  margin-top: auto;
+  margin-bottom: auto;
+}
 .dt-message-input--remaining-char {
   font-size: 1.2rem;
 }
@@ -750,9 +602,6 @@ export default {
   cursor: default;
 }
 
-.dt-message-input-notice .d-notice__icon {
-  margin-right: 8px;
-}
 .dt-message-input--cancel-button {
   color: var(--dt-color-black-500);
   margin-right: var(--dt-space-300);

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -1,21 +1,5 @@
 <template>
   <div class="d-h264">
-    <!-- <dt-notice
-      v-if="showNotice"
-      data-qa="dt-message-input-error-notice"
-      :class="noticeClasses"
-      :kind="noticeKind"
-      :close-button-props="computedCloseButtonProps"
-      @close="noticeClose"
-    >
-      {{ noticeMessage }}
-      <template #icon>
-        <dt-icon
-          size="300"
-          name="alert-circle"
-        />
-      </template>
-    </dt-notice> -->
     <dt-recipe-message-input
       ref="input"
       v-model="modelValue"

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -1,9 +1,24 @@
 <template>
   <div class="d-h264">
+    <!-- <dt-notice
+      v-if="showNotice"
+      data-qa="dt-message-input-error-notice"
+      :class="noticeClasses"
+      :kind="noticeKind"
+      :close-button-props="computedCloseButtonProps"
+      @close="noticeClose"
+    >
+      {{ noticeMessage }}
+      <template #icon>
+        <dt-icon
+          size="300"
+          name="alert-circle"
+        />
+      </template>
+    </dt-notice> -->
     <dt-recipe-message-input
       ref="input"
-      v-model:show-notice="$attrs.showNotice"
-      v-model="$attrs.modelValue"
+      v-model="modelValue"
       :input-aria-label="$attrs.inputAriaLabel"
       :auto-focus="$attrs.autoFocus"
       :editable="$attrs.editable"
@@ -12,22 +27,15 @@
       :output-format="$attrs.outputFormat"
       :placeholder="$attrs.placeholder"
       :disable-send="$attrs.disableSend"
-      :has-character-limit="$attrs.hasCharacterLimit"
-      :character-limit-count="$attrs.characterLimitCount"
-      :character-limit-warning="$attrs.characterLimitWarning"
-      :character-limit-warning-message="$attrs.characterLimitWarningMessage"
-      :notice-kind="$attrs.noticeKind"
-      :notice-message="$attrs.noticeMessage"
-      :send-button-aria-label="$attrs.sendButtonAriaLabel"
-      :send-tooltip-label="$attrs.sendTooltipLabel"
-      :emoji-picker-props="$attrs.emojiPickerProps"
-      :emoji-button-aria-label="$attrs.emojiButtonAriaLabel"
-      :image-button-aria-label="$attrs.imageButtonAriaLabel"
       :max-height="$attrs.maxHeight"
-      :is-edit="$attrs.isEdit"
-      :save-changes-button-text="$attrs.saveChangesButtonText"
-      :cancel-button-aria-label="$attrs.cancelButtonAriaLabel"
-      :cancel-button-text="$attrs.cancelButtonText"
+      :show-emoji-picker="$attrs.showEmojiPicker"
+      :emoji-picker-props="$attrs.emojiPickerProps"
+      :emoji-tooltip-message="$attrs.emojiTooltipMessage"
+      :emoji-button-aria-label="$attrs.emojiButtonAriaLabel"
+      :show-character-limit="$attrs.showCharacterLimit"
+      :show-image-picker="$attrs.showImagePicker"
+      :show-send="$attrs.showSend"
+      :show-cancel="$attrs.showCancel"
       @submit="$attrs.onSubmit"
       @focus="$attrs.onFocus"
       @blur="$attrs.onBlur"
@@ -38,23 +46,9 @@
       @add-media="$attrs.onAddMedia"
       @notice-close="$attrs.onNoticeClose"
       @cancel="$attrs.onCancel"
-    >
-      <template
-        #footerLeft
-      >
-        <div class="d-body-small d-fc-muted">
-          <b>Dwight</b> is typing...
-        </div>
-      </template>
-      <template
-        #footerRight
-      >
-        <div class="d-body-small d-fc-tertiary">
-          <b>Shift</b> + <b>Return</b> to add a new line
-        </div>
-      </template>
-    </dt-recipe-message-input>
+    />
   </div>
+
   <button @click="$refs.input.focus()">
     focus test
   </button>
@@ -66,5 +60,10 @@ import DtRecipeMessageInput from './message_input.vue';
 export default {
   name: 'DtRecipeMessageInputDefault',
   components: { DtRecipeMessageInput },
+  data () {
+    return {
+      modelValue: this.$attrs.modelValue,
+    };
+  },
 };
 </script>


### PR DESCRIPTION
## Description
Message input currently includes notice, footer contents that make it hard to extend it for cases like standalone message input, edit message case etc. Hence we remove the need to have additional content and just have the message input with ability to show/hide individual buttons.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![refactor](https://media1.tenor.com/m/eQ8OVVGD5rIAAAAC/refactor.gif)
