### PR TITLE
feat(focus-ring): NO-JIRA reduce focus ring size

### DIFF
--- a/apps/dialtone-documentation/docs/utilities/interactivity/outline.md
+++ b/apps/dialtone-documentation/docs/utilities/interactivity/outline.md
@@ -21,8 +21,12 @@ Use `d-ol-{focusring|focusring-inset|none}` to change an elements' outline.
 
 ```html
 <div class="d-ol-focusring">...</div>
+<div class="d-ol-focusring-inset">...</div>
 <div class="d-ol-none">...</div>
 ```
+
+* Use `d-ol-focusring` to add a focus ring that will render **outside** of the element.
+* Use `d-ol-focusring-inset` to add a focus ring that renders **within** the edge of the element. This is particularly useful when the containing element bleeds to the edge of its parent or its `overflow` property is set to `hidden`.
 
 <script setup>
   import { outline } from '@data/interactivity.json';

--- a/apps/dialtone-documentation/docs/utilities/interactivity/outline.md
+++ b/apps/dialtone-documentation/docs/utilities/interactivity/outline.md
@@ -7,14 +7,14 @@ description: Utilities for controlling an element's outline.
 
 Use `d-ol-{focusring|focusring-inset|none}` to change an elements' outline.
 
-<code-well-header class="d-fl-col5 d-flg8 d-fw-wrap d-p24 d-bgc-bold d-bgo50 d-w100p d-hmn102" custom>
-  <div class="d-fl-center d-p16 d-bgc-bold d-code--sm d-ol-focusring">
+<code-well-header class="d-fl-col5 d-flg8 d-fw-wrap d-p24 d-bgc-bold d-w100p d-hmn102" custom>
+  <div class="d-fl-center d-p16 d-bgc-primary d-code--sm d-ol-focusring">
     .d-ol-focusring
   </div>
-  <div class="d-fl-center d-p16 d-bgc-bold d-code--sm d-ol-focusring-inset">
+  <div class="d-fl-center d-p16 d-bgc-primary d-code--sm d-ol-focusring-inset">
     .d-ol-focusring-inset
   </div>
-  <div class="d-fl-center d-p16 d-bgc-bold d-code--sm d-ol-none">
+  <div class="d-fl-center d-p16 d-bgc-primary d-code--sm d-ol-none">
     .d-ol-none
   </div>
 </code-well-header>

--- a/packages/dialtone-css/lib/build/less/utilities/interactivity.less
+++ b/packages/dialtone-css/lib/build/less/utilities/interactivity.less
@@ -42,9 +42,9 @@
 //      Sets the style, width, color, and other characteristics
 //      elements' outlines. These shouldn't be confused with borders.
 //  ----------------------------------------------------------------------------
-.d-ol-focusring { box-shadow: var(--dt-shadow-focus) !important; }
-.d-ol-focusring-inset { box-shadow: var(--dt-shadow-focus-inset) !important; }
-.d-ol-none { box-shadow: none !important; }
+.d-ol-focusring { box-shadow: var(--dt-shadow-focus) !important; outline: none !important; }
+.d-ol-focusring-inset { box-shadow: var(--dt-shadow-focus-inset) !important; outline: none !important; }
+.d-ol-none { box-shadow: none !important; outline: none !important; }
 
 //============================================================================
 //  $   POINTER EVENTS

--- a/packages/dialtone-tokens/tokens/base/default.json
+++ b/packages/dialtone-tokens/tokens/base/default.json
@@ -492,7 +492,7 @@
           "x": "{size.0}",
           "y": "{size.0}",
           "blur": "{size.0}",
-          "spread": "{size.300}",
+          "spread": "{size.200} + {size.100}",
           "color": "{color.border.focus}",
           "type": "dropShadow"
         }
@@ -505,7 +505,7 @@
           "x": "{size.0}",
           "y": "{size.0}",
           "blur": "{size.0}",
-          "spread": "{size.200} + {size.100}",
+          "spread": "{size.200}",
           "color": "{color.border.focus}",
           "type": "innerShadow"
         }


### PR DESCRIPTION
# Reduce focus ring size

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Description

Now that focus ring style has been in play in product for a while now, it's a touch overbearing. This reduces it by one miserable pixel.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :camera: Screenshots / GIFs

![image](https://github.com/dialpad/dialtone/assets/1165933/3475769a-13a7-4faa-bf65-5d2884ccef5d)