### PR TITLE
docs: use CodeExampleTabs from badge to button-group

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeWellHeader.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeWellHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="d-bar8 d-of-hidden">
+  <aside class="d-bar8">
     <header :class="classes">
       <slot />
     </header>

--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-syntax.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-syntax.less
@@ -35,7 +35,7 @@ code {
 code[class*="language-"],
 pre[class*="language-"] {
 	margin: 0;
-	color: var(--dt-color-black-400);
+	color: var(--dt-color-foreground-secondary);
 	font-size: var(--dt-font-size-100);
 	font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
 	line-height: var(--dt-font-line-height-400);

--- a/apps/dialtone-documentation/docs/components/avatar.md
+++ b/apps/dialtone-documentation/docs/components/avatar.md
@@ -101,15 +101,15 @@ showHtmlWarning />
 htmlCode='
 <div class="d-avatar d-avatar--{$size} d-avatar--{$color}">
   <div class="d-avatar__canvas">
-      <span class="d-avatar__initials">DP</span>
+    <span class="d-avatar__initials">DP</span>
   </div>
 </div>
 '
 vueCode='
 <!-- colors 100 to 1800 are valid -->
 <dt-avatar
-    full-name="DP"
-    color="100"
+  full-name="DP"
+  color="100"
 />
 '
 showHtmlWarning />

--- a/apps/dialtone-documentation/docs/components/avatar.md
+++ b/apps/dialtone-documentation/docs/components/avatar.md
@@ -77,14 +77,14 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 htmlCode='
 <div class="d-avatar d-avatar--{$size}">
   <div class="d-avatar__canvas">
-      <span class="d-avatar__icon">
+    <span class="d-avatar__icon">
       <svg>...</svg>
-      </span>
+    </span>
   </div>
 </div>'
 vueCode='
 <dt-avatar
-    icon-name="person"
+  icon-name="person"
 />
 '
 showHtmlWarning />
@@ -124,7 +124,7 @@ showHtmlWarning />
 htmlCode='
 <div class="d-avatar d-avatar--{$size}">
   <div class="d-avatar__canvas">
-      <img class="d-avatar__image" src="/path/to/image" alt="avatar user" />
+    <img class="d-avatar__image" src="/path/to/image" alt="avatar user" />
   </div>
 </div>
 '
@@ -145,27 +145,27 @@ showHtmlWarning />
 htmlCode='
 <div class="d-avatar d-avatar--xs">
   <div class="d-avatar__canvas">
-      <svg>...</svg>
+    <svg>...</svg>
   </div>
 </div>
 <div class="d-avatar d-avatar--sm">
   <div class="d-avatar__canvas">
-      <svg>...</svg>
+    <svg>...</svg>
   </div>
 </div>
 <div class="d-avatar d-avatar--md">
   <div class="d-avatar__canvas">
-      <svg>...</svg>
+    <svg>...</svg>
   </div>
 </div>
 <div class="d-avatar d-avatar--lg">
   <div class="d-avatar__canvas">
-      <svg>...</svg>
+    <svg>...</svg>
   </div>
 </div>
 <div class="d-avatar d-avatar--xl">
   <div class="d-avatar__canvas">
-      <svg>...</svg>
+    <svg>...</svg>
   </div>
 </div>
 '
@@ -191,13 +191,13 @@ showHtmlWarning />
 htmlCode='
 <div class="d-avatar d-avatar--group">
   <div class="d-avatar__canvas">
-      <img class="d-avatar__image" src="/assets/images/person.png" alt="Person Avatar"/>
+    <img class="d-avatar__image" src="/assets/images/person.png" alt="Person Avatar"/>
   </div>
   <span class="d-avatar__count"><span class="d-avatar__count-number">12</span></span>
 </div>
 <div class="d-avatar d-avatar--group">
   <div class="d-avatar__canvas">
-      <img class="d-avatar__image" src="/assets/images/person.png" alt="Person Avatar"/>
+    <img class="d-avatar__image" src="/assets/images/person.png" alt="Person Avatar"/>
   </div>
   <span class="d-avatar__count"><span class="d-avatar__count-number">1</span></span>
 </div>
@@ -233,12 +233,12 @@ Positions the [Presence](components/presence.html) component at each size.
 htmlCode='
 <div class="d-avatar d-avatar--{$size)">
   <div class="d-avatar__canvas">
-      ...
+    ...
   </div>
   <div class="d-avatar__presence">
-      <div class="d-presence d-avatar__presence d-avatar__presence--md"><!---->
-          <div class="d-presence__inner d-presence__inner--{$status}" />
-      </div>
+    <div class="d-presence d-avatar__presence d-avatar__presence--md"><!---->
+      <div class="d-presence__inner d-presence__inner--{$status}" />
+    </div>
   </div>
 </div>
 '

--- a/apps/dialtone-documentation/docs/components/avatar.md
+++ b/apps/dialtone-documentation/docs/components/avatar.md
@@ -76,11 +76,11 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 <code-example-tabs
 htmlCode='
 <div class="d-avatar d-avatar--{$size}">
-    <div class="d-avatar__canvas">
-        <span class="d-avatar__icon">
-        <svg>...</svg>
-        </span>
-    </div>
+  <div class="d-avatar__canvas">
+      <span class="d-avatar__icon">
+      <svg>...</svg>
+      </span>
+  </div>
 </div>'
 vueCode='
 <dt-avatar
@@ -100,9 +100,9 @@ showHtmlWarning />
 <code-example-tabs
 htmlCode='
 <div class="d-avatar d-avatar--{$size} d-avatar--{$color}">
-    <div class="d-avatar__canvas">
-        <span class="d-avatar__initials">DP</span>
-    </div>
+  <div class="d-avatar__canvas">
+      <span class="d-avatar__initials">DP</span>
+  </div>
 </div>
 '
 vueCode='
@@ -123,9 +123,9 @@ showHtmlWarning />
 <code-example-tabs
 htmlCode='
 <div class="d-avatar d-avatar--{$size}">
-    <div class="d-avatar__canvas">
-        <img class="d-avatar__image" src="/path/to/image" alt="avatar user" />
-    </div>
+  <div class="d-avatar__canvas">
+      <img class="d-avatar__image" src="/path/to/image" alt="avatar user" />
+  </div>
 </div>
 '
 vueCode='
@@ -144,29 +144,29 @@ showHtmlWarning />
 <code-example-tabs
 htmlCode='
 <div class="d-avatar d-avatar--xs">
-    <div class="d-avatar__canvas">
-        <svg>...</svg>
-    </div>
+  <div class="d-avatar__canvas">
+      <svg>...</svg>
+  </div>
 </div>
 <div class="d-avatar d-avatar--sm">
-    <div class="d-avatar__canvas">
-        <svg>...</svg>
-    </div>
+  <div class="d-avatar__canvas">
+      <svg>...</svg>
+  </div>
 </div>
 <div class="d-avatar d-avatar--md">
-    <div class="d-avatar__canvas">
-        <svg>...</svg>
-    </div>
+  <div class="d-avatar__canvas">
+      <svg>...</svg>
+  </div>
 </div>
 <div class="d-avatar d-avatar--lg">
-    <div class="d-avatar__canvas">
-        <svg>...</svg>
-    </div>
+  <div class="d-avatar__canvas">
+      <svg>...</svg>
+  </div>
 </div>
 <div class="d-avatar d-avatar--xl">
-    <div class="d-avatar__canvas">
-        <svg>...</svg>
-    </div>
+  <div class="d-avatar__canvas">
+      <svg>...</svg>
+  </div>
 </div>
 '
 vueCode='
@@ -190,16 +190,16 @@ showHtmlWarning />
 <code-example-tabs
 htmlCode='
 <div class="d-avatar d-avatar--group">
-    <div class="d-avatar__canvas">
-        <img class="d-avatar__image" src="/assets/images/person.png" alt="Person Avatar"/>
-    </div>
-    <span class="d-avatar__count"><span class="d-avatar__count-number">12</span></span>
+  <div class="d-avatar__canvas">
+      <img class="d-avatar__image" src="/assets/images/person.png" alt="Person Avatar"/>
+  </div>
+  <span class="d-avatar__count"><span class="d-avatar__count-number">12</span></span>
 </div>
 <div class="d-avatar d-avatar--group">
-    <div class="d-avatar__canvas">
-        <img class="d-avatar__image" src="/assets/images/person.png" alt="Person Avatar"/>
-    </div>
-    <span class="d-avatar__count"><span class="d-avatar__count-number">1</span></span>
+  <div class="d-avatar__canvas">
+      <img class="d-avatar__image" src="/assets/images/person.png" alt="Person Avatar"/>
+  </div>
+  <span class="d-avatar__count"><span class="d-avatar__count-number">1</span></span>
 </div>
 '
 vueCode='
@@ -232,14 +232,14 @@ Positions the [Presence](components/presence.html) component at each size.
 <code-example-tabs
 htmlCode='
 <div class="d-avatar d-avatar--{$size)">
-    <div class="d-avatar__canvas">
-        ...
-    </div>
-    <div class="d-avatar__presence">
-        <div class="d-presence d-avatar__presence d-avatar__presence--md"><!---->
-            <div class="d-presence__inner d-presence__inner--{$status}" />
-        </div>
-    </div>
+  <div class="d-avatar__canvas">
+      ...
+  </div>
+  <div class="d-avatar__presence">
+      <div class="d-presence d-avatar__presence d-avatar__presence--md"><!---->
+          <div class="d-presence__inner d-presence__inner--{$status}" />
+      </div>
+  </div>
 </div>
 '
 vueCode='

--- a/apps/dialtone-documentation/docs/components/badge.md
+++ b/apps/dialtone-documentation/docs/components/badge.md
@@ -48,9 +48,13 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   <span class="d-badge"><span class="d-badge__label">Label</span></span>
 </code-well-header>
 
-```html
-<span class="d-badge"><span class="d-badge__label">Label</span></span>
-```
+<code-example-tabs
+htmlCode='
+<span class="d-badge"><span class="d-badge__label">Label</span></span>'
+vueCode='
+<dt-badge type="default" kind="label" text="Label" />
+'
+showHtmlWarning />
 
 ### Count
 
@@ -58,9 +62,13 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   <span class="d-badge d-badge--count"><span class="d-badge__label">1</span></span>
 </code-well-header>
 
-```html
-<span class="d-badge d-badge--count"><span class="d-badge__label">1</span></span>
-```
+<code-example-tabs
+htmlCode='
+<span class="d-badge d-badge--count"><span class="d-badge__label">1</span></span>'
+vueCode='
+<dt-badge type="default" kind="count" default="1" />
+'
+showHtmlWarning />
 
 ## Type
 
@@ -150,7 +158,8 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   </tbody>
 </table>
 
-```html
+<code-example-tabs
+htmlCode='
 <span class="d-badge"><span class="d-badge__label">Label</span></span>
 <span class="d-badge d-badge--info"><span class="d-badge__label">Label</span></span>
 <span class="d-badge d-badge--success"><span class="d-badge__label">Label</span></span>
@@ -163,14 +172,29 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   </span>
   <span class="d-badge__label">Label</span>
 </span>
-
 <span class="d-badge d-badge--count"><span class="d-badge__label">1</span></span>
 <span class="d-badge d-badge--count d-badge--info"><span class="d-badge__label">2</span></span>
 <span class="d-badge d-badge--count d-badge--success"><span class="d-badge__label">3</span></span>
 <span class="d-badge d-badge--count d-badge--warning"><span class="d-badge__label">4</span></span>
 <span class="d-badge d-badge--count d-badge--critical"><span class="d-badge__label">5</span></span>
 <span class="d-badge d-badge--count d-badge--bulletin"><span class="d-badge__label">6</span></span>
-```
+'
+vueCode='
+<dt-badge type="default" kind="label" text="Label" />
+<dt-badge type="info" kind="label" text="Label" />
+<dt-badge type="success" kind="label" text="Label" />
+<dt-badge type="warning" kind="label" text="Label" />
+<dt-badge type="critical" kind="label" text="Label" />
+<dt-badge type="bulletin" kind="label" text="Label" />
+<dt-badge type="ai" text="Label" kind="label" icon-left="dialpad-ai" />
+<dt-badge type="default" text="1" kind="count" />
+<dt-badge type="info" text="1" kind="count" />
+<dt-badge type="success" text="1" kind="count" />
+<dt-badge type="warning" text="1" kind="count" />
+<dt-badge type="critical" text="1" kind="count" />
+<dt-badge type="bulletin" text="1" kind="count" />
+'
+showHtmlWarning />
 
 ## Icon
 
@@ -191,7 +215,8 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   </dt-stack>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <span class="d-badge">
   <span class="d-badge__icon-left">
     <dt-icon name="lightning-bolt" size="200" />
@@ -205,7 +230,12 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
     <dt-icon name="lightning-bolt" size="200" />
   </span>
 </span>
-```
+'
+vueCode='
+<dt-badge type="default" text="Label" kind="label" icon-left="lightning-bolt"/>
+<dt-badge type="default" text="Label" kind="label" icon-right="lightning-bolt"/>
+'
+showHtmlWarning />
 
 ## Decorative
 
@@ -259,12 +289,38 @@ Decorative badges label and classify items for quick recognition.
   </dt-stack>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <span class="d-badge d-badge--decorate-{$color}">
   <span class="d-badge__decorative"></span>
   <span class="d-badge__label">Label</span>
 </span>
-```
+'
+vueCode='
+<dt-badge text="Label" decoration="black-400" />
+<dt-badge text="Label" decoration="black-500" />
+<dt-badge text="Label" decoration="black-900" />
+<dt-badge text="Label" decoration="red-200" />
+<dt-badge text="Label" decoration="red-300" />
+<dt-badge text="Label" decoration="red-400" />
+<dt-badge text="Label" decoration="purple-200" />
+<dt-badge text="Label" decoration="purple-300" />
+<dt-badge text="Label" decoration="purple-400" />
+<dt-badge text="Label" decoration="purple-500" />
+<dt-badge text="Label" decoration="blue-200" />
+<dt-badge text="Label" decoration="blue-300" />
+<dt-badge text="Label" decoration="blue-400" />
+<dt-badge text="Label" decoration="green-300" />
+<dt-badge text="Label" decoration="green-400" />
+<dt-badge text="Label" decoration="green-500" />
+<dt-badge text="Label" decoration="gold-300" />
+<dt-badge text="Label" decoration="gold-400" />
+<dt-badge text="Label" decoration="gold-500" />
+<dt-badge text="Label" decoration="magenta-200" />
+<dt-badge text="Label" decoration="magenta-300" />
+<dt-badge text="Label" decoration="magenta-400" />
+'
+showHtmlWarning />
 
 <dialtone-usage>
 <template #do>

--- a/apps/dialtone-documentation/docs/components/badge.md
+++ b/apps/dialtone-documentation/docs/components/badge.md
@@ -242,7 +242,7 @@ showHtmlWarning />
 Decorative badges label and classify items for quick recognition.
 
 <code-well-header bgclass="d-bgc-primary">
-  <dt-stack direction="row" gap="500">
+  <dt-stack direction="row" gap="500" class="d-ai-baseline">
     <dt-stack gap="500">
       <span class="d-label-compact">Black</span>
       <span class="d-badge d-badge--decorate-black-400"><span class="d-badge__decorative"></span><span class="d-badge__label">Label</span></span>

--- a/apps/dialtone-documentation/docs/components/banner.md
+++ b/apps/dialtone-documentation/docs/components/banner.md
@@ -47,7 +47,8 @@ Banners are a type of notice and so you can use the following [Notice](notice.md
   Message body
 </dt-banner>
 
-```html
+<code-example-tabs
+htmlCode='
 <aside class="d-banner d-banner--base" role="alert" aria-hidden="false">
   <div class="d-banner__dialog" role="alertdialog" aria-labelledy="info-alert-title" aria-describedby="info-alert-desc">
     <div class="d-notice__icon">...</div>
@@ -62,7 +63,18 @@ Banners are a type of notice and so you can use the following [Notice](notice.md
 <aside class="d-banner d-banner--info" role="alert" aria-hidden="false">...</aside>
 <aside class="d-banner d-banner--success" role="alert" aria-hidden="false">...</aside>
 <aside class="d-banner d-banner--warning" role="alert" aria-hidden="false">...</aside>
-```
+'
+vueCode='
+<dt-banner kind="base" title="Optional banner title"> Message body </dt-banner>
+<dt-banner kind="error" title="Optional banner title"> Message body </dt-banner>
+<dt-banner kind="info" title="Optional banner title"> Message body </dt-banner>
+<dt-banner kind="success" title="Optional banner title"> Message body </dt-banner>
+<dt-banner kind="warning" title="Optional banner title"> Message body </dt-banner>
+<dt-banner background-image="{$background-image}" background-size="contain"> Message body </dt-banner>
+<dt-banner pinned="true" kind="warning" title="Optional banner title"> Message body </dt-banner>
+<dt-banner important="true" kind="warning" title="Optional banner title"> Message body </dt-banner>
+'
+showHtmlWarning />
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/banner.md
+++ b/apps/dialtone-documentation/docs/components/banner.md
@@ -56,7 +56,7 @@ htmlCode='
       <h2 class="d-notice__title" id="info-alert-title">...</h2>
       <p class="d-notice__message" id="info-alert-desc">...</p>
     </div>
-    <div class="d-notice__actions">...</div>
+  <div class="d-notice__actions">...</div>
 </aside>
 
 <aside class="d-banner d-banner--error" role="alert" aria-hidden="false">...</aside>

--- a/apps/dialtone-documentation/docs/components/breadcrumbs.md
+++ b/apps/dialtone-documentation/docs/components/breadcrumbs.md
@@ -96,28 +96,28 @@ htmlCode='
 '
 vueCode='
 <dt-breadcrumbs 
-    :breadcrumbs="[
-    {
-      href: `#`,
-      label: `Root`,
-    },
-    {
-      href: `#`,
-      label: `Section`,
-    },
-    {
-      href: `#`,
-      label: `Section`,
-    },
-    {
-      href: `#`,
-      label: `Section`,
-    },
-    {
-      href: `#`,
-      label: `Current Page`,
-      selected: true,
-    },
+  :breadcrumbs="[
+  {
+    href: `#`,
+    label: `Root`,
+  },
+  {
+    href: `#`,
+    label: `Section`,
+  },
+  {
+    href: `#`,
+    label: `Section`,
+  },
+  {
+    href: `#`,
+    label: `Section`,
+  },
+  {
+    href: `#`,
+    label: `Current Page`,
+    selected: true,
+  },
   ]" />
 '
 showHtmlWarning />
@@ -150,49 +150,49 @@ showHtmlWarning />
 htmlCode='
 <nav class="d-breadcrumbs d-breadcrumbs--inverted" aria-label="inverted breadcrumb">
   <ol>
-      <li class="d-breadcrumbs__item">
-          <a href="#" class="d-link d-link--inverted">Root</a>
-      </li>
-      <li class="d-breadcrumbs__item">
-          <a href="#" class="d-link d-link--inverted">Section</a>
-      </li>
-      <li class="d-breadcrumbs__item">
-          <a href="#" class="d-link d-link--inverted">Section</a>
-      </li>
-      <li class="d-breadcrumbs__item">
-          <a href="#" class="d-link d-link--inverted">Section</a>
-      </li>
-      <li class="d-breadcrumbs__item d-breadcrumbs__item--selected">
-          <a href="#" class="d-link d-link--inverted" aria-current="location">Current Page</a>
-      </li>
+    <li class="d-breadcrumbs__item">
+        <a href="#" class="d-link d-link--inverted">Root</a>
+    </li>
+    <li class="d-breadcrumbs__item">
+        <a href="#" class="d-link d-link--inverted">Section</a>
+    </li>
+    <li class="d-breadcrumbs__item">
+        <a href="#" class="d-link d-link--inverted">Section</a>
+    </li>
+    <li class="d-breadcrumbs__item">
+        <a href="#" class="d-link d-link--inverted">Section</a>
+    </li>
+    <li class="d-breadcrumbs__item d-breadcrumbs__item--selected">
+        <a href="#" class="d-link d-link--inverted" aria-current="location">Current Page</a>
+    </li>
   </ol>
 </nav>
 '
 vueCode='
 <dt-breadcrumbs 
-    inverted
-    :breadcrumbs="[
-    {
-      href: `#`,
-      label: `Root`,
-    },
-    {
-      href: `#`,
-      label: `Section`,
-    },
-    {
-      href: `#`,
-      label: `Section`,
-    },
-    {
-      href: `#`,
-      label: `Section`,
-    },
-    {
-      href: `#`,
-      label: `Current Page`,
-      selected: true,
-    },
+  inverted
+  :breadcrumbs="[
+  {
+    href: `#`,
+    label: `Root`,
+  },
+  {
+    href: `#`,
+    label: `Section`,
+  },
+  {
+    href: `#`,
+    label: `Section`,
+  },
+  {
+    href: `#`,
+    label: `Section`,
+  },
+  {
+    href: `#`,
+    label: `Current Page`,
+    selected: true,
+  },
   ]" />
 '
 showHtmlWarning />

--- a/apps/dialtone-documentation/docs/components/breadcrumbs.md
+++ b/apps/dialtone-documentation/docs/components/breadcrumbs.md
@@ -72,7 +72,8 @@ Breadcrumbs are always treated as secondary and should not entirely replace the 
     </nav>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <nav class="d-breadcrumbs" aria-label="breadcrumb">
   <ol>
     <li class="d-breadcrumbs__item">
@@ -92,7 +93,34 @@ Breadcrumbs are always treated as secondary and should not entirely replace the 
     </li>
   </ol>
 </nav>
-```
+'
+vueCode='
+<dt-breadcrumbs 
+    :breadcrumbs="[
+    {
+      href: `#`,
+      label: `Root`,
+    },
+    {
+      href: `#`,
+      label: `Section`,
+    },
+    {
+      href: `#`,
+      label: `Section`,
+    },
+    {
+      href: `#`,
+      label: `Section`,
+    },
+    {
+      href: `#`,
+      label: `Current Page`,
+      selected: true,
+    },
+  ]" />
+'
+showHtmlWarning />
 
 ### Inverted
 
@@ -118,7 +146,8 @@ Breadcrumbs are always treated as secondary and should not entirely replace the 
     </nav>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <nav class="d-breadcrumbs d-breadcrumbs--inverted" aria-label="inverted breadcrumb">
   <ol>
       <li class="d-breadcrumbs__item">
@@ -138,7 +167,35 @@ Breadcrumbs are always treated as secondary and should not entirely replace the 
       </li>
   </ol>
 </nav>
-```
+'
+vueCode='
+<dt-breadcrumbs 
+    inverted
+    :breadcrumbs="[
+    {
+      href: `#`,
+      label: `Root`,
+    },
+    {
+      href: `#`,
+      label: `Section`,
+    },
+    {
+      href: `#`,
+      label: `Section`,
+    },
+    {
+      href: `#`,
+      label: `Section`,
+    },
+    {
+      href: `#`,
+      label: `Current Page`,
+      selected: true,
+    },
+  ]" />
+'
+showHtmlWarning />
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/breadcrumbs.md
+++ b/apps/dialtone-documentation/docs/components/breadcrumbs.md
@@ -97,27 +97,27 @@ htmlCode='
 vueCode='
 <dt-breadcrumbs 
   :breadcrumbs="[
-  {
-    href: `#`,
-    label: `Root`,
-  },
-  {
-    href: `#`,
-    label: `Section`,
-  },
-  {
-    href: `#`,
-    label: `Section`,
-  },
-  {
-    href: `#`,
-    label: `Section`,
-  },
-  {
-    href: `#`,
-    label: `Current Page`,
-    selected: true,
-  },
+    {
+      href: `#`,
+      label: `Root`,
+    },
+    {
+      href: `#`,
+      label: `Section`,
+    },
+    {
+      href: `#`,
+      label: `Section`,
+    },
+    {
+      href: `#`,
+      label: `Section`,
+    },
+    {
+      href: `#`,
+      label: `Current Page`,
+      selected: true,
+    },
   ]" />
 '
 showHtmlWarning />
@@ -172,27 +172,27 @@ vueCode='
 <dt-breadcrumbs 
   inverted
   :breadcrumbs="[
-  {
-    href: `#`,
-    label: `Root`,
-  },
-  {
-    href: `#`,
-    label: `Section`,
-  },
-  {
-    href: `#`,
-    label: `Section`,
-  },
-  {
-    href: `#`,
-    label: `Section`,
-  },
-  {
-    href: `#`,
-    label: `Current Page`,
-    selected: true,
-  },
+    {
+      href: `#`,
+      label: `Root`,
+    },
+    {
+      href: `#`,
+      label: `Section`,
+    },
+    {
+      href: `#`,
+      label: `Section`,
+    },
+    {
+      href: `#`,
+      label: `Section`,
+    },
+    {
+      href: `#`,
+      label: `Current Page`,
+      selected: true,
+    },
   ]" />
 '
 showHtmlWarning />

--- a/apps/dialtone-documentation/docs/components/button-group.md
+++ b/apps/dialtone-documentation/docs/components/button-group.md
@@ -88,8 +88,8 @@ htmlCode='
 '
 vueCode='
 <dt-button-group alignment="end">
-    <dt-button importance="primary">Confirm</dt-button>
-    <dt-button importance="outlined">Cancel</dt-button>
+  <dt-button importance="primary">Confirm</dt-button>
+  <dt-button importance="outlined">Cancel</dt-button>
 </dt-button-group>
 '
 showHtmlWarning />

--- a/apps/dialtone-documentation/docs/components/button-group.md
+++ b/apps/dialtone-documentation/docs/components/button-group.md
@@ -13,12 +13,24 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-button-group
   </dt-button-group>
 </code-well-header>
 
-```html
-<dt-button-group alignment="start" class="d-gg8">
-  <dt-button importance="primary">Confirm</dt-button>
-  <dt-button importance="outlined">Cancel</dt-button>
+<code-example-tabs
+htmlCode='
+<div role="group" class="d-btn-group d-btn-group--start" alignment="start">
+    <button type="button" class="base-button__button d-btn d-btn--primary">
+        <span class="d-btn__label base-button__label"> Confirm </span>
+    </button>
+    <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
+        <span class="d-btn__label base-button__label"> Cancel </span>
+    </button>
+</div>
+'
+vueCode='
+<dt-button-group>
+    <dt-button importance="primary">Confirm</dt-button>
+    <dt-button importance="outlined">Cancel</dt-button>
 </dt-button-group>
-```
+'
+showHtmlWarning />
 
 ## Variants
 
@@ -34,29 +46,53 @@ When aligned to `start`, the `primary` button is on the **left** side of the gro
   </dt-button-group>
 </code-well-header>
 
-```html
-<dt-button-group alignment="start" class="d-gg8">
-  <dt-button importance="primary">Confirm</dt-button>
-  <dt-button importance="outlined">Cancel</dt-button>
+<code-example-tabs
+htmlCode='
+<div role="group" class="d-btn-group d-btn-group--start" alignment="start">
+    <button type="button" class="base-button__button d-btn d-btn--primary">
+        <span class="d-btn__label base-button__label"> Confirm </span>
+    </button>
+    <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
+        <span class="d-btn__label base-button__label"> Cancel </span>
+    </button>
+</div>
+'
+vueCode='
+<dt-button-group>
+    <dt-button importance="primary">Confirm</dt-button>
+    <dt-button importance="outlined">Cancel</dt-button>
 </dt-button-group>
-```
+'
+showHtmlWarning />
 
 ### End
 
 When aligned to `end`, the `primary` button is on the **right** side of the group.
 <code-well-header class="d-d-block">
-  <dt-button-group alignment="end" class="d-gg8">
+  <dt-button-group alignment="end">
     <dt-button importance="outlined">Cancel</dt-button>
     <dt-button importance="primary">Confirm</dt-button>
   </dt-button-group>
 </code-well-header>
 
-```html
-<dt-button-group alignment="end" class="d-gg8">
-  <dt-button importance="outlined">Cancel</dt-button>
-  <dt-button importance="primary">Confirm</dt-button>
+<code-example-tabs
+htmlCode='
+<div role="group" class="d-btn-group d-btn-group--end">
+    <button type="button" class="base-button__button d-btn d-btn--primary">
+        <span class="d-btn__label base-button__label"> Confirm </span>
+    </button>
+    <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
+        <span class="d-btn__label base-button__label"> Cancel </span>
+    </button>
+</div>
+'
+vueCode='
+<dt-button-group alignment="end">
+    <dt-button importance="primary">Confirm</dt-button>
+    <dt-button importance="outlined">Cancel</dt-button>
 </dt-button-group>
-```
+'
+showHtmlWarning />
 
 ### Space-between
 
@@ -68,12 +104,24 @@ When set to `space-between`, the elements are evenly distributed within the row,
   </dt-button-group>
 </code-well-header>
 
-```html
-<dt-button-group alignment="space-between" class="d-gg8">
-  <dt-button importance="primary">Confirm</dt-button>
-  <dt-button importance="outlined">Cancel</dt-button>
+<code-example-tabs
+htmlCode='
+<div role="group" class="d-btn-group d-btn-group--space-between">
+    <button type="button" class="base-button__button d-btn d-btn--primary">
+        <span class="d-btn__label base-button__label"> Confirm </span>
+    </button>
+    <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
+        <span class="d-btn__label base-button__label"> Cancel </span>
+    </button>
+</div>
+'
+vueCode='
+<dt-button-group alignment="space-between">
+    <dt-button importance="primary">Confirm</dt-button>
+    <dt-button importance="outlined">Cancel</dt-button>
 </dt-button-group>
-```
+'
+showHtmlWarning />
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/button-group.md
+++ b/apps/dialtone-documentation/docs/components/button-group.md
@@ -16,18 +16,18 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-button-group
 <code-example-tabs
 htmlCode='
 <div role="group" class="d-btn-group d-btn-group--start" alignment="start">
-    <button type="button" class="base-button__button d-btn d-btn--primary">
-        <span class="d-btn__label base-button__label"> Confirm </span>
-    </button>
-    <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
-        <span class="d-btn__label base-button__label"> Cancel </span>
-    </button>
+  <button type="button" class="base-button__button d-btn d-btn--primary">
+    <span class="d-btn__label base-button__label"> Confirm </span>
+  </button>
+  <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
+    <span class="d-btn__label base-button__label"> Cancel </span>
+  </button>
 </div>
 '
 vueCode='
 <dt-button-group>
-    <dt-button importance="primary">Confirm</dt-button>
-    <dt-button importance="outlined">Cancel</dt-button>
+  <dt-button importance="primary">Confirm</dt-button>
+  <dt-button importance="outlined">Cancel</dt-button>
 </dt-button-group>
 '
 showHtmlWarning />
@@ -49,18 +49,18 @@ When aligned to `start`, the `primary` button is on the **left** side of the gro
 <code-example-tabs
 htmlCode='
 <div role="group" class="d-btn-group d-btn-group--start" alignment="start">
-    <button type="button" class="base-button__button d-btn d-btn--primary">
-        <span class="d-btn__label base-button__label"> Confirm </span>
-    </button>
-    <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
-        <span class="d-btn__label base-button__label"> Cancel </span>
-    </button>
+  <button type="button" class="base-button__button d-btn d-btn--primary">
+    <span class="d-btn__label base-button__label"> Confirm </span>
+  </button>
+  <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
+    <span class="d-btn__label base-button__label"> Cancel </span>
+  </button>
 </div>
 '
 vueCode='
 <dt-button-group>
-    <dt-button importance="primary">Confirm</dt-button>
-    <dt-button importance="outlined">Cancel</dt-button>
+  <dt-button importance="primary">Confirm</dt-button>
+  <dt-button importance="outlined">Cancel</dt-button>
 </dt-button-group>
 '
 showHtmlWarning />
@@ -78,12 +78,12 @@ When aligned to `end`, the `primary` button is on the **right** side of the grou
 <code-example-tabs
 htmlCode='
 <div role="group" class="d-btn-group d-btn-group--end">
-    <button type="button" class="base-button__button d-btn d-btn--primary">
-        <span class="d-btn__label base-button__label"> Confirm </span>
-    </button>
-    <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
-        <span class="d-btn__label base-button__label"> Cancel </span>
-    </button>
+  <button type="button" class="base-button__button d-btn d-btn--primary">
+    <span class="d-btn__label base-button__label"> Confirm </span>
+  </button>
+  <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
+    <span class="d-btn__label base-button__label"> Cancel </span>
+  </button>
 </div>
 '
 vueCode='
@@ -107,18 +107,18 @@ When set to `space-between`, the elements are evenly distributed within the row,
 <code-example-tabs
 htmlCode='
 <div role="group" class="d-btn-group d-btn-group--space-between">
-    <button type="button" class="base-button__button d-btn d-btn--primary">
-        <span class="d-btn__label base-button__label"> Confirm </span>
-    </button>
-    <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
-        <span class="d-btn__label base-button__label"> Cancel </span>
-    </button>
+  <button type="button" class="base-button__button d-btn d-btn--primary">
+    <span class="d-btn__label base-button__label"> Confirm </span>
+  </button>
+  <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
+    <span class="d-btn__label base-button__label"> Cancel </span>
+  </button>
 </div>
 '
 vueCode='
 <dt-button-group alignment="space-between">
-    <dt-button importance="primary">Confirm</dt-button>
-    <dt-button importance="outlined">Cancel</dt-button>
+  <dt-button importance="primary">Confirm</dt-button>
+  <dt-button importance="outlined">Cancel</dt-button>
 </dt-button-group>
 '
 showHtmlWarning />

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -181,11 +181,18 @@ The base button should be the go-to button for most of your needs. When in doubt
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn" type="button"><span class="d-btn__label">...</span></button>
-```
+'
+vueCode='
+<dt-button> Place call </dt-button>
+<dt-button importance="outlined"> Place call </dt-button>
+<dt-button importance="clear"> Place call </dt-button>
+'
+showHtmlWarning />
 
 ### Danger
 
@@ -205,11 +212,18 @@ The danger button style is used to communicate critical or destructive actions s
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <button class="d-btn d-btn--danger d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--danger d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--danger" type="button"><span class="d-btn__label">...</span></button>
-```
+'
+vueCode='
+<dt-button kind="danger"> Place call </dt-button>
+<dt-button kind="danger" importance="outlined"> Place call </dt-button>
+<dt-button kind="danger" importance="clear"> Place call </dt-button>
+'
+showHtmlWarning />
 
 ### Inverted
 
@@ -229,11 +243,18 @@ The inverted button style is used to visually separate buttons set on darker bac
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <button class="d-btn d-btn--inverted d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--inverted d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--inverted" type="button"><span class="d-btn__label">...</span></button>
-```
+'
+vueCode='
+<dt-button kind="inverted"> Place call </dt-button>
+<dt-button kind="inverted" importance="outlined"> Place call </dt-button>
+<dt-button kind="inverted" importance="clear"> Place call </dt-button>
+'
+showHtmlWarning />
 
 ### Muted
 
@@ -250,10 +271,16 @@ The muted button style is used to communicate non-primary actions for contexts i
   </div>
 </code-well-header>
 
- ```html
+<code-example-tabs
+htmlCode='
 <button class="d-btn d-btn--muted" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--muted d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
-```
+'
+vueCode='
+<dt-button kind="muted" importance="clear"> Place call </dt-button>
+<dt-button kind="muted" importance="outlined"> Place call </dt-button>
+'
+showHtmlWarning />
 
 ### Disabled
 
@@ -273,12 +300,17 @@ All button styles and variations appear the same when disabled.
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <button class="d-btn" type="button" disabled><span class="d-btn__label">...</span></button>
 <span class="d-c-not-allowed">
   <button class="d-btn d-btn--disabled" type="button" aria-disabled="true"><span class="d-btn__label">...</span></button>
 </span>
-```
+'
+vueCode='
+<dt-button disabled> Place call </dt-button>
+'
+showHtmlWarning />
 
 ### Active
 
@@ -315,12 +347,22 @@ Different button styles and variations appear different when active.
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <button class="d-btn d-btn--active" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--primary d-btn--active" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--danger d-btn--active" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--inverted d-btn--primary d-btn--active" type="button"><span class="d-btn__label">...</span></button>
-```
+<button class="d-btn d-btn--primary d-btn--muted d-btn--active" type="button"><span class="d-btn__label">...</span></button>
+'
+vueCode='
+<dt-button active importance="clear"> Place call </dt-button>
+<dt-button active> Place call </dt-button>
+<dt-button active kind="danger" importance="clear"> Place call </dt-button>
+<dt-button active kind="inverted"> Place call </dt-button>
+<dt-button active kind="muted"> Place call </dt-button>
+'
+showHtmlWarning />
 
 ### Link
 
@@ -333,10 +375,16 @@ Buttons can be styled as a [Link](link.md) in situations for which you need the 
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <button type="button" class="d-link">...</button>
 <button type="button" class="d-link" disabled>...</button>
-```
+'
+vueCode='
+<dt-button link> Place call </dt-button>
+<dt-button link disabled> Place call </dt-button>
+'
+showHtmlWarning />
 
 ## Sizes
 
@@ -362,13 +410,22 @@ The base button font size is 16px and should be used in most cases. Every button
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <button class="d-btn d-btn--primary d-btn--xs" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--primary d-btn--sm" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--primary d-btn--lg" type="button"><span class="d-btn__label">...</span></button>
 <button class="d-btn d-btn--primary d-btn--xl" type="button"><span class="d-btn__label">...</span></button>
-```
+'
+vueCode='
+<dt-button size="xs"> Place call </dt-button>
+<dt-button size="sm"> Place call </dt-button>
+<dt-button> Place call </dt-button>
+<dt-button size="lg"> Place call </dt-button>
+<dt-button size="xl"> Place call </dt-button>
+'
+showHtmlWarning />
 
 ## Loading
 
@@ -388,11 +445,18 @@ Loading buttons are useful for communicating a delay between the button interact
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <button class="d-btn d-btn--loading d-btn--primary" type="button"><span class="d-btn__label">Place call</span></button>
 <button class="d-btn d-btn--loading d-btn--outlined" type="button"><span class="d-btn__label">Place call</span></button>
 <button class="d-btn d-btn--danger d-btn--loading" type="button"><span class="d-btn__label">Place call</span></button>
-```
+'
+vueCode='
+<dt-button loading> Place call </dt-button>
+<dt-button loading importance="outlined"> Place call </dt-button>
+<dt-button loading importance="clear" kind="danger"> Place call </dt-button>
+'
+showHtmlWarning />
 
 ## Icon support
 
@@ -423,7 +487,8 @@ Button labels can include an icon next to the text. Every button style can accep
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <button class="d-btn d-btn--outlined" type="button">
   <span class="d-btn__icon d-btn__icon--left">...</span>
   <span class="d-btn__label">...</span>
@@ -436,7 +501,21 @@ Button labels can include an icon next to the text. Every button style can accep
   <span class="d-btn__icon d-btn__icon--right">...</span>
   <span class="d-btn__label">...</span>
 </button>
-```
+'
+vueCode='
+<!-- icon-position can be "right/top/bottom" , 
+     no icon-position will be left -->
+<dt-button importance="outlined" icon-position="right">
+    <template #icon>
+        <dt-icon
+            name="phone"
+            size="300"
+        />
+    </template>
+    Label
+</dt-button>
+'
+showHtmlWarning />
 
 ### Icon only
 
@@ -452,13 +531,44 @@ Sometimes an icon-only, circle button is desired. These buttons are used for tog
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <button class="d-btn d-btn--circle" type="button">...</button>
 <button class="d-btn d-btn--circle d-btn--outlined" type="button">...</button>
 <button class="d-btn d-btn--circle d-btn--danger" type="button">...</button>
 <button class="d-btn d-btn--circle d-btn--danger d-btn--outlined" type="button">...</button>
 <button class="d-btn d-btn--circle d-btn--danger d-btn--primary" type="button">...</button>
-```
+'
+vueCode='
+<!-- circle clear-->
+<dt-button circle importance="clear">
+    <template #icon>
+        <dt-icon
+            name="phone"
+            size="300"
+        />
+    </template>
+</dt-button>
+<!-- circle outlined-->
+<dt-button circle importance="outlined">
+    <template #icon>
+        <dt-icon
+            name="phone"
+            size="300"
+        />
+    </template>
+</dt-button>
+<!-- circle outlined danger-->
+<dt-button circle kind="danger" importance="outlined">
+    <template #icon>
+        <dt-icon
+            name="phone"
+            size="300"
+        />
+    </template>
+</dt-button>
+'
+showHtmlWarning />
 
 <code-well-header bgclass="d-bgc-contrast">
   <div class="d-d-flex d-flow8">
@@ -468,11 +578,24 @@ Sometimes an icon-only, circle button is desired. These buttons are used for tog
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <button class="d-btn d-btn--circle btn--inverted" type="button">...</button>
 <button class="d-btn d-btn--circle btn--inverted d-btn--outlined" type="button">...</button>
 <button class="d-btn d-btn--circle btn--inverted d-btn--primary" type="button">...</button>
-```
+'
+vueCode='
+<!-- circle inverted clear-->
+<dt-button circle kind="inverted" importance="clear">
+    <template #icon>
+        <dt-icon
+            name="phone"
+            size="300"
+        />
+    </template>
+</dt-button>
+'
+showHtmlWarning />
 
 If you want to use the rectangular button, use the icon only styles.
 
@@ -483,10 +606,32 @@ If you want to use the rectangular button, use the icon only styles.
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <button class="d-btn d-btn--icon-only" type="button">...</button>
 <button class="d-btn d-btn--icon-only d-btn--outlined" type="button">...</button>
-```
+'
+vueCode='
+<!-- clear-->
+<dt-button importance="clear">
+    <template #icon>
+        <dt-icon
+            name="phone"
+            size="300"
+        />
+    </template>
+</dt-button>
+<!-- outlined-->
+<dt-button importance="outlined">
+    <template #icon>
+        <dt-icon
+            name="phone"
+            size="300"
+        />
+    </template>
+</dt-button>
+'
+showHtmlWarning />
 
 ## Branded
 

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -558,8 +558,26 @@ vueCode='
     />
   </template>
 </dt-button>
+<!-- circle clear danger-->
+<dt-button circle kind="danger" importance="clear">
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+    />
+  </template>
+</dt-button>
 <!-- circle outlined danger-->
 <dt-button circle kind="danger" importance="outlined">
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+    />
+ </template>
+</dt-button>
+<!-- circle danger-->
+<dt-button circle kind="danger">
   <template #icon>
     <dt-icon
       name="phone"

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -506,13 +506,13 @@ vueCode='
 <!-- icon-position can be "right/top/bottom" , 
      no icon-position will be left -->
 <dt-button importance="outlined" icon-position="right">
-    <template #icon>
-        <dt-icon
-            name="phone"
-            size="300"
-        />
-    </template>
-    Label
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+    />
+  </template>
+  Label
 </dt-button>
 '
 showHtmlWarning />
@@ -542,30 +542,30 @@ htmlCode='
 vueCode='
 <!-- circle clear-->
 <dt-button circle importance="clear">
-    <template #icon>
-        <dt-icon
-            name="phone"
-            size="300"
-        />
-    </template>
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+    />
+  </template>
 </dt-button>
 <!-- circle outlined-->
 <dt-button circle importance="outlined">
-    <template #icon>
-        <dt-icon
-            name="phone"
-            size="300"
-        />
-    </template>
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+    />
+  </template>
 </dt-button>
 <!-- circle outlined danger-->
 <dt-button circle kind="danger" importance="outlined">
-    <template #icon>
-        <dt-icon
-            name="phone"
-            size="300"
-        />
-    </template>
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+    />
+ </template>
 </dt-button>
 '
 showHtmlWarning />
@@ -587,12 +587,12 @@ htmlCode='
 vueCode='
 <!-- circle inverted clear-->
 <dt-button circle kind="inverted" importance="clear">
-    <template #icon>
-        <dt-icon
-            name="phone"
-            size="300"
-        />
-    </template>
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+     />
+  </template>
 </dt-button>
 '
 showHtmlWarning />
@@ -614,21 +614,21 @@ htmlCode='
 vueCode='
 <!-- clear-->
 <dt-button importance="clear">
-    <template #icon>
-        <dt-icon
-            name="phone"
-            size="300"
-        />
-    </template>
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+    />
+  </template>
 </dt-button>
 <!-- outlined-->
 <dt-button importance="outlined">
-    <template #icon>
-        <dt-icon
-            name="phone"
-            size="300"
-        />
-    </template>
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+    />
+  </template>
 </dt-button>
 '
 showHtmlWarning />

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -290,12 +290,7 @@ All button styles and variations appear the same when disabled.
 <code-well-header>
   <div class="d-d-flex d-flow8">
     <div>
-      <button class="d-btn" type="button" disabled><span class="d-btn__label">Place call</span></button>
-    </div>
-    <div>
-      <span class="d-c-not-allowed">
-        <button class="d-btn d-btn--disabled" type="button" aria-disabled="true"><span class="d-btn__label">Place call</span></button>
-      </span>
+      <button type="button" disabled="disabled" class="base-button__button d-btn d-btn--primary" ><span class="d-btn__label base-button__label">Place call</span></button>
     </div>
   </div>
 </code-well-header>
@@ -574,7 +569,7 @@ vueCode='
       name="phone"
       size="300"
     />
- </template>
+  </template>
 </dt-button>
 <!-- circle danger-->
 <dt-button circle kind="danger">
@@ -583,7 +578,7 @@ vueCode='
       name="phone"
       size="300"
     />
- </template>
+  </template>
 </dt-button>
 '
 showHtmlWarning />

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -290,7 +290,7 @@ All button styles and variations appear the same when disabled.
 <code-well-header>
   <div class="d-d-flex d-flow8">
     <div>
-      <button type="button" disabled="disabled" class="base-button__button d-btn d-btn--primary" ><span class="d-btn__label base-button__label">Place call</span></button>
+      <button type="button" disabled="disabled" class="base-button__button d-btn d-btn--primary"><span class="d-btn__label base-button__label">Place call</span></button>
     </div>
   </div>
 </code-well-header>
@@ -298,9 +298,6 @@ All button styles and variations appear the same when disabled.
 <code-example-tabs
 htmlCode='
 <button class="d-btn" type="button" disabled><span class="d-btn__label">...</span></button>
-<span class="d-c-not-allowed">
-  <button class="d-btn d-btn--disabled" type="button" aria-disabled="true"><span class="d-btn__label">...</span></button>
-</span>
 '
 vueCode='
 <dt-button disabled> Place call </dt-button>
@@ -600,6 +597,24 @@ htmlCode='
 vueCode='
 <!-- circle inverted clear-->
 <dt-button circle kind="inverted" importance="clear">
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+     />
+  </template>
+</dt-button>
+<!-- circle inverted outlined-->
+<dt-button circle kind="inverted" importance="outlined">
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+     />
+  </template>
+</dt-button>
+<!-- circle inverted primary-->
+<dt-button circle kind="inverted">
   <template #icon>
     <dt-icon
       name="phone"


### PR DESCRIPTION
# use CodeExampleTabs from badge to button-group

Jira ticket: https://dialpad.atlassian.net/browse/DLT-691

Implemented our new CodeExampleTabs component into:

- badge
- banner
- breadcrumbs
- button
- button-group


Images:

<img width="966" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/0512747e-e32a-48dd-bb7c-2a9222d3ce89">

<img width="966" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/02afb744-a458-460c-9a27-85df37068547">

<img width="966" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/b2b5d4bd-099b-432c-9d89-b089c6ea5a46">

<img width="966" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/412f7b62-5956-476e-8402-3caab64e5092">

