### PR TITLE
fix: avatar validation

### DIFF
--- a/packages/dialtone-vue2/components/avatar/avatar.vue
+++ b/packages/dialtone-vue2/components/avatar/avatar.vue
@@ -421,7 +421,7 @@ export default {
 
     validateProps () {
       if (this.imageSrc && this.imageAlt === undefined) {
-        throw new Error('full-name or image-alt must be set if image-src is provided');
+        console.error('image-alt required if image-src is provided. Can be set to "" (empty string) if the image is described in text nearby');
       }
     },
 

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
@@ -6,6 +6,7 @@
     <dt-avatar
       :full-name="name"
       :image-src="avatarSrc"
+      image-alt=""
       size="xs"
     />
     {{ name }}

--- a/packages/dialtone-vue3/components/avatar/avatar.vue
+++ b/packages/dialtone-vue3/components/avatar/avatar.vue
@@ -421,7 +421,7 @@ export default {
 
     validateProps () {
       if (this.imageSrc && this.imageAlt === undefined) {
-        throw new Error('full-name or image-alt must be set if image-src is provided');
+        console.error('image-alt required if image-src is provided. Can be set to "" (empty string) if the image is described in text nearby');
       }
     },
 

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
@@ -6,6 +6,7 @@
     <dt-avatar
       :full-name="name"
       :image-src="avatarSrc"
+      image-alt=""
       size="xs"
     />
     {{ name }}


### PR DESCRIPTION
# Fix avatar validation

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/l0LE9VQLvhEIIIOoNJ/giphy.gif?cid=790b7611itwgyh0yhg09fpvduuztrdoo4sjrmcx2ec9jf7wv&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

No JIRA

## :book: Description

- Changed avatar-alt validation from throwing an error to just logging into console, this is not really something that should throw an error.
- Added avatar-alt default value to mention suggestion component.
- Updated error comment.

## :bulb: Context

Found that mention suggestion was not working correctly.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.