### PR TITLE
fix(emoji-row): tooltip position when content changes

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -8,6 +8,7 @@
       <dt-tooltip
         class="dt-emoji-row__tooltip"
         content-class="d-wmx464"
+        sticky="popper"
         @shown="(shown) => emojiHovered(reaction, shown)"
       >
         <span aria-hidden="true">

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -8,6 +8,7 @@
       <dt-tooltip
         class="dt-emoji-row__tooltip"
         content-class="d-wmx464"
+        sticky="popper"
         @shown="(shown) => emojiHovered(reaction, shown)"
       >
         <span aria-hidden="true">


### PR DESCRIPTION
# fix(emoji-row): tooltip position when content changes

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMnBrZXRqdW9pM3RrMXBmNWd1ZnN1NnRid2tmajEyNmttMjM3eGczcyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Z9zo37ooUzwNwzmw4w/giphy.gif)

## :hammer_and_wrench: Type Of Change
<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DP-90663
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adds `sticky= "popper"` to the tooltip in the emoji row recipe so that it doesn't change it's position when adding a reaction.
Tested with `npm link` and this solves the issue:

## With this fix:
![tooltip-emoji](https://github.com/dialpad/dialtone/assets/24460973/e8199c58-dccb-4a32-80b0-4c1960741df6)
<!--- Describe specifically what the changes are -->

## Before:
![tooltip-emoji-beta](https://github.com/dialpad/dialtone/assets/24460973/5c853274-f321-454b-b066-3435fe2cecdc)



