### PR TITLE
fix: remove markRaw

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/suggestion.js
@@ -1,4 +1,3 @@
-import { markRaw } from 'vue';
 import { VueRenderer } from '@tiptap/vue-2';
 import { emojisIndexed } from '@/components/emoji_picker/emojis';
 
@@ -59,7 +58,7 @@ export default {
         component = new VueRenderer(SuggestionList, {
           parent: this,
           propsData: {
-            itemComponent: markRaw(EmojiSuggestion),
+            itemComponent: EmojiSuggestion,
             itemType: 'emoji',
             ...props,
           },

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/suggestion.js
@@ -1,4 +1,3 @@
-import { markRaw } from 'vue';
 import { VueRenderer } from '@tiptap/vue-2';
 import tippy from 'tippy.js';
 
@@ -20,7 +19,7 @@ export default {
         component = new VueRenderer(SuggestionList, {
           parent: this,
           propsData: {
-            itemComponent: markRaw(MentionSuggestion),
+            itemComponent: MentionSuggestion,
             itemType: 'mention',
             ...props,
           },


### PR DESCRIPTION
# Fix Rich Text editor - Remove markRaw

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/7J4Lvpz55rocVYccdH/giphy.gif?cid=82a1493brubsn19ls6u5cdi5c72uohnpu1ju3x25y2147q4c&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

No Jira ticket

## :book: Description

Removed markRaw from vue2 version of DtRichTextEditor plugins as this is exclusive of vue 2.7+ and dialpad is using 2.6.14

## :bulb: Context

Issues implementing DtRecipeMessageInput on dialpad were reported, worked with @bianca-artola-dialpad and found out this markRaw issues.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

Release and update on product side.