### PR TITLE
fix: emoji_picker box-sizing

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/emoji-picker.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji-picker.less
@@ -38,6 +38,8 @@
     width: auto;
     max-width: calc(var(--dt-size-925) + var(--dt-size-400));
     margin: 0 var(--dt-space-500);
+    // !important to default value to override popover dialog box-sizing: border-box style
+    box-sizing: content-box !important;
   }
 
   &--footer {


### PR DESCRIPTION
# fix: emoji_picker box-sizing

In `with_popover` story.
Seems like popover is using `box-sizing: border-box` style, this is malfunctioning the emoji_pikcer style.

I added `box-sizing: content-box !important;` to override it with the default value.

Im not sure why or what could trigger this issue now.

Fix for Vue2 and Vue3 version.


BEFORE:
<img width="409" alt="Screenshot 2024-01-15 at 13 12 33" src="https://github.com/dialpad/dialtone/assets/89984179/cb41d9c0-b2c2-4284-bff7-f7febbfc67db">


AFTER:
<img width="409" alt="Screenshot 2024-01-15 at 13 12 53" src="https://github.com/dialpad/dialtone/assets/89984179/0a42f9df-2028-4fa7-ba0b-209f530743d0">
