### PR TITLE
fix(emoji): NO-JIRA alignment in vue 3

### DIFF
--- a/packages/dialtone-vue3/components/emoji/emoji.vue
+++ b/packages/dialtone-vue3/components/emoji/emoji.vue
@@ -1,5 +1,5 @@
 <template>
-  <span class="d-emoji__wrapper">
+  <span :class="['d-emoji', 'd-icon', emojiSize]">
     <dt-skeleton
       v-show="imgLoading && showSkeleton"
       :offset="0"


### PR DESCRIPTION
# fix(emoji): NO-JIRA alignment in vue 3

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWZkajZnM2JneHpkbGIxYWpnYWRvcXc1M3Nqa3prN2txeG95eXI4ZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/7H8IhoxzqhJtJ07R6T/giphy-downsized-large.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Looks like at some point we made a change to emoji in vue 2 and it wasn't made in vue 3. This should fix it.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

## :camera: Screenshots / GIFs

Before:
![Screenshot 2024-04-12 at 2 23 39 PM](https://github.com/dialpad/dialtone/assets/64808812/e1f71fde-29d2-4a52-9b21-3592c6c0c0b9)

After:
![Screenshot 2024-04-12 at 2 23 43 PM](https://github.com/dialpad/dialtone/assets/64808812/b16d7f94-a422-4e00-9400-be5f829188e2)

