### PR TITLE
fix(contact-row): DP-95121 remove attrs from emoji wrapper

### DIFF
--- a/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -54,7 +54,7 @@ export default {
       return split.map((item) => {
         if (replaceList.includes(item)) {
           return this.$createElement(DtEmoji, {
-            props: { code: item, size: this.size, ...this.$attrs },
+            props: { code: item, size: this.size },
           });
         }
         return this.$createElement('span', item);

--- a/packages/dialtone-vue2/recipes/leftbar/contact_row/contact_row_variants.story.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_row/contact_row_variants.story.vue
@@ -86,6 +86,20 @@
         call-button-tooltip="Call"
       />
     </div>
+    <div>
+      <h3>
+        With emojis in the name
+      </h3>
+      <dt-recipe-contact-row
+        name=":smile: :fire: Jaqueline Nackos"
+        avatar-presence="active"
+        avatar-seed="JN"
+        avatar-alt="Avatar person"
+        :avatar-src="$attrs.avatarSrc"
+        user-status="Good Morning! :smile:"
+        call-button-tooltip="Call"
+      />
+    </div>
   </dt-stack>
 </template>
 

--- a/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -54,7 +54,7 @@ export default {
       const split = textContent.split(regexp);
       return split.map((item) => {
         if (replaceList.includes(item)) {
-          return h(DtEmoji, { ...this.$attrs, size: this.size, code: item });
+          return h(DtEmoji, { size: this.size, code: item });
         }
         return h('span', item);
       });

--- a/packages/dialtone-vue3/recipes/leftbar/contact_row/contact_row_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_row/contact_row_variants.story.vue
@@ -86,6 +86,20 @@
         call-button-tooltip="Call"
       />
     </div>
+    <div>
+      <h3>
+        With emojis in the name
+      </h3>
+      <dt-recipe-contact-row
+        name=":smile: :fire: Jaqueline Nackos"
+        avatar-presence="active"
+        avatar-seed="JN"
+        avatar-alt="Avatar person"
+        :avatar-src="$attrs.avatarSrc"
+        user-status="Good Morning! :smile:"
+        call-button-tooltip="Call"
+      />
+    </div>
   </dt-stack>
 </template>
 


### PR DESCRIPTION
# fix(contact-row): DP-95121 remove attrs from emoji wrapper

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/UO5elnTqo4vSg/giphy.gif?cid=82a1493brpvcm7kg3ozkeqhin3s9muzrz03fmumibcghvtyy&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
[DP-95121]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Passing `this.$attrs` to the emoji element would add `d-emoji__wrapper dt-leftbar-row__description` class, which contains `display:  block` and it's not what we want for the emoji. Happens only on Vue 3.
<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

If new component:

<!--- There are lots of things to remember when adding a new component to the system! This is so you don't forget any of them. -->

- I am exporting any new components or constants:
  - [ ] from the index.js in the component directory.
  - [ ] from the index.js in the root (either `packages/dialtone-vue2` or `packages/dialtone-vue3`).
- [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
- [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
- [ ] I have added the new component to `common/components_list.cjs`
- [ ] I have created a component story in storybook
- [ ] I have created story / stories for any relevant component variants in storybook
- [ ] I have created a docs page for the component in storybook.
- [ ] I have checked that changing all props/slots via the UI in storybook works as expected.

## :camera: Screenshots / GIFs

## Before
<img width="262" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/6a96c781-6bba-42b2-b935-0c684c49cf2e">

## Now
<img width="265" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/09ee6f09-3d3f-4234-8254-c9e25ed03295">


<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->


[DP-95121]: https://dialpad.atlassian.net/browse/DP-95121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ