### PR TITLE
fix(emoji-picker): set correct search icon size

### DIFF
--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_search.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_search.vue
@@ -11,7 +11,10 @@
       @keydown.enter="selectFirstEmoji"
     >
       <template #leftIcon>
-        <dt-icon name="search" />
+        <dt-icon
+          name="search"
+          size="200"
+        />
       </template>
       <template
         v-if="modelValue.length > 0"

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_search.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_search.vue
@@ -11,7 +11,10 @@
       @keydown.enter="$emit('select-first-emoji')"
     >
       <template #leftIcon>
-        <dt-icon name="search" />
+        <dt-icon
+          name="search"
+          size="200"
+        />
       </template>
       <template
         v-if="modelValue.length > 0"


### PR DESCRIPTION
Just fixing emoji picker search icon size.

designs here: https://www.figma.com/file/GJiRmWORmDi0zxLJfwn8yp/Conversation-View-%2B-Messaging-Layouts?node-id=138%3A46120&mode=dev