### PR TITLE
feat(feed-item-row): add attachment slot

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.mdx
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.mdx
@@ -17,7 +17,8 @@ and the content which can be either a message or a rich media.
 
 The default feed item row contains 4 slots:
 
-- **default** slot - the content whether it be text or the rich media card
+- **default** slot - contains the textual content of the feed item. Can also contain code blocks.
+- **attachment** slot - contains any image, video or pill style content such as "Feed Item Pill"
 - **threading** slot - the threading row component which is below the reactions slot
 - **menu** slot - the actions menu for current feed row. Floats towards the right and shows when isActive is true.
 - **reactions** slot - the emoji reactions list component below the content slot.

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
@@ -13,6 +13,7 @@ export const argsData = {
   shortTime: '4:54',
   onFocus: action('focus'),
   onHover: action('hover'),
+  attachment: '<img src="https://i1.sndcdn.com/avatars-000181324408-652e57-t500x500.jpg"></img>',
   default: `Elementum fames :smile: nullam elementum velit proin vitae aliquet.
   Platea nulla consectetur consequat sagittis nullam et ultricies nisl rhoncus
   aliquet elementum venenatis :laughing: quisque.`,
@@ -40,6 +41,15 @@ export const argTypesData = {
     table and description within the controls accurately reflects the correct names of our component's props and slots.
   */
   default: {
+    control: 'text',
+    table: {
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+
+  attachment: {
     control: 'text',
     table: {
       type: {

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
@@ -13,7 +13,7 @@ export const argsData = {
   shortTime: '4:54',
   onFocus: action('focus'),
   onHover: action('hover'),
-  attachment: '<img src="https://i1.sndcdn.com/avatars-000181324408-652e57-t500x500.jpg"></img>',
+  attachment: '<img alt="dwight" src="https://i1.sndcdn.com/avatars-000181324408-652e57-t500x500.jpg"></img>',
   default: `Elementum fames :smile: nullam elementum velit proin vitae aliquet.
   Platea nulla consectetur consequat sagittis nullam et ultricies nisl rhoncus
   aliquet elementum venenatis :laughing: quisque.`,

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.test.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.test.js
@@ -22,6 +22,7 @@ describe('DtFeedItemRow tests', () => {
   let avatarImgWrapper;
   let leftTimeWrapper;
   let contentWrapper;
+  let attachmentWrapper;
   let reactionsWrapper;
   let menuWrapper;
 
@@ -39,6 +40,7 @@ describe('DtFeedItemRow tests', () => {
     headerWrapper = wrapper.find('[data-qa="dt-feed-item-row--header"]');
     leftTimeWrapper = wrapper.find('[data-qa="dt-feed-item-row--left-time"]');
     contentWrapper = wrapper.find('[data-qa="dt-feed-item-row--content"]');
+    attachmentWrapper = wrapper.find('[data-qa="dt-feed-item-row--attachment"]');
     reactionsWrapper = wrapper.find('[data-qa="dt-feed-item-row--reactions"]');
     menuWrapper = wrapper.find('[data-qa="dt-feed-item-row--menu"]');
   };
@@ -151,6 +153,21 @@ describe('DtFeedItemRow tests', () => {
 
       it('should render default content in the slot provided', () => {
         expect(contentWrapper.text()).toBe(TEST_CONTENT);
+      });
+    });
+
+    describe('When attachment slot content is provided', () => {
+      const TEST_CONTENT = 'Test attachment content';
+      beforeEach(() => {
+        slots = {
+          attachment: TEST_CONTENT,
+        };
+        _mountWrapper();
+        _setChildWrappers();
+      });
+
+      it('should render default content in the slot provided', () => {
+        expect(attachmentWrapper.text()).toBe(TEST_CONTENT);
       });
     });
 

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -62,6 +62,13 @@
       >
         <slot />
       </span>
+      <div
+        v-if="$slots.attachment"
+        data-qa="dt-feed-item-row--attachment"
+        class="dt-feed-item-row__attachment"
+      >
+        <slot name="attachment" />
+      </div>
     </article>
 
     <template #bottom>
@@ -302,6 +309,11 @@ export default {
 <style lang="less" scoped>
 .dt-feed-item-row {
 
+  width: var(--dt-size-100-percent);
+  box-sizing: border-box;
+  position: relative;
+  padding: var(--dt-space-300) var(--dt-space-500);
+
   &:focus-visible {
     box-shadow: var(--dt-shadow-focus-inset);
   }
@@ -325,11 +337,6 @@ export default {
     transition-property: background-color;
   }
 
-  width: var(--dt-size-100-percent);
-  box-sizing: border-box;
-  position: relative;
-  padding: var(--dt-space-300) var(--dt-space-500);
-
   &__avatar-container {
     padding-top: var(--dt-space-300);
     padding-bottom: var(--dt-space-300);
@@ -337,6 +344,26 @@ export default {
 
   &__content {
     padding-left: var(--dt-space-300);
+  }
+
+  &__attachment {
+    padding-top: var(--dt-space-200);
+    padding-bottom: var(--dt-space-300);
+
+    &:deep(img)  {
+      border: var(--dt-color-border-subtle) solid var(--dt-size-border-100);
+      border-radius: var(--dt-size-radius-400);
+      display: block;
+      max-width: 30rem;
+      max-height: 30rem;
+      min-width: 5.6rem;
+      min-height: 5.6rem;
+    }
+
+    &:deep(video)  {
+      display: block;
+      height: 25.0rem;
+    }
   }
 
   &__header {

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -433,7 +433,7 @@ export default {
     min-width: initial;
   }
 
-  &:deep(> .dt-item-layout > .dt-item-layout--bottom) {
+  &:deep(> .dt-item-layout > .dt-item-layout--content > .dt-item-layout--bottom) {
     display: flex;
     flex-direction: column;
     margin-top: 0;

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
@@ -27,6 +27,14 @@
       />
     </template>
     <template
+      v-if="$attrs.attachment"
+      #attachment
+    >
+      <span
+        v-html="$attrs.attachment"
+      />
+    </template>
+    <template
       v-if="$attrs.threading"
       #threading
     >

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -16,13 +16,18 @@
           @focus="$attrs.onFocus"
         >
           <template v-if="$attrs.default">
-            <span v-html="$attrs.default" />
+            <dt-emoji-text-wrapper
+              element-type="span"
+              size="400"
+            >
+              {{ $attrs.default }}
+            </dt-emoji-text-wrapper>
           </template>
           <template
             #threading
           >
             <dt-stack
-              class="feed-item-row__thread d-d-flex d-ai-center"
+              class="feed-item-row__thread d-pl4 d-d-flex d-ai-center"
               direction="row"
               gap="400"
             >
@@ -87,7 +92,7 @@
       </ul>
     </div>
     <div>
-      <h3>Feed item with rich media</h3>
+      <h3>Feed item with image attachment</h3>
       <ul class="d-py8">
         <dt-recipe-feed-item-row
           :show-header="true"
@@ -99,49 +104,51 @@
           @hover="$attrs.onHover"
           @focus="$attrs.onFocus"
         >
-          <dt-image-viewer
-            :image-src="fryImage"
-            image-alt="Alt Text"
-            close-aria-label="Close"
-            image-button-class="d-wmn64 d-hmn64 w-wmx332 d-hmx332"
-            aria-label="Click to open image"
-          />
-          <template
-            #threading
-          >
-            <dt-stack
-              class="feed-item-row__thread d-d-flex d-ai-center"
-              direction="row"
-              gap="400"
-            >
-              <dt-stack
-                direction="row"
-                gap="300"
-              >
-                <dt-avatar
-                  v-for="person of persons"
-                  :key="person"
-                  :full-name="person"
-                  seed="seed"
-                  size="sm"
-                />
-              </dt-stack>
-              <dt-stack
-                direction="row"
-                gap="400"
-              >
-                <div class="d-fs-100 d-lh200 d-d-flex d-ai-center">
-                  <a class="d-link d-pr4">3 replies</a>
-                  <span class="feed-item-row__reply">Last reply an hour ago</span>
-                </div>
-              </dt-stack>
-            </dt-stack>
+          Some text alongside a gif
+          <template #attachment>
+            <dt-image-viewer
+              :image-src="fryImage"
+              image-alt="Alt Text"
+              close-aria-label="Close"
+              image-button-class="d-wmn64 d-hmn64 w-wmx332 d-hmx332"
+              aria-label="Click to open image"
+            />
           </template>
           <template
             #reactions
           >
             <dt-recipe-emoji-row
-              :reactions="$attrs.reactions"
+              :reactions="mockReactions"
+            />
+          </template>
+        </dt-recipe-feed-item-row>
+      </ul>
+    </div>
+    <div>
+      <h3>With video attachment</h3>
+      <ul class="d-py8">
+        <dt-recipe-feed-item-row
+          ref="feedItemRowFade"
+          :show-header="false"
+          :avatar-image-url="$attrs.avatarImageUrl"
+          :display-name="$attrs.displayName"
+          :time="$attrs.time"
+          :short-time="$attrs.shortTime"
+          :is-active="true"
+        >
+          <template v-if="$attrs.default">
+            <dt-emoji-text-wrapper
+              element-type="span"
+              size="400"
+            >
+              {{ $attrs.default }}
+            </dt-emoji-text-wrapper>
+          </template>
+          <template #attachment>
+            <!-- eslint-disable-next-line vuejs-accessibility/media-has-caption -->
+            <video
+              controls
+              src="https://www.w3schools.com/html/mov_bbb.mp4"
             />
           </template>
         </dt-recipe-feed-item-row>
@@ -162,7 +169,12 @@
           @focus="$attrs.onFocus"
         >
           <template v-if="$attrs.default">
-            <span v-html="$attrs.default" />
+            <dt-emoji-text-wrapper
+              element-type="span"
+              size="400"
+            >
+              {{ $attrs.default }}
+            </dt-emoji-text-wrapper>
           </template>
         </dt-recipe-feed-item-row>
       </ul>
@@ -188,7 +200,12 @@
           @focus="$attrs.onFocus"
         >
           <template v-if="$attrs.default">
-            <span v-html="$attrs.default" />
+            <dt-emoji-text-wrapper
+              element-type="span"
+              size="400"
+            >
+              {{ $attrs.default }}
+            </dt-emoji-text-wrapper>
           </template>
         </dt-recipe-feed-item-row>
       </ul>
@@ -204,56 +221,55 @@
           :time="$attrs.time"
           :short-time="$attrs.shortTime"
           :is-active="true"
-          :state="fadeState"
-          @hover="$attrs.onHover"
-          @focus="$attrs.onFocus"
         >
-          <dt-recipe-feed-item-pill
-            default-toggled
-            title="Ben called you"
-            icon-name="phone-outgoing"
-            wrapper-class="d-w628"
-            border-color="ai"
-          >
-            <template #subtitle>
-              Lasted 8 min • Ended at 11:56 AM
-            </template>
-            <template #right>
-              <div>
-                <dt-button
-                  aria-label="Open external link"
-                  kind="muted"
-                  importance="clear"
-                  :circle="true"
-                  @click.stop=""
-                >
-                  <template #icon>
-                    <dt-icon
-                      name="external-link"
-                      size="300"
-                    />
-                  </template>
-                </dt-button>
-              </div>
-            </template>
-            <template #content>
-              <div class="d-p16">
-                <p>
-                  The agent from Dialpad called to follow up on a support ticket
-                  that Jeff was handling for them regarding Dialpad CTI. They apologized
-                  for calling outside of the requested time and expressed that they had
-                  asked the team to look into the issue and would email them after the call.
-                </p>
-                <p class="d-fs-100 d-mt12">
-                  <strong>Actions items</strong>
-                </p>
-                <p class="d-d-flex">
-                  <strong class="d-mr4">1. </strong>
-                  The agent needs to inform the team to check on Vijay's request or ticket regarding Dialpad CTI.
-                </p>
-              </div>
-            </template>
-          </dt-recipe-feed-item-pill>
+          <template #attachment>
+            <dt-recipe-feed-item-pill
+              default-toggled
+              title="Ben called you"
+              icon-name="phone-outgoing"
+              wrapper-class="d-w628"
+              border-color="ai"
+            >
+              <template #subtitle>
+                Lasted 8 min • Ended at 11:56 AM
+              </template>
+              <template #right>
+                <div>
+                  <dt-button
+                    aria-label="Open external link"
+                    kind="muted"
+                    importance="clear"
+                    :circle="true"
+                    @click.stop=""
+                  >
+                    <template #icon>
+                      <dt-icon
+                        name="external-link"
+                        size="300"
+                      />
+                    </template>
+                  </dt-button>
+                </div>
+              </template>
+              <template #content>
+                <div class="d-p16">
+                  <p>
+                    The agent from Dialpad called to follow up on a support ticket
+                    that Jeff was handling for them regarding Dialpad CTI. They apologized
+                    for calling outside of the requested time and expressed that they had
+                    asked the team to look into the issue and would email them after the call.
+                  </p>
+                  <p class="d-fs-100 d-mt12">
+                    <strong>Actions items</strong>
+                  </p>
+                  <p class="d-d-flex">
+                    <strong class="d-mr4">1. </strong>
+                    The agent needs to inform the team to check on Vijay's request or ticket regarding Dialpad CTI.
+                  </p>
+                </div>
+              </template>
+            </dt-recipe-feed-item-pill>
+          </template>
         </dt-recipe-feed-item-row>
       </ul>
     </div>
@@ -266,6 +282,7 @@ import DtRecipeFeedItemRow from './feed_item_row.vue';
 import { DtRecipeEmojiRow } from '../emoji_row';
 import { DtRecipeFeedItemPill } from '../feed_pill';
 import { DtStack } from '@/components/stack';
+import { DtEmojiTextWrapper } from '@/components/emoji_text_wrapper';
 import { DtAvatar } from '@/components/avatar';
 import { DtIcon } from '@/components/icon';
 import { DtImageViewer } from '@/components/image_viewer';
@@ -277,6 +294,7 @@ export default {
   name: 'DtRecipeFeedItemRowVariants',
 
   components: {
+    DtEmojiTextWrapper,
     DtRecipeEmojiRow,
     DtRecipeFeedItemRow,
     DtRecipeFeedItemPill,

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.mdx
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.mdx
@@ -17,7 +17,8 @@ and the content which can be either a message or a rich media.
 
 The default feed item row contains 4 slots:
 
-- **default** slot - the content whether it be text or the rich media card
+- **default** slot - contains the textual content of the feed item. Can also contain code blocks.
+- **attachment** slot - contains any image, video or pill style content such as "Feed Item Pill"
 - **threading** slot - the threading row component which is below the reactions slot
 - **menu** slot - the actions menu for current feed row. Floats towards the right and shows when isActive is true.
 - **reactions** slot - the emoji reactions list component below the content slot.

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
@@ -13,6 +13,7 @@ export const argsData = {
   shortTime: '4:54',
   onFocus: action('focus'),
   onHover: action('hover'),
+  attachment: '<img src="https://i1.sndcdn.com/avatars-000181324408-652e57-t500x500.jpg"></img>',
   default: `Elementum fames :smile: nullam elementum velit proin vitae aliquet.
   Platea nulla consectetur consequat sagittis nullam et ultricies nisl rhoncus
   aliquet elementum venenatis :laughing: quisque.`,
@@ -40,6 +41,15 @@ export const argTypesData = {
     table and description within the controls accurately reflects the correct names of our component's props and slots.
   */
   default: {
+    control: 'text',
+    table: {
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+
+  attachment: {
     control: 'text',
     table: {
       type: {

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
@@ -13,7 +13,7 @@ export const argsData = {
   shortTime: '4:54',
   onFocus: action('focus'),
   onHover: action('hover'),
-  attachment: '<img src="https://i1.sndcdn.com/avatars-000181324408-652e57-t500x500.jpg"></img>',
+  attachment: '<img alt="dwight" src="https://i1.sndcdn.com/avatars-000181324408-652e57-t500x500.jpg"></img>',
   default: `Elementum fames :smile: nullam elementum velit proin vitae aliquet.
   Platea nulla consectetur consequat sagittis nullam et ultricies nisl rhoncus
   aliquet elementum venenatis :laughing: quisque.`,

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.test.js
@@ -16,6 +16,7 @@ describe('DtFeedItemRow tests', () => {
   let avatarImgWrapper;
   let leftTimeWrapper;
   let contentWrapper;
+  let attachmentWrapper;
   let reactionsWrapper;
   let menuWrapper;
 
@@ -36,6 +37,7 @@ describe('DtFeedItemRow tests', () => {
     headerWrapper = wrapper.find('[data-qa="dt-feed-item-row--header"]');
     leftTimeWrapper = wrapper.find('[data-qa="dt-feed-item-row--left-time"]');
     contentWrapper = wrapper.find('[data-qa="dt-feed-item-row--content"]');
+    attachmentWrapper = wrapper.find('[data-qa="dt-feed-item-row--attachment"]');
     reactionsWrapper = wrapper.find('[data-qa="dt-feed-item-row--reactions"]');
     menuWrapper = wrapper.find('[data-qa="dt-feed-item-row--menu"]');
   };
@@ -125,6 +127,21 @@ describe('DtFeedItemRow tests', () => {
 
       it('should render default content in the slot provided', () => {
         expect(contentWrapper.text()).toBe(TEST_CONTENT);
+      });
+    });
+
+    describe('When attachment slot content is provided', () => {
+      const TEST_CONTENT = 'Test attachment content';
+      beforeEach(() => {
+        slots = {
+          attachment: TEST_CONTENT,
+        };
+        _mountWrapper();
+        _setChildWrappers();
+      });
+
+      it('should render default content in the slot provided', () => {
+        expect(attachmentWrapper.text()).toBe(TEST_CONTENT);
       });
     });
 

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -432,7 +432,7 @@ export default {
     min-width: initial;
   }
 
-  &:deep(> .dt-item-layout > .dt-item-layout--bottom) {
+  &:deep(> .dt-item-layout > .dt-item-layout--content > .dt-item-layout--bottom) {
     display: flex;
     flex-direction: column;
     margin-top: 0;

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -62,6 +62,13 @@
       >
         <slot />
       </span>
+      <div
+        v-if="$slots.attachment"
+        data-qa="dt-feed-item-row--attachment"
+        class="dt-feed-item-row__attachment"
+      >
+        <slot name="attachment" />
+      </div>
     </article>
 
     <template #bottom>
@@ -301,6 +308,11 @@ export default {
 <style lang="less" scoped>
 .dt-feed-item-row {
 
+  width: var(--dt-size-100-percent);
+  box-sizing: border-box;
+  position: relative;
+  padding: var(--dt-space-300) var(--dt-space-500);
+
   &:focus-visible {
     box-shadow: var(--dt-shadow-focus-inset);
   }
@@ -324,11 +336,6 @@ export default {
     transition-property: background-color;
   }
 
-  width: var(--dt-size-100-percent);
-  box-sizing: border-box;
-  position: relative;
-  padding: var(--dt-space-300) var(--dt-space-500);
-
   &__avatar-container {
     padding-top: var(--dt-space-300);
     padding-bottom: var(--dt-space-300);
@@ -336,6 +343,26 @@ export default {
 
   &__content {
     padding-left: var(--dt-space-300);
+  }
+
+  &__attachment {
+    padding-top: var(--dt-space-200);
+    padding-bottom: var(--dt-space-300);
+
+    &:deep(img)  {
+      border: var(--dt-color-border-subtle) solid var(--dt-size-border-100);
+      border-radius: var(--dt-size-radius-400);
+      display: block;
+      max-width: 30rem;
+      max-height: 30rem;
+      min-width: 5.6rem;
+      min-height: 5.6rem;
+    }
+
+    &:deep(video)  {
+      display: block;
+      height: 25.0rem;
+    }
   }
 
   &__header {

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
@@ -27,6 +27,14 @@
       />
     </template>
     <template
+      v-if="$attrs.attachment"
+      #attachment
+    >
+      <span
+        v-html="$attrs.attachment"
+      />
+    </template>
+    <template
       v-if="$attrs.threading"
       #threading
     >

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -16,13 +16,18 @@
           @focus="$attrs.onFocus"
         >
           <template v-if="$attrs.default">
-            <span v-html="$attrs.default" />
+            <dt-emoji-text-wrapper
+              element-type="span"
+              size="400"
+            >
+              {{ $attrs.default }}
+            </dt-emoji-text-wrapper>
           </template>
           <template
             #threading
           >
             <dt-stack
-              class="feed-item-row__thread d-d-flex d-ai-center"
+              class="feed-item-row__thread d-pl4 d-d-flex d-ai-center"
               direction="row"
               gap="400"
             >
@@ -87,7 +92,7 @@
       </ul>
     </div>
     <div>
-      <h3>Feed item with rich media</h3>
+      <h3>Feed item with image attachment</h3>
       <ul class="d-py8">
         <dt-recipe-feed-item-row
           :show-header="true"
@@ -99,49 +104,51 @@
           @hover="$attrs.onHover"
           @focus="$attrs.onFocus"
         >
-          <dt-image-viewer
-            :image-src="fryImage"
-            image-alt="Alt Text"
-            close-aria-label="Close"
-            image-button-class="d-wmn64 d-hmn64 w-wmx332 d-hmx332"
-            aria-label="Click to open image"
-          />
-          <template
-            #threading
-          >
-            <dt-stack
-              class="feed-item-row__thread d-d-flex d-ai-center"
-              direction="row"
-              gap="400"
-            >
-              <dt-stack
-                direction="row"
-                gap="300"
-              >
-                <dt-avatar
-                  v-for="person of persons"
-                  :key="person"
-                  :full-name="person"
-                  seed="seed"
-                  size="sm"
-                />
-              </dt-stack>
-              <dt-stack
-                direction="row"
-                gap="400"
-              >
-                <div class="d-fs-100 d-lh200 d-d-flex d-ai-center">
-                  <a class="d-link d-pr4">3 replies</a>
-                  <span class="feed-item-row__reply">Last reply an hour ago</span>
-                </div>
-              </dt-stack>
-            </dt-stack>
+          Some text alongside a gif
+          <template #attachment>
+            <dt-image-viewer
+              :image-src="fryImage"
+              image-alt="Alt Text"
+              close-aria-label="Close"
+              image-button-class="d-wmn64 d-hmn64 w-wmx332 d-hmx332"
+              aria-label="Click to open image"
+            />
           </template>
           <template
             #reactions
           >
             <dt-recipe-emoji-row
-              :reactions="reactions"
+              :reactions="mockReactions"
+            />
+          </template>
+        </dt-recipe-feed-item-row>
+      </ul>
+    </div>
+    <div>
+      <h3>With video attachment</h3>
+      <ul class="d-py8">
+        <dt-recipe-feed-item-row
+          ref="feedItemRowFade"
+          :show-header="false"
+          :avatar-image-url="$attrs.avatarImageUrl"
+          :display-name="$attrs.displayName"
+          :time="$attrs.time"
+          :short-time="$attrs.shortTime"
+          :is-active="true"
+        >
+          <template v-if="$attrs.default">
+            <dt-emoji-text-wrapper
+              element-type="span"
+              size="400"
+            >
+              {{ $attrs.default }}
+            </dt-emoji-text-wrapper>
+          </template>
+          <template #attachment>
+            <!-- eslint-disable-next-line vuejs-accessibility/media-has-caption -->
+            <video
+              controls
+              src="https://www.w3schools.com/html/mov_bbb.mp4"
             />
           </template>
         </dt-recipe-feed-item-row>
@@ -162,7 +169,12 @@
           @focus="$attrs.onFocus"
         >
           <template v-if="defaultSlot">
-            <span v-html="defaultSlot" />
+            <dt-emoji-text-wrapper
+              element-type="span"
+              size="400"
+            >
+              {{ defaultSlot }}
+            </dt-emoji-text-wrapper>
           </template>
         </dt-recipe-feed-item-row>
       </ul>
@@ -188,7 +200,12 @@
           @focus="$attrs.onFocus"
         >
           <template v-if="defaultSlot">
-            <span v-html="defaultSlot" />
+            <dt-emoji-text-wrapper
+              element-type="span"
+              size="400"
+            >
+              {{ defaultSlot }}
+            </dt-emoji-text-wrapper>
           </template>
         </dt-recipe-feed-item-row>
       </ul>
@@ -204,56 +221,55 @@
           :time="$attrs.time"
           :short-time="$attrs.shortTime"
           :is-active="true"
-          :state="fadeState"
-          @hover="$attrs.onHover"
-          @focus="$attrs.onFocus"
         >
-          <dt-recipe-feed-item-pill
-            default-toggled
-            title="Ben called you"
-            icon-name="phone-outgoing"
-            wrapper-class="d-w628"
-            border-color="ai"
-          >
-            <template #subtitle>
-              Lasted 8 min • Ended at 11:56 AM
-            </template>
-            <template #right>
-              <div>
-                <dt-button
-                  aria-label="Open external link"
-                  kind="muted"
-                  importance="clear"
-                  :circle="true"
-                  @click.stop=""
-                >
-                  <template #icon>
-                    <dt-icon
-                      name="external-link"
-                      size="300"
-                    />
-                  </template>
-                </dt-button>
-              </div>
-            </template>
-            <template #content>
-              <div class="d-p16">
-                <p>
-                  The agent from Dialpad called to follow up on a support ticket
-                  that Jeff was handling for them regarding Dialpad CTI. They apologized
-                  for calling outside of the requested time and expressed that they had
-                  asked the team to look into the issue and would email them after the call.
-                </p>
-                <p class="d-fs-100 d-mt12">
-                  <strong>Actions items</strong>
-                </p>
-                <p class="d-d-flex">
-                  <strong class="d-mr4">1. </strong>
-                  The agent needs to inform the team to check on Vijay's request or ticket regarding Dialpad CTI.
-                </p>
-              </div>
-            </template>
-          </dt-recipe-feed-item-pill>
+          <template #attachment>
+            <dt-recipe-feed-item-pill
+              default-toggled
+              title="Ben called you"
+              icon-name="phone-outgoing"
+              wrapper-class="d-w628"
+              border-color="ai"
+            >
+              <template #subtitle>
+                Lasted 8 min • Ended at 11:56 AM
+              </template>
+              <template #right>
+                <div>
+                  <dt-button
+                    aria-label="Open external link"
+                    kind="muted"
+                    importance="clear"
+                    :circle="true"
+                    @click.stop=""
+                  >
+                    <template #icon>
+                      <dt-icon
+                        name="external-link"
+                        size="300"
+                      />
+                    </template>
+                  </dt-button>
+                </div>
+              </template>
+              <template #content>
+                <div class="d-p16">
+                  <p>
+                    The agent from Dialpad called to follow up on a support ticket
+                    that Jeff was handling for them regarding Dialpad CTI. They apologized
+                    for calling outside of the requested time and expressed that they had
+                    asked the team to look into the issue and would email them after the call.
+                  </p>
+                  <p class="d-fs-100 d-mt12">
+                    <strong>Actions items</strong>
+                  </p>
+                  <p class="d-d-flex">
+                    <strong class="d-mr4">1. </strong>
+                    The agent needs to inform the team to check on Vijay's request or ticket regarding Dialpad CTI.
+                  </p>
+                </div>
+              </template>
+            </dt-recipe-feed-item-pill>
+          </template>
         </dt-recipe-feed-item-row>
       </ul>
     </div>
@@ -266,6 +282,7 @@ import DtRecipeFeedItemRow from './feed_item_row.vue';
 import { DtRecipeEmojiRow } from '../emoji_row';
 import { DtRecipeFeedItemPill } from '../feed_pill';
 import { DtStack } from '@/components/stack';
+import { DtEmojiTextWrapper } from '@/components/emoji_text_wrapper';
 import { DtAvatar } from '@/components/avatar';
 import { DtIcon } from '@/components/icon';
 import { DtImageViewer } from '@/components/image_viewer';
@@ -277,6 +294,7 @@ export default {
   name: 'DtRecipeFeedItemRowVariants',
 
   components: {
+    DtEmojiTextWrapper,
     DtRecipeEmojiRow,
     DtRecipeFeedItemRow,
     DtRecipeFeedItemPill,


### PR DESCRIPTION
# feat(feed-item-row): add attachment slot

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa25lODRlODZ1cXY4YXdqajU2emU0ZXBmZTl3MWpxeWt1aXhvYXdvZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/GpCMacav9VprdAgmVa/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1509

## :book: Description

Added attachment slot for rendering images / videos to match new conversation view designs from: https://www.figma.com/file/GJiRmWORmDi0zxLJfwn8yp/Conversation-View-%2B-Messaging-Layouts?node-id=104%3A71837&mode=dev

Added a few more examples to the variants to demonstrate this.

## :bulb: Context

Noticed when going through the issues on ticket DLT-1509 that we never implemented a separate attachment slot for images / video / pills etc. Everything currently just goes into the main content slot and this was causing some spacing issues. I think the attachment slot will work nicely for us to be able to control the styling of non text content as compared to text content. Will definitely take some reworking to get all the correct items passed into this slot on the product side but I think it will be worth it.

Note that we probably cannot render code blocks in the attachment slot as shown in the designs, as code blocks can be embedded in between text, for example:

> here is a codeblock
> 
> ```
> my code here {
>   codez();
> }
> ```
> 
> here is some more text

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

Pass correct elements into this slot on product.

## :camera: Screenshots / GIFs

![Screenshot 2024-03-11 at 4 37 52 PM](https://github.com/dialpad/dialtone/assets/64808812/32372146-e038-4e89-a31f-d9f0a9f80114)

