### PR TITLE
chore: Icon search field icon size

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/views/IconCatalog.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/views/IconCatalog.vue
@@ -17,6 +17,7 @@
         </template>
         <template #rightIcon>
           <dt-button
+            v-if="!isSearchEmpty"
             id="search-input-button-close"
             kind="muted"
             importance="clear"
@@ -167,6 +168,8 @@ const resetCategory = () => {
   selectedCategory.value = '';
 };
 
+const isSearchEmpty = computed(() => !search.value || search.value.trim().length === 0);
+
 const hasSearchResults = computed(() => Object.keys(filteredIconsList.value).length > 0);
 
 /**
@@ -258,6 +261,6 @@ onMounted(() => {
 <style scoped>
   /* more or less a hack, 🤷‍♂️ */
   #search-input-button-close {
-    margin-right: var(--dt-size-300-negative);
+    margin-right: var(--dt-size-350-negative);
   }
 </style>

--- a/apps/dialtone-documentation/docs/.vuepress/views/IconCatalog.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/views/IconCatalog.vue
@@ -13,19 +13,20 @@
         @keyup="searchIcon"
       >
         <template #leftIcon>
-          <dt-icon name="search" />
+          <dt-icon name="search" size="300" />
         </template>
         <template #rightIcon>
           <dt-button
             id="search-input-button-close"
             kind="muted"
             importance="clear"
+            size="xs"
             circle
             aria-label="Clear filters"
             @click="resetSearch"
           >
             <template #icon>
-              <dt-icon name="close" />
+              <dt-icon name="close" size="200" />
             </template>
           </dt-button>
         </template>


### PR DESCRIPTION
# Icon search field icon size

![image](https://github.com/dialpad/dialtone/assets/1165933/00882977-4037-43e0-af55-1dbebde241dd)

## :hammer_and_wrench: Type Of Change

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [x] Other (chore)

## :book: Description

1. Correct Icon Search field icon size
2. Conditionally display clear button

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.