### PR TITLE
fix: missing exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "9.7.0",
   "description": "Dialpad's Dialtone design system monorepo",
   "scripts": {
-    "test": "nx run-many --target=test",
-    "build": "nx run-many --target=build",
-    "lint": "nx run-many --target=lint --projects=dialtone-css,dialtone-vue2,dialtone-vue3,dialtone-documentation",
+    "test:all": "nx run-many --target=test",
+    "build:all": "nx run-many --target=build",
+    "lint:all": "nx run-many --target=lint",
     "start:dialtone": "nx run-many --target=start --projects=dialtone-css,dialtone-documentation",
     "start:dialtone-vue3": "nx run-many --target=start --projects=dialtone-css,dialtone-vue3",
     "start:dialtone-vue2": "nx run-many --target=start --projects=dialtone-css,dialtone-vue2",
@@ -110,6 +110,21 @@
         "default": "./dist/vue2/directives.cjs"
       }
     },
+    "./vue2/message_input": {
+      "import": {
+        "types": "./dist/vue2/types/message_input.d.ts",
+        "default": "./dist/vue2/message_input.js"
+      },
+      "require": {
+        "types": "./dist/vue2/types/message_input.d.ts",
+        "default": "./dist/vue2/message_input.cjs"
+      }
+    },
+    "./vue2/css": {
+      "style": "./dist/vue2/style.css"
+    },
+    "./vue2/CHANGELOG.json": "./packages/dialtone-vue2/CHANGELOG.json",
+    "./vue2/component-documentation.json": "./dist/vue2/component-documentation.json",
     "./vue3": {
       "style": "./dist/vue3/style.css",
       "import": {
@@ -141,6 +156,21 @@
         "default": "./dist/vue3/directives.cjs"
       }
     },
+    "./vue3/message_input": {
+      "import": {
+        "types": "./dist/vue3/types/message_input.d.ts",
+        "default": "./dist/vue3/message_input.js"
+      },
+      "require": {
+        "types": "./dist/vue3/types/message_input.d.ts",
+        "default": "./dist/vue3/message_input.cjs"
+      }
+    },
+    "./vue3/css": {
+      "style": "./dist/vue3/style.css"
+    },
+    "./vue3/CHANGELOG.json": "./packages/dialtone-vue3/CHANGELOG.json",
+    "./vue3/component-documentation.json": "./dist/vue3/component-documentation.json",
     "./eslint-plugin": "./dist/eslint-plugin/index.js"
   },
   "homepage": "https://dialtone.dialpad.com",

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.mdx
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.mdx
@@ -26,5 +26,5 @@ It further has the logic to handle character limit logic and other message input
 ### Import
 
 ```jsx
-import { DtRecipeMessageInput } from '@dialpad/dialtone-vue';
+import { DtRecipeMessageInput } from '@dialpad/dialtone-vue/message_input';
 ```

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.mdx
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.mdx
@@ -26,5 +26,5 @@ It further has the logic to handle character limit logic and other message input
 ### Import
 
 ```jsx
-import { DtRecipeMessageInput } from '@dialpad/dialtone-vue';
+import { DtRecipeMessageInput } from '@dialpad/dialtone-vue/message_input';
 ```


### PR DESCRIPTION
# Fix missing exports

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGcwbmh0OGY1bHp5ZjEzamJ6ZndsYXMwczBpNnRkZXNxdWN0MGx2aiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/QgAZA5Db6H4BAgqr5c/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

No Jira ticket

## :book: Description

- Added missing exports on mono package
- I have doubts if we should update the documentation to match the mono package usage (import from `@dialpad/dialtone/vue2` or continue with the exports from `@dialpad/dialtone-vue`.

## :bulb: Context

A user reported issues while using DtRecipeMessageInput, while investigated noticed that we were missing some exports.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.