### PR TITLE
fix(combobox): NO-JIRA remove bad validation

### DIFF
--- a/packages/dialtone-vue2/components/combobox/combobox.vue
+++ b/packages/dialtone-vue2/components/combobox/combobox.vue
@@ -401,7 +401,7 @@ export default {
     validateEmptyListProps () {
       if (this.$slots.emptyListItem) { return; }
 
-      if ((this.emptyList && !this.emptyStateMessage) || (!this.emptyList && this.emptyStateMessage)) {
+      if (this.emptyList && !this.emptyStateMessage) {
         console.error(`Invalid props: you must pass both props emptyList and emptyStateMessage to show the
       empty message.`);
       }

--- a/packages/dialtone-vue3/components/combobox/combobox.vue
+++ b/packages/dialtone-vue3/components/combobox/combobox.vue
@@ -402,7 +402,7 @@ export default {
     validateEmptyListProps () {
       if (this.$slots.emptyListItem) { return; }
 
-      if ((this.emptyList && !this.emptyStateMessage) || (!this.emptyList && this.emptyStateMessage)) {
+      if (this.emptyList && !this.emptyStateMessage) {
         console.error(`Invalid props: you must pass both props emptyList and emptyStateMessage to show the
       empty message.`);
       }


### PR DESCRIPTION
# fix(combobox): remove bad validation

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmx2NndxdjBtOHZkNWNiZGx1dmZhcmx5OGt3ZmhoZWo3cWU3ZjFmMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/GxmqepIBKZEa25dkpP/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-92013

## :book: Description

Remove unnecessary validation in combobox

## :bulb: Context

It makes sense to validate that there is a emptyStateMessage set when emptyList is shown, but you should be allowed to have an emptyStateMessage when emptyList is not shown. Removed this validation.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
