### PR TITLE
fix(callbox): correct color on voice chat icon

### DIFF
--- a/packages/dialtone-vue2/recipes/leftbar/callbox/callbox_variants.story.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/callbox/callbox_variants.story.vue
@@ -304,7 +304,8 @@
             class="d-ai-center d-of-x-hidden"
           >
             <dt-icon
-              name="activity"
+              class="voice-chat-icon"
+              name="waveform"
               size="100"
             />
             <p class="d-to-ellipsis d-ws-nowrap d-of-hidden">
@@ -480,5 +481,9 @@ export default {
   height: 140px;
   object-fit: cover;
   width: 100%;
+}
+
+.voice-chat-icon {
+  color: var(--dt-color-purple-400);
 }
 </style>

--- a/packages/dialtone-vue2/recipes/leftbar/style/leftbar_row.less
+++ b/packages/dialtone-vue2/recipes/leftbar/style/leftbar_row.less
@@ -224,7 +224,7 @@
   }
 
   &__active-voice {
-    color: var(--dt-color-foreground-success);
+    color: var(--dt-color-purple-400);
     display: inline-flex;
     .opacity-pulsate();
   }

--- a/packages/dialtone-vue3/recipes/leftbar/callbox/callbox_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/callbox/callbox_variants.story.vue
@@ -304,7 +304,8 @@
             class="d-ai-center d-of-x-hidden"
           >
             <dt-icon
-              name="activity"
+              class="voice-chat-icon"
+              name="waveform"
               size="100"
             />
             <p class="d-to-ellipsis d-ws-nowrap d-of-hidden">
@@ -487,5 +488,9 @@ export default {
   height: 140px;
   object-fit: cover;
   width: 100%;
+}
+
+.voice-chat-icon {
+  color: var(--dt-color-purple-400);
 }
 </style>

--- a/packages/dialtone-vue3/recipes/leftbar/style/leftbar_row.less
+++ b/packages/dialtone-vue3/recipes/leftbar/style/leftbar_row.less
@@ -224,7 +224,7 @@
   }
 
   &__active-voice {
-    color: var(--dt-color-foreground-success);
+    color: var(--dt-color-purple-400);
     display: inline-flex;
     .opacity-pulsate();
   }


### PR DESCRIPTION
## Description
The voice chat icon color on the new designs was supposed to be purple but it was set as green. Correcting this, will require a small change in product as well due to the slot in callbox.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/26ufmyrjQ4BmKN7xe/giphy.gif)
