### PR TITLE
fix: NO-JIRA dialtone-vue peer dependencies

### DIFF
--- a/packages/dialtone-vue2/package.json
+++ b/packages/dialtone-vue2/package.json
@@ -110,7 +110,7 @@
     "yorkie": "^2.0.0"
   },
   "peerDependencies": {
-    "@dialpad/dialtone-css": "7.30.0 || workspace:*",
+    "@dialpad/dialtone-css": "workspace:*",
     "@dialpad/dialtone-icons": "workspace:*",
     "vue": ">=2.6"
   },

--- a/packages/dialtone-vue3/package.json
+++ b/packages/dialtone-vue3/package.json
@@ -108,7 +108,7 @@
     "yorkie": "^2.0.0"
   },
   "peerDependencies": {
-    "@dialpad/dialtone-css": "7.30.0 || workspace:*",
+    "@dialpad/dialtone-css": "workspace:*",
     "@dialpad/dialtone-icons": "workspace:*",
     "vue": ">=3.2"
   },


### PR DESCRIPTION
# Fix peer dependencies

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/l5WY063RdLr0VLNCR9/giphy.gif?cid=790b7611jvpirnl4xsgnvjb5xw3o35nh3k3269k40s7gyiz5&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

No Jira

## :book: Description

- Updated @dialpad/dialtone-css peer dependency on dialtone-vue
- This will not impact anything on product as we're no longer using standalone versions.

## :bulb: Context

- pnpm is not able to translate "7.30.0||workspace:*" to actual version, it needs to be an specific version like "workspace:*", so while installing dialtone-vue individually it was failing to find the dialtone-css version.

## :pencil: Checklist

For all PRs:

- [ ] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.