### PR TITLE
fix(tooltip): initialization issue

### DIFF
--- a/packages/dialtone-vue2/components/tooltip/tooltip.stories.js
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.stories.js
@@ -15,7 +15,6 @@ export const argsData = {
   default: `This is a simple tooltip. You can set the position of the tooltip using the placement prop!`,
   sticky: false,
   onShown: action('shown'),
-  showTooltip: null,
 };
 
 export const argTypesData = {

--- a/packages/dialtone-vue2/components/tooltip/tooltip.stories.js
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.stories.js
@@ -15,6 +15,7 @@ export const argsData = {
   default: `This is a simple tooltip. You can set the position of the tooltip using the placement prop!`,
   sticky: false,
   onShown: action('shown'),
+  showTooltip: null,
 };
 
 export const argTypesData = {
@@ -114,6 +115,11 @@ export const argTypesData = {
       type: {
         summary: 'boolean',
       },
+    },
+  },
+  showTooltip: {
+    table: {
+      disable: true,
     },
   },
 };

--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -322,16 +322,16 @@ export default {
       };
     },
 
-    appendToElement () {
-      return this.appendTo === 'body' ? this.anchor?.getRootNode()?.querySelector('body') : this.appendTo;
-    },
-
     tippyProps () {
+      const appendToElement = this.appendTo === 'body'
+        ? this.anchor?.getRootNode()?.querySelector('body')
+        : this.appendTo;
+
       return {
         offset: this.offset,
         interactive: false,
         trigger: 'manual',
-        appendTo: this.appendToElement,
+        appendTo: appendToElement,
         placement: this.placement,
         sticky: this.sticky,
         popperOptions: getPopperOptions({
@@ -363,14 +363,14 @@ export default {
     isShown (isShown) {
       if (isShown) {
         this.setProps();
-        this.tip.show();
+        this.tip?.show();
       } else {
-        this.tip.hide();
+        this.tip?.hide();
       }
     },
 
     sticky (sticky) {
-      this.tip.setProps({
+      this.tip?.setProps({
         sticky,
       });
     },
@@ -416,7 +416,7 @@ export default {
     onEnterAnchor (e) {
       // Note: This is to stop the call of mouseenter event when touchstart event is triggered,
       //       as when triggered by click or touch, the relatedTarget property of MouseEvent is null
-      if(this.isTouchDevice && !e.relatedTarget) return;
+      if (this.isTouchDevice && !e.relatedTarget) return;
 
       if (this.delay) {
         this.inTimer = setTimeout(function (event) {

--- a/packages/dialtone-vue2/components/tooltip/tooltip_default.story.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip_default.story.vue
@@ -19,7 +19,7 @@
         :append-to="$attrs.appendTo"
         :content-class="$attrs.contentClass"
         :transition="$attrs.transition"
-        :show="$attrs.showTooltip"
+        :show="showTooltip"
         :enabled="$attrs.enabled"
         :delay="$attrs.delay"
         :external-anchor="$attrs.externalAnchor"
@@ -31,7 +31,7 @@
         >
           <dt-button
             importance="outlined"
-            :kind="$attrs.buttonKind"
+            :kind="buttonKind"
           >
             {{ $attrs.anchor }}
           </dt-button>

--- a/packages/dialtone-vue3/components/tooltip/tooltip.stories.js
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.stories.js
@@ -15,7 +15,6 @@ export const argsData = {
   default: `This is a simple tooltip. You can set the position of the tooltip using the placement prop!`,
   sticky: false,
   onShown: action('shown'),
-  showTooltip: null,
 };
 
 export const argTypesData = {

--- a/packages/dialtone-vue3/components/tooltip/tooltip.stories.js
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.stories.js
@@ -15,6 +15,7 @@ export const argsData = {
   default: `This is a simple tooltip. You can set the position of the tooltip using the placement prop!`,
   sticky: false,
   onShown: action('shown'),
+  showTooltip: null,
 };
 
 export const argTypesData = {
@@ -112,6 +113,11 @@ export const argTypesData = {
       type: {
         summary: 'boolean',
       },
+    },
+  },
+  showTooltip: {
+    table: {
+      disable: true,
     },
   },
 };

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -330,16 +330,16 @@ export default {
       };
     },
 
-    appendToElement () {
-      return this.appendTo === 'body' ? this.anchor?.getRootNode()?.querySelector('body') : this.appendTo;
-    },
-
     tippyProps () {
+      const appendToElement = this.appendTo === 'body'
+        ? this.anchor?.getRootNode()?.querySelector('body')
+        : this.appendTo;
+
       return {
         offset: this.offset,
         interactive: false,
         trigger: 'manual',
-        appendTo: this.appendToElement,
+        appendTo: appendToElement,
         placement: this.placement,
         sticky: this.sticky,
         popperOptions: getPopperOptions({
@@ -371,14 +371,14 @@ export default {
     isShown (isShown) {
       if (isShown) {
         this.setProps();
-        this.tip.show();
+        this.tip?.show();
       } else {
-        this.tip.hide();
+        this.tip?.hide();
       }
     },
 
     sticky (sticky) {
-      this.tip.setProps({
+      this.tip?.setProps({
         sticky,
       });
     },
@@ -424,7 +424,7 @@ export default {
     onEnterAnchor (e) {
       // Note: This is to stop the call of mouseenter event when touchstart event is triggered,
       //       as when triggered by click or touch, the relatedTarget property of MouseEvent is null
-      if(this.isTouchDevice && !e.relatedTarget) return;
+      if (this.isTouchDevice && !e.relatedTarget) return;
 
       if (this.delay) {
         this.inTimer = setTimeout(function (event) {

--- a/packages/dialtone-vue3/components/tooltip/tooltip_default.story.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip_default.story.vue
@@ -21,7 +21,7 @@
         :content-class="$attrs.contentClass"
         :content-appear="$attrs.contentAppear"
         :transition="$attrs.transition"
-        :show.sync="$attrs.show"
+        :show="showTooltip"
         :enabled="$attrs.enabled"
         :delay="$attrs.delay"
         :external-anchor="$attrs.externalAnchor"


### PR DESCRIPTION
# fix(tooltip): initialization issue

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeTM0ZDFqaTY3cWdhMjA0aHFuOHY4aXVveDZzMjRsZnNxZG94c3dxOCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/jrutBd1N7ZhsINAPzs/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-90362

## :book: Description

There were problems with reactivity here since we are using a ref in a computed property, which you are not really supposed to do. Moved it into tippyProps itself and it seems to have fixed the issue. tested on product via pnpm link.

## :bulb: Context

dt-tooltips were not working in product at all after this change, erroring out with a null reference.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
