### PR TITLE
NO-MERGE: fix: vue3 storybook stories

### DIFF
--- a/packages/dialtone-vue3/common/storybook_utils.js
+++ b/packages/dialtone-vue3/common/storybook_utils.js
@@ -19,6 +19,41 @@ export const createTemplateFromVueFile = (args, argTypes, templateComponent) => 
   template: '<template-component v-bind="args"></template-component>',
 });
 
+export function createRenderConfig (component, defaultTemplate, argsData) {
+  return {
+    components: { [component.name]: defaultTemplate },
+    setup () {
+      return { argsData };
+    },
+    template: `<${component.name} v-bind="argsData"></${component.name}>`,
+  };
+}
+
+// export function createRenderConfig (component, defaultTemplate, argsData) {
+//   return {
+//     components: { [component.name]: defaultTemplate },
+//     setup () {
+//       return { argsData };
+//     },
+//     template: createTemplate(component.name, argsData),
+//   };
+// }
+//
+// function createTemplate (componentName, argsData) {
+//   let template = `<${componentName} `;
+//
+//   Object.entries(argsData).forEach(([key, value]) => {
+//     if (value === undefined) {
+//       // If the value is undefined, do not include it in the template
+//       return;
+//     }
+//     template += `${key}="${value}" `;
+//   });
+//
+//   template += `></${componentName}>`;
+//   return template;
+// }
+
 /**
  * Gets the full list of icon component names from the dialtone package
  * @returns {string[]} icon component names
@@ -53,4 +88,5 @@ export default {
   generateTemplate,
   createTemplateFromVueFile,
   getIconNames,
+  createRenderConfig,
 };

--- a/packages/dialtone-vue3/components/avatar/avatar.stories.js
+++ b/packages/dialtone-vue3/components/avatar/avatar.stories.js
@@ -1,4 +1,4 @@
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createRenderConfig, createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
 import DtAvatar from './avatar.vue';
 import { AVATAR_SIZE_MODIFIERS, AVATAR_PRESENCE_STATES, AVATAR_COLORS } from './avatar_constants';
 import DtAvatarDefaultTemplate from './avatar_default.story.vue';
@@ -126,7 +126,28 @@ export const Default = {
 };
 
 export const Variants = {
-  render: VariantsTemplate,
+  // render: VariantsTemplate,
+  // render: (argsData) => createRenderConfig(DtAvatar, DtAvatarVariantsTemplate, argsData),
+
+  render (argsData) {
+    return ({
+      components: { DtAvatar: DtAvatarVariantsTemplate },
+      setup () {
+        return { argsData };
+      },
+      template: `<DtAvatar
+          :onClick="argsData.onClick"
+          :size="argsData.size"
+          :presence="argsData.presence"
+          :fullName="argsData.fullName"
+          :imageAlt="argsData.imageAlt"
+          :imageSrc="argsData.imageSrc"
+          :seed="argsData.seed"
+          :iconName="argsData.iconName"
+          :iconSize="argsData.iconSize"
+      ></DtAvatar>`,
+    });
+  },
   parameters: {
     percy: {
       args: {


### PR DESCRIPTION
PR to discuss vue3 stories solution:

In [vue2 ](https://dialpad.atlassian.net/browse/DLT-1439) It was fixed creating a [createRenderConfig](https://github.com/dialpad/dialtone/pull/71) utility function .

In vue3 I tried the same way but seems like `v-bind` is not working correctly:
<img width="1243" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/01636c06-c219-4fa7-aa60-745639e5aeeb">


I found a way to make it work, which I dont like it, but it works...:

```
render (argsData) {
    return ({
      components: { DtAvatar: DtAvatarVariantsTemplate },
      setup () {
        return { argsData };
      },
      template: `<DtAvatar
          :onClick="argsData.onClick"
          :size="argsData.size"
          :presence="argsData.presence"
          :fullName="argsData.fullName"
          :imageAlt="argsData.imageAlt"
          :imageSrc="argsData.imageSrc"
          :seed="argsData.seed"
          :iconName="argsData.iconName"
          :iconSize="argsData.iconSize"
      ></DtAvatar>`,
    });
  },
```

<img width="1243" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/a9dee5f0-cc6e-46f6-8ad5-bc27aa49569d">
