### PR TITLE
fix(message-input): color contrast on cancel button

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -405,7 +405,7 @@ export default {
      */
     showSend: {
       type: [Boolean, Object],
-      default: () => ({ icon: 'send', ariaLabel: 'send' }),
+      default: () => ({ icon: 'send' }),
     },
 
     /**

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -405,7 +405,7 @@ export default {
      */
     showSend: {
       type: [Boolean, Object],
-      default: () => ({ icon: 'send' }),
+      default: () => ({ icon: 'send', ariaLabel: 'send' }),
     },
 
     /**
@@ -650,7 +650,6 @@ export default {
 }
 
 .dt-message-input--cancel-button {
-  color: var(--dt-color-black-500);
   margin-right: var(--dt-space-300);
 }
 </style>

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -405,7 +405,7 @@ export default {
      */
     showSend: {
       type: [Boolean, Object],
-      default: () => ({ icon: 'send', ariaLabel: 'send' }),
+      default: () => ({ icon: 'send' }),
     },
 
     /**

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -405,7 +405,7 @@ export default {
      */
     showSend: {
       type: [Boolean, Object],
-      default: () => ({ icon: 'send' }),
+      default: () => ({ icon: 'send', ariaLabel: 'send' }),
     },
 
     /**
@@ -650,7 +650,6 @@ export default {
 }
 
 .dt-message-input--cancel-button {
-  color: var(--dt-color-black-500);
   margin-right: var(--dt-space-300);
 }
 </style>


### PR DESCRIPTION
# [fix(message-input): color contrast on cancel button](https://github.com/dialpad/dialtone/commit/29ea4974176ead6e8d9424deb9002f655bc1280d)

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1591

## :book: Description

Remove custom text color from cancel button

## :bulb: Context

So it does not fail accessibility tests

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
