### PR TITLE
fix: theme tooltip to stay in place when clicking it

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Navbar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Navbar.vue
@@ -132,6 +132,7 @@
       </dt-tooltip>
       <dt-tooltip
         placement="bottom"
+        sticky="popper"
       >
         <template #default>
           <span class="d-tt-capitalize">{{ `${currentTheme} theme` }}</span>


### PR DESCRIPTION
## Description
Small visual fix for the change theme tooltip in the docs.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)

| Before | Now |
|-------|------|
| ![tooltip-before](https://github.com/dialpad/dialtone/assets/24460973/2653bd17-8838-4d2e-b00f-b32eec8c1a2b) | ![tooltip-now](https://github.com/dialpad/dialtone/assets/24460973/c9897229-c36f-43e2-8cf2-4503067895cd) |
