### PR TITLE
docs: add composition tokens tooltips

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/TokenTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/TokenTable.vue
@@ -55,7 +55,23 @@
         <td
           class="d-code--sm"
         >
-          <div class="d-wmx264">
+          <div v-if="isCompositionToken(tokenValue)" class="d-wmx264">
+            <span v-for="value in tokenValue" :key="value">
+              <span v-if="valueIsDivided(value)">
+                <span v-dt-tooltip="getTokenValue(getFirstValue(value))">
+                  {{ getFirstValue(value) }}
+                </span>
+                /
+                <span v-dt-tooltip="getTokenValue(getSecondValue(value))">
+                  {{ getSecondValue(value) }}&nbsp;
+                </span>
+              </span>
+              <span v-else v-dt-tooltip="getTokenValue(value)">
+                {{ value }}&nbsp;
+              </span>
+            </span>
+          </div>
+          <div v-else class="d-wmx264">
             {{ tokenValue }}
           </div>
         </td>
@@ -108,9 +124,29 @@ export default {
   },
 
   methods: {
+    getTokenValue (value) {
+      return this.tokens.find(token => token.name === value.replace(/,$/, ''))?.tokenValue.toString();
+    },
+
+    isCompositionToken (value) {
+      return Array.isArray(value);
+    },
+
     remToPixels (value) {
       if (this.category !== 'size' && this.category !== 'space') return;
       return `${parseFloat(value.replace('rem', '')) * 10}px`;
+    },
+
+    valueIsDivided (value) {
+      return value.includes(' / ');
+    },
+
+    getFirstValue (value) {
+      return value.split(' / ')[0];
+    },
+
+    getSecondValue (value) {
+      return value.split(' / ')[1];
     },
   },
 };

--- a/apps/dialtone-documentation/docs/.vuepress/common/token-utilities.js
+++ b/apps/dialtone-documentation/docs/.vuepress/common/token-utilities.js
@@ -9,9 +9,14 @@ export function getComposedTypographyTokens () {
   dialtoneTypographies
     .forEach(typographyName => {
       const composedVar = `--dt-typography-${typographyName}`;
-      // eslint-disable-next-line max-len
-      const tokenValue = `var(${composedVar}-font-weight) var(${composedVar}-font-size)/var(${composedVar}-line-height) var(${composedVar}-font-family)`;
-      tokens.push({ exampleValue: tokenValue, name: `var(${composedVar})`, tokenValue });
+      const weight = `var(${composedVar}-font-weight)`;
+      const sizeLineHeight = `var(${composedVar}-font-size) / var(${composedVar}-line-height)`;
+      const fontFamily = `var(${composedVar}-font-family)`;
+      tokens.push({
+        exampleValue: `${weight} ${sizeLineHeight} ${fontFamily}`,
+        name: `var(${composedVar})`,
+        tokenValue: [weight, sizeLineHeight, fontFamily],
+      });
     });
   return tokens;
 }
@@ -36,7 +41,7 @@ export function getComposedShadowTokens (theme) {
           return `var(${shadowVar}-${shadowNumber}-x) var(${shadowVar}-${shadowNumber}-y) var(${shadowVar}-${shadowNumber}-blur) var(${shadowVar}-${shadowNumber}-spread) var(${shadowVar}-${shadowNumber}-color)`;
         }).join(', ');
 
-      tokens.push({ exampleValue: tokenValue, name: `var(${shadowVar})`, tokenValue });
+      tokens.push({ exampleValue: tokenValue, name: `var(${shadowVar})`, tokenValue: tokenValue.split(' ') });
     });
   return tokens;
 }

--- a/apps/dialtone-documentation/docs/.vuepress/theme/client.js
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/client.js
@@ -2,6 +2,8 @@ import { defineClientConfig } from '@vuepress/client';
 import Layout from './layouts/Layout.vue';
 import NotFound from './layouts/NotFound.vue';
 
+import { DtTooltipDirective } from '@dialpad/dialtone-vue/directives';
+
 // CSS
 import '@dialpad/dialtone-css/lib/dist/css/dialtone.css';
 import './assets/less/dialtone-docs.less';
@@ -69,6 +71,7 @@ async function registerDialtoneVue (app) {
     app.component(key, module[key]);
   });
   app.provide('dialtoneComponents', dialtoneComponents);
+  app.use(DtTooltipDirective);
   window.DIALTONE_CONSTANTS = dialtoneConstants;
 }
 

--- a/packages/dialtone-css/lib/build/less/components/tooltip.less
+++ b/packages/dialtone-css/lib/build/less/components/tooltip.less
@@ -54,7 +54,6 @@
     line-height: var(--tooltip-line-height);
     letter-spacing: calc(var(--dt-space-100) * 0.25);
     text-align: center;
-    word-wrap: break-word;
     background-color: var(--tooltip-color-background);
     border-radius: var(--tooltip-border-radius);
 

--- a/packages/dialtone-css/lib/build/less/components/tooltip.less
+++ b/packages/dialtone-css/lib/build/less/components/tooltip.less
@@ -54,6 +54,7 @@
     line-height: var(--tooltip-line-height);
     letter-spacing: calc(var(--dt-space-100) * 0.25);
     text-align: center;
+    word-wrap: break-word;
     background-color: var(--tooltip-color-background);
     border-radius: var(--tooltip-border-radius);
 

--- a/packages/dialtone-tokens/tokens/base/default.json
+++ b/packages/dialtone-tokens/tokens/base/default.json
@@ -294,11 +294,11 @@
   "font": {
     "family": {
       "body": {
-        "value": "-apple-system,BlinkMacSystemFont,\"SF Pro\",\"Segoe UI Adjusted\",\"Segoe UI\",SFMono,\"Helvetica Neue\",Cantarell,Ubuntu,Roboto,Arial,\"Noto Sans\",sans-serif,\"Apple Color Emoji\",\"Segoe UI Emoji\",\"Segoe UI Symbol\",\"Noto Color Emoji\"",
+        "value": "-apple-system, BlinkMacSystemFont, \"SF Pro\", \"Segoe UI Adjusted\", \"Segoe UI\", SFMono, \"Helvetica Neue\", Cantarell, Ubuntu, Roboto, Arial, \"Noto Sans\", sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\"",
         "type": "fontFamilies"
       },
       "expressive": {
-        "value": "Archivo,{font.family.body}",
+        "value": "Archivo, {font.family.body}",
         "type": "fontFamilies"
       },
       "mono": {


### PR DESCRIPTION
# docs: add composition tokens tooltips

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/vMbC8xqhIf9ny/giphy.gif?cid=790b7611vd03x95u0573k2ed362a30p5sb2899t58r3ayll8&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1506

<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adds tooltips with the value for each separate tokens for composition tokens.
To test it, look for the first tokens in the list for Typography and Shadow.
<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :camera: Screenshots / GIFs
![tokens-tooltips](https://github.com/dialpad/dialtone/assets/24460973/06ff5686-2ece-4c20-bb61-f5f14c1ff43f)

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->
