### PR TITLE
fix: lower aggression of feed-item-row deep selector

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -385,13 +385,13 @@ export default {
     right: var(--dt-space-450);
   }
 
-  &:deep(.dt-item-layout) {
+  &:deep(> .dt-item-layout) {
     font: var(--dt-typography-body-compact-base);
     min-height: initial;
     padding: 0px;
   }
 
-  &:deep(.dt-item-layout--left) {
+  &:deep(> .dt-item-layout > .dt-item-layout--left) {
     align-self: flex-start;
     text-align: end;
     display: block;
@@ -401,12 +401,12 @@ export default {
     min-width: calc(var(--dt-space-600) + var(--dt-space-300));
   }
 
-  &:deep(.dt-item-layout--right) {
+  &:deep(> .dt-item-layout > .dt-item-layout--right) {
     padding: 0;
     min-width: initial;
   }
 
-  &:deep(.dt-item-layout--bottom) {
+  &:deep(> .dt-item-layout > .dt-item-layout--bottom) {
     display: flex;
     flex-direction: column;
     margin-top: 0;

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -193,7 +193,7 @@
         </dt-recipe-feed-item-row>
       </ul>
     </div>
-    <div>
+    <div class="d-h332">
       <h3>Feed item pill within</h3>
       <ul class="d-py8">
         <dt-recipe-feed-item-row

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -193,6 +193,70 @@
         </dt-recipe-feed-item-row>
       </ul>
     </div>
+    <div>
+      <h3>Feed item pill within</h3>
+      <ul class="d-py8">
+        <dt-recipe-feed-item-row
+          ref="feedItemRowFade"
+          :show-header="false"
+          :avatar-image-url="$attrs.avatarImageUrl"
+          :display-name="$attrs.displayName"
+          :time="$attrs.time"
+          :short-time="$attrs.shortTime"
+          :is-active="true"
+          :state="fadeState"
+          @hover="$attrs.onHover"
+          @focus="$attrs.onFocus"
+        >
+          <dt-recipe-feed-item-pill
+            default-toggled
+            title="Ben called you"
+            icon-name="phone-outgoing"
+            wrapper-class="d-w628"
+            border-color="ai"
+          >
+            <template #subtitle>
+              Lasted 8 min • Ended at 11:56 AM
+            </template>
+            <template #right>
+              <div>
+                <dt-button
+                  aria-label="Open external link"
+                  kind="muted"
+                  importance="clear"
+                  :circle="true"
+                  @click.stop=""
+                >
+                  <template #icon>
+                    <dt-icon
+                      name="external-link"
+                      size="300"
+                    />
+                  </template>
+                </dt-button>
+              </div>
+            </template>
+            <template #content>
+              <div class="d-p16">
+                <p>
+                  The agent from Dialpad called to follow up on a support ticket
+                  that Jeff was handling for them regarding Dialpad CTI. They apologized
+                  for calling outside of the requested time and expressed that they had
+                  asked the team to look into the issue and would email them after the call.
+                </p>
+                <p class="d-fs-100 d-mt12">
+                  <strong>Actions items</strong>
+                </p>
+                <p class="d-d-flex">
+                  <strong class="d-mr4">1. </strong>
+                  The agent needs to inform the team to check on Vijay's request or ticket regarding Dialpad CTI.
+                </p>
+              </div>
+            </template>
+          </dt-recipe-feed-item-pill>
+        </dt-recipe-feed-item-row>
+      </ul>
+    </div>
   </dt-stack>
 </template>
 
@@ -200,6 +264,7 @@
 import DtRecipeFeedItemRow from './feed_item_row.vue';
 
 import { DtRecipeEmojiRow } from '../emoji_row';
+import { DtRecipeFeedItemPill } from '../feed_pill';
 import { DtStack } from '@/components/stack';
 import { DtAvatar } from '@/components/avatar';
 import { DtIcon } from '@/components/icon';
@@ -214,6 +279,7 @@ export default {
   components: {
     DtRecipeEmojiRow,
     DtRecipeFeedItemRow,
+    DtRecipeFeedItemPill,
     DtStack,
     DtAvatar,
     DtIcon,

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -384,13 +384,13 @@ export default {
     right: var(--dt-space-450);
   }
 
-  &:deep(.dt-item-layout) {
+  &:deep(> .dt-item-layout) {
     font: var(--dt-typography-body-compact-base);
     min-height: initial;
     padding: 0px;
   }
 
-  &:deep(.dt-item-layout--left) {
+  &:deep(> .dt-item-layout > .dt-item-layout--left) {
     align-self: flex-start;
     text-align: end;
     display: block;
@@ -400,12 +400,12 @@ export default {
     min-width: calc(var(--dt-space-600) + var(--dt-space-300));
   }
 
-  &:deep(.dt-item-layout--right) {
+  &:deep(> .dt-item-layout > .dt-item-layout--right) {
     padding: 0;
     min-width: initial;
   }
 
-  &:deep(.dt-item-layout--bottom) {
+  &:deep(> .dt-item-layout > .dt-item-layout--bottom) {
     display: flex;
     flex-direction: column;
     margin-top: 0;

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -193,7 +193,7 @@
         </dt-recipe-feed-item-row>
       </ul>
     </div>
-    <div>
+    <div class="d-h332">
       <h3>Feed item pill within</h3>
       <ul class="d-py8">
         <dt-recipe-feed-item-row

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -193,6 +193,70 @@
         </dt-recipe-feed-item-row>
       </ul>
     </div>
+    <div>
+      <h3>Feed item pill within</h3>
+      <ul class="d-py8">
+        <dt-recipe-feed-item-row
+          ref="feedItemRowFade"
+          :show-header="false"
+          :avatar-image-url="$attrs.avatarImageUrl"
+          :display-name="$attrs.displayName"
+          :time="$attrs.time"
+          :short-time="$attrs.shortTime"
+          :is-active="true"
+          :state="fadeState"
+          @hover="$attrs.onHover"
+          @focus="$attrs.onFocus"
+        >
+          <dt-recipe-feed-item-pill
+            default-toggled
+            title="Ben called you"
+            icon-name="phone-outgoing"
+            wrapper-class="d-w628"
+            border-color="ai"
+          >
+            <template #subtitle>
+              Lasted 8 min • Ended at 11:56 AM
+            </template>
+            <template #right>
+              <div>
+                <dt-button
+                  aria-label="Open external link"
+                  kind="muted"
+                  importance="clear"
+                  :circle="true"
+                  @click.stop=""
+                >
+                  <template #icon>
+                    <dt-icon
+                      name="external-link"
+                      size="300"
+                    />
+                  </template>
+                </dt-button>
+              </div>
+            </template>
+            <template #content>
+              <div class="d-p16">
+                <p>
+                  The agent from Dialpad called to follow up on a support ticket
+                  that Jeff was handling for them regarding Dialpad CTI. They apologized
+                  for calling outside of the requested time and expressed that they had
+                  asked the team to look into the issue and would email them after the call.
+                </p>
+                <p class="d-fs-100 d-mt12">
+                  <strong>Actions items</strong>
+                </p>
+                <p class="d-d-flex">
+                  <strong class="d-mr4">1. </strong>
+                  The agent needs to inform the team to check on Vijay's request or ticket regarding Dialpad CTI.
+                </p>
+              </div>
+            </template>
+          </dt-recipe-feed-item-pill>
+        </dt-recipe-feed-item-row>
+      </ul>
+    </div>
   </dt-stack>
 </template>
 
@@ -200,6 +264,7 @@
 import DtRecipeFeedItemRow from './feed_item_row.vue';
 
 import { DtRecipeEmojiRow } from '../emoji_row';
+import { DtRecipeFeedItemPill } from '../feed_pill';
 import { DtStack } from '@/components/stack';
 import { DtAvatar } from '@/components/avatar';
 import { DtIcon } from '@/components/icon';
@@ -214,6 +279,7 @@ export default {
   components: {
     DtRecipeEmojiRow,
     DtRecipeFeedItemRow,
+    DtRecipeFeedItemPill,
     DtStack,
     DtAvatar,
     DtIcon,


### PR DESCRIPTION
# fix: lower aggression of feed-item-row deep selector

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaW9tb3Roc3JsbzR2eXVjOXZxdDJidmVncHV5dzQ3amFuemd2YzR5eCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MlyicdUndRbn5zUiAL/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Made the deep selectors only apply to their target elements in feed-item-row. 

Added new example for feed item pill within feed item row.

## :bulb: Context

selectors were aggressively overriding child components due to high specificity causing the pill component to look like this:

![unnamed](https://github.com/dialpad/dialtone/assets/64808812/535ed98b-8a5f-4e15-8140-5c720a41b893)

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
