### PR TITLE
fix: NO-JIRA icons build process

### DIFF
--- a/apps/dialtone-documentation/project.json
+++ b/apps/dialtone-documentation/project.json
@@ -1,6 +1,5 @@
 {
   "name": "dialtone-documentation",
-  "implicitDependencies": ["dialtone-icons-vue3"],
   "targets": {
     "build-docs": {
       "executor": "nx:run-script",

--- a/packages/dialtone-icons/package.json
+++ b/packages/dialtone-icons/package.json
@@ -2,9 +2,6 @@
   "name": "@dialpad/dialtone-icons",
   "version": "4.13.1",
   "description": "Dialtone icon library",
-  "scripts": {
-    "build": "gulp"
-  },
   "files": [
     "dist",
     "vue2/dist",

--- a/packages/dialtone-icons/project.json
+++ b/packages/dialtone-icons/project.json
@@ -2,11 +2,21 @@
   "name": "dialtone-icons",
   "targets": {
     "build": {
-      "executor": "nx:run-script",
+      "executor": "nx:run-commands",
       "options": {
-        "script": "build"
+        "cwd": "{projectRoot}",
+        "commands": [
+          {
+            "command": "gulp"
+          },
+          {
+            "command": "nx run-many --target=build --projects=dialtone-icons-vue2,dialtone-icons-vue3 --parallel=2"
+          }
+        ],
+        "parallel": false
       },
-      "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/transformSVGtoVue.cjs", "{projectRoot}/gulpfile.cjs"]
+      "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/transformSVGtoVue.cjs", "{projectRoot}/gulpfile.cjs"],
+      "outputs": ["{projectRoot}/src/icons", "{projectRoot}/dist", "{projectRoot}/vue2/dist", "{projectRoot}/vue3/dist"]
     },
     "publish": {
       "executor": "nx:run-commands",

--- a/packages/dialtone-icons/vue2/project.json
+++ b/packages/dialtone-icons/vue2/project.json
@@ -1,11 +1,10 @@
 {
   "name": "dialtone-icons-vue2",
-  "implicitDependencies": ["dialtone-icons"],
   "targets": {
     "build": {
       "executor": "nx:run-script",
-      "inputs": ["{workspaceRoot}/packages/dialtone-icons/src/icons/*.vue"],
-      "outputs": ["{workspaceRoot}/packages/dialtone-icons/dist"],
+      "inputs": ["{workspaceRoot}/packages/dialtone-icons/src/icons/*"],
+      "outputs": ["{projectRoot}/dist"],
       "options": {
         "script": "build"
       }

--- a/packages/dialtone-icons/vue2/vite.config.js
+++ b/packages/dialtone-icons/vue2/vite.config.js
@@ -23,7 +23,6 @@ export default defineConfig({
       external: ['vue'],
       output: {
         minifyInternalExports: true,
-        sourcemap: true,
       },
     },
     minify: true,

--- a/packages/dialtone-icons/vue3/project.json
+++ b/packages/dialtone-icons/vue3/project.json
@@ -1,11 +1,10 @@
 {
   "name": "dialtone-icons-vue3",
-  "implicitDependencies": ["dialtone-icons"],
   "targets": {
     "build": {
       "executor": "nx:run-script",
-      "inputs": ["{workspaceRoot}/packages/dialtone-icons/src/icons/*.vue"],
-      "outputs": ["{workspaceRoot}/packages/dialtone-icons/dist"],
+      "inputs": ["{workspaceRoot}/packages/dialtone-icons/src/icons/*"],
+      "outputs": ["{projectRoot}/dist"],
       "options": {
         "script": "build"
       }

--- a/packages/dialtone-icons/vue3/vite.config.js
+++ b/packages/dialtone-icons/vue3/vite.config.js
@@ -23,7 +23,6 @@ export default defineConfig({
       external: ['vue'],
       output: {
         minifyInternalExports: true,
-        sourcemap: true,
       },
     },
     minify: true,

--- a/packages/dialtone-tokens/project.json
+++ b/packages/dialtone-tokens/project.json
@@ -28,6 +28,6 @@
       "options": {
         "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-tokens/release-local.config.cjs"
       }
-    },
+    }
   }
 }

--- a/packages/dialtone-vue2/project.json
+++ b/packages/dialtone-vue2/project.json
@@ -1,6 +1,5 @@
 {
   "name": "dialtone-vue2",
-  "implicitDependencies": ["dialtone-icons-vue2"],
   "targets": {
     "build": {
       "executor": "nx:run-script",

--- a/packages/dialtone-vue3/project.json
+++ b/packages/dialtone-vue3/project.json
@@ -1,6 +1,5 @@
 {
   "name": "dialtone-vue3",
-  "implicitDependencies": ["dialtone-icons-vue3"],
   "targets": {
     "build": {
       "executor": "nx:run-script",

--- a/percy.base_config.cjs
+++ b/percy.base_config.cjs
@@ -66,4 +66,13 @@ module.exports = {
     enableJavaScript: true,
     widths: [1280],
   },
+  discovery: {
+    disableCache: true,
+    allowedHostnames: [
+      'proxyme.percy.io',
+      'render.percy.local',
+    ],
+    networkIdleTimeout: 150,
+    concurrency: 1,
+  },
 };

--- a/project.json
+++ b/project.json
@@ -2,8 +2,6 @@
   "name": "dialtone",
   "implicitDependencies": [
     "dialtone-css",
-    "dialtone-icons-vue2",
-    "dialtone-icons-vue3",
     "dialtone-tokens",
     "dialtone-vue2",
     "dialtone-vue3",


### PR DESCRIPTION
# Fix icons build process

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGRvYXp4cnFycWw4M2p4MW1tM3NuMTM3NHExcmg0MDVpdjh2ejI5dyZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/3gOFmePWIquBEKqbYe/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Description

- Changed the logic to build icons, after #278 I missed to build dialtone-icons-vue2 and dialtone-icons-vue3.
- Now should be easier to build dialtone-icons and it'd build dialtone-icons-vue2 and dialtone-icons-vue3 in parallel and cache automatically.
- Added Percy config back to make tests reliable again.

## :bulb: Context

A version of dialtone-icons was realease and it didn't included the vue2 and vue3 icons build.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.