### PR TITLE
fix(typography): DLT-1676 add font-smoothing

### DIFF
--- a/packages/dialtone-css/lib/build/less/dialtone-globals.less
+++ b/packages/dialtone-css/lib/build/less/dialtone-globals.less
@@ -51,4 +51,5 @@ body {
     font: var(--dt-typography-body-md);
     background-color: var(--dt-color-surface-primary);
     -webkit-text-size-adjust: 100%;
+    -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
# Add font-smoothing

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

[DLT-1676](https://dialpad.atlassian.net/browse/DLT-1676)

## :book: Description

`-webkit-font-smoothing: antialiased;` has been part of DP product codebase since the beginning. DPM doesn’t have it which has made DPM feel ever so slightly “off” from DP. 

This really affects Chrome (and Electron app) on Mac as it’s a proprietary property that will never be official CSS spec. This will not affect iOS, Android and Windows' Chrome.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

[DLT-1676]: https://dialpad.atlassian.net/browse/DLT-1676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ