### PR TITLE
fix: nx affected dependencies

### DIFF
--- a/apps/dialtone-documentation/project.json
+++ b/apps/dialtone-documentation/project.json
@@ -3,37 +3,11 @@
   "targets": {
     "build-docs": {
       "executor": "nx:run-script",
-      "dependsOn": [
-        {
-          "projects": [
-            "dialtone-css",
-            "dialtone-icons",
-            "dialtone-vue3"
-          ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "outputs": [],
-      "options": {
-        "script": "build",
-        "parallel": true
-      }
+      "options": { "script": "build" }
     },
     "start": {
       "executor": "nx:run-script",
-      "outputs": [],
-      "dependsOn": [
-        {
-          "projects": ["dialtone-vue3", "dialtone-icons"],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "options": {
-        "script": "start",
-        "parallel": true
-      }
+      "options": { "script": "start" }
     }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -4,18 +4,13 @@
     "defaultBase": "production"
   },
   "targetDefaults": {
-    "build": {
-      "cache": true,
-      "dependsOn": ["^build"]
-    },
-    "test": {
-      "cache": false,
-      "dependsOn": ["^build"]
-    },
-    "release": {
-      "cache": false,
-      "dependsOn": ["build", "^build"]
-    }
+    "build": { "cache": true, "dependsOn": ["^build"] },
+    "build-docs": { "cache": true, "dependsOn": ["^build"] },
+    "test": { "dependsOn": ["^build"] },
+    "release": { "dependsOn": ["build", "^build"] },
+    "release-local": { "dependsOn": ["build", "^build"] },
+    "release-github": { "dependsOn": ["build", "^build"] },
+    "start": { "dependsOn": ["^build"] }
   },
   "installation": {
     "version": "17.0.2"

--- a/packages/dialtone-css/project.json
+++ b/packages/dialtone-css/project.json
@@ -1,72 +1,27 @@
 {
   "name": "dialtone-css",
   "targets": {
-    "release-local": {
-      "executor": "nx:run-commands",
-      "outputs": [],
-      "dependsOn": [
-        {
-          "projects": [
-            "dialtone-tokens"
-          ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-css/release-local.config.cjs",
-        "parallel": false
-      }
-    },
     "release": {
       "executor": "nx:run-commands",
-      "outputs": [],
-      "dependsOn": [
-        {
-          "projects": [
-            "dialtone-tokens"
-          ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
       "options": {
-        "command": "pnpm publish --filter ./packages/dialtone-css",
-        "parallel": false
+        "command": "pnpm publish --filter ./packages/dialtone-css"
       }
     },
     "release-github": {
       "executor": "nx:run-commands",
-      "outputs": [],
-      "dependsOn": [
-        {
-          "projects": [
-            "dialtone-tokens"
-          ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
       "options": {
-        "command": "pnpm semantic-release-plus --extends ./packages/dialtone-css/release-ci.config.cjs",
-        "parallel": false
+        "command": "pnpm semantic-release-plus --extends ./packages/dialtone-css/release-ci.config.cjs"
+      }
+    },
+    "release-local": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-css/release-local.config.cjs"
       }
     },
     "start": {
       "executor": "nx:run-script",
-      "outputs": [],
-      "dependsOn": [
-        {
-          "projects": [
-            "dialtone-tokens"
-          ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "options": {
-        "script": "start"
-      }
+      "options": { "script": "start" }
     }
   }
 }

--- a/packages/dialtone-icons/project.json
+++ b/packages/dialtone-icons/project.json
@@ -1,28 +1,22 @@
 {
   "name": "dialtone-icons",
   "targets": {
-    "release-local": {
-      "executor": "nx:run-commands",
-      "outputs": [],
-      "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-icons/release-local.config.cjs",
-        "parallel": false
-      }
-    },
     "release": {
       "executor": "nx:run-commands",
-      "outputs": [],
       "options": {
-        "command": "pnpm publish --filter ./packages/dialtone-icons",
-        "parallel": false
+        "command": "pnpm publish --filter ./packages/dialtone-icons"
       }
     },
     "release-github": {
       "executor": "nx:run-commands",
-      "outputs": [],
       "options": {
-        "command": "pnpm semantic-release-plus --extends ./packages/dialtone-icons/release-ci.config.cjs",
-        "parallel": false
+        "command": "pnpm semantic-release-plus --extends ./packages/dialtone-icons/release-ci.config.cjs"
+      }
+    },
+    "release-local": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-icons/release-local.config.cjs"
       }
     }
   }

--- a/packages/dialtone-tokens/project.json
+++ b/packages/dialtone-tokens/project.json
@@ -1,55 +1,33 @@
 {
   "name": "dialtone-tokens",
   "targets": {
-    "release-local": {
-      "executor": "nx:run-commands",
-      "outputs": [],
-      "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-tokens/release-local.config.cjs",
-        "parallel": false
-      }
+    "publish:android-package": {
+      "executor": "nx:run-script",
+      "dependsOn": [{ "target": "build" }],
+      "options": { "script": "publish:android-package" }
+    },
+    "publish:ios-package": {
+      "executor": "nx:run-script",
+      "dependsOn": [{ "target": "build" }],
+      "options": { "script": "publish:ios-package" }
     },
     "release": {
       "executor": "nx:run-commands",
-      "outputs": [],
       "options": {
-        "command": "pnpm publish --filter ./packages/dialtone-tokens",
-        "parallel": false
+        "command": "pnpm publish --filter ./packages/dialtone-tokens"
       }
     },
     "release-github": {
       "executor": "nx:run-commands",
-      "outputs": [],
       "options": {
-        "command": "pnpm semantic-release-plus --extends ./packages/dialtone-tokens/release-ci.config.cjs",
-        "parallel": false
+        "command": "pnpm semantic-release-plus --extends ./packages/dialtone-tokens/release-ci.config.cjs"
       }
     },
-    "publish:ios-package": {
-      "executor": "nx:run-script",
-      "dependsOn": [
-        {
-          "projects": [ "dialtone-tokens"],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
+    "release-local": {
+      "executor": "nx:run-commands",
       "options": {
-        "script": "publish:ios-package"
+        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-tokens/release-local.config.cjs"
       }
     },
-    "publish:android-package": {
-      "executor": "nx:run-script",
-      "dependsOn": [
-        {
-          "projects": [ "dialtone-tokens"],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "options": {
-        "script": "publish:android-package"
-      }
-    }
   }
 }

--- a/packages/dialtone-vue2/project.json
+++ b/packages/dialtone-vue2/project.json
@@ -3,85 +3,33 @@
   "targets": {
     "build": {
       "executor": "nx:run-script",
-      "dependsOn": [
-        {
-          "projects": [ "dialtone-icons" ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "outputs": [],
-      "options": {
-        "script": "build",
-        "parallel": false
-      }
+      "options": { "script": "build" }
     },
     "build-docs": {
       "executor": "nx:run-script",
-      "dependsOn": [
-        {
-          "projects": [ "dialtone-css", "dialtone-icons" ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "outputs": [],
-      "options": {
-        "script": "storybook:build",
-        "parallel": false
-      }
-    },
-    "release-local": {
-      "executor": "nx:run-commands",
-      "outputs": [],
-      "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-vue2/release-local.config.cjs",
-        "parallel": false
-      }
+      "options": { "script": "storybook:build" }
     },
     "release": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        {
-          "projects": [ "dialtone-icons" ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "outputs": [],
       "options": {
-        "command": "pnpm publish --filter ./packages/dialtone-vue2 --tag latest",
-        "parallel": false
+        "command": "pnpm publish --filter ./packages/dialtone-vue2 --tag latest"
       }
     },
     "release-github": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        {
-          "projects": [ "dialtone-icons" ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "outputs": [],
       "options": {
-        "command": "pnpm semantic-release-plus --extends ./packages/dialtone-vue2/release-ci.config.cjs",
-        "parallel": false
+        "command": "pnpm semantic-release-plus --extends ./packages/dialtone-vue2/release-ci.config.cjs"
+      }
+    },
+    "release-local": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-vue2/release-local.config.cjs"
       }
     },
     "test": {
       "executor": "nx:run-script",
-      "dependsOn": [
-        {
-          "projects": [ "dialtone-icons" ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "options": {
-        "script": "test",
-        "parallel": true
-      }
+      "options": { "script": "test" }
     }
   }
 }

--- a/packages/dialtone-vue3/project.json
+++ b/packages/dialtone-vue3/project.json
@@ -3,85 +3,33 @@
   "targets": {
     "build": {
       "executor": "nx:run-script",
-      "dependsOn": [
-        {
-          "projects": [ "dialtone-icons" ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "outputs": [],
-      "options": {
-        "script": "build",
-        "parallel": false
-      }
+      "options": { "script": "build" }
     },
     "build-docs": {
       "executor": "nx:run-script",
-      "dependsOn": [
-        {
-          "projects": [ "dialtone-css", "dialtone-icons" ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "outputs": [],
-      "options": {
-        "script": "storybook:build",
-        "parallel": true
-      }
-    },
-    "release-local": {
-      "executor": "nx:run-commands",
-      "outputs": [],
-      "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-vue3/release-local.config.cjs",
-        "parallel": false
-      }
+      "options": { "script": "storybook:build" }
     },
     "release": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        {
-          "projects": [ "dialtone-icons" ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "outputs": [],
       "options": {
-        "command": "pnpm publish --filter ./packages/dialtone-vue3 --tag vue3",
-        "parallel": false
+        "command": "pnpm publish --filter ./packages/dialtone-vue3 --tag vue3"
       }
     },
     "release-github": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        {
-          "projects": [ "dialtone-icons" ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "outputs": [],
       "options": {
-        "command": "pnpm semantic-release-plus --extends ./packages/dialtone-vue3/release-ci.config.cjs",
-        "parallel": false
+        "command": "pnpm semantic-release-plus --extends ./packages/dialtone-vue3/release-ci.config.cjs"
+      }
+    },
+    "release-local": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-vue3/release-local.config.cjs"
       }
     },
     "test": {
       "executor": "nx:run-script",
-      "dependsOn": [
-        {
-          "projects": [ "dialtone-icons" ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "options": {
-        "script": "test",
-        "parallel": true
-      }
+      "options": { "script": "test" }
     }
   }
 }

--- a/packages/eslint-plugin-dialtone/project.json
+++ b/packages/eslint-plugin-dialtone/project.json
@@ -1,17 +1,8 @@
 {
   "name": "eslint-plugin-dialtone",
   "targets": {
-    "release-local": {
-      "executor": "nx:run-commands",
-      "outputs": [],
-      "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/eslint-plugin-dialtone/release-local.config.cjs",
-        "parallel": false
-      }
-    },
     "release": {
       "executor": "nx:run-commands",
-      "outputs": [],
       "options": {
         "command": "pnpm publish --filter ./packages/eslint-plugin-dialtone",
         "parallel": false
@@ -19,9 +10,15 @@
     },
     "release-github": {
       "executor": "nx:run-commands",
-      "outputs": [],
       "options": {
         "command": "pnpm semantic-release-plus --extends ./packages/eslint-plugin-dialtone/release-ci.config.cjs",
+        "parallel": false
+      }
+    },
+    "release-local": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/eslint-plugin-dialtone/release-local.config.cjs",
         "parallel": false
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,24 @@ importers:
       '@dialpad/conventional-changelog-angular':
         specifier: ^1.1.1
         version: 1.1.1
+      '@dialpad/dialtone-css':
+        specifier: workspace:*
+        version: link:packages/dialtone-css
+      '@dialpad/dialtone-icons':
+        specifier: workspace:*
+        version: link:packages/dialtone-icons
+      '@dialpad/dialtone-tokens':
+        specifier: workspace:*
+        version: link:packages/dialtone-tokens
+      '@dialpad/dialtone-vue2':
+        specifier: ./packages/dialtone-vue2
+        version: link:packages/dialtone-vue2
+      '@dialpad/dialtone-vue3':
+        specifier: ./packages/dialtone-vue3
+        version: link:packages/dialtone-vue3
+      '@dialpad/eslint-plugin-dialtone':
+        specifier: workspace:*
+        version: link:packages/eslint-plugin-dialtone
       '@dialpad/semantic-release-changelog-json':
         specifier: ^1.0.0
         version: 1.0.0(semantic-release@21.1.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,24 +23,6 @@ importers:
       '@dialpad/conventional-changelog-angular':
         specifier: ^1.1.1
         version: 1.1.1
-      '@dialpad/dialtone-css':
-        specifier: workspace:*
-        version: link:packages/dialtone-css
-      '@dialpad/dialtone-icons':
-        specifier: workspace:*
-        version: link:packages/dialtone-icons
-      '@dialpad/dialtone-tokens':
-        specifier: workspace:*
-        version: link:packages/dialtone-tokens
-      '@dialpad/dialtone-vue2':
-        specifier: ./packages/dialtone-vue2
-        version: link:packages/dialtone-vue2
-      '@dialpad/dialtone-vue3':
-        specifier: ./packages/dialtone-vue3
-        version: link:packages/dialtone-vue3
-      '@dialpad/eslint-plugin-dialtone':
-        specifier: workspace:*
-        version: link:packages/eslint-plugin-dialtone
       '@dialpad/semantic-release-changelog-json':
         specifier: ^1.0.0
         version: 1.0.0(semantic-release@21.1.2)

--- a/project.json
+++ b/project.json
@@ -1,67 +1,23 @@
 {
   "name": "dialtone",
+  "implicitDependencies": [
+    "dialtone-css",
+    "dialtone-icons",
+    "dialtone-tokens",
+    "dialtone-vue2",
+    "dialtone-vue3",
+    "eslint-plugin-dialtone"
+  ],
   "targets": {
     "build": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        {
-          "projects": [
-            "dialtone-css",
-            "dialtone-icons",
-            "dialtone-tokens",
-            "dialtone-vue2",
-            "dialtone-vue3",
-            "eslint-plugin-dialtone"
-          ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
       "options": {
         "command": "gulp",
         "parallel": false
       }
     },
-    "release-local": {
-      "executor": "nx:run-commands",
-      "outputs": [],
-      "dependsOn": [
-        {
-          "projects": [
-            "dialtone-css",
-            "dialtone-icons",
-            "dialtone-tokens",
-            "dialtone-vue2",
-            "dialtone-vue3",
-            "eslint-plugin-dialtone"
-          ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
-      "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./release-local.config.cjs",
-        "parallel": false
-      }
-    },
     "release": {
       "executor": "nx:run-commands",
-      "outputs": [],
-      "dependsOn": [
-        {
-          "projects": [
-            "dialtone",
-            "dialtone-css",
-            "dialtone-icons",
-            "dialtone-tokens",
-            "dialtone-vue2",
-            "dialtone-vue3",
-            "eslint-plugin-dialtone"
-          ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
       "options": {
         "command": "pnpm publish --tag next",
         "parallel": false
@@ -69,23 +25,15 @@
     },
     "release-github": {
       "executor": "nx:run-commands",
-      "outputs": [],
-      "dependsOn": [
-        {
-          "projects": [
-            "dialtone-css",
-            "dialtone-icons",
-            "dialtone-tokens",
-            "dialtone-vue2",
-            "dialtone-vue3",
-            "eslint-plugin-dialtone"
-          ],
-          "target": "build",
-          "params": "ignore"
-        }
-      ],
       "options": {
         "command": "pnpm semantic-release-plus --extends ./release-ci.config.cjs",
+        "parallel": false
+      }
+    },
+    "release-local": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm semantic-release-plus --no-ci --extends ./release-local.config.cjs",
         "parallel": false
       }
     }


### PR DESCRIPTION
# Fix NX affected dependencies

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/3o6Zt2FsmthIOdUm5y/giphy.gif?cid=82a1493bmdx6nlwtg35lymypk9fnymgclxan4kjmm2qw55zg&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

No Jira ticket

## :book: Description

- Added implicit dependencies to root package
- Clean up unneeded configs from packages project.json

## :bulb: Context

We had issues related to release the mono-package because the dependencies were not
being detected by NX.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

- Remove 9.5.1 tag and release from GitHub
- Release dialtone 9.5.1 version again

## :link: Sources

https://nx.dev/reference/project-configuration#implicitdependencies
