### PR TITLE
fix: NO-JIRA add cjs support for dialtone-emojis

### DIFF
--- a/packages/dialtone-emojis/index.cjs
+++ b/packages/dialtone-emojis/index.cjs
@@ -1,0 +1,61 @@
+'use strict';
+
+const ActivityDefault = require('./src/activity-default.json');
+const ActivityLight = require('./src/activity-light.json');
+const ActivityMediumLight = require('./src/activity-medium-light.json');
+const ActivityMedium = require('./src/activity-medium.json');
+const ActivityMediumDark = require('./src/activity-medium-dark.json');
+const ActivityDark = require('./src/activity-dark.json');
+const Flags = require('./src/flags.json');
+const Food = require('./src/food.json');
+const Nature = require('./src/nature.json');
+const ObjectsDefault = require('./src/objects-default.json');
+const ObjectsLight = require('./src/objects-light.json');
+const ObjectsMediumLight = require('./src/objects-medium-light.json');
+const ObjectsMedium = require('./src/objects-medium.json');
+const ObjectsMediumDark = require('./src/objects-medium-dark.json');
+const ObjectsDark = require('./src/objects-dark.json');
+const PeopleDefault = require('./src/people-default.json');
+const PeopleLight = require('./src/people-light.json');
+const PeopleMediumLight = require('./src/people-medium-light.json');
+const PeopleMedium = require('./src/people-medium.json');
+const PeopleMediumDark = require('./src/people-medium-dark.json');
+const PeopleDark = require('./src/people-dark.json');
+const Symbols = require('./src/symbols.json');
+const Travel = require('./src/travel.json');
+
+const emojisGrouped = {
+  ActivityDefault,
+  ActivityLight,
+  ActivityMediumLight,
+  ActivityMedium,
+  ActivityMediumDark,
+  ActivityDark,
+  Flags,
+  Food,
+  Nature,
+  ObjectsDefault,
+  ObjectsLight,
+  ObjectsMediumLight,
+  ObjectsMedium,
+  ObjectsMediumDark,
+  ObjectsDark,
+  PeopleDefault,
+  PeopleLight,
+  PeopleMediumLight,
+  PeopleMedium,
+  PeopleMediumDark,
+  PeopleDark,
+  Symbols,
+  Travel,
+};
+
+const emojisIndexed = [].concat(...Object.values(emojisGrouped)).reduce((accumulator, item) => {
+  accumulator[item.unicode_character] = item;
+  return accumulator;
+}, {});
+
+module.exports = {
+  emojisGrouped,
+  emojisIndexed
+}

--- a/packages/dialtone-emojis/package.json
+++ b/packages/dialtone-emojis/package.json
@@ -38,5 +38,6 @@
   "files": [
     "src"
   ],
-  "main": "index.js"
+  "main": "index.cjs",
+  "module": "index.js"
 }


### PR DESCRIPTION
# Add CJS support for dialtone-emojis

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZTVueGE2MW04NzkwZnNyNHNqZnc3dWk3MGx1MG82bWx6cHJvaHUxaiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3luQu2Q8wfIVZiqSHq/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Description

- Converted ESM index.js to CJS, did this manually as currently dialtone-emojis doesn't have a bundler setup

## :bulb: Context

DPM needs CJS on tests, and dialtone-emojis doesn't have CJS support it'd not work.

## :pencil: Checklist

For all PRs:

- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

- Release and update on DPM
- Add gulp to dialtone-emojis to transform ESM to CJS automatically