### PR TITLE
docs: DLT-1576 use CodeExampleTabs from Link to Pagination

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="d-d-flex d-ai-flex-end d-jc-space-between d-w100p">
-    <div class="d-w100p d-mr8">
+    <div v-if="bannerTitle" class="d-w100p d-mr8">
       <dt-select-menu
-        v-if="bannerTitle"
         label="Kind of Banner"
         size="sm"
         @change="changeBannerKind"

--- a/apps/dialtone-documentation/docs/components/list-item.md
+++ b/apps/dialtone-documentation/docs/components/list-item.md
@@ -14,9 +14,8 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
       <template #left>
         <dt-icon name="check" />
       </template>
-      <span />
       <template #subtitle>
-        <span />{subtitle}
+        {subtitle}
       </template>
       <template #bottom>
         {bottom}
@@ -27,6 +26,65 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
     </dt-list-item>
   </ul>
 </code-well-header>
+
+<code-example-tabs
+htmlCode='
+<ul>
+  <li id="dt4" class="dt-list-item dt-list-item--focusable" tabindex="0" role="listitem">
+    <div class="dt-item-layout">
+      <section class="dt-item-layout--left">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-500" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </section>
+      <section class="dt-item-layout--content">
+        <div class="dt-item-layout--subtitle">
+          {subtitle}
+        </div>
+        <div class="dt-item-layout--bottom">
+          {bottom}
+        </div>
+      </section>
+      <section class="dt-item-layout--right">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-500" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </section>
+    </div>
+  </li>
+</ul>
+'
+vueCode='
+<ul>
+  <dt-list-item navigationType="tab">
+    <template #left>
+      <dt-icon name="check" />
+    </template>
+    <template #subtitle>
+      {subtitle}
+    </template>
+    <template #bottom>
+      {bottom}
+    </template>
+    <template #right>
+      <dt-icon name="external-link" />
+    </template>
+  </dt-list-item>
+</ul>
+'
+showHtmlWarning />
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -126,7 +126,6 @@ vueCode='
     </dt-button>
     <dt-button
       id="confirm-button"
-      :kind="$attrs.kind"
       importance="primary"
       class="d-ml6"
     >
@@ -210,7 +209,6 @@ vueCode='
     </dt-button>
     <dt-button
       id="confirm-button"
-      :kind="$attrs.kind"
       importance="primary"
       class="d-ml6"
     >
@@ -293,7 +291,7 @@ vueCode='
     </dt-button>
     <dt-button
       id="confirm-button"
-      :kind="$attrs.kind"
+      kind="danger"
       importance="primary"
       class="d-ml6"
     >
@@ -376,7 +374,6 @@ vueCode='
     </dt-button>
     <dt-button
       id="confirm-button"
-      :kind="$attrs.kind"
       importance="primary"
       class="d-ml6"
     >
@@ -462,7 +459,6 @@ vueCode='
     </dt-button>
     <dt-button
       id="confirm-button"
-      :kind="$attrs.kind"
       importance="primary"
       class="d-ml6"
     >

--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -8,38 +8,7 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-modal--defau
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8923%3A20396&viewport=-724%2C-52%2C0.38&t=xHutRjwo1o5zMTgT-11
 ---
 <code-well-header>
-  <div class="d-d-grid d-gg16 d-g-cols4 md:d-g-cols2 d-fs-200">
-    <a class="d-link" href="#base-style">
-      <figure class="d-m0">
-        <img class="d-bar4 d-w100p" alt="Modal screen: Base" :src="$withBase('/assets/images/screen-modal--base.png')">
-        <figcaption>Base Style</figcaption>
-      </figure>
-    </a>
-    <a class="d-link" href="#fixed-header-and-footer">
-      <figure class="d-m0">
-        <img class="d-bar4 d-w100p" alt="Modal screen: Fixed header and footer" :src="$withBase('/assets/images/screen-modal--fixed-header-and-footer.png')">
-        <figcaption>
-          Fixed header and footer
-        </figcaption>
-      </figure>
-    </a>
-    <a class="d-link" href="#danger">
-      <figure class="d-m0">
-        <img class="d-bar4 d-w100p" alt="Modal screen: Danger" :src="$withBase('/assets/images/screen-modal--danger.png')">
-        <figcaption>
-          Danger
-        </figcaption>
-      </figure>
-    </a>
-    <a class="d-link" href="#full-screen">
-      <figure class="d-m0">
-        <img class="d-bar4 d-w100p" alt="Modal screen: Full Screen" :src="$withBase('/assets/images/screen-modal--fullscreen.png')">
-        <figcaption>
-          Full Screen
-        </figcaption>
-      </figure>
-    </a>
-  </div>
+  <example-modal />
 </code-well-header>
 
 ## Usage
@@ -97,19 +66,81 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
   <example-modal />
 </code-well-header>
 
-```html
-<aside class="d-modal" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
-  <div class="d-modal__dialog" role="document">
-    <h2 class="d-modal__header" id="modal-title">…</h2>
-    <p class="d-modal__content" id="modal-description">…</p>
+<code-example-tabs
+htmlCode='
+<button type="button" class="base-button__button d-btn d-btn--primary">
+  <span class="d-btn__label base-button__label"> Click to open </span>
+</button>
+<aside id="modal-base" class="d-modal d-m0 d-modal--animate-in" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="false">
+  <div class="d-modal__dialog d-modal__dialog--animate-in" role="document">
+    <h2 class="d-modal__header">
+      Example title
+    </h2>
+    <div class="d-modal__content">
+      <p id="modal-description">
+        Sed at orci quis nunc finibus gravida eget vitae est...
+      </p>
+      <p class="d-mt16"><a href="#" class="d-link">Show me a modal banner</a></p>
+    </div>
     <footer class="d-modal__footer">
-      <button class="d-btn" type="button">…</button>
-      <button class="d-btn d-btn--primary" type="button">…</button>
+      <button class="d-btn d-btn--primary" type="button">
+        Save changes
+      </button>
+      <button class="d-btn" type="button">
+        Cancel
+      </button>
     </footer>
-    <button href="#" class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close"><IconClose /></button>
+    <button class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close">
+      <span class="d-btn__icon">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
   </div>
 </aside>
-```
+'
+vueCode='
+<dt-modal
+  title="Example title"
+  close-button-props="Close"
+  :show="isOpen"
+  @update:show="updateShow"
+  copy="Lorem ipsum ..."
+>
+  <template
+    #footer
+  >
+    <dt-button
+      id="cancel-button"
+      :kind="secondaryButtonKind"
+      importance="clear"
+    >
+      Cancel
+    </dt-button>
+    <dt-button
+      id="confirm-button"
+      :kind="$attrs.kind"
+      importance="primary"
+      class="d-ml6"
+    >
+      Confirm
+    </dt-button>
+  </template>
+</dt-modal>
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
+'
+showHtmlWarning />
 
 ### Fixed header and footer
 
@@ -117,19 +148,83 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
   <example-modal kind="fixed" />
 </code-well-header>
 
-```html
-<aside class="d-modal" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
-  <div class="d-modal__dialog d-modal__dialog--scrollable" role="document">
-    <h2 class="d-modal__header" id="modal-title">…</h2>
-    <p class="d-modal__content" id="modal-description">…</p>
+<code-example-tabs
+htmlCode='
+<button type="button" class="base-button__button d-btn d-btn--primary">
+  <span class="d-btn__label base-button__label"> Click to open </span>
+</button>
+<aside id="modal-base" class="d-modal d-m0 d-modal--animate-in" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="false">
+  <div class="d-modal__dialog d-modal__dialog--animate-in d-modal__dialog--scrollable d-hmx764" role="document">
+    <h2 class="d-modal__header">
+      Example title
+    </h2>
+    <div class="d-modal__content">
+      <p id="modal-description">
+        Sed at orci quis nunc finibus gravida eget vitae est...
+      </p>
+      <p class="d-mt16"><a href="#" class="d-link">Show me a modal banner</a></p>
+    </div>
     <footer class="d-modal__footer">
-      <button class="d-btn" type="button">…</button>
-      <button class="d-btn d-btn--primary" type="button">…</button>
+      <button class="d-btn d-btn--primary" type="button">
+        Save changes
+      </button>
+      <button class="d-btn" type="button">
+        Cancel
+      </button>
     </footer>
-    <button href="#" class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close"><IconClose /></button>
+    <button class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close">
+      <span class="d-btn__icon">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
   </div>
 </aside>
-```
+'
+vueCode='
+<dt-modal
+  title="Example title"
+  close-button-props="Close"
+  :show="isOpen"
+  @update:show="updateShow"
+  :showFooter="true"
+  :fixed-header-footer="true"
+  copy="Sed at orci quis nunc finibus gravida eget vitae est..."
+>
+  <template
+    #footer
+  >
+    <dt-button
+      id="cancel-button"
+      :kind="secondaryButtonKind"
+      importance="clear"
+    >
+      Cancel
+    </dt-button>
+    <dt-button
+      id="confirm-button"
+      :kind="$attrs.kind"
+      importance="primary"
+      class="d-ml6"
+    >
+      Confirm
+    </dt-button>
+  </template>
+</dt-modal>
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
+'
+showHtmlWarning />
 
 ### Danger
 
@@ -137,19 +232,82 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
   <example-modal kind="danger" />
 </code-well-header>
 
-```html
-<aside class="d-modal d-modal--danger" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
-  <div class="d-modal__dialog" role="document">
-    <h2 class="d-modal__header" id="modal-title">…</h2>
-    <p class="d-modal__content" id="modal-description">…</p>
+<code-example-tabs
+htmlCode='
+<button type="button" class="base-button__button d-btn d-btn--primary">
+  <span class="d-btn__label base-button__label"> Click to open </span>
+</button>
+<aside id="modal-base" class="d-modal d-m0 d-modal--danger d-modal--animate-in" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="false">
+  <div class="d-modal__dialog d-modal__dialog--animate-in" role="document">
+    <h2 class="d-modal__header">
+      Example title
+    </h2>
+    <div class="d-modal__content">
+      <p id="modal-description">
+        Sed at orci quis nunc finibus gravida eget vitae est...
+      </p>
+      <p class="d-mt16"><a href="#" class="d-link">Show me a modal banner</a></p>
+    </div>
     <footer class="d-modal__footer">
-      <button class="d-btn" type="button">…</button>
-      <button class="d-btn d-btn--danger d-btn--primary" type="button">…</button>
+      <button class="d-btn d-btn--primary d-btn--danger" type="button">
+        Save changes
+      </button>
+      <button class="d-btn d-btn--muted" type="button">
+        Cancel
+      </button>
     </footer>
-    <button href="#" class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close"><IconClose \></button>
+    <button class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close">
+      <span class="d-btn__icon">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
   </div>
 </aside>
-```
+'
+vueCode='
+<dt-modal
+  title="Example title"
+  close-button-props="Close"
+  :show="isOpen"
+  kind="danger"
+  copy="Sed at orci quis nunc finibus gravida eget vitae est..."
+  @update:show="updateShow"
+>
+  <template
+    #footer
+  >
+    <dt-button
+      id="cancel-button"
+      :kind="secondaryButtonKind"
+      importance="clear"
+    >
+      Cancel
+    </dt-button>
+    <dt-button
+      id="confirm-button"
+      :kind="$attrs.kind"
+      importance="primary"
+      class="d-ml6"
+    >
+      Confirm
+    </dt-button>
+  </template>
+</dt-modal>
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
+'
+showHtmlWarning />
 
 ### Full Screen
 
@@ -157,19 +315,82 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
   <example-modal kind="full-screen" />
 </code-well-header>
 
-```html
-<aside class="d-modal d-modal--full" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
-  <div class="d-modal__dialog" role="document">
-    <h2 class="d-modal__header" id="modal-title">…</h2>
-    <p class="d-modal__content" id="modal-description">…</p>
+<code-example-tabs
+htmlCode='
+<button type="button" class="base-button__button d-btn d-btn--primary">
+  <span class="d-btn__label base-button__label"> Click to open </span>
+</button>
+<aside id="modal-base" class="d-modal d-m0 d-modal--full d-modal--animate-in" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="false">
+  <div class="d-modal__dialog d-modal__dialog--animate-in" role="document">
+    <h2 class="d-modal__header">
+      Example title
+    </h2>
+    <div class="d-modal__content">
+      <p id="modal-description">
+        Sed at orci quis nunc finibus gravida eget vitae est...
+      </p>
+      <p class="d-mt16"><a href="#" class="d-link">Show me a modal banner</a></p>
+    </div>
     <footer class="d-modal__footer">
-      <button class="d-btn" type="button">…</button>
-      <button class="d-btn d-btn--primary" type="button">…</button>
+      <button class="d-btn d-btn--primary" type="button">
+        Save changes
+      </button>
+      <button class="d-btn" type="button">
+        Cancel
+      </button>
     </footer>
-    <button href="#" class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close"><IconClose \></button>
+    <button class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close">
+      <span class="d-btn__icon">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
   </div>
 </aside>
-```
+'
+vueCode='
+<dt-modal
+  title="Example title"
+  close-button-props="Close"
+  :show="isOpen"
+  size="full"
+  copy="Sed at orci quis nunc finibus gravida eget vitae est..."
+  @update:show="updateShow"
+>
+  <template
+    #footer
+  >
+    <dt-button
+      id="cancel-button"
+      :kind="secondaryButtonKind"
+      importance="clear"
+    >
+      Cancel
+    </dt-button>
+    <dt-button
+      id="confirm-button"
+      :kind="$attrs.kind"
+      importance="primary"
+      class="d-ml6"
+    >
+      Confirm
+    </dt-button>
+  </template>
+</dt-modal>
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
+'
+showHtmlWarning />
 
 ### Has Banner
 
@@ -179,20 +400,83 @@ When there is a need of more context information regarding the content of the Mo
   <example-modal kind="default" bannerKind="success" bannerTitle="This banner can have different kinds." />
 </code-well-header>
 
-```html
-<aside class="d-modal" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
-  <div class="d-modal__banner d-modal__banner--success">...</div>
-  <div class="d-modal__dialog" role="document">
-    <h2 class="d-modal__header" id="modal-title">…</h2>
-    <p class="d-modal__content" id="modal-description">…</p>
+<code-example-tabs
+htmlCode='
+<button type="button" class="base-button__button d-btn d-btn--primary">
+  <span class="d-btn__label base-button__label"> Click to open </span>
+</button>
+<aside id="modal-base" class="d-modal d-m0 d-modal--animate-in" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="false">
+  <div class="d-modal__banner d-modal__banner--success">This banner can have different kinds.</div>
+  <div class="d-modal__dialog d-modal__dialog--animate-in" role="document">
+    <h2 class="d-modal__header">
+      Example title
+    </h2>
+    <div class="d-modal__content">
+      <p id="modal-description">
+        Sed at orci quis nunc finibus gravida eget vitae est...
+      </p>
+    </div>
     <footer class="d-modal__footer">
-      <button class="d-btn" type="button">…</button>
-      <button class="d-btn d-btn--primary" type="button">…</button>
+      <button class="d-btn d-btn--primary" type="button">
+        Save changes
+      </button>
+      <button class="d-btn" type="button">
+        Cancel
+      </button>
     </footer>
-    <button href="#" class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close"><IconClose /></button>
+    <button class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close">
+      <span class="d-btn__icon">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
   </div>
 </aside>
-```
+'
+vueCode='
+<dt-modal
+  title="Example title"
+  close-button-props="Close"
+  :show="isOpen"
+  banner-title="This banner can have different kinds."
+  banner-kind="success"
+  copy="Sed at orci quis nunc finibus gravida eget vitae est..."
+  @update:show="updateShow"
+>
+  <template
+    #footer
+  >
+    <dt-button
+      id="cancel-button"
+      :kind="secondaryButtonKind"
+      importance="clear"
+    >
+      Cancel
+    </dt-button>
+    <dt-button
+      id="confirm-button"
+      :kind="$attrs.kind"
+      importance="primary"
+      class="d-ml6"
+    >
+      Confirm
+    </dt-button>
+  </template>
+</dt-modal>
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
+'
+showHtmlWarning />
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/notice.md
+++ b/apps/dialtone-documentation/docs/components/notice.md
@@ -236,8 +236,8 @@ vueCode='
     <dt-button
       size="sm"
       importance="outlined"
-      :kind="buttonKind"
-      @click="$attrs.onClick"
+      kind="muted"
+      @click="onClick"
     >
       Action
     </dt-button>
@@ -259,8 +259,8 @@ vueCode='
     <dt-button
       size="sm"
       importance="outlined"
-      :kind="buttonKind"
-      @click="$attrs.onClick"
+      kind="muted"
+      @click="onClick"
     >
       Action
     </dt-button>
@@ -282,8 +282,8 @@ vueCode='
     <dt-button
       size="sm"
       importance="outlined"
-      :kind="buttonKind"
-      @click="$attrs.onClick"
+      kind="muted"
+      @click="onClick"
     >
       Action
     </dt-button>
@@ -305,8 +305,8 @@ vueCode='
     <dt-button
       size="sm"
       importance="outlined"
-      :kind="buttonKind"
-      @click="$attrs.onClick"
+      kind="muted"
+      @click="onClick"
     >
       Action
     </dt-button>
@@ -328,8 +328,8 @@ vueCode='
     <dt-button
       size="sm"
       importance="outlined"
-      :kind="buttonKind"
-      @click="$attrs.onClick"
+      kind="muted"
+      @click="onClick"
     >
       Action
     </dt-button>
@@ -555,8 +555,8 @@ vueCode='
     <dt-button
       size="sm"
       importance="outlined"
-      :kind="buttonKind"
-      @click="$attrs.onClick"
+      kind="inverted"
+      @click="onClick"
     >
       Action
     </dt-button>
@@ -579,8 +579,8 @@ vueCode='
     <dt-button
       size="sm"
       importance="outlined"
-      :kind="buttonKind"
-      @click="$attrs.onClick"
+      kind="inverted"
+      @click="onClick"
     >
       Action
     </dt-button>
@@ -603,8 +603,8 @@ vueCode='
     <dt-button
       size="sm"
       importance="outlined"
-      :kind="buttonKind"
-      @click="$attrs.onClick"
+      kind="inverted"
+      @click="onClick"
     >
       Action
     </dt-button>
@@ -627,8 +627,8 @@ vueCode='
     <dt-button
       size="sm"
       importance="outlined"
-      :kind="buttonKind"
-      @click="$attrs.onClick"
+      kind="inverted"
+      @click="onClick"
     >
       Action
     </dt-button>
@@ -651,8 +651,8 @@ vueCode='
     <dt-button
       size="sm"
       importance="outlined"
-      :kind="buttonKind"
-      @click="$attrs.onClick"
+      kind="inverted"
+      @click="onClick"
     >
       Action
     </dt-button>

--- a/apps/dialtone-documentation/docs/components/notice.md
+++ b/apps/dialtone-documentation/docs/components/notice.md
@@ -32,21 +32,311 @@ Used in most scenarios when the message should be noticeable but not dominate.
   <example-notice kind="warning" title="Warning title (optional)" />
 </code-well-header>
 
-```html
-<aside class="d-notice d-notice--base" role="status" aria-hidden="false">
-  <div class="d-notice__icon">...</div>
-  <div class="d-notice__content">
-    <h2 class="d-notice__title">...</h2>
-    <p class="d-notice__message">...</p>
+<code-example-tabs
+htmlCode='
+<aside class="d-notice d-notice--base">
+  <div aria-hidden="true" class="d-notice__icon">
+    <span class="d-icon__wrapper">
+      <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-400" style="display: none;">
+        <div
+          class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+          style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+        ></div>
+      </div>
+      <svg>...</svg>
+    </span>
   </div>
-  <div class="d-notice__actions">...</div>
+  <div class="d-notice__content" role="status">
+    <p class="d-notice__title">Base title (optional)</p>
+    <p class="d-notice__message">
+      <span> Message body with <a href="#" class="d-link d-link--muted">a link</a>. </span>
+    </p>
+  </div>
+  <div class="d-notice__actions">
+    <button type="button" class="base-button__button d-btn d-btn--outlined d-btn--muted d-btn--sm">
+      <span class="d-btn__label base-button__label"> Action </span>
+    </button>
+    <button type="button" aria-label="Close" class="base-button__button d-btn d-btn--sm d-btn--circle d-btn--icon-only">
+      <span class="base-button__icon d-btn__icon d-btn__icon--left">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-200" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
+  </div>
 </aside>
-
-<aside class="d-notice d-notice--error" role="status" aria-hidden="false">...</aside>
-<aside class="d-notice d-notice--info" role="status" aria-hidden="false">...</aside>
-<aside class="d-notice d-notice--success" role="status" aria-hidden="false">...</aside>
-<aside class="d-notice d-notice--warning" role="status" aria-hidden="false">...</aside>
-```
+<aside class="d-notice d-notice--info">
+  <div aria-hidden="true" class="d-notice__icon">
+    <span class="d-icon__wrapper">
+      <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-400" style="display: none;">
+        <div
+          class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+          style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+        ></div>
+      </div>
+      <svg>...</svg>
+    </span>
+  </div>
+  <div class="d-notice__content" role="status">
+    <p class="d-notice__title">Info title (optional)</p>
+    <p class="d-notice__message">
+      <span> Message body with <a href="#" class="d-link d-link--muted">a link</a>. </span>
+    </p>
+  </div>
+  <div class="d-notice__actions">
+    <button type="button" class="base-button__button d-btn d-btn--outlined d-btn--muted d-btn--sm">
+      <span class="d-btn__label base-button__label"> Action </span>
+    </button>
+    <button type="button" aria-label="Close" class="base-button__button d-btn d-btn--sm d-btn--circle d-btn--icon-only">
+      <span class="base-button__icon d-btn__icon d-btn__icon--left">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-200" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
+  </div>
+</aside>
+<aside class="d-notice d-notice--error">
+  <div aria-hidden="true" class="d-notice__icon">
+    <span class="d-icon__wrapper">
+      <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-400" style="display: none;">
+        <div
+          class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+          style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+        ></div>
+      </div>
+      <svg>...</svg>
+    </span>
+  </div>
+  <div class="d-notice__content" role="status">
+    <p class="d-notice__title">Error title (optional)</p>
+    <p class="d-notice__message">
+      <span> Message body with <a href="#" class="d-link d-link--muted">a link</a>. </span>
+    </p>
+  </div>
+  <div class="d-notice__actions">
+    <button type="button" class="base-button__button d-btn d-btn--outlined d-btn--muted d-btn--sm">
+      <span class="d-btn__label base-button__label"> Action </span>
+    </button>
+    <button type="button" aria-label="Close" class="base-button__button d-btn d-btn--sm d-btn--circle d-btn--icon-only">
+      <span class="base-button__icon d-btn__icon d-btn__icon--left">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-200" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
+  </div>
+</aside>
+<aside class="d-notice d-notice--success">
+  <div aria-hidden="true" class="d-notice__icon">
+    <span class="d-icon__wrapper">
+      <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-400" style="display: none;">
+        <div
+          class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+          style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+        ></div>
+      </div>
+      <svg>...</svg>
+    </span>
+  </div>
+  <div class="d-notice__content" role="status">
+    <p class="d-notice__title">Success title (optional)</p>
+    <p class="d-notice__message">
+      <span> Message body with <a href="#" class="d-link d-link--muted">a link</a>. </span>
+    </p>
+  </div>
+  <div class="d-notice__actions">
+    <button type="button" class="base-button__button d-btn d-btn--outlined d-btn--muted d-btn--sm">
+      <span class="d-btn__label base-button__label"> Action </span>
+    </button>
+    <button type="button" aria-label="Close" class="base-button__button d-btn d-btn--sm d-btn--circle d-btn--icon-only">
+      <span class="base-button__icon d-btn__icon d-btn__icon--left">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-200" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
+  </div>
+</aside>
+<aside class="d-notice d-notice--warning">
+  <div aria-hidden="true" class="d-notice__icon">
+    <span class="d-icon__wrapper">
+      <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-400" style="display: none;">
+        <div
+          class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+          style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+        ></div>
+      </div>
+      <svg>...</svg>
+    </span>
+  </div>
+  <div class="d-notice__content" role="status">
+    <p class="d-notice__title">Warning title (optional)</p>
+    <p class="d-notice__message">
+      <span> Message body with <a href="#" class="d-link d-link--muted">a link</a>. </span>
+    </p>
+  </div>
+  <div class="d-notice__actions">
+    <button type="button" class="base-button__button d-btn d-btn--outlined d-btn--muted d-btn--sm">
+      <span class="d-btn__label base-button__label"> Action </span>
+    </button>
+    <button type="button" aria-label="Close" class="base-button__button d-btn d-btn--sm d-btn--circle d-btn--icon-only">
+      <span class="base-button__icon d-btn__icon d-btn__icon--left">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-200" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
+  </div>
+</aside>
+'
+vueCode='
+<dt-notice
+  title="Base title (optional)"
+>
+  <span>
+    Message body with
+    <a
+      href="#"
+      class="d-link"
+      :class="linkClass"
+    >a link</a>.
+  </span>
+  <template #action>
+    <dt-button
+      size="sm"
+      importance="outlined"
+      :kind="buttonKind"
+      @click="$attrs.onClick"
+    >
+      Action
+    </dt-button>
+  </template>
+</dt-notice>
+<dt-notice
+  title="Info title (optional)"
+  kind="info"
+>
+  <span>
+    Message body with
+    <a
+      href="#"
+      class="d-link"
+      :class="linkClass"
+    >a link</a>.
+  </span>
+  <template #action>
+    <dt-button
+      size="sm"
+      importance="outlined"
+      :kind="buttonKind"
+      @click="$attrs.onClick"
+    >
+      Action
+    </dt-button>
+  </template>
+</dt-notice>
+<dt-notice
+  title="Error title (optional)"
+  kind="error"
+>
+  <span>
+    Message body with
+    <a
+      href="#"
+      class="d-link"
+      :class="linkClass"
+    >a link</a>.
+  </span>
+  <template #action>
+    <dt-button
+      size="sm"
+      importance="outlined"
+      :kind="buttonKind"
+      @click="$attrs.onClick"
+    >
+      Action
+    </dt-button>
+  </template>
+</dt-notice>
+<dt-notice
+  title="Success title (optional)"
+  kind="success"
+>
+  <span>
+    Message body with
+    <a
+      href="#"
+      class="d-link"
+      :class="linkClass"
+    >a link</a>.
+  </span>
+  <template #action>
+    <dt-button
+      size="sm"
+      importance="outlined"
+      :kind="buttonKind"
+      @click="$attrs.onClick"
+    >
+      Action
+    </dt-button>
+  </template>
+</dt-notice>
+<dt-notice
+  title="Warning title (optional)"
+  kind="warning"
+>
+  <span>
+    Message body with
+    <a
+      href="#"
+      class="d-link"
+      :class="linkClass"
+    >a link</a>.
+  </span>
+  <template #action>
+    <dt-button
+      size="sm"
+      importance="outlined"
+      :kind="buttonKind"
+      @click="$attrs.onClick"
+    >
+      Action
+    </dt-button>
+  </template>
+</dt-notice>
+'
+showHtmlWarning />
 
 ### Important
 
@@ -60,22 +350,316 @@ Used occasionally in scenarios when the message needs to dominate.
   <example-notice important kind="warning" title="Warning title (optional)" />
 </code-well-header>
 
-```html
-<aside class="d-notice d-notice--base d-notice--important" role="alert" aria-hidden="false">
-  <div class="d-notice__icon">...</div>
-  <div class="d-notice__content">
-    <h2 class="d-notice__title">...</h2>
-    <p class="d-notice__message">...</p>
+<code-example-tabs
+htmlCode='
+<aside class="d-notice d-notice--base d-notice--important">
+  <div aria-hidden="true" class="d-notice__icon">
+    <span class="d-icon__wrapper">
+      <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-400" style="display: none;">
+        <div
+          class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+          style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+        ></div>
+      </div>
+      <svg>...</svg>
+    </span>
   </div>
-  <div class="d-notice__actions">...</div>
+  <div class="d-notice__content" role="status">
+    <p class="d-notice__title">Base title (optional)</p>
+    <p class="d-notice__message">
+      <span> Message body with <a href="#" class="d-link d-link--muted">a link</a>. </span>
+    </p>
+  </div>
+  <div class="d-notice__actions">
+    <button type="button" class="base-button__button d-btn d-btn--outlined d-btn--muted d-btn--sm">
+        <span class="d-btn__label base-button__label"> Action </span>
+    </button>
+    <button type="button" aria-label="Close" class="base-button__button d-btn d-btn--sm d-btn--circle d-btn--icon-only">
+      <span class="base-button__icon d-btn__icon d-btn__icon--left">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-200" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
+  </div>
 </aside>
-
-<aside class="d-notice d-notice--error d-notice--important" role="alert" aria-hidden="false">…</aside>
-<aside class="d-notice d-notice--info d-notice--important" role="alert" aria-hidden="false">…</aside>
-<aside class="d-notice d-notice--success d-notice--important" role="alert" aria-hidden="false">…</aside>
-<aside class="d-notice d-notice--warning d-notice--important" role="alert" aria-hidden="false">…</aside>
-```
-
+<aside class="d-notice d-notice--info d-notice--important">
+  <div aria-hidden="true" class="d-notice__icon">
+    <span class="d-icon__wrapper">
+      <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-400" style="display: none;">
+        <div
+          class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+          style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+        ></div>
+      </div>
+      <svg>...</svg>
+    </span>
+  </div>
+  <div class="d-notice__content" role="status">
+    <p class="d-notice__title">Info title (optional)</p>
+    <p class="d-notice__message">
+      <span> Message body with <a href="#" class="d-link d-link--muted">a link</a>. </span>
+    </p>
+  </div>
+  <div class="d-notice__actions">
+    <button type="button" class="base-button__button d-btn d-btn--outlined d-btn--muted d-btn--sm">
+        <span class="d-btn__label base-button__label"> Action </span>
+    </button>
+    <button type="button" aria-label="Close" class="base-button__button d-btn d-btn--sm d-btn--circle d-btn--icon-only">
+      <span class="base-button__icon d-btn__icon d-btn__icon--left">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-200" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
+  </div>
+</aside>
+<aside class="d-notice d-notice--error d-notice--important">
+  <div aria-hidden="true" class="d-notice__icon">
+    <span class="d-icon__wrapper">
+      <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-400" style="display: none;">
+        <div
+          class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+          style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+        ></div>
+      </div>
+      <svg>...</svg>
+    </span>
+  </div>
+  <div class="d-notice__content" role="status">
+    <p class="d-notice__title">Error title (optional)</p>
+    <p class="d-notice__message">
+      <span> Message body with <a href="#" class="d-link d-link--muted">a link</a>. </span>
+    </p>
+  </div>
+  <div class="d-notice__actions">
+    <button type="button" class="base-button__button d-btn d-btn--outlined d-btn--muted d-btn--sm">
+        <span class="d-btn__label base-button__label"> Action </span>
+    </button>
+    <button type="button" aria-label="Close" class="base-button__button d-btn d-btn--sm d-btn--circle d-btn--icon-only">
+      <span class="base-button__icon d-btn__icon d-btn__icon--left">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-200" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
+  </div>
+</aside>
+<aside class="d-notice d-notice--success d-notice--important">
+  <div aria-hidden="true" class="d-notice__icon">
+    <span class="d-icon__wrapper">
+      <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-400" style="display: none;">
+        <div
+          class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+          style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+        ></div>
+      </div>
+      <svg>...</svg>
+    </span>
+  </div>
+  <div class="d-notice__content" role="status">
+    <p class="d-notice__title">Success title (optional)</p>
+    <p class="d-notice__message">
+      <span> Message body with <a href="#" class="d-link d-link--muted">a link</a>. </span>
+    </p>
+  </div>
+  <div class="d-notice__actions">
+    <button type="button" class="base-button__button d-btn d-btn--outlined d-btn--muted d-btn--sm">
+        <span class="d-btn__label base-button__label"> Action </span>
+    </button>
+    <button type="button" aria-label="Close" class="base-button__button d-btn d-btn--sm d-btn--circle d-btn--icon-only">
+      <span class="base-button__icon d-btn__icon d-btn__icon--left">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-200" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
+  </div>
+</aside>
+<aside class="d-notice d-notice--warning d-notice--important">
+  <div aria-hidden="true" class="d-notice__icon">
+    <span class="d-icon__wrapper">
+      <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-400" style="display: none;">
+        <div
+          class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+          style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+        ></div>
+      </div>
+      <svg>...</svg>
+    </span>
+  </div>
+  <div class="d-notice__content" role="status">
+    <p class="d-notice__title">Warning title (optional)</p>
+    <p class="d-notice__message">
+      <span> Message body with <a href="#" class="d-link d-link--muted">a link</a>. </span>
+    </p>
+  </div>
+  <div class="d-notice__actions">
+    <button type="button" class="base-button__button d-btn d-btn--outlined d-btn--muted d-btn--sm">
+        <span class="d-btn__label base-button__label"> Action </span>
+    </button>
+    <button type="button" aria-label="Close" class="base-button__button d-btn d-btn--sm d-btn--circle d-btn--icon-only">
+      <span class="base-button__icon d-btn__icon d-btn__icon--left">
+        <span class="d-icon__wrapper">
+          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-200" style="display: none;">
+            <div
+              class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            ></div>
+          </div>
+          <svg>...</svg>
+        </span>
+      </span>
+    </button>
+  </div>
+</aside>
+'
+vueCode='
+<dt-notice
+  title="Base title (optional)"
+  important
+>
+  <span>
+    Message body with
+    <a
+      href="#"
+      class="d-link"
+      :class="linkClass"
+    >a link</a>.
+  </span>
+  <template #action>
+    <dt-button
+      size="sm"
+      importance="outlined"
+      :kind="buttonKind"
+      @click="$attrs.onClick"
+    >
+      Action
+    </dt-button>
+  </template>
+</dt-notice>
+<dt-notice
+  title="Info title (optional)"
+  kind="info"
+  important
+>
+  <span>
+    Message body with
+    <a
+      href="#"
+      class="d-link"
+      :class="linkClass"
+    >a link</a>.
+  </span>
+  <template #action>
+    <dt-button
+      size="sm"
+      importance="outlined"
+      :kind="buttonKind"
+      @click="$attrs.onClick"
+    >
+      Action
+    </dt-button>
+  </template>
+</dt-notice>
+<dt-notice
+  title="Error title (optional)"
+  kind="error"
+  important
+>
+  <span>
+    Message body with
+    <a
+      href="#"
+      class="d-link"
+      :class="linkClass"
+    >a link</a>.
+  </span>
+  <template #action>
+    <dt-button
+      size="sm"
+      importance="outlined"
+      :kind="buttonKind"
+      @click="$attrs.onClick"
+    >
+      Action
+    </dt-button>
+  </template>
+</dt-notice>
+<dt-notice
+  title="Success title (optional)"
+  kind="success"
+  important
+>
+  <span>
+    Message body with
+    <a
+      href="#"
+      class="d-link"
+      :class="linkClass"
+    >a link</a>.
+  </span>
+  <template #action>
+    <dt-button
+      size="sm"
+      importance="outlined"
+      :kind="buttonKind"
+      @click="$attrs.onClick"
+    >
+      Action
+    </dt-button>
+  </template>
+</dt-notice>
+<dt-notice
+  title="Warning title (optional)"
+  kind="warning"
+  important
+>
+  <span>
+    Message body with
+    <a
+      href="#"
+      class="d-link"
+      :class="linkClass"
+    >a link</a>.
+  </span>
+  <template #action>
+    <dt-button
+      size="sm"
+      importance="outlined"
+      :kind="buttonKind"
+      @click="$attrs.onClick"
+    >
+      Action
+    </dt-button>
+  </template>
+</dt-notice>
+'
+showHtmlWarning />
 ## Vue API
 
 <component-vue-api component-name="notice" />

--- a/apps/dialtone-documentation/docs/components/pagination.md
+++ b/apps/dialtone-documentation/docs/components/pagination.md
@@ -18,6 +18,85 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   />
 </code-well-header>
 
+<code-example-tabs
+htmlCode='
+<nav aria-label="Pagination" class="d-pagination">
+  <button class="base-button__button d-btn d-btn--primary d-btn--icon-only d-pagination__button d-fc-black-300 d-bgc-transparent" type="button" disabled="" aria-label="Previous page">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">
+      <span class="d-icon__wrapper">
+        <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
+          <div
+            class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+            style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+          ></div>
+        </div>
+        <svg>...</svg>
+      </span>
+    </span>
+  </button>
+  <div class="">
+    <button class="base-button__button d-btn d-btn--primary" type="button">
+        <span class="d-btn__label base-button__label">1</span>
+    </button>
+  </div>
+  <div class="">
+    <button class="base-button__button d-btn d-btn--muted" type="button">
+        <span class="d-btn__label base-button__label">2</span>
+    </button>
+  </div>
+  <div class="">
+    <button class="base-button__button d-btn d-btn--muted" type="button">
+        <span class="d-btn__label base-button__label">3</span>
+    </button>
+  </div>
+  <div class="">
+    <button class="base-button__button d-btn d-btn--muted" type="button">
+        <span class="d-btn__label base-button__label">4</span>
+    </button>
+  </div>
+  <div class="d-pagination__separator">
+    <div class="d-pagination__separator-icon" >
+      <span class="d-icon__wrapper">
+        <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
+          <div
+            class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+            style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+          ></div>
+        </div>
+        <svg>...</svg>
+      </span>
+    </div>
+  </div>
+  <div class="">
+    <button class="base-button__button d-btn d-btn--muted" type="button">
+        <span class="d-btn__label base-button__label">25</span>
+    </button>
+  </div>
+  <button class="base-button__button d-btn d-btn--muted d-btn--icon-only d-pagination__button d-fc-tertiary" type="button" aria-label="Next page">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">
+      <span class="d-icon__wrapper">
+        <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
+          <div
+            class="skeleton-placeholder d-bar-circle skeleton-placeholder--animate"
+            style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+          ></div>
+        </div>
+        <svg>...</svg>
+      </span>
+    </span>
+  </button>
+</nav>
+'
+vueCode='
+<dt-pagination
+  :total-pages="25"
+  aria-label="Pagination"
+  prev-aria-label="Previous page"
+  next-aria-label="Next page"
+/>
+'
+showHtmlWarning />
+
 ## Vue API
 
 <component-vue-api component-name="pagination" />


### PR DESCRIPTION
# use CodeExampleTabs from Link to Pagination

Jira ticket: [DLT-1576](https://dialpad.atlassian.net/browse/DLT-1576)

link: Belu will update this one.
list-item: [Preview](https://dialtone.dialpad.com/deploy-previews/pr-261/components/list-item.html)
modal: [Preview](https://dialtone.dialpad.com/deploy-previews/pr-261/components/modal.html)
notice: [Preview](https://dialtone.dialpad.com/deploy-previews/pr-261/components/notice.html)
pagination: [Preview](https://dialtone.dialpad.com/deploy-previews/pr-261/components/pagination.html
)

--------

<img width="990" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/c5e8f2cf-00e8-44d8-b965-02b77c59ae4e">

<img width="990" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/e9db5a27-b8a3-42b5-ab35-1be10592d54d">




[DLT-1576]: https://dialpad.atlassian.net/browse/DLT-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ