### PR TITLE
fix: use mixin property to detect mixin

### DIFF
--- a/packages/stylelint-plugin-dialtone/lib/index.js
+++ b/packages/stylelint-plugin-dialtone/lib/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const requireIndex = require("requireindex");
+const noMixins = require("./rules/no-mixins");
 
 // import all rules in lib/rules
-module.exports = requireIndex(__dirname + "/rules");
+module.exports = [noMixins];

--- a/packages/stylelint-plugin-dialtone/lib/index.js
+++ b/packages/stylelint-plugin-dialtone/lib/index.js
@@ -2,5 +2,4 @@
 
 const noMixins = require("./rules/no-mixins");
 
-// import all rules in lib/rules
 module.exports = [noMixins];

--- a/packages/stylelint-plugin-dialtone/lib/rules/no-mixins.js
+++ b/packages/stylelint-plugin-dialtone/lib/rules/no-mixins.js
@@ -26,6 +26,7 @@ const ruleFunction = (primary) => {
 
     // This iterates through one selector at a time, so you don't have to worry about checking for nested selectors.
     root.walkAtRules((ruleNode) => {
+      // docs for mixin property used here: https://github.com/shellscape/postcss-less?tab=readme-ov-file#mixins
       if (!ruleNode.mixin) return;
       report({
         result,

--- a/packages/stylelint-plugin-dialtone/lib/rules/no-mixins.js
+++ b/packages/stylelint-plugin-dialtone/lib/rules/no-mixins.js
@@ -8,7 +8,7 @@ const {
 const ruleName = '@dialpad/stylelint-plugin-dialtone/no-mixins';
 
 const messages = ruleMessages(ruleName, {
-  noMixinsRejected: (selector) => `Please avoid using LESS mixins "${selector}"`,
+  noMixinsRejected: (mixinName) => `Please avoid using LESS mixins "${mixinName}"`,
 });
 
 const meta = {
@@ -25,20 +25,15 @@ const ruleFunction = (primary) => {
     if (!validOptions) return;
 
     // This iterates through one selector at a time, so you don't have to worry about checking for nested selectors.
-    root.walkRules((ruleNode) => {
-      const { source } = ruleNode;
-
-      // any line that starts with a period and ends with a semicolon is a LESS mixin.
-      const regex = /\.[\S]+;/gm;
-
-      const matches = [...source.input.css.matchAll(regex)];
-      for (const match of matches) {
+    root.walkAtRules((ruleNode) => {
+      if (ruleNode.mixin) {
         report({
           result,
           ruleName,
-          message: messages.noMixinsRejected(match[0]),
           node: ruleNode,
-          word: match[0],
+          start: ruleNode.source.start,
+          end: ruleNode.source.end,
+          message: messages.noMixinsRejected(ruleNode.name),
         });
       }
     });

--- a/packages/stylelint-plugin-dialtone/lib/rules/no-mixins.js
+++ b/packages/stylelint-plugin-dialtone/lib/rules/no-mixins.js
@@ -26,16 +26,15 @@ const ruleFunction = (primary) => {
 
     // This iterates through one selector at a time, so you don't have to worry about checking for nested selectors.
     root.walkAtRules((ruleNode) => {
-      if (ruleNode.mixin) {
-        report({
-          result,
-          ruleName,
-          node: ruleNode,
-          start: ruleNode.source.start,
-          end: ruleNode.source.end,
-          message: messages.noMixinsRejected(ruleNode.name),
-        });
-      }
+      if (!ruleNode.mixin) return;
+      report({
+        result,
+        ruleName,
+        node: ruleNode,
+        start: ruleNode.source.start,
+        end: ruleNode.source.end,
+        message: messages.noMixinsRejected(ruleNode.name),
+      });
     });
   };
 };

--- a/packages/stylelint-plugin-dialtone/package.json
+++ b/packages/stylelint-plugin-dialtone/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stylelint-plugin-dialtone",
+  "name": "@dialpad/stylelint-plugin-dialtone",
   "version": "1.0.0",
   "description": "dialtone stylelint plugin",
   "keywords": [

--- a/packages/stylelint-plugin-dialtone/package.json
+++ b/packages/stylelint-plugin-dialtone/package.json
@@ -46,9 +46,6 @@
     "lint:docs": "markdownlint 'docs/**/*.md'",
     "test": "node --test ./tests/lib/rules/*.mjs"
   },
-  "dependencies": {
-    "requireindex": "^1.2.0"
-  },
   "devDependencies": {
     "stylelint": "15.11.0",
     "stylelint-test-rule-node": "^0.2.1"

--- a/packages/stylelint-plugin-dialtone/tests/lib/rules/no-mixins.mjs
+++ b/packages/stylelint-plugin-dialtone/tests/lib/rules/no-mixins.mjs
@@ -25,14 +25,14 @@ testRule({
         .aMixin();
       }`,
       description: 'simple class definition containing a LESS mixin',
-      message: messages.noMixinsRejected('.aMixin();'),
+      message: messages.noMixinsRejected('aMixin'),
     },
     {
       code: `.a {
         .aMixin;
       }`,
       description: 'simple class definition containing the older syntax for LESS mixins',
-      message: messages.noMixinsRejected('.aMixin;'),
+      message: messages.noMixinsRejected('aMixin'),
     },
     {
       code: `.a {
@@ -43,8 +43,8 @@ testRule({
       }`,
       description: 'multiple mixins in a class definition',
       warnings: [
-        { message: messages.noMixinsRejected('.aMixin;') },
-        { message: messages.noMixinsRejected('.otherMixin();') },
+        { message: messages.noMixinsRejected('aMixin') },
+        { message: messages.noMixinsRejected('otherMixin') },
       ],
     },
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -897,10 +897,6 @@ importers:
         version: 10.2.0
 
   packages/stylelint-plugin-dialtone:
-    dependencies:
-      requireindex:
-        specifier: ^1.2.0
-        version: 1.2.0
     devDependencies:
       stylelint:
         specifier: 15.11.0


### PR DESCRIPTION
# fix: use mixin property to detect mixin

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZXZpeXJ2NG55dnNvNGJzOG5tN21tZHdyaDhoNGZ4czFicm15bzRoeCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/BPJmthQ3YRwD6QqcVD/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Apparently there is a "mixin" property directly on the node in stylelint when it is a mixin, so this is a much better way to detect rather than regex 😄 

## :bulb: Context

A bunch of false positives were happening with the prior regex

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

Attempt product implementation
