### PR TITLE
chore: Add d-link style release notes links

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/MarkdownRender.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/MarkdownRender.vue
@@ -24,7 +24,11 @@ const props = defineProps({
 const markdownToHtml = computed(() => {
   // eslint-disable-next-line new-cap
   const md = new markdownIt({ html: true });
-  const renderedMarkdown = md.render(props.markdown);
+  let renderedMarkdown = md.render(props.markdown);
+
+  // Add 'd-link' class to all <a> tags
+  renderedMarkdown = renderedMarkdown.replace(/<a /g, '<a class="d-link" ');
+
   return renderedMarkdown;
 });
 </script>


### PR DESCRIPTION
# Add d-link style release notes links

![image](https://github.com/dialpad/dialtone/assets/1165933/cb0305b9-9228-423e-b99c-faa489aeecd4)


## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Description

Blue links were bugging me.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.
