### PR TITLE
fix(emoji-row): update emoji-row to use more semantic colors

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -128,8 +128,8 @@ export default {
     &--selected {
       color: var(--dt-color-link-primary);
       border-width: var(--dt-size-border-150);
-      background-color: var(--dt-color-purple-100);
-      border-color: var(--dt-color-brand-purple);
+      background-color: var(--dt-action-color-background-inverted-primary-hover);
+      border-color: var(--dt-color-border-brand);
       .dt-emoji-row__reaction-number {
         font-weight: var(--dt-font-weight-bold);
       }

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -128,8 +128,8 @@ export default {
     &--selected {
       color: var(--dt-color-link-primary);
       border-width: var(--dt-size-border-150);
-      background-color: var(--dt-color-purple-100);
-      border-color: var(--dt-color-brand-purple);
+      background-color: var(--dt-action-color-background-inverted-primary-hover);
+      border-color: var(--dt-color-border-brand);
       .dt-emoji-row__reaction-number {
         font-weight: var(--dt-font-weight-bold);
       }


### PR DESCRIPTION
# fix(emoji-row): update emoji-row to use more semantic colors

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2xxZ2NkN3NqcWwzc3JwNDl6cTloemJpYjlvOTdyZzNlNTB1aWVldyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2JJA0CticyQSoKYw/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

Update emoji row to use some semantic colors so the current t-mobile theming works correctly

## :bulb: Context

There were some problems with the tmobile theme on emoji row showing purple colors.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.

## :crystal_ball: Next Steps

Update in product, cp to beta

## :link: Sources

https://dialtone.dialpad.com/tokens/color.html
