### PR TITLE
feat(message-input): DLT-1665 add paste event

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -52,6 +52,12 @@ export const argTypesData = {
     },
   },
 
+  onPasteMedia: {
+    table: {
+      disable: true,
+    },
+  },
+
   onNoticeClose: {
     table: {
       disable: true,
@@ -124,6 +130,7 @@ export const argsData = {
   onSelectMedia: action('select-media'),
   onSelectedEmoji: action('selected-emoji'),
   onAddMedia: action('add-media'),
+  onPasteMedia: action('paste-media'),
   onNoticeClose: action('notice-close'),
   onSkinTone: action('skin-tone'),
   onCancel: action('cancel'),

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -10,6 +10,7 @@
     @drag-over="onDrag"
     @drop="onDrop"
     @keydown.enter.exact="onSend"
+    @paste="onPaste"
   >
     <!-- Some wrapper to restrict the height and show the scrollbar -->
     <div
@@ -461,6 +462,14 @@ export default {
     'add-media',
 
     /**
+     * Fires when media is pasted into the message input
+     *
+     * @event paste-media
+     * @type {Array}
+     */
+    'paste-media',
+
+    /**
      * Fires when cancel button is pressed (only on edit mode)
      *
      * @event cancel
@@ -566,6 +575,14 @@ export default {
       const dt = e.dataTransfer;
       const files = Array.from(dt.files);
       this.$emit('add-media', files);
+    },
+
+    onPaste (e) {
+      if (e.clipboardData.files.length) {
+        e.preventDefault();
+        const files = [...e.clipboardData.files];
+        this.$emit('paste-media', files);
+      }
     },
 
     onSkinTone (skinTone) {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -579,6 +579,7 @@ export default {
 
     onPaste (e) {
       if (e.clipboardData.files.length) {
+        e.stopPropagation();
         e.preventDefault();
         const files = [...e.clipboardData.files];
         this.$emit('paste-media', files);

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -30,6 +30,7 @@
         @selected-emoji="$attrs.onSelectedEmoji"
         @skin-tone="$attrs.onSkinTone"
         @add-media="$attrs.onAddMedia"
+        @paste-media="$attrs.onPasteMedia"
         @notice-close="$attrs.onNoticeClose"
         @cancel="$attrs.onCancel"
       />

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -52,6 +52,12 @@ export const argTypesData = {
     },
   },
 
+  onPasteMedia: {
+    table: {
+      disable: true,
+    },
+  },
+
   onNoticeClose: {
     table: {
       disable: true,
@@ -124,6 +130,7 @@ export const argsData = {
   onSelectMedia: action('select-media'),
   onSelectedEmoji: action('selected-emoji'),
   onAddMedia: action('add-media'),
+  onPasteMedia: action('paste-media'),
   onNoticeClose: action('notice-close'),
   onSkinTone: action('skin-tone'),
   onCancel: action('cancel'),

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -10,6 +10,7 @@
     @drag-over="onDrag"
     @drop="onDrop"
     @keydown.enter.exact="onSend"
+    @paste="onPaste"
   >
     <!-- Some wrapper to restrict the height and show the scrollbar -->
     <div
@@ -461,6 +462,14 @@ export default {
     'add-media',
 
     /**
+     * Fires when media is pasted into the message input
+     *
+     * @event paste-media
+     * @type {Array}
+     */
+    'paste-media',
+
+    /**
      * Fires when cancel button is pressed (only on edit mode)
      *
      * @event cancel
@@ -566,6 +575,14 @@ export default {
       const dt = e.dataTransfer;
       const files = Array.from(dt.files);
       this.$emit('add-media', files);
+    },
+
+    onPaste (e) {
+      if (e.clipboardData.files.length) {
+        e.preventDefault();
+        const files = [...e.clipboardData.files];
+        this.$emit('paste-media', files);
+      }
     },
 
     onSkinTone (skinTone) {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -579,6 +579,7 @@ export default {
 
     onPaste (e) {
       if (e.clipboardData.files.length) {
+        e.stopPropagation();
         e.preventDefault();
         const files = [...e.clipboardData.files];
         this.$emit('paste-media', files);

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -29,6 +29,7 @@
       @selected-emoji="$attrs.onSelectedEmoji"
       @skin-tone="$attrs.onSkinTone"
       @add-media="$attrs.onAddMedia"
+      @paste-media="$attrs.onPasteMedia"
       @notice-close="$attrs.onNoticeClose"
       @cancel="$attrs.onCancel"
     />


### PR DESCRIPTION
# add(message-input): DLT-1665 add paste event

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWFtNzI5cnc0eGR6eDVidHpucjVxZXF5MnZwNGEwOWIwc3d3dW13eCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/XaPTUtaN2fBk5Nq33t/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-1665
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adding `paste` event on the `message-input-recipe` component to listen for paste events that contains images. For web side,  `paste-media` event so we can use the data for rendering previews.
<!--- Describe specifically what the changes are -->

## :bulb: Context
On the current input we allow paste for images so we should add this ability. Adding the preview for the image will be done on web side.

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

