### PR TITLE
fix(typography): added uppercase to eyebrow headline style

### DIFF
--- a/apps/dialtone-documentation/docs/_data/type.json
+++ b/apps/dialtone-documentation/docs/_data/type.json
@@ -34,7 +34,7 @@
   "typographyStyles": [
     {
       "var": "d-headline--eyebrow",
-      "output": "font: var(--dt-typography-headline-eyebrow)"
+      "output": "font: var(--dt-typography-headline-eyebrow); text-transform: var(--dt-typography-headline-eyebrow-text-case);"
     },
     {
       "var": "d-headline--sm",

--- a/packages/dialtone-css/lib/build/less/utilities/typography.less
+++ b/packages/dialtone-css/lib/build/less/utilities/typography.less
@@ -58,6 +58,7 @@ ul {
 .d-headline--eyebrow,
 .d-headline-eyebrow {
     font: var(--dt-typography-headline-eyebrow);
+    text-transform: var(--dt-typography-headline-eyebrow-text-case);
 }
 
 .d-headline--sm,


### PR DESCRIPTION
# Added back uppercase to eyebrow headline style
![image](https://github.com/dialpad/dialtone/assets/1165933/48bd446b-f1bc-4fda-a6af-141d386c2524)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1647

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.