### PR TITLE
fix: tooltip directive on vue3

### DIFF
--- a/packages/dialtone-vue3/directives/tooltip/tooltip.js
+++ b/packages/dialtone-vue3/directives/tooltip/tooltip.js
@@ -1,10 +1,11 @@
 import { DtTooltip } from '@/components/tooltip';
 import { getUniqueString } from '@/common/utils';
-import { createApp, h } from 'vue';
+import { createApp, getCurrentInstance, h } from 'vue';
 
 export const DtTooltipDirective = {
   name: 'dt-tooltip-directive',
   install (app) {
+    let tooltipInstance;
     const mountPoint = document.createElement('div');
     document.body.appendChild(mountPoint);
 
@@ -16,6 +17,10 @@ export const DtTooltipDirective = {
         return {
           tooltips: [],
         };
+      },
+
+      mounted () {
+        tooltipInstance = getCurrentInstance();
       },
 
       methods: {
@@ -68,7 +73,7 @@ export const DtTooltipDirective = {
         }
       },
       unmounted (anchor) {
-        DtTooltipDirectiveApp._instance?.ctx.removeTooltip(anchor.getAttribute('data-dt-tooltip-id'));
+        tooltipInstance.ctx.removeTooltip(anchor.getAttribute('data-dt-tooltip-id'));
       },
     });
 
@@ -78,7 +83,8 @@ export const DtTooltipDirective = {
       const placement = binding.arg || DEFAULT_PLACEMENT;
 
       anchor.setAttribute('data-dt-tooltip-id', tooltipId);
-      DtTooltipDirectiveApp._instance?.ctx.addOrUpdateTooltip(tooltipId, message, placement);
+
+      tooltipInstance.ctx.addOrUpdateTooltip(tooltipId, message, placement);
     }
   },
 };


### PR DESCRIPTION
# Fix tooltip directive on vue 3

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/3o7TKBTLxmltGUyCD6/giphy.gif?cid=790b7611y09kac6w4ihemdpy2md4og672z2k9xkuhn6zwlrn&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1567

## :book: Description

- Assigned the current app instance to `tooltipInstance` on mounted to avoid it being undefined

## :bulb: Context

Tooltip directive were not working on production vue 3, this was to an issue were the `_instance` property of the tooltip app was undefined, changed the way we obtain it to solve the issue.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

## :link: Sources

https://stackoverflow.com/questions/67168389/vue-3-with-composition-api-different-object-structure-for-getting-context-global
