### PR TITLE
fix(style): align text decoration treatments

### DIFF
--- a/apps/dialtone-documentation/docs/components/link.md
+++ b/apps/dialtone-documentation/docs/components/link.md
@@ -7,6 +7,24 @@ image: assets/images/components/link.png
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-link--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21226&viewport=-746%2C-197%2C1.41&t=xHutRjwo1o5zMTgT-11
 ---
+
+<div>
+  <dt-stack direction="row" gap="500" class="d-mb16">
+    <u>native underline</u>
+    <del>native del</del>
+    <ins>native ins</ins>
+    <abbr title="asdf">native abbr</abbr>
+    <s>native strikethrough</s>
+    <a href="#link">native link</a>
+  </dt-stack>
+  <dt-stack direction="row" gap="500" class="d-mb16">
+    <a href="#link" class="d-link">d-link</a>
+    <u class="d-td-underline">d-td-underline</u>
+    <u class="d-td-dotted">d-td-dotted</u>
+    <u class="d-td-line-through">d-td-line-through</u>
+  </dt-stack>
+</div>
+
 <code-well-header>
   <a href="#link" class="d-link">Base link</a>
 </code-well-header>

--- a/apps/dialtone-documentation/docs/components/link.md
+++ b/apps/dialtone-documentation/docs/components/link.md
@@ -8,23 +8,6 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-link--defaul
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21226&viewport=-746%2C-197%2C1.41&t=xHutRjwo1o5zMTgT-11
 ---
 
-<div>
-  <dt-stack direction="row" gap="500" class="d-mb16">
-    <u>native underline</u>
-    <del>native del</del>
-    <ins>native ins</ins>
-    <abbr title="asdf">native abbr</abbr>
-    <s>native strikethrough</s>
-    <a href="#link">native link</a>
-  </dt-stack>
-  <dt-stack direction="row" gap="500" class="d-mb16">
-    <a href="#link" class="d-link">d-link</a>
-    <u class="d-td-underline">d-td-underline</u>
-    <u class="d-td-dotted">d-td-dotted</u>
-    <u class="d-td-line-through">d-td-line-through</u>
-  </dt-stack>
-</div>
-
 <code-well-header>
   <a href="#link" class="d-link">Base link</a>
 </code-well-header>

--- a/packages/dialtone-css/lib/build/less/components/link.less
+++ b/packages/dialtone-css/lib/build/less/components/link.less
@@ -30,7 +30,7 @@
     font: inherit;
     text-decoration: var(--link-text-decoration);
     text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100));
-    text-decoration-thickness: var(--dt-size-border-100);
+    text-decoration-thickness: var(--dt-size-border-50);
     background-color: transparent;
     border: 0;
     transition-timing-function: var(--ttf-out-quint);

--- a/packages/dialtone-css/lib/build/less/dialtone-reset.less
+++ b/packages/dialtone-css/lib/build/less/dialtone-reset.less
@@ -75,6 +75,14 @@ pre {
 
 a {
   background-color: transparent;
+  text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100));
+  text-decoration-thickness: var(--dt-size-border-50);
+}
+
+ins,
+u {
+  text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100));
+  text-decoration-thickness: var(--dt-size-border-50);
 }
 
 /**
@@ -86,6 +94,13 @@ abbr[title] {
   border-bottom: none; /* 1 */
   text-decoration: underline; /* 2 */
   text-decoration: underline dotted; /* 2 */
+  text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100));
+  text-decoration-thickness: var(--dt-size-border-100);
+}
+
+del,
+s {
+  text-decoration-thickness: var(--dt-size-border-100) !important;
 }
 
 /**

--- a/packages/dialtone-css/lib/build/less/utilities/typography.less
+++ b/packages/dialtone-css/lib/build/less/utilities/typography.less
@@ -211,14 +211,17 @@ ul {
 .d-td-underline {
     text-decoration: underline !important;
     text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100)) !important;
-    text-decoration-thickness: var(--dt-size-border-100) !important;
+    text-decoration-thickness: var(--dt-size-border-50) !important;
 }
 .d-td-dotted {
     text-decoration: underline dotted !important;
     text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100)) !important;
     text-decoration-thickness: var(--dt-size-border-100) !important;
 }
-.d-td-line-through { text-decoration: line-through !important; }
+.d-td-line-through {
+    text-decoration: line-through !important;
+    text-decoration-thickness: var(--dt-size-border-100) !important;
+}
 .d-td-unset { text-decoration: unset !important; }
 
 


### PR DESCRIPTION
# Align all text-decoration treatments

<img width="652" alt="image" src="https://github.com/dialpad/dialtone/assets/1165933/e34620aa-3602-48a2-8c65-a73a581945d5">

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Description

Text underlines across DT elements and native elements were out of sync. 

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.