### PR TITLE
feat: DLT-1678 build all themes

### DIFF
--- a/packages/dialtone-tokens/build-sd-transforms.js
+++ b/packages/dialtone-tokens/build-sd-transforms.js
@@ -83,10 +83,10 @@ export async function run () {
           actions: ['buildDocJson'],
           basePxFontSize: Number.parseFloat(BASE_FONT_SIZE),
           buildPath: 'dist/less/',
-          theme: theme.name,
+          theme: themeName,
           files: [
             {
-              destination: `variables-${theme.name}.less`,
+              destination: `variables-${themeName}.less`,
               format: 'less/variables',
             },
           ],


### PR DESCRIPTION
# Tokens - Build all themes

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/5epqQGCG4Nr6E/giphy.gif?cid=790b7611krszb3nnofuaupsuh90r83sjidq1l8hfjzgifv6e&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1678

## :book: Description

- Changed `sd-transforms` to build all themes instead of just light and dark, this will build CSS/LESS output and enable expressive theme to be built.
- `build-token-transformer` work will be delayed as right now needs to be manually setup and that'd is hard to maintain, created a ticket to do that in the future: https://dialpad.atlassian.net/browse/DLT-1687

## :bulb: Context

Themes and Brands are growing rapidly on dialtone-tokens, we need to build them all in a more automated way, right now we're only outputting dialtone-theme light/dark as default.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.