### PR TITLE
docs: move contributing guide to "guides"

### DIFF
--- a/apps/dialtone-documentation/docs/_data/site-nav.json
+++ b/apps/dialtone-documentation/docs/_data/site-nav.json
@@ -8,10 +8,6 @@
           "link": "/about/dialtone.html"
         },
         {
-          "text": "Contributing",
-          "link": "/about/contributing.html"
-        },
-        {
           "text": "What's New",
           "link": "/about/whats-new/"
         }
@@ -64,6 +60,10 @@
         {
           "text": "Getting started",
           "link": "/guides/getting-started/"
+        },
+        {
+          "text": "Contributing",
+          "link": "/guides/contributing/"
         },
         {
           "text": "Design principles",

--- a/apps/dialtone-documentation/docs/guides/contributing/index.md
+++ b/apps/dialtone-documentation/docs/guides/contributing/index.md
@@ -11,7 +11,7 @@ TBD
 
 ### Code
 
-To make changes in our Design System please first read the
+To make code changes in our Design System please first read the
 [CONTRIBUTING.md](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md#contributing)
 in our Dialtone repository.
 


### PR DESCRIPTION
# docs: move contributing guide to "guides"

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/2AVDG3vH0DVuiS9EYg/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Description

Moved contributing guide from "about" to "guides"

## :bulb: Context

A lot of devs were having trouble finding the contributing guide. The first place they are going to look for it is obviously "guides"

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
