### PR TITLE
fix(editor): DLT-1593 add quick replies icon to editor

### DIFF
--- a/packages/dialtone-vue2/components/button/button.vue
+++ b/packages/dialtone-vue2/components/button/button.vue
@@ -29,7 +29,7 @@
       />
     </span>
     <span
-      v-if="!!$slots.default && !!$slots.default[0].text?.trim()"
+      v-if="$slots.default"
       data-qa="dt-button-label"
       :class="['d-btn__label', 'base-button__label', labelClass]"
     >

--- a/packages/dialtone-vue2/components/button/button.vue
+++ b/packages/dialtone-vue2/components/button/button.vue
@@ -29,7 +29,7 @@
       />
     </span>
     <span
-      v-if="$slots.default"
+      v-if="!!$slots.default && !!$slots.default[0].text?.trim()"
       data-qa="dt-button-label"
       :class="['d-btn__label', 'base-button__label', labelClass]"
     >

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -32,7 +32,6 @@
               :active="$refs.richTextEditor?.editor?.isActive(button.selector)"
               size="xs"
               :aria-label="button.tooltipMessage"
-              :class="{ 'd-btn--icon-only': !button.label }"
               @click="button.onClick()"
             >
               <template #icon>
@@ -41,7 +40,7 @@
                   size="200"
                 />
               </template>
-              {{ button.label }}
+              <span v-if="button.label">{{ button.label }}</span>
             </dt-button>
           </template>
         </dt-tooltip>

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -41,6 +41,7 @@
                   class="d-fw-bold"
                 />
               </template>
+              {{ button.label || '' }}
             </dt-button>
           </template>
         </dt-tooltip>
@@ -504,11 +505,18 @@ export default {
         buttonGroup: [buttonData],
       }));
       return [
+        { key: 'new', buttonGroup: this.newButtons },
         { key: 'format', buttonGroup: this.textFormatButtons },
         { key: 'alignment', buttonGroup: this.alignmentButtons },
         { key: 'list', buttonGroup: this.listButtons },
         ...individualButtonStacks,
       ].filter(buttonGroupData => buttonGroupData.buttonGroup.length > 0);
+    },
+
+    newButtons () {
+      return [
+        { showBtn: this.showQuickRepliesButton, label: 'Quick reply', selector: 'quickReplies', iconName: 'lightning-bolt', dataQA: 'dt-editor-quick-replies-btn', tooltipMessage: 'Quick Reply', onClick: this.onQuickRepliesClick },
+      ].filter(button => button.showBtn);
     },
 
     textFormatButtons () {
@@ -540,7 +548,6 @@ export default {
       return [
         { showBtn: this.showQuoteButton, selector: 'blockquote', iconName: 'quote', dataQA: 'dt-editor-blockquote-btn', tooltipMessage: 'Quote', onClick: this.onBlockquoteToggle },
         { showBtn: this.showCodeBlockButton, selector: 'codeBlock', iconName: 'code-block', dataQA: 'dt-editor-code-block-btn', tooltipMessage: 'Code', onClick: this.onCodeBlockToggle },
-        { showBtn: this.showQuickRepliesButton, selector: 'quickReplies', iconName: 'lightning-bolt', dataQA: 'dt-editor-quick-replies-btn', tooltipMessage: 'Quick Replies', onClick: this.onQuickRepliesClick },
       ].filter(button => button.showBtn);
     },
 

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -32,6 +32,7 @@
               :active="$refs.richTextEditor?.editor?.isActive(button.selector)"
               size="xs"
               :aria-label="button.tooltipMessage"
+              :class="{ 'd-btn--icon-only': !button.label }"
               @click="button.onClick()"
             >
               <template #icon>
@@ -41,7 +42,7 @@
                   class="d-fw-bold"
                 />
               </template>
-              {{ button.label || '' }}
+              {{ button.label }}
             </dt-button>
           </template>
         </dt-tooltip>

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -39,7 +39,6 @@
                 <dt-icon
                   :name="button.iconName"
                   size="200"
-                  class="d-fw-bold"
                 />
               </template>
               {{ button.label }}

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -159,7 +159,7 @@
         data-qa="dt-rich-text-editor"
         :editable="editable"
         :input-aria-label="inputAriaLabel"
-        :input-class="`${inputClass} d-ol-none d-my6`"
+        :input-class="`d-ml16 d-ol-none d-my6 ${inputClass}`"
         :output-format="htmlOutputFormat"
         :auto-focus="autoFocus"
         :placeholder="placeholder"

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -39,7 +39,6 @@
                 <dt-icon
                   :name="button.iconName"
                   size="200"
-                  class="d-fw-bold"
                 />
               </template>
               {{ button?.label }}

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -32,6 +32,7 @@
               :active="$refs.richTextEditor?.editor?.isActive(button.selector)"
               size="xs"
               :aria-label="button.tooltipMessage"
+              :class="{ 'd-btn--icon-only': !button.label }"
               @click="button.onClick()"
             >
               <template #icon>
@@ -41,7 +42,7 @@
                   class="d-fw-bold"
                 />
               </template>
-              {{ button.label || '' }}
+              {{ button?.label }}
             </dt-button>
           </template>
         </dt-tooltip>

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -160,7 +160,7 @@
         data-qa="dt-rich-text-editor"
         :editable="editable"
         :input-aria-label="inputAriaLabel"
-        :input-class="`${inputClass} d-ol-none d-my6`"
+        :input-class="`d-ml16 d-ol-none d-my6 ${inputClass}`"
         :output-format="htmlOutputFormat"
         :auto-focus="autoFocus"
         :placeholder="placeholder"

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -41,6 +41,7 @@
                   class="d-fw-bold"
                 />
               </template>
+              {{ button.label || '' }}
             </dt-button>
           </template>
         </dt-tooltip>
@@ -506,11 +507,18 @@ export default {
         buttonGroup: [buttonData],
       }));
       return [
+        { key: 'new', buttonGroup: this.newButtons },
         { key: 'format', buttonGroup: this.textFormatButtons },
         { key: 'alignment', buttonGroup: this.alignmentButtons },
         { key: 'list', buttonGroup: this.listButtons },
         ...individualButtonStacks,
       ].filter(buttonGroupData => buttonGroupData.buttonGroup.length > 0);
+    },
+
+    newButtons () {
+      return [
+        { showBtn: this.showQuickRepliesButton, label: 'Quick reply', selector: 'quickReplies', iconName: 'lightning-bolt', dataQA: 'dt-editor-quick-replies-btn', tooltipMessage: 'Quick Reply', onClick: this.onQuickRepliesClick },
+      ].filter(button => button.showBtn);
     },
 
     textFormatButtons () {
@@ -542,7 +550,6 @@ export default {
       return [
         { showBtn: this.showQuoteButton, selector: 'blockquote', iconName: 'quote', dataQA: 'dt-editor-blockquote-btn', tooltipMessage: 'Quote', onClick: this.onBlockquoteToggle },
         { showBtn: this.showCodeBlockButton, selector: 'codeBlock', iconName: 'code-block', dataQA: 'dt-editor-code-block-btn', tooltipMessage: 'Code', onClick: this.onCodeBlockToggle },
-        { showBtn: this.showQuickRepliesButton, selector: 'quickReplies', iconName: 'lightning-bolt', dataQA: 'dt-editor-quick-replies-btn', tooltipMessage: 'Quick Replies', onClick: this.onQuickRepliesClick },
       ].filter(button => button.showBtn);
     },
 


### PR DESCRIPTION
# fix(editor): add quick replies icon to editor

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/4ayE7jjRuUBQk/giphy.gif?cid=790b7611vqkaau9qouqo8mj4z2n0ub8vm4u2uzr845eqg528&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

[DLT-1593](https://dialpad.atlassian.net/browse/DLT-1593)

## :book: Description

Received some feedback from design team regarding the new icon that I'd added for _quick replies_. They requested that we add a label this icon and move it to the front because it's 'new' and it will be clearer for the users to see it this way.
The idea is to leave it like this for now and in the future we can revert it back to just the icon (no label) once users have familiarized themselves with what the icon does.

Change was requested by Pablo Martel and Ted Goas from design team, in case we need to discuss this change further.
## :bulb: Context

I added this quick replies icon in this [previous PR](https://github.com/dialpad/dialtone/pull/193) to be used for the quick replies in email feature.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

<img width="1166" alt="Screenshot 2024-03-21 at 16 48 04" src="https://github.com/dialpad/dialtone/assets/12575023/9eb414f0-8e33-4a45-8d94-0e8f675b822c">


[DLT-1593]: https://dialpad.atlassian.net/browse/DLT-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ