### PR TITLE
fix(message-input): DLT-1672 allow spaces in mention suggestions

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/suggestion.js
@@ -66,7 +66,6 @@ export default {
       },
 
       onExit () {
-        console.log('EXIT');
         popup[0].destroy();
         component.destroy();
       },

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/suggestion.js
@@ -10,6 +10,8 @@ export default {
   // This will also activate the mention plugin on the editor
   // items: ({ query }) => { return [] },
 
+  allowSpaces: true,
+
   render: () => {
     let component;
     let popup;
@@ -64,6 +66,7 @@ export default {
       },
 
       onExit () {
+        console.log('EXIT');
         popup[0].destroy();
         component.destroy();
       },

--- a/packages/dialtone-vue2/components/rich_text_editor/mention_suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/mention_suggestion.js
@@ -4,17 +4,17 @@ export default {
     const CONTACT_LIST = [
       {
         id: '1',
-        name: 'Test',
+        name: 'Test Person',
         avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
       },
       {
         id: '2',
-        name: 'Test2',
+        name: 'Test Person 2',
         avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
       },
       {
         id: '3',
-        name: 'Test3',
+        name: 'Test Person 3',
         avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
       },
     ];

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/suggestion.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/suggestion.js
@@ -66,7 +66,6 @@ export default {
       },
 
       onExit () {
-        console.log('EXIT');
         popup[0].destroy();
         component.destroy();
       },

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/suggestion.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/suggestion.js
@@ -11,6 +11,8 @@ export default {
   // This will also activate the mention plugin on the editor
   // items: ({ query }) => { return [] },
 
+  allowSpaces: true,
+
   render: () => {
     let component;
     let popup;
@@ -64,6 +66,7 @@ export default {
       },
 
       onExit () {
+        console.log('EXIT');
         popup[0].destroy();
         component.destroy();
       },

--- a/packages/dialtone-vue3/components/rich_text_editor/mention_suggestion.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/mention_suggestion.js
@@ -4,17 +4,17 @@ export default {
     const CONTACT_LIST = [
       {
         id: '1',
-        name: 'Test',
+        name: 'Test Person',
         avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
       },
       {
         id: '2',
-        name: 'Test2',
+        name: 'Test Person 2',
         avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
       },
       {
         id: '3',
-        name: 'Test3',
+        name: 'Test Person 3',
         avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
       },
     ];


### PR DESCRIPTION
# fix(message-input): DLT-1672 allow spaces in mention suggestions

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjJtYWNhcXk0M3NwbGM2aWF6MjlyNTBuc3I1YW12Y2w5MjZ3enpxYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/gRW0PUY7Z9Mvm/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1672

## :book: Description

Set allowSpaces option on mention suggestions

## :bulb: Context

Prior to this change typing a space while the mentions dialog was open would cause it to close.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.

## :link: Sources

https://tiptap.dev/docs/editor/api/utilities/suggestion#allow-spaces
