### PR TITLE
docs: fix storybook reactivity

### DIFF
--- a/packages/dialtone-vue2/common/storybook_utils.js
+++ b/packages/dialtone-vue2/common/storybook_utils.js
@@ -4,7 +4,7 @@ import iconNames from '@dialpad/dialtone-icons/dist/icons.json';
  * Will use a Vue SFC to render the template rather than a template string.
  * This is useful for more complex components that are hard to work with and
  * get messy when rendered via a template string. Will pass args and argTypes
- * into the component so it is able to be live edited with storybook controls addon.
+ * into the component, so it is able to be live edited with storybook controls addon.
  * @param component this will get the component name
  * @param defaultTemplate we will mount in this component
  * @param argsData storybook control args
@@ -14,10 +14,11 @@ import iconNames from '@dialpad/dialtone-icons/dist/icons.json';
 export function createRenderConfig (component, defaultTemplate, argsData) {
   return {
     components: { [component.name]: defaultTemplate },
-    setup () {
-      return { argsData };
+    props: [...Object.keys(component.props), ...Object.keys(argsData)],
+    setup (props) {
+      return { props };
     },
-    template: `<${component.name} v-bind="argsData"></${component.name}>`,
+    template: `<${component.name} v-bind="props" />`,
   };
 }
 

--- a/packages/dialtone-vue2/components/avatar/avatar.vue
+++ b/packages/dialtone-vue2/components/avatar/avatar.vue
@@ -346,8 +346,22 @@ export default {
   watch: {
     fullName: {
       immediate: true,
-      handler (newName) {
-        this.formatInitials(newName);
+      handler () {
+        this.formatInitials();
+      },
+    },
+
+    size: {
+      immediate: true,
+      handler () {
+        this.formatInitials();
+      },
+    },
+
+    group: {
+      immediate: true,
+      handler () {
+        this.formatInitials();
       },
     },
 
@@ -375,8 +389,8 @@ export default {
       el.addEventListener('error', () => this._erroredImageEventHandler(el), { once: true });
     },
 
-    formatInitials (string) {
-      const initials = extractInitialsFromName(string);
+    formatInitials () {
+      const initials = extractInitialsFromName(this.fullName);
 
       if (this.validatedSize === 'xs') {
         this.formattedInitials = '';

--- a/packages/dialtone-vue2/components/badge/badge.stories.js
+++ b/packages/dialtone-vue2/components/badge/badge.stories.js
@@ -89,7 +89,6 @@ export default {
 
 export const Default = {
   render: (argsData) => createRenderConfig(DtBadge, DtBadgeDefaultTemplate, argsData),
-
   args: {
     default: 'Badge',
   },


### PR DESCRIPTION
# Fix Storybook reactivity issues.

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/g697zr42aee76RqD89/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Description

- Fixed general reactivity issues on Storybook Vue 2 version.
- Fixed DtAvatar reactivity issues while changing size.

## :bulb: Context

After #71 we loosed reactivity on all documentation stories.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

## :camera: Screenshots / GIFs

**Before**

https://github.com/dialpad/dialtone/assets/87546543/ebba711f-6800-4349-bed2-e89e8cbbd623

**After**

https://github.com/dialpad/dialtone/assets/87546543/5d2d77b0-0d47-41da-8cdc-bc32710689c9
