### PR TITLE
fix: add box-sizing, padding, margin to reset

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -25,14 +25,6 @@
 //      [1]     Universally set border-box
 //  ----------------------------------------------------------------------------
 
-* {
-  &,
-  &::before,
-  &::after {
-    box-sizing: border-box; // [1]
-  }
-}
-
 html {
   scroll-behavior: smooth;
   scroll-padding-top: 7.2rem;

--- a/packages/dialtone-css/lib/build/less/dialtone-reset.less
+++ b/packages/dialtone-css/lib/build/less/dialtone-reset.less
@@ -3,6 +3,17 @@
 /* Document
    ========================================================================== */
 
+* {
+  padding: 0;
+  margin: 0;
+
+  &,
+  &::before,
+  &::after {
+    box-sizing: border-box;
+  }
+}
+
 /**
  * 1. Correct the line height in all browsers.
  * 2. Prevent adjustments of font size after orientation changes in iOS.
@@ -15,14 +26,6 @@ html {
 
 /* Sections
    ========================================================================== */
-
-/**
- * Remove the margin in all browsers.
- */
-
-body {
-  margin: 0;
-}
 
 /**
  * Render the `main` element consistently in IE.
@@ -258,7 +261,6 @@ fieldset {
 
 legend {
   display: table; /* 1 */
-  box-sizing: border-box; /* 1 */
   max-width: 100%; /* 1 */
   padding: 0; /* 3 */
   color: inherit; /* 2 */
@@ -288,7 +290,6 @@ textarea {
 
 [type="checkbox"],
 [type="radio"] {
-  box-sizing: border-box; /* 1 */
   padding: 0; /* 2 */
 }
 

--- a/packages/dialtone-vue2/.storybook/preview-head.html
+++ b/packages/dialtone-vue2/.storybook/preview-head.html
@@ -2,8 +2,4 @@
   .sbdocs.sbdocs-content {
     max-width: 2000px;
   }
-
-  * {
-    box-sizing: border-box;
-  }
 </style>

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_pill/feed_item_pill.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_pill/feed_item_pill.vue
@@ -180,12 +180,17 @@ export default {
 
   &__layout {
     padding: var(--dt-space-400);
+    gap: var(--dt-space-300);
     width: 100%;
+
+    &:deep(> .dt-item-layout--left) {
+      padding-right: var(--dt-space-0);
+      justify-content: center;
+    }
   }
 
   &__icon {
     animation: fade 0.15s ease-in;
-    margin-right: var(--dt-space-400);
   }
 
   &__content {

--- a/packages/dialtone-vue3/.storybook/preview-head.html
+++ b/packages/dialtone-vue3/.storybook/preview-head.html
@@ -2,8 +2,4 @@
   .sbdocs.sbdocs-content {
     max-width: 2000px;
   }
-
-  * {
-    box-sizing: border-box;
-  }
 </style>

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_pill/feed_item_pill.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_pill/feed_item_pill.vue
@@ -180,12 +180,17 @@ export default {
 
   &__layout {
     padding: var(--dt-space-400);
+    gap: var(--dt-space-300);
     width: 100%;
+
+    &:deep(> .dt-item-layout--left) {
+      padding-right: var(--dt-space-0);
+      justify-content: center;
+    }
   }
 
   &__icon {
     animation: fade 0.15s ease-in;
-    margin-right: var(--dt-space-400);
   }
 
   &__content {


### PR DESCRIPTION
# fix: add box-sizing, padding, margin to reset

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExemJnOXp0YTFqNHA2b2c1NWQ4aTVsbW50N3I1c2FrdW44M3N6MnR1eSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EZICHGrSD5QEFCxMiC/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

https://dialpad.atlassian.net/browse/DLT-1633

Added box-sizing: border-box, padding 0 and margin 0 to our reset

## :bulb: Context

Finding a lot of spacing inconsistencies between DP1, DP2, and even our storybook. Found that DP1 has margin / padding 0 set on all elements which overrides the default user agent padding/margin. Our storybook and DP2 don't have this set, causing the spacing issues.

Set box-sizing: border-box as well since that's another one we should probably have.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
