### PR TITLE
fix: error in stories when component.props is undefined

### DIFF
--- a/packages/dialtone-vue2/common/storybook_utils.js
+++ b/packages/dialtone-vue2/common/storybook_utils.js
@@ -14,7 +14,7 @@ import iconNames from '@dialpad/dialtone-icons/dist/icons.json';
 export function createRenderConfig (component, defaultTemplate, argsData) {
   return {
     components: { [component.name]: defaultTemplate },
-    props: [...Object.keys(component.props), ...Object.keys(argsData)],
+    props: [...Object.keys(component.props ?? {}), ...Object.keys(argsData)],
     setup (props) {
       return { props };
     },


### PR DESCRIPTION
# fix: error in stories when component.props is undefined

## :hammer_and_wrench: Type Of Change
Small fix for some stories that were broken in staging. The stories were failing with `Cannot convert undefined or null to object`, due to `component.props` being undefined when no props where passed.

Affected stories:

Components/Checkbox: Variants
Recipes/Chips/Grouped Chip: Default
Components/Radio Group: Variants
<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->
**Before**
<img width="1434" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/e093bdfa-7574-4785-aa27-69dc4c2c034d">


**After**
<img width="983" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/eeecaf67-e66c-4cf3-b4bc-53ada3f3ee09">

