### PR TITLE
fix: load archivo font

### DIFF
--- a/packages/dialtone-css/lib/build/less/dialtone-globals.less
+++ b/packages/dialtone-css/lib/build/less/dialtone-globals.less
@@ -18,6 +18,27 @@
 //      [3]     Prevent adjustments of font size after orientation changes in iOS.
 //  ----------------------------------------------------------------------------
 
+@font-face {
+  font-weight: 400;
+  font-family: Archivo;
+  font-style: normal;
+  src: url('../fonts/Archivo-Regular.woff2') format('woff2');
+}
+
+@font-face {
+  font-weight: 700;
+  font-family: Archivo;
+  font-style: normal;
+  src: url('../fonts/Archivo-Bold.woff2') format('woff2');
+}
+
+@font-face {
+  font-weight: 600;
+  font-family: Archivo;
+  font-style: normal;
+  src: url('../fonts/Archivo-SemiBold.woff2') format('woff2');
+}
+
 html,
 body {
     margin: 0;
@@ -32,14 +53,4 @@ body {
     line-height: var(--dt-typography-body-base-line-height);
     background-color: var(--dt-color-surface-primary);
     -webkit-text-size-adjust: 100%;
-}
-
-//  ============================================================================
-//  @   FOCUS VISIBLE
-//  ----------------------------------------------------------------------------
-// This will hide the focus indicator if the element receives focus via the mouse,
-// but it will still show up on keyboard focus.
-//
-.js-focus-visible :focus:not(.focus-visible) {
-  outline: none;
 }


### PR DESCRIPTION
# fix: load archivo font

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Archivo font was not being loaded even though it was provided in the package and used in utility classes. Added into dialtone-globals.
