### PR TITLE
fix: vue2 storybook components and recipe

### DIFF
--- a/packages/dialtone-vue2/common/storybook_utils.js
+++ b/packages/dialtone-vue2/common/storybook_utils.js
@@ -5,18 +5,21 @@ import iconNames from '@dialpad/dialtone-icons/dist/icons.json';
  * This is useful for more complex components that are hard to work with and
  * get messy when rendered via a template string. Will pass args and argTypes
  * into the component so it is able to be live edited with storybook controls addon.
- * @param {object} args storybook control args
- * @param {object} argTypes storybook control argument settings
- * @param {component} templateComponent vue component template for rendering to storybook.
- *                                      Note this should not be the component itself,
- *                                      but rather the usage of that component.
+ * @param component this will get the component name
+ * @param defaultTemplate we will mount in this component
+ * @param argsData storybook control args
  * @returns {component} the template component with props and args added.
  */
-export const createTemplateFromVueFile = (args, argTypes, templateComponent) => ({
-  components: { templateComponent },
-  props: Object.keys(argTypes),
-  template: '<template-component v-bind="$props"></template-component>',
-});
+
+export function createRenderConfig (component, defaultTemplate, argsData) {
+  return {
+    components: { [component.name]: defaultTemplate },
+    setup () {
+      return { argsData };
+    },
+    template: `<${component.name} v-bind="argsData"></${component.name}>`,
+  };
+}
 
 /**
  * Gets the full list of icon component names from the dialtone package
@@ -50,6 +53,6 @@ export const generateTemplate = (component,
 
 export default {
   generateTemplate,
-  createTemplateFromVueFile,
   getIconNames,
+  createRenderConfig,
 };

--- a/packages/dialtone-vue2/components/avatar/avatar.stories.js
+++ b/packages/dialtone-vue2/components/avatar/avatar.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 import DtAvatar from './avatar.vue';
 import { AVATAR_SIZE_MODIFIERS, AVATAR_PRESENCE_STATES, AVATAR_COLORS } from './avatar_constants';
 import DtAvatarDefaultTemplate from './avatar_default.story.vue';
@@ -108,16 +108,9 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtAvatarDefaultTemplate);
-
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtAvatarVariantsTemplate);
-
 // Stories
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtAvatar, DtAvatarDefaultTemplate, argsData),
   decorators: [
     () => ({
       template: `<div class="d-d-flex"><story /></div>`,
@@ -126,7 +119,7 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtAvatar, DtAvatarVariantsTemplate, argsData),
   parameters: {
     percy: {
       args: {

--- a/packages/dialtone-vue2/components/badge/badge.stories.js
+++ b/packages/dialtone-vue2/components/badge/badge.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 import DtBadge from './badge.vue';
 import DtBadgeDefaultTemplate from './badge_default.story.vue';
 import DtBadgeVariantsTemplate from './badge_variants.story.vue';
@@ -87,16 +87,8 @@ export default {
   argTypes: argTypesData,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtBadgeDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtBadgeVariantsTemplate);
-const ExamplesTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtBadgeExamplesTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtBadge, DtBadgeDefaultTemplate, argsData),
 
   args: {
     default: 'Badge',
@@ -104,8 +96,7 @@ export const Default = {
 };
 
 export const Count = {
-  render: DefaultTemplate,
-
+  render: (argsData) => createRenderConfig(DtBadge, DtBadgeDefaultTemplate, argsData),
   args: {
     default: '1',
     kind: 'count',
@@ -113,13 +104,13 @@ export const Count = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtBadge, DtBadgeVariantsTemplate, argsData),
   parameters: { options: { showPanel: false }, controls: { disable: true } },
   args: {},
 };
 
 export const Examples = {
-  render: ExamplesTemplate,
+  render: (argsData) => createRenderConfig(DtBadge, DtBadgeExamplesTemplate, argsData),
   parameters: { options: { showPanel: false }, controls: { disable: true } },
   args: {},
 };

--- a/packages/dialtone-vue2/components/banner/banner.stories.js
+++ b/packages/dialtone-vue2/components/banner/banner.stories.js
@@ -1,7 +1,7 @@
 import DtBanner from './banner.vue';
+import { createRenderConfig } from '@/common/storybook_utils';
 
 import BannerDefault from './banner_default.story.vue';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import { argsData as noticeArgsData, argTypesData as noticeArgTypesData } from '../notice/notice.stories.js';
 
 import backgroundImage from '@/common/assets/dialpad-gradient.png';
@@ -48,10 +48,8 @@ export default {
   excludeStories: /.Data$/,
 };
 
-const Template = (args, { argTypes }) => createTemplateFromVueFile(args, argTypes, BannerDefault);
-
 export const Default = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtBanner, BannerDefault, argsData),
 
   args: {
     title: 'Optional title',
@@ -69,37 +67,37 @@ export const Default = {
 };
 
 export const Error = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtBanner, BannerDefault, argsData),
   args: { ...Default.args, kind: 'error' },
   parameters: Default.parameters,
 };
 
 export const Info = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtBanner, BannerDefault, argsData),
   args: { ...Default.args, kind: 'info' },
   parameters: Default.parameters,
 };
 
 export const Success = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtBanner, BannerDefault, argsData),
   args: { ...Default.args, kind: 'success' },
   parameters: Default.parameters,
 };
 
 export const Warning = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtBanner, BannerDefault, argsData),
   args: { ...Default.args, kind: 'warning' },
   parameters: Default.parameters,
 };
 
 export const Pinned = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtBanner, BannerDefault, argsData),
   args: { ...Default.args, pinned: true },
   parameters: Default.parameters,
 };
 
 export const CustomBackground = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtBanner, BannerDefault, argsData),
 
   args: {
     ...Default.args,

--- a/packages/dialtone-vue2/components/breadcrumbs/breadcrumb_item.stories.js
+++ b/packages/dialtone-vue2/components/breadcrumbs/breadcrumb_item.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtBreadcrumbItem from './breadcrumb_item.vue';
 
 import DtBreadcrumbItemDefaultTemplate from './breadcrumb_item_default.story.vue';
@@ -22,12 +22,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtBreadcrumbItemDefaultTemplate);
-
 export const BreadcrumbItem = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtBreadcrumbItem, DtBreadcrumbItemDefaultTemplate, argsData),
   args: {},
   parameters: {
     a11y: {

--- a/packages/dialtone-vue2/components/breadcrumbs/breadcrumbs.stories.js
+++ b/packages/dialtone-vue2/components/breadcrumbs/breadcrumbs.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtBreadcrumbs from './breadcrumbs.vue';
 
 import DtBreadcrumbsDefaultTemplate from './breadcrumbs_default.story.vue';
@@ -67,19 +67,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtBreadcrumbsDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtBreadcrumbsVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtBreadcrumbs, DtBreadcrumbsDefaultTemplate, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtBreadcrumbs, DtBreadcrumbsVariantsTemplate, argsData),
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue2/components/button/button.stories.js
+++ b/packages/dialtone-vue2/components/button/button.stories.js
@@ -11,7 +11,7 @@ import { LINK_KIND_MODIFIERS } from '../link/link_constants';
 
 import ButtonDefault from './button_default.story.vue';
 import ButtonVariants from './button_variants.story.vue';
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 
 export const argsData = {
   onClick: action('click'),
@@ -160,21 +160,16 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-const Template = (args, { argTypes }) => createTemplateFromVueFile(args, argTypes, ButtonDefault);
-
 export const Default = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtButton, ButtonDefault, argsData),
 
   args: {
     default: 'Button',
   },
 };
 
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, ButtonVariants);
-
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtButton, ButtonVariants, argsData),
   parameters: { options: { showPanel: false }, controls: { disable: true } },
   args: {},
 };

--- a/packages/dialtone-vue2/components/button_group/button_group.stories.js
+++ b/packages/dialtone-vue2/components/button_group/button_group.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtButtonGroup from './button_group.vue';
 
 import DtButtonGroupDefaultTemplate from './button_group_default.story.vue';
@@ -35,14 +35,7 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtButtonGroupDefaultTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtButtonGroup, DtButtonGroupDefaultTemplate, argsData),
   args: {},
 };

--- a/packages/dialtone-vue2/components/card/card.stories.js
+++ b/packages/dialtone-vue2/components/card/card.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtCard from './card.vue';
 
 import DtCardDefaultTemplate from './card_default.story.vue';
@@ -62,15 +62,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtCardDefaultTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtCard, DtCardDefaultTemplate, argsData),
   args: {},
 
   parameters: {
@@ -90,7 +83,7 @@ export const Default = {
 };
 
 export const WithHeader = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtCard, DtCardDefaultTemplate, argsData),
 
   args: {
     showHeader: true,
@@ -99,7 +92,7 @@ export const WithHeader = {
 };
 
 export const WithFooter = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtCard, DtCardDefaultTemplate, argsData),
 
   args: {
     showFooter: true,
@@ -108,7 +101,7 @@ export const WithFooter = {
 };
 
 export const WithHeaderAndFooter = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtCard, DtCardDefaultTemplate, argsData),
 
   args: {
     showHeader: true,
@@ -118,7 +111,7 @@ export const WithHeaderAndFooter = {
 };
 
 export const WithScrollableContent = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtCard, DtCardDefaultTemplate, argsData),
 
   args: {
     maxHeight: '50px',

--- a/packages/dialtone-vue2/components/checkbox/checkbox.stories.js
+++ b/packages/dialtone-vue2/components/checkbox/checkbox.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import { VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 import CheckboxDefault from './checkbox_default.story.vue';
 import CheckboxVariants from './checkbox_variants.story.vue';
@@ -140,19 +140,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Checkbox Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, CheckboxDefault);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, CheckboxVariants);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtCheckbox, CheckboxDefault, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtCheckbox, CheckboxVariants, argsData),
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/components/checkbox_group/checkbox_group.stories.js
+++ b/packages/dialtone-vue2/components/checkbox_group/checkbox_group.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtCheckboxGroup from './checkbox_group.vue';
 
 import CheckboxGroupDefaultTemplate from './checkbox_group_default.story.vue';
@@ -140,21 +140,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => {
-  return createTemplateFromVueFile(args, argTypes, CheckboxGroupDefaultTemplate);
-};
-const VariantsTemplate = (args, { argTypes }) => {
-  return createTemplateFromVueFile(args, argTypes, CheckboxGroupVariantsTemplate);
-};
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtCheckboxGroup, CheckboxGroupDefaultTemplate, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtCheckboxGroup, CheckboxGroupVariantsTemplate, argsData),
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue2/components/chip/chip.stories.js
+++ b/packages/dialtone-vue2/components/chip/chip.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 import DtChip from './chip.vue';
 
 import DtChipDefaultTemplate from './chip_default.story.vue';
@@ -119,19 +119,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtChipDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtChipVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtChip, DtChipDefaultTemplate, argsData),
   args: { default: 'Chip' },
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtChip, DtChipVariantsTemplate, argsData),
 
   parameters: {
     percy: {

--- a/packages/dialtone-vue2/components/codeblock/codeblock.stories.js
+++ b/packages/dialtone-vue2/components/codeblock/codeblock.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtCodeblock from './codeblock.vue';
 
 import DtCodeblockDefaultTemplate from './codeblock_default.story.vue';
@@ -22,15 +22,8 @@ export default {
   parameters: {},
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtCodeblockDefaultTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtCodeblock, DtCodeblockDefaultTemplate, argsData),
 
   args: {
     text: 'function someFunction() {\n  return "some result";\n}',

--- a/packages/dialtone-vue2/components/collapsible/collapsible.stories.js
+++ b/packages/dialtone-vue2/components/collapsible/collapsible.stories.js
@@ -1,6 +1,6 @@
 import { action } from '@storybook/addon-actions';
 import { DtCollapsible } from './';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 
 import DtCollapsibleDefaultStory from './collapsible_default.story.vue';
 
@@ -73,15 +73,8 @@ export default {
   excludeStories: /.Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtCollapsibleDefaultStory,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtCollapsible, DtCollapsibleDefaultStory, argsData),
 
   args: {
     maxWidth: '512px',

--- a/packages/dialtone-vue2/components/combobox/combobox.stories.js
+++ b/packages/dialtone-vue2/components/combobox/combobox.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtCombobox from './combobox.vue';
 
 import DtComboboxDefaultTemplate from './combobox_default.story.vue';
@@ -209,15 +209,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtComboboxDefaultTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtCombobox, DtComboboxDefaultTemplate, argsData),
 
   args: {
     items: [
@@ -238,7 +231,7 @@ export const Default = {
 };
 
 export const Empty = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtCombobox, DtComboboxDefaultTemplate, argsData),
 
   args: {
     items: [],

--- a/packages/dialtone-vue2/components/datepicker/datepicker.stories.js
+++ b/packages/dialtone-vue2/components/datepicker/datepicker.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtDatepicker from './datepicker.vue';
 import DtDatepickerDefaultTemplate from './datepicker_default.story.vue';
 import DtDatepickerWithPopoverTemplate from './datepicker_popover.story.vue';
@@ -110,21 +110,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const Template = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtDatepickerDefaultTemplate,
-);
-
-const WithPopoverTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtDatepickerWithPopoverTemplate,
-);
-
 export const Default = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtDatepicker, DtDatepickerDefaultTemplate, argsData),
   args: {},
   parameters: {
     percy: {
@@ -136,7 +123,7 @@ export const Default = {
 };
 
 export const WithPopover = {
-  render: WithPopoverTemplate,
+  render: (argsData) => createRenderConfig(DtDatepicker, DtDatepickerWithPopoverTemplate, argsData),
   args: {},
   parameters: {
     options: { showPanel: false },

--- a/packages/dialtone-vue2/components/description_list/description_list.stories.js
+++ b/packages/dialtone-vue2/components/description_list/description_list.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import { DT_STACK_GAP } from '@/components/stack/stack_constants';
 import DtDescriptionList from './description_list.vue';
 import DtDescriptionListDefaultTemplate from './description_list_default.story.vue';
@@ -97,16 +97,9 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtDescriptionListDefaultTemplate,
-);
-
 // Stories
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtDescriptionList, DtDescriptionListDefaultTemplate, argsData),
   args: {},
 };
 

--- a/packages/dialtone-vue2/components/dropdown/dropdown.stories.js
+++ b/packages/dialtone-vue2/components/dropdown/dropdown.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtDropdown from './dropdown.vue';
 
 import DtDropdownDefaultTemplate from './dropdown_default.story.vue';
@@ -149,20 +149,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtDropdownDefaultTemplate,
-);
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtDropdownVariantsTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtDropdown, DtDropdownDefaultTemplate, argsData),
   args: {},
 
   parameters: {
@@ -181,7 +169,7 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtDropdown, DtDropdownVariantsTemplate, argsData),
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue2/components/emoji/emoji.stories.js
+++ b/packages/dialtone-vue2/components/emoji/emoji.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import { ICON_SIZE_MODIFIERS } from '@/components/icon/icon_constants';
 import DtEmoji from './emoji.vue';
 
@@ -33,25 +33,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtEmojiDefaultTemplate,
-);
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtEmojiVariantsTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtEmoji, DtEmojiDefaultTemplate, argsData),
   args: {},
 };
 
 export const CustomEmoji = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtEmoji, DtEmojiDefaultTemplate, argsData),
 
   args: {
     code: ':shipit:',
@@ -59,7 +47,7 @@ export const CustomEmoji = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtEmoji, DtEmojiVariantsTemplate, argsData),
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.stories.js
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtEmojiPicker from './emoji_picker.vue';
 import DtEmojiPickerDefaultTemplate from './emoji_picker_default.story.vue';
 import DtEmojiPickerWithPopoverTemplate from './emoji_picker_popover.story.vue';
@@ -111,27 +111,14 @@ export default {
   },
 };
 
-// Templates
-const Template = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtEmojiPickerDefaultTemplate,
-);
-
-const WithPopoverTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtEmojiPickerWithPopoverTemplate,
-);
-
 // Stories
 export const Default = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtEmojiPicker, DtEmojiPickerDefaultTemplate, argsData),
   args: {},
 };
 
 export const WithPopover = {
-  render: WithPopoverTemplate,
+  render: (argsData) => createRenderConfig(DtEmojiPicker, DtEmojiPickerWithPopoverTemplate, argsData),
   args: {},
   parameters: {
     options: {

--- a/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.stories.js
+++ b/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import { ICON_SIZE_MODIFIERS } from '@/components/icon/icon_constants';
 import DtEmojiTextWrapper from './emoji_text_wrapper.vue';
 
@@ -49,20 +49,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtEmojiTextWrapperDefaultTemplate,
-);
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtEmojiTextWrapperVariantsTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtEmojiTextWrapper, DtEmojiTextWrapperDefaultTemplate, argsData),
 
   args: {
     default:
@@ -71,7 +59,8 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtEmojiTextWrapper, DtEmojiTextWrapperVariantsTemplate, argsData),
+
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/components/icon/icon.stories.js
+++ b/packages/dialtone-vue2/components/icon/icon.stories.js
@@ -3,7 +3,7 @@ import { ICON_SIZE_MODIFIERS } from './icon_constants';
 
 import DtIconDefaultTemplate from './icon_default.story.vue';
 import DtIconVariantsTemplate from './icon_variants.story.vue';
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 const iconsList = getIconNames();
 export const argTypesData = {
   size: {
@@ -33,19 +33,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtIconDefaultTemplate,
-);
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtIconVariantsTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtIcon, DtIconDefaultTemplate, argsData),
 
   args: {
     name: 'accessibility',
@@ -53,7 +42,7 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtIcon, DtIconVariantsTemplate, argsData),
   args: { limit: undefined },
   parameters: {
     percy: {

--- a/packages/dialtone-vue2/components/image_viewer/image_viewer.stories.js
+++ b/packages/dialtone-vue2/components/image_viewer/image_viewer.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtImageViewer from './image_viewer.vue';
 
 import DtImageViewerDefaultTemplate from './image_viewer_default.story.vue';
@@ -139,20 +139,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtImageViewerDefaultTemplate,
-);
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtImageViewerVariantsTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtImageViewer, DtImageViewerDefaultTemplate, argsData),
 
   args: {
     imageSrc: defaultImage,
@@ -164,7 +152,7 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtImageViewer, DtImageViewerVariantsTemplate, argsData),
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue2/components/input/input.stories.js
+++ b/packages/dialtone-vue2/components/input/input.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 import DtInput from './input.vue';
 import { INPUT_SIZES, INPUT_TYPES } from './input_constants';
 
@@ -268,9 +268,7 @@ export default {
 };
 
 export const Default = {
-  render: (args, { argTypes }) => {
-    return createTemplateFromVueFile(args, argTypes, InputDefault);
-  },
+  render: (argsData) => createRenderConfig(DtInput, InputDefault, argsData),
 };
 
 export const WithDescription = {

--- a/packages/dialtone-vue2/components/input_group/input_group.stories.js
+++ b/packages/dialtone-vue2/components/input_group/input_group.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtInputGroup from './input_group.vue';
 
 import InputGroupDefaultTemplate from './input_group_default.story.vue';
@@ -115,19 +115,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, InputGroupDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, InputGroupVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtInputGroup, InputGroupDefaultTemplate, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtInputGroup, InputGroupVariantsTemplate, argsData),
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue2/components/item_layout/item_layout.stories.js
+++ b/packages/dialtone-vue2/components/item_layout/item_layout.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtItemLayout from './item_layout.vue';
 import DtItemLayoutDefaultTemplate from './item_layout_default.story.vue';
 
@@ -73,15 +73,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtItemLayoutDefaultTemplate,
-);
-
 // Stories
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtItemLayout, DtItemLayoutDefaultTemplate, argsData),
   args: {},
 };

--- a/packages/dialtone-vue2/components/keyboard_shortcut/keyboard_shortcut.stories.js
+++ b/packages/dialtone-vue2/components/keyboard_shortcut/keyboard_shortcut.stories.js
@@ -1,5 +1,5 @@
 import { SHORTCUTS_ALIASES_LIST } from './keyboard_shortcut_constants';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtKeyboardShortcut from './keyboard_shortcut.vue';
 
 import DtKeyboardShortcutDefaultTemplate from './keyboard_shortcut_default.story.vue';
@@ -32,19 +32,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtKeyboardShortcutDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtKeyboardShortcutVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtKeyboardShortcut, DtKeyboardShortcutDefaultTemplate, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtKeyboardShortcut, DtKeyboardShortcutVariantsTemplate, argsData),
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/components/lazy_show/lazy_show.stories.js
+++ b/packages/dialtone-vue2/components/lazy_show/lazy_show.stories.js
@@ -1,6 +1,6 @@
 import { DtLazyShow } from './';
 import LazyShowDefault from './lazy_show_default.story.vue';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 
 const argTypesData = {
   // Slots
@@ -30,9 +30,7 @@ export default {
   excludeStories: /.Data$/,
 };
 
-const Template = (args, { argTypes }) => createTemplateFromVueFile(args, argTypes, LazyShowDefault);
-
 export const Default = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtLazyShow, LazyShowDefault, argsData),
   args: {},
 };

--- a/packages/dialtone-vue2/components/link/link.stories.js
+++ b/packages/dialtone-vue2/components/link/link.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import { action } from '@storybook/addon-actions';
 import DtLink from './link.vue';
 
@@ -106,19 +106,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtLinkDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtLinkVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtLink, DtLinkDefaultTemplate, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtLink, DtLinkVariantsTemplate, argsData),
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue2/components/list_item/list_item.stories.js
+++ b/packages/dialtone-vue2/components/list_item/list_item.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 import DtListItem from './list_item.vue';
 
 import { LIST_ITEM_NAVIGATION_TYPES, LIST_ITEM_TYPES } from './list_item_constants';
@@ -152,14 +152,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtListItemDefaultTemplate);
-const CustomTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtListItemCustomTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtListItem, DtListItemDefaultTemplate, argsData),
 
   args: {
     left: 'globe-2',
@@ -172,6 +166,6 @@ export const Default = {
 };
 
 export const Custom = {
-  render: CustomTemplate,
+  render: (argsData) => createRenderConfig(DtListItem, DtListItemCustomTemplate, argsData),
   args: {},
 };

--- a/packages/dialtone-vue2/components/list_item_group/list_item_group.stories.js
+++ b/packages/dialtone-vue2/components/list_item_group/list_item_group.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtListItemGroup from './list_item_group.vue';
 
 import DtListItemGroupDefaultTemplate from './list_item_group_default.story.vue';
@@ -38,11 +38,7 @@ export default {
   parameters: {},
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtListItemGroupDefaultTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtListItemGroup, DtListItemGroupDefaultTemplate, argsData),
   args: {},
 };

--- a/packages/dialtone-vue2/components/modal/modal.stories.js
+++ b/packages/dialtone-vue2/components/modal/modal.stories.js
@@ -2,7 +2,7 @@ import DtModal from './modal.vue';
 
 import DtModalDefaultTemplate from './modal_default.story.vue';
 import { MODAL_KIND_MODIFIERS, MODAL_SIZE_MODIFIERS } from './modal_constants';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import { action } from '@storybook/addon-actions';
 import { NOTICE_KINDS } from '@/components/notice';
 
@@ -142,12 +142,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtModalDefaultTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtModal, DtModalDefaultTemplate, argsData),
 
   args: {},
   parameters: {
@@ -160,7 +156,7 @@ export const Default = {
 };
 
 export const WithFooter = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtModal, DtModalDefaultTemplate, argsData),
 
   args: {
     showFooter: true,
@@ -170,7 +166,7 @@ export const WithFooter = {
 };
 
 export const WithFixedHeaderFooter = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtModal, DtModalDefaultTemplate, argsData),
 
   args: {
     showFooter: true,
@@ -182,7 +178,7 @@ export const WithFixedHeaderFooter = {
 };
 
 export const WithBanner = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtModal, DtModalDefaultTemplate, argsData),
 
   args: {
     bannerTitle: 'Example banner',
@@ -192,7 +188,7 @@ export const WithBanner = {
 };
 
 export const WithDangerStyle = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtModal, DtModalDefaultTemplate, argsData),
 
   args: {
     kind: 'danger',
@@ -203,7 +199,7 @@ export const WithDangerStyle = {
 };
 
 export const WithFullSize = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtModal, DtModalDefaultTemplate, argsData),
 
   args: {
     size: 'full',
@@ -214,7 +210,7 @@ export const WithFullSize = {
 };
 
 export const WithCustomHeaderAndContent = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtModal, DtModalDefaultTemplate, argsData),
 
   args: {
     header: `

--- a/packages/dialtone-vue2/components/notice/notice.stories.js
+++ b/packages/dialtone-vue2/components/notice/notice.stories.js
@@ -3,7 +3,7 @@ import DtNotice from './notice.vue';
 import { NOTICE_KINDS, NOTICE_ROLES } from './notice_constants';
 import NoticeDefault from './notice_default.story.vue';
 
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 
 const iconsList = getIconNames();
 
@@ -117,10 +117,8 @@ export default {
   excludeStories: /.Data$/,
 };
 
-const Template = (args, { argTypes }) => createTemplateFromVueFile(args, argTypes, NoticeDefault);
-
 export const Default = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtNotice, NoticeDefault, argsData),
 
   args: {
     title: 'Base title (optional)',
@@ -129,7 +127,7 @@ export const Default = {
 };
 
 export const Error = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtNotice, NoticeDefault, argsData),
 
   args: {
     ...Default.args,
@@ -139,7 +137,7 @@ export const Error = {
 };
 
 export const Info = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtNotice, NoticeDefault, argsData),
 
   args: {
     ...Default.args,
@@ -149,7 +147,7 @@ export const Info = {
 };
 
 export const Success = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtNotice, NoticeDefault, argsData),
 
   args: {
     ...Default.args,
@@ -159,7 +157,7 @@ export const Success = {
 };
 
 export const Warning = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtNotice, NoticeDefault, argsData),
 
   args: {
     ...Default.args,
@@ -169,7 +167,7 @@ export const Warning = {
 };
 
 export const Important = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtNotice, NoticeDefault, argsData),
 
   args: {
     ...Default.args,

--- a/packages/dialtone-vue2/components/pagination/pagination.stories.js
+++ b/packages/dialtone-vue2/components/pagination/pagination.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtPagination from './pagination.vue';
 
 import DtPaginationDefaultTemplate from './pagination_default.story.vue';
@@ -73,14 +73,9 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtPaginationDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtPaginationVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtPagination, DtPaginationDefaultTemplate, argsData),
+
   args: {},
 
   parameters: {
@@ -103,7 +98,8 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtPagination, DtPaginationVariantsTemplate, argsData),
+
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue2/components/popover/popover.stories.js
+++ b/packages/dialtone-vue2/components/popover/popover.stories.js
@@ -7,7 +7,7 @@ import {
 } from './';
 import PopoverDefault from './popover_default.story.vue';
 import PopoverVariants from './popover_variants.story.vue';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 
 import { action } from '@storybook/addon-actions';
 import { POPOVER_DIRECTIONS, POPOVER_STICKY_VALUES } from './popover_constants';
@@ -202,12 +202,9 @@ export default {
   excludeStories: /.Data$/,
 };
 
-const Template = (args, { argTypes }) => createTemplateFromVueFile(args, argTypes, PopoverDefault);
-const TemplateVariants = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, PopoverVariants);
-
 export const Default = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtPopover, PopoverDefault, argsData),
+
   args: {},
 
   decorators: [
@@ -220,7 +217,8 @@ export const Default = {
 };
 
 export const Variants = {
-  render: TemplateVariants,
+  render: (argsData) => createRenderConfig(DtPopover, PopoverVariants, argsData),
+
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue2/components/presence/presence.stories.js
+++ b/packages/dialtone-vue2/components/presence/presence.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 
 import Presence from './presence.vue';
 import { PRESENCE_STATES_LIST } from './presence_constants';
@@ -32,19 +32,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, PresenceDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, PresenceVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(Presence, PresenceDefaultTemplate, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(Presence, PresenceVariantsTemplate, argsData),
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/components/radio/radio.stories.js
+++ b/packages/dialtone-vue2/components/radio/radio.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import { VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 import RadioDefault from './radio_default.story.vue';
 import RadioVariants from './radio_variants.story.vue';
@@ -142,19 +142,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Radio Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, RadioDefault);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, RadioVariants);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRadio, RadioDefault, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtRadio, RadioVariants, argsData),
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/components/radio_group/radio_group.stories.js
+++ b/packages/dialtone-vue2/components/radio_group/radio_group.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRadioGroup from './radio_group.vue';
 
 import RadioGroupDefaultTemplate from './radio_group_default.story.vue';
@@ -132,19 +132,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, RadioGroupDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, RadioGroupVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(RadioGroupVariantsTemplate,RadioGroupDefaultTemplate , argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(RadioGroupVariantsTemplate,RadioGroupVariantsTemplate , argsData),
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRichTextEditor from './rich_text_editor.vue';
 import DtRichTextEditorDefaultTemplate from './rich_text_editor_default.story.vue';
 import {
@@ -94,12 +94,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtRichTextEditorDefaultTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRichTextEditor, DtRichTextEditorDefaultTemplate, argsData),
 };
 
 export const WithLinks = {

--- a/packages/dialtone-vue2/components/root_layout/root_layout.stories.js
+++ b/packages/dialtone-vue2/components/root_layout/root_layout.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 // import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import {
   ROOT_LAYOUT_RESPONSIVE_BREAKPOINTS,
   ROOT_LAYOUT_SIDEBAR_POSITIONS,
@@ -127,14 +127,8 @@ export default {
   },
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtRootLayoutDefaultTemplate);
-const StickyTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtRootLayoutStickyTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRootLayout, DtRootLayoutDefaultTemplate, argsData),
 
   args: {
     default: argsData.default.repeat(40),
@@ -142,7 +136,7 @@ export const Default = {
 };
 
 export const StickyHeader = {
-  render: StickyTemplate,
+  render: (argsData) => createRenderConfig(DtRootLayout, DtRootLayoutStickyTemplate, argsData),
 
   args: {
     headerSticky: true,

--- a/packages/dialtone-vue2/components/select_menu/select_menu.stories.js
+++ b/packages/dialtone-vue2/components/select_menu/select_menu.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import { SELECT_SIZE_MODIFIERS } from './select_menu_constants';
 import DtSelectMenu from './select_menu.vue';
 
@@ -218,19 +218,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtSelectMenuDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtSelectMenuVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtSelectMenu, DtSelectMenuDefaultTemplate, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtSelectMenu, DtSelectMenuVariantsTemplate, argsData),
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue2/components/skeleton/skeleton.stories.js
+++ b/packages/dialtone-vue2/components/skeleton/skeleton.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtSkeleton from './skeleton.vue';
 
 import DtSkeletonDefaultTemplate from './skeleton_default.story.vue';
@@ -88,14 +88,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtSkeletonDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtSkeletonVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtSkeleton, DtSkeletonDefaultTemplate, argsData),
 
   decorators: [
     () => ({
@@ -107,7 +101,7 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtSkeleton, DtSkeletonVariantsTemplate, argsData),
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/components/stack/stack.stories.js
+++ b/packages/dialtone-vue2/components/stack/stack.stories.js
@@ -1,7 +1,7 @@
 import DtStack from './stack.vue';
 
 import StackDefault from './stack_default.story.vue';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import {
   DT_STACK_DIRECTION,
   DT_STACK_GAP,
@@ -65,9 +65,7 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-const Template = (args, { argTypes }) => createTemplateFromVueFile(args, argTypes, StackDefault);
-
 export const Default = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtStack, StackDefault, argsData),
   args: {},
 };

--- a/packages/dialtone-vue2/components/tabs/tabs.stories.js
+++ b/packages/dialtone-vue2/components/tabs/tabs.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtTabGroup from './tab_group.vue';
 
 import DtTabsDefaultTemplate from './tabs_default.story.vue';
@@ -79,19 +79,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtTabsDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtTabsVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtTabGroup, DtTabsDefaultTemplate, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtTabGroup, DtTabsVariantsTemplate, argsData),
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/components/toast/toast.stories.js
+++ b/packages/dialtone-vue2/components/toast/toast.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 import DtToast from './toast.vue';
 
 import DtToastDefaultTemplate from './toast_default.story.vue';
@@ -137,9 +137,7 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtToastDefaultTemplate);
+const DefaultTemplate = (argsData) => createRenderConfig(DtToast, DtToastDefaultTemplate, argsData);
 
 export const Default = {
   render: DefaultTemplate,

--- a/packages/dialtone-vue2/components/toggle/toggle.stories.js
+++ b/packages/dialtone-vue2/components/toggle/toggle.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import ToggleDefault from './toggle_default.story.vue';
 import ToggleVariants from './toggle_variants.story.vue';
 
@@ -122,14 +122,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Toggle Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, ToggleDefault);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, ToggleVariants);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtToggle, ToggleDefault, argsData),
   args: {},
 
   parameters: {
@@ -148,7 +142,7 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtToggle, ToggleVariants, argsData),
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue2/components/tooltip/tooltip.stories.js
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtTooltip from './tooltip.vue';
 import DtTooltipFlipTemplate from './tooltip_flip.story.vue';
 import DtTooltipDefault from './tooltip_default.story.vue';
@@ -120,23 +120,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const TooltipFlipTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtTooltipFlipTemplate);
-const TooltipDefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtTooltipDefault);
-const TooltipVariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtTooltipVariantsTemplate);
-const TooltipChangeOnClick = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtTooltipChangeOnClick);
-
 export const Default = {
-  render: TooltipDefaultTemplate,
+  render: (argsData) => createRenderConfig(DtTooltip, DtTooltipDefault, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: TooltipVariantsTemplate,
+  render: (argsData) => createRenderConfig(DtTooltip, DtTooltipVariantsTemplate, argsData),
   args: {},
   parameters: {
     options: { showPanel: false },
@@ -150,8 +140,7 @@ export const Variants = {
 };
 
 export const Flip = {
-  render: TooltipFlipTemplate,
-
+  render: (argsData) => createRenderConfig(DtTooltip, DtTooltipFlipTemplate, argsData),
   args: {
     default: 'Scroll down to see how the tooltip changes based on the available space.',
   },
@@ -163,7 +152,7 @@ export const Flip = {
 };
 
 export const ChangeOnClick = {
-  render: TooltipChangeOnClick,
+  render: (argsData) => createRenderConfig(DtTooltip, DtTooltipChangeOnClick, argsData),
   args: {
     anchor: 'Click to see the tooltip content change',
     sticky: 'popper',

--- a/packages/dialtone-vue2/directives/tooltip/tooltip.stories.js
+++ b/packages/dialtone-vue2/directives/tooltip/tooltip.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils.js';
+import { createRenderConfig } from '@/common/storybook_utils.js';
 import TooltipDirectiveDefaultTemplate from './tooltip_directive_default.story.vue';
 
 export const argsData = {};
@@ -14,13 +14,9 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, TooltipDirectiveDefaultTemplate);
-
 // Stories
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig('<div></div>', TooltipDirectiveDefaultTemplate, argsData),
   parameters: {
     options: { showPanel: false },
     controls: { disable: true },

--- a/packages/dialtone-vue2/docs/storybook/writing_storybook.mdx
+++ b/packages/dialtone-vue2/docs/storybook/writing_storybook.mdx
@@ -247,9 +247,9 @@ export default {
   excludeStories: /.Data$/,
 };
 
-const Template = (args, { argTypes }) => createTemplateFromVueFile(args, argTypes, NoticeDefault);
-
-export const Default = Template.bind({});
+export const Default = {
+  render: (argsData) => createRenderConfig(DtNotice, NoticeDefault, argsData),
+};
 Default.args = {
   title: 'Notice title',
   default: 'Main content of the notice goes here.',

--- a/packages/dialtone-vue2/docs/templates/story_template.mdx
+++ b/packages/dialtone-vue2/docs/templates/story_template.mdx
@@ -6,7 +6,7 @@ import { Meta, Subtitle } from '@storybook/blocks';
 
 ```jsx
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtMyComponent from './my_component.vue';
 import MyComponentMdx from './my_component.mdx';
 import MyComponentDefaultTemplate from './my_component_default.story.vue';
@@ -104,22 +104,14 @@ export default {
   },
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  MyComponentDefaultTemplate,
-);
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  MyComponentVariantsTemplate,
-);
-
 // Stories
-export const Default = DefaultTemplate.bind({});
+export const Default = {
+  render: (argsData) => createRenderConfig(DtMyComponent, MyComponentDefaultTemplate, argsData),
+};
 Default.args = {};
 
-export const Variants = VariantsTemplate.bind({});
+export const Variants = VariantsTemplate.bind({
+  render: (argsData) => createRenderConfig(DtMyComponent, MyComponentVariantsTemplate, argsData),
+});
 Variants.args = {};
 ```

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button/callbar_button.stories.js
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button/callbar_button.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 import DtRecipeCallbarButton from './callbar_button.vue';
 import { CALLBAR_BUTTON_VALID_WIDTH_SIZE } from './callbar_button_constants';
 
@@ -127,25 +127,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeCallbarButtonDefaultTemplate,
-);
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeCallbarButtonVariantsTemplate,
-);
-const CallbarTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeCallbarButtonCallbarTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeCallbarButton, DtRecipeCallbarButtonDefaultTemplate, argsData),
 
   args: {
     default: 'Button',
@@ -156,13 +139,13 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeCallbarButton, DtRecipeCallbarButtonVariantsTemplate, argsData),
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };
 
 export const Callbar = {
-  render: CallbarTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeCallbarButton, DtRecipeCallbarButtonCallbarTemplate, argsData),
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 import DtRecipeCallbarButtonWithPopover from './callbar_button_with_popover.vue';
 
 import DtRecipeCallbarButtonWithPopoverDefaultTemplate from './callbar_button_with_popover_default.story.vue';
@@ -212,20 +212,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeCallbarButtonWithPopoverDefaultTemplate,
-);
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeCallbarButtonWithPopoverVariantsTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeCallbarButtonWithPopover, DtRecipeCallbarButtonWithPopoverDefaultTemplate, argsData),
 
   args: {
     default: 'Button',
@@ -243,7 +231,7 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeCallbarButtonWithPopover, DtRecipeCallbarButtonWithPopoverVariantsTemplate, argsData),
   args: {},
   parameters: {
     options: { showPanel: false },

--- a/packages/dialtone-vue2/recipes/cards/ivr_node/ivr_node.stories.js
+++ b/packages/dialtone-vue2/recipes/cards/ivr_node/ivr_node.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeIvrNode from './ivr_node.vue';
 
 import DtRecipeIvrNodeDefaultTemplate from './ivr_node_default.story.vue';
@@ -94,12 +94,7 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeIvrNodeDefaultTemplate,
-);
+const DefaultTemplate = (argsData) => createRenderConfig(DtRecipeIvrNode, DtRecipeIvrNodeDefaultTemplate, argsData);
 
 export const Default = {
   render: DefaultTemplate,

--- a/packages/dialtone-vue2/recipes/chips/grouped_chip/grouped_chip.stories.js
+++ b/packages/dialtone-vue2/recipes/chips/grouped_chip/grouped_chip.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 import DtRecipeGroupedChip from './grouped_chip.vue';
 
 import DtRecipeGroupedChipDefaultTemplate from './grouped_chip_default.story.vue';
@@ -80,12 +80,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtRecipeGroupedChipDefaultTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeGroupedChip, DtRecipeGroupedChipDefaultTemplate, argsData),
 
   args: {
     leftIcon: 'clock',

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeComboboxMultiSelect from './combobox_multi_select.vue';
 
 import DtRecipeComboboxMultiSelectDefaultTemplate from './combobox_multi_select_default.story.vue';
@@ -132,20 +132,12 @@ export default {
   argTypes: argTypesData,
   excludeStories: /.*Data$/,
 };
-
-// Templates
-const Template = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeComboboxMultiSelectDefaultTemplate,
-);
-
 export const Default = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtRecipeComboboxMultiSelect, DtRecipeComboboxMultiSelectDefaultTemplate, argsData),
 };
 
 export const WithMaxSelectValidation = {
-  render: Template,
+  render: (argsData) => createRenderConfig(DtRecipeComboboxMultiSelect, DtRecipeComboboxMultiSelectDefaultTemplate, argsData),
 
   args: {
     description: 'Select up to 2 options.',

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_with_popover/combobox_with_popover.stories.js
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_with_popover/combobox_with_popover.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeComboboxWithPopover from './combobox_with_popover.vue';
 
 import DtRecipeComboboxWithPopoverDefaultTemplate from './combobox_with_popover_default.story.vue';
@@ -217,16 +217,8 @@ export default {
   argTypes: argTypesData,
   excludeStories: /.*Data$/,
 };
-
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeComboboxWithPopoverDefaultTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeComboboxWithPopover, DtRecipeComboboxWithPopoverDefaultTemplate, argsData),
 
   args: {
     items: [
@@ -265,7 +257,7 @@ export const Default = {
 };
 
 export const Empty = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeComboboxWithPopover, DtRecipeComboboxWithPopoverDefaultTemplate, argsData),
 
   args: {
     items: [],

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeEmojiRow from './emoji_row.vue';
 import DtRecipeEmojiRowDefaultTemplate from './emoji_row_default.story.vue';
 
@@ -57,16 +57,9 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeEmojiRowDefaultTemplate,
-);
-
 // Stories
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeEmojiRow, DtRecipeEmojiRowDefaultTemplate, argsData),
 
   args: {
     reactions: [

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeFeedItemRow from './feed_item_row.vue';
 import DtRecipeFeedItemRowDefaultTemplate from './feed_item_row_default.story.vue';
 import DtRecipeFeedItemRowVariantsTemplate from './feed_item_row_variants.story.vue';
@@ -115,20 +115,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeFeedItemRowDefaultTemplate,
-);
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeFeedItemRowVariantsTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeFeedItemRow, DtRecipeFeedItemRowDefaultTemplate, argsData),
 
   args: {
     showHeader: true,
@@ -153,7 +141,7 @@ Default.parameters = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeFeedItemRow, DtRecipeFeedItemRowVariantsTemplate, argsData),
 
   args: {
   },

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_pill/feed_item_pill.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_pill/feed_item_pill.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeFeedItemPill from './feed_item_pill.vue';
 import DtRecipeFeedItemPillDefaultTemplate from './feed_item_pill_default.story.vue';
 import DtRecipeFeedItemPillVariantsTemplate from './feed_item_pill_variants.story.vue';
@@ -56,30 +56,16 @@ export default {
   argTypes,
   excludeStories: /.*Data$/,
 };
-
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeFeedItemPillDefaultTemplate,
-);
-
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeFeedItemPillVariantsTemplate,
-);
-
 // Stories
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeFeedItemPill, DtRecipeFeedItemPillDefaultTemplate, argsData),
   parameters: {
     a11y: { disable: true },
   },
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeFeedItemPill, DtRecipeFeedItemPillVariantsTemplate, argsData),
   parameters: {
     options: { showPanel: false },
     a11y: { disable: true },

--- a/packages/dialtone-vue2/recipes/conversation_view/time_pill/time_pill.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/time_pill/time_pill.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeTimePill from './time_pill.vue';
 
 import DtRecipeTimePillDefaultTemplate from './time_pill_default.story.vue';
@@ -37,12 +37,8 @@ export default {
 
 const today = new Date('1999-03-28');
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtRecipeTimePillDefaultTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeTimePill, DtRecipeTimePillDefaultTemplate, argsData),
 
   args: {
     dateTime: today.toISOString().split('T')[0],

--- a/packages/dialtone-vue2/recipes/header/settings_menu_button/settings_menu_button.stories.js
+++ b/packages/dialtone-vue2/recipes/header/settings_menu_button/settings_menu_button.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeSettingsMenuButton from './settings_menu_button.vue';
 import DtRecipeSettingsMenuButtonDefaultTemplate from './settings_menu_button_default.story.vue';
 
@@ -52,16 +52,8 @@ export default {
   argTypes: argTypesData,
   excludeStories: /.*Data$/,
 };
-
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeSettingsMenuButtonDefaultTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeSettingsMenuButton, DtRecipeSettingsMenuButtonDefaultTemplate, argsData),
 
   args: {
     default: 'Update',

--- a/packages/dialtone-vue2/recipes/leftbar/callbox/callbox.stories.js
+++ b/packages/dialtone-vue2/recipes/leftbar/callbox/callbox.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeCallbox from './callbox.vue';
 import DtRecipeCallboxDefaultTemplate from './callbox_default.story.vue';
 import DtRecipeCallboxVariantsTemplate from './callbox_variants.story.vue';
@@ -35,20 +35,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeCallboxDefaultTemplate,
-);
-
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeCallboxVariantsTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeCallbox, DtRecipeCallboxDefaultTemplate, argsData),
   args: {
     video: 'Video slot',
     badge: 'Badge slot',
@@ -67,7 +55,7 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeCallbox, DtRecipeCallboxVariantsTemplate, argsData),
 
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/recipes/leftbar/contact_row/contact_row.stories.js
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_row/contact_row.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeContactRow from './contact_row.vue';
 
 import DtRecipeContactRowDefaultTemplate from './contact_row_default.story.vue';
@@ -77,18 +77,12 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtRecipeContactRowDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtRecipeContactRowVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeContactRow, DtRecipeContactRowDefaultTemplate, argsData),
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeContactRow, DtRecipeContactRowVariantsTemplate, argsData),
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/recipes/leftbar/general_row/general_row.stories.js
+++ b/packages/dialtone-vue2/recipes/leftbar/general_row/general_row.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import { action } from '@storybook/addon-actions';
 import DtRecipeGeneralRow from './general_row.vue';
 
@@ -96,18 +96,14 @@ export default {
   decorators: [decorator],
   excludeStories: /.*Data$/,
 };
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtRecipeGeneralRowDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtRecipeGeneralRowVariantsTemplate);
 
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeGeneralRow, DtRecipeGeneralRowDefaultTemplate, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeGeneralRow, DtRecipeGeneralRowVariantsTemplate, argsData),
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/recipes/leftbar/group_row/group_row.stories.js
+++ b/packages/dialtone-vue2/recipes/leftbar/group_row/group_row.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeGroupRow from './group_row.vue';
 
 import DtRecipeGroupRowDefaultTemplate from './group_row_default.story.vue';
@@ -42,20 +42,13 @@ export default {
   decorators: [decorator],
   excludeStories: /.*Data$/,
 };
-
-// Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtRecipeGroupRowDefaultTemplate);
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtRecipeGroupRowVariantsTemplate);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeGroupRow, DtRecipeGroupRowDefaultTemplate, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeGroupRow, DtRecipeGroupRowVariantsTemplate, argsData),
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/recipes/leftbar/unread_pill/unread_pill.stories.js
+++ b/packages/dialtone-vue2/recipes/leftbar/unread_pill/unread_pill.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeUnreadPill from './unread_pill.vue';
 
 import DtRecipeUnreadPillDefaultTemplate from './unread_pill_default.story.vue';
@@ -69,20 +69,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeUnreadPillDefaultTemplate,
-);
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeUnreadPillVariantsTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeUnreadPill, DtRecipeUnreadPillDefaultTemplate, argsData),
 
   args: {
     default: 'Unread mentions',
@@ -92,7 +80,7 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeUnreadPill, DtRecipeUnreadPillVariantsTemplate, argsData),
   args: {},
   parameters: { options: { showPanel: false }, controls: { disable: true } },
 };

--- a/packages/dialtone-vue2/recipes/list_items/contact_info/contact_info.stories.js
+++ b/packages/dialtone-vue2/recipes/list_items/contact_info/contact_info.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
 import DtRecipeContactInfo from './contact_info.vue';
 
 import DtRecipeContactInfoDefaultTemplate from './contact_info_default.story.vue';
@@ -129,20 +129,8 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeContactInfoDefaultTemplate,
-);
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeContactInfoVariantsTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeContactInfo, DtRecipeContactInfoDefaultTemplate, argsData),
 
   args: {
     avatarSrc: avatarImage,
@@ -204,7 +192,7 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeContactInfo, DtRecipeContactInfoVariantsTemplate, argsData),
 
   args: {
     avatarFullName: 'Natalie Woods',

--- a/packages/dialtone-vue2/recipes/notices/top_banner_info/top_banner_info.stories.js
+++ b/packages/dialtone-vue2/recipes/notices/top_banner_info/top_banner_info.stories.js
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeTopBannerInfo from './top_banner_info.vue';
 
 import DtRecipeTopBannerInfoDefaultTemplate from './top_banner_info_default.story.vue';
@@ -92,25 +92,13 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-// Templates
-const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeTopBannerInfoDefaultTemplate,
-);
-const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
-  args,
-  argTypes,
-  DtRecipeTopBannerInfoVariantsTemplate,
-);
-
 export const Default = {
-  render: DefaultTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeTopBannerInfo, DtRecipeTopBannerInfoDefaultTemplate, argsData),
   args: {},
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render: (argsData) => createRenderConfig(DtRecipeTopBannerInfo, DtRecipeTopBannerInfoVariantsTemplate, argsData),
   args: {},
 
   parameters: {

--- a/packages/dialtone-vue3/components/avatar/avatar.stories.js
+++ b/packages/dialtone-vue3/components/avatar/avatar.stories.js
@@ -1,4 +1,4 @@
-import { getIconNames } from '@/common/storybook_utils';
+import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
 import DtAvatar from './avatar.vue';
 import { AVATAR_SIZE_MODIFIERS, AVATAR_PRESENCE_STATES, AVATAR_COLORS } from './avatar_constants';
 import DtAvatarDefaultTemplate from './avatar_default.story.vue';
@@ -109,48 +109,24 @@ export default {
 };
 
 // Templates
+const DefaultTemplate = (args, { argTypes }) =>
+  createTemplateFromVueFile(args, argTypes, DtAvatarDefaultTemplate);
+
+const VariantsTemplate = (args, { argTypes }) =>
+  createTemplateFromVueFile(args, argTypes, DtAvatarVariantsTemplate);
+
+// Stories
 export const Default = {
-  render (argsData) {
-    return ({
-      components: { DtAvatar: DtAvatarDefaultTemplate },
-      setup () {
-        return { argsData };
-      },
-      template: `<DtAvatar
-          :onClick="argsData.onClick"
-          :size="argsData.size"
-          :presence="argsData.presence"
-          :fullName="argsData.fullName"
-          :imageAlt="argsData.imageAlt"
-          :imageSrc="argsData.imageSrc"
-          :seed="argsData.seed"
-          :iconName="argsData.iconName"
-          :iconSize="argsData.iconSize"
-      ></DtAvatar>`,
-    });
-  },
+  render: DefaultTemplate,
+  decorators: [
+    () => ({
+      template: `<div class="d-d-flex"><story /></div>`,
+    }),
+  ],
 };
 
 export const Variants = {
-  render (argsData) {
-    return ({
-      components: { DtAvatar: DtAvatarVariantsTemplate },
-      setup () {
-        return { argsData };
-      },
-      template: `<DtAvatar
-          :onClick="argsData.onClick"
-          :size="argsData.size"
-          :presence="argsData.presence"
-          :fullName="argsData.fullName"
-          :imageAlt="argsData.imageAlt"
-          :imageSrc="argsData.imageSrc"
-          :seed="argsData.seed"
-          :iconName="argsData.iconName"
-          :iconSize="argsData.iconSize"
-      ></DtAvatar>`,
-    });
-  },
+  render: VariantsTemplate,
   parameters: {
     percy: {
       args: {

--- a/packages/dialtone-vue3/components/avatar/avatar.stories.js
+++ b/packages/dialtone-vue3/components/avatar/avatar.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { getIconNames } from '@/common/storybook_utils';
 import DtAvatar from './avatar.vue';
 import { AVATAR_SIZE_MODIFIERS, AVATAR_PRESENCE_STATES, AVATAR_COLORS } from './avatar_constants';
 import DtAvatarDefaultTemplate from './avatar_default.story.vue';
@@ -109,24 +109,48 @@ export default {
 };
 
 // Templates
-const DefaultTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtAvatarDefaultTemplate);
-
-const VariantsTemplate = (args, { argTypes }) =>
-  createTemplateFromVueFile(args, argTypes, DtAvatarVariantsTemplate);
-
-// Stories
 export const Default = {
-  render: DefaultTemplate,
-  decorators: [
-    () => ({
-      template: `<div class="d-d-flex"><story /></div>`,
-    }),
-  ],
+  render (argsData) {
+    return ({
+      components: { DtAvatar: DtAvatarDefaultTemplate },
+      setup () {
+        return { argsData };
+      },
+      template: `<DtAvatar
+          :onClick="argsData.onClick"
+          :size="argsData.size"
+          :presence="argsData.presence"
+          :fullName="argsData.fullName"
+          :imageAlt="argsData.imageAlt"
+          :imageSrc="argsData.imageSrc"
+          :seed="argsData.seed"
+          :iconName="argsData.iconName"
+          :iconSize="argsData.iconSize"
+      ></DtAvatar>`,
+    });
+  },
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  render (argsData) {
+    return ({
+      components: { DtAvatar: DtAvatarVariantsTemplate },
+      setup () {
+        return { argsData };
+      },
+      template: `<DtAvatar
+          :onClick="argsData.onClick"
+          :size="argsData.size"
+          :presence="argsData.presence"
+          :fullName="argsData.fullName"
+          :imageAlt="argsData.imageAlt"
+          :imageSrc="argsData.imageSrc"
+          :seed="argsData.seed"
+          :iconName="argsData.iconName"
+          :iconSize="argsData.iconSize"
+      ></DtAvatar>`,
+    });
+  },
   parameters: {
     percy: {
       args: {


### PR DESCRIPTION
## Description
Fixed all code previews of components and recipes on storybook doc.

Removed `createTemplateFromVueFile` and created `createRenderConfig` function on `storybook_utils.js` file

Before:
<img width="1244" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/44e26eda-5977-434a-b1db-c6dd205687eb">


After:
<img width="1244" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/75ed82dd-037c-459a-8a39-76fd91cb87a5">

