### PR TITLE
fix(feed-item-row): accessibility error

### DIFF
--- a/packages/dialtone-vue2/components/list_item/list_item.test.js
+++ b/packages/dialtone-vue2/components/list_item/list_item.test.js
@@ -7,7 +7,7 @@ const MOCK_CLICK_STUB = vi.fn();
 const baseProps = {
   id: 'dt-item',
   navigationType: LIST_ITEM_NAVIGATION_TYPES.ARROW_KEYS,
-  role: 'tab',
+  role: 'option',
 };
 const baseListeners = {
   click: MOCK_CLICK_STUB,

--- a/packages/dialtone-vue2/components/list_item/list_item.test.js
+++ b/packages/dialtone-vue2/components/list_item/list_item.test.js
@@ -7,6 +7,7 @@ const MOCK_CLICK_STUB = vi.fn();
 const baseProps = {
   id: 'dt-item',
   navigationType: LIST_ITEM_NAVIGATION_TYPES.ARROW_KEYS,
+  role: 'tab',
 };
 const baseListeners = {
   click: MOCK_CLICK_STUB,

--- a/packages/dialtone-vue2/components/list_item/list_item.vue
+++ b/packages/dialtone-vue2/components/list_item/list_item.vue
@@ -9,7 +9,7 @@
     }]"
     :tabindex="isFocusable ? 0 : -1"
     :role="role"
-    :aria-selected="isHighlighted"
+    :aria-selected="hasAriaSelected"
     v-on="listItemListeners"
   >
     <component
@@ -47,6 +47,8 @@ import {
 import utils from '@/common/utils';
 import { DtIcon } from '@/components/icon';
 import { DtItemLayout } from '@/components/item_layout';
+
+const ARIA_SELECTED_ALLOWED_ROLES = ['gridcell', 'option', 'row', 'tab'];
 
 /**
  * A list item is an element that can be used to represent individual items in a list.
@@ -206,6 +208,14 @@ export default {
         return this.highlightId && this.highlightId() ? this.id === this.highlightId() : this.mouseHighlighted;
       }
       return false;
+    },
+
+    hasAriaSelected () {
+      if (ARIA_SELECTED_ALLOWED_ROLES.includes(this.role)) {
+        return this.isHighlighted;
+      } else {
+        return undefined;
+      }
     },
 
     isFocusable () {

--- a/packages/dialtone-vue2/components/list_item/list_item.vue
+++ b/packages/dialtone-vue2/components/list_item/list_item.vue
@@ -9,7 +9,7 @@
     }]"
     :tabindex="isFocusable ? 0 : -1"
     :role="role"
-    :aria-selected="hasAriaSelected"
+    :aria-selected="role === 'option' ? isHighlighted : undefined"
     v-on="listItemListeners"
   >
     <component
@@ -48,7 +48,7 @@ import utils from '@/common/utils';
 import { DtIcon } from '@/components/icon';
 import { DtItemLayout } from '@/components/item_layout';
 
-const ARIA_SELECTED_ALLOWED_ROLES = ['gridcell', 'option', 'row', 'tab'];
+const ROLES = ['listitem', 'option'];
 
 /**
  * A list item is an element that can be used to represent individual items in a list.
@@ -84,6 +84,7 @@ export default {
     role: {
       type: String,
       default: 'listitem',
+      validator: (role) => (ROLES).includes(role),
     },
 
     /**
@@ -208,14 +209,6 @@ export default {
         return this.highlightId && this.highlightId() ? this.id === this.highlightId() : this.mouseHighlighted;
       }
       return false;
-    },
-
-    hasAriaSelected () {
-      if (ARIA_SELECTED_ALLOWED_ROLES.includes(this.role)) {
-        return this.isHighlighted;
-      } else {
-        return undefined;
-      }
     },
 
     isFocusable () {

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
@@ -133,10 +133,6 @@ Default.parameters = {
     config: {
       rules: [
         {
-          id: 'aria-allowed-attr',
-          enabled: false,
-        },
-        {
           id: 'color-contrast',
           enabled: false,
         },

--- a/packages/dialtone-vue3/components/list_item/list_item.test.js
+++ b/packages/dialtone-vue3/components/list_item/list_item.test.js
@@ -7,7 +7,7 @@ const MOCK_CLICK_STUB = vi.fn();
 const baseProps = {
   id: 'dt-item',
   navigationType: LIST_ITEM_NAVIGATION_TYPES.ARROW_KEYS,
-  role: 'tab',
+  role: 'option',
 };
 const baseAttrs = {
   onClick: MOCK_CLICK_STUB,

--- a/packages/dialtone-vue3/components/list_item/list_item.test.js
+++ b/packages/dialtone-vue3/components/list_item/list_item.test.js
@@ -7,6 +7,7 @@ const MOCK_CLICK_STUB = vi.fn();
 const baseProps = {
   id: 'dt-item',
   navigationType: LIST_ITEM_NAVIGATION_TYPES.ARROW_KEYS,
+  role: 'tab',
 };
 const baseAttrs = {
   onClick: MOCK_CLICK_STUB,

--- a/packages/dialtone-vue3/components/list_item/list_item.vue
+++ b/packages/dialtone-vue3/components/list_item/list_item.vue
@@ -10,7 +10,7 @@
     }]"
     :tabindex="isFocusable ? 0 : -1"
     :role="role"
-    :aria-selected="hasAriaSelected"
+    :aria-selected="role === 'option' ? isHighlighted : undefined"
     v-on="listItemListeners"
   >
     <component
@@ -49,7 +49,7 @@ import utils from '@/common/utils';
 import { DtIcon } from '@/components/icon';
 import { DtItemLayout } from '@/components/item_layout';
 
-const ARIA_SELECTED_ALLOWED_ROLES = ['gridcell', 'option', 'row', 'tab'];
+const ROLES = ['listitem', 'option'];
 
 /**
  * A list item is an element that can be used to represent individual items in a list.
@@ -85,6 +85,7 @@ export default {
     role: {
       type: String,
       default: 'listitem',
+      validator: (role) => (ROLES).includes(role),
     },
 
     /**
@@ -207,14 +208,6 @@ export default {
         return this.highlightId && this.highlightId() ? this.id === this.highlightId() : this.mouseHighlighted;
       }
       return false;
-    },
-
-    hasAriaSelected () {
-      if (ARIA_SELECTED_ALLOWED_ROLES.includes(this.role)) {
-        return this.isHighlighted;
-      } else {
-        return undefined;
-      }
     },
 
     isFocusable () {

--- a/packages/dialtone-vue3/components/list_item/list_item.vue
+++ b/packages/dialtone-vue3/components/list_item/list_item.vue
@@ -10,7 +10,7 @@
     }]"
     :tabindex="isFocusable ? 0 : -1"
     :role="role"
-    :aria-selected="isHighlighted"
+    :aria-selected="hasAriaSelected"
     v-on="listItemListeners"
   >
     <component
@@ -48,6 +48,8 @@ import {
 import utils from '@/common/utils';
 import { DtIcon } from '@/components/icon';
 import { DtItemLayout } from '@/components/item_layout';
+
+const ARIA_SELECTED_ALLOWED_ROLES = ['gridcell', 'option', 'row', 'tab'];
 
 /**
  * A list item is an element that can be used to represent individual items in a list.
@@ -205,6 +207,14 @@ export default {
         return this.highlightId && this.highlightId() ? this.id === this.highlightId() : this.mouseHighlighted;
       }
       return false;
+    },
+
+    hasAriaSelected () {
+      if (ARIA_SELECTED_ALLOWED_ROLES.includes(this.role)) {
+        return this.isHighlighted;
+      } else {
+        return undefined;
+      }
     },
 
     isFocusable () {

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
@@ -145,10 +145,6 @@ Default.parameters = {
     config: {
       rules: [
         {
-          id: 'aria-allowed-attr',
-          enabled: false,
-        },
-        {
           id: 'color-contrast',
           enabled: false,
         },


### PR DESCRIPTION
# fix(feed-item-row): accessibility error

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZWFkNHltN2Y2cGQxMjl6N3Z2cGZoc2tsaGFmeXM4YWZlZjE4eDRneSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mx4B7Wui0EL23gwGdq/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-1592
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Fixes the a11y violation `aria-allowed-attr` that was disabled in Storybook.
When enabling the rule, I could repro in vue 3.
The error was happening when the role is `listitem`, since it's assigning an `aria-selected` which is not allowed for that role. Even if the value is false, the attribute is being assigned in vue 3 anyways, so to fix it I am setting it to `undefined` if the rol doesn't allow it, considering the roles listed here: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected

## Before
<img width="1006" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/4bdb6770-3b1e-46e4-b2e5-5094066abd9f">

## Now
<img width="1378" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/768857a3-1b6a-4c1e-a0ef-7bab8ffe0565">


<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.
