### PR TITLE
docs: NO-JIRA fix example in blog post

### DIFF
--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-3-20.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-3-20.md
@@ -22,7 +22,7 @@ Our previous naming convention, while functional, lacked uniformity and clarity.
 
 #### Key Advantages:
 
-- **Simplified CSS usage,** now all types are named with this structure: `d-{category}--{size}-{strength*}-{density*}`, e.g. `d-body-compact-small`
+- **Simplified CSS usage,** now all types are named with this structure: `d-{category}--{size}-{strength*}-{density*}`, e.g. `d-body--sm-compact`
 
 - **Aligned Across Platforms,** Figma styles more strictly match the naming convention of CSS Utilities and CSS Variables, making integration smoother and collaboration better.
 


### PR DESCRIPTION
# docs: fix example in blog post

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Description

Small error in the blog post that was causing some developers confusion. The example was showing the old format of the utility class instead of the new one.
