### PR TITLE
feat(message-input): add mentions to message input

### DIFF
--- a/packages/dialtone-icons/src/keywords.json
+++ b/packages/dialtone-icons/src/keywords.json
@@ -214,15 +214,35 @@
       ]
     },
     "brand": {
-      "agent-assist": ["ai", "conversation", "chat"],
-      "ai-notes": ["artificial", "intelligence"],
+      "agent-assist": [
+        "ai",
+        "conversation",
+        "chat"
+      ],
+      "ai-notes": [
+        "artificial",
+        "intelligence"
+      ],
       "coaching-hub": [],
-      "dialpad-ai-reversed": ["dp", "brand"],
-      "dialpad-ai": ["artificial", "intelligence", "voice"],
+      "dialpad-ai-reversed": [
+        "dp",
+        "brand"
+      ],
+      "dialpad-ai": [
+        "artificial",
+        "intelligence",
+        "voice"
+      ],
       "dialpad-logomark": [],
-      "dp-phone": ["call", "dialpad"],
+      "dp-phone": [
+        "call",
+        "dialpad"
+      ],
       "waveform": [],
-      "zoom-logo": ["video", "competitor"]
+      "zoom-logo": [
+        "video",
+        "competitor"
+      ]
     },
     "brand-full-color": {
       "airtable": [],
@@ -270,7 +290,10 @@
       "microsoft": [],
       "miro": [],
       "monday-com": [],
-      "o365-calendar": ["microsoft", "office"],
+      "o365-calendar": [
+        "microsoft",
+        "office"
+      ],
       "office-365": [],
       "pipedrive": [],
       "play-store-badge": [],
@@ -280,7 +303,10 @@
       "slack": [],
       "snapchat": [],
       "telegram": [],
-      "threads": ["meta", "facebook"],
+      "threads": [
+        "meta",
+        "facebook"
+      ],
       "tiktok": [],
       "toggl": [],
       "twitter": [],
@@ -289,7 +315,9 @@
       "visa": [],
       "we-chat": [],
       "whatsapp": [],
-      "x-brand": ["twitter"],
+      "x-brand": [
+        "twitter"
+      ],
       "zendesk": [],
       "zoho-crm": [],
       "zoho-desk": [],

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -2,6 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeMessageInput from './message_input.vue';
 import DtRecipeMessageInputDefaultTemplate from './message_input_default.story.vue';
+import mentionSuggestion from '@/components/rich_text_editor/mention_suggestion';
 
 /*
   Controls
@@ -111,6 +112,7 @@ export const argsData = {
     warning: 500,
     message: 'You have exceeded the character limit',
   },
+  mentionSuggestion,
   onSubmit: action('submit'),
   onFocus: action('focus'),
   onBlur: action('blur'),

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -26,6 +26,7 @@
         :auto-focus="autoFocus"
         :link="link"
         :placeholder="placeholder"
+        :mention-suggestion="mentionSuggestion"
         v-bind="$attrs"
         @focus="onFocus"
         @blur="onBlur"
@@ -414,6 +415,22 @@ export default {
       type: [Boolean, Object],
       default: () => ({ text: 'Cancel' }),
     },
+
+    /**
+     * suggestion object containing the items query function.
+     * The valid keys passed into this object can be found here: https://tiptap.dev/api/utilities/suggestion
+     *
+     * The only required key is the items function which is used to query the contacts for suggestion.
+     * items({ query }) => { return [ContactObject]; }
+     * ContactObject format:
+     * { name: string, avatarSrc: string, id: string }
+     *
+     * When null, it does not add the plugin.
+     */
+    mentionSuggestion: {
+      type: Object,
+      default: null,
+    },
   },
 
   emits: [
@@ -601,9 +618,7 @@ export default {
 
     onFocus (event) {
       this.hasFocus = true;
-      console.log('B', this.hasFocus);
       this.$refs.richTextEditor.focusEditor();
-      console.log('A', this.hasFocus);
       this.$emit('focus', event);
     },
 

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -13,6 +13,7 @@
         :placeholder="$attrs.placeholder"
         :disable-send="$attrs.disableSend"
         :max-height="$attrs.maxHeight"
+        :mention-suggestion="$attrs.mentionSuggestion"
         :show-emoji-picker="$attrs.showEmojiPicker"
         :emoji-picker-props="$attrs.emojiPickerProps"
         :emoji-tooltip-message="$attrs.emojiTooltipMessage"

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -2,6 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import DtRecipeMessageInput from './message_input.vue';
 import DtRecipeMessageInputDefaultTemplate from './message_input_default.story.vue';
+import mentionSuggestion from '@/components/rich_text_editor/mention_suggestion';
 
 /*
   Controls
@@ -111,6 +112,7 @@ export const argsData = {
     warning: 500,
     message: 'You have exceeded the character limit',
   },
+  mentionSuggestion,
   onSubmit: action('submit'),
   onFocus: action('focus'),
   onBlur: action('blur'),

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -26,6 +26,7 @@
         :auto-focus="autoFocus"
         :link="link"
         :placeholder="placeholder"
+        :mention-suggestion="mentionSuggestion"
         v-bind="$attrs"
         @focus="onFocus"
         @blur="onBlur"
@@ -413,6 +414,22 @@ export default {
     showCancel: {
       type: [Boolean, Object],
       default: () => ({ text: 'Cancel' }),
+    },
+
+    /**
+     * suggestion object containing the items query function.
+     * The valid keys passed into this object can be found here: https://tiptap.dev/api/utilities/suggestion
+     *
+     * The only required key is the items function which is used to query the contacts for suggestion.
+     * items({ query }) => { return [ContactObject]; }
+     * ContactObject format:
+     * { name: string, avatarSrc: string, id: string }
+     *
+     * When null, it does not add the plugin.
+     */
+    mentionSuggestion: {
+      type: Object,
+      default: null,
     },
   },
 

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -12,6 +12,7 @@
       :placeholder="$attrs.placeholder"
       :disable-send="$attrs.disableSend"
       :max-height="$attrs.maxHeight"
+      :mention-suggestion="$attrs.mentionSuggestion"
       :show-emoji-picker="$attrs.showEmojiPicker"
       :emoji-picker-props="$attrs.emojiPickerProps"
       :emoji-tooltip-message="$attrs.emojiTooltipMessage"


### PR DESCRIPTION
# feat(message-input): add mentions to message input

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExenlqeDdrZnoxZ3VyaWY5cTVmYmxiZDJwd2kzNzRnNDM1djYycGx5NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/WlBb2UXOOYbuLXgwW4/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

- [x] Feature

## :book: Description

Added mentionSuggestions to the message input component

## :bulb: Context

We've had mentionSuggestions in the rich_text_editor component for a while. This prop just needed to be exposed in the message input component. Had a request from product for this.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.

## :crystal_ball: Next Steps

Let messaging team know once this is released.

## :camera: Screenshots / GIFs

![Screenshot 2024-02-23 at 2 02 52 PM](https://github.com/dialpad/dialtone/assets/64808812/e84ab8cb-7fb7-47d8-9795-b6cee093a70a)

## :link: Sources

https://tiptap.dev/docs/editor/api/utilities/suggestion
