### PR TITLE
ci: fix a11y staging tests

### DIFF
--- a/.github/workflows/a11y_tests.yml
+++ b/.github/workflows/a11y_tests.yml
@@ -47,9 +47,8 @@ jobs:
     if: ${{ needs.filter-actions.outputs.dialtone-vue-2 == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
+      - name: Check out branch
+        uses: actions/checkout@v4
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -95,9 +94,8 @@ jobs:
     if: ${{ needs.filter-actions.outputs.dialtone-vue-3 == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
+      - name: Check out branch
+        uses: actions/checkout@v4
 
       - name: Use Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
# Fix a11y tests on staging

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/dmvodzjX8wU7icE3TL/giphy.gif?cid=82a1493bzxzf4umok68ll9s2al51omukf7tbkja1mm7qtwk5&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] CI

## :book: Jira Ticket

No Jira

## :book: Description

Changed the checkout step to be compatible with PR and Push

## :bulb: Context

Forgot that this will run on staging too