### PR TITLE
fix(tooltip): remove validators from directive

### DIFF
--- a/packages/dialtone-vue2/directives/tooltip/tooltip.js
+++ b/packages/dialtone-vue2/directives/tooltip/tooltip.js
@@ -1,4 +1,4 @@
-import { DtTooltip, TOOLTIP_DIRECTIONS } from '@/components/tooltip';
+import { DtTooltip } from '@/components/tooltip';
 import { getUniqueString } from '@/common/utils';
 
 export const DtTooltipDirective = {
@@ -62,30 +62,8 @@ export const DtTooltipDirective = {
 
     DtTooltipDirectiveApp.$mount(mountPoint);
 
-    const isValidBindingTextValue = (value) => typeof value === 'string' && value?.trim();
-    const isValidBindingPlacementValue = (value) => value === undefined || TOOLTIP_DIRECTIONS.includes(value);
-
     Vue.directive('dt-tooltip', {
       bind (anchor, binding) {
-        if (!isValidBindingTextValue(binding.value)) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            'Missing value for v-dt-tooltip directive on: ',
-            anchor,
-            'received value: ',
-            binding.value,
-          );
-          return;
-        }
-        if (!isValidBindingPlacementValue(binding.arg)) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            'Wrong placement value provided for v-dt-tooltip directive on: '
-            , anchor,
-            'received value: ',
-            binding.arg);
-          return;
-        }
         // Initial tooltip setup
         setupTooltip(anchor, binding);
       },

--- a/packages/dialtone-vue2/directives/tooltip/tooltip_directive_default.story.vue
+++ b/packages/dialtone-vue2/directives/tooltip/tooltip_directive_default.story.vue
@@ -19,6 +19,10 @@
     <dt-button v-dt-tooltip:top-end="'Tooltip on top end'">
       Button with tooltip
     </dt-button>
+
+    <dt-button v-dt-tooltip="empty">
+      Empty tooltip
+    </dt-button>
   </dt-stack>
 </template>
 
@@ -29,5 +33,10 @@ import DtIcon from '@/components/icon/icon.vue';
 export default {
   name: 'DtTooltipDirectiveDefault',
   components: { DtIcon, DtButton, DtStack },
+  data () {
+    return {
+      empty: undefined,
+    };
+  },
 };
 </script>

--- a/packages/dialtone-vue3/directives/tooltip/tooltip.js
+++ b/packages/dialtone-vue3/directives/tooltip/tooltip.js
@@ -1,4 +1,4 @@
-import { DtTooltip, TOOLTIP_DIRECTIONS } from '@/components/tooltip';
+import { DtTooltip } from '@/components/tooltip';
 import { getUniqueString } from '@/common/utils';
 import { createApp, h } from 'vue';
 
@@ -56,30 +56,8 @@ export const DtTooltipDirective = {
 
     DtTooltipDirectiveApp.mount(mountPoint);
 
-    const isValidBindingTextValue = (value) => typeof value === 'string' && value?.trim();
-    const isValidBindingPlacementValue = (value) => value === undefined || TOOLTIP_DIRECTIONS.includes(value);
-
     app.directive('dt-tooltip', {
-      beforeMount (anchor, binding) {
-        if (!isValidBindingTextValue(binding.value)) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            'Missing value for v-dt-tooltip directive on: ',
-            anchor,
-            'received value: ',
-            binding.value,
-          );
-          return;
-        }
-        if (!isValidBindingPlacementValue(binding.arg)) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            'Wrong placement value provided for v-dt-tooltip directive on: '
-            , anchor,
-            'received value: ',
-            binding.arg);
-          return;
-        }
+      bind (anchor, binding) {
         // Initial tooltip setup
         setupTooltip(anchor, binding);
       },

--- a/packages/dialtone-vue3/directives/tooltip/tooltip.js
+++ b/packages/dialtone-vue3/directives/tooltip/tooltip.js
@@ -57,7 +57,7 @@ export const DtTooltipDirective = {
     DtTooltipDirectiveApp.mount(mountPoint);
 
     app.directive('dt-tooltip', {
-      bind (anchor, binding) {
+      beforeMount (anchor, binding) {
         // Initial tooltip setup
         setupTooltip(anchor, binding);
       },

--- a/packages/dialtone-vue3/directives/tooltip/tooltip_directive_default.story.vue
+++ b/packages/dialtone-vue3/directives/tooltip/tooltip_directive_default.story.vue
@@ -19,6 +19,10 @@
     <dt-button v-dt-tooltip:top-end="'Tooltip on top end'">
       Button with tooltip
     </dt-button>
+
+    <dt-button v-dt-tooltip="empty">
+      Empty tooltip
+    </dt-button>
   </dt-stack>
 </template>
 
@@ -29,5 +33,10 @@ import DtIcon from '@/components/icon/icon.vue';
 export default {
   name: 'DtTooltipDirectiveDefault',
   components: { DtIcon, DtButton, DtStack },
+  data () {
+    return {
+      empty: undefined,
+    };
+  },
 };
 </script>


### PR DESCRIPTION
# fix(tooltip): remove validators from directive

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaXAxcHN1ZTVhbWk3eGRvbDFjZTd0YTYzbW83cmJ0bTVzNDNmamEzaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/8tbZH3lN7j560/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1557

## :book: Description

Removed the custom validators on the tooltip directive, as they are handled by the prop validators on the component

## :bulb: Context

This was causing issues in product with warnings triggering when tooltip message is undefined, which is actually a valid case it should just not show a tooltip. I think we did this initially because the validator was throwing an error instead of a warning on incorrect prop validation, but that is actually what it's supposed to do. If you pass an incorrect placement the tooltip should not render and it should be an error.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
