### PR TITLE
refactor: lint pr check update

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,4 +1,4 @@
-name: Lint PR
+name: Lint PR Title
 
 on:
   pull_request:
@@ -31,15 +31,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Lint pull request commit message when it has a single commit
-        if: ${{ github.event.pull_request.commits == '1' }}
-        run: |
-          echo "Since your PR has a single commit, this commit should adhere to the commit message convention."
-          echo "correct format: <type>(<scope>): <subject>"
-          echo "example: feat: add dialbot icon"
-          echo "Please amend your commit message (git commit --amend) if commitlint reports an error and push using: git push --force-with-lease"
-          git show -s --format=%B HEAD^2 | pnpm commitlint --verbose
 
       - name: Lint pull request title
         run: |


### PR DESCRIPTION
# Lint pr check update

## :book: Description

JIRA TICKET: [DLT-1527](https://dialpad.atlassian.net/browse/DLT-1527)

Our current commit check checks the commit name if there is only one commit on a PR, and the PR title if there is more than one commit. 
We did this previously because GitHub has no option to change this behaviour. Github has a new option to always “use pull request title” when doing a squash commit. 

This has already been enabled on the repo but we need to change our commit naming check to no longer check the commit message, and only check the PR title.



[DLT-1527]: https://dialpad.atlassian.net/browse/DLT-1527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ