### PR TITLE
fix: illustrations not showing in docs

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -531,10 +531,20 @@ a.header-anchor {
   width: var(--dt-size-650);
   height: var(--dt-size-650);
   margin-bottom: var(--dt-space-300);
+
+  svg {
+    width: 100%;
+    height: auto;
+  }
 }
 
 .dialtone-icon-card__icon--autosize {
   margin-bottom: var(--dt-space-300);
+
+  svg {
+    width: 100%;
+    height: auto;
+  }
 }
 
 .dialtone-icon-card__title {


### PR DESCRIPTION
## Description
Broken here: https://github.com/dialpad/dialtone/pull/39

### Before:

<img width="917" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/d0124f18-bf35-46eb-90e8-875e406d63d6">

### After:

<img width="1011" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/51b85290-7c7d-4629-8cae-fd3589798582">


## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](path/to/gif)
