### PR TITLE
fix(emoji): dlt-1650 pad emoji unicode string with 0's

### DIFF
--- a/packages/dialtone-vue2/common/emoji.js
+++ b/packages/dialtone-vue2/common/emoji.js
@@ -145,12 +145,12 @@ export function shortcodeToEmojiData (shortcode) {
 export function unicodeToString (emoji) {
   let key = '';
   for (const codePoint of emoji) {
-    const codepoint = codePoint.codePointAt(0).toString(16);
+    const codepoint = codePoint.codePointAt(0).toString(16).padStart(4, '0');
 
     // skip 200d and fe0f as these are not included in emoji_strategy.json keys
     if (['200d', 'fe0f'].includes(codepoint)) continue;
     if (key !== '') { key = key + '-'; }
-    key = key + codePoint.codePointAt(0).toString(16);
+    key = key + codepoint;
   }
   return key;
 }

--- a/packages/dialtone-vue2/common/emoji.test.js
+++ b/packages/dialtone-vue2/common/emoji.test.js
@@ -1,8 +1,15 @@
-import { getEmojiData, validateCustomEmojiJson } from '@/common/emoji';
+import { getEmojiData, validateCustomEmojiJson, unicodeToString } from '@/common/emoji';
 import { withValidCustomEmojis, withNotAllRequiredProps, withValidUnicodeEmojis } from './custom-emoji-test.js';
 
 describe('Emoji Tests', () => {
   describe('Validation Tests', () => {
+    describe('When a unicode emoji is passed in to unicodeToString that starts with 00', () => {
+      it('The preceding 0s should be included in the returned value', async () => {
+        const result = unicodeToString('1️⃣');
+        expect(result).toBe('0031-20e3');
+      });
+    });
+
     describe('When a custom emoji json is provided with valid emojis', () => {
       beforeEach(async () => {
         await validateCustomEmojiJson(withValidCustomEmojis);

--- a/packages/dialtone-vue3/common/emoji.js
+++ b/packages/dialtone-vue3/common/emoji.js
@@ -145,12 +145,12 @@ export function shortcodeToEmojiData (shortcode) {
 export function unicodeToString (emoji) {
   let key = '';
   for (const codePoint of emoji) {
-    const codepoint = codePoint.codePointAt(0).toString(16);
+    const codepoint = codePoint.codePointAt(0).toString(16).padStart(4, '0');
 
     // skip 200d and fe0f as these are not included in emoji_strategy.json keys
     if (['200d', 'fe0f'].includes(codepoint)) continue;
     if (key !== '') { key = key + '-'; }
-    key = key + codePoint.codePointAt(0).toString(16);
+    key = key + codepoint;
   }
   return key;
 }

--- a/packages/dialtone-vue3/common/emoji.test.js
+++ b/packages/dialtone-vue3/common/emoji.test.js
@@ -1,8 +1,15 @@
-import { getEmojiData, validateCustomEmojiJson } from '@/common/emoji';
+import { getEmojiData, validateCustomEmojiJson, unicodeToString } from '@/common/emoji';
 import { withValidCustomEmojis, withNotAllRequiredProps, withValidUnicodeEmojis } from './custom-emoji-test.js';
 
 describe('Emoji Tests', () => {
   describe('Validation Tests', () => {
+    describe('When a unicode emoji is passed in to unicodeToString that starts with 00', () => {
+      it('The preceding 0s should be included in the returned value', async () => {
+        const result = unicodeToString('1️⃣');
+        expect(result).toBe('0031-20e3');
+      });
+    });
+
     describe('When a custom emoji json is provided with valid emojis', () => {
       beforeEach(async () => {
         await validateCustomEmojiJson(withValidCustomEmojis);


### PR DESCRIPTION
# fix(emoji): DLT-1650 pad emoji unicode string with 0's

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcjVhdGs0eHJpaWZpNTNjcjkycWJteXMxb3phZW50Y2FmZjNidnEwMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/13SYTDifJqy2Ck/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1650

## :book: Description

Our unicode strings were not being padded with 0's, however they are in the emoji_strategy.json so we were not getting a match when we should have been. Padded converted unicode strings to always have 4 characters.

## :bulb: Context

Certain emojis are not showing up in production

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

![Screenshot 2024-03-20 at 12 26 36 PM](https://github.com/dialpad/dialtone/assets/64808812/726bca67-f1ff-4d94-9ce2-f3ae63a4a65b)

## :link: Sources

https://emojipedia.org/keycap-digit-one#emoji
