### PR TITLE
feat(badge): updated horizontal padding

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/badge.less
+++ b/packages/dialtone-css/lib/build/less/components/badge.less
@@ -29,7 +29,7 @@
   --badge-gap: var(--dt-space-300);
   --badge-letter-spacing: var(--dt-size-50);
   --badge-padding-y: var(--dt-space-100);
-  --badge-padding-x: var(--dt-space-400);
+  --badge-padding-x: var(--dt-space-350);
   --badge-text-case: none;
   --badge-decorative-color: var(--dt-color-black-900);
 

--- a/packages/dialtone-css/lib/build/less/components/badge.less
+++ b/packages/dialtone-css/lib/build/less/components/badge.less
@@ -54,7 +54,6 @@
 
   //  Kind
   //  --------------------------------------------------------------------------
-
   &--count {
     --badge-radius: var(--dt-size-radius-pill);
     --badge-padding-x: calc(var(--dt-space-400) - var(--dt-space-100));
@@ -64,7 +63,6 @@
 
   //  TYPE
   //  --------------------------------------------------------------------------
-
   &--info {
     --badge-color-background: var(--dt-badge-color-background-info);
   }
@@ -118,7 +116,6 @@
 
   //  SLOTS
   //  --------------------------------------------------------------------------
-
   &__decorative {
     display: inline-flex;
     width: var(--dt-size-400);


### PR DESCRIPTION
# Update Badge Horizontal Padding

<img width="575" alt="image" src="https://github.com/dialpad/dialtone/assets/1165933/01e0efbb-40f0-4587-9843-3b760fd4e4bc">

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.