### PR TITLE
docs: fix old dialpad.design links

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -4,7 +4,7 @@
 //
 //  These are various visual styles for Dialtone's documentation.
 //  For more information, please visit:
-//  https://dialpad.design/
+//  https://dialtone.dialpad.com/
 //
 //
 //  TABLE OF CONTENTS
@@ -43,7 +43,6 @@ html {
 //      Override
 //  ----------------------------------------------------------------------------
 html body {
-
   --docsearch-primary-color: var(--dt-color-brand-purple);
   --docsearch-text-color: var(--dt-color-foreground-primary);
   --docsearch-spacing: var(--dt-space-550);
@@ -56,6 +55,7 @@ html body {
   --docsearch-modal-height: var(--dt-size-1000);
   --docsearch-modal-background: var(--dt-color-surface-secondary);
   --docsearch-modal-shadow: var(--dt-shadow-large);
+  /* stylelint-disable-next-line meowtec/no-px */
   --docsearch-searchbox-height: 40px;
   // --docsearch-searchbox-background
   --docsearch-searchbox-focus-background: var(--dt-inputs-color-background-default);
@@ -69,15 +69,16 @@ html body {
   --docsearch-key-shadow: inset 0 0 0 1px var(--dt-color-border-default);
   --docsearch-footer-height: var(--dt-size-650);
   --docsearch-footer-background: var(--dt-color-surface-primary);
+  /* stylelint-disable-next-line meowtec/no-px */
   --docsearch-footer-shadow: 0 -1px 0 0 var(--dt-color-border-subtle),0 -1px 3px 0 rgba(0,0,0,.2);
 
   .DocSearch-Modal {
-    border-radius: var(--dt-size-radius-500);
+    margin-top: 15vh;
     background-clip: padding-box;
     border: var(--dt-size-100) solid var(--dt-color-border-subtle);
+    border-radius: var(--dt-size-radius-500);
     border-radius: var(--dt-size-500);
     box-shadow: var(--dt-shadow-large);
-    margin-top: 15vh;
   }
 
   .DocSearch-SearchBar {
@@ -86,8 +87,8 @@ html body {
   }
 
   .DocSearch-Form {
-    padding-left: var(--dt-space-450);
     padding-right: var(--dt-space-450);
+    padding-left: var(--dt-space-450);
     border-radius: var(--dt-size-radius-400);
   }
 
@@ -98,9 +99,11 @@ html body {
 
   .DocSearch-Input {
     font-size: var(--dt-font-size-300);
+
     &:focus-visible {
       box-shadow: none;
     }
+
     &::placeholder {
       color: var(--dt-inputs-color-foreground-placeholder);
     }
@@ -135,14 +138,15 @@ html body {
 
   .DocSearch-Hit-source {
     padding: var(--dt-space-400) var(--dt-space-300) 0;
-    font-size: var(--dt-font-size-200);
-    font-weight: var(--dt-font-weight-bold);
     color: var(--dt-color-foreground-primary);
+    font-weight: var(--dt-font-weight-bold);
+    font-size: var(--dt-font-size-200);
   }
 
   .DocSearch-Title {
-    font-size: var(--dt-font-size-300);
     color: var(--dt-color-foreground-secondary);
+    font-size: var(--dt-font-size-300);
+
     strong {
       color: var(--dt-color-foreground-primary);
     }
@@ -157,15 +161,15 @@ html body {
   }
 
   .DocSearch-Hits mark {
-    background: var(--dt-color-surface-warning);
-    color: var(--dt-color-foreground-primary);
     padding: var(--dt-space-200);
+    color: var(--dt-color-foreground-primary);
+    background: var(--dt-color-surface-warning);
   }
 
   .DocSearch-Hit a {
-    border-radius: var(--dt-size-radius-300);
-    padding-left: var(--dt-space-450);
     padding-right: var(--dt-space-450);
+    padding-left: var(--dt-space-450);
+    border-radius: var(--dt-size-radius-300);
   }
 
   .DocSearch-Hit-action svg,
@@ -176,15 +180,15 @@ html body {
 
   .DocSearch-Hit-content-wrapper {
     margin: 0 var(--dt-space-200);
-    line-height: var(--dt-font-line-height-200);
     font-weight: var(--dt-font-weight-normal);
+    line-height: var(--dt-font-line-height-200);
   }
 
   .DocSearch-Hit-action {
     // no overrides
   }
 
-  .DocSearch-Hit[aria-selected=true] mark {
+  .DocSearch-Hit[aria-selected="true"] mark {
     color: var(--dt-color-foreground-primary) !important;
     text-decoration: none;
   }
@@ -194,8 +198,8 @@ html body {
   }
 
   .DocSearch-Hit-path {
-    font-size: var(--dt-font-size-100);
     color: var(--dt-color-foreground-muted);
+    font-size: var(--dt-font-size-100);
   }
 
   .DocSearch-HitsFooter {
@@ -227,17 +231,14 @@ html body {
   }
 
   .DocSearch-Help {
+    margin-top: var(--dt-space-400);
     color: var(--dt-color-foreground-secondary);
+    font-size: var(--dt-font-size-100);
   }
 
   .DocSearch-NoResults {
-    font-size: var(--dt-font-size-200);
     padding: var(--dt-space-600) 0;
-  }
-
-  .DocSearch-Help {
-    margin-top: var(--dt-space-400);
-    font-size: var(--dt-font-size-100);
+    font-size: var(--dt-font-size-200);
   }
 
   .DocSearch-Prefill {
@@ -273,35 +274,33 @@ html body {
 //      appropriate to ship as part of Dialtone.
 //  ----------------------------------------------------------------------------
 .dialtone-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--dt-size-700);
+  padding: var(--dt-space-500);
+  padding-left: var(--dt-space-400);
   background-color: var(--dt-color-surface-secondary);
   // TODO: redo 😜
   border-bottom: var(--dt-size-100) solid var(--dt-color-border-subtle);
-  display: flex;
-  height: var(--dt-size-700);
-  align-items: center;
-  padding: var(--dt-space-500);
-  padding-left: var(--dt-space-400);
-  justify-content: space-between;
 }
 
 .dialtone-sidebar {
-  // TODO: redo 😜
-  height: calc(100vh - var(--dt-space-700));
-  background-color: var(--dt-color-surface-secondary);
-  border-right: var(--dt-size-100) solid var(--dt-color-border-subtle);
-  overflow-y: auto;
   position: sticky;
   top: var(--dt-size-700);
+  // TODO: redo 😜
+  height: calc(100vh - var(--dt-space-700));
+  overflow-y: auto;
+  background-color: var(--dt-color-surface-secondary);
+  border-right: var(--dt-size-100) solid var(--dt-color-border-subtle);
 
 
   &__list {
-    width: calc(var(--dt-size-300) * 64);
     top: var(--dt-space-700);
     bottom: 0;
-    padding-top: var(--dt-size-550);
-    padding-left: var(--dt-size-500);
-    padding-right: var(--dt-size-500);
-    padding-bottom: 96px;
+    width: calc(var(--dt-size-300) * 64);
+    /* stylelint-disable-next-line meowtec/no-px */
+    padding: var(--dt-size-550) var(--dt-size-500) 96px var(--dt-size-500);
   }
 }
 
@@ -427,8 +426,8 @@ a.header-anchor {
 
 .dialtone-icon-grid__item {
   position: relative;
-  height: var(--dt-size-750);
   width: var(--dt-size-100-percent);
+  height: var(--dt-size-750);
 }
 
 .dialtone-icon-card {
@@ -439,6 +438,7 @@ a.header-anchor {
 
   .d-popover {
     height: 100%;
+
     > div {
       height: 100%;
     }
@@ -545,7 +545,6 @@ a.header-anchor {
   }
 
   &--image {
-
     @media (max-width: 640px) {
       display: none;
     }

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Home.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Home.vue
@@ -645,10 +645,16 @@
         </router-link>
         <a
           class="d-link"
-          href="https://vue.dialpad.design/"
+          href="https://dialpad.dialtone.com/vue"
           target="_blank"
           rel="noopener noreferrer"
-        >Browse Vue components</a>
+        >Browse Vue 2 components</a>
+        <a
+          class="d-link"
+          href="https://dialpad.dialtone.com/vue3"
+          target="_blank"
+          rel="noopener noreferrer"
+        >Browse Vue 3 components</a>
       </div>
     </div>
     <div class="link d-body-base d-gc3 d-px32 d-ta-center">

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Navbar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Navbar.vue
@@ -25,7 +25,7 @@
         <template #anchor>
           <a
             class="d-btn d-btn--muted d-btn--circle"
-            href="https://vue.dialpad.design"
+            href="https://dialtone.dialpad.com/vue"
             target="_blank"
             rel="noreferrer noopener"
           >

--- a/apps/dialtone-documentation/docs/.vuepress/theme/index.js
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/index.js
@@ -114,7 +114,7 @@ export const dialtoneVuepressTheme = (options) => {
         placeholder: 'Search Dialtone',
       }),
       sitemapPlugin({
-        hostname: 'https://dialpad.design',
+        hostname: 'https://dialtone.dialpad.com',
       }),
     ],
     extendsMarkdown: (md) => {

--- a/apps/dialtone-documentation/docs/about/dialtone.md
+++ b/apps/dialtone-documentation/docs/about/dialtone.md
@@ -26,7 +26,7 @@ description: Dialtone is Dialpad's Design System that unites product teams aroun
       <h3 class="d-docsite--header-3">Dialtone-vue</h3>
       <a
         class="d-d-inline-flex d-pt12"
-        href="https://github.com/dialpad/dialtone-vue"
+        href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone-vue3"
       >
         <img
           alt="Dialtone Vue version number"
@@ -47,7 +47,7 @@ Dialtone provides two options to use the components: CSS and Vue.
 
 ### Vue components (recommended)
 
-Use [Vue components](https://vue.dialpad.design/) in the case your project supports Vue since these components are built conforming to [WCAG AA Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/glance/)
+Use [Vue components](https://dialtone.dialpad.com/vue) in the case your project supports Vue since these components are built conforming to [WCAG AA Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/glance/)
 and with usability and performance in mind.
 
 ### CSS components
@@ -56,10 +56,6 @@ If Vue isn't supported in your application, you can use the [CSS components](../
 for writing the correct markup, managing DOM elements and events, and making it [accessible for all users](../getting-started/accessibility/fundamentals.md).
 
 See more about [components usage](../getting-started/usage.md/#components).
-
-### Previous Version
-
-[Dialtone 6](https://dialpad.design/version6/) remains viewable, though is no longer being maintained. [Reach out](#contact-us) to the Dialtone team if you have any questions.
 
 ## Intake
 
@@ -79,7 +75,7 @@ for reporting any issue.
 
 ## Contact Us
 
-- [#dialtone](https://dialpad.slack.com/messages/dialtone/) Slack channel
+- #dialtone Dialpad channel
 - [dialtone@dialpad.com](mailto:dialtone@dialpad.com)
 
 <script setup>

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2022-11-18.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2022-11-18.md
@@ -23,7 +23,7 @@ This blog is pretty barebones to start but we'll be updating it with new feature
 
 ## Icons
 
-We just released an entirely new set of icons for Dialtone 7. This comes along with a new [Dialtone Icon Component](http://dialpad.design/components/icon.html) and [Dialtone Vue Icon Component](https://vue.dialpad.design/?path=/story/components-icon--default) which makes using Dialtone icons easier than it ever has been in the past. Please see the [migration guide](https://github.com/dialpad/dialtone/blob/staging/migration_guide/MIGRATION_GUIDE.md#icons) for the new icons if you are looking to update your old Dialtone 6 icons to the new ones. The Dialtone 6 icons will be around for a while longer but they will be going away after all migrations are complete. To use the new icons please use the new [Dialtone Vue Icon Component](https://vue.dialpad.design/?path=/story/components-icon--default) over the pure CSS version. The CSS version should only be used where you can't use Vue (ex: backbone). We will continue to add features into the icon documentation page such as search and improved previewing options.
+We just released an entirely new set of icons for Dialtone 7. This comes along with a new [Dialtone Icon Component](http://dialtone.dialpad.com/components/icon.html) and [Dialtone Vue Icon Component](https://dialtone.dialpad.com/vue/?path=/story/components-icon--default) which makes using Dialtone icons easier than it ever has been in the past. Please see the [migration guide](https://github.com/dialpad/dialtone/blob/staging/migration_guide/MIGRATION_GUIDE.md#icons) for the new icons if you are looking to update your old Dialtone 6 icons to the new ones. The Dialtone 6 icons will be around for a while longer but they will be going away after all migrations are complete. To use the new icons please use the new [Dialtone Vue Icon Component](https://dialtone.dialpad.com/vue/?path=/story/components-icon--default) over the pure CSS version. The CSS version should only be used where you can't use Vue (ex: backbone). We will continue to add features into the icon documentation page such as search and improved previewing options.
 
 ## Overview pages
 
@@ -33,13 +33,13 @@ Our lead designer Francis has been working hard on new overview pages for each s
 
 We've added a small size option to the toggle component which you can see here:
 
-[Small Toggle](https://vue.dialpad.design/?path=/story/components-toggle--default&args=size:sm)
+[Small Toggle](https://dialtone.dialpad.com/vue/?path=/story/components-toggle--default&args=size:sm)
 
 ## Presence component
 
 We've added a component to display user presence into Dialtone. The next step for this is to integrate it into avatar, which is currently being worked on and coming very soon.
 
-[Presence](https://vue.dialpad.design/?path=/story/components-presence--default)
+[Presence](https://dialtone.dialpad.com/vue/?path=/story/components-presence--default)
 
 ## New member
 

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2022-12-9.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2022-12-9.md
@@ -11,8 +11,8 @@ Hello and happy Friday to you all as we approach the holiday season! :christmas_
 
 We'll be performing a number of redesigns to existing Dialtone components over the coming months. Some of these updates may involve breaking changes to existing Vue components and Dialtone classes. Today's update involves badge which we have just reworked for better styling, functionality and convenience.
 
-- [Badge](https://dialpad.design/components/badge.html)
-- [Badge Vue Component](https://vue.dialpad.design/?path=/story/components-badge--default)
+- [Badge](https://dialtone.dialpad.com/components/badge.html)
+- [Badge Vue Component](https://dialtone.dialpad.com/vue/?path=/story/components-badge--default)
 
 ## Badge
 
@@ -163,14 +163,14 @@ The migration has been performed for all existing `DtBadge` components and `d-ba
 ### Styling & documentation changes
 
 - Visual styling updates.
-- You no longer set a badge to a specific color, you set it to a "type" with a specific semantic intent. See [badge documenatation](https://dialpad.design/components/badge.html#type) for all the possible types.
+- You no longer set a badge to a specific color, you set it to a "type" with a specific semantic intent. See [badge documenatation](https://dialtone.dialpad.com/components/badge.html#type) for all the possible types.
 - Two different kinds of badge "label" which is meant for alphanumeric text and "count" which makes the badge circular and is intended for numerical text only.
 - Improved documentation for badge usage and best practices.
 - Support for icons on either side of the badge.
 
 ### Vue component changes
 
-- New iconLeft and iconRight prop on the vue component. pass in any icon name from the [icon catalog](https://dialpad.design/components/icon.html) to set the icon.
+- New iconLeft and iconRight prop on the vue component. pass in any icon name from the [icon catalog](https://dialtone.dialpad.com/components/icon.html) to set the icon.
 - New prop "kind", set to "label" or "count".
 - New prop "type", replaces "color".
 - Special case: setting the type to 'ai' will automatically display the AI icon on the left. This can be overridden if desired by setting the iconLeft prop.
@@ -185,7 +185,7 @@ We have also made some updates to the avatar component. You'll notice that when 
 
 Very fancy!! :monocle_face: Thanks to Francis and Jose for this one.
 
-The new presence component has also been released and is integrated into the Avatar. You'll notice there is a new prop on the [Vue component](https://vue.dialpad.design/?path=/story/components-avatar--default) called presence in which you can set the presence state for the avatar.
+The new presence component has also been released and is integrated into the Avatar. You'll notice there is a new prop on the [Vue component](https://dialtone.dialpad.com/vue/?path=/story/components-avatar--default) called presence in which you can set the presence state for the avatar.
 
 <code-well-header>
   <dt-avatar presence="away">BP</dt-avatar>

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2023-10-30.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2023-10-30.md
@@ -11,13 +11,13 @@ Hi everyone, hope you're having a great week. It's time for an update. First off
 
 ## Deprecated icons
 
-We've had a new icon set in Dialtone for quite a while now which you can see here: [Icon List](https://dialpad.design/components/icon). Over the last quarter we've performed the migration on Dialpad to convert all of our icons to the new set. Two weeks from now on November 13th we will be removing the old icons from Dialtone. This means if you have an application outside of ubervoice that is using the old icons after Nov 13th it will error upon update to the latest Dialtone version.
+We've had a new icon set in Dialtone for quite a while now which you can see here: [Icon List](https://dialtone.dialpad.com/components/icon). Over the last quarter we've performed the migration on Dialpad to convert all of our icons to the new set. Two weeks from now on November 13th we will be removing the old icons from Dialtone. This means if you have an application outside of ubervoice that is using the old icons after Nov 13th it will error upon update to the latest Dialtone version.
 
 ### How do I know if I'm using the old icons?
 
 The old icons will have a path like this: `@dialpad/dialtone/lib/dist/vue/icons/IconName.vue` or `@dialpad/dialtone-legacy/lib/dist/vue/icons/IconName.vue`
 
-The new icons should be used via the [DtIcon](https://vue.dialpad.design/?path=/story/components-icon--default) component like so:
+The new icons should be used via the [DtIcon](https://dialtone.dialpad.com/vue/?path=/story/components-icon--default) component like so:
 
 ```js
 import { DtIcon } from '@dialpad/dialtone-vue';
@@ -35,11 +35,11 @@ import IconArrowUp from '@dialpad/dialtone-icons/dist/svg/arrow-up.svg';
 
 ### How do I migrate?
 
-Simply replace the existing icon with a corresponding icon from [Icon List](https://dialpad.design/components/icon) passing the name into the DtIcon component. Some of the equivalent icons may be named differently than in the old system. If you are unable to find a reasonable replacement icon please let us know in #dialtone on slack. We can also assist with any complications that may arise from the migration.
+Simply replace the existing icon with a corresponding icon from [Icon List](https://dialtone.dialpad.com/components/icon) passing the name into the DtIcon component. Some of the equivalent icons may be named differently than in the old system. If you are unable to find a reasonable replacement icon please let us know in #dialtone on slack. We can also assist with any complications that may arise from the migration.
 
 ## New tooltip directive
 
-In addition to our `DtTooltip` vue component, we now have a tooltip directive: [v-dt-tooltip](https://vue.dialpad.design/?path=/docs/directives-tooltip--docs) see: [storybook example](https://vue.dialpad.design/?path=/story/directives-tooltip--default). This is very similar to the v-tooltip directive we have in ubervoice, and is going to make it much easier to replace going forward.
+In addition to our `DtTooltip` vue component, we now have a tooltip directive: [v-dt-tooltip](https://dialtone.dialpad.com/vue/?path=/docs/directives-tooltip--docs) see: [storybook example](https://dialtone.dialpad.com/vue/?path=/story/directives-tooltip--default). This is very similar to the v-tooltip directive we have in ubervoice, and is going to make it much easier to replace going forward.
 
 ### How do I use it?
 

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2023-2-7.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2023-2-7.md
@@ -47,7 +47,7 @@ It now needs to have an additional wrapper div with class `d-avatar__canvas` and
 </div>
 ```
 
-Ideally just upgrade any elements affected by this to the [avatar vue component](https://vue.dialpad.design/?path=/story/components-avatar--default). If that is not possible then modify the HTML to reflect the above structure. Thanks!
+Ideally just upgrade any elements affected by this to the [avatar vue component](https://dialtone.dialpad.com/vue/?path=/story/components-avatar--default). If that is not possible then modify the HTML to reflect the above structure. Thanks!
 
 </BlogPost>
 

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2023-8-3.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2023-8-3.md
@@ -7,7 +7,7 @@ posted: '2023-8-3'
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">
 
-As many of you already know, Dialtone 8 has been available on a separate branch for a while now and is being used in our primary applications. The migration to Dialtone 8 has been completed on Dialpad Meetings and is currently in progress for Dialpad. As of today we are promoting Dialtone 8 to the main branch. This means you no longer have to use the @next tag for Dialtone and Dialtone Vue and can update to the main branch in your applications. No further updates will be made to Dialtone 7 except for maybe emergency bug fixes. Dialtone 8 documentation will now exist on <https://dialpad.design>. You may still see the documentation site for Dialtone 7 at <https://dialpad.design/legacy>
+As many of you already know, Dialtone 8 has been available on a separate branch for a while now and is being used in our primary applications. The migration to Dialtone 8 has been completed on Dialpad Meetings and is currently in progress for Dialpad. As of today we are promoting Dialtone 8 to the main branch. This means you no longer have to use the @next tag for Dialtone and Dialtone Vue and can update to the main branch in your applications. No further updates will be made to Dialtone 7 except for maybe emergency bug fixes. Dialtone 8 documentation will now exist on <https://dialtone.dialpad.com>. You may still see the documentation site for Dialtone 7 at <https://dialtone.dialpad.com/legacy>
 
 ## What's new in Dialtone 8?
 

--- a/apps/dialtone-documentation/docs/components/avatar.md
+++ b/apps/dialtone-documentation/docs/components/avatar.md
@@ -4,7 +4,7 @@ description: An avatar is a visual representation of a user or object.
 status: ready
 thumb: true
 image: assets/images/components/avatar.png
-storybook: https://vue.dialpad.design/?path=/story/components-avatar--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-avatar--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8918%3A21289&viewport=137%2C605%2C0.46&t=xHutRjwo1o5zMTgT-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/badge.md
+++ b/apps/dialtone-documentation/docs/components/badge.md
@@ -4,7 +4,7 @@ description: A badge is a compact UI element providing brief, descriptive inform
 status: ready
 thumb: true
 image: assets/images/components/badge.png
-storybook: https://vue.dialpad.design/?path=/story/components-badge--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-badge--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8914%3A21227&viewport=656%2C314%2C0.55&t=xHutRjwo1o5zMTgT-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/banner.md
+++ b/apps/dialtone-documentation/docs/components/banner.md
@@ -4,7 +4,7 @@ description: A banner is a type of Notice, delivering system and engagement mess
 status: ready
 thumb: true
 image: assets/images/components/banner.png
-storybook: https://vue.dialpad.design/?path=/story/components-banner--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-banner--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8922%3A20410&viewport=-178%2C151%2C0.23&t=xHutRjwo1o5zMTgT-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/breadcrumbs.md
+++ b/apps/dialtone-documentation/docs/components/breadcrumbs.md
@@ -4,7 +4,7 @@ description: Breadcrumbs are links used to provide context for the currently-vie
 status: ready
 thumb: true
 image: assets/images/components/breadcrumbs.png
-storybook: https://vue.dialpad.design/?path=/story/components-breadcrumbs--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-breadcrumbs--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8918%3A21306&viewport=-61%2C443%2C1.12&t=xHutRjwo1o5zMTgT-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/button-group.md
+++ b/apps/dialtone-documentation/docs/components/button-group.md
@@ -3,7 +3,7 @@ title: Button group
 description: Used for grouping buttons that share a relationship or perform similar actions.
 thumb: true
 image: assets/images/components/button-group.png
-storybook: https://vue.dialpad.design/?path=/story/components-button-group--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-button-group--default
 ---
 
 <code-well-header class="d-d-block">

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -4,7 +4,7 @@ description: A button is an UI element which signals key actions to take an acti
 status: ready
 thumb: true
 image: assets/images/components/button.png
-storybook: https://vue.dialpad.design/?path=/story/components-button--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-button--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8923%3A20208&viewport=-1695%2C219%2C0.19&t=xHutRjwo1o5zMTgT-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/card.md
+++ b/apps/dialtone-documentation/docs/components/card.md
@@ -5,7 +5,7 @@ status: ready
 thumb: true
 image: assets/images/components/card.png
 figma: planned
-storybook: https://vue.dialpad.design/?path=/story/components-card--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-card--default
 ---
 
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/checkbox-group.md
+++ b/apps/dialtone-documentation/docs/components/checkbox-group.md
@@ -4,7 +4,7 @@ description: Checkbox groups are convenient components for a grouping of related
 status: ready
 thumb: true
 image: assets/images/components/checkbox-group.png
-storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-checkbox-group--default
 ---
 
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/checkbox.md
+++ b/apps/dialtone-documentation/docs/components/checkbox.md
@@ -4,7 +4,7 @@ description: A checkbox is an input control that allows users to select zero, on
 status: ready
 thumb: true
 image: assets/images/components/checkbox.png
-storybook: https://vue.dialpad.design/?path=/story/components-checkbox--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-checkbox--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8921%3A21160&viewport=-351%2C484%2C0.54&t=xHutRjwo1o5zMTgT-11
 ---
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/chip.md
+++ b/apps/dialtone-documentation/docs/components/chip.md
@@ -4,7 +4,7 @@ description: A Chip is a compact UI element that provides brief, descriptive inf
 status: ready
 thumb: true
 image: assets/images/components/chip.png
-storybook: https://vue.dialpad.design/?path=/story/components-chip--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-chip--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=9937%3A64802
 ---
 

--- a/apps/dialtone-documentation/docs/components/collapsible.md
+++ b/apps/dialtone-documentation/docs/components/collapsible.md
@@ -5,7 +5,7 @@ status: ready
 thumb: true
 image: assets/images/components/collapsible.png
 figma: planned
-storybook: https://vue.dialpad.design/?path=/story/components-collapsible--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-collapsible--default
 ---
 
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/combobox.md
+++ b/apps/dialtone-documentation/docs/components/combobox.md
@@ -5,7 +5,7 @@ status: ready
 thumb: true
 image: assets/images/components/combobox.png
 figma: planned
-storybook: https://vue.dialpad.design/?path=/story/components-combobox--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-combobox--default
 ---
 
 <code-well-header bgclass="d-bgc-neutral-white">

--- a/apps/dialtone-documentation/docs/components/datepicker.md
+++ b/apps/dialtone-documentation/docs/components/datepicker.md
@@ -4,7 +4,7 @@ thumb: true
 image: assets/images/components/datepicker.png
 description: Datepicker component will provide a calendar to select a date.
 status: beta
-storybook: https://vue.dialpad.design/?path=/story/components-datepicker--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-datepicker--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT8-Component-Library?type=design&node-id=13998-87&mode=design&t=k5q7YXo32w6HoOmK-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/dropdown.md
+++ b/apps/dialtone-documentation/docs/components/dropdown.md
@@ -4,7 +4,7 @@ description: A Dropdown presents a list of options or actions.
 status: planned
 thumb: true
 image: assets/images/components/dropdown.png
-storybook: https://vue.dialpad.design/?path=/story/components-dropdown--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-dropdown--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=10732%3A69099
 ---
 

--- a/apps/dialtone-documentation/docs/components/emoji-picker.md
+++ b/apps/dialtone-documentation/docs/components/emoji-picker.md
@@ -4,7 +4,7 @@ thumb: true
 image: assets/images/components/emoji-picker.png
 description: A emoji picker component that allows you to view and select an emoji from a list.
 status: beta
-storybook: https://vue.dialpad.design/vue3/?path=/story/components-emoji-picker--default
+storybook: https://dialtone.dialpad.com/vue/vue3/?path=/story/components-emoji-picker--default
 ---
 #### Default Scroller
 

--- a/apps/dialtone-documentation/docs/components/emoji-text-wrapper.md
+++ b/apps/dialtone-documentation/docs/components/emoji-text-wrapper.md
@@ -4,7 +4,7 @@ description: "Wrapper to find and replace shortcodes like :smile: or unicode cha
 status: ready
 thumb: true
 image: assets/images/components/emoji-text-wrapper.png
-storybook: https://vue.dialpad.design/?path=/story/components-emoji-text-wrapper--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-emoji-text-wrapper--default
 ---
 
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/emoji.md
+++ b/apps/dialtone-documentation/docs/components/emoji.md
@@ -5,7 +5,7 @@ status: ready
 thumb: true
 image: assets/images/components/emoji.png
 figma: planned
-storybook: https://vue.dialpad.design/?path=/story/components-emoji--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-emoji--default
 ---
 
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/icon.md
+++ b/apps/dialtone-documentation/docs/components/icon.md
@@ -4,7 +4,7 @@ description: An icon is used to visually communicate commands, meaning, status, 
 status: ready
 thumb: true
 image: assets/images/components/icon.png
-storybook: https://vue.dialpad.design/?path=/docs/components-icon--default
+storybook: https://dialtone.dialpad.com/vue/?path=/docs/components-icon--default
 figma_url: https://www.figma.com/file/zz40wi0uW9MvaJ5RuhcRZR/DT-Core%3A-Icons-7?node-id=1473%3A3757&viewport=-168%2C479%2C1&t=OhX4ilCDvb7Tqkx4-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/input.md
+++ b/apps/dialtone-documentation/docs/components/input.md
@@ -4,7 +4,7 @@ description: An input field is an input control that allows users to enter alpha
 status: ready
 thumb: true
 image: assets/images/components/input.png
-storybook: https://vue.dialpad.design/?path=/story/components-input--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-input--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8923%3A21866&viewport=-983%2C83%2C0.16&t=xHutRjwo1o5zMTgT-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/item-layout.md
+++ b/apps/dialtone-documentation/docs/components/item-layout.md
@@ -4,7 +4,7 @@ description: An item layout provides a standardized group of containers to enabl
 status: ready
 thumb: true
 image: assets/images/components/item-layout.png
-storybook: https://vue.dialpad.design/?path=/story/components-item-layout--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-item-layout--default
 ---
 
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/keyboard-shortcut.md
+++ b/apps/dialtone-documentation/docs/components/keyboard-shortcut.md
@@ -4,7 +4,7 @@ description: This component displays a visual representation of a keyboard short
 status: ready
 thumb: true
 image: assets/images/components/keyboard-shortcut.png
-storybook: https://vue.dialpad.design/?path=/story/components-keyboard-shortcut--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-keyboard-shortcut--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components?type=design&node-id=8922-20524&mode=design&t=4VsDQfzhbBwFVFl2-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/lazy-show.md
+++ b/apps/dialtone-documentation/docs/components/lazy-show.md
@@ -4,7 +4,7 @@ description: Lazy show is a utility component that prevents its children from be
 status: ready
 thumb: true
 image: assets/images/components/lazy-show.png
-storybook: https://vue.dialpad.design/?path=/story/utilities-lazy-show--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/utilities-lazy-show--default
 ---
 
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/link.md
+++ b/apps/dialtone-documentation/docs/components/link.md
@@ -4,7 +4,7 @@ description: A link is a navigational element that can be found on its own, with
 status: ready
 thumb: true
 image: assets/images/components/link.png
-storybook: https://vue.dialpad.design/?path=/story/components-link--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-link--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21226&viewport=-746%2C-197%2C1.41&t=xHutRjwo1o5zMTgT-11
 ---
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/list-item.md
+++ b/apps/dialtone-documentation/docs/components/list-item.md
@@ -4,7 +4,7 @@ description: A list item is an element that can be used to represent individual 
 status: ready
 thumb: true
 image: assets/images/components/list-item.png
-storybook: https://vue.dialpad.design/?path=/story/components-list-item--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-list-item--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=10732%3A69390
 ---
 

--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -4,7 +4,7 @@ description: A modal focuses the user’s attention on a single task or message.
 status: ready
 thumb: true
 image: assets/images/components/modal.png
-storybook: https://vue.dialpad.design/?path=/story/components-modal--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-modal--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8923%3A20396&viewport=-724%2C-52%2C0.38&t=xHutRjwo1o5zMTgT-11
 ---
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/notice.md
+++ b/apps/dialtone-documentation/docs/components/notice.md
@@ -4,7 +4,7 @@ description: A notice is an informational and assistive message that appears inl
 status: ready
 thumb: true
 image: assets/images/components/notice.png
-storybook: https://vue.dialpad.design/?path=/story/components-notice--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-notice--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8921%3A23341&viewport=145%2C-209%2C0.31&t=xHutRjwo1o5zMTgT-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/pagination.md
+++ b/apps/dialtone-documentation/docs/components/pagination.md
@@ -4,7 +4,7 @@ description: Pagination allows you to divide large amounts of content into small
 status: ready
 thumb: true
 image: assets/images/components/pagination.png
-storybook: https://vue.dialpad.design/?path=/story/components-pagination--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-pagination--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=10984%3A76640
 ---
 

--- a/apps/dialtone-documentation/docs/components/popover.md
+++ b/apps/dialtone-documentation/docs/components/popover.md
@@ -4,7 +4,7 @@ description: A Popover displays a content overlay when its anchor element is act
 status: ready
 thumb: true
 image: assets/images/components/popover.png
-storybook: https://vue.dialpad.design/?path=/story/components-popover--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-popover--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8921%3A22411&viewport=831%2C-269%2C0.43&t=xHutRjwo1o5zMTgT-11
 ---
 <code-well-header bgclass="d-bgc-primary">

--- a/apps/dialtone-documentation/docs/components/presence.md
+++ b/apps/dialtone-documentation/docs/components/presence.md
@@ -4,7 +4,7 @@ description: A visual control element indicating the current status of a user.
 status: ready
 thumb: true
 image: assets/images/components/presence.png
-storybook: https://vue.dialpad.design/?path=/docs/components-presence--default
+storybook: https://dialtone.dialpad.com/vue/?path=/docs/components-presence--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=9628%3A59018&viewport=-1353%2C1919%2C1.91&t=xHutRjwo1o5zMTgT-11
 ---
 <code-well-header bgclass="d-bgc-primary">

--- a/apps/dialtone-documentation/docs/components/radio-group.md
+++ b/apps/dialtone-documentation/docs/components/radio-group.md
@@ -4,7 +4,7 @@ description: Radio groups are control elements that allow the user to make a sin
 status: ready
 thumb: true
 image: assets/images/components/radio-group.png
-storybook: https://vue.dialpad.design/?path=/story/components-radio-group--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-radio-group--default
 ---
 
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/radio.md
+++ b/apps/dialtone-documentation/docs/components/radio.md
@@ -4,7 +4,7 @@ description: A radio is an input control that allows users to select only one op
 status: ready
 thumb: true
 image: assets/images/components/radio.png
-storybook: https://vue.dialpad.design/?path=/story/components-radio--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-radio--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A22042&viewport=-451%2C205%2C0.6&t=xHutRjwo1o5zMTgT-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/root-layout.md
+++ b/apps/dialtone-documentation/docs/components/root-layout.md
@@ -4,7 +4,7 @@ description: A root layout provides a standardized group of containers to displa
 status: ready
 thumb: true
 image: assets/images/components/root-layout.png
-storybook: https://vue.dialpad.design/?path=/story/components-root-layout--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-root-layout--default
 ---
 
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/scroller.md
+++ b/apps/dialtone-documentation/docs/components/scroller.md
@@ -4,7 +4,7 @@ description: A scroller component that allows blazing fast scrolling of any amou
 status: beta
 thumb: true
 image: assets/images/components/scroller.png
-storybook: https://vue.dialpad.design/vue3/?path=/story/components-scroller--default
+storybook: https://dialtone.dialpad.com/vue/vue3/?path=/story/components-scroller--default
 ---
 
 #### Default Scroller

--- a/apps/dialtone-documentation/docs/components/select-menu.md
+++ b/apps/dialtone-documentation/docs/components/select-menu.md
@@ -4,7 +4,7 @@ description: A select menu is an input control that allows users to choose one o
 status: ready
 thumb: true
 image: assets/images/components/select-menu.png
-storybook: https://vue.dialpad.design/?path=/story/components-select-menu--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-select-menu--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21569&viewport=-1857%2C206%2C0.37&t=xHutRjwo1o5zMTgT-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/skeleton.md
+++ b/apps/dialtone-documentation/docs/components/skeleton.md
@@ -4,7 +4,7 @@ status: ready
 thumb: true
 image: assets/images/components/skeleton.png
 description: Skeleton loader is a non-interactive placeholder that displays a preview of the UI to visually communicate that content is in the process of loading. Skeleton is used to provide a low fidelity representation of the user interface (UI) before content appears on the page.
-storybook: https://vue.dialpad.design/?path=/story/components-skeleton--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-skeleton--default
 figma: planned
 ---
 

--- a/apps/dialtone-documentation/docs/components/stack.md
+++ b/apps/dialtone-documentation/docs/components/stack.md
@@ -4,7 +4,7 @@ description: Stack is a layout component used to group elements together and app
 status: beta
 thumb: true
 image: assets/images/components/stack.png
-storybook: https://vue.dialpad.design/?path=/story/components-stack--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-stack--default
 ---
 
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -3,7 +3,7 @@ title: Tabs
 status: ready
 thumb: true
 description: Tabs allow users to navigation between grouped content in different views while within the same page context.
-storybook: https://vue.dialpad.design/?path=/story/components-tabs--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-tabs--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21321&viewport=306%2C-547%2C1.01&t=xHutRjwo1o5zMTgT-11
 ---
 <code-well-header bgclass="d-bgc-primary">

--- a/apps/dialtone-documentation/docs/components/toast.md
+++ b/apps/dialtone-documentation/docs/components/toast.md
@@ -4,7 +4,7 @@ status: ready
 thumb: true
 image: assets/images/components/toast.png
 description: A toast notice, sometimes called a snackbar, is a time-based message that appears based on users' actions. It contains at-a-glance information about outcomes and can be paired with actions.
-storybook: https://vue.dialpad.design/?path=/story/components-toast--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-toast--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21834&viewport=-496%2C632%2C0.48&t=xHutRjwo1o5zMTgT-11
 ---
 

--- a/apps/dialtone-documentation/docs/components/toggle.md
+++ b/apps/dialtone-documentation/docs/components/toggle.md
@@ -4,7 +4,7 @@ status: ready
 thumb: true
 image: assets/images/components/toggle.png
 description: A toggle, or "switch", is a button control element that allows the user to make a binary selection.
-storybook: https://vue.dialpad.design/?path=/story/components-toggle--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-toggle--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21460&viewport=-359%2C250%2C0.49&t=xHutRjwo1o5zMTgT-11
 ---
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/tooltip.md
+++ b/apps/dialtone-documentation/docs/components/tooltip.md
@@ -4,7 +4,7 @@ status: ready
 thumb: true
 image: assets/images/components/tooltip.png
 description: A tooltip is a floating label that briefly explains an action, function, or an element. Its content is exclusively text and shouldn't be vital information for users. If richer media is desired, consider using a popover instead.
-storybook: https://vue.dialpad.design/?path=/story/components-tooltip--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-tooltip--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21626&viewport=-614%2C359%2C0.86&t=xHutRjwo1o5zMTgT-11
 ---
 <code-well-header class='d-hmn164'>

--- a/apps/dialtone-documentation/docs/components/validation-messages.md
+++ b/apps/dialtone-documentation/docs/components/validation-messages.md
@@ -4,7 +4,7 @@ status: ready
 thumb: true
 image: assets/images/components/validation-messages.png
 description: Validation messages are used to convey information to the user about the current state of the input element. These messages can have an error, warning or success type.
-storybook: https://vue.dialpad.design/?path=/story/components-validation-messages--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-validation-messages--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=11399%3A76354&t=LqzEvQfr3DMHh7Og-11
 ---
 

--- a/apps/dialtone-documentation/docs/guides/getting-started/index.md
+++ b/apps/dialtone-documentation/docs/guides/getting-started/index.md
@@ -49,7 +49,7 @@ Though an atomic CSS approach comes with many advantages, we know it also offers
 
 ### Components
 
-There are two methods to implement Dialtone components: Vue (recommended) and CSS. Vue is the preferred method as it's more robust and readily accessible out-of-the-box. [Get started with Vue components](https://vue.dialpad.design/).
+There are two methods to implement Dialtone components: Vue (recommended) and CSS. Vue is the preferred method as it's more robust and readily accessible out-of-the-box. [Get started with Vue components](https://dialtone.dialpad.com/vue/).
 In the event Dialtone Vue doesn't suit your needs, Dialtone's CSS library offers the same set of components. These may require more work to implement and make accessible, but will work in a pinch.
 
 <code-well-header>

--- a/packages/dialtone-css/README.md
+++ b/packages/dialtone-css/README.md
@@ -5,13 +5,13 @@ be stored here and documented on our site under `apps/dialtone-documentation`.
 
 ## Installation
 
-### Install it via NPM:
+### Install it via NPM
 
 ```shell
 npm install @dialpad/dialtone-css@latest
 ```
 
-### Import dialtone:
+### Import dialtone
 
 - CSS/LESS:
 
@@ -47,7 +47,7 @@ It is required to do this for Dialtone to function.
 ## Building Dialtone locally
 
 To build Dialtone locally, visit
-our [installation instructions](https://dialtone.dialpad.design/guides/getting-started/#build-dialtone-locally).
+our [installation instructions](https://dialtone.dialpad.com/guides/getting-started/#build-dialtone-locally).
 
 ## Contributing
 

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -4,7 +4,7 @@
 //
 //  These are avatars classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/avatars
+//  visit https://dialtone.dialpad.com/components/avatars
 //
 //  TABLE OF CONTENTS
 //  • BASE STYLE

--- a/packages/dialtone-css/lib/build/less/components/badge.less
+++ b/packages/dialtone-css/lib/build/less/components/badge.less
@@ -4,7 +4,7 @@
 //
 //  These are badge classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/badges
+//  visit https://dialtone.dialpad.com/components/badges
 //
 //  TABLE OF CONTENTS
 //  • COMPONENT CSS VARIABLES

--- a/packages/dialtone-css/lib/build/less/components/banner.less
+++ b/packages/dialtone-css/lib/build/less/components/banner.less
@@ -5,7 +5,7 @@
 //  These are the styles for banners, which are a type of notice used
 //  to alert users about important information relevant to them.
 //  For further documentation of these styles, please visit:
-//  https://dialpad.design/components/banners
+//  https://dialtone.dialpad.com/components/banners
 //
 //  ============================================================================
 //  $   BASE WRAPPER

--- a/packages/dialtone-css/lib/build/less/components/breadcrumbs.less
+++ b/packages/dialtone-css/lib/build/less/components/breadcrumbs.less
@@ -3,7 +3,7 @@
 //  COMPONENTS: BREADCRUMBS
 //
 //  These are breadcrumb classes for Dialpad's design system Dialtone.
-//  For further information, visit https://dialpad.design/components/breadcrumbs
+//  For further information, visit https://dialtone.dialpad.com/components/breadcrumbs
 //
 //  TABLE OF CONTENTS
 //  • WRAPPER
@@ -85,4 +85,3 @@
         }
     }
 }
-

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -4,7 +4,7 @@
 //
 //  These are button classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/buttons
+//  visit https://dialtone.dialpad.com/components/buttons
 //
 //  TABLE OF CONTENTS
 //  • BASE STYLE

--- a/packages/dialtone-css/lib/build/less/components/card.less
+++ b/packages/dialtone-css/lib/build/less/components/card.less
@@ -4,7 +4,7 @@
 //
 //  These are card classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/card
+//  visit https://dialtone.dialpad.com/components/card
 //
 //  TABLE OF CONTENTS
 //  • BASE STYLE

--- a/packages/dialtone-css/lib/build/less/components/chip.less
+++ b/packages/dialtone-css/lib/build/less/components/chip.less
@@ -4,7 +4,7 @@
 //
 //  These are chip classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/chip
+//  visit https://dialtone.dialpad.com/components/chip
 //
 //  TABLE OF CONTENTS
 //  • BASE STYLE

--- a/packages/dialtone-css/lib/build/less/components/collapsible.less
+++ b/packages/dialtone-css/lib/build/less/components/collapsible.less
@@ -4,7 +4,7 @@
 //
 //  These are collapsible classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/collapsible
+//  visit https://dialtone.dialpad.com/components/collapsible
 //
 //  TABLE OF CONTENTS
 //  • BASE STYLE

--- a/packages/dialtone-css/lib/build/less/components/combobox.less
+++ b/packages/dialtone-css/lib/build/less/components/combobox.less
@@ -4,7 +4,7 @@
 //
 //  These are combobox classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/combobox
+//  visit https://dialtone.dialpad.com/components/combobox
 //
 //  TABLE OF CONTENTS
 //  • EMPTY LIST

--- a/packages/dialtone-css/lib/build/less/components/forms.less
+++ b/packages/dialtone-css/lib/build/less/components/forms.less
@@ -4,7 +4,7 @@
 //
 //  These are form classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/forms
+//  visit https://dialtone.dialpad.com/components/forms
 //
 //  TABLE OF CONTENTS
 //  • FIELDSETS

--- a/packages/dialtone-css/lib/build/less/components/icon.less
+++ b/packages/dialtone-css/lib/build/less/components/icon.less
@@ -4,7 +4,7 @@
 //
 //  These are icon component classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/icon.html
+//  visit https://dialtone.dialpad.com/components/icon.html
 //
 //  TABLE OF CONTENTS
 //  • SIZE

--- a/packages/dialtone-css/lib/build/less/components/input.less
+++ b/packages/dialtone-css/lib/build/less/components/input.less
@@ -4,7 +4,7 @@
 //
 //  These are input classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/inputs
+//  visit https://dialtone.dialpad.com/components/inputs
 //
 //  TABLE OF CONTENTS
 //  • VARIABLES

--- a/packages/dialtone-css/lib/build/less/components/item-layout.less
+++ b/packages/dialtone-css/lib/build/less/components/item-layout.less
@@ -4,7 +4,7 @@
 //
 // Custom layout to enable developer to use list-item like stack.
 // It is used as base for `dt-list-item` component
-// visit https://dialpad.design/components/item_layout
+// visit https://dialtone.dialpad.com/components/item_layout
 //
 //  TABLE OF CONTENTS
 //  • BASE STYLE

--- a/packages/dialtone-css/lib/build/less/components/link.less
+++ b/packages/dialtone-css/lib/build/less/components/link.less
@@ -4,7 +4,7 @@
 //
 //  These are link classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/links
+//  visit https://dialtone.dialpad.com/components/links
 //
 //  TABLE OF CONTENTS
 //  • BASE STYLE

--- a/packages/dialtone-css/lib/build/less/components/list-group.less
+++ b/packages/dialtone-css/lib/build/less/components/list-group.less
@@ -4,7 +4,7 @@
 //
 //  These are the list group definitions, which are used by classes or can be
 //  used within Vue components. For further documentation of these values,
-//  please visit https://dialpad.design/components/list-groups
+//  please visit https://dialtone.dialpad.com/components/list-groups
 //
 //  ============================================================================
 .d-list-group,

--- a/packages/dialtone-css/lib/build/less/components/modal.less
+++ b/packages/dialtone-css/lib/build/less/components/modal.less
@@ -4,7 +4,7 @@
 //
 //  These are modal classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/modals
+//  visit https://dialtone.dialpad.com/components/modals
 //
 //  TABLE OF CONTENTS
 //  • BASE STYLES

--- a/packages/dialtone-css/lib/build/less/components/notice.less
+++ b/packages/dialtone-css/lib/build/less/components/notice.less
@@ -4,7 +4,7 @@
 //
 //  These are the styles for notices, which are used by alert users to
 //  information they might need. For further documentation of these styles,
-//  please visit https://dialpad.design/components/notices
+//  please visit https://dialtone.dialpad.com/components/notices
 //
 //  ============================================================================
 //  $   BASE WRAPPER

--- a/packages/dialtone-css/lib/build/less/components/popover.less
+++ b/packages/dialtone-css/lib/build/less/components/popover.less
@@ -4,7 +4,7 @@
 //
 //  These are popover classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/popover
+//  visit https://dialtone.dialpad.com/components/popover
 //
 //  TABLE OF CONTENTS
 //  • POPOVER

--- a/packages/dialtone-css/lib/build/less/components/presence.less
+++ b/packages/dialtone-css/lib/build/less/components/presence.less
@@ -4,7 +4,7 @@
 //
 //  These are presence classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/presence
+//  visit https://dialtone.dialpad.com/components/presence
 
 .d-presence {
   --presence-color-border-base: var(--dt-theme-sidebar-color-background);

--- a/packages/dialtone-css/lib/build/less/components/radio-checkbox.less
+++ b/packages/dialtone-css/lib/build/less/components/radio-checkbox.less
@@ -4,7 +4,7 @@
 //
 //  These are input classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/inputs
+//  visit https://dialtone.dialpad.com/components/inputs
 //
 //  TABLE OF CONTENTS
 //  • SHARED STYLES

--- a/packages/dialtone-css/lib/build/less/components/root-layout.less
+++ b/packages/dialtone-css/lib/build/less/components/root-layout.less
@@ -4,7 +4,7 @@
 //
 //  These are the styles for root layout for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/root-layout.html
+//  visit https://dialtone.dialpad.com/components/root-layout.html
 //
 //  TABLE OF CONTENTS
 //  • BASE STYLE

--- a/packages/dialtone-css/lib/build/less/components/selects.less
+++ b/packages/dialtone-css/lib/build/less/components/selects.less
@@ -4,7 +4,7 @@
 //
 //  These are select menu classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/select
+//  visit https://dialtone.dialpad.com/components/select
 //
 //  TABLE OF CONTENTS
 //  • SELECT MENUS

--- a/packages/dialtone-css/lib/build/less/components/skeleton.less
+++ b/packages/dialtone-css/lib/build/less/components/skeleton.less
@@ -5,7 +5,7 @@
 //  These are the styles for skeleton component.
 //  The --placeholder-from-color and --placeholder-to-color custom properties can be set on the parent class of the
 //  placeholder to control the animation colors.
-//  For further documentation of these styles, please visit https://dialpad.design/components/skeleton
+//  For further documentation of these styles, please visit https://dialtone.dialpad.com/components/skeleton
 //
 //
 //  TABLE OF CONTENTS

--- a/packages/dialtone-css/lib/build/less/components/table.less
+++ b/packages/dialtone-css/lib/build/less/components/table.less
@@ -4,7 +4,7 @@
 //
 //  These are table component classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/tables
+//  visit https://dialtone.dialpad.com/components/tables
 //
 //  TABLE OF CONTENTS
 //  • DEFAULT STYLE

--- a/packages/dialtone-css/lib/build/less/components/tabs.less
+++ b/packages/dialtone-css/lib/build/less/components/tabs.less
@@ -4,7 +4,7 @@
 //
 //  These are tab classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/tabs
+//  visit https://dialtone.dialpad.com/components/tabs
 //
 //  TABLE OF CONTENTS
 //  • BASE STYLE

--- a/packages/dialtone-css/lib/build/less/components/toast.less
+++ b/packages/dialtone-css/lib/build/less/components/toast.less
@@ -4,7 +4,7 @@
 //
 //  These are the styles for toast notices, which are used by alert users to
 //  information they might need. For further documentation of these styles,
-//  please visit https://dialpad.design/components/toasts
+//  please visit https://dialtone.dialpad.com/components/toasts
 
 //  ============================================================================
 //  @   TOAST CONTAINER

--- a/packages/dialtone-css/lib/build/less/components/toggle.less
+++ b/packages/dialtone-css/lib/build/less/components/toggle.less
@@ -4,7 +4,7 @@
 //
 //  These are toggle classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/toggle
+//  visit https://dialtone.dialpad.com/components/toggle
 //
 //  TABLE OF CONTENTS
 //  • BASE STYLE

--- a/packages/dialtone-css/lib/build/less/components/tooltip.less
+++ b/packages/dialtone-css/lib/build/less/components/tooltip.less
@@ -4,7 +4,7 @@
 //
 //  These are tooltip classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/components/tooltips
+//  visit https://dialtone.dialpad.com/components/tooltips
 //
 //  TABLE OF CONTENTS
 //  • VARIABLES

--- a/packages/dialtone-css/lib/build/less/dialtone-globals.less
+++ b/packages/dialtone-css/lib/build/less/dialtone-globals.less
@@ -4,7 +4,7 @@
 //
 //  This file provides global CSS styles for Dialtone. For more Information
 //  about Dialtone and these classes, please visit:
-//  https://dialpad.design
+//  https://dialtone.dialpad.com
 //
 //  ============================================================================
 

--- a/packages/dialtone-css/lib/build/less/dialtone-variables.less
+++ b/packages/dialtone-css/lib/build/less/dialtone-variables.less
@@ -5,7 +5,7 @@
 //  This file provides the tokens and definitions for Dialtone. This file
 //  OUTPUTS NO CSS. Instead use this file as an import for your Vue app.
 //  For documentation about these tokens, definitions, and related CSS classes,
-//  please visit: https://dialpad.design
+//  please visit: https://dialtone.dialpad.com
 //
 //  ============================================================================
 //  $   VARIABLES

--- a/packages/dialtone-css/lib/build/less/dialtone.less
+++ b/packages/dialtone-css/lib/build/less/dialtone.less
@@ -3,7 +3,7 @@
 //
 //  This file provides CSS classes for Dialtone, the Dialpad design system.
 //  For further information about these classes, please visit:
-//  https://dialpad.design
+//  https://dialtone.dialpad.com
 //
 //
 //  ============================================================================

--- a/packages/dialtone-css/lib/build/less/themes/default.less
+++ b/packages/dialtone-css/lib/build/less/themes/default.less
@@ -4,7 +4,7 @@
 //
 //  This file contains all the theme-able portions of Dialtone.
 //  For further information about these classes, please visit:
-//  https://dialpad.design/themes
+//  https://dialtone.dialpad.com/themes
 //
 //  ============================================================================
 //  THEME VARIABLES

--- a/packages/dialtone-css/lib/build/less/themes/example.less
+++ b/packages/dialtone-css/lib/build/less/themes/example.less
@@ -4,7 +4,7 @@
 //
 //  Use this file to create Dialtone themes..
 //  For further information about these theming, please visit:
-//  https://dialpad.design/themes
+//  https://dialtone.dialpad.com/themes
 //
 //  TABLE OF CONTENTS:
 //    - REFERENCE FILES

--- a/packages/dialtone-css/lib/build/less/utilities/backgrounds.less
+++ b/packages/dialtone-css/lib/build/less/utilities/backgrounds.less
@@ -4,7 +4,7 @@
 //
 //  These are border utility classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/utilities/borders
+//  visit https://dialtone.dialpad.com/utilities/borders
 //
 //  TABLE OF CONTENTS
 //  • BACKGROUND ATTACHMENT

--- a/packages/dialtone-css/lib/build/less/utilities/borders.less
+++ b/packages/dialtone-css/lib/build/less/utilities/borders.less
@@ -4,7 +4,7 @@
 //
 //  These are border utility classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/utilities/borders
+//  visit https://dialtone.dialpad.com/utilities/borders
 //
 //  TABLE OF CONTENTS
 //  • BORDERS

--- a/packages/dialtone-css/lib/build/less/utilities/colors.less
+++ b/packages/dialtone-css/lib/build/less/utilities/colors.less
@@ -4,7 +4,7 @@
 //
 //  These are all the color utility classes for Dialpad's design system Dialtone.
 //  For further information about these classes, please visit their respective
-//  documentation pages at https://dialpad.design
+//  documentation pages at https://dialtone.dialpad.com
 //
 //  TABLE OF CONTENTS
 //  • TEXT COLORS

--- a/packages/dialtone-css/lib/build/less/utilities/effects.less
+++ b/packages/dialtone-css/lib/build/less/utilities/effects.less
@@ -4,7 +4,7 @@
 //
 //  These are effects utility classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/utilities/effects
+//  visit https://dialtone.dialpad.com/utilities/effects
 //
 //  TABLE OF CONTENTS
 //  • ANIMATIONS

--- a/packages/dialtone-css/lib/build/less/utilities/flex.less
+++ b/packages/dialtone-css/lib/build/less/utilities/flex.less
@@ -4,7 +4,7 @@
 //
 //  These are the flexbox utility classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes, visit:
-//  https://dialpad.design/utilities/layout/flex/
+//  https://dialtone.dialpad.com/utilities/layout/flex/
 //
 //  TABLE OF CONTENTS
 //  • ALIGN CONTENT

--- a/packages/dialtone-css/lib/build/less/utilities/grid.less
+++ b/packages/dialtone-css/lib/build/less/utilities/grid.less
@@ -4,7 +4,7 @@
 //
 //  These are the CSS grid utility classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/utilities/grid
+//  visit https://dialtone.dialpad.com/utilities/grid
 //
 //  TABLE OF CONTENTS
 //  • GRID VARIABLES

--- a/packages/dialtone-css/lib/build/less/utilities/interactivity.less
+++ b/packages/dialtone-css/lib/build/less/utilities/interactivity.less
@@ -4,7 +4,7 @@
 //
 //  These are interactivity utility classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/utilities/interactivity
+//  visit https://dialtone.dialpad.com/utilities/interactivity
 //
 //  TABLE OF CONTENTS
 //  • CURSOR

--- a/packages/dialtone-css/lib/build/less/utilities/layout.less
+++ b/packages/dialtone-css/lib/build/less/utilities/layout.less
@@ -4,7 +4,7 @@
 //
 //  These are layout utility classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/utilities/layout
+//  visit https://dialtone.dialpad.com/utilities/layout
 //
 //  TABLE OF CONTENTS
 //  • BOX SIZING

--- a/packages/dialtone-css/lib/build/less/utilities/sizing.less
+++ b/packages/dialtone-css/lib/build/less/utilities/sizing.less
@@ -4,7 +4,7 @@
 //
 //  These are sizing utility classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/utilities/sizing
+//  visit https://dialtone.dialpad.com/utilities/sizing
 //
 //  TABLE OF CONTENTS
 //  • HEIGHT

--- a/packages/dialtone-css/lib/build/less/utilities/spacing.less
+++ b/packages/dialtone-css/lib/build/less/utilities/spacing.less
@@ -4,7 +4,7 @@
 //
 //  These are spacing utility classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/utilities/spacing
+//  visit https://dialtone.dialpad.com/utilities/spacing
 //
 //  TABLE OF CONTENTS
 //  • AUTO-SPACING

--- a/packages/dialtone-css/lib/build/less/utilities/typography.less
+++ b/packages/dialtone-css/lib/build/less/utilities/typography.less
@@ -4,7 +4,7 @@
 //
 //  These are utility typography classes for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/utilties/typography
+//  visit https://dialtone.dialpad.com/utilties/typography
 //
 //  TABLE OF CONTENTS
 //  • FONT FAMILY

--- a/packages/dialtone-css/lib/build/less/variables/typography.less
+++ b/packages/dialtone-css/lib/build/less/variables/typography.less
@@ -6,7 +6,7 @@
 //
 //  These are typography constants for Dialpad's design system Dialtone.
 //  For further documentation of these and other classes,
-//  visit https://dialpad.design/tokens/typography
+//  visit https://dialtone.dialpad.com/tokens/typography
 //
 //  TABLE OF CONTENTS
 //  • Line heights

--- a/packages/dialtone-css/lib/build/less/variables/visual-styles.less
+++ b/packages/dialtone-css/lib/build/less/variables/visual-styles.less
@@ -6,7 +6,7 @@
 //
 //  These are various visual style tokens and mixins for Dialpad's design
 //  system Dialtone. For further documentation of these values, please visit:
-//  https://dialpad.design/tokens/visual-styles
+//  https://dialtone.dialpad.com/tokens/visual-styles
 //
 //  TABLE OF CONTENTS
 //  • BACKGROUND PATTERNS

--- a/packages/dialtone-css/migration_guide/Dialtone_7.md
+++ b/packages/dialtone-css/migration_guide/Dialtone_7.md
@@ -524,7 +524,7 @@ Search for | Replace with
 
 Do a search in [Icon docs][icon-docs] to find an icon that matches your needs.
 For icon component documentation on props (naming and sizing), check
-[Dialtone Vue - Icon component](https://vue.dialpad.design/?path=/story/components-icon--default).
+[Dialtone Vue - Icon component](https://dialtone.dialpad.com/vue/?path=/story/components-icon--default).
 *Check with your designer or ask in #dialtone if you are having trouble finding a replacement for an existing icon*
 
 **If you can use vue components**:
@@ -565,7 +565,7 @@ Remove any usage of `d-svg` and `d-svg--*`.
 Remove any custom icon sizing e.g. `.foo .icon { width: xxx; height: yyy; }.`
 and replace with the correct sizing class in [icon documentation][icon-docs].
 
-[icon-docs]: https://dialpad.design/components/icon.html
+[icon-docs]: https://dialtone.dialpad.com/components/icon.html
 
 #### Badge
 

--- a/packages/dialtone-css/package.json
+++ b/packages/dialtone-css/package.json
@@ -8,7 +8,7 @@
     "Design System",
     "CSS"
   ],
-  "homepage": "https://dialpad.design",
+  "homepage": "https://dialtone.dialpad.com",
   "bugs": {
     "email": "dialtone@dialpad.com"
   },

--- a/packages/dialtone-tokens/build.gradle
+++ b/packages/dialtone-tokens/build.gradle
@@ -55,7 +55,7 @@ afterEvaluate {
                 pom {
                     name = 'Dialtone Tokens'
                     description = "Design tokens for Dialpad's design system, Dialtone."
-                    url = 'https://dialpad.design'
+                    url = 'https://dialtone.dialpad.com'
 
                     licenses {
                         license {

--- a/packages/dialtone-tokens/package.json
+++ b/packages/dialtone-tokens/package.json
@@ -25,7 +25,7 @@
   "bugs": {
     "url": "https://github.com/dialpad/dialtone-tokens/issues"
   },
-  "homepage": "https://dialpad.design/",
+  "homepage": "https://dialtone.dialpad.com/",
   "devDependencies": {
     "@tokens-studio/sd-transforms": "^0.11.0",
     "maven": "^5.0.0",

--- a/packages/dialtone-tokens/pom.xml
+++ b/packages/dialtone-tokens/pom.xml
@@ -10,7 +10,7 @@
 
   <name>Dialtone Tokens</name>
   <description>Design tokens for Dialpad's design system, Dialtone.</description>
-  <url>https://dialpad.design</url>
+  <url>https://dialtone.dialpad.com</url>
 
   <licenses>
     <license>

--- a/packages/dialtone-tokens/pom.xml.versionsBackup
+++ b/packages/dialtone-tokens/pom.xml.versionsBackup
@@ -10,7 +10,7 @@
 
   <name>Dialtone Tokens</name>
   <description>Design tokens for Dialpad's design system, Dialtone.</description>
-  <url>https://dialpad.design</url>
+  <url>https://dialtone.dialpad.com</url>
 
   <licenses>
     <license>

--- a/packages/dialtone-vue2/.storybook/dialtone-themes.js
+++ b/packages/dialtone-vue2/.storybook/dialtone-themes.js
@@ -6,7 +6,7 @@ import { create } from '@storybook/theming/create';
 
 const _baseThemeVariables = {
   brandTitle: 'Dialpad storybook',
-  brandUrl: 'https://dialpad.design',
+  brandUrl: 'https://dialtone.dialpad.com',
   brandImage: 'https://static.dialpadcdn.com/dialtone/dialpad_logo.svg',
   fontBase: '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
 }

--- a/packages/dialtone-vue2/common/dates.js
+++ b/packages/dialtone-vue2/common/dates.js
@@ -57,7 +57,7 @@ export function setDateLocale (locale) {
 
 /**
  * This formats a date to the Dialtone standard medium date format as shown here:
- * https://dialpad.design/guides/writing-guidelines/#formats-by-length
+ * https://dialtone.dialpad.com/guides/writing-guidelines/#formats-by-length
  * @param {Date} date A javascript date object
  * @returns {string} A string in the format of 'September 2, 2022'
  */

--- a/packages/dialtone-vue2/components/avatar/avatar.vue
+++ b/packages/dialtone-vue2/components/avatar/avatar.vue
@@ -92,7 +92,7 @@ const ICONS_LIST = getIconNames();
 
 /**
  * An avatar is a visual representation of a user or object.
- * @see https://dialpad.design/components/avatar.html
+ * @see https://dialtone.dialpad.com/components/avatar.html
  */
 export default {
   name: 'DtAvatar',

--- a/packages/dialtone-vue2/components/badge/badge.vue
+++ b/packages/dialtone-vue2/components/badge/badge.vue
@@ -46,7 +46,7 @@ import { DtIcon } from '@/components/icon';
 /**
  * A badge is a compact UI element that provides brief, descriptive information about an element.
  * It is terse, ideally one word.
- * @see https://dialpad.design/components/badge.html
+ * @see https://dialtone.dialpad.com/components/badge.html
  */
 export default {
   name: 'DtBadge',
@@ -58,7 +58,7 @@ export default {
   props: {
     /**
      * Icon on the left side of the badge. Supports any valid icon name from the icon catalog at
-     * https://dialpad.design/components/icon.html#icon-catalog. If type:'ai' is set, the ai icon
+     * https://dialtone.dialpad.com/components/icon.html#icon-catalog. If type:'ai' is set, the ai icon
      * will automatically be shown here, but this can be overridden by setting this prop.
      */
     iconLeft: {
@@ -68,7 +68,7 @@ export default {
 
     /**
      * Icon on the right side of the badge. Supports any valid icon name from the icon catalog at
-     * https://dialpad.design/components/icon.html#icon-catalog
+     * https://dialtone.dialpad.com/components/icon.html#icon-catalog
      */
     iconRight: {
       type: String,

--- a/packages/dialtone-vue2/components/banner/banner.vue
+++ b/packages/dialtone-vue2/components/banner/banner.vue
@@ -57,7 +57,7 @@ import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
 /**
  * Banners are a type of notice, delivering system and engagement messaging.
  * These are highly intrusive notices and should be used sparingly and appropriately.
- * @see https://dialpad.design/components/banner.html
+ * @see https://dialtone.dialpad.com/components/banner.html
  */
 export default {
   name: 'DtBanner',

--- a/packages/dialtone-vue2/components/breadcrumbs/breadcrumbs.vue
+++ b/packages/dialtone-vue2/components/breadcrumbs/breadcrumbs.vue
@@ -30,7 +30,7 @@ import utils from '@/common/utils';
 /**
  * Breadcrumbs are links used to provide context for the currently-viewed page
  * and where it is located within the overall site structure.
- * @see https://dialpad.design/components/breadcrumbs.html
+ * @see https://dialtone.dialpad.com/components/breadcrumbs.html
  */
 export default {
   name: 'DtBreadcrumbs',

--- a/packages/dialtone-vue2/components/button/button.vue
+++ b/packages/dialtone-vue2/components/button/button.vue
@@ -58,7 +58,7 @@ import { LINK_KIND_MODIFIERS } from '@/components/link';
  * A button is a UI element which allows users to take an action throughout the app.
  * It is important a button is identifiable, consistent, and communicates its actions clearly,
  * and is appropriately sized to its action.
- * @see https://dialpad.design/components/button.html
+ * @see https://dialtone.dialpad.com/components/button.html
  */
 export default {
   name: 'DtButton',

--- a/packages/dialtone-vue2/components/button/button_constants.js
+++ b/packages/dialtone-vue2/components/button/button_constants.js
@@ -67,7 +67,7 @@ function _invalidCombinationMessage (circle, kind, importance) {
   return `You cannot have a ${circle ? 'circle ' : ''}button \
 with kind: ${kind} and importance: ${importance} as it \
 does not exist in our design system. \
-See https://dialpad.design/components/button.html for a \
+See https://dialtone.dialpad.com/components/button.html for a \
 list of available button styles`;
 }
 

--- a/packages/dialtone-vue2/components/card/card.vue
+++ b/packages/dialtone-vue2/components/card/card.vue
@@ -45,7 +45,7 @@
 /**
  * A card contains summary content and actions about a single subject.
  * It can be used by itself or within a list, and is generally interactive.
- * @see https://dialpad.design/components/card.html
+ * @see https://dialtone.dialpad.com/components/card.html
  */
 export default {
   name: 'DtCard',

--- a/packages/dialtone-vue2/components/checkbox/checkbox.vue
+++ b/packages/dialtone-vue2/components/checkbox/checkbox.vue
@@ -65,7 +65,7 @@ import { DtValidationMessages } from '../validation_messages';
 /**
  * Checkboxes are control elements that allow the user to make a selection.They are typically used in a
  * Checkbox Group which allows the user to make one or more selections from a list of options.
- * @see https://dialpad.design/components/checkbox.html
+ * @see https://dialtone.dialpad.com/components/checkbox.html
  */
 export default {
   name: 'DtCheckbox',

--- a/packages/dialtone-vue2/components/checkbox_group/checkbox_group.vue
+++ b/packages/dialtone-vue2/components/checkbox_group/checkbox_group.vue
@@ -6,7 +6,7 @@ import { DtInputGroup } from '../input_group';
  * Checkbox Groups are convenience components for a grouping of related Checkboxes.
  * While each Checkbox within the group is independent, the `v-model` on the group provides
  * a convenient interface for determining which Checkboxes within the group are checked.
- * @see https://dialpad.design/components/checkbox_group.html
+ * @see https://dialtone.dialpad.com/components/checkbox_group.html
  */
 export default {
   name: 'DtCheckboxGroup',

--- a/packages/dialtone-vue2/components/chip/chip.vue
+++ b/packages/dialtone-vue2/components/chip/chip.vue
@@ -67,7 +67,7 @@ import { getUniqueString } from '@/common/utils';
  * A chip is a compact UI element that provides brief, descriptive information about an element.
  * It is terse, ideally one word. It is important a button is identifiable, consistent, and
  * communicates its actions clearly, and is appropriately sized to its action.
- * @see https://dialpad.design/components/chip.html
+ * @see https://dialtone.dialpad.com/components/chip.html
  */
 export default {
   name: 'DtChip',

--- a/packages/dialtone-vue2/components/collapsible/collapsible.vue
+++ b/packages/dialtone-vue2/components/collapsible/collapsible.vue
@@ -80,7 +80,7 @@ import { DtIcon } from '@/components/icon';
 
 /**
  * A collapsible is a component consisting of an interactive anchor that toggled the expandable/collapsible element.
- * @see https://dialpad.design/components/collapsible.html
+ * @see https://dialtone.dialpad.com/components/collapsible.html
  */
 export default {
   name: 'DtCollapsible',

--- a/packages/dialtone-vue2/components/combobox/combobox.vue
+++ b/packages/dialtone-vue2/components/combobox/combobox.vue
@@ -58,7 +58,7 @@ import { LABEL_SIZES } from '@/components/combobox/combobox_constants';
 /**
  * A combobox is a semantic component that displays an input element combined with a listbox,
  * which enables the user to select items from the list.
- * @see https://dialpad.design/components/combobox.html
+ * @see https://dialtone.dialpad.com/components/combobox.html
  */
 export default {
   name: 'DtCombobox',

--- a/packages/dialtone-vue2/components/emoji/emoji.vue
+++ b/packages/dialtone-vue2/components/emoji/emoji.vue
@@ -35,7 +35,7 @@ import { DtSkeleton } from '../skeleton';
 
 /**
  * Renders an emoji from a shortcode such as :smile: or unicode character such as 😄
- * @see https://dialpad.design/components/emoji.html
+ * @see https://dialtone.dialpad.com/components/emoji.html
  */
 export default {
   name: 'DtEmoji',
@@ -57,7 +57,7 @@ export default {
 
     /**
      * The size of the emoji. Can be any of the icon size utility classes from
-     * <a class="d-link" href="https://dialpad.design/components/icon.html" target="_blank"> Dialpad Icon Size</a>
+     * <a class="d-link" href="https://dialtone.dialpad.com/components/icon.html" target="_blank"> Dialpad Icon Size</a>
      * @values 100, 200, 300, 400, 500, 600, 700, 800
      */
     size: {

--- a/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -5,7 +5,7 @@ import { ICON_SIZE_MODIFIERS } from '@/components/icon/icon_constants';
 
 /**
  * Wrapper to find and replace shortcodes like :smile: or unicode chars such as 😄 with our custom Emojis implementation.
- * @see https://dialpad.design/components/emoji_text_wrapper.html
+ * @see https://dialtone.dialpad.com/components/emoji_text_wrapper.html
  */
 export default {
   name: 'DtEmojiTextWrapper',

--- a/packages/dialtone-vue2/components/icon/icon.vue
+++ b/packages/dialtone-vue2/components/icon/icon.vue
@@ -21,7 +21,7 @@ const dialtoneIcons = import.meta.glob(
 
 /**
  * The Icon component provides a set of glyphs and sizes to provide context your application.
- * @see https://dialpad.design/components/icon.html
+ * @see https://dialtone.dialpad.com/components/icon.html
  */
 export default {
   name: 'DtIcon',

--- a/packages/dialtone-vue2/components/input/input.vue
+++ b/packages/dialtone-vue2/components/input/input.vue
@@ -124,7 +124,7 @@ import { MessagesMixin } from '../../common/mixins/input.js';
  * It can have a range of options and supports single line and multi-line lengths,
  * as well as varying formats, including numbers, masked passwords, etc.
  * @property {Boolean} placeholder attribute
- * @see https://dialpad.design/components/input.html
+ * @see https://dialtone.dialpad.com/components/input.html
  */
 export default {
   name: 'DtInput',

--- a/packages/dialtone-vue2/components/input_group/input_group.vue
+++ b/packages/dialtone-vue2/components/input_group/input_group.vue
@@ -34,7 +34,7 @@ import { DtValidationMessages } from '../validation_messages';
  * Input Groups are convenience components for a grouping of related inputs.
  * While each input within the group could be independent, the `v-model` on the group
  * provides a convenient interface for determining the current state of the group.
- * @see https://dialpad.design/components/input_group.html
+ * @see https://dialtone.dialpad.com/components/input_group.html
  */
 export default {
   name: 'DtInputGroup',

--- a/packages/dialtone-vue2/components/item_layout/item_layout.vue
+++ b/packages/dialtone-vue2/components/item_layout/item_layout.vue
@@ -62,7 +62,7 @@
 /**
  * Custom layout to enable developer to use list-item like stack.
  * It is used as base for `dt-list-item` component
- * @see https://dialpad.design/components/item_layout.html
+ * @see https://dialtone.dialpad.com/components/item_layout.html
  */
 <script>
 export default {

--- a/packages/dialtone-vue2/components/keyboard_shortcut/keyboard_shortcut.vue
+++ b/packages/dialtone-vue2/components/keyboard_shortcut/keyboard_shortcut.vue
@@ -46,7 +46,7 @@ import { SHORTCUTS_ICON_ALIASES, SHORTCUTS_ICON_SEPARATOR } from './keyboard_sho
 
 /**
  * This component displays a visual representation of a keyboard shortcut to the user.
- * @see https://dialpad.design/components/keyboard_shortcut.html
+ * @see https://dialtone.dialpad.com/components/keyboard_shortcut.html
  */
 export default {
   name: 'DtKeyboardShortcut',

--- a/packages/dialtone-vue2/components/lazy_show/lazy_show.vue
+++ b/packages/dialtone-vue2/components/lazy_show/lazy_show.vue
@@ -19,7 +19,7 @@
 <script>
 /**
  * Lazy Show is a utility component that prevents its children from being rendered until the first time it is shown.
- * @see https://dialpad.design/components/lazy_show.html
+ * @see https://dialtone.dialpad.com/components/lazy_show.html
  */
 export default {
   name: 'DtLazyShow',

--- a/packages/dialtone-vue2/components/link/link.vue
+++ b/packages/dialtone-vue2/components/link/link.vue
@@ -20,7 +20,7 @@ import { LINK_VARIANTS, LINK_KIND_MODIFIERS } from './link_constants';
  * A link is a navigational element that can be found on its own, within other text, or directly following content.
  * @property {String} href attribute
  * @property {String} rel attribute
- * @see https://dialpad.design/components/link.html
+ * @see https://dialtone.dialpad.com/components/link.html
  */
 export default {
   name: 'DtLink',

--- a/packages/dialtone-vue2/components/list_item/list_item.vue
+++ b/packages/dialtone-vue2/components/list_item/list_item.vue
@@ -50,7 +50,7 @@ import { DtItemLayout } from '@/components/item_layout';
 
 /**
  * A list item is an element that can be used to represent individual items in a list.
- * @see https://dialpad.design/components/list_item.html
+ * @see https://dialtone.dialpad.com/components/list_item.html
  */
 export default {
   name: 'DtListItem',

--- a/packages/dialtone-vue2/components/modal/modal.vue
+++ b/packages/dialtone-vue2/components/modal/modal.vue
@@ -134,7 +134,7 @@ import { NOTICE_KINDS } from '@/components/notice';
 /**
  * Modals focus the user’s attention exclusively on one task or piece of information
  * via a window that sits on top of the page content.
- * @see https://dialpad.design/components/modal.html
+ * @see https://dialtone.dialpad.com/components/modal.html
  */
 export default {
   name: 'DtModal',

--- a/packages/dialtone-vue2/components/notice/notice.vue
+++ b/packages/dialtone-vue2/components/notice/notice.vue
@@ -46,7 +46,7 @@ import SrOnlyCloseButtonMixin from '../../common/mixins/sr_only_close_button';
 
 /**
  * A notice is an informational and assistive message that appears inline with content.
- * @see https://dialpad.design/components/notice.html
+ * @see https://dialtone.dialpad.com/components/notice.html
  */
 export default {
   name: 'DtNotice',

--- a/packages/dialtone-vue2/components/pagination/pagination.vue
+++ b/packages/dialtone-vue2/components/pagination/pagination.vue
@@ -75,7 +75,7 @@ import { DtIcon } from '@/components/icon';
 
 /**
  * Pagination allows you to divide large amounts of content into smaller chunks across multiple pages.
- * @see https://dialpad.design/components/pagination.html
+ * @see https://dialtone.dialpad.com/components/pagination.html
  */
 export default {
   name: 'DtPagination',

--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -136,7 +136,7 @@ import SrOnlyCloseButton from '@/common/sr_only_close_button.vue';
 
 /**
  * A Popover displays a content overlay when its anchor element is activated.
- * @see https://dialpad.design/components/popover.html
+ * @see https://dialtone.dialpad.com/components/popover.html
  */
 export default {
   name: 'DtPopover',

--- a/packages/dialtone-vue2/components/presence/presence.vue
+++ b/packages/dialtone-vue2/components/presence/presence.vue
@@ -26,7 +26,7 @@
 import { PRESENCE_STATES, PRESENCE_STATES_LIST } from './presence_constants';
 /**
  * Presence is a user status visual indicator element.
- * @see https://dialpad.design/components/presence.html
+ * @see https://dialtone.dialpad.com/components/presence.html
  */
 export default {
   name: 'DtPresence',

--- a/packages/dialtone-vue2/components/radio/radio.vue
+++ b/packages/dialtone-vue2/components/radio/radio.vue
@@ -61,7 +61,7 @@ import { DtValidationMessages } from '../validation_messages';
 /**
  * Radios are control elements that allow the user to make a single selection.
  * They are typically used in a Radio Group which allows the user to make a selection from a list of options.
- * @see https://dialpad.design/components/radio.html
+ * @see https://dialtone.dialpad.com/components/radio.html
  */
 export default {
   name: 'DtRadio',

--- a/packages/dialtone-vue2/components/radio_group/radio_group.vue
+++ b/packages/dialtone-vue2/components/radio_group/radio_group.vue
@@ -3,7 +3,7 @@ import { DtInputGroup } from '../input_group';
 
 /**
  * Radio Groups are control elements that allow the user to make a single selection from a list of options.
- * @see https://dialpad.design/components/radio_group.html
+ * @see https://dialtone.dialpad.com/components/radio_group.html
  */
 export default {
   name: 'DtRadioGroup',

--- a/packages/dialtone-vue2/components/select_menu/select_menu.vue
+++ b/packages/dialtone-vue2/components/select_menu/select_menu.vue
@@ -98,7 +98,7 @@ import { DtValidationMessages } from '../validation_messages';
  * @property {Boolean} disabled attribute
  * @property {String} name attribute
  * @property {String} value attribute
- * @see https://dialpad.design/components/select.html
+ * @see https://dialtone.dialpad.com/components/select.html
  */
 export default {
   name: 'DtSelectMenu',

--- a/packages/dialtone-vue2/components/skeleton/skeleton.vue
+++ b/packages/dialtone-vue2/components/skeleton/skeleton.vue
@@ -45,7 +45,7 @@ import DtSkeletonText from './skeleton-text.vue';
  * Skeleton loader is a non-interactive placeholder that displays a preview of the UI to visually communicate
  * that content is in the process of loading. Skeleton is used to provide a low fidelity
  * representation of the user interface (UI) before content appears on the page.
- * @see https://dialpad.design/components/skeleton.html
+ * @see https://dialtone.dialpad.com/components/skeleton.html
  */
 export default {
   name: 'DtSkeleton',

--- a/packages/dialtone-vue2/components/tabs/tab.vue
+++ b/packages/dialtone-vue2/components/tabs/tab.vue
@@ -29,7 +29,7 @@ import { DtButton } from '../button';
 
 /**
  * Tabs allow users to navigation between grouped content in different views while within the same page context.
- * @see https://dialpad.design/components/tabs.html
+ * @see https://dialtone.dialpad.com/components/tabs.html
  */
 export default {
   name: 'DtTab',

--- a/packages/dialtone-vue2/components/tabs/tab_group.vue
+++ b/packages/dialtone-vue2/components/tabs/tab_group.vue
@@ -41,7 +41,7 @@ import {
 
 /**
  * Tabs allow users to navigation between grouped content in different views while within the same page context.
- * @see https://dialpad.design/components/tabs.html
+ * @see https://dialtone.dialpad.com/components/tabs.html
  */
 export default {
   name: 'DtTabGroup',

--- a/packages/dialtone-vue2/components/tabs/tab_panel.vue
+++ b/packages/dialtone-vue2/components/tabs/tab_panel.vue
@@ -19,7 +19,7 @@ import Modal from '../../common/mixins/modal.js';
 
 /**
  * Tabs allow users to navigation between grouped content in different views while within the same page context.
- * @see https://dialpad.design/components/tabs.html
+ * @see https://dialtone.dialpad.com/components/tabs.html
  */
 export default {
   name: 'DtTabPanel',

--- a/packages/dialtone-vue2/components/toast/toast.vue
+++ b/packages/dialtone-vue2/components/toast/toast.vue
@@ -57,7 +57,7 @@ import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
 /**
  * A toast notice, sometimes called a snackbar, is a time-based message that appears based on users' actions.
  * It contains at-a-glance information about outcomes and can be paired with actions.
- * @see https://dialpad.design/components/toast.html
+ * @see https://dialtone.dialpad.com/components/toast.html
  */
 export default {
   name: 'DtToast',

--- a/packages/dialtone-vue2/components/toggle/toggle.vue
+++ b/packages/dialtone-vue2/components/toggle/toggle.vue
@@ -36,7 +36,7 @@ import { TOGGLE_CHECKED_VALUES, TOGGLE_SIZE_MODIFIERS } from '@/components/toggl
 
 /**
  * A toggle (or "switch") is a button control element that allows the user to make a binary (on/off) selection.
- * @see https://dialpad.design/components/toggle.html
+ * @see https://dialtone.dialpad.com/components/toggle.html
  */
 export default {
 

--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -66,7 +66,7 @@ import {
  * A tooltip is a floating label that briefly explains an action, function, or an element.
  * Its content is exclusively text and shouldn't be vital information for users.
  * If richer media is desired, consider using a popover instead.
- * @see https://dialpad.design/components/tooltip.html
+ * @see https://dialtone.dialpad.com/components/tooltip.html
  */
 export default {
   name: 'DtTooltip',

--- a/packages/dialtone-vue2/components/validation_messages/validation_messages.vue
+++ b/packages/dialtone-vue2/components/validation_messages/validation_messages.vue
@@ -32,7 +32,7 @@ import {
 /**
  * Validation messages are used to convey information to the user about the current state of the input element.
  * These messages can have an error, warning or success type.
- * @see https://dialpad.design/components/validation_messages.html
+ * @see https://dialtone.dialpad.com/components/validation_messages.html
  */
 export default {
   name: 'DtValidationMessages',

--- a/packages/dialtone-vue2/css/dialtone-globals.less
+++ b/packages/dialtone-vue2/css/dialtone-globals.less
@@ -1,5 +1,5 @@
 // Import dialtone style definitions as references globally so they can be used in
-// mixins. See: https://dialpad.design
+// mixins. See: https://dialtone.dialpad.com
 @import '@dialpad/dialtone-css/lib/build/less/components/modal';
 
 // Reset base font size to 12px.

--- a/packages/dialtone-vue2/docs/welcome.mdx
+++ b/packages/dialtone-vue2/docs/welcome.mdx
@@ -12,7 +12,7 @@ import { LogoContainer, Logo } from './components';
 
 <img src={`https://img.shields.io/badge/npm-${version.replaceAll('-', '--')}-7C52FF`} alt={`Version ${version}`} />
 
-Dialtone Vue is a library of Vue components for <a class="d-link" href="https://dialpad.design/">Dialtone</a>, by Dialpad.
+Dialtone Vue is a library of Vue components for <a class="d-link" href="https://dialtone.dialpad.com/">Dialtone</a>, by Dialpad.
 
 ## Goals
 
@@ -42,4 +42,4 @@ Dialpad projects.
 - **Bradley Hawkins** - Product Design
 - **Federico Sarassola** - Product Design
 
-[dt-components]: https://dialpad.design/components
+[dt-components]: https://dialtone.dialpad.com/components

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button/callbar_button.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button/callbar_button.vue
@@ -58,7 +58,7 @@ export default {
      * Determines whether the button should have active styling
      * default is false.
      * @values true, false
-     * @see https://dialpad.design/components/button/
+     * @see https://dialtone.dialpad.com/components/button/
      */
     active: {
       type: Boolean,
@@ -69,7 +69,7 @@ export default {
      * Determines whether the button should have danger styling
      * default is false.
      * @values true, false
-     * @see https://dialpad.design/components/button/
+     * @see https://dialtone.dialpad.com/components/button/
      */
     danger: {
       type: Boolean,
@@ -89,7 +89,7 @@ export default {
     /**
      * Whether the button is a circle or not.
      * @values true, false
-     * @see https://dialpad.design/components/button/
+     * @see https://dialtone.dialpad.com/components/button/
      */
     circle: {
       type: Boolean,

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -185,7 +185,7 @@ export default {
      * Determines whether the button should have active styling
      * default is false.
      * @values true, false
-     * @see https://dialpad.design/components/button/
+     * @see https://dialtone.dialpad.com/components/button/
      */
     active: {
       type: Boolean,
@@ -196,7 +196,7 @@ export default {
      * Determines whether the button should have danger styling
      * default is false.
      * @values true, false
-     * @see https://dialpad.design/components/button/
+     * @see https://dialtone.dialpad.com/components/button/
      */
     danger: {
       type: Boolean,

--- a/packages/dialtone-vue3/.github/CONTRIBUTING.md
+++ b/packages/dialtone-vue3/.github/CONTRIBUTING.md
@@ -68,7 +68,7 @@ This is why it is important to evaluate the change carefully and asses its impac
 Any new components or updates to existing components require the following:
 
 - Unit tests covering the entire change.
-- Storybook documentation including a live rendered component via controls and MDX. See [the documentation](https://vue.dialpad.design/?path=/story/docs-storybook-getting-started--page)
+- Storybook documentation including a live rendered component via controls and MDX. See [the documentation](https://dialtone.dialpad.com/vue/?path=/story/docs-storybook-getting-started--page)
 - Component is accessible according to requirements.
   - Navigable by keyboard.
   - Read by a screen reader.
@@ -98,6 +98,7 @@ After you have discussed your change with the Dialtone team, follow these steps 
 - 'visual-test-ready' if your PR includes visual UI changes.
 - 'no-visual-test' if not UI changes.
 
+<!-- markdownlint-disable MD029 -->
 8. Run `./copy_pr_vue3.sh` in the root of the repository to copy your current changes in the vue 2 folder to the vue 3 folder.
 9. Create a pull request into the `staging-vue3` branch, reviewers will be automatically added and notified of your PR.
 10. Any subsequent changes that need to be copied to your Vue 3 branch can be done so with `./copy_pr_vue3.sh GIT_SHA` where GIT_SHA is the commit SHA before the first one you wish to copy.
@@ -110,8 +111,8 @@ Releases are done on demand by the Dialtone team, and are done fairly regularly.
 
 ### CSS
 
-We should use [Dialtone tokens](https://dialpad.design/tokens/) in Dialtone Vue for all component styling.
-Avoid using [utility classes](https://dialpad.design/utilities/) in Dialtone Vue, those should be only used at the application level.
+We should use [Dialtone tokens](https://dialtone.dialpad.com/tokens/) in Dialtone Vue for all component styling.
+Avoid using [utility classes](https://dialtone.dialpad.com/utilities/) in Dialtone Vue, those should be only used at the application level.
 
 ### How We Use Slots
 
@@ -340,7 +341,7 @@ directory. See any existing examples of mdx files within that folder for more de
 We use ESLint to promote best practices throughout our codebase.
 ESLint will check any of our javascript or vue code for styling or syntax errors.
 The configuration can be found in [.eslintrc.cjs](../.eslintrc.cjs).
-Any changes code changes you make will be automatically linted upon commit (configuration in 
+Any changes code changes you make will be automatically linted upon commit (configuration in
 [lintstagedrc.cjs](../../../lintstagedrc.cjs)).
 You can manually run ESLint via `npm run lint`.
 

--- a/packages/dialtone-vue3/.storybook/dialtone-themes.js
+++ b/packages/dialtone-vue3/.storybook/dialtone-themes.js
@@ -6,7 +6,7 @@ import { create } from '@storybook/theming/create';
 
 const _baseThemeVariables = {
   brandTitle: 'Dialpad storybook',
-  brandUrl: 'https://dialpad.design',
+  brandUrl: 'https://dialtone.dialpad.com',
   brandImage: 'https://static.dialpadcdn.com/dialtone/dialpad_logo.svg',
   fontBase: '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
 }

--- a/packages/dialtone-vue3/common/dates.js
+++ b/packages/dialtone-vue3/common/dates.js
@@ -57,7 +57,7 @@ export function setDateLocale (locale) {
 
 /**
  * This formats a date to the Dialtone standard medium date format as shown here:
- * https://dialpad.design/guides/writing-guidelines/#formats-by-length
+ * https://dialtone.dialpad.com/guides/writing-guidelines/#formats-by-length
  * @param {Date} date A javascript date object
  * @returns {string} A string in the format of 'September 2, 2022'
  */

--- a/packages/dialtone-vue3/components/avatar/avatar.vue
+++ b/packages/dialtone-vue3/components/avatar/avatar.vue
@@ -92,7 +92,7 @@ const ICONS_LIST = getIconNames();
 
 /**
  * An avatar is a visual representation of a user or object.
- * @see https://dialpad.design/components/avatar.html
+ * @see https://dialtone.dialpad.com/components/avatar.html
  */
 export default {
   name: 'DtAvatar',

--- a/packages/dialtone-vue3/components/badge/badge.vue
+++ b/packages/dialtone-vue3/components/badge/badge.vue
@@ -46,7 +46,7 @@ import { DtIcon } from '@/components/icon';
 /**
  * A badge is a compact UI element that provides brief, descriptive information about an element.
  * It is terse, ideally one word.
- * @see https://dialpad.design/components/badge.html
+ * @see https://dialtone.dialpad.com/components/badge.html
  */
 export default {
   name: 'DtBadge',
@@ -58,7 +58,7 @@ export default {
   props: {
     /**
      * Icon on the left side of the badge. Supports any valid icon name from the icon catalog at
-     * https://dialpad.design/components/icon.html#icon-catalog. If type:'ai' is set, the ai icon
+     * https://dialtone.dialpad.com/components/icon.html#icon-catalog. If type:'ai' is set, the ai icon
      * will automatically be shown here, but this can be overridden by setting this prop.
      */
     iconLeft: {
@@ -68,7 +68,7 @@ export default {
 
     /**
      * Icon on the right side of the badge. Supports any valid icon name from the icon catalog at
-     * https://dialpad.design/components/icon.html#icon-catalog
+     * https://dialtone.dialpad.com/components/icon.html#icon-catalog
      */
     iconRight: {
       type: String,

--- a/packages/dialtone-vue3/components/banner/banner.vue
+++ b/packages/dialtone-vue3/components/banner/banner.vue
@@ -55,7 +55,7 @@ import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
 /**
  * Banners are a type of notice, delivering system and engagement messaging.
  * These are highly intrusive notices and should be used sparingly and appropriately.
- * @see https://dialpad.design/components/banner.html
+ * @see https://dialtone.dialpad.com/components/banner.html
  */
 export default {
   name: 'DtBanner',

--- a/packages/dialtone-vue3/components/breadcrumbs/breadcrumbs.vue
+++ b/packages/dialtone-vue3/components/breadcrumbs/breadcrumbs.vue
@@ -29,7 +29,7 @@ import utils from '@/common/utils';
 /**
  * Breadcrumbs are links used to provide context for the currently-viewed page
  * and where it is located within the overall site structure.
- * @see https://dialpad.design/components/breadcrumbs.html
+ * @see https://dialtone.dialpad.com/components/breadcrumbs.html
  */
 export default {
   name: 'DtBreadcrumbs',

--- a/packages/dialtone-vue3/components/button/button.vue
+++ b/packages/dialtone-vue3/components/button/button.vue
@@ -60,7 +60,7 @@ import { LINK_KIND_MODIFIERS } from '@/components/link';
  * A button is a UI element which allows users to take an action throughout the app.
  * It is important a button is identifiable, consistent, and communicates its actions clearly,
  * and is appropriately sized to its action.
- * @see https://dialpad.design/components/button.html
+ * @see https://dialtone.dialpad.com/components/button.html
  */
 export default {
   name: 'DtButton',

--- a/packages/dialtone-vue3/components/button/button_constants.js
+++ b/packages/dialtone-vue3/components/button/button_constants.js
@@ -67,7 +67,7 @@ function _invalidCombinationMessage (circle, kind, importance) {
   return `You cannot have a ${circle ? 'circle ' : ''}button \
 with kind: ${kind} and importance: ${importance} as it \
 does not exist in our design system. \
-See https://dialpad.design/components/button.html for a \
+See https://dialtone.dialpad.com/components/button.html for a \
 list of available button styles`;
 }
 

--- a/packages/dialtone-vue3/components/card/card.vue
+++ b/packages/dialtone-vue3/components/card/card.vue
@@ -47,7 +47,7 @@ import { hasSlotContent } from '@/common/utils';
 /**
  * A card contains summary content and actions about a single subject.
  * It can be used by itself or within a list, and is generally interactive.
- * @see https://dialpad.design/components/card.html
+ * @see https://dialtone.dialpad.com/components/card.html
  */
 export default {
   name: 'DtCard',

--- a/packages/dialtone-vue3/components/checkbox/checkbox.vue
+++ b/packages/dialtone-vue3/components/checkbox/checkbox.vue
@@ -65,7 +65,7 @@ import { DtValidationMessages } from '../validation_messages';
 /**
  * Checkboxes are control elements that allow the user to make a selection.They are typically used in a
  * Checkbox Group which allows the user to make one or more selections from a list of options.
- * @see https://dialpad.design/components/checkbox.html
+ * @see https://dialtone.dialpad.com/components/checkbox.html
  */
 export default {
   name: 'DtCheckbox',

--- a/packages/dialtone-vue3/components/checkbox_group/checkbox_group.vue
+++ b/packages/dialtone-vue3/components/checkbox_group/checkbox_group.vue
@@ -6,7 +6,7 @@ import { DtInputGroup } from '../input_group';
  * Checkbox Groups are convenience components for a grouping of related Checkboxes.
  * While each Checkbox within the group is independent, the `v-model` on the group provides
  * a convenient interface for determining which Checkboxes within the group are checked.
- * @see https://dialpad.design/components/checkbox_group.html
+ * @see https://dialtone.dialpad.com/components/checkbox_group.html
  */
 export default {
   name: 'DtCheckboxGroup',

--- a/packages/dialtone-vue3/components/chip/chip.vue
+++ b/packages/dialtone-vue3/components/chip/chip.vue
@@ -67,7 +67,7 @@ import { getUniqueString, hasSlotContent } from '@/common/utils';
  * A chip is a compact UI element that provides brief, descriptive information about an element.
  * It is terse, ideally one word. It is important a button is identifiable, consistent, and
  * communicates its actions clearly, and is appropriately sized to its action.
- * @see https://dialpad.design/components/chip.html
+ * @see https://dialtone.dialpad.com/components/chip.html
  */
 export default {
   name: 'DtChip',

--- a/packages/dialtone-vue3/components/collapsible/collapsible.vue
+++ b/packages/dialtone-vue3/components/collapsible/collapsible.vue
@@ -80,7 +80,7 @@ import { DtIcon } from '@/components/icon';
 
 /**
  * A collapsible is a component consisting of an interactive anchor that toggled the expandable/collapsible element.
- * @see https://dialpad.design/components/collapsible.html
+ * @see https://dialtone.dialpad.com/components/collapsible.html
  */
 export default {
   name: 'DtCollapsible',

--- a/packages/dialtone-vue3/components/combobox/combobox.vue
+++ b/packages/dialtone-vue3/components/combobox/combobox.vue
@@ -58,7 +58,7 @@ import { LABEL_SIZES } from '@/components/combobox/combobox_constants';
 /**
  * A combobox is a semantic component that displays an input element combined with a listbox,
  * which enables the user to select items from the list.
- * @see https://dialpad.design/components/combobox.html
+ * @see https://dialtone.dialpad.com/components/combobox.html
  */
 export default {
   name: 'DtCombobox',

--- a/packages/dialtone-vue3/components/emoji/emoji.vue
+++ b/packages/dialtone-vue3/components/emoji/emoji.vue
@@ -35,7 +35,7 @@ import { DtSkeleton } from '../skeleton';
 
 /**
  * Renders an emoji from a shortcode such as :smile: or unicode character such as 😄
- * @see https://dialpad.design/components/emoji.html
+ * @see https://dialtone.dialpad.com/components/emoji.html
  */
 export default {
   name: 'DtEmoji',
@@ -57,7 +57,7 @@ export default {
 
     /**
      * The size of the emoji. Can be any of the icon size utility classes from
-     * <a class="d-link" href="https://dialpad.design/components/icon.html" target="_blank"> Dialpad Icon Size</a>
+     * <a class="d-link" href="https://dialtone.dialpad.com/components/icon.html" target="_blank"> Dialpad Icon Size</a>
      * @values 100, 200, 300, 400, 500, 600, 700, 800
      */
     size: {

--- a/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -6,7 +6,7 @@ import { ICON_SIZE_MODIFIERS } from '@/components/icon/icon_constants';
 
 /**
  * Wrapper to find and replace shortcodes like :smile: or unicode chars such as 😄 with our custom Emojis implementation.
- * @see https://dialpad.design/components/emoji_text_wrapper.html
+ * @see https://dialtone.dialpad.com/components/emoji_text_wrapper.html
  */
 export default {
   name: 'DtEmojiTextWrapper',

--- a/packages/dialtone-vue3/components/icon/icon.vue
+++ b/packages/dialtone-vue3/components/icon/icon.vue
@@ -21,7 +21,7 @@ const dialtoneIcons = import.meta.glob(
 
 /**
  * The Icon component provides a set of glyphs and sizes to provide context your application.
- * @see https://dialpad.design/components/icon.html
+ * @see https://dialtone.dialpad.com/components/icon.html
  */
 export default {
   name: 'DtIcon',

--- a/packages/dialtone-vue3/components/input/input.vue
+++ b/packages/dialtone-vue3/components/input/input.vue
@@ -125,7 +125,7 @@ import { MessagesMixin } from '../../common/mixins/input.js';
  * It can have a range of options and supports single line and multi-line lengths,
  * as well as varying formats, including numbers, masked passwords, etc.
  * @property {Boolean} placeholder attribute
- * @see https://dialpad.design/components/input.html
+ * @see https://dialtone.dialpad.com/components/input.html
  */
 export default {
   name: 'DtInput',

--- a/packages/dialtone-vue3/components/input_group/input_group.vue
+++ b/packages/dialtone-vue3/components/input_group/input_group.vue
@@ -35,7 +35,7 @@ import { hasSlotContent } from '@/common/utils';
  * Input Groups are convenience components for a grouping of related inputs.
  * While each input within the group could be independent, the `v-model` on the group
  * provides a convenient interface for determining the current state of the group.
- * @see https://dialpad.design/components/input_group.html
+ * @see https://dialtone.dialpad.com/components/input_group.html
  */
 export default {
   name: 'DtInputGroup',

--- a/packages/dialtone-vue3/components/item_layout/item_layout.vue
+++ b/packages/dialtone-vue3/components/item_layout/item_layout.vue
@@ -62,7 +62,7 @@
 /**
  * Custom layout to enable developer to use list-item like stack.
  * It is used as base for `dt-list-item` component
- * @see https://dialpad.design/components/item_layout.html
+ * @see https://dialtone.dialpad.com/components/item_layout.html
  */
 <script>
 export default {

--- a/packages/dialtone-vue3/components/keyboard_shortcut/keyboard_shortcut.vue
+++ b/packages/dialtone-vue3/components/keyboard_shortcut/keyboard_shortcut.vue
@@ -46,7 +46,7 @@ import { SHORTCUTS_ICON_ALIASES, SHORTCUTS_ICON_SEPARATOR } from './keyboard_sho
 
 /**
  * This component displays a visual representation of a keyboard shortcut to the user.
- * @see https://dialpad.design/components/keyboard_shortcut.html
+ * @see https://dialtone.dialpad.com/components/keyboard_shortcut.html
  */
 export default {
   name: 'DtKeyboardShortcut',

--- a/packages/dialtone-vue3/components/lazy_show/lazy_show.vue
+++ b/packages/dialtone-vue3/components/lazy_show/lazy_show.vue
@@ -18,7 +18,7 @@
 <script>
 /**
  * Lazy Show is a utility component that prevents its children from being rendered until the first time it is shown.
- * @see https://dialpad.design/components/lazy_show.html
+ * @see https://dialtone.dialpad.com/components/lazy_show.html
  */
 export default {
   name: 'DtLazyShow',

--- a/packages/dialtone-vue3/components/link/link.vue
+++ b/packages/dialtone-vue3/components/link/link.vue
@@ -19,7 +19,7 @@ import { LINK_VARIANTS, LINK_KIND_MODIFIERS } from './link_constants';
  * A link is a navigational element that can be found on its own, within other text, or directly following content.
  * @property {String} href attribute
  * @property {String} rel attribute
- * @see https://dialpad.design/components/link.html
+ * @see https://dialtone.dialpad.com/components/link.html
  */
 export default {
   name: 'DtLink',

--- a/packages/dialtone-vue3/components/list_item/list_item.vue
+++ b/packages/dialtone-vue3/components/list_item/list_item.vue
@@ -51,7 +51,7 @@ import { DtItemLayout } from '@/components/item_layout';
 
 /**
  * A list item is an element that can be used to represent individual items in a list.
- * @see https://dialpad.design/components/list_item.html
+ * @see https://dialtone.dialpad.com/components/list_item.html
  */
 export default {
   name: 'DtListItem',

--- a/packages/dialtone-vue3/components/modal/modal.vue
+++ b/packages/dialtone-vue3/components/modal/modal.vue
@@ -130,7 +130,7 @@ import { NOTICE_KINDS } from '@/components/notice';
 /**
  * Modals focus the user’s attention exclusively on one task or piece of information
  * via a window that sits on top of the page content.
- * @see https://dialpad.design/components/modal.html
+ * @see https://dialtone.dialpad.com/components/modal.html
  */
 export default {
   name: 'DtModal',

--- a/packages/dialtone-vue3/components/notice/notice.vue
+++ b/packages/dialtone-vue3/components/notice/notice.vue
@@ -45,7 +45,7 @@ import SrOnlyCloseButtonMixin from '../../common/mixins/sr_only_close_button';
 
 /**
  * A notice is an informational and assistive message that appears inline with content.
- * @see https://dialpad.design/components/notice.html
+ * @see https://dialtone.dialpad.com/components/notice.html
  */
 export default {
   name: 'DtNotice',

--- a/packages/dialtone-vue3/components/pagination/pagination.vue
+++ b/packages/dialtone-vue3/components/pagination/pagination.vue
@@ -75,7 +75,7 @@ import { DtIcon } from '@/components/icon';
 
 /**
  * Pagination allows you to divide large amounts of content into smaller chunks across multiple pages.
- * @see https://dialpad.design/components/pagination.html
+ * @see https://dialtone.dialpad.com/components/pagination.html
  */
 export default {
   name: 'DtPagination',

--- a/packages/dialtone-vue3/components/popover/popover.vue
+++ b/packages/dialtone-vue3/components/popover/popover.vue
@@ -145,7 +145,7 @@ import { TOOLTIP_DELAY_MS } from '@/components/tooltip/index.js';
 
 /**
  * A Popover displays a content overlay when its anchor element is activated.
- * @see https://dialpad.design/components/popover.html
+ * @see https://dialtone.dialpad.com/components/popover.html
  */
 export default {
   name: 'DtPopover',

--- a/packages/dialtone-vue3/components/presence/presence.vue
+++ b/packages/dialtone-vue3/components/presence/presence.vue
@@ -26,7 +26,7 @@
 import { PRESENCE_STATES, PRESENCE_STATES_LIST } from './presence_constants';
 /**
  * Presence is a user status visual indicator element.
- * @see https://dialpad.design/components/presence.html
+ * @see https://dialtone.dialpad.com/components/presence.html
  */
 export default {
   name: 'DtPresence',

--- a/packages/dialtone-vue3/components/radio/radio.vue
+++ b/packages/dialtone-vue3/components/radio/radio.vue
@@ -62,7 +62,7 @@ import { hasSlotContent } from '@/common/utils';
 /**
  * Radios are control elements that allow the user to make a single selection.
  * They are typically used in a Radio Group which allows the user to make a selection from a list of options.
- * @see https://dialpad.design/components/radio.html
+ * @see https://dialtone.dialpad.com/components/radio.html
  */
 export default {
   name: 'DtRadio',

--- a/packages/dialtone-vue3/components/radio_group/radio_group.vue
+++ b/packages/dialtone-vue3/components/radio_group/radio_group.vue
@@ -3,7 +3,7 @@ import { DtInputGroup } from '../input_group';
 
 /**
  * Radio Groups are control elements that allow the user to make a single selection from a list of options.
- * @see https://dialpad.design/components/radio_group.html
+ * @see https://dialtone.dialpad.com/components/radio_group.html
  */
 export default {
   name: 'DtRadioGroup',

--- a/packages/dialtone-vue3/components/select_menu/select_menu.vue
+++ b/packages/dialtone-vue3/components/select_menu/select_menu.vue
@@ -98,7 +98,7 @@ import { DtValidationMessages } from '../validation_messages';
  * @property {Boolean} disabled attribute
  * @property {String} name attribute
  * @property {String} value attribute
- * @see https://dialpad.design/components/select.html
+ * @see https://dialtone.dialpad.com/components/select.html
  */
 export default {
   name: 'DtSelectMenu',

--- a/packages/dialtone-vue3/components/skeleton/skeleton.vue
+++ b/packages/dialtone-vue3/components/skeleton/skeleton.vue
@@ -45,7 +45,7 @@ import DtSkeletonText from './skeleton-text.vue';
  * Skeleton loader is a non-interactive placeholder that displays a preview of the UI to visually communicate
  * that content is in the process of loading. Skeleton is used to provide a low fidelity
  * representation of the user interface (UI) before content appears on the page.
- * @see https://dialpad.design/components/skeleton.html
+ * @see https://dialtone.dialpad.com/components/skeleton.html
  */
 export default {
   name: 'DtSkeleton',

--- a/packages/dialtone-vue3/components/tabs/tab.vue
+++ b/packages/dialtone-vue3/components/tabs/tab.vue
@@ -29,7 +29,7 @@ import { DtButton } from '../button';
 
 /**
  * Tabs allow users to navigation between grouped content in different views while within the same page context.
- * @see https://dialpad.design/components/tabs.html
+ * @see https://dialtone.dialpad.com/components/tabs.html
  */
 export default {
   name: 'DtTab',

--- a/packages/dialtone-vue3/components/tabs/tab_group.vue
+++ b/packages/dialtone-vue3/components/tabs/tab_group.vue
@@ -42,7 +42,7 @@ import {
 
 /**
  * Tabs allow users to navigation between grouped content in different views while within the same page context.
- * @see https://dialpad.design/components/tabs.html
+ * @see https://dialtone.dialpad.com/components/tabs.html
  */
 export default {
   name: 'DtTabGroup',

--- a/packages/dialtone-vue3/components/tabs/tab_panel.vue
+++ b/packages/dialtone-vue3/components/tabs/tab_panel.vue
@@ -19,7 +19,7 @@ import Modal from '../../common/mixins/modal.js';
 
 /**
  * Tabs allow users to navigation between grouped content in different views while within the same page context.
- * @see https://dialpad.design/components/tabs.html
+ * @see https://dialtone.dialpad.com/components/tabs.html
  */
 export default {
   name: 'DtTabPanel',

--- a/packages/dialtone-vue3/components/toast/toast.vue
+++ b/packages/dialtone-vue3/components/toast/toast.vue
@@ -55,7 +55,7 @@ import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
 /**
  * A toast notice, sometimes called a snackbar, is a time-based message that appears based on users' actions.
  * It contains at-a-glance information about outcomes and can be paired with actions.
- * @see https://dialpad.design/components/toast.html
+ * @see https://dialtone.dialpad.com/components/toast.html
  */
 export default {
   name: 'DtToast',

--- a/packages/dialtone-vue3/components/toggle/toggle.vue
+++ b/packages/dialtone-vue3/components/toggle/toggle.vue
@@ -35,7 +35,7 @@ import { TOGGLE_CHECKED_VALUES, TOGGLE_SIZE_MODIFIERS } from '@/components/toggl
 
 /**
  * A toggle (or "switch") is a button control element that allows the user to make a binary (on/off) selection.
- * @see https://dialpad.design/components/toggle.html
+ * @see https://dialtone.dialpad.com/components/toggle.html
  */
 export default {
 

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -66,7 +66,7 @@ import {
  * A tooltip is a floating label that briefly explains an action, function, or an element.
  * Its content is exclusively text and shouldn't be vital information for users.
  * If richer media is desired, consider using a popover instead.
- * @see https://dialpad.design/components/tooltip.html
+ * @see https://dialtone.dialpad.com/components/tooltip.html
  */
 export default {
   name: 'DtTooltip',

--- a/packages/dialtone-vue3/components/validation_messages/validation_messages.vue
+++ b/packages/dialtone-vue3/components/validation_messages/validation_messages.vue
@@ -32,7 +32,7 @@ import {
 /**
  * Validation messages are used to convey information to the user about the current state of the input element.
  * These messages can have an error, warning or success type.
- * @see https://dialpad.design/components/validation_messages.html
+ * @see https://dialtone.dialpad.com/components/validation_messages.html
  */
 export default {
   name: 'DtValidationMessages',

--- a/packages/dialtone-vue3/css/dialtone-globals.less
+++ b/packages/dialtone-vue3/css/dialtone-globals.less
@@ -1,5 +1,5 @@
 // Import dialtone style definitions as references globally so they can be used in
-// mixins. See: https://dialpad.design
+// mixins. See: https://dialtone.dialpad.com
 @import '@dialpad/dialtone-css/lib/build/less/components/modal';
 
 // Reset base font size to 12px.

--- a/packages/dialtone-vue3/docs/welcome.mdx
+++ b/packages/dialtone-vue3/docs/welcome.mdx
@@ -12,7 +12,7 @@ import { LogoContainer, Logo } from './components';
 
 <img src={`https://img.shields.io/badge/npm-${version.replaceAll('-', '--')}-7C52FF`} alt={`Version ${version}`} />
 
-Dialtone Vue is a library of Vue components for <a class="d-link" href="https://dialpad.design/">Dialtone</a>, by Dialpad.
+Dialtone Vue is a library of Vue components for <a class="d-link" href="https://dialtone.dialpad.com/">Dialtone</a>, by Dialpad.
 
 ## Goals
 
@@ -42,4 +42,4 @@ Dialpad projects.
 - **Bradley Hawkins** - Product Design
 - **Federico Sarassola** - Product Design
 
-[dt-components]: https://dialpad.design/components
+[dt-components]: https://dialtone.dialpad.com/components

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button/callbar_button.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button/callbar_button.vue
@@ -58,7 +58,7 @@ export default {
      * Determines whether the button should have active styling
      * default is false.
      * @values true, false
-     * @see https://dialpad.design/components/button/
+     * @see https://dialtone.dialpad.com/components/button/
      */
     active: {
       type: Boolean,
@@ -69,7 +69,7 @@ export default {
      * Determines whether the button should have danger styling
      * default is false.
      * @values true, false
-     * @see https://dialpad.design/components/button/
+     * @see https://dialtone.dialpad.com/components/button/
      */
     danger: {
       type: Boolean,
@@ -89,7 +89,7 @@ export default {
     /**
      * Whether the button is a circle or not.
      * @values true, false
-     * @see https://dialpad.design/components/button/
+     * @see https://dialtone.dialpad.com/components/button/
      */
     circle: {
       type: Boolean,

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -180,7 +180,7 @@ export default {
      * Determines whether the button should have active styling
      * default is false.
      * @values true, false
-     * @see https://dialpad.design/components/button/
+     * @see https://dialtone.dialpad.com/components/button/
      */
     active: {
       type: Boolean,
@@ -191,7 +191,7 @@ export default {
      * Determines whether the button should have danger styling
      * default is false.
      * @values true, false
-     * @see https://dialpad.design/components/button/
+     * @see https://dialtone.dialpad.com/components/button/
      */
     danger: {
       type: Boolean,

--- a/packages/dialtone-vue3/recipes/conversation_view/attachment_carousel/attachment_carousel.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/attachment_carousel/attachment_carousel.stories.js
@@ -22,69 +22,69 @@ import DtRecipeAttachmentCarouselDefaultTemplate from './attachment_carousel_def
 const mediaList = [
   {
     type: 'image',
-    path: 'https://vue.dialpad.design/assets/test-078acfea.jpg',
+    path: 'https://dialtone.dialpad.com/vue/assets/test-078acfea.jpg',
     altText: 'Image Alt Text',
   },
   {
     type: 'image',
     isUploading: true,
     progress: 97,
-    path: 'https://vue.dialpad.design/assets/test-078acfea.jpg',
+    path: 'https://dialtone.dialpad.com/vue/assets/test-078acfea.jpg',
     altText: 'Image Alt Text',
   },
   {
     type: 'image',
-    path: 'https://vue.dialpad.design/assets/fry-21e0f1a9.gif',
+    path: 'https://dialtone.dialpad.com/vue/assets/fry-21e0f1a9.gif',
     altText: 'Image Alt Text',
   },
   {
     type: 'image',
-    path: 'https://vue.dialpad.design/assets/test-078acfea.jpg',
+    path: 'https://dialtone.dialpad.com/vue/assets/test-078acfea.jpg',
     altText: 'Image Alt Text',
   },
   {
     type: 'image',
-    path: 'https://vue.dialpad.design/assets/test-078acfea.jpg',
+    path: 'https://dialtone.dialpad.com/vue/assets/test-078acfea.jpg',
     altText: 'Image Alt Text',
   },
   {
     type: 'image',
-    path: 'https://vue.dialpad.design/assets/test-078acfea.jpg',
+    path: 'https://dialtone.dialpad.com/vue/assets/test-078acfea.jpg',
     altText: 'Image Alt Text',
   },
   {
     type: 'image',
-    path: 'https://vue.dialpad.design/assets/test-078acfea.jpg',
+    path: 'https://dialtone.dialpad.com/vue/assets/test-078acfea.jpg',
     altText: 'Image Alt Text',
   },
   {
     type: 'image',
-    path: 'https://vue.dialpad.design/assets/test-078acfea.jpg',
+    path: 'https://dialtone.dialpad.com/vue/assets/test-078acfea.jpg',
     altText: 'Image Alt Text',
   },
   {
     type: 'image',
-    path: 'https://vue.dialpad.design/assets/test-078acfea.jpg',
+    path: 'https://dialtone.dialpad.com/vue/assets/test-078acfea.jpg',
     altText: 'Image Alt Text',
   },
   {
     type: 'image',
-    path: 'https://vue.dialpad.design/assets/test-078acfea.jpg',
+    path: 'https://dialtone.dialpad.com/vue/assets/test-078acfea.jpg',
     altText: 'Image Alt Text',
   },
   {
     type: 'image',
-    path: 'https://vue.dialpad.design/assets/test-078acfea.jpg',
+    path: 'https://dialtone.dialpad.com/vue/assets/test-078acfea.jpg',
     altText: 'Image Alt Text',
   },
   {
     type: 'image',
-    path: 'https://vue.dialpad.design/assets/test-078acfea.jpg',
+    path: 'https://dialtone.dialpad.com/vue/assets/test-078acfea.jpg',
     altText: 'Image Alt Text',
   },
   {
     type: 'image',
-    path: 'https://vue.dialpad.design/assets/test-078acfea.jpg',
+    path: 'https://dialtone.dialpad.com/vue/assets/test-078acfea.jpg',
     altText: 'Image Alt Text',
   },
 ];

--- a/packages/eslint-plugin-dialtone/lib/rules/custom-implementation.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/custom-implementation.js
@@ -20,7 +20,7 @@ module.exports = {
     fixable: null, // Or `code` or `whitespace`
     schema: [], // Add a schema if the rule has options
     messages: {
-      avoidRequireContext: 'Avoid custom dialtone icons implementation. Use DtIcon component instead https://vue.dialpad.design/?path=/docs/components-icon--default',
+      avoidRequireContext: 'Avoid custom dialtone icons implementation. Use DtIcon component instead https://dialtone.dialpad.com/vue/?path=/docs/components-icon--default',
       avoidCustomImport: 'Avoid importing dialtone icons with custom webpack alias'
     }
   },

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-component.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-component.js
@@ -32,31 +32,31 @@ module.exports = {
         fileName: 'select_menu',
         componentName: 'SelectMenu',
         replacement: 'DtComboboxWithPopover',
-        link: 'https://vue.dialpad.design/?path=/story/recipes-comboboxes-combobox-with-popover--default'
+        link: 'https://dialtone.dialpad.com/vue/?path=/story/recipes-comboboxes-combobox-with-popover--default'
       },
       {
         fileName: 'dropdown_menu',
         componentName: 'DropdownMenu',
         replacement: 'DtSelectMenu',
-        link: 'https://vue.dialpad.design/?path=/story/components-select-menu--default'
+        link: 'https://dialtone.dialpad.com/vue/?path=/story/components-select-menu--default'
       },
       {
         fileName: 'base_toggle',
         componentName: 'BaseToggle',
         replacement: 'DtToggle',
-        link: 'https://vue.dialpad.design/?path=/story/components-toggle--default'
+        link: 'https://dialtone.dialpad.com/vue/?path=/story/components-toggle--default'
       },
       {
         fileName: 'base_date_picker',
         componentName: 'BaseDatePicker',
         replacement: 'DtDatepicker',
-        link: 'https://vue.dialpad.design/?path=/story/components-datepicker--default'
+        link: 'https://dialtone.dialpad.com/vue/?path=/story/components-datepicker--default'
       },
       {
         fileName: 'checkbox',
         componentName: 'Checkbox',
         replacement: 'DtCheckbox',
-        link: 'https://vue.dialpad.design/?path=/story/components-checkbox--default'
+        link: 'https://dialtone.dialpad.com/vue/?path=/story/components-checkbox--default'
       }
     ]
 

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-directive.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-directive.js
@@ -30,7 +30,7 @@ module.exports = {
       {
         directiveName: 'tooltip',
         replacement: 'dt-tooltip',
-        link: 'https://vue.dialpad.design/?path=/docs/directives-tooltip--docs',
+        link: 'https://dialtone.dialpad.com/vue/?path=/docs/directives-tooltip--docs',
       },
     ];
 

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-icons.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-icons.js
@@ -20,7 +20,7 @@ module.exports = {
         fixable: null, // Or `code` or `whitespace`
         schema: [], // Add a schema if the rule has options
         messages: {
-            avoidDeprecatedImport: 'Avoid usage of old dialtone icons [deprecated]. Check https://dialpad.design/components/icon.html for details.',
+            avoidDeprecatedImport: 'Avoid usage of old dialtone icons [deprecated]. Check https://dialtone.dialpad.com/components/icon.html for details.',
         },
     },
     create(context) {

--- a/packages/eslint-plugin-dialtone/package.json
+++ b/packages/eslint-plugin-dialtone/package.json
@@ -47,6 +47,7 @@
     "requireindex": "^1.2.0"
   },
   "devDependencies": {
+    "eslint-plugin-eslint-plugin": "^5.2.1",
     "mocha": "^10.0.0"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -757,6 +757,9 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
     devDependencies:
+      eslint-plugin-eslint-plugin:
+        specifier: ^5.2.1
+        version: 5.2.1(eslint@8.55.0)
       mocha:
         specifier: ^10.0.0
         version: 10.2.0
@@ -7093,7 +7096,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.3.8(typescript@5.2.2)
-      vue-component-type-helpers: 1.8.26
+      vue-component-type-helpers: 1.8.27
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -13702,6 +13705,17 @@ packages:
       eslint: 8.55.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
+    dev: true
+
+  /eslint-plugin-eslint-plugin@5.2.1(eslint@8.55.0):
+    resolution: {integrity: sha512-W+WergGahmRTz5yhw/+6TVqlXZkxucK0rM6KWRjona3MYx8+QJ+9KpXn3sYi1lgLduitfmT8YiAmO4RPC/mxEQ==}
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      eslint: 8.55.0
+      eslint-utils: 3.0.0(eslint@8.55.0)
+      estraverse: 5.3.0
     dev: true
 
   /eslint-plugin-import@2.29.0(eslint@8.55.0):
@@ -27777,8 +27791,8 @@ packages:
     resolution: {integrity: sha512-lqWs/7fdRXoSBAlbouHBX+LNuaY6gI9xWW34m/ZIz9zVPYHEyw0b2/zaCBwlKx0NtKTeF/6pOpvrxVkh7nhIYg==}
     dev: true
 
-  /vue-component-type-helpers@1.8.26:
-    resolution: {integrity: sha512-CIwb7s8cqUuPpHDk+0DY8EJ/x8tzdzqw8ycX8hhw1GnbngTgSsIceHAqrrLjmv8zXi+j5XaiqYRQMw8sKyyjkw==}
+  /vue-component-type-helpers@1.8.27:
+    resolution: {integrity: sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==}
     dev: true
 
   /vue-demi@0.14.6(vue@3.3.8):


### PR DESCRIPTION
# docs: fix old dialpad.design links

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZzhhM3Vsc3E1YnRpMjMwNDR0ZTJ4OTFhMjl3cWYyOWdvZTNiaDFieSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/sTczweWUTxLqg/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Description

Fixed a ton of old dialpad.design links within the repo.
