### PR TITLE
docs(design-tokens): a few quick color descriptions

### DIFF
--- a/packages/dialtone-tokens/tokens/base/default.json
+++ b/packages/dialtone-tokens/tokens/base/default.json
@@ -3,15 +3,18 @@
     "neutral": {
       "white": {
         "value": "#ffffff",
-        "type": "color"
+        "type": "color",
+        "description": "White color independent of any theme."
       },
       "black": {
         "value": "#000000",
-        "type": "color"
+        "type": "color",
+        "description": "Black color independent of any theme."
       },
       "transparent": {
         "value": "transparent",
-        "type": "color"
+        "type": "color",
+        "description": "Transparent color independent of any theme."
       }
     },
     "black": {
@@ -213,17 +216,20 @@
     "gradient": {
       "magenta-purple": {
         "value": "linear-gradient(135deg, {color.brand.magenta} 10%, {color.brand.purple} 90%)",
-        "type": "color"
+        "type": "color",
+        "description": "Gradient for Ai-oriented treatments."
       }
     },
     "brand": {
       "purple": {
         "value": "#7C52FF",
-        "type": "color"
+        "type": "color",
+        "description": "Primary brand color."
       },
       "magenta": {
         "value": "#F9008E",
-        "type": "color"
+        "type": "color",
+        "description": "Secondary brand color, typically used as an accent color."
       }
     }
   },


### PR DESCRIPTION
## Description

Added a few Design Token descriptions. Also doing so as a way to validate PR'ing to `dialtone/packages/dialtone-tokens` now that it's a monorepo.

These descriptions should appear in [deploy preview's Tokens/Color page](https://dialtone.dialpad.com/tokens/color.html).

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
![dean-winchester](https://github.com/dialpad/dialtone/assets/1165933/09b71b52-30a4-4992-b760-d64d76ead0f0)
