### PR TITLE
fix: message input select media

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -597,8 +597,8 @@ export default {
       this.$refs.messageInputImageUpload.$refs.input.click();
     },
 
-    onImageUpload (val) {
-      this.$emit('select-media', val);
+    onImageUpload () {
+      this.$emit('select-media', this.$refs.messageInputImageUpload.$refs.input.files);
     },
 
     toggleEmojiPicker () {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -597,8 +597,8 @@ export default {
       this.$refs.messageInputImageUpload.$refs.input.click();
     },
 
-    onImageUpload (val) {
-      this.$emit('select-media', val);
+    onImageUpload () {
+      this.$emit('select-media', this.$refs.messageInputImageUpload.$refs.input.files);
     },
 
     toggleEmojiPicker () {


### PR DESCRIPTION
# Fix select-media event on DtRecipeMessageInput

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGY5OGQxcGY3ZjN5NXRyOWRueXRhcnZtY2FmNTB4Mjhma3Q4a2h3byZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Lxynuz6WSgsZbAghBD/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

No Jira

## :book: Description

Changed the value emitted by `select-media` event to emit the files object instead of just the file names.

## :bulb: Context

@bianca-artola-dialpad reported that message input component was only emitting file name and they need more information, emitting the whole object should fix their issues.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.

## :link: Sources

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file