### PR TITLE
fix: warn console error cleanup

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -174,12 +174,14 @@
             <dt-button
               data-qa="dt-message-input-send-btn"
               size="sm"
-              :kind="sendButtonKind"
-              :circle="Boolean(showSend.icon)"
+              kind="default"
               importance="primary"
-              :class="{
-                'message-input-button__disabled d-fc-muted': isSendDisabled,
-              }"
+              :class="[
+                'd-btn--circle',
+                {
+                  'message-input-button__disabled d-fc-muted': isSendDisabled,
+                },
+              ]"
               :aria-label="showSend.ariaLabel"
               :aria-disabled="isSendDisabled"
               @click="onSend"
@@ -542,10 +544,6 @@ export default {
 
     emojiPickerHovered () {
       return this.emojiPickerFocus || this.emojiPickerOpened;
-    },
-
-    sendButtonKind () {
-      return !this.isSendDisabled ? 'default' : 'muted';
     },
   },
 

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -174,12 +174,14 @@
             <dt-button
               data-qa="dt-message-input-send-btn"
               size="sm"
-              :kind="sendButtonKind"
-              :circle="Boolean(showSend.icon)"
+              kind="default"
               importance="primary"
-              :class="{
-                'message-input-button__disabled d-fc-muted': isSendDisabled,
-              }"
+              :class="[
+                'd-btn--circle',
+                {
+                  'message-input-button__disabled d-fc-muted': isSendDisabled,
+                },
+              ]"
               :aria-label="showSend.ariaLabel"
               :aria-disabled="isSendDisabled"
               @click="onSend"
@@ -542,10 +544,6 @@ export default {
 
     emojiPickerHovered () {
       return this.emojiPickerFocus || this.emojiPickerOpened;
-    },
-
-    sendButtonKind () {
-      return !this.isSendDisabled ? 'default' : 'muted';
     },
   },
 


### PR DESCRIPTION
# Fix Console warn regarding button type

The send button had importance="primary" and type="default" with circle: true, this was causing warning on console due to some invalid combination. Used dialtone classes to achieve the same and mute those console warnings.

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](path/to/gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [x] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: [Jira Ticket](https://dialpad.atlassian.net/browse/DP-94060)
