### PR TITLE
chore: fix dialtone-css version

### DIFF
--- a/packages/dialtone-css/package.json
+++ b/packages/dialtone-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dialpad/dialtone-css",
-  "version": "1.0.0",
+  "version": "8.22.1",
   "description": "Dialpad's design system",
   "keywords": [
     "Dialpad",


### PR DESCRIPTION
## Description

Updated dialtone-css version to 8.22.1, updated tags accordingly so semantic-release picks up from there.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/OhQ6uyPHADwpnnYM6G/giphy.gif?cid=82a1493bmmy3kdwse24wp2cd529vk39o35njfaqggeu0113d&ep=v1_gifs_trending&rid=giphy.gif&ct=g)
