### PR TITLE
ci: NO-JIRA release icons and emojis on every change type

### DIFF
--- a/.github/COMMIT_CONVENTION.md
+++ b/.github/COMMIT_CONVENTION.md
@@ -38,7 +38,13 @@ Must be one of the following:
 * **style**: not relevant changes (whitespace, code formatting, semicolons, etc).
 * **test**: changes that add or modify tests.
 
-> Only `feat`, `fix`, `perf` and `refactor` types trigger a new release. Commits with `BREAKING CHANGE:` in the footer of the commit message, regardless of type, will generate a `MAJOR` release.
+> Only `feat`, `fix`, `perf` and `refactor` types trigger a new release.
+>
+> Dialtone icons and Dialtone emojis packages trigger a patch release on `build`, `chore`, `ci`, `docs`, `style` and
+> `test` also.
+>
+> Commits with `BREAKING CHANGE:` in the footer of the commit message, regardless of type, will generate a `MAJOR`
+> release.
 
 ### Scope:
 

--- a/package.json
+++ b/package.json
@@ -130,17 +130,6 @@
     "stylelint": "15.11.0",
     "tippy.js": "^6.3.7"
   },
-  "peerDependenciesMeta": {
-    "@linusborg/vue-simple-portal": {
-      "optional": true
-    },
-    "@tiptap/vue-2": {
-      "optional": true
-    },
-    "@tiptap/vue-3": {
-      "optional": true
-    }
-  },
   "homepage": "https://dialtone.dialpad.com",
   "keywords": [
     "Dialpad",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
   "peerDependencies": {
     "@dialpad/dialtone-icons": "workspace:*",
     "@dialpad/dialtone-emojis": "workspace:*",
-    "@dialpad/dialtone-tokens": "workspace:*",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-blockquote": "^2.1.16",

--- a/packages/dialtone-emojis/release-local.config.cjs
+++ b/packages/dialtone-emojis/release-local.config.cjs
@@ -16,7 +16,13 @@ module.exports = {
     ['@semantic-release/commit-analyzer', {
       preset: 'angular',
       releaseRules: [
-        { type: 'refactor', release: 'patch' },
+        {type: 'build', release: 'patch'},
+        {type: 'chore', release: 'patch'},
+        {type: 'ci', release: 'patch'},
+        {type: 'docs', release: 'patch'},
+        {type: 'refactor', release: 'patch'},
+        {type: 'style', release: 'patch'},
+        {type: 'test', release: 'patch'},
       ],
     }],
     ['@semantic-release/release-notes-generator', {

--- a/packages/dialtone-icons/release-local.config.cjs
+++ b/packages/dialtone-icons/release-local.config.cjs
@@ -16,7 +16,13 @@ module.exports = {
     ['@semantic-release/commit-analyzer', {
       preset: 'angular',
       releaseRules: [
-        { type: 'refactor', release: 'patch' },
+        {type: 'build', release: 'patch'},
+        {type: 'chore', release: 'patch'},
+        {type: 'ci', release: 'patch'},
+        {type: 'docs', release: 'patch'},
+        {type: 'refactor', release: 'patch'},
+        {type: 'style', release: 'patch'},
+        {type: 'test', release: 'patch'},
       ],
     }],
     ['@semantic-release/release-notes-generator', {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@dialpad/dialtone-icons':
         specifier: workspace:*
         version: link:packages/dialtone-icons
-      '@dialpad/dialtone-tokens':
-        specifier: workspace:*
-        version: link:packages/dialtone-tokens
       '@linusborg/vue-simple-portal':
         specifier: ^0.1.5
         version: 0.1.5(vue@2.7.15)


### PR DESCRIPTION
# Release icons and emojis on every change type

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/aoegxxFogBQm74XCWY/giphy.gif?cid=790b76116171abqeclmfue2qjk5ezzix1ucg8uiiynk2povk&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] CI

## :book: Jira Ticket

No Jira

## :book: Description

- Added build, chore, ci, docs, style and test types to bump a patch version on dialtone-icons and dialtone-emojis
- Remove unneeded `dialtone-tokens` from peer dependencies
- Removed peer dependencies meta as the monopackage would not install any of the `@tiptap/vue-x` dependency.

## :bulb: Context

Now that `@dialpad/dialtone-icons` and `@dialpad/dialtone-emojis` are external dependencies again, we need to make sure every change to them bumps the version and trigger a release, otherwise, we'll continue having the issue of outdated icons version.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.