### PR TITLE
docs: fix datepicker table dark mode

### DIFF
--- a/packages/dialtone-vue2/components/datepicker/datepicker_default.story.vue
+++ b/packages/dialtone-vue2/components/datepicker/datepicker_default.story.vue
@@ -5,7 +5,7 @@
     </p>
     <br>
     <br>
-    <table>
+    <table class="d-table">
       <tr>
         <th>Format</th>
         <th>Result</th>
@@ -80,24 +80,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-table {
-    border-collapse: collapse;
-    width: 100%;
-  }
-
-  th, td {
-    padding: 8px;
-    text-align: left;
-    border-bottom: 1px solid #ddd;
-  }
-
-  th {
-    background-color: #f2f2f2;
-  }
-
-  tr:nth-child(even) {
-    background-color: #f9f9f9;
-  }
-</style>

--- a/packages/dialtone-vue3/components/datepicker/datepicker_default.story.vue
+++ b/packages/dialtone-vue3/components/datepicker/datepicker_default.story.vue
@@ -5,7 +5,7 @@
     </p>
     <br>
     <br>
-    <table>
+    <table class="d-table">
       <tr>
         <th>Format</th>
         <th>Result</th>
@@ -70,24 +70,3 @@ const props = defineProps({
 
 const currentSelectedDate = ref(props.date);
 </script>
-
-<style scoped>
-table {
-    border-collapse: collapse;
-    width: 100%;
-  }
-
-  th, td {
-    padding: 8px;
-    text-align: left;
-    border-bottom: 1px solid #ddd;
-  }
-
-  th {
-    background-color: #f2f2f2;
-  }
-
-  tr:nth-child(even) {
-    background-color: #f9f9f9;
-  }
-</style>


### PR DESCRIPTION
# docs: fix datepicker table dark mode

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/mfsBwmweYFu8geNmFs/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-1416

## :book: Description
Adds 'd-table' class to the table and removes custom styles.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

If new component:

<!--- There are lots of things to remember when adding a new component to the system! This is so you don't forget any of them. -->

- I am exporting any new components or constants:
  - [ ] from the index.js in the component directory.
  - [ ] from the index.js in the root (either `packages/dialtone-vue2` or `packages/dialtone-vue3`).
- [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
- [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
- [ ] I have added the new component to `common/components_list.cjs` in `packages/dialtone-vue2` and `packages/dialtone-vue3`
- [ ] I have created a component story in storybook
- [ ] I have created story / stories for any relevant component variants in storybook
- [ ] I have created a docs page for the component in storybook.
- [ ] I have checked that changing all props/slots via the UI in storybook works as expected.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

| Before | Now |
|------|------|
| <img width="1270" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/cb8c721e-d631-4d61-a547-52de26ffc831"> | <img width="1257" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/5db2edf5-e647-4c20-9bda-b0a651163bed"> |


## :link: Sources

<!--- Add any links to external reference material -->
