### PR TITLE
fix(select-menu): corrected selectmenu's icon color in dark mode

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/selects.less
+++ b/packages/dialtone-css/lib/build/less/components/selects.less
@@ -41,6 +41,10 @@
     transform: translateY(-50%);
     content: '';
     pointer-events: none;
+
+    .dialtone-theme-dark & {
+      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSIxMiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDEyIDEyIj4KICA8cGF0aCBmaWxsPSIjQUFBIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0zLjE0NiA3LjE0NmEuNS41IDAgMCAxIC43MDggMEw2IDkuMjkzbDIuMTQ2LTIuMTQ3YS41LjUgMCAxIDEgLjcwOC43MDhsLTIuNSAyLjVhLjUuNSAwIDAgMS0uNzA4IDBsLTIuNS0yLjVhLjUuNSAwIDAgMSAwLS43MDhabTIuNS01LjVhLjUuNSAwIDAgMSAuNzA4IDBsMi41IDIuNWEuNS41IDAgMSAxLS43MDguNzA4TDYgMi43MDcgMy44NTQgNC44NTRhLjUuNSAwIDAgMS0uNzA4LS43MDhsMi41LTIuNVoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPgo8L3N2Zz4K');
+    }
   }
 }
 


### PR DESCRIPTION
# PR Title

Corrected selectmenu's icon color in dark mode

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :pencil: Checklist

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :camera: Screenshots / GIFs

![image](https://github.com/dialpad/dialtone/assets/1165933/a550d96f-c99b-4815-bcc0-92df54b6e9ab)
