### PR TITLE
fix: change dialtone-icons to peer

### DIFF
--- a/packages/dialtone-vue2/package.json
+++ b/packages/dialtone-vue2/package.json
@@ -31,7 +31,6 @@
     "CHANGELOG.json"
   ],
   "dependencies": {
-    "@dialpad/dialtone-icons": "workspace:^",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-code-block": "^2.0.3",
@@ -51,6 +50,7 @@
   },
   "devDependencies": {
     "@dialpad/dialtone-css": "workspace:^",
+    "@dialpad/dialtone-icons": "workspace:^",
     "@percy/cli": "^1.27.4",
     "@percy/storybook": "^5.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
@@ -101,6 +101,7 @@
   },
   "peerDependencies": {
     "@dialpad/dialtone-css": "^7.30.0 || ^8.21.2",
+    "@dialpad/dialtone-icons": "^4.3.0",
     "vue": ">=2.6"
   },
   "bugs": {

--- a/packages/dialtone-vue3/package.json
+++ b/packages/dialtone-vue3/package.json
@@ -31,7 +31,6 @@
     "CHANGELOG.json"
   ],
   "dependencies": {
-    "@dialpad/dialtone-icons": "workspace:^",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-code-block": "^2.0.3",
     "@tiptap/extension-document": "^2.0.3",
@@ -50,6 +49,7 @@
   },
   "devDependencies": {
     "@dialpad/dialtone-css": "workspace:^",
+    "@dialpad/dialtone-icons": "workspace:^",
     "@percy/cli": "^1.27.4",
     "@percy/storybook": "^5.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
@@ -99,6 +99,7 @@
   },
   "peerDependencies": {
     "@dialpad/dialtone-css": "^7.30.0 || ^8.21.2",
+    "@dialpad/dialtone-icons": "^4.3.0",
     "vue": ">=3.2"
   },
   "bugs": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,9 +358,6 @@ importers:
 
   packages/dialtone-vue2:
     dependencies:
-      '@dialpad/dialtone-icons':
-        specifier: workspace:^
-        version: link:../dialtone-icons
       '@linusborg/vue-simple-portal':
         specifier: ^0.1.5
         version: 0.1.5(vue@2.7.15)
@@ -413,6 +410,9 @@ importers:
       '@dialpad/dialtone-css':
         specifier: workspace:^
         version: link:../dialtone-css
+      '@dialpad/dialtone-icons':
+        specifier: workspace:^
+        version: link:../dialtone-icons
       '@percy/cli':
         specifier: ^1.27.4
         version: 1.27.4(typescript@5.2.2)
@@ -557,9 +557,6 @@ importers:
 
   packages/dialtone-vue3:
     dependencies:
-      '@dialpad/dialtone-icons':
-        specifier: workspace:^
-        version: link:../dialtone-icons
       '@tiptap/core':
         specifier: ^2.0.3
         version: 2.0.3(@tiptap/pm@2.1.12)
@@ -609,6 +606,9 @@ importers:
       '@dialpad/dialtone-css':
         specifier: workspace:^
         version: link:../dialtone-css
+      '@dialpad/dialtone-icons':
+        specifier: workspace:^
+        version: link:../dialtone-icons
       '@percy/cli':
         specifier: ^1.27.4
         version: 1.27.4(typescript@5.2.2)
@@ -7093,7 +7093,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.3.8(typescript@5.2.2)
-      vue-component-type-helpers: 1.8.25
+      vue-component-type-helpers: 1.8.26
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -27777,8 +27777,8 @@ packages:
     resolution: {integrity: sha512-lqWs/7fdRXoSBAlbouHBX+LNuaY6gI9xWW34m/ZIz9zVPYHEyw0b2/zaCBwlKx0NtKTeF/6pOpvrxVkh7nhIYg==}
     dev: true
 
-  /vue-component-type-helpers@1.8.25:
-    resolution: {integrity: sha512-NCA6sekiJIMnMs4DdORxATXD+/NRkQpS32UC+I1KQJUasx+Z7MZUb3Y+MsKsFmX+PgyTYSteb73JW77AibaCCw==}
+  /vue-component-type-helpers@1.8.26:
+    resolution: {integrity: sha512-CIwb7s8cqUuPpHDk+0DY8EJ/x8tzdzqw8ycX8hhw1GnbngTgSsIceHAqrrLjmv8zXi+j5XaiqYRQMw8sKyyjkw==}
     dev: true
 
   /vue-demi@0.14.6(vue@3.3.8):


### PR DESCRIPTION
## Description

Changed dialtone-icons to peer dependecy to avoid having to release a dialtone-vue version to use the latest icons.
*this is not going to be needed once people is using mono-package, but will save us some time for now.*

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/TlfY7QPkCPTjE3OaHF/giphy.gif?cid=82a1493bfmbmis68kdqifseut0ln59ddih6yk7vo8h1ux53t&ep=v1_gifs_trending&rid=giphy.gif&ct=g)
