### PR TITLE
docs: remove leftover from code-example-tabs component

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
@@ -1,7 +1,6 @@
 <template>
   <dt-tab-group class="code-example-tab-group" @change="selectedPanelId = $event.selected">
     <template #tabs>
-      {{ selectedPanelId }}
       <div class="d-d-flex d-jc-space-between d-ai-flex-start d-w100p">
         <div>
           <dt-tab


### PR DESCRIPTION
# Remove leftover from code-example-tabs component

Before:
<img width="454" alt="Screenshot 2024-03-01 at 13 05 55" src="https://github.com/dialpad/dialtone/assets/89984179/fa248906-3e9f-44e4-924e-0ddcdd81a0a6">

After:
<img width="454" alt="Screenshot 2024-03-01 at 13 05 31" src="https://github.com/dialpad/dialtone/assets/89984179/6bd8fb4e-753d-4f86-959a-81e9b70e4dc0">
