### PR TITLE
fix(emoji-row): DLT-1677 correct emoji reaction size

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -106,52 +106,53 @@ export default {
   }
 
   &__reaction {
-  --emoji-item-color-inset-shadow: transparent;
-  --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-default);
-  --emoji-item-color-background: var(--dt-action-color-background-muted-hover);
+    --emoji-item-color-inset-shadow: transparent;
+    --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-default);
+    --emoji-item-color-background: var(--dt-action-color-background-muted-hover);
 
-  padding: var(--dt-space-300) var(--dt-space-400);
-  border-radius: var(--dt-size-radius-pill);
-  border: 0;
-  color: var(--emoji-item-color-foreground);
-  background-color: var(--emoji-item-color-background);
-  box-shadow: inset 0 0 0 var(--dt-size-border-150) var(--emoji-item-color-inset-shadow);
+    padding: var(--dt-space-300) var(--dt-space-400);
+    border-radius: var(--dt-size-radius-pill);
+    border: 0;
+    color: var(--emoji-item-color-foreground);
+    background-color: var(--emoji-item-color-background);
+    box-shadow: inset 0 0 0 var(--dt-size-border-150) var(--emoji-item-color-inset-shadow);
+    height: var(--dt-size-550);
 
-  &.dt-emoji-row__picker {
-    padding: var(--dt-space-200) var(--dt-space-350);
-  }
-
-  &:hover {
-    --emoji-item-color-inset-shadow: var(--dt-color-border-subtle);
-    --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-hover);
-  }
-
-  &:active {
-    --emoji-item-color-background: var(--dt-action-color-background-muted-active);
-    --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-active);
-
-    transform: scale(.98);
-  }
-
-  &--selected {
-    --emoji-item-color-inset-shadow: var(--dt-color-border-brand);
-    --emoji-item-color-foreground: var(--dt-color-link-primary);
-    --emoji-item-color-background: var(--dt-action-color-background-base-hover);
-
-    .dt-emoji-row__reaction-number {
-      font-weight: var(--dt-font-weight-bold);
+    &.dt-emoji-row__picker {
+      padding: var(--dt-space-200) var(--dt-space-350);
     }
 
     &:hover {
-      --emoji-item-color-inset-shadow: var(--dt-color-border-brand-strong);
-      --emoji-item-color-foreground: var(--dt-color-link-primary-hover);
+      --emoji-item-color-inset-shadow: var(--dt-color-border-subtle);
+      --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-hover);
     }
 
     &:active {
-      --emoji-item-color-background: var(--dt-action-color-background-base-active);
+      --emoji-item-color-background: var(--dt-action-color-background-muted-active);
+      --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-active);
+
+      transform: scale(.98);
+    }
+
+    &--selected {
+      --emoji-item-color-inset-shadow: var(--dt-color-border-brand);
+      --emoji-item-color-foreground: var(--dt-color-link-primary);
+      --emoji-item-color-background: var(--dt-action-color-background-base-hover);
+
+      .dt-emoji-row__reaction-number {
+        font-weight: var(--dt-font-weight-bold);
+      }
+
+      &:hover {
+        --emoji-item-color-inset-shadow: var(--dt-color-border-brand-strong);
+        --emoji-item-color-foreground: var(--dt-color-link-primary-hover);
+      }
+
+      &:active {
+        --emoji-item-color-background: var(--dt-action-color-background-base-active);
+      }
     }
   }
-}
 
   &__emoji {
     margin-right: var(--dt-space-300);

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -106,52 +106,53 @@ export default {
   }
 
   &__reaction {
-  --emoji-item-color-inset-shadow: transparent;
-  --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-default);
-  --emoji-item-color-background: var(--dt-action-color-background-muted-hover);
+    --emoji-item-color-inset-shadow: transparent;
+    --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-default);
+    --emoji-item-color-background: var(--dt-action-color-background-muted-hover);
 
-  padding: var(--dt-space-300) var(--dt-space-400);
-  border-radius: var(--dt-size-radius-pill);
-  border: 0;
-  color: var(--emoji-item-color-foreground);
-  background-color: var(--emoji-item-color-background);
-  box-shadow: inset 0 0 0 var(--dt-size-border-150) var(--emoji-item-color-inset-shadow);
+    padding: var(--dt-space-300) var(--dt-space-400);
+    border-radius: var(--dt-size-radius-pill);
+    border: 0;
+    color: var(--emoji-item-color-foreground);
+    background-color: var(--emoji-item-color-background);
+    box-shadow: inset 0 0 0 var(--dt-size-border-150) var(--emoji-item-color-inset-shadow);
+    height: var(--dt-size-550);
 
-  &.dt-emoji-row__picker {
-    padding: var(--dt-space-200) var(--dt-space-350);
-  }
-
-  &:hover {
-    --emoji-item-color-inset-shadow: var(--dt-color-border-subtle);
-    --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-hover);
-  }
-
-  &:active {
-    --emoji-item-color-background: var(--dt-action-color-background-muted-active);
-    --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-active);
-
-    transform: scale(.98);
-  }
-
-  &--selected {
-    --emoji-item-color-inset-shadow: var(--dt-color-border-brand);
-    --emoji-item-color-foreground: var(--dt-color-link-primary);
-    --emoji-item-color-background: var(--dt-action-color-background-base-hover);
-
-    .dt-emoji-row__reaction-number {
-      font-weight: var(--dt-font-weight-bold);
+    &.dt-emoji-row__picker {
+      padding: var(--dt-space-200) var(--dt-space-350);
     }
 
     &:hover {
-      --emoji-item-color-inset-shadow: var(--dt-color-border-brand-strong);
-      --emoji-item-color-foreground: var(--dt-color-link-primary-hover);
+      --emoji-item-color-inset-shadow: var(--dt-color-border-subtle);
+      --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-hover);
     }
 
     &:active {
-      --emoji-item-color-background: var(--dt-action-color-background-base-active);
+      --emoji-item-color-background: var(--dt-action-color-background-muted-active);
+      --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-active);
+
+      transform: scale(.98);
+    }
+
+    &--selected {
+      --emoji-item-color-inset-shadow: var(--dt-color-border-brand);
+      --emoji-item-color-foreground: var(--dt-color-link-primary);
+      --emoji-item-color-background: var(--dt-action-color-background-base-hover);
+
+      .dt-emoji-row__reaction-number {
+        font-weight: var(--dt-font-weight-bold);
+      }
+
+      &:hover {
+        --emoji-item-color-inset-shadow: var(--dt-color-border-brand-strong);
+        --emoji-item-color-foreground: var(--dt-color-link-primary-hover);
+      }
+
+      &:active {
+        --emoji-item-color-background: var(--dt-action-color-background-base-active);
+      }
     }
   }
-}
 
   &__emoji {
     margin-right: var(--dt-space-300);


### PR DESCRIPTION
# Correct emoji reaction size

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1677

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.