### PR TITLE
docs: DLT-1574 use CodeExampleTabs from Datepicker to Emoji text wrapper

### DIFF
--- a/apps/dialtone-documentation/docs/components/datepicker.md
+++ b/apps/dialtone-documentation/docs/components/datepicker.md
@@ -19,17 +19,140 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT8-Component-Libra
   />
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
+<div class="d-stack d-stack--gap-400 d-datepicker">
+  <div class="d-datepicker__hd">
+    <div class="d-stack d-stack--row d-stack--gap-300 d-datepicker__month-year">
+      <nav class="d-stack d-stack--row d-stack--gap-200 d-datepicker__nav">
+        <div data-qa="dt-tooltip-container">
+          <span data-qa="dt-tooltip-anchor">
+            <button class="base-button__button d-btn d-btn--muted d-btn--xs d-btn--circle d-datepicker__nav-btn" data-qa="dt-button" type="button" aria-label="Change to Previous year 2023" id="prevYearButton">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">
+                <svg>...</svg>
+              </span>
+            </button>
+          </span>
+        </div>
+        <div data-qa="dt-tooltip-container">
+          <span data-qa="dt-tooltip-anchor">
+            <button class="base-button__button d-btn d-btn--muted d-btn--xs d-btn--circle d-datepicker__nav-btn" data-qa="dt-button" type="button" aria-label="Change to Previous month February" id="prevMonthButton">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">
+                <svg>...</svg>
+              </span>
+            </button>
+          </span>
+        </div>
+      </nav>
+      <div id="calendar-heading" class="d-datepicker__month-year-title">March 2024</div>
+      <nav class="d-stack d-stack--row d-stack--gap-200 d-datepicker__nav">
+        <div data-qa="dt-tooltip-container">
+          <span data-qa="dt-tooltip-anchor">
+            <button class="base-button__button d-btn d-btn--muted d-btn--xs d-btn--circle d-datepicker__nav-btn" data-qa="dt-button" type="button" aria-label="Change to Next month April" id="nextMonthButton">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">
+                <svg>...</svg>
+              </span>
+            </button>
+          </span>
+        </div>
+        <div data-qa="dt-tooltip-container">
+          <span data-qa="dt-tooltip-anchor">
+            <button class="base-button__button d-btn d-btn--muted d-btn--xs d-btn--circle d-datepicker__nav-btn" data-qa="dt-button" type="button" aria-label="Change to Next year 2025" id="nextYearButton">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">
+                <svg>...</svg>
+              </span>
+            </button>
+          </span>
+        </div>
+      </nav>
+    </div>
+  </div>
+  <div class="d-datepicker__bd">
+    <table class="d-datepicker__calendar" aria-labelledby="calendar-heading">
+      <thead>
+        <tr>
+          <th scope="col" class="d-datepicker__cell d-datepicker__cell--header"><span class="d-datepicker__weekday" title="Su" aria-label="Su">Su</span></th>
+          <th scope="col" class="d-datepicker__cell d-datepicker__cell--header"><span class="d-datepicker__weekday" title="Mo" aria-label="Mo">Mo</span></th>
+          ...
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="d-datepicker__cell" role="listbox">
+            <button class="base-button__button d-btn d-btn--sm d-btn--circle d-datepicker__day d-datepicker__day--disabled" data-qa="dt-button" type="button" disabled="" aria-label="Select day 25 February 2024" aria-selected="false" role="option">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">25</span>
+            </button>
+          </td>
+          <td class="d-datepicker__cell" role="listbox">
+            <button class="base-button__button d-btn d-btn--sm d-btn--circle d-datepicker__day d-datepicker__day--disabled" data-qa="dt-button" type="button" disabled="" aria-label="Select day 26 February 2024" aria-selected="false" role="option">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">26</span>
+            </button>
+          </td>
+          <td class="d-datepicker__cell" role="listbox">
+            <button class="base-button__button d-btn d-btn--sm d-btn--circle d-datepicker__day d-datepicker__day--disabled" data-qa="dt-button" type="button" disabled="" aria-label="Select day 27 February 2024" aria-selected="false" role="option">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">27</span>
+            </button>
+          </td>
+          <td class="d-datepicker__cell" role="listbox">
+            <button class="base-button__button d-btn d-btn--sm d-btn--circle d-datepicker__day d-datepicker__day--disabled" data-qa="dt-button" type="button" disabled="" aria-label="Select day 28 February 2024" aria-selected="false" role="option">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">28</span>
+            </button>
+          </td>
+          <td class="d-datepicker__cell" role="listbox">
+            <button class="base-button__button d-btn d-btn--sm d-btn--circle d-datepicker__day d-datepicker__day--disabled" data-qa="dt-button" type="button" disabled="" aria-label="Select day 29 February 2024" aria-selected="false" role="option">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">29</span>
+            </button>
+          </td>
+          <td class="d-datepicker__cell" role="listbox">
+            <button class="base-button__button d-btn d-btn--sm d-btn--circle d-datepicker__day" data-qa="dt-button" type="button" aria-label="Select day 1 March 2024" aria-selected="false" role="option">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">1</span>
+            </button>
+          </td>
+          <td class="d-datepicker__cell" role="listbox">
+            <button class="base-button__button d-btn d-btn--sm d-btn--circle d-datepicker__day" data-qa="dt-button" type="button" aria-label="Select day 2 March 2024" aria-selected="false" role="option">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">2</span>
+            </button>
+          </td>
+        </tr>
+        <tr>
+          <td class="d-datepicker__cell" role="listbox">
+            <button class="base-button__button d-btn d-btn--sm d-btn--circle d-datepicker__day" data-qa="dt-button" type="button" aria-label="Select day 3 March 2024" aria-selected="false" role="option">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">3</span>
+            </button>
+          </td>
+          <td class="d-datepicker__cell" role="listbox">
+            <button class="base-button__button d-btn d-btn--sm d-btn--circle d-datepicker__day" data-qa="dt-button" type="button" aria-label="Select day 4 March 2024" aria-selected="false" role="option">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">4</span>
+            </button>
+          </td>
+          <td class="d-datepicker__cell" role="listbox">
+            <button class="base-button__button d-btn d-btn--sm d-btn--circle d-datepicker__day" data-qa="dt-button" type="button" aria-label="Select day 5 March 2024" aria-selected="false" role="option">
+              <span data-qa="dt-button-label" class="d-btn__label base-button__label">5</span>
+            </button>
+          </td>
+          ...
+        </tr>
+        <tr>
+          ...
+        </tr>
+        ...
+      </tbody>
+    </table>
+  </div>
+</div>
+'
+vueCode='
 <dt-datepicker
-    change-to-label="Change to"
-    prev-month-label="Previous month"
-    next-month-label="Next month"
-    prev-year-label="Previous year"
-    next-year-label="Next year"
-    select-day-label="Select day"
-    :selected-date="new Date()"
-  />
-```
+  change-to-label="Change to"
+  prev-month-label="Previous month"
+  next-month-label="Next month"
+  prev-year-label="Previous year"
+  next-year-label="Next year"
+  select-day-label="Select day"
+  :selected-date="new Date()"
+/>
+'
+showHtmlWarning />
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/dropdown.md
+++ b/apps/dialtone-documentation/docs/components/dropdown.md
@@ -9,7 +9,23 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 ---
 
 <code-well-header bgclass="d-bgc-neutral-white">
-  <video class="d-w60p" src="/assets/images/components/preview--dropdown.mp4" autoplay loop></video>
+<body>
+  <dt-dropdown>
+    <template #anchor>
+      <dt-button>
+        Click to open
+      </dt-button>
+    </template>
+    <template #list>
+      <dt-list-item>
+        Menu item 1
+      </dt-list-item>
+      <dt-list-item>
+        Menu item 2
+      </dt-list-item>
+    </template>
+  </dt-dropdown>
+</body>
 </code-well-header>
 
 <code-example-tabs
@@ -20,6 +36,24 @@ htmlCode='
       <button class="base-button__button d-btn d-btn--primary">
         <span class="d-btn__label base-button__label"> Click to open </span>
       </button>
+    </div>
+  </div>
+</div>
+<div class="tippy-box d-ps-absolute" data-tippy-root="" id="tippy-35" data-popper-placement="bottom" style="...">
+  <div id="dt209" role="menu" aria-hidden="false" aria-labelledby="DtPopover__anchor210" aria-modal="false" class="d-popover__dialog d-popover__dialog--modal" tabindex="-1" style="width: auto;">
+    <div class="d-popover__content">
+      <ul id="dt208" class="d-dropdown-list d-py0">
+        <li id="dt216" class="dt-list-item dt-list-item--static" tabindex="-1" role="listitem">
+          <div class="dt-item-layout">
+            <section class="dt-item-layout--content">
+              <div class="dt-item-layout--title">
+                Menu item 1
+              </div>
+            </section>
+          </div>
+        </li>
+        ...
+      </ul>
     </div>
   </div>
 </div>

--- a/apps/dialtone-documentation/docs/components/dropdown.md
+++ b/apps/dialtone-documentation/docs/components/dropdown.md
@@ -8,21 +8,36 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-dropdown--de
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=10732%3A69099
 ---
 
-<code-well-header bgclass="d-bgc-neutral-white">
+<code-well-header>
 <body>
-  <dt-dropdown>
+  <dt-dropdown class="d-mr8">
     <template #anchor>
       <dt-button>
         Click to open
       </dt-button>
     </template>
     <template #list>
-      <dt-list-item>
-        Menu item 1
-      </dt-list-item>
-      <dt-list-item>
-        Menu item 2
-      </dt-list-item>
+      <dt-list-item-group
+        heading-class="d-py4 d-px8 d-fw-semibold d-c-default"
+        heading="Menu Heading A"
+      >
+        <dt-list-item>
+          Menu Item 1
+        </dt-list-item>
+        <dt-dropdown-separator />
+        <dt-list-item>
+          Menu Item 2
+        </dt-list-item>
+      </dt-list-item-group>
+      <dt-dropdown-separator />
+      <dt-list-item-group
+        heading-class="d-py4 d-px8 d-fw-semibold d-c-default"
+        heading="Menu Heading B"
+      >
+        <dt-list-item>
+          Menu Item 3
+        </dt-list-item>
+      </dt-list-item-group>
     </template>
   </dt-dropdown>
 </body>
@@ -39,39 +54,79 @@ htmlCode='
     </div>
   </div>
 </div>
-<div class="tippy-box d-ps-absolute" data-tippy-root="" id="tippy-35" data-popper-placement="bottom" style="...">
-  <div id="dt209" role="menu" aria-hidden="false" aria-labelledby="DtPopover__anchor210" aria-modal="false" class="d-popover__dialog d-popover__dialog--modal" tabindex="-1" style="width: auto;">
+<div class="tippy-box d-ps-absolute" data-tippy-root="" id="tippy-13" data-popper-placement="bottom" style="...">
+  <div id="dt7" role="menu" aria-hidden="false" aria-labelledby="DtPopover__anchor8" aria-modal="false" class="d-popover__dialog d-popover__dialog--modal" tabindex="-1" style="...">
     <div class="d-popover__content">
-      <ul id="dt208" class="d-dropdown-list d-py0">
-        <li id="dt216" class="dt-list-item dt-list-item--static" tabindex="-1" role="listitem">
-          <div class="dt-item-layout">
-            <section class="dt-item-layout--content">
-              <div class="dt-item-layout--title">
-                Menu item 1
-              </div>
-            </section>
-          </div>
-        </li>
-        ...
+      <ul id="dt6" class="d-dropdown-list d-py0">
+        <ul id="dt16" class="d-list-item-group" role="group" aria-labelledby="dt16-heading">
+          <li id="dt16-heading" role="presentation" class="dt-dropdown-list--header d-py4 d-px8 d-fw-semibold d-c-default">Menu Heading A</li>
+          <li id="dt17" class="dt-list-item dt-list-item--static" tabindex="-1" role="listitem">
+            <div class="dt-item-layout">
+              <section class="dt-item-layout--content">
+                <div class="dt-item-layout--title">
+                  Menu Item 1
+                </div>
+              </section>
+            </div>
+          </li>
+          <li aria-hidden="true" class="dt-list-separator"></li>
+          <li id="dt18" class="dt-list-item dt-list-item--static" tabindex="-1" role="listitem">
+            <div class="dt-item-layout">
+              <section class="dt-item-layout--content">
+                <div class="dt-item-layout--title">
+                  Menu Item 2
+                </div>
+              </section>
+            </div>
+          </li>
+        </ul>
+        <li aria-hidden="true" class="dt-list-separator"></li>
+        <ul id="dt19" class="d-list-item-group" role="group" aria-labelledby="dt19-heading">
+          <li id="dt19-heading" role="presentation" class="dt-dropdown-list--header d-py4 d-px8 d-fw-semibold d-c-default">Menu Heading B</li>
+          <li id="dt20" class="dt-list-item dt-list-item--static" tabindex="-1" role="listitem">
+            <div class="dt-item-layout">
+              <section class="dt-item-layout--content">
+                <div class="dt-item-layout--title">
+                  Menu Item 3
+                </div>
+              </section>
+            </div>
+          </li>
+        </ul>
       </ul>
     </div>
   </div>
 </div>
 '
 vueCode='
-<dt-dropdown>
+<dt-dropdown class="d-mr8">
   <template #anchor>
     <dt-button>
-      Click to open
+      with sections and headings
     </dt-button>
   </template>
   <template #list>
-    <dt-list-item>
-      Menu item 1
-    </dt-list-item>
-    <dt-list-item>
-      Menu item 2
-    </dt-list-item>
+    <dt-list-item-group
+      heading-class="d-py4 d-px8 d-fw-semibold d-c-default"
+      heading="Menu Heading A"
+    >
+      <dt-list-item>
+        Menu Item 1
+      </dt-list-item>
+      <dt-dropdown-separator />
+      <dt-list-item>
+        Menu Item 2
+      </dt-list-item>
+    </dt-list-item-group>
+    <dt-dropdown-separator />
+    <dt-list-item-group
+      heading-class="d-py4 d-px8 d-fw-semibold d-c-default"
+      heading="Menu Heading B"
+    >
+      <dt-list-item>
+        Menu Item 3
+      </dt-list-item>
+    </dt-list-item-group>
   </template>
 </dt-dropdown>
 '

--- a/apps/dialtone-documentation/docs/components/dropdown.md
+++ b/apps/dialtone-documentation/docs/components/dropdown.md
@@ -12,6 +12,37 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   <video class="d-w60p" src="/assets/images/components/preview--dropdown.mp4" autoplay loop></video>
 </code-well-header>
 
+<code-example-tabs
+htmlCode='
+<div>
+  <div class="d-popover">
+    <div id="DtPopover__anchor2">
+      <button class="base-button__button d-btn d-btn--primary">
+        <span class="d-btn__label base-button__label"> Click to open </span>
+      </button>
+    </div>
+  </div>
+</div>
+'
+vueCode='
+<dt-dropdown>
+  <template #anchor>
+    <dt-button>
+      Click to open
+    </dt-button>
+  </template>
+  <template #list>
+    <dt-list-item>
+      Menu item 1
+    </dt-list-item>
+    <dt-list-item>
+      Menu item 2
+    </dt-list-item>
+  </template>
+</dt-dropdown>
+'
+showHtmlWarning />
+
 ## Vue API
 
 <component-vue-api component-name="dropdown" />

--- a/apps/dialtone-documentation/docs/components/emoji-picker.md
+++ b/apps/dialtone-documentation/docs/components/emoji-picker.md
@@ -175,8 +175,18 @@ vueCode='
 <dt-emoji-picker
     :skin-tone="Default"
     skin-selector-button-tooltip-label="Change default skin tone"
-    :tab-set-labels="tabSetLabels[]"
-    :recently-used-emojis="recentlyUsedEmojis[]"
+    :tab-set-labels=["Most recently used", "Smileys and people", ...]
+    :recently-used-emojis=[
+      {
+        name: "thumbs up",
+        ...
+      },
+      {
+        name: "thumbs up: medium-light skin tone",
+        ...
+      }
+      ...
+    ]
     search-results-label="Search results"
     search-no-results-label="Search results"
     search-placeholder-label="Search..."

--- a/apps/dialtone-documentation/docs/components/emoji-picker.md
+++ b/apps/dialtone-documentation/docs/components/emoji-picker.md
@@ -76,21 +76,115 @@ storybook: https://dialtone.dialpad.com/vue/vue3/?path=/story/components-emoji-p
     />
 </code-well-header>
 
-```html
-<template>
-  <dt-emoji-picker
+<code-example-tabs
+htmlCode='
+<div class="d-emoji-picker">
+  <div class="d-emoji-picker--header">
+    <div class="d-emoji-picker__tabset">
+      <div data-qa="dt-tab-group">
+        <div class="d-tablist d-emoji-picker__tabset-list" role="tablist" aria-label="">
+          <button
+            class="base-button__button d-btn d-btn--primary d-tab d-tab--selected"
+            data-qa="dt-tab"
+            type="button"
+            aria-label="Most recently used"
+            id="dt-tab-1"
+            role="tab"
+            aria-selected="true"
+            aria-controls="d-emoji-picker-list"
+            tabindex="1"
+          >
+            <span data-qa="dt-button-label" class="d-btn__label base-button__label">
+              <svg>...</svg>
+            </span>
+          </button>
+          <button class="base-button__button d-btn d-btn--primary d-tab" data-qa="dt-tab" type="button" aria-label="Smileys and people" id="dt-tab-2" role="tab" aria-selected="false" aria-controls="d-emoji-picker-list" tabindex="2">
+            ...
+          </button>
+          ...
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="d-emoji-picker--body">
+    <div class="d-emoji-picker__search d-emoji-picker__alignment">
+      <div class="base-input" data-qa="dt-input">
+        <label class="base-input__label" data-qa="dt-input-label-wrapper">
+          <div class="d-input__wrapper">
+            <span class="base-input__icon--left d-input-icon--left d-input-icon undefined" data-qa="dt-input-left-icon-wrapper">
+              <svg>...</svg>
+            </span>
+            <input name="" type="text" class="base-input__input d-input d-input-icon--left" data-qa="dt-input-input" id="searchInput" placeholder="Search..." />
+          </div>
+        </label>
+      </div>
+    </div>
+    <div class="d-emoji-picker__selector">
+      <div id="d-emoji-picker-list" class="d-emoji-picker__list">
+        <div class="d-emoji-picker__category d-emoji-picker__alignment" data-index="0"><p>Most recently used</p></div>
+        <div class="d-emoji-picker__alignment" data-index="1">
+          <div class="d-emoji-picker__tab">
+            <button type="button" aria-label="thumbs up"><img class="d-icon d-icon--size-500" alt="thumbs up" aria-label="thumbs up" title="thumbs up" src="https://static.dialpadcdn.com/joypixels/png/unicode/32/1f44d.png" /></button>
+            <button type="button" aria-label="thumbs up: medium-light skin tone">
+              <img
+                class="d-icon d-icon--size-500"
+                alt="thumbs up: medium-light skin tone"
+                aria-label="thumbs up: medium-light skin tone"
+                title="thumbs up: medium-light skin tone"
+                src="https://static.dialpadcdn.com/joypixels/png/unicode/32/1f44d-1f3fc.png"
+              />
+            </button>
+            ...
+          </div>
+        </div>
+        <div class="d-emoji-picker__alignment" data-index="2">
+          <p>Smileys and people</p>
+          ...
+        </div>
+        <div class="d-emoji-picker__alignment" data-index="3">
+          <p>Nature</p>
+          ...
+        </div>
+        ...
+      </div>
+    </div>
+  </div>
+  <div class="d-emoji-picker--footer">
+    <div class="d-emoji-picker__data"></div>
+    <div data-qa="skin-selector">
+      <div class="d-emoji-picker__skin-list" style="display: none;">
+        <button class="">
+          <img class="d-icon d-icon--size-500" alt=":wave_tone1:" aria-label=":wave_tone1:" title=":wave_tone1:" src="https://static.dialpadcdn.com/joypixels/png/unicode/32/1f44b-1f3fb.png" />
+        </button>
+        ...
+      </div>
+      <div class="d-emoji-picker__skin-selected">
+        <div data-qa="dt-tooltip-container">
+          <span data-qa="dt-tooltip-anchor">
+            <button aria-label="Change default skin tone" tabindex="-1">
+              <img class="d-icon d-icon--size-500" alt=":wave:" aria-label=":wave:" title=":wave:" src="https://static.dialpadcdn.com/joypixels/png/unicode/32/1f44b.png" />
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+'
+vueCode='
+<dt-emoji-picker
     :skin-tone="Default"
-    :skin-selector-button-tooltip-label="'Change default skin tone'"
+    skin-selector-button-tooltip-label="Change default skin tone"
     :tab-set-labels="tabSetLabels[]"
     :recently-used-emojis="recentlyUsedEmojis[]"
-    :search-results-label="'Search results'"
-    :search-no-results-label="'Search results'"
-    :search-placeholder-label="'Search...'"
+    search-results-label="Search results"
+    search-no-results-label="Search results"
+    search-placeholder-label="Search..."
     @skin-tone="skinTone = $event"
     @selected-emoji="selectedEmoji"
   />
-</template>
-```
+'
+showHtmlWarning />
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/emoji-text-wrapper.md
+++ b/apps/dialtone-documentation/docs/components/emoji-text-wrapper.md
@@ -13,6 +13,40 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-emoji-text-w
   </dt-emoji-text-wrapper>
 </code-well-header>
 
+<code-example-tabs
+htmlCode='
+<div class="d-emoji-text-wrapper">
+  <span> Some text with :invalid-emoji: </span>
+  <span class="d-emoji d-icon d-icon--size-500">
+    <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-500" style="display: none;">
+      <div class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate" style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"></div>
+    </div>
+    <img class="d-icon d-icon--size-500" aria-label="grinning face with smiling eyes" alt="😄" title="grinning face with smiling eyes" src="https://cdn.jsdelivr.net/joypixels/assets/6.6/png/unicode/32/1f604.png" style="" />
+  </span>
+  <span> </span>
+  <span class="d-emoji d-icon d-icon--size-500">
+    <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-500" style="display: none;">
+      <div class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate" style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"></div>
+    </div>
+    <img class="d-icon d-icon--size-500" aria-label="crying face" alt="😢" title="crying face" src="https://cdn.jsdelivr.net/joypixels/assets/6.6/png/unicode/32/1f622.png" style="" />
+  </span>
+  <span> and </span>
+  <span class="d-emoji d-icon d-icon--size-500">
+    <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-500" style="display: none;">
+      <div class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate" style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"></div>
+    </div>
+    <img class="d-icon d-icon--size-500" aria-label="grinning face with smiling eyes" alt="😄" title="grinning face with smiling eyes" src="https://cdn.jsdelivr.net/joypixels/assets/6.6/png/unicode/32/1f604.png" style="" />
+  </span>
+  <span>, and custom emojis :octocat: :shipit: </span>
+</div>
+'
+vueCode='
+<dt-emoji-text-wrapper>
+  Some text with :invalid-emoji: :smile: :cry: and 😄, and custom emojis :octocat: :shipit:
+</dt-emoji-text-wrapper>
+'
+showHtmlWarning />
+
 ## Vue API
 
 <component-vue-api component-name="emojitextwrapper" />

--- a/apps/dialtone-documentation/docs/components/emoji.md
+++ b/apps/dialtone-documentation/docs/components/emoji.md
@@ -12,6 +12,34 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-emoji--defau
   <dt-emoji code=":smile:" />
 </code-well-header>
 
+<code-example-tabs
+htmlCode='
+<div>
+  <span class="d-emoji d-icon d-icon--size-500" code=":smile:" size="500">
+    <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-500" style="display: none;">
+      <div 
+        class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate" 
+        style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;">
+      </div>
+    </div>
+    <img 
+      aria-label="grinning face with smiling eyes" 
+      alt="😄" 
+      title="grinning face with smiling eyes" 
+      src="https://static.dialpadcdn.com/joypixels/svg/unicode/1f604.svg" 
+      class="d-icon d-icon--size-500" 
+    />
+  </span>
+</div>
+'
+vueCode='
+<dt-emoji
+  code="smile"
+  size="500"
+/>
+'
+showHtmlWarning />
+
 ## Vue API
 
 <component-vue-api component-name="emoji" />


### PR DESCRIPTION
# use CodeExampleTabs from Datepicker to Emoji text wrapper

Jira ticket: [DLT-1574](https://dialpad.atlassian.net/browse/DLT-1574)


[DLT-1574]: https://dialpad.atlassian.net/browse/DLT-1574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


1. Datepicker - [Preview](https://dialtone.dialpad.com/deploy-previews/pr-231/components/datepicker.html)
2. Dropdown - [Preview](https://dialtone.dialpad.com/deploy-previews/pr-231/components/dropdown.html)
3. Emoji - [Preview](https://dialtone.dialpad.com/deploy-previews/pr-231/components/emoji.html)
4. Emoji picker - [Preview](https://dialtone.dialpad.com/deploy-previews/pr-231/components/emoji-picker.html)
5. Emoji text wrapper - [Preview](https://dialtone.dialpad.com/deploy-previews/pr-231/components/emoji-text-wrapper.html)

------
<img width="249" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/6db4a1e6-ba4b-406a-bacc-ce3c61846bd4">

<img width="606" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/5c4539c4-bc56-4e0d-8ad9-cab072dd82ee">
