### PR TITLE
fix(popover): remove data-popper-escaped

### DIFF
--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -1016,13 +1016,3 @@ export default {
   },
 };
 </script>
-
-<style lang="less">
-.tippy-box[data-popper-reference-hidden],
-.tippy-box[data-popper-escaped] {
-  .d-popover__dialog {
-    visibility: hidden;
-    pointer-events: none;
-  }
-}
-</style>

--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -511,8 +511,7 @@ export default {
 </script>
 
 <style lang="less">
-.tippy-box[data-popper-reference-hidden],
-.tippy-box[data-popper-escaped] {
+.tippy-box[data-popper-reference-hidden] {
   .d-tooltip {
     visibility: hidden;
     pointer-events: none;

--- a/packages/dialtone-vue3/components/popover/popover.vue
+++ b/packages/dialtone-vue3/components/popover/popover.vue
@@ -1052,13 +1052,3 @@ export default {
   },
 };
 </script>
-
-<style lang="less">
-.tippy-box[data-popper-reference-hidden],
-.tippy-box[data-popper-escaped] {
-  .d-popover__dialog {
-    visibility: hidden;
-    pointer-events: none;
-  }
-}
-</style>

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -520,8 +520,7 @@ export default {
 </script>
 
 <style lang="less">
-.tippy-box[data-popper-reference-hidden],
-.tippy-box[data-popper-escaped] {
+.tippy-box[data-popper-reference-hidden] {
   .d-tooltip {
     visibility: hidden;
     pointer-events: none;


### PR DESCRIPTION
# fix(popover): remove data-popper-escaped

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbXF5Nm03eG8xeGczNGVxdm1vY3l0ejk1aTh4YTVpdHl1cnhvNWZ2dCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/nagxKKFv9vVCj2mB4J/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1570

## :book: Description

Removed data-popper. classes from popover completely
Removed data-popper-escaped from tooltip

## :bulb: Context

This statement was causing issues hiding the popover when it shouldn't. I don't think this is necessary at all for popover as it renders modally 99% of the time so it can't be scrolled out of view. Also removed data-popper-escaped from tooltip, since we use fallback statements to move the placement when it's out of the viewport it shouldn't be necessary.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
