### PR TITLE
fix(message-input): DLT-1714 limit file type on image picker

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -76,6 +76,7 @@
             <dt-input
               ref="messageInputImageUpload"
               data-qa="dt-message-input-image-input"
+              accept="image/*, video/*"
               type="file"
               class="d-ps-absolute"
               multiple

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -76,6 +76,7 @@
             <dt-input
               ref="messageInputImageUpload"
               data-qa="dt-message-input-image-input"
+              accept="image/*, video/*"
               type="file"
               class="d-ps-absolute"
               multiple


### PR DESCRIPTION
# fix(message-input): DLT-1714 limit file type on image picker

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaWljcmpnYWZsa21pOTBjYzFzcXVieDFqejF6eDF1MzdlajU4Z3h5MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MuztdWJQ4PR7i/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-1714
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
This pr adds _accept_ parameter for the input on the message_input component so we can limit the file types the file input should accept. Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept

## :bulb: Context
Currently, on Dialpad app we only allow sending images and videos, no PDFs or other file types. Also as the icon is an Image I think is correct to limit it to only allow images and videos.
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
