### PR TITLE
docs: use CodeExampleTabs component for avatar page

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
@@ -4,17 +4,17 @@
       <div class="d-d-flex d-jc-space-between d-ai-flex-start d-w100p">
         <div>
           <dt-tab
-            id="vueTab"
-            label="vueCode"
-            panel-id="vuePanel"
+            :id="vueTabId"
+            label="Vue code"
+            :panel-id="vuePanelId"
             selected
           >
             Vue
           </dt-tab>
           <dt-tab
-            id="htmlTab"
-            label="htmlCode"
-            panel-id="htmlPanel"
+            :id="htmlTabId"
+            label="HTML code"
+            :panel-id="htmlPanelId"
           >
             HTML
           </dt-tab>
@@ -28,16 +28,16 @@
       </div>
     </template>
     <dt-tab-panel
-      id="vuePanel"
-      tab-id="vueTab"
+      :id="vuePanelId"
+      :tab-id="vueTabId"
     >
       <div class="language-html" data-ext="html">
         <pre class="language-html" v-html="highlightedVue" />
       </div>
     </dt-tab-panel>
     <dt-tab-panel
-      id="htmlPanel"
-      tab-id="htmlTab"
+      :id="htmlPanelId"
+      :tab-id="htmlTabId"
     >
       <dt-banner
         v-if="showHtmlWarning"
@@ -59,6 +59,7 @@
 import Prism from 'prismjs';
 import CopyButton from './CopyButton.vue';
 import { ref } from 'vue';
+import { getUniqueString } from '@dialtone/common/utils';
 
 const props = defineProps({
   htmlCode: {
@@ -78,6 +79,10 @@ const highlightedHtml = Prism.highlight(props.htmlCode.trim(), Prism.languages.h
 const highlightedVue = Prism.highlight(props.vueCode.trim(), Prism.languages.html, 'html');
 
 const selectedTab = ref('0');
+const vueTabId = getUniqueString();
+const vuePanelId = getUniqueString();
+const htmlTabId = getUniqueString();
+const htmlPanelId = getUniqueString();
 </script>
 
 <style scoped lang="less">

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
@@ -19,9 +19,10 @@
             HTML
           </dt-tab>
         </div>
+        <!-- aria label blank so no tooltip displays since it would be redundant to the "Copy code" text -->
         <copy-button
           :text="selectedTab === 'htmlPanel' ? trimmedHtmlCode : trimmedVueCode"
-          aria-label="Copy code"
+          aria-label=""
         >
           Copy code
         </copy-button>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
@@ -1,21 +1,31 @@
 <template>
-  <dt-tab-group class="code-example-tab-group">
+  <dt-tab-group class="code-example-tab-group" @change="selectedTab = $event.selected">
     <template #tabs>
-      <dt-tab
-        id="vueTab"
-        label="vueCode"
-        panel-id="vuePanel"
-        selected
-      >
-        Vue
-      </dt-tab>
-      <dt-tab
-        id="htmlTab"
-        label="htmlCode"
-        panel-id="htmlPanel"
-      >
-        HTML
-      </dt-tab>
+      <div class="d-d-flex d-jc-space-between d-ai-flex-start d-w100p">
+        <div>
+          <dt-tab
+            id="vueTab"
+            label="vueCode"
+            panel-id="vuePanel"
+            selected
+          >
+            Vue
+          </dt-tab>
+          <dt-tab
+            id="htmlTab"
+            label="htmlCode"
+            panel-id="htmlPanel"
+          >
+            HTML
+          </dt-tab>
+        </div>
+        <copy-button
+          :text="selectedTab === 'htmlPanel' ? trimmedHtmlCode : trimmedVueCode"
+          aria-label="Copy code"
+        >
+          Copy code
+        </copy-button>
+      </div>
     </template>
     <dt-tab-panel
       id="vuePanel"
@@ -23,11 +33,6 @@
     >
       <div class="language-html" data-ext="html">
         <pre class="language-html" v-html="highlightedVue" />
-        <copy-button
-          class="code-copy-button"
-          :text="trimmedVueCode"
-          aria-label="Copy Vue code"
-        />
       </div>
     </dt-tab-panel>
     <dt-tab-panel
@@ -45,11 +50,6 @@
       </dt-banner>
       <div class="language-html" data-ext="html">
         <pre class="language-html" v-html="highlightedHtml" />
-        <copy-button
-          class="code-copy-button"
-          :text="trimmedHtmlCode"
-          aria-label="Copy Html code"
-        />
       </div>
     </dt-tab-panel>
   </dt-tab-group>
@@ -58,6 +58,7 @@
 <script setup>
 import Prism from 'prismjs';
 import CopyButton from './CopyButton.vue';
+import { ref } from 'vue';
 
 const props = defineProps({
   htmlCode: {
@@ -75,6 +76,8 @@ const trimmedHtmlCode = props.htmlCode.replace(/^\n/gm, '');
 const trimmedVueCode = props.vueCode.replace(/^\n/gm, '');
 const highlightedHtml = Prism.highlight(props.htmlCode.trim(), Prism.languages.html, 'html');
 const highlightedVue = Prism.highlight(props.vueCode.trim(), Prism.languages.html, 'html');
+
+const selectedTab = ref('0');
 </script>
 
 <style scoped lang="less">
@@ -83,11 +86,6 @@ const highlightedVue = Prism.highlight(props.vueCode.trim(), Prism.languages.htm
   .language-html {
     margin-top: 0;
     position: relative;
-    .code-copy-button {
-      position: absolute;
-      top: var(--dt-space-450);
-      right: var(--dt-space-450);
-    }
   }
 }
 </style>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
@@ -1,6 +1,7 @@
 <template>
-  <dt-tab-group class="code-example-tab-group" @change="selectedTab = $event.selected">
+  <dt-tab-group class="code-example-tab-group" @change="selectedPanelId = $event.selected">
     <template #tabs>
+      {{ selectedPanelId }}
       <div class="d-d-flex d-jc-space-between d-ai-flex-start d-w100p">
         <div>
           <dt-tab
@@ -21,7 +22,7 @@
         </div>
         <!-- aria label blank so no tooltip displays since it would be redundant to the "Copy code" text -->
         <copy-button
-          :text="selectedTab === 'htmlPanel' ? trimmedHtmlCode : trimmedVueCode"
+          :text="selectedPanelId === htmlPanelId ? trimmedHtmlCode : trimmedVueCode"
           aria-label=""
         >
           Copy code
@@ -79,11 +80,12 @@ const trimmedVueCode = props.vueCode.replace(/^\n/gm, '');
 const highlightedHtml = Prism.highlight(props.htmlCode.trim(), Prism.languages.html, 'html');
 const highlightedVue = Prism.highlight(props.vueCode.trim(), Prism.languages.html, 'html');
 
-const selectedTab = ref('0');
 const vueTabId = getUniqueString();
 const vuePanelId = getUniqueString();
 const htmlTabId = getUniqueString();
 const htmlPanelId = getUniqueString();
+
+const selectedPanelId = ref(vuePanelId);
 </script>
 
 <style scoped lang="less">

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <dt-tab-group class="example-tab-group">
+  <dt-tab-group class="code-example-tab-group">
     <template #tabs>
       <dt-tab
         id="vueTab"
@@ -40,7 +40,8 @@
         kind="warning"
         hide-close
       >
-        This component needs Javascript to work as the example
+        When using HTML / CSS code only the visuals of the component are rendered. It may require
+        additional javascript to function the same way as the example.
       </dt-banner>
       <div class="language-html" data-ext="html">
         <pre class="language-html" v-html="highlightedHtml" />
@@ -70,12 +71,14 @@ const props = defineProps({
   showHtmlWarning: Boolean,
 });
 
+const trimmedHtmlCode = props.htmlCode.replace(/^\n/gm, '');
+const trimmedVueCode = props.vueCode.replace(/^\n/gm, '');
 const highlightedHtml = Prism.highlight(props.htmlCode.trim(), Prism.languages.html, 'html');
 const highlightedVue = Prism.highlight(props.vueCode.trim(), Prism.languages.html, 'html');
 </script>
 
 <style scoped lang="less">
-.example-tab-group {
+.code-example-tab-group {
   margin-top: var(--dt-space-500);
   .language-html {
     margin-top: 0;

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
@@ -7,14 +7,14 @@
         panel-id="vuePanel"
         selected
       >
-        Vue code
+        Vue
       </dt-tab>
       <dt-tab
         id="htmlTab"
         label="htmlCode"
         panel-id="htmlPanel"
       >
-        HTML code
+        HTML
       </dt-tab>
     </template>
     <dt-tab-panel

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CopyButton.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CopyButton.vue
@@ -6,18 +6,19 @@
     <template #anchor>
       <dt-button
         :aria-label="ariaLabel"
-        :circle="true"
+        :circle="$slots.default ? false : true"
         size="xs"
         importance="clear"
         kind="muted"
         @click="copyToClipboard"
       >
-        <template #icon>
+        <template #icon="{ iconSize }">
           <dt-icon
             name="copy"
-            size="300"
+            :size="iconSize"
           />
         </template>
+        <slot />
       </dt-button>
     </template>
   </dt-tooltip>

--- a/apps/dialtone-documentation/docs/.vuepress/client.js
+++ b/apps/dialtone-documentation/docs/.vuepress/client.js
@@ -15,7 +15,7 @@ import TokenTable from './baseComponents/TokenTable.vue';
 import ComponentVueApi from './baseComponents/ComponentVueApi.vue';
 import ComponentAccessibleTable from './baseComponents/ComponentAccessibleTable.vue';
 import ComponentCombinator from './baseComponents/ComponentCombinator.vue';
-import ExampleTabs from './baseComponents/ExampleTabs.vue';
+import CodeExampleTabs from './baseComponents/CodeExampleTabs.vue';
 import SvgLoader from './baseComponents/SvgLoader.vue';
 import DialtoneUsage from './baseComponents/DialtoneUsage.vue';
 
@@ -36,7 +36,7 @@ export default defineClientConfig({
     app.component('ComponentVueApi', ComponentVueApi);
     app.component('ComponentAccessibleTable', ComponentAccessibleTable);
     app.component('ComponentCombinator', ComponentCombinator);
-    app.component('ExampleTabs', ExampleTabs);
+    app.component('CodeExampleTabs', CodeExampleTabs);
     app.component('SvgLoader', SvgLoader);
     app.component('DialtoneUsage', DialtoneUsage);
   },

--- a/apps/dialtone-documentation/docs/components/avatar.md
+++ b/apps/dialtone-documentation/docs/components/avatar.md
@@ -16,6 +16,41 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
     </div>
 </code-well-header>
 
+<code-example-tabs
+htmlCode='
+<!-- icon -->
+<div class="d-avatar d-avatar--lg">
+    <div class="d-avatar__canvas">
+        <svg>...</svg>
+    </div>
+</div>
+<!-- initials -->
+<div class="d-avatar d-avatar--lg d-avatar--color-1000">
+    <div class="d-avatar__canvas">
+        <span class="d-avatar__initials">dp</span>
+    </div>
+    <div class="d-presence d-avatar__presence d-avatar__presence--lg">
+        <div class="d-presence__inner d-presence__inner--busy" />
+    </div>
+</div>
+<!-- image -->
+<div class="d-avatar d-avatar--lg d-avatar--color-1800">
+    <div class="d-avatar__canvas d-avatar--image-loaded">
+        <img class="d-avatar__image" data-qa="dt-avatar-image" src="/assets/images/person.png" alt="avatar user">
+    </div>
+    <div class="d-presence d-avatar__presence d-avatar__presence--lg" data-qa="dt-presence" role="status" aria-live="off">
+        <div class="d-presence__inner d-presence__inner--active" />
+    </div>
+</div>
+'
+vueCode='
+<dt-avatar size="lg" icon-name="user" icon-size="500" />
+<dt-avatar size="lg" full-name="dp" color="1000" presence="busy" />
+<dt-avatar size="lg" image-src="/assets/images/person.png" image-alt="avatar user" presence="active" />
+'
+showHtmlWarning>
+</code-example-tabs>
+
 <!-- <component-combinator component-name="DtAvatar" /> -->
 
 ## Usage
@@ -73,15 +108,22 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
     <dt-avatar icon-name="user" icon-size="300" />
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div class="d-avatar d-avatar--{$size}">
     <div class="d-avatar__canvas">
         <span class="d-avatar__icon">
-            <svg>...</svg>
+        <svg>...</svg>
         </span>
     </div>
-</div>
-```
+</div>'
+vueCode='
+<dt-avatar
+    icon-name="person"
+/>
+'
+showHtmlWarning>
+</code-example-tabs>
 
 ### Initials
 
@@ -91,13 +133,23 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
     </dt-stack>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div class="d-avatar d-avatar--{$size} d-avatar--{$color}">
     <div class="d-avatar__canvas">
         <span class="d-avatar__initials">DP</span>
     </div>
 </div>
-```
+'
+vueCode='
+<!-- colors 100 to 1800 are valid -->
+<dt-avatar
+    full-name="DP"
+    color="100"
+/>
+'
+showHtmlWarning>
+</code-example-tabs>
 
 ### Image
 
@@ -105,13 +157,19 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   <dt-avatar image-src="/assets/images/person.png" image-alt="avatar user" />
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div class="d-avatar d-avatar--{$size}">
     <div class="d-avatar__canvas">
-        <img class="d-avatar__image" src="/path/to/image" />
+        <img class="d-avatar__image" src="/path/to/image" alt="avatar user" />
     </div>
 </div>
-```
+'
+vueCode='
+<dt-avatar image-src="/assets/images/person.png" image-alt="avatar user" />
+'
+showHtmlWarning>
+</code-example-tabs>
 
 ### Sizes
 
@@ -121,23 +179,43 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
     </div>
 </code-well-header>
 
-```html
-    <div class="d-avatar d-avatar--xs">
-        ...
+<code-example-tabs
+htmlCode='
+<div class="d-avatar d-avatar--xs">
+    <div class="d-avatar__canvas">
+        <svg>...</svg>
     </div>
-    <div class="d-avatar d-avatar--sm">
-        ...
+</div>
+<div class="d-avatar d-avatar--sm">
+    <div class="d-avatar__canvas">
+        <svg>...</svg>
     </div>
-    <div class="d-avatar d-avatar--md">
-        ...
+</div>
+<div class="d-avatar d-avatar--md">
+    <div class="d-avatar__canvas">
+        <svg>...</svg>
     </div>
-    <div class="d-avatar d-avatar--lg">
-        ...
+</div>
+<div class="d-avatar d-avatar--lg">
+    <div class="d-avatar__canvas">
+        <svg>...</svg>
     </div>
-    <div class="d-avatar d-avatar--xl">
-        ...
+</div>
+<div class="d-avatar d-avatar--xl">
+    <div class="d-avatar__canvas">
+        <svg>...</svg>
     </div>
-```
+</div>
+'
+vueCode='
+<dt-avatar size="xs" icon-name="user" />
+<dt-avatar size="sm" icon-name="user" />
+<dt-avatar size="md" icon-name="user" />
+<dt-avatar size="lg" icon-name="user" />
+<dt-avatar size="xl" icon-name="user" />
+'
+showHtmlWarning>
+</code-example-tabs>
 
 ### Group
 
@@ -148,20 +226,27 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
     </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div class="d-avatar d-avatar--group">
     <div class="d-avatar__canvas">
-        <img class="d-avatar__image" src="/assets/images/person.png" alt=""/>
+        <img class="d-avatar__image" src="/assets/images/person.png" alt="Person Avatar"/>
     </div>
     <span class="d-avatar__count"><span class="d-avatar__count-number">12</span></span>
 </div>
 <div class="d-avatar d-avatar--group">
     <div class="d-avatar__canvas">
-        <img class="d-avatar__image" src="/assets/images/person.png" alt=""/>
+        <img class="d-avatar__image" src="/assets/images/person.png" alt="Person Avatar"/>
     </div>
     <span class="d-avatar__count"><span class="d-avatar__count-number">1</span></span>
 </div>
-```
+'
+vueCode='
+<dt-avatar :group="11" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+<dt-avatar :group="3" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+'
+showHtmlWarning>
+</code-example-tabs>
 
 ### Presence
 
@@ -184,18 +269,33 @@ Positions the [Presence](components/presence.html) component at each size.
     </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div class="d-avatar d-avatar--{$size)">
     <div class="d-avatar__canvas">
         ...
     </div>
     <div class="d-avatar__presence">
-        <div class="d-presence">
-            <div class="d-presence__inner d-presence__inner--{$status}"></div>
+        <div class="d-presence d-avatar__presence d-avatar__presence--md"><!---->
+            <div class="d-presence__inner d-presence__inner--{$status}" />
         </div>
     </div>
 </div>
-```
+'
+vueCode='
+<dt-avatar size="xs" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+<dt-avatar size="sm" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+<dt-avatar size="md" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+<dt-avatar size="lg" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+<dt-avatar size="xl" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+<dt-avatar size="xs" presence="active" color="1200" />
+<dt-avatar size="sm" presence="away" color="500" full-name="W" />
+<dt-avatar size="md" presence="busy" color="800" full-name="FR" />
+<dt-avatar size="lg" presence="offline" color="1200" full-name="JH" />
+<dt-avatar size="xl" color="1500" full-name="AE" />
+'
+showHtmlWarning>
+</code-example-tabs>
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/avatar.md
+++ b/apps/dialtone-documentation/docs/components/avatar.md
@@ -87,8 +87,7 @@ vueCode='
     icon-name="person"
 />
 '
-showHtmlWarning>
-</code-example-tabs>
+showHtmlWarning />
 
 ### Initials
 
@@ -113,8 +112,7 @@ vueCode='
     color="100"
 />
 '
-showHtmlWarning>
-</code-example-tabs>
+showHtmlWarning />
 
 ### Image
 
@@ -133,8 +131,7 @@ htmlCode='
 vueCode='
 <dt-avatar image-src="/assets/images/person.png" image-alt="avatar user" />
 '
-showHtmlWarning>
-</code-example-tabs>
+showHtmlWarning />
 
 ### Sizes
 
@@ -179,8 +176,7 @@ vueCode='
 <dt-avatar size="lg" icon-name="user" />
 <dt-avatar size="xl" icon-name="user" />
 '
-showHtmlWarning>
-</code-example-tabs>
+showHtmlWarning />
 
 ### Group
 
@@ -210,8 +206,7 @@ vueCode='
 <dt-avatar :group="11" image-src="/assets/images/person.png" image-alt="Person Avatar" />
 <dt-avatar :group="3" image-src="/assets/images/person.png" image-alt="Person Avatar" />
 '
-showHtmlWarning>
-</code-example-tabs>
+showHtmlWarning />
 
 ### Presence
 
@@ -259,8 +254,7 @@ vueCode='
 <dt-avatar size="lg" presence="offline" color="1200" full-name="JH" />
 <dt-avatar size="xl" color="1500" full-name="AE" />
 '
-showHtmlWarning>
-</code-example-tabs>
+showHtmlWarning />
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/avatar.md
+++ b/apps/dialtone-documentation/docs/components/avatar.md
@@ -16,41 +16,6 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
     </div>
 </code-well-header>
 
-<code-example-tabs
-htmlCode='
-<!-- icon -->
-<div class="d-avatar d-avatar--lg">
-    <div class="d-avatar__canvas">
-        <svg>...</svg>
-    </div>
-</div>
-<!-- initials -->
-<div class="d-avatar d-avatar--lg d-avatar--color-1000">
-    <div class="d-avatar__canvas">
-        <span class="d-avatar__initials">dp</span>
-    </div>
-    <div class="d-presence d-avatar__presence d-avatar__presence--lg">
-        <div class="d-presence__inner d-presence__inner--busy" />
-    </div>
-</div>
-<!-- image -->
-<div class="d-avatar d-avatar--lg d-avatar--color-1800">
-    <div class="d-avatar__canvas d-avatar--image-loaded">
-        <img class="d-avatar__image" data-qa="dt-avatar-image" src="/assets/images/person.png" alt="avatar user">
-    </div>
-    <div class="d-presence d-avatar__presence d-avatar__presence--lg" data-qa="dt-presence" role="status" aria-live="off">
-        <div class="d-presence__inner d-presence__inner--active" />
-    </div>
-</div>
-'
-vueCode='
-<dt-avatar size="lg" icon-name="user" icon-size="500" />
-<dt-avatar size="lg" full-name="dp" color="1000" presence="busy" />
-<dt-avatar size="lg" image-src="/assets/images/person.png" image-alt="avatar user" presence="active" />
-'
-showHtmlWarning>
-</code-example-tabs>
-
 <!-- <component-combinator component-name="DtAvatar" /> -->
 
 ## Usage

--- a/packages/dialtone-vue2/components/tabs/tab_group.vue
+++ b/packages/dialtone-vue2/components/tabs/tab_group.vue
@@ -192,8 +192,8 @@ export default {
     },
 
     getTabChildren () {
-      return this.$children.map(({ $el }) => $el)
-        .filter(({ className }) => className.includes('d-tab'))
+      const tabs = Array.from(this.$refs.tabs.querySelectorAll('.d-tab'));
+      return tabs
         .map(el => {
           return ({
             context: el,

--- a/packages/dialtone-vue2/components/tabs/tab_group.vue
+++ b/packages/dialtone-vue2/components/tabs/tab_group.vue
@@ -192,8 +192,7 @@ export default {
     },
 
     getTabChildren () {
-      const tabs = Array.from(this.$refs.tabs.querySelectorAll('.d-tab'));
-      return tabs
+      return Array.from(this.$el.querySelectorAll('.d-tab'))
         .map(el => {
           return ({
             context: el,

--- a/packages/dialtone-vue3/components/tabs/tab_group.vue
+++ b/packages/dialtone-vue3/components/tabs/tab_group.vue
@@ -193,9 +193,8 @@ export default {
     },
 
     getTabChildren () {
-      const tabs = Array.from(this.$refs.tabs.children);
+      const tabs = Array.from(this.$refs.tabs.querySelectorAll('.d-tab'));
       return tabs
-        .filter(({ className }) => className.includes('d-tab'))
         .map(el => {
           return ({
             context: el,


### PR DESCRIPTION
# docs: use CodeExampleTabs component for avatar page

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbmNtcXNrM2xqbHNvdnFoNm5zZm9keWdqMnYza2JlMXNhOHA0ODhydyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/2A75RyXVzzSI2bx4Gj/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Description

Implemented our new CodeExampleTabs component into the avatar page. Also made a few small fixes to the CodeExampleTabs component that I noticed while trying to use it.

Renamed ExampleTabs to CodeExampleTabs as there was already another component in our library called ExampleTabs on the tabs page and it was very confusing.

## :bulb: Context

Was trying to figure out how much effort it would be to start implementing this component on all of our pages so tried doing it on one page myself. Not a difficult task but a bit time consuming and tedious. I will break up our existing story for this into multiple stories so we can start working on it next sprint https://dialpad.atlassian.net/browse/DLT-691

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

Break up stories, pull into next sprint.

## :camera: Screenshots / GIFs

![Screenshot 2024-02-22 at 2 34 13 PM](https://github.com/dialpad/dialtone/assets/64808812/d480083f-f33a-4fd2-a29d-84e0834c1bda)
