### PR TITLE
fix(feed-item-row): make image / video class

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.mdx
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.mdx
@@ -18,7 +18,9 @@ and the content which can be either a message or a rich media.
 The default feed item row contains 4 slots:
 
 - **default** slot - contains the textual content of the feed item. Can also contain code blocks.
-- **attachment** slot - contains any image, video or pill style content such as "Feed Item Pill"
+- **attachment** slot - contains any image, video or pill style content such as "Feed Item Pill" if you are inserting an
+  image or video into this slot, set the `dt-feed-item-row__image` or `dt-feed-item-row__video` class respectively to
+  get the correct default dimensions and styling.
 - **threading** slot - the threading row component which is below the reactions slot
 - **menu** slot - the actions menu for current feed row. Floats towards the right and shows when isActive is true.
 - **reactions** slot - the emoji reactions list component below the content slot.

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
@@ -13,7 +13,7 @@ export const argsData = {
   shortTime: '4:54',
   onFocus: action('focus'),
   onHover: action('hover'),
-  attachment: '<img alt="dwight" src="https://i1.sndcdn.com/avatars-000181324408-652e57-t500x500.jpg"></img>',
+  attachment: '<img class="dt-feed-item-row__image" alt="dwight" src="https://i1.sndcdn.com/avatars-000181324408-652e57-t500x500.jpg"></img>',
   default: `Elementum fames :smile: nullam elementum velit proin vitae aliquet.
   Platea nulla consectetur consequat sagittis nullam et ultricies nisl rhoncus
   aliquet elementum venenatis :laughing: quisque.`,

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -350,7 +350,7 @@ export default {
     padding-top: var(--dt-space-200);
     padding-bottom: var(--dt-space-300);
 
-    &:deep(img)  {
+    &:deep(.dt-feed-item-row__image)  {
       border: var(--dt-color-border-subtle) solid var(--dt-size-border-100);
       border-radius: var(--dt-size-radius-400);
       display: block;
@@ -360,7 +360,7 @@ export default {
       min-height: 5.6rem;
     }
 
-    &:deep(video)  {
+    &:deep(.dt-feed-item-row__video)  {
       display: block;
       height: 25.0rem;
     }

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -110,7 +110,7 @@
               :image-src="fryImage"
               image-alt="Alt Text"
               close-aria-label="Close"
-              image-button-class="d-wmn64 d-hmn64 w-wmx332 d-hmx332"
+              image-button-class="dt-feed-item-row__image d-wmn64 d-hmn64 w-wmx332 d-hmx332"
               aria-label="Click to open image"
             />
           </template>
@@ -147,6 +147,7 @@
           <template #attachment>
             <!-- eslint-disable-next-line vuejs-accessibility/media-has-caption -->
             <video
+              class="dt-feed-item-row__video"
               controls
               src="https://www.w3schools.com/html/mov_bbb.mp4"
             />

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.mdx
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.mdx
@@ -18,7 +18,9 @@ and the content which can be either a message or a rich media.
 The default feed item row contains 4 slots:
 
 - **default** slot - contains the textual content of the feed item. Can also contain code blocks.
-- **attachment** slot - contains any image, video or pill style content such as "Feed Item Pill"
+- **attachment** slot - contains any image, video or pill style content such as "Feed Item Pill" if you are inserting an
+  image or video into this slot, set the `dt-feed-item-row__image` or `dt-feed-item-row__video` class respectively to
+  get the correct default dimensions and styling.
 - **threading** slot - the threading row component which is below the reactions slot
 - **menu** slot - the actions menu for current feed row. Floats towards the right and shows when isActive is true.
 - **reactions** slot - the emoji reactions list component below the content slot.

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.stories.js
@@ -13,7 +13,7 @@ export const argsData = {
   shortTime: '4:54',
   onFocus: action('focus'),
   onHover: action('hover'),
-  attachment: '<img alt="dwight" src="https://i1.sndcdn.com/avatars-000181324408-652e57-t500x500.jpg"></img>',
+  attachment: '<img class="dt-feed-item-row__image" alt="dwight" src="https://i1.sndcdn.com/avatars-000181324408-652e57-t500x500.jpg"></img>',
   default: `Elementum fames :smile: nullam elementum velit proin vitae aliquet.
   Platea nulla consectetur consequat sagittis nullam et ultricies nisl rhoncus
   aliquet elementum venenatis :laughing: quisque.`,

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -349,7 +349,7 @@ export default {
     padding-top: var(--dt-space-200);
     padding-bottom: var(--dt-space-300);
 
-    &:deep(img)  {
+    &:deep(.dt-feed-item-row__image)  {
       border: var(--dt-color-border-subtle) solid var(--dt-size-border-100);
       border-radius: var(--dt-size-radius-400);
       display: block;
@@ -359,7 +359,7 @@ export default {
       min-height: 5.6rem;
     }
 
-    &:deep(video)  {
+    &:deep(.dt-feed-item-row__video)  {
       display: block;
       height: 25.0rem;
     }

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -110,7 +110,7 @@
               :image-src="fryImage"
               image-alt="Alt Text"
               close-aria-label="Close"
-              image-button-class="d-wmn64 d-hmn64 w-wmx332 d-hmx332"
+              image-button-class="dt-feed-item-row__image d-wmn64 d-hmn64 w-wmx332 d-hmx332"
               aria-label="Click to open image"
             />
           </template>
@@ -147,6 +147,7 @@
           <template #attachment>
             <!-- eslint-disable-next-line vuejs-accessibility/media-has-caption -->
             <video
+              class="dt-feed-item-row__video"
               controls
               src="https://www.w3schools.com/html/mov_bbb.mp4"
             />


### PR DESCRIPTION
# fix(feed-item-row): make image / video class

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmZ4aTZpdm9jNWxsMHd5M3ZkMHBjY2ZqNzN5a3dubjlpMzZhejQxNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/vIpCeF7YcCrygqAn3R/giphy-downsized-large.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Changed the img and video tag selectors to be a custom class you have to apply directly to the element.

## :bulb: Context

The previous solution was over aggressive and caused images within complex elements such as the feed item pill to be resized unintentionally. Now this class must be applied on the product side to get the correct default styling for images / videos

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.

For all CSS changes:

- [x] I have used design tokens whenever possible.

## :crystal_ball: Next Steps

Bring into my other PR in product to solve issues.
