### PR TITLE
feat: datepicker full language support

### DIFF
--- a/packages/dialtone-vue2/components/datepicker/datepicker.test.js
+++ b/packages/dialtone-vue2/components/datepicker/datepicker.test.js
@@ -1,7 +1,7 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import { formatMonth } from '@/components/datepicker/utils.js';
 import DtDatepicker from './datepicker.vue';
-import { MONTH_FORMAT } from '@/components/datepicker/datepicker_constants.js';
+import { INTL_MONTH_FORMAT } from '@/components/datepicker/datepicker_constants.js';
 
 const MOCK_DAY = 21;
 const MOCK_MONTH = 6; // Note: month is zero-based, so 6 represents July
@@ -10,7 +10,7 @@ const MOCK_TEST_DATE = new Date(MOCK_YEAR, MOCK_MONTH, MOCK_DAY);
 
 const MOCK_TODAY_YEAR = MOCK_TEST_DATE.getFullYear();
 const MOCK_TODAY_MONTH = MOCK_TEST_DATE.getMonth();
-const MOCK_FORMATTED_TODAY_MONTH = formatMonth(MOCK_TODAY_MONTH, MONTH_FORMAT);
+const MOCK_FORMATTED_TODAY_MONTH = formatMonth(MOCK_TODAY_MONTH, INTL_MONTH_FORMAT);
 const MOCK_HEADER_SELECTED_DATE = `${MOCK_FORMATTED_TODAY_MONTH} ${MOCK_TODAY_YEAR}`;
 
 const baseProps = {
@@ -144,13 +144,13 @@ describe('DtDatepicker Tests', () => {
       it('previous month button should has correct aria label', () => {
         expect(prevMonthButton.attributes('aria-label'))
         // eslint-disable-next-line max-len
-          .toContain(`${baseProps.changeToLabel} ${baseProps.prevMonthLabel} ${formatMonth(MOCK_TODAY_MONTH - 1, MONTH_FORMAT)}`);
+          .toContain(`${baseProps.changeToLabel} ${baseProps.prevMonthLabel} ${formatMonth(MOCK_TODAY_MONTH - 1, INTL_MONTH_FORMAT)}`);
       });
 
       it('next month button should has correct aria label', () => {
         expect(nextMonthButton.attributes('aria-label'))
         // eslint-disable-next-line max-len
-          .toContain(`${baseProps.changeToLabel} ${baseProps.nextMonthLabel} ${formatMonth(MOCK_TODAY_MONTH + 1, MONTH_FORMAT)}`);
+          .toContain(`${baseProps.changeToLabel} ${baseProps.nextMonthLabel} ${formatMonth(MOCK_TODAY_MONTH + 1, INTL_MONTH_FORMAT)}`);
       });
 
       it('next year button should has correct aria label', () => {
@@ -267,7 +267,7 @@ describe('DtDatepicker Tests', () => {
 
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
     });
 
     it('should update month when next month button is clicked', async () => {
@@ -275,7 +275,7 @@ describe('DtDatepicker Tests', () => {
 
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH + 1, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH + 1, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
     });
 
     it('should go to previous month on left arrow press on first day', async () => {
@@ -285,7 +285,7 @@ describe('DtDatepicker Tests', () => {
 
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
     });
 
     it('should go to next month on right arrow press on last day', async () => {
@@ -296,7 +296,7 @@ describe('DtDatepicker Tests', () => {
       // Should be June
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
 
       const daysJune = wrapper.findAll('.d-datepicker__day');
 
@@ -305,7 +305,7 @@ describe('DtDatepicker Tests', () => {
       // Should be July again
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
     });
 
     it('should go to prev month on up arrow press on some day of first week month', async () => {
@@ -316,7 +316,7 @@ describe('DtDatepicker Tests', () => {
       // Should be June
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
     });
 
     it('should go to next month on down arrow press on some day of last week month', async () => {
@@ -327,7 +327,7 @@ describe('DtDatepicker Tests', () => {
       // Should be June
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
 
       const daysJune = wrapper.findAll('.d-datepicker__day');
 
@@ -336,7 +336,7 @@ describe('DtDatepicker Tests', () => {
       // Should be July again
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
     });
 
     it('should emit selected-date event when a day is clicked', async () => {

--- a/packages/dialtone-vue2/components/datepicker/datepicker.vue
+++ b/packages/dialtone-vue2/components/datepicker/datepicker.vue
@@ -7,6 +7,7 @@
     <div class="d-datepicker__hd">
       <month-year-picker
         ref="monthYearPicker"
+        :locale="locale"
         :prev-month-label="prevMonthLabel"
         :next-month-label="nextMonthLabel"
         :prev-year-label="prevYearLabel"

--- a/packages/dialtone-vue2/components/datepicker/datepicker_constants.js
+++ b/packages/dialtone-vue2/components/datepicker/datepicker_constants.js
@@ -6,3 +6,5 @@
 export const WEEK_START = 0;
 
 export const MONTH_FORMAT = 'MMMM';
+
+export const INTL_MONTH_FORMAT = 'long';

--- a/packages/dialtone-vue2/components/datepicker/datepicker_default.story.vue
+++ b/packages/dialtone-vue2/components/datepicker/datepicker_default.story.vue
@@ -12,31 +12,31 @@
       </tr>
       <tr>
         <td>formatLong</td>
-        <td>{{ formatLong(currentSelectedDate) }}</td>
+        <td>{{ formatLong(currentSelectedDate, $attrs.locale) }}</td>
       </tr>
       <tr>
         <td>formatMedium</td>
-        <td>{{ formatMedium(currentSelectedDate) }}</td>
+        <td>{{ formatMedium(currentSelectedDate, $attrs.locale) }}</td>
       </tr>
       <tr>
         <td>formatShort</td>
-        <td>{{ formatShort(currentSelectedDate) }}</td>
+        <td>{{ formatShort(currentSelectedDate, $attrs.locale) }}</td>
       </tr>
       <tr>
         <td>formatShort (no weekday)</td>
-        <td>{{ formatShort(currentSelectedDate, false) }}</td>
+        <td>{{ formatShort(currentSelectedDate, $attrs.locale, false) }}</td>
       </tr>
       <tr>
         <td>formatNoYear</td>
-        <td>{{ formatNoYear(currentSelectedDate) }}</td>
+        <td>{{ formatNoYear(currentSelectedDate, $attrs.locale) }}</td>
       </tr>
       <tr>
         <td>formatNoYear (abbreviated)</td>
-        <td>{{ formatNoYear(currentSelectedDate, true) }}</td>
+        <td>{{ formatNoYear(currentSelectedDate, $attrs.locale, true) }}</td>
       </tr>
       <tr>
         <td>formatNumerical</td>
-        <td>{{ formatNumerical(currentSelectedDate) }}</td>
+        <td>{{ formatNumerical(currentSelectedDate, $attrs.locale) }}</td>
       </tr>
     </table>
     <br>

--- a/packages/dialtone-vue2/components/datepicker/formatUtils.js
+++ b/packages/dialtone-vue2/components/datepicker/formatUtils.js
@@ -1,25 +1,23 @@
-import { format } from 'date-fns';
-
-export function formatLong (date) {
-  return format(date, 'EEEE, MMMM d, yyyy');
+export function formatLong (date, locale = 'default') {
+  return new Intl.DateTimeFormat(locale, { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }).format(date);
 }
 
-export function formatMedium (date) {
-  return format(date, 'MMMM d, yyyy');
+export function formatMedium (date, locale = 'default') {
+  return new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'long', day: 'numeric' }).format(date);
 }
 
-export function formatShort (date, showWeekday = true) {
-  const formatString = showWeekday ? 'EEE, MMM d, yyyy' : 'MMM d, yyyy';
-  return format(date, formatString);
+export function formatShort (date, locale = 'default', showWeekday = true) {
+  const options = showWeekday ? { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' } : { year: 'numeric', month: 'short', day: 'numeric' };
+  return new Intl.DateTimeFormat(locale, options).format(date);
 }
 
-export function formatNoYear (date, abbreviated = false) {
-  const formatString = abbreviated ? 'MMM d' : 'MMMM d';
-  return format(date, formatString);
+export function formatNoYear (date, locale = 'default', abbreviated = false) {
+  const monthFormat = abbreviated ? 'short' : 'long';
+  return new Intl.DateTimeFormat(locale, { month: monthFormat, day: 'numeric' }).format(date);
 }
 
-export function formatNumerical (date) {
-  return format(date, 'MM/dd/yy');
+export function formatNumerical (date, locale = 'default') {
+  return new Intl.DateTimeFormat(locale, { year: '2-digit', month: '2-digit', day: '2-digit' }).format(date);
 }
 
 export default {

--- a/packages/dialtone-vue2/components/datepicker/modules/month-year-picker.vue
+++ b/packages/dialtone-vue2/components/datepicker/modules/month-year-picker.vue
@@ -49,7 +49,7 @@
             :circle="true"
             class="d-datepicker__nav-btn"
             type="button"
-            :aria-label="`${changeToLabel} ${prevMonthLabel} ${formattedMonth(selectMonth - 1, MONTH_FORMAT)}`"
+            :aria-label="`${changeToLabel} ${prevMonthLabel} ${formattedMonth(selectMonth - 1)}`"
             @click="changeMonth(-1)"
             @keydown="handleKeyDown($event)"
           >
@@ -65,7 +65,7 @@
       id="calendar-heading"
       class="d-datepicker__month-year-title"
     >
-      {{ formattedMonth(selectMonth, MONTH_FORMAT) }}
+      {{ formattedMonth(selectMonth) }}
 
       {{ selectYear }}
     </div>
@@ -89,7 +89,7 @@
             kind="muted"
             class="d-datepicker__nav-btn"
             type="button"
-            :aria-label="`${changeToLabel} ${nextMonthLabel} ${formattedMonth(selectMonth + 1, MONTH_FORMAT)}`"
+            :aria-label="`${changeToLabel} ${nextMonthLabel} ${formattedMonth(selectMonth + 1)}`"
             @click="changeMonth(1)"
             @keydown="handleKeyDown($event)"
           >
@@ -133,7 +133,7 @@
 import { DtIcon } from '@/components/icon';
 import { getYear, addMonths, getMonth, set, subMonths, getDate } from 'date-fns';
 import { getCalendarDays, formatMonth } from '../utils';
-import { MONTH_FORMAT } from '../datepicker_constants';
+import { INTL_MONTH_FORMAT } from '../datepicker_constants';
 import DtStack from '@/components/stack/stack.vue';
 import DtTooltip from '@/components/tooltip/tooltip.vue';
 import DtButton from '@/components/button/button.vue';
@@ -144,6 +144,11 @@ export default {
   components: { DtButton, DtTooltip, DtStack, DtIcon },
 
   props: {
+    locale: {
+      type: String,
+      required: true,
+    },
+
     prevMonthLabel: {
       type: String,
       required: true,
@@ -223,11 +228,7 @@ export default {
     },
 
     formattedMonth () {
-      return (month, format) => formatMonth(month, format);
-    },
-
-    MONTH_FORMAT () {
-      return MONTH_FORMAT;
+      return (month) => formatMonth(month, INTL_MONTH_FORMAT, this.locale);
     },
   },
 

--- a/packages/dialtone-vue2/components/datepicker/utils.js
+++ b/packages/dialtone-vue2/components/datepicker/utils.js
@@ -1,5 +1,5 @@
 import {
-  startOfWeek, addDays, getMonth, isEqual, format,
+  startOfWeek, addDays, getMonth, isEqual,
   addMonths, startOfMonth, getDay, getDate,
   subMonths, endOfMonth,
 } from 'date-fns';
@@ -88,8 +88,8 @@ export const getWeekDayNames = (locale, weekStart) => {
   return [days[weekStart]].concat(...afterWeekStart).concat(...beforeWeekStart);
 };
 
-export const formatMonth = (month, monthFormat) => {
-  return format(new Date(2000, month, 1), monthFormat);
+export const formatMonth = (month, monthFormat, locale) => {
+  return new Intl.DateTimeFormat(locale, { month: monthFormat }).format(new Date(2000, month, 1));
 };
 
 export const calculateNextFocusDate = (currentDate) => {

--- a/packages/dialtone-vue3/components/datepicker/composables/useMonthYearPicker.js
+++ b/packages/dialtone-vue3/components/datepicker/composables/useMonthYearPicker.js
@@ -14,7 +14,7 @@ export function useMonthYearPicker (props, emits) {
   });
 
   const formattedMonth = computed(() => {
-    return (month, format) => formatMonth(month, format);
+    return (month, format, locale) => formatMonth(month, format, locale);
   });
 
   watch(selectMonth, () => {

--- a/packages/dialtone-vue3/components/datepicker/datepicker.test.js
+++ b/packages/dialtone-vue3/components/datepicker/datepicker.test.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { formatMonth } from '@/components/datepicker/utils.js';
 import DtDatepicker from './datepicker.vue';
-import { MONTH_FORMAT } from '@/components/datepicker/datepicker_constants.js';
+import { INTL_MONTH_FORMAT } from '@/components/datepicker/datepicker_constants.js';
 
 const MOCK_DAY = 21;
 const MOCK_MONTH = 6; // Note: month is zero-based, so 6 represents July
@@ -10,7 +10,7 @@ const MOCK_TEST_DATE = new Date(MOCK_YEAR, MOCK_MONTH, MOCK_DAY);
 
 const MOCK_TODAY_YEAR = MOCK_TEST_DATE.getFullYear();
 const MOCK_TODAY_MONTH = MOCK_TEST_DATE.getMonth();
-const MOCK_FORMATTED_TODAY_MONTH = formatMonth(MOCK_TODAY_MONTH, MONTH_FORMAT);
+const MOCK_FORMATTED_TODAY_MONTH = formatMonth(MOCK_TODAY_MONTH, INTL_MONTH_FORMAT);
 const MOCK_HEADER_SELECTED_DATE = `${MOCK_FORMATTED_TODAY_MONTH} ${MOCK_TODAY_YEAR}`;
 
 const baseProps = {
@@ -138,13 +138,13 @@ describe('DtDatepicker Tests', () => {
       it('previous month button should has correct aria label', () => {
         expect(prevMonthButton.attributes('aria-label'))
         // eslint-disable-next-line max-len
-          .toContain(`${baseProps.changeToLabel} ${baseProps.prevMonthLabel} ${formatMonth(MOCK_TODAY_MONTH - 1, MONTH_FORMAT)}`);
+          .toContain(`${baseProps.changeToLabel} ${baseProps.prevMonthLabel} ${formatMonth(MOCK_TODAY_MONTH - 1, INTL_MONTH_FORMAT)}`);
       });
 
       it('next month button should has correct aria label', () => {
         expect(nextMonthButton.attributes('aria-label'))
         // eslint-disable-next-line max-len
-          .toContain(`${baseProps.changeToLabel} ${baseProps.nextMonthLabel} ${formatMonth(MOCK_TODAY_MONTH + 1, MONTH_FORMAT)}`);
+          .toContain(`${baseProps.changeToLabel} ${baseProps.nextMonthLabel} ${formatMonth(MOCK_TODAY_MONTH + 1, INTL_MONTH_FORMAT)}`);
       });
 
       it('next year button should has correct aria label', () => {
@@ -261,7 +261,7 @@ describe('DtDatepicker Tests', () => {
 
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
     });
 
     it('should update month when next month button is clicked', async () => {
@@ -269,7 +269,7 @@ describe('DtDatepicker Tests', () => {
 
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH + 1, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH + 1, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
     });
 
     it('should go to previous month on left arrow press on first day', async () => {
@@ -279,7 +279,7 @@ describe('DtDatepicker Tests', () => {
 
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
     });
 
     it('should go to next month on right arrow press on last day', async () => {
@@ -290,7 +290,7 @@ describe('DtDatepicker Tests', () => {
       // Should be June
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
 
       const daysJune = wrapper.findAll('.d-datepicker__day');
 
@@ -299,7 +299,7 @@ describe('DtDatepicker Tests', () => {
       // Should be July again
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
     });
 
     it('should go to prev month on up arrow press on some day of first week month', async () => {
@@ -310,7 +310,7 @@ describe('DtDatepicker Tests', () => {
       // Should be June
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
     });
 
     it('should go to next month on down arrow press on some day of last week month', async () => {
@@ -321,7 +321,7 @@ describe('DtDatepicker Tests', () => {
       // Should be June
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH - 1, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
 
       const daysJune = wrapper.findAll('.d-datepicker__day');
 
@@ -330,7 +330,7 @@ describe('DtDatepicker Tests', () => {
       // Should be July again
       expect(datepickerValue
         .text())
-        .toBe(`${formatMonth(MOCK_TODAY_MONTH, MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
+        .toBe(`${formatMonth(MOCK_TODAY_MONTH, INTL_MONTH_FORMAT)} ${MOCK_TODAY_YEAR}`);
     });
 
     it('should emit selected-date event when a day is clicked', async () => {

--- a/packages/dialtone-vue3/components/datepicker/datepicker.vue
+++ b/packages/dialtone-vue3/components/datepicker/datepicker.vue
@@ -7,6 +7,7 @@
     <div class="d-datepicker__hd">
       <month-year-picker
         ref="monthYearPicker"
+        :locale="locale"
         :prev-month-label="prevMonthLabel"
         :next-month-label="nextMonthLabel"
         :prev-year-label="prevYearLabel"

--- a/packages/dialtone-vue3/components/datepicker/datepicker_constants.js
+++ b/packages/dialtone-vue3/components/datepicker/datepicker_constants.js
@@ -6,3 +6,5 @@
 export const WEEK_START = 0;
 
 export const MONTH_FORMAT = 'MMMM';
+
+export const INTL_MONTH_FORMAT = 'long';

--- a/packages/dialtone-vue3/components/datepicker/datepicker_default.story.vue
+++ b/packages/dialtone-vue3/components/datepicker/datepicker_default.story.vue
@@ -12,31 +12,31 @@
       </tr>
       <tr>
         <td>formatLong</td>
-        <td>{{ formatLong(currentSelectedDate) }}</td>
+        <td>{{ formatLong(currentSelectedDate, $attrs.locale) }}</td>
       </tr>
       <tr>
         <td>formatMedium</td>
-        <td>{{ formatMedium(currentSelectedDate) }}</td>
+        <td>{{ formatMedium(currentSelectedDate, $attrs.locale) }}</td>
       </tr>
       <tr>
         <td>formatShort</td>
-        <td>{{ formatShort(currentSelectedDate) }}</td>
+        <td>{{ formatShort(currentSelectedDate, $attrs.locale) }}</td>
       </tr>
       <tr>
         <td>formatShort (no weekday)</td>
-        <td>{{ formatShort(currentSelectedDate, false) }}</td>
+        <td>{{ formatShort(currentSelectedDate, $attrs.locale, false) }}</td>
       </tr>
       <tr>
         <td>formatNoYear</td>
-        <td>{{ formatNoYear(currentSelectedDate) }}</td>
+        <td>{{ formatNoYear(currentSelectedDate, $attrs.locale) }}</td>
       </tr>
       <tr>
         <td>formatNoYear (abbreviated)</td>
-        <td>{{ formatNoYear(currentSelectedDate, true) }}</td>
+        <td>{{ formatNoYear(currentSelectedDate, $attrs.locale, true) }}</td>
       </tr>
       <tr>
         <td>formatNumerical</td>
-        <td>{{ formatNumerical(currentSelectedDate) }}</td>
+        <td>{{ formatNumerical(currentSelectedDate, $attrs.locale) }}</td>
       </tr>
     </table>
     <br>

--- a/packages/dialtone-vue3/components/datepicker/formatUtils.js
+++ b/packages/dialtone-vue3/components/datepicker/formatUtils.js
@@ -1,25 +1,23 @@
-import { format } from 'date-fns';
-
-export function formatLong (date) {
-  return format(date, 'EEEE, MMMM d, yyyy');
+export function formatLong (date, locale = 'default') {
+  return new Intl.DateTimeFormat(locale, { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }).format(date);
 }
 
-export function formatMedium (date) {
-  return format(date, 'MMMM d, yyyy');
+export function formatMedium (date, locale = 'default') {
+  return new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'long', day: 'numeric' }).format(date);
 }
 
-export function formatShort (date, showWeekday = true) {
-  const formatString = showWeekday ? 'EEE, MMM d, yyyy' : 'MMM d, yyyy';
-  return format(date, formatString);
+export function formatShort (date, locale = 'default', showWeekday = true) {
+  const options = showWeekday ? { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' } : { year: 'numeric', month: 'short', day: 'numeric' };
+  return new Intl.DateTimeFormat(locale, options).format(date);
 }
 
-export function formatNoYear (date, abbreviated = false) {
-  const formatString = abbreviated ? 'MMM d' : 'MMMM d';
-  return format(date, formatString);
+export function formatNoYear (date, locale = 'default', abbreviated = false) {
+  const monthFormat = abbreviated ? 'short' : 'long';
+  return new Intl.DateTimeFormat(locale, { month: monthFormat, day: 'numeric' }).format(date);
 }
 
-export function formatNumerical (date) {
-  return format(date, 'MM/dd/yy');
+export function formatNumerical (date, locale = 'default') {
+  return new Intl.DateTimeFormat(locale, { year: '2-digit', month: '2-digit', day: '2-digit' }).format(date);
 }
 
 export default {

--- a/packages/dialtone-vue3/components/datepicker/modules/month-year-picker.vue
+++ b/packages/dialtone-vue3/components/datepicker/modules/month-year-picker.vue
@@ -49,7 +49,7 @@
             :circle="true"
             class="d-datepicker__nav-btn"
             type="button"
-            :aria-label="`${changeToLabel} ${prevMonthLabel} ${formattedMonth(selectMonth - 1, MONTH_FORMAT)}`"
+            :aria-label="`${changeToLabel} ${prevMonthLabel} ${formattedMonth(selectMonth - 1, INTL_MONTH_FORMAT, locale)}`"
             @click="changeMonth(-1)"
             @keydown="handleKeyDown($event)"
           >
@@ -65,7 +65,7 @@
       id="calendar-heading"
       class="d-datepicker__month-year-title"
     >
-      {{ formattedMonth(selectMonth, MONTH_FORMAT) }}
+      {{ formattedMonth(selectMonth, INTL_MONTH_FORMAT, locale) }}
 
       {{ selectYear }}
     </div>
@@ -89,7 +89,7 @@
             :circle="true"
             class="d-datepicker__nav-btn"
             type="button"
-            :aria-label="`${changeToLabel} ${nextMonthLabel} ${formattedMonth(selectMonth + 1, MONTH_FORMAT)}`"
+            :aria-label="`${changeToLabel} ${nextMonthLabel} ${formattedMonth(selectMonth + 1, INTL_MONTH_FORMAT, locale)}`"
             @click="changeMonth(1)"
             @keydown="handleKeyDown($event)"
           >
@@ -134,11 +134,16 @@ import { DtIcon } from '@/components/icon';
 import { DtStack } from '@/components/stack';
 import { DtButton } from '@/components/button';
 import { DtTooltip } from '@/components/tooltip';
-import { MONTH_FORMAT } from '../datepicker_constants';
+import { INTL_MONTH_FORMAT } from '../datepicker_constants';
 import { onMounted } from 'vue';
 import { useMonthYearPicker } from '@/components/datepicker/composables/useMonthYearPicker.js';
 
 const props = defineProps({
+  locale: {
+    type: String,
+    required: true,
+  },
+
   prevMonthLabel: {
     type: String,
     required: true,

--- a/packages/dialtone-vue3/components/datepicker/utils.js
+++ b/packages/dialtone-vue3/components/datepicker/utils.js
@@ -1,5 +1,5 @@
 import {
-  startOfWeek, addDays, getMonth, isEqual, format,
+  startOfWeek, addDays, getMonth, isEqual,
   addMonths, startOfMonth, getDay, getDate,
   subMonths, endOfMonth,
 } from 'date-fns';
@@ -88,8 +88,8 @@ export const getWeekDayNames = (locale, weekStart) => {
   return [days[weekStart]].concat(...afterWeekStart).concat(...beforeWeekStart);
 };
 
-export const formatMonth = (month, monthFormat) => {
-  return format(new Date(2000, month, 1), monthFormat);
+export const formatMonth = (month, monthFormat, locale) => {
+  return new Intl.DateTimeFormat(locale, { month: monthFormat }).format(new Date(2000, month, 1));
 };
 
 export const calculateNextFocusDate = (currentDate) => {


### PR DESCRIPTION
# Datepicker full language support

Datepicker now has full language support.

Previously month didnt has the `locale` prop working, now to make it work we are using the ECMAScript Internationalization API.

Also all the utils functions are working with the given `locale`.

You can test it going to the deploy preview and updating the `locale` prop in controls sections with something like `ja` `es` `de`

BEFORE:
<img width="906" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/6b467f8e-f01b-4110-878f-37b53b5332d9">


AFTER:
<img width="906" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/0469fc7c-7bb3-421c-923c-535aad62b07e">



