### PR TITLE
fix: input focus within

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/input.less
+++ b/packages/dialtone-css/lib/build/less/components/input.less
@@ -169,7 +169,8 @@
         background-color: transparent;
         border: none;
 
-        &:focus {
+        &:focus,
+        &:focus-within {
             border: none;
             outline: 0;
             box-shadow: none !important;


### PR DESCRIPTION
# Input focus within

Jira ticket: [DLT-1386](https://dialpad.atlassian.net/browse/DLT-1386)

There were some situations where this outline appear on focus:

<img width="530" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/a7eda55b-2275-457d-8d72-772457edf4c1">

<img width="530" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/10252610-ee41-4cdb-a459-a90bd808a34a">

<img width="530" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/f40b83a4-1a21-4598-81e5-ba30f326eb27">

---

Seems like it was a missing pseudo-class`:focus-within`.
I added it to our `dialtone-css` package and solve all variants of this issue.

---

`packages/dialtone-css/lib/build/less/components/input.less`

```
 &:focus,
        &:focus-within {
            border: none;
            outline: 0;
            box-shadow: none !important;
        }
```

After:

Vue3 fix:
<img width="642" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/4d14045f-06e4-480a-b219-06d4e09a2453">

Vue2 fix:
<img width="642" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/a43f0d79-5c73-4a97-9233-87036dcdf01c">





[DLT-1386]: https://dialpad.atlassian.net/browse/DLT-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ