### PR TITLE
docs: DLT-1575 use CodeExampleTabs from Icon to Lazy show

### DIFF
--- a/apps/dialtone-documentation/docs/components/icon.md
+++ b/apps/dialtone-documentation/docs/components/icon.md
@@ -10,6 +10,34 @@ figma_url: https://www.figma.com/file/zz40wi0uW9MvaJ5RuhcRZR/DT-Core%3A-Icons-7?
 
 Check out our complete icon collection in the [Icon Catalog](/design/icons/#icon-catalog).
 
+<code-well-header>
+    <dt-icon name="inbox" />
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<svg
+  aria-hidden="true"
+  focusable="false"
+  data-name="[ICON_NAME]"
+  class="
+    d-icon
+    d-icon--size-[SIZE]
+    d-icon--[ICON_NAME]
+  "
+  viewBox="0 0 12 12"
+>
+  ...
+</svg>
+'
+vueCode='
+<dt-icon
+  size="500"
+  name="inbox"
+/>
+'
+showHtmlWarning />
+
 ## Usage
 
 ### Changing the Icon
@@ -166,30 +194,6 @@ We encourage utilizing the [Stack component](/components/stack/) for aligning el
 - Icons contrast guidelines are the same as Typography.
 
 - Avoid using icons as clickable elements; instead, use the [Icon Button](/components/button.html#icon-only) for interactive actions.
-
-## HTML
-
-### Base Styles
-
-<code-well-header>
-    <dt-icon name="inbox" />
-</code-well-header>
-
-```html
-<svg
-  aria-hidden="true"
-  focusable="false"
-  data-name="[ICON_NAME]"
-  class="
-    d-icon
-    d-icon--size-[SIZE]
-    d-icon--[ICON_NAME]
-  "
-  viewBox="0 0 12 12"
->
-  ...
-</svg>
-```
 
 ### Sizes
 

--- a/apps/dialtone-documentation/docs/components/icon.md
+++ b/apps/dialtone-documentation/docs/components/icon.md
@@ -14,30 +14,6 @@ Check out our complete icon collection in the [Icon Catalog](/design/icons/#icon
     <dt-icon name="inbox" />
 </code-well-header>
 
-<code-example-tabs
-htmlCode='
-<svg
-  aria-hidden="true"
-  focusable="false"
-  data-name="[ICON_NAME]"
-  class="
-    d-icon
-    d-icon--size-[SIZE]
-    d-icon--[ICON_NAME]
-  "
-  viewBox="0 0 12 12"
->
-  ...
-</svg>
-'
-vueCode='
-<dt-icon
-  size="500"
-  name="inbox"
-/>
-'
-showHtmlWarning />
-
 ## Usage
 
 ### Changing the Icon

--- a/apps/dialtone-documentation/docs/components/icon.md
+++ b/apps/dialtone-documentation/docs/components/icon.md
@@ -10,10 +10,6 @@ figma_url: https://www.figma.com/file/zz40wi0uW9MvaJ5RuhcRZR/DT-Core%3A-Icons-7?
 
 Check out our complete icon collection in the [Icon Catalog](/design/icons/#icon-catalog).
 
-<code-well-header>
-    <dt-icon name="inbox" />
-</code-well-header>
-
 ## Usage
 
 ### Changing the Icon

--- a/apps/dialtone-documentation/docs/components/input.md
+++ b/apps/dialtone-documentation/docs/components/input.md
@@ -54,7 +54,8 @@ An input is normally paired with a label, but there are times when it can be use
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div>
   <label class="d-label" for="Dialtone--InputExample1a">...</label>
   <input class="d-input" id="Dialtone--InputExample1a" type="text" placeholder="..." />
@@ -67,7 +68,13 @@ An input is normally paired with a label, but there are times when it can be use
   <label class="d-label" for="Dialtone--InputExample1b">...</label>
   <input class="d-input" id="Dialtone--InputExample1b" type="text" placeholder="..." disabled />
 </div>
-```
+'
+vueCode='
+<dt-input label="Label" placeholder="Placeholder" />
+<dt-input label="Label" value="Value" />
+<dt-input label="Label" placeholder="Placeholder" disabled />
+'
+showHtmlWarning />
 
 <code-well-header>
   <div class="d-stack16 d-w100p">
@@ -77,7 +84,8 @@ An input is normally paired with a label, but there are times when it can be use
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div>
   <label class="d-label" for="Dialtone--TextareaExample1a">...</label>
   <textarea class="d-textarea" id="Dialtone--TextareaExample1a" type="text" placeholder="..."></textarea>
@@ -90,7 +98,13 @@ An input is normally paired with a label, but there are times when it can be use
   <label class="d-label" for="Dialtone--TextareaExample1b">...</label>
   <textarea class="d-textarea" id="Dialtone--TextareaExample1b" type="text" placeholder="..." disabled></textarea>
 </div>
-```
+'
+vueCode='
+<dt-input label="Label" placeholder="Placeholder" type="textarea" />
+<dt-input label="Label" type="textarea" value="Value" />
+<dt-input label="Label" placeholder="Placeholder" type="textarea" disabled />
+'
+showHtmlWarning />
 
 ### With Description Text
 
@@ -100,11 +114,16 @@ An input is normally paired with a label, but there are times when it can be use
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <label class="d-label" for="Dialtone--InputExample2">...</label>
 <span class="d-description">...</span>
 <input class="d-input" id="Dialtone--InputExample2" type="text" placeholder="..." />
-```
+'
+vueCode='
+<dt-input label="Label" description="Helpful description text" placeholder="Placeholder"/>
+'
+showHtmlWarning />
 
 <code-well-header>
   <div class="d-w100p">
@@ -112,11 +131,16 @@ An input is normally paired with a label, but there are times when it can be use
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <label class="d-label" for="Dialtone--TextareaExample">...</label>
 <span class="d-description">...</span>
 <textarea class="d-textarea" id="Dialtone--TextareaExample" type="text" placeholder="..."></textarea>
-```
+'
+vueCode='
+<dt-input label="Label" description="Helpful description text" type="textarea" placeholder="Placeholder"/>
+'
+showHtmlWarning />
 
 ### With validation states
 
@@ -130,7 +154,8 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div>
   <label class="d-label" for="Dialtone--InputExample3">...</label>
   <input class="d-input d-input--error" id="Dialtone--InputExample3" type="email" placeholder="..." value="..." />
@@ -146,7 +171,13 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
   <input class="d-input d-input--warning" id="Dialtone--InputExample5" type="email" placeholder="..." value="..." />
   <span class="d-validation-message d-validation-message--warning">...</span>
 </div>
-```
+'
+vueCode='
+<dt-input label="Label" type="email" value="Value" :messages="[messages.error]"/>
+<dt-input label="Label" type="email" value="Value" :messages="[messages.success]"/>
+<dt-input label="Label" type="email" value="Value" :messages="[messages.warning]"/>
+'
+showHtmlWarning />
 
 <code-well-header>
   <div class="d-stack16 d-w100p">
@@ -156,7 +187,8 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div>
   <label class="d-label" for="Dialtone--TextareaExample3">...</label>
   <textarea class="d-textarea d-textarea--error" id="Dialtone--TextareaExample3" type="email" placeholder="..." value="..."></textarea>
@@ -172,7 +204,13 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
   <textarea class="d-textarea d-textarea--warning" id="Dialtone--TextareaExample5" type="email" placeholder="..." value="..."></textarea>
   <span class="d-validation-message d-validation-message--warning">...</span>
 </div>
-```
+'
+vueCode='
+<dt-input label="Label" type="textarea" value="Value" :messages="[messages.error]"/>
+<dt-input label="Label" type="textarea" value="Value" :messages="[messages.success]"/>
+<dt-input label="Label" type="textarea" value="Value" :messages="[messages.warning]"/>
+'
+showHtmlWarning />
 
 ### With icons
 
@@ -191,7 +229,8 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div>
   <label class="d-label" for="Dialtone--InputExample--IconLeft">Label</label>
   <div class="d-input__wrapper">
@@ -203,10 +242,23 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
   <label class="d-label" for="Dialtone--InputExample--IconRight">Label</label>
   <div class="d-input__wrapper">
     <input class="d-input d-input-icon--right" id="Dialtone--InputExample--IconRight" type="text" placeholder="Placeholder" />
-     <span class="d-input-icon d-input-icon--right"><dt-icon name="lock" size="200" /></span>
+    <span class="d-input-icon d-input-icon--right"><dt-icon name="lock" size="200" /></span>
   </div>
 </div>
-```
+'
+vueCode='
+<dt-input label="Left icon" type="text" placeholder="Placeholder">
+  <template #leftIcon>
+    <dt-icon name="send" size="200" />
+  </template>
+</dt-input>
+<dt-input label="Right icon" type="text" placeholder="Placeholder">
+  <template #rightIcon>
+    <dt-icon name="lock" size="200" />
+  </template>
+</dt-input>
+'
+showHtmlWarning />
 
 <code-well-header>
   <div class="d-stack16 d-w100p">
@@ -223,7 +275,8 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div>
   <label class="d-label" for="Dialtone--InputExample--IconLeft">...</label>
   <div class="d-input__wrapper">
@@ -231,7 +284,20 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
     <textarea class="d-textarea d-input-icon--left" id="Dialtone--InputExample--IconLeft" type="text" placeholder="..."></textarea>
   </div>
 </div>
-```
+'
+vueCode='
+<dt-input label="Left icon" type="textarea" placeholder="Placeholder">
+  <template #leftIcon>
+    <dt-icon name="send" size="200" />
+  </template>
+</dt-input>
+<dt-input label="Right icon" type="textarea" placeholder="Placeholder">
+  <template #rightIcon>
+    <dt-icon name="lock" size="200" />
+  </template>
+</dt-input>
+'
+showHtmlWarning />
 
 ### Input sizes
 
@@ -247,7 +313,8 @@ We offer different sizes for instances in which the interface requires a smaller
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div>
   <label>
     <div class="d-label d-label--xs">Extra small</div>
@@ -288,7 +355,15 @@ We offer different sizes for instances in which the interface requires a smaller
     </div>
   </label>
 </div>
-```
+'
+vueCode='
+<dt-input label="Extra Small" type="text" placeholder="Placeholder" size="xs" />
+<dt-input label="Small" type="text" placeholder="Placeholder" size="sm" />
+<dt-input label="Medium" type="text" placeholder="Placeholder" size="md" />
+<dt-input label="Large" type="text" placeholder="Placeholder" size="lg" />
+<dt-input label="Extra large" type="text" placeholder="Placeholder" size="xl" />
+'
+showHtmlWarning />
 
 <code-well-header>
   <div class="d-stack16 d-w100p">
@@ -300,7 +375,8 @@ We offer different sizes for instances in which the interface requires a smaller
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div>
   <label>
     <div class="d-label d-label--xs">Extra small</div>
@@ -341,7 +417,15 @@ We offer different sizes for instances in which the interface requires a smaller
     </div>
   </label>
 </div>
-```
+'
+vueCode='
+<dt-input label="Extra Small" type="textarea" placeholder="Placeholder" size="xs" />
+<dt-input label="Small" type="textarea" placeholder="Placeholder" size="sm" />
+<dt-input label="Medium" type="textarea" placeholder="Placeholder" size="md" />
+<dt-input label="Large" type="textarea" placeholder="Placeholder" size="lg" />
+<dt-input label="Extra large" type="textarea" placeholder="Placeholder" size="xl" />
+'
+showHtmlWarning />
 
 ### Icon Sizes
 
@@ -372,7 +456,8 @@ You may use different icon sizes in different sized inputs
   </div>
 </code-well-header>
 
-```html
+<code-example-tabs
+htmlCode='
 <div>
   <div>
     <label class="d-label" for="Dialtone--InputExample--IconLeft">Input:sm Icon:lg</label>
@@ -409,7 +494,30 @@ You may use different icon sizes in different sized inputs
     <textarea class="d-textarea d-input-icon--left d-textarea--lg" id="Dialtone--TextareaExample--IconLeft-lg-md" type="text" placeholder="Placeholder"></textarea>
   </div>
 </div>
-```
+'
+vueCode='
+<dt-input label="Small input with large icon" type="text" placeholder="Placeholder" icon-size="lg" size="sm">
+  <template #leftIcon>
+    <dt-icon name="send" size="200" />
+  </template>
+</dt-input>
+<dt-input label="Medium input with extra large icon" type="text" placeholder="Placeholder" icon-size="xl">
+  <template #leftIcon>
+    <dt-icon name="send" size="200" />
+  </template>
+</dt-input>
+<dt-input label="Extra large input with medium icon" type="text" placeholder="Placeholder" icon-size="md" size="xl">
+  <template #leftIcon>
+    <dt-icon name="send" size="200" />
+  </template>
+</dt-input>
+<dt-input label="Large textarea with medium icon" type="textarea" placeholder="Placeholder" icon-size="md" size="lg">
+  <template #leftIcon>
+    <dt-icon name="send" size="200" />
+  </template>
+</dt-input>
+'
+showHtmlWarning />
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/item-layout.md
+++ b/apps/dialtone-documentation/docs/components/item-layout.md
@@ -28,6 +28,55 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-item-layout-
 </dt-item-layout>
 </code-well-header>
 
+<code-example-tabs
+htmlCode='
+<div class="dt-item-layout">
+  <section class="dt-item-layout--left">
+    <svg>...</svg>
+  </section>
+  <section class="dt-item-layout--content">
+    <div class="dt-item-layout--title">
+      Layout title
+    </div>
+    <div class="dt-item-layout--subtitle dt-item-layout--subtitle--with-title">
+      Subtitle
+    </div>
+    <div class="dt-item-layout--bottom">
+      <span class="d-badge">
+        <span class="d-badge__label">Content</span>
+      </span>
+    </div>
+  </section>
+  <section class="dt-item-layout--right">
+    <svg>...</svg>
+  </section>
+  <section class="dt-item-layout--selected">
+    <svg>...</svg>
+  </section>
+</div>
+'
+vueCode='
+<dt-item-layout>
+  <template #left>
+    <dt-icon name="lock" />
+  </template>
+  Layout title
+  <template #subtitle>
+    Subtitle
+  </template>
+  <template #bottom>
+    <dt-badge>Content</dt-badge>
+  </template>
+  <template #right>
+    <dt-icon name="share" />
+  </template>
+  <template #selected>
+    <dt-icon name="check" />
+  </template>
+</dt-item-layout>
+'
+showHtmlWarning />
+
 ## Vue API
 
 <component-vue-api component-name="itemLayout" />

--- a/apps/dialtone-documentation/docs/components/keyboard-shortcut.md
+++ b/apps/dialtone-documentation/docs/components/keyboard-shortcut.md
@@ -20,9 +20,20 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   <dt-keyboard-shortcut shortcut="{cmd}+Ctrl+X"/>
 </code-well-header>
 
-```html
-  <dt-keyboard-shortcut shortcut="{cmd}+Ctrl+X"/>
-```
+<code-example-tabs
+htmlCode='
+<kbd class="d-keyboard-shortcut">
+  <svg>...</svg>
+  <svg>...</svg>
+  <span aria-hidden="true" class="d-keyboard-shortcut__item">Ctrl</span>
+  <svg>...</svg>
+  <span aria-hidden="true" class="d-keyboard-shortcut__item">X</span>
+</kbd>
+'
+vueCode='
+<dt-keyboard-shortcut shortcut="{cmd}+Ctrl+X"/>
+'
+showHtmlWarning />
 
 ### Inverted
 
@@ -30,9 +41,20 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   <dt-keyboard-shortcut inverted shortcut="{cmd}+Ctrl+X" />
 </code-well-header>
 
-```html
-  <dt-keyboard-shortcut inverted shortcut="{cmd}+Ctrl+X" />
-```
+<code-example-tabs
+htmlCode='
+<kbd class="d-keyboard-shortcut d-keyboard-shortcut--inverted">
+  <svg>...</svg>
+  <svg>...</svg>
+  <span aria-hidden="true" class="d-keyboard-shortcut__item d-keyboard-shortcut__item--inverted">Ctrl</span>
+  <svg>...</svg>
+  <span aria-hidden="true" class="d-keyboard-shortcut__item d-keyboard-shortcut__item--inverted">X</span>
+</kbd>
+'
+vueCode='
+<dt-keyboard-shortcut inverted shortcut="{cmd}+Ctrl+X" />
+'
+showHtmlWarning />
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/lazy-show.md
+++ b/apps/dialtone-documentation/docs/components/lazy-show.md
@@ -36,6 +36,7 @@ vueCode='
 </dt-button>
 <dt-lazy-show
   transition="fade"
+  :show="isShown"
 >
   Im Lazy!
 </dt-lazy-show>

--- a/apps/dialtone-documentation/docs/components/lazy-show.md
+++ b/apps/dialtone-documentation/docs/components/lazy-show.md
@@ -19,6 +19,29 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/utilities-lazy-show--de
   </dt-lazy-show>
 </code-well-header>
 
+<code-example-tabs
+htmlCode='
+<button class="base-button__button d-btn d-btn--primary" type="button">
+  <span class="d-btn__label base-button__label">
+    Toggle
+  </span>
+</button>
+<div>
+  Im Lazy!
+</div>
+'
+vueCode='
+<dt-button @click="isShown = !isShown">
+  Toggle
+</dt-button>
+<dt-lazy-show
+  transition="fade"
+>
+  Im Lazy!
+</dt-lazy-show>
+'
+showHtmlWarning />
+
 <script>
 export default {
   data() {


### PR DESCRIPTION
# use CodeExampleTabs from Icon to Lazy show

Jira ticket: [DLT-1575](https://dialpad.atlassian.net/browse/DLT-1575)

[DLT-1575]: https://dialpad.atlassian.net/browse/DLT-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


1. Icon - [Preview](https://dialtone.dialpad.com/deploy-previews/pr-232/components/icon.html)
2. Input - [Preview](https://dialtone.dialpad.com/deploy-previews/pr-232/components/input.html)
3. Item layout - [Preview](https://dialtone.dialpad.com/deploy-previews/pr-232/components/item-layout.html)
4. Keyboard shortcut - [Preview](https://dialtone.dialpad.com/deploy-previews/pr-232/components/keyboard-shortcut.html)
5. Lazy show - [Preview](https://dialtone.dialpad.com/deploy-previews/pr-232/components/lazy-show.html)

--------
<img width="977" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/6c35c897-ba68-4c71-baa4-00b59b362769">

<img width="977" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/f5d41951-aa70-41d5-91c1-75501f3d04d3">
