### PR TITLE
fix(emoji): skeleton display issue

### DIFF
--- a/packages/dialtone-vue2/components/emoji/emoji.vue
+++ b/packages/dialtone-vue2/components/emoji/emoji.vue
@@ -3,8 +3,8 @@
     <dt-skeleton
       v-show="imgLoading && showSkeleton"
       :offset="0"
-      :class="emojiSize"
-      :shape-option="{ shape: 'square', contentClass: emojiSize, size: 'auto' }"
+      :class="['d-icon', emojiSize]"
+      :shape-option="{ shape: 'circle', size: '100%' }"
     />
     <img
       v-show="!imgLoading"
@@ -152,6 +152,8 @@ export default {
       handler: async function () {
         this.imgLoading = true;
       },
+
+      immediate: true,
     },
   },
 

--- a/packages/dialtone-vue3/components/emoji/emoji.vue
+++ b/packages/dialtone-vue3/components/emoji/emoji.vue
@@ -3,8 +3,8 @@
     <dt-skeleton
       v-show="imgLoading && showSkeleton"
       :offset="0"
-      :class="emojiSize"
-      :shape-option="{ shape: 'square', contentClass: emojiSize, size: 'auto' }"
+      :class="['d-icon', emojiSize]"
+      :shape-option="{ shape: 'circle', size: '100%' }"
     />
     <img
       v-show="!imgLoading"
@@ -152,6 +152,8 @@ export default {
       handler: async function () {
         this.imgLoading = true;
       },
+
+      immediate: true,
     },
   },
 


### PR DESCRIPTION
# fix(emoji): skeleton display issue

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZjIxYThpejgwd2l3cmp2ejUxcDk2MGpiODBsaXo4bmFwdXZwb3JtdiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/upLcueh7KWGx5WVvrS/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1552

## :book: Description

added d-icon which is now needed, and made inner image expand to the size of it's container. Also added immediate watcher as it was not triggering initally.

## :bulb: Context

Emoji skeletons were not displaying, noticed in feed-item-row

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.

## :camera: Screenshots / GIFs

![2024-02-09 16 35 55](https://github.com/dialpad/dialtone/assets/64808812/7dc4dc27-7aed-441a-ac5b-71b3863506f3)

