### PR TITLE
fix: inset shadow generation

### DIFF
--- a/packages/dialtone-css/postcss/dialtone-generators.cjs
+++ b/packages/dialtone-css/postcss/dialtone-generators.cjs
@@ -765,12 +765,14 @@ function boxShadows (declaration, mode = 'light') {
     .keys(dialtoneShadows)
     .forEach(shadowName => {
       const shadowVar = `--dt-shadow-${shadowName}`;
+      // in css inset shadows are defined by adding the inset keyword
+      const isInset = shadowName.includes('inset');
       const times = dialtoneShadows[shadowName];
       const value = Array(times)
         .fill(undefined)
         .map((val, i) => {
           const shadowNumber = i + 1;
-          return `var(${shadowVar}-${shadowNumber}-x) var(${shadowVar}-${shadowNumber}-y) var(${shadowVar}-${shadowNumber}-blur) var(${shadowVar}-${shadowNumber}-spread) var(${shadowVar}-${shadowNumber}-color)`;
+          return `var(${shadowVar}-${shadowNumber}-x) var(${shadowVar}-${shadowNumber}-y) var(${shadowVar}-${shadowNumber}-blur) var(${shadowVar}-${shadowNumber}-spread) var(${shadowVar}-${shadowNumber}-color)${isInset ? ' inset' : ''}`;
         }).join(', ');
 
       if (mode === 'light') {


### PR DESCRIPTION
# fix: inset shadow generation

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/ahrnBCBcKwwBJWbZot/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Description

Added keyword "inset" when shadow is inset.

## :bulb: Context

An inset shadow requires the keyword "inset" at the end of the shadow definition. 

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :link: Sources

https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#inset
