### PR TITLE
fix: dist exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,8 @@
     },
     "./vue3/CHANGELOG.json": "./packages/dialtone-vue3/CHANGELOG.json",
     "./vue3/component-documentation.json": "./dist/vue3/component-documentation.json",
-    "./eslint-plugin": "./dist/eslint-plugin/index.js"
+    "./eslint-plugin": "./dist/eslint-plugin/index.js",
+    "./dist/*": "./dist/*"
   },
   "homepage": "https://dialtone.dialpad.com",
   "keywords": [


### PR DESCRIPTION
# Fix dist exports

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/wofyg8nxsWEmtR7eOK/giphy.gif?cid=790b76119l0uepmh7pkbvxxkn8ul59ggit55nfhffz8h0gxj&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

No Jira ticket

## :book: Description

Added `./dist/*`export to monopackage so people is able to import anything within dist/ folder.

## :bulb: Context

People where trying to import spotIllustrations and couldn't find them

## :pencil: Checklist

For all PRs:

- [ ] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.