### PR TITLE
fix(feed-item-row): set inset focus ring on feed item

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -299,6 +299,11 @@ export default {
 
 <style lang="less" scoped>
 .dt-feed-item-row {
+
+  &:focus-visible {
+    box-shadow: var(--dt-shadow-focus-inset);
+  }
+
   &--state-searched {
     background-color: var(--dt-color-surface-warning-subtle);
   }

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -298,6 +298,11 @@ export default {
 
 <style lang="less" scoped>
 .dt-feed-item-row {
+
+  &:focus-visible {
+    box-shadow: var(--dt-shadow-focus-inset);
+  }
+
   &--state-searched {
     background-color: var(--dt-color-surface-warning-subtle);
   }


### PR DESCRIPTION
Set inset focus ring on feed-item so the focus ring doesn't go behind the borders of the feed list.