### PR TITLE
fix(popover): reading from undefined ref

### DIFF
--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -678,7 +678,7 @@ export default {
       ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
       : null;
     this.anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
-    this.popoverContentEl = this.$refs.content.$el;
+    this.popoverContentEl = this.$refs.content?.$el;
 
     if (this.isOpen) {
       this.initTippyInstance();

--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -879,7 +879,7 @@ export default {
 
     focusInitialElement () {
       if (this.initialFocusElement === 'dialog') {
-        this.$refs.content.$el.focus();
+        this.$refs.content?.$el.focus();
       }
       // find by ID
       if (this.initialFocusElement.startsWith('#')) {

--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -879,7 +879,7 @@ export default {
 
     focusInitialElement () {
       if (this.initialFocusElement === 'dialog') {
-        this.$refs.content?.$el.focus();
+        this.$refs.content?.$el?.focus();
       }
       // find by ID
       if (this.initialFocusElement.startsWith('#')) {

--- a/packages/dialtone-vue3/components/popover/popover.vue
+++ b/packages/dialtone-vue3/components/popover/popover.vue
@@ -705,7 +705,7 @@ export default {
       ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
       : null;
     this.anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
-    this.popoverContentEl = this.$refs.content.$el;
+    this.popoverContentEl = this.$refs.content?.$el;
 
     if (this.isOpen) {
       this.initTippyInstance();
@@ -913,7 +913,7 @@ export default {
 
     focusInitialElement () {
       if (this.initialFocusElement === 'dialog') {
-        this.$refs.content.$el.focus();
+        this.$refs.content?.$el?.focus();
       }
       // find by ID
       if (this.initialFocusElement.startsWith('#')) {


### PR DESCRIPTION
# fix(popover): reading from undefined ref

Issue in Sentry: https://dialpad.sentry.io/issues/4974421022/?project=5269274&referrer=jira_integration
<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

https://media.giphy.com/media/iibH5ymW6LFvSIVyUc/giphy.gif?cid=790b7611vnvfweg99ws8n48qb29ixn6fsdv4xw3q7hzl3o51&ep=v1_gifs_search&rid=giphy.gif&ct=g

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-1559
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
I could not repro this in the app or in Storybook, but looking in the code, we were accessing `this.$refs.content.$el?` and `this.$refs.content` might be undefined. Changed this to `this.$refs.content?.$el?` so that the error would not happen anymore. 
<!--- Describe specifically what the changes are -->
