### PR TITLE
fix(emoji-row): NO-JIRA set reaction-number line-height to 1

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -160,7 +160,12 @@ export default {
   }
 
   &__reaction-number {
-    font: var(--dt-typography-body-sm);
+    // set font properties individually to change line height,
+    // as font shorthand property will override line-height.
+    font-weight: var(--dt-typography-body-sm-font-weight);
+    font-size: var(--dt-typography-body-sm-font-size);
+    font-family: var(--dt-typography-body-sm-font-family);
+    line-height: var(--dt-font-line-height-100);
     font-variant: tabular-nums;
   }
 }

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -160,7 +160,13 @@ export default {
   }
 
   &__reaction-number {
-    font: var(--dt-typography-body-sm);
+    // set font properties individually to change line height,
+    // as font shorthand property will override line-height.
+    font-weight: var(--dt-typography-body-sm-font-weight);
+    font-size: var(--dt-typography-body-sm-font-size);
+    font-family: var(--dt-typography-body-sm-font-family);
+    line-height: var(--dt-font-line-height-100);
+    font-variant: tabular-nums;
   }
 }
 </style>


### PR DESCRIPTION
# fix(emoji-row): set reaction-number line-height to 1

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMXp6YmJ0ZGdsYTRwamhmMGlncGUxZ2RiMGpxbm5odmh3c3RkZWNpcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/13FrpeVH09Zrb2/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Set line-height of reaction-number to 1

## :bulb: Context

Some strange subpixel math happening in product where the alignment of the number would be off by 1 pixel for certain line-heights.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.

## :crystal_ball: Next Steps

Update in product, remove the quick hack I put in.
