### PR TITLE
fix(root-layout): focus ring on scrollable regions

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/root-layout.less
+++ b/packages/dialtone-css/lib/build/less/components/root-layout.less
@@ -50,6 +50,10 @@
     height: 100%;
     overflow: hidden auto;
     box-shadow: none;
+
+    &:focus-visible {
+      box-shadow: var(--dt-shadow-focus-inset);
+    }
   }
 
   &__content {
@@ -58,7 +62,7 @@
     box-shadow: none;
 
     &:focus-visible {
-      box-shadow: none;
+      box-shadow: var(--dt-shadow-focus-inset);
     }
   }
 


### PR DESCRIPTION
# fix(root-layout): focus ring on scrollable regions

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGw1bTF4d25vcnRrM3h3ZmlkM3R1ems3OGo0dWQ3ZzJkZjFnOHpweCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MCOyeespFudGwqwnyH/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Added inset focus ring on focus visible to sidebar and content sections

## :bulb: Context

By accessibility rules scrolling regions must be focusable, however our root layout component does not currently indicate focus. Added an inset focus ring on focus-visible. This gets cut off by the scrollbar if it is shown, however I cannot find any possible way to fix this due to the component taking up all available space with no padding / margin 🤷. This solution is still better than nothing

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.

## :camera: Screenshots / GIFs

![Screenshot 2024-02-28 at 12 14 54 PM](https://github.com/dialpad/dialtone/assets/64808812/726f0c12-046f-41e7-955a-108f3a5fba5c)


## :link: Sources

https://accessibilityinsights.io/info-examples/web/scrollable-region-focusable/