### PR TITLE
docs: aside overflow behavior

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/PageToc.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/PageToc.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="lg:d-ps-relative lg:d-w100p d-ps-fixed dialtone-toc">
+  <aside class="d-of-auto d-h75p lg:d-ps-relative lg:d-w100p d-ps-fixed dialtone-toc">
     <h2 class="d-headline-eyebrow d-fw-semibold d-fc-secondary d-px12 d-pb4">
       On this page
     </h2>

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/PageToc.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/PageToc.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="d-of-auto d-h75p lg:d-ps-relative lg:d-w100p d-ps-fixed dialtone-toc">
+  <aside class="d-of-auto d-py32 lg:d-ps-relative lg:d-w100p d-ps-fixed dialtone-toc">
     <h2 class="d-headline-eyebrow d-fw-semibold d-fc-secondary d-px12 d-pb4">
       On this page
     </h2>
@@ -24,6 +24,6 @@ const options = {
 <style>
 .dialtone-toc {
   width: var(--dt-size-850);
-  margin-top: var(--dt-space-600);
+  height: calc(100vh - var(--dt-size-700));
 }
 </style>


### PR DESCRIPTION
# docs: aside overflow behavior
<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/l41Ygr7sR5limRkek/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/jira/software/c/projects/DLT/issues/DLT-1568

## :book: Description

In the docs page https://dialtone.dialpad.com/  the right sidebar is not scrollable so it gets cut when the window is not tall enough.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.