### PR TITLE
feat: text decoration scopes

### DIFF
--- a/apps/dialtone-documentation/docs/utilities/effects/opacity.md
+++ b/apps/dialtone-documentation/docs/utilities/effects/opacity.md
@@ -23,6 +23,39 @@ Use `d-o{n}` to change the opacity of your element.
 <div class="d-o0">...</div>
 ```
 
+## Hover
+Use `h:d-o{n}` to change an element's :hover state opacity.
+
+<code-well-header class="d-fl-col5 d-flg8 d-fw-wrap d-p24 d-bgc-magenta-100 d-bgo50 d-w100p d-hmn102" custom>
+  <div class="d-fl-center d-p16 d-bar8 d-bgc-magenta-100 d-fc-magenta-400 d-fs-200 d-fw-bold h:d-o50">hover to opacity .d-o50</div>
+</code-well-header>
+
+```html
+<p class="h:d-o50">...</p>
+```
+
+## Focus
+Use `f:d-o{n}` to change an element's :focus and :focus-within state opacity.
+
+<code-well-header class="d-fl-col5 d-flg8 d-fw-wrap d-p24 d-bgc-magenta-100 d-bgo50 d-w100p d-hmn102" custom>
+  <button class="d-ba-none d-fl-center d-p16 d-bar8 d-bgc-magenta-100 d-fc-magenta-400 d-fs-200 d-fw-bold f:d-o50">Click me to opacity .d-o50</button>
+</code-well-header>
+
+```html
+<p class="f:d-o50">...</p>
+```
+
+## Focus visible
+Use `fv:d-o{n}` to change an element's :focus-visible state opacity [only when focused by keyboard].
+
+<code-well-header class="d-fl-col5 d-flg8 d-fw-wrap d-p24 d-bgc-magenta-100 d-bgo50 d-w100p d-hmn102" custom>
+  <button class="d-ba-none d-fl-center d-p16 d-bar8 d-bgc-magenta-100 d-fc-magenta-400 d-fs-200 d-fw-bold fv:d-o50">Focus me to opacity .d-o50</button>
+</code-well-header>
+
+```html
+<p class="fv:d-o50">...</p>
+```
+
 <script setup>
   const opacities = [
     {className: 0, value: 0},

--- a/apps/dialtone-documentation/docs/utilities/typography/text-decoration.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/text-decoration.md
@@ -56,7 +56,7 @@ Use `d-td-none` to remove text decorations.
 </script>
 
 ## Hover
-Use h:d-td-{n} to change an element's :hover state text decoration.
+Use `h:d-td-{n}` to change an element's :hover state text decoration.
 
 <code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-magenta-100 d-w100p d-hmn102" custom>
   <p class="d-fs-300 d-fc-magenta-300 h:d-td-underline">The quick brown fox jumps over the lazy dog.</p>
@@ -67,10 +67,12 @@ Use h:d-td-{n} to change an element's :hover state text decoration.
 ```
 
 ## Focus
-Use f:d-td-{n} to change an element's :focus and :focus-within state text decoration.
+Use `f:d-td-{n}` to change an element's :focus and :focus-within state text decoration.
 
-<code-well-header class="d-fl-center d-p24 d-bgc-neutral-white d-w100p d-hmn102" custom>
-  <button class="d-ba-none d-fl-center d-p16 d-bar8 d-bgc-magenta-100 d-fs-200 d-fw-bold d-bs-none f:d-td-underline">Click me</button>
+<code-well-header class="d-d-flex d-p24 d-bgc-magenta-100 d-w100p d-hmn102" custom>
+  <button class="d-ba-none d-bgc-magenta-100 d-fs-200 d-bs-none f:d-td-underline">
+    <p class="d-fs-300 d-fc-magenta-300 d-fc-red">Click me</p>
+  </button>
 </code-well-header>
 
 ```html
@@ -78,10 +80,12 @@ Use f:d-td-{n} to change an element's :focus and :focus-within state text decora
 ```
 
 ## Focus visible
-Use fv:d-td-{n} to change an element's :focus-visible state text decoration [only when focused by keyboard].
+Use `fv:d-td-{n}` to change an element's :focus-visible state text decoration [only when focused by keyboard].
 
-<code-well-header class="d-fl-center d-p24 d-bgc-neutral-white d-w100p d-hmn102" custom>
-  <button class="d-ba-none d-fl-center d-p16 d-bar8 d-bgc-magenta-100 d-fs-200 d-fw-bold d-bs-none fv:d-td-underline">Focus me</button>
+<code-well-header class="d-d-flex d-p24 d-bgc-purple-100 d-w100p d-hmn102" custom>
+  <button class="d-ba-none d-bgc-purple-100 d-fs-200 d-bs-none fv:d-td-underline">
+    <p class="d-fs-300 d-fc-purple-300 d-fc-red">Focus me</p>
+  </button>
 </code-well-header>
 
 ```html

--- a/apps/dialtone-documentation/docs/utilities/typography/text-decoration.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/text-decoration.md
@@ -55,6 +55,39 @@ Use `d-td-none` to remove text decorations.
   import { decoration } from '@data/type.json';
 </script>
 
+## Hover
+Use h:d-td-{n} to change an element's :hover state text decoration.
+
+<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-magenta-100 d-w100p d-hmn102" custom>
+  <p class="d-fs-300 d-fc-magenta-300 h:d-td-underline">The quick brown fox jumps over the lazy dog.</p>
+</code-well-header>
+
+```html
+<p class="h:d-td-underline">...</p>
+```
+
+## Focus
+Use f:d-td-{n} to change an element's :focus and :focus-within state text decoration.
+
+<code-well-header class="d-fl-center d-p24 d-bgc-neutral-white d-w100p d-hmn102" custom>
+  <button class="d-ba-none d-fl-center d-p16 d-bar8 d-bgc-magenta-100 d-fs-200 d-fw-bold d-bs-none f:d-td-underline">Click me</button>
+</code-well-header>
+
+```html
+<p class="f:d-td-underline">...</p>
+```
+
+## Focus visible
+Use fv:d-td-{n} to change an element's :focus-visible state text decoration [only when focused by keyboard].
+
+<code-well-header class="d-fl-center d-p24 d-bgc-neutral-white d-w100p d-hmn102" custom>
+  <button class="d-ba-none d-fl-center d-p16 d-bar8 d-bgc-magenta-100 d-fs-200 d-fw-bold d-bs-none fv:d-td-underline">Focus me</button>
+</code-well-header>
+
+```html
+<p class="fv:d-td-underline">...</p>
+```
+
 ## Classes
 
 <utility-class-table>

--- a/packages/dialtone-css/postcss/constants.cjs
+++ b/packages/dialtone-css/postcss/constants.cjs
@@ -249,6 +249,13 @@ module.exports = {
       'ExtraExtraLarge',
 
     ].join('|'),
+    TEXT_DECORATION: [
+      'dotted',
+      'line-through',
+      'none',
+      'underline',
+      'unset',
+    ].join('|'),
   },
   WIDTH_HEIGHTS: {
     0: '0',

--- a/packages/dialtone-css/postcss/constants.cjs
+++ b/packages/dialtone-css/postcss/constants.cjs
@@ -256,6 +256,16 @@ module.exports = {
       'underline',
       'unset',
     ].join('|'),
+    OPACITY_VARIATIONS: [
+      '0',
+      '10',
+      '25',
+      '50',
+      '75',
+      '90',
+      '95',
+      '99'
+    ].join('|'),
   },
   WIDTH_HEIGHTS: {
     0: '0',

--- a/packages/dialtone-css/postcss/dialtone-generators.cjs
+++ b/packages/dialtone-css/postcss/dialtone-generators.cjs
@@ -828,6 +828,7 @@ function _generateHoverFocusVariations (rule) {
   const borderColorRegex = new RegExp(`\\.d-bc-(${REGEX_OPTIONS.BORDER_COLORS})(-(${REGEX_OPTIONS.BORDER_COLOR_VARIATIONS}))?`);
   const boxShadowRegex = new RegExp(`\\.d-bs-(${REGEX_OPTIONS.BOX_SHADOWS})`);
   const textDecorationRegex = new RegExp(`\\.d-td-(${REGEX_OPTIONS.TEXT_DECORATION})`);
+  const opacityRegex = new RegExp(`\\.d-o(${REGEX_OPTIONS.OPACITY_VARIATIONS})`);
   const found = [
     backgroundGradientRegex,
     fontColorRegex,
@@ -835,6 +836,7 @@ function _generateHoverFocusVariations (rule) {
     borderColorRegex,
     boxShadowRegex,
     textDecorationRegex,
+    opacityRegex,
   ].some(regex => regex.test(rule.selector));
   if (!found) return;
   const selectors = rule.selectors.map(selector => appendHoverFocusSelectors(selector));

--- a/packages/dialtone-css/postcss/dialtone-generators.cjs
+++ b/packages/dialtone-css/postcss/dialtone-generators.cjs
@@ -827,12 +827,14 @@ function _generateHoverFocusVariations (rule) {
   const backgroundColorRegex = new RegExp(`\\.d-bgc-(${REGEX_OPTIONS.BACKGROUND_COLORS})(-(${REGEX_OPTIONS.BACKGROUND_COLOR_VARIATIONS}))?`);
   const borderColorRegex = new RegExp(`\\.d-bc-(${REGEX_OPTIONS.BORDER_COLORS})(-(${REGEX_OPTIONS.BORDER_COLOR_VARIATIONS}))?`);
   const boxShadowRegex = new RegExp(`\\.d-bs-(${REGEX_OPTIONS.BOX_SHADOWS})`);
+  const textDecorationRegex = new RegExp(`\\.d-td-(${REGEX_OPTIONS.TEXT_DECORATION})`);
   const found = [
     backgroundGradientRegex,
     fontColorRegex,
     backgroundColorRegex,
     borderColorRegex,
     boxShadowRegex,
+    textDecorationRegex,
   ].some(regex => regex.test(rule.selector));
   if (!found) return;
   const selectors = rule.selectors.map(selector => appendHoverFocusSelectors(selector));


### PR DESCRIPTION
# Text decoration scopes

JIRA TICKET: [DLT-1499](https://dialpad.atlassian.net/browse/DLT-1499)

We are adding `f:` `h:` `fv:` scopes to `text-decoration` and `opacity` classes.


[DLT-1499]: https://dialpad.atlassian.net/browse/DLT-1499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ