### PR TITLE
feat: DP-91907 add leftbar contact centers recipe

### DIFF
--- a/packages/dialtone-vue2/index.js
+++ b/packages/dialtone-vue2/index.js
@@ -84,6 +84,7 @@ export * from './recipes/conversation_view/time_pill';
 export * from './recipes/header/settings_menu_button';
 export * from './recipes/item_layout/contact_info';
 export * from './recipes/leftbar/callbox';
+export * from './recipes/leftbar/contact_centers_row';
 export * from './recipes/leftbar/contact_row';
 export * from './recipes/leftbar/general_row';
 export * from './recipes/leftbar/group_row';

--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row.mdx
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row.mdx
@@ -1,0 +1,50 @@
+import { Canvas, Story, Subtitle, Controls, Meta } from '@storybook/blocks';
+import * as ContactCentersRowStories from './contact_centers_row.stories.js';
+
+<Meta of={ContactCentersRowStories}/>
+
+# Contact Centers Row
+
+<Subtitle>
+  This component covers the Ai Contact Centers leftbar row that will contain complex controls in the same row.
+</Subtitle>
+
+## Base Style
+
+<Canvas>
+  <Story of={ContactCentersRowStories.Default} />
+</Canvas>
+
+
+## Off duty agent
+
+<Canvas>
+  <Story of={ContactCentersRowStories.OffDuty} />
+</Canvas>
+
+## Variants
+
+<Canvas>
+  <Story of={ContactCentersRowStories.Variants} />
+</Canvas>
+
+## Slots, Props & Events
+
+<Controls />
+
+## Usage
+
+### Import
+
+```js
+import { DtRecipeContactCentersRow } from '@dialpad/dialtone-vue';
+```
+
+### Simple Ai Contact Centers row
+
+```html
+<dt-recipe-contact-centers-row
+  description="Channel name"
+  unread-count="29"
+/>
+```

--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row.stories.js
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row.stories.js
@@ -1,0 +1,107 @@
+import { action } from '@storybook/addon-actions';
+import { createRenderConfig } from '@/common/storybook_utils';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
+import DtRecipeContactCentersRowDefaultTemplate from './contact_centers_row_default.story.vue';
+import DtRecipeContactCentersRowOffDutyTemplate from './contact_centers_row_off_duty.story.vue';
+import DtRecipeContactCentersRowVariantsTemplate from './contact_centers_row_variants.story.vue';
+
+// Default Prop Values
+export const argsData = {
+  description: 'Ai Contact Centers',
+  menuButtonAriaLabel: 'Menu button',
+  click: action('click'),
+  clickMenu: action('click-menu'),
+};
+
+export const argTypesData = {
+  // Slots
+  right: {
+    name: 'right',
+    description: 'Slot right hand side content. Ex. agent on duty status component',
+    table: {
+      category: 'slots',
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'text',
+    },
+  },
+
+  timer: {
+    name: 'timer',
+    description: 'Slot displayed at the bottom of the row. Ex. agent off duty timer',
+    table: {
+      category: 'slots',
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'text',
+    },
+  },
+
+  // Action Event Handlers
+  click: {
+    description: 'Native click event on the row itself',
+    table: {
+      category: 'events',
+      type: { summary: 'event' },
+    },
+  },
+
+  'click-menu': {
+    description: 'Native click event on the menu button',
+    table: {
+      category: 'events',
+      type: { summary: 'event' },
+    },
+  },
+
+  clickMenu: {
+    table: {
+      disable: true,
+    },
+  },
+};
+
+const decorator = () => ({
+  template: `<div style="background-color: var(--dt-theme-sidebar-color-background)" class="d-wmx264 d-p8"><story />
+  </div>`,
+});
+
+// Story Collection
+export default {
+  title: 'Recipes/Leftbar/Contact Centers Row',
+  component: DtRecipeContactCentersRow,
+  args: argsData,
+  argTypes: argTypesData,
+  decorators: [decorator],
+  excludeStories: /.*Data$/,
+};
+
+export const Default = {
+  render: (argsData) => createRenderConfig(
+    DtRecipeContactCentersRow,
+    DtRecipeContactCentersRowDefaultTemplate,
+    argsData,
+  ),
+  args: {},
+};
+
+export const OffDuty = {
+  render: (argsData) => createRenderConfig(
+    DtRecipeContactCentersRow,
+    DtRecipeContactCentersRowOffDutyTemplate,
+    argsData,
+  ),
+  args: {},
+};
+
+export const Variants = {
+  render: (argsData) => createRenderConfig(
+    DtRecipeContactCentersRow,
+    DtRecipeContactCentersRowVariantsTemplate,
+    argsData,
+  ),
+  args: {},
+  parameters: { options: { showPanel: false }, controls: { disable: true } },
+};

--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row.test.js
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row.test.js
@@ -1,0 +1,104 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
+
+// Constants
+const basePropsData = {
+  description: 'Ai Contact Centers',
+  menuButtonAriaLabel: 'Menu button',
+};
+
+describe('DtRecipeContactCentersRow Tests', () => {
+  let testContext;
+
+  beforeAll(() => {
+    testContext = {};
+  });
+
+  // Wrappers
+  let wrapper;
+  let iconType;
+  let description;
+  let unreadBadge;
+
+  // Environment
+  let propsData = basePropsData;
+  let attrs = {};
+  let slots = {};
+  let provide = {};
+
+  // Helpers
+  const _setChildWrappers = async () => {
+    await vi.dynamicImportSettled();
+    iconType = wrapper.find('[data-qa="dt-leftbar-row-icon"]');
+    description = wrapper.find('[data-qa="dt-leftbar-row-description"]');
+    unreadBadge = wrapper.find('[data-qa="dt-leftbar-row-unread-badge"]');
+  };
+
+  const _setWrappers = async () => {
+    wrapper = mount(DtRecipeContactCentersRow, {
+      propsData,
+      attrs,
+      slots,
+      provide,
+      localVue: testContext.localVue,
+    });
+    await _setChildWrappers();
+  };
+
+  // Setup
+  beforeAll(() => {
+    testContext.localVue = createLocalVue();
+  });
+
+  beforeEach(async () => {
+    propsData = basePropsData;
+    slots = {};
+    await _setWrappers();
+  });
+
+  // Teardown
+  afterEach(() => {
+    propsData = basePropsData;
+    attrs = {};
+    slots = {};
+    provide = {};
+  });
+  afterAll(() => {});
+
+  describe('Presentation Tests', () => {
+    describe('When the leftbar renders', () => {
+      // Test Setup
+      beforeEach(() => {
+        _setWrappers();
+      });
+
+      it('should exist', () => {
+        expect(wrapper.exists()).toBeTruthy();
+      });
+
+      it('should render the icon', () => {
+        expect(iconType.exists()).toBe(true);
+        expect(iconType.find('svg').exists()).toBeTruthy();
+      });
+
+      it('should render the description', () => {
+        expect(description.text()).toBe(basePropsData.description);
+      });
+    });
+
+    describe('When a unreadCount is provided', () => {
+      // Test Environment
+      const unreadCount = 25;
+
+      // Test Setup
+      beforeEach(async () => {
+        propsData = { ...propsData, unreadCount };
+        await _setWrappers();
+      });
+
+      it('should render the unreadCount', () => {
+        expect(unreadBadge.text()).toBe(`${unreadCount}`);
+      });
+    });
+  });
+});

--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row.vue
@@ -1,0 +1,217 @@
+<template>
+  <div
+    :class="[
+      'dt-leftbar-row__container',
+      { 'dt-leftbar-row__container--off-duty': $slots.timer },
+    ]"
+  >
+    <div
+      :class="leftbarContactCentersRowClasses"
+      data-qa="dt-recipe-contact-centers-row"
+    >
+      <a
+        class="dt-leftbar-row__primary"
+        :data-qa="$attrs['data-qa'] ?? 'dt-leftbar-row-link'"
+        :aria-label="getAriaLabel"
+        :title="description"
+        :href="$attrs.href ?? 'javascript:void(0)'"
+        v-bind="$attrs"
+        v-on="$listeners"
+      >
+        <div class="dt-leftbar-row__alpha">
+          <dt-icon-headphones
+            size="300"
+            data-qa="dt-leftbar-row-icon"
+          />
+        </div>
+        <div
+          class="dt-leftbar-row__label"
+          :style="`flex-basis: ${labelWidth}`"
+        >
+          <dt-emoji-text-wrapper
+            class="dt-leftbar-row__description"
+            data-qa="dt-leftbar-row-description"
+            size="200"
+          >
+            {{ description }}
+          </dt-emoji-text-wrapper>
+        </div>
+      </a>
+      <div class="dt-leftbar-row__omega">
+        <slot name="right" />
+        <div class="dt-leftbar-row__action-container">
+          <dt-badge
+            v-if="showUnreadCount"
+            class="dt-leftbar-row__unread-badge"
+            data-qa="dt-leftbar-row-unread-badge"
+            kind="count"
+            type="bulletin"
+          >
+            {{ unreadCount }}
+          </dt-badge>
+          <dt-button
+            class="dt-leftbar-row__action"
+            data-qa="dt-leftbar-row-action-button"
+            :aria-label="menuButtonAriaLabel"
+            importance="clear"
+            size="xs"
+            circle
+            @click.stop="$emit('click-menu', $event)"
+          >
+            <template #icon>
+              <dt-icon-chevron-down size="100" />
+            </template>
+          </dt-button>
+        </div>
+      </div>
+    </div>
+    <div class="dt-leftbar-row__bottom">
+      <slot name="timer" />
+    </div>
+  </div>
+</template>
+
+<script>
+import { DtBadge } from '@/components/badge';
+import { DtButton } from '@/components/button';
+import DtIconHeadphones from '@dialpad/dialtone-icons/vue2/headphones';
+import DtIconChevronDown from '@dialpad/dialtone-icons/vue2/chevron-down';
+import DtEmojiTextWrapper from '@/components/emoji_text_wrapper/emoji_text_wrapper.vue';
+import { safeConcatStrings } from '@/common/utils';
+
+export default {
+  name: 'DtRecipeGeneralRow',
+
+  components: {
+    DtButton,
+    DtBadge,
+    DtEmojiTextWrapper,
+    DtIconHeadphones,
+    DtIconChevronDown,
+  },
+
+  inheritAttrs: false,
+
+  props: {
+    /**
+     * Will be read out by a screen reader upon focus of this row. If not defined "description" will be read.
+     */
+    ariaLabel: {
+      type: String,
+      default: '',
+    },
+
+    /**
+     * Text displayed next to the icon. Required.
+     */
+    description: {
+      type: String,
+      required: true,
+    },
+
+    /**
+     * Determines if the row is selected
+     */
+    selected: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Number of unread messages
+     */
+    unreadCount: {
+      type: Number,
+      default: 0,
+    },
+
+    /**
+     * Aria label for the menu button.
+     */
+    menuButtonAriaLabel: {
+      type: String,
+      required: true,
+    },
+  },
+
+  emits: [
+    /**
+     * Native click event on the row itself
+     *
+     * @event click
+     * @type {PointerEvent | KeyboardEvent}
+     */
+    'click',
+
+    /**
+     * Menu button clicked
+     *
+     * @event call
+     * @type {PointerEvent | KeyboardEvent}
+     */
+    'click-menu',
+  ],
+
+  data () {
+    return {
+      labelWidth: 'auto',
+    };
+  },
+
+  computed: {
+    leftbarContactCentersRowClasses () {
+      return [
+        'dt-leftbar-row',
+        'dt-leftbar-row--contact-centers',
+        {
+          'dt-leftbar-row--unread-count': this.showUnreadCount,
+          'dt-leftbar-row--selected': this.selected,
+        },
+      ];
+    },
+
+    getAriaLabel () {
+      return this.ariaLabel
+        ? this.ariaLabel
+        : safeConcatStrings([this.description, this.unreadCountTooltip]);
+    },
+
+    showUnreadCount () {
+      return this.unreadCount > 0;
+    },
+  },
+
+  watch: {
+    $props: {
+      deep: true,
+      handler () {
+        this.adjustLabelWidth();
+      },
+    },
+  },
+
+  mounted () {
+    this.resizeObserver = new ResizeObserver(this.adjustLabelWidth);
+    this.resizeObserver.observe(this.$el);
+    this.adjustLabelWidth();
+  },
+
+  beforeDestroy: function () {
+    this.resizeObserver.disconnect();
+  },
+
+  methods: {
+    adjustLabelWidth () {
+      const labelWidth = this.$el?.querySelector('.dt-leftbar-row__primary')?.clientWidth || 0;
+      const omegaWidth = this.$el?.querySelector('.dt-leftbar-row__omega')?.clientWidth || 0;
+      const alphaWidth = this.$el?.querySelector('.dt-leftbar-row__alpha')?.clientWidth || 0;
+      const paddings = 12;
+      this.labelWidth = labelWidth - (omegaWidth + alphaWidth + paddings) + 'px';
+    },
+  },
+};
+</script>
+
+<style lang="less" scoped>
+@import "../style/leftbar_row.less";
+</style>

--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row_default.story.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row_default.story.vue
@@ -1,0 +1,52 @@
+<template>
+  <dt-recipe-contact-centers-row
+    :description="$attrs.description"
+    :unread-count="$attrs.unreadCount"
+    :aria-label="$attrs.ariaLabel"
+    :menu-button-aria-label="$attrs.menuButtonAriaLabel"
+    :selected="$attrs.selected"
+    @click="$attrs.click"
+    @click-menu="$attrs.clickMenu"
+  >
+    <template
+      v-if="$attrs.right"
+      #right
+    >
+      <span v-html="$attrs.right" />
+    </template>
+    <template
+      v-else
+      #right
+    >
+      <dt-button
+        size="sm"
+        kind="muted"
+        importance="clear"
+        class="d-bar-pill d-py4 d-fc-success d-to-ellipsis"
+      >
+        <template #icon>
+          <dt-icon-bell-ring size="100" />
+        </template>
+        <span class="d-truncate d-wmx128">
+          Available
+        </span>
+      </dt-button>
+    </template>
+  </dt-recipe-contact-centers-row>
+</template>
+
+<script>
+import { DtButton } from '@/components/button';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
+import DtIconBellRing from '@dialpad/dialtone-icons/vue2/bell-ring';
+
+export default {
+  name: 'DtRecipeContactCentersRowDefault',
+
+  components: {
+    DtButton,
+    DtRecipeContactCentersRow,
+    DtIconBellRing,
+  },
+};
+</script>

--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row_off_duty.story.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row_off_duty.story.vue
@@ -1,0 +1,66 @@
+<template>
+  <dt-recipe-contact-centers-row
+    :description="$attrs.description"
+    :unread-count="$attrs.unreadCount"
+    :aria-label="$attrs.ariaLabel"
+    :menu-button-aria-label="$attrs.menuButtonAriaLabel"
+    :selected="$attrs.selected"
+    @click="$attrs.click"
+    @click-menu="$attrs.clickMenu"
+  >
+    <template
+      v-if="$attrs.right"
+      #right
+    >
+      <span v-html="$attrs.right" />
+    </template>
+    <template
+      v-else
+      #right
+    >
+      <dt-button
+        size="sm"
+        kind="muted"
+        importance="clear"
+        class="d-bar-pill d-py4 d-fc-error d-to-ellipsis"
+      >
+        <template #icon>
+          <dt-icon-bell-ring size="100" />
+        </template>
+        <span class="d-truncate d-wmx128">
+          Off duty
+        </span>
+      </dt-button>
+    </template>
+    <template #timer>
+      <div class="d-d-flex d-jc-space-between d-ai-center d-p8">
+        <div class="d-headline--xl">
+          01:15
+        </div>
+        <dt-button
+          size="sm"
+          kind="muted"
+          importance="outlined"
+        >
+          I'm back
+        </dt-button>
+      </div>
+    </template>
+  </dt-recipe-contact-centers-row>
+</template>
+
+<script>
+import { DtButton } from '@/components/button';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
+import DtIconBellRing from '@dialpad/dialtone-icons/vue2/bell-ring';
+
+export default {
+  name: 'DtRecipeContactCentersRowDefault',
+
+  components: {
+    DtButton,
+    DtRecipeContactCentersRow,
+    DtIconBellRing,
+  },
+};
+</script>

--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row_variants.story.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row_variants.story.vue
@@ -1,0 +1,153 @@
+<template>
+  <dt-stack gap="600">
+    <div>
+      <h3 class="d-mb8">
+        Ai Contact Centers leftbar
+      </h3>
+      <dt-recipe-contact-centers-row
+        description="Ai Contact Centers"
+        menu-button-aria-label="Menu button"
+      >
+        <template #right>
+          <dt-button
+            importance="clear"
+            kind="muted"
+            :class="[
+              'leftbar-call-centers-duty-status__button',
+              'd-bar-pill',
+              'd-py4',
+              'd-fc-success',
+            ]"
+            class="d-to-ellipsis"
+            size="sm"
+            data-qa="leftbar-call-centers-duty-value"
+            aria-label="Available"
+          >
+            <template #icon>
+              <dt-icon-bell-ring size="100" />
+            </template>
+            <span class="d-truncate d-wmx128">
+              Available
+            </span>
+          </dt-button>
+        </template>
+      </dt-recipe-contact-centers-row>
+    </div>
+    <div>
+      <h3 class="d-mb8">
+        Ai Contact Centers selected
+      </h3>
+      <dt-recipe-contact-centers-row
+        description="Ai Contact Centers"
+        menu-button-aria-label="Menu button"
+        selected
+      >
+        <template #right>
+          <dt-button
+            importance="clear"
+            kind="muted"
+            :class="[
+              'leftbar-call-centers-duty-status__button',
+              'd-bar-pill',
+              'd-py4',
+              'd-fc-success',
+            ]"
+            class="d-to-ellipsis"
+            size="sm"
+            data-qa="leftbar-call-centers-duty-value"
+            aria-label="Available"
+          >
+            <template #icon>
+              <dt-icon-bell-ring size="100" />
+            </template>
+            <span class="d-truncate d-wmx128">
+              Available
+            </span>
+          </dt-button>
+        </template>
+      </dt-recipe-contact-centers-row>
+    </div>
+    <div>
+      <h3 class="d-mb8">
+        Ai Contact Centers with unread messages
+      </h3>
+      <dt-recipe-contact-centers-row
+        description="Ai Contact Centers"
+        menu-button-aria-label="Menu button"
+        unread-count="7"
+        unread-count-tooltip="7 unread messages"
+      >
+        <template #right>
+          <dt-button
+            importance="clear"
+            kind="muted"
+            :class="[
+              'leftbar-call-centers-duty-status__button',
+              'd-bar-pill',
+              'd-py4',
+              'd-fc-success',
+            ]"
+            class="d-to-ellipsis"
+            size="sm"
+            data-qa="leftbar-call-centers-duty-value"
+            aria-label="Available"
+          >
+            <template #icon>
+              <dt-icon-bell-ring size="100" />
+            </template>
+            <span class="d-truncate d-wmx128">
+              Available
+            </span>
+          </dt-button>
+        </template>
+      </dt-recipe-contact-centers-row>
+    </div>
+    <div>
+      <h3 class="d-mb8">
+        Ai Contact Centers selected with unread messages
+      </h3>
+      <dt-recipe-contact-centers-row
+        description="Ai Contact Centers"
+        menu-button-aria-label="Menu button"
+        selected
+        unread-count="7"
+      >
+        <template #right>
+          <dt-button
+            importance="clear"
+            kind="muted"
+            :class="[
+              'leftbar-call-centers-duty-status__button',
+              'd-bar-pill',
+              'd-py4',
+              'd-fc-success',
+            ]"
+            class="d-to-ellipsis"
+            size="sm"
+            data-qa="leftbar-call-centers-duty-value"
+            aria-label="Available"
+          >
+            <template #icon>
+              <dt-icon-bell-ring size="100" />
+            </template>
+            <span class="d-truncate d-wmx128">
+              Available
+            </span>
+          </dt-button>
+        </template>
+      </dt-recipe-contact-centers-row>
+    </div>
+  </dt-stack>
+</template>
+
+<script>
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
+import { DtStack } from '@/components/stack';
+import { DtButton } from '@/components/button';
+import DtIconBellRing from '@dialpad/dialtone-icons/vue2/bell-ring';
+
+export default {
+  name: 'DtRecipeContactCentersRowVariants',
+  components: { DtRecipeContactCentersRow, DtStack, DtButton, DtIconBellRing },
+};
+</script>

--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/index.js
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/index.js
@@ -1,0 +1,1 @@
+export { default as DtRecipeContactCentersRow } from './contact_centers_row.vue';

--- a/packages/dialtone-vue2/recipes/leftbar/style/leftbar_row.less
+++ b/packages/dialtone-vue2/recipes/leftbar/style/leftbar_row.less
@@ -238,6 +238,31 @@
     font-weight: var(--dt-font-weight-medium);
   }
 
+  &__container--off-duty {
+      border-radius: var(--dt-size-radius-500);
+      background-color: var(--dt-badge-color-background-critical);
+      border: var(--dt-size-100) solid var(--dt-color-border-subtle);
+
+     &:deep(.dt-leftbar-row__primary) {
+       margin: calc(var(--dt-size-100) * -1);
+     }
+  }
+
+  &--contact-centers {
+    &:deep(.dt-leftbar-row__alpha) {
+      padding-right: var(--dt-space-450);
+      padding-left: var(--dt-space-450);
+    }
+
+    .dt-leftbar-row__action-container {
+      display: inline-flex;
+      align-items: center;
+      justify-content: flex-end;
+      min-width: var(--dt-size-600);
+      height: var(--dt-size-500);
+    }
+  }
+
   //  ============================================================================
   //  $   LABEL'S ELEMENTS
   //  ----------------------------------------------------------------------------

--- a/packages/dialtone-vue3/index.js
+++ b/packages/dialtone-vue3/index.js
@@ -85,6 +85,7 @@ export * from './recipes/conversation_view/time_pill';
 export * from './recipes/header/settings_menu_button';
 export * from './recipes/item_layout/contact_info';
 export * from './recipes/leftbar/callbox';
+export * from './recipes/leftbar/contact_centers_row';
 export * from './recipes/leftbar/contact_row';
 export * from './recipes/leftbar/general_row';
 export * from './recipes/leftbar/group_row';

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.mdx
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.mdx
@@ -1,0 +1,50 @@
+import { Canvas, Story, Subtitle, Controls, Meta } from '@storybook/blocks';
+import * as ContactCentersRowStories from './contact_centers_row.stories.js';
+
+<Meta of={ContactCentersRowStories}/>
+
+# Contact Centers Row
+
+<Subtitle>
+  This component covers the Ai Contact Centers leftbar row that will contain complex controls in the same row.
+</Subtitle>
+
+## Base Style
+
+<Canvas>
+  <Story of={ContactCentersRowStories.Default} />
+</Canvas>
+
+
+## Off duty agent
+
+<Canvas>
+  <Story of={ContactCentersRowStories.OffDuty} />
+</Canvas>
+
+## Variants
+
+<Canvas>
+  <Story of={ContactCentersRowStories.Variants} />
+</Canvas>
+
+## Slots, Props & Events
+
+<Controls />
+
+## Usage
+
+### Import
+
+```js
+import { DtRecipeContactCentersRow } from '@dialpad/dialtone-vue';
+```
+
+### Simple Ai Contact Centers row
+
+```html
+<dt-recipe-contact-centers-row
+  description="Channel name"
+  unread-count="29"
+/>
+```

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.stories.js
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.stories.js
@@ -1,0 +1,103 @@
+import { action } from '@storybook/addon-actions';
+import { createTemplateFromVueFile } from '@/common/storybook_utils';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
+import DtRecipeContactCentersRowDefaultTemplate from './contact_centers_row_default.story.vue';
+import DtRecipeContactCentersRowOffDutyTemplate from './contact_centers_row_off_duty.story.vue';
+import DtRecipeContactCentersRowVariantsTemplate from './contact_centers_row_variants.story.vue';
+
+// Default Prop Values
+export const argsData = {
+  description: 'Ai Contact Centers',
+  menuButtonAriaLabel: 'Menu button',
+  click: action('click'),
+  clickMenu: action('click-menu'),
+};
+
+export const argTypesData = {
+  // Slots
+  right: {
+    name: 'right',
+    description: 'Slot right hand side content. Ex. agent on duty status component',
+    table: {
+      category: 'slots',
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'text',
+    },
+  },
+
+  timer: {
+    name: 'timer',
+    description: 'Slot displayed at the bottom of the row. Ex. agent off duty timer',
+    table: {
+      category: 'slots',
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'text',
+    },
+  },
+
+  // Action Event Handlers
+  click: {
+    description: 'Native click event on the row itself',
+    table: {
+      category: 'events',
+      type: { summary: 'event' },
+    },
+  },
+
+  'click-menu': {
+    description: 'Native click event on the menu button',
+    table: {
+      category: 'events',
+      type: { summary: 'event' },
+    },
+  },
+
+  clickMenu: {
+    table: {
+      disable: true,
+    },
+  },
+};
+
+const decorator = () => ({
+  template: `<div style="background-color: var(--dt-theme-sidebar-color-background)" class="d-wmx264 d-p8"><story />
+  </div>`,
+});
+
+// Story Collection
+export default {
+  title: 'Recipes/Leftbar/Contact Centers Row',
+  component: DtRecipeContactCentersRow,
+  args: argsData,
+  argTypes: argTypesData,
+  decorators: [decorator],
+  excludeStories: /.*Data$/,
+};
+
+// Templates
+const DefaultTemplate = (args, { argTypes }) =>
+  createTemplateFromVueFile(args, argTypes, DtRecipeContactCentersRowDefaultTemplate);
+const OffDutyTemplate = (args, { argTypes }) =>
+  createTemplateFromVueFile(args, argTypes, DtRecipeContactCentersRowOffDutyTemplate);
+const VariantsTemplate = (args, { argTypes }) =>
+  createTemplateFromVueFile(args, argTypes, DtRecipeContactCentersRowVariantsTemplate);
+
+export const Default = {
+  render: DefaultTemplate,
+  args: {},
+};
+
+export const OffDuty = {
+  render: OffDutyTemplate,
+  args: {},
+};
+
+export const Variants = {
+  render: VariantsTemplate,
+  args: {},
+  parameters: { options: { showPanel: false }, controls: { disable: true } },
+};

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.test.js
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.test.js
@@ -1,0 +1,88 @@
+import { mount } from '@vue/test-utils';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
+
+// Constants
+const basePropsData = {
+  description: 'Ai Contact Centers',
+  menuButtonAriaLabel: 'Menu button',
+};
+
+describe('DtRecipeContactCentersRow Tests', () => {
+  // Wrappers
+  let wrapper;
+  let iconType;
+  let description;
+  let unreadBadge;
+
+  // Environment
+  let props = basePropsData;
+  let attrs = {};
+  let slots = {};
+  let provide = {};
+
+  // Helpers
+  const updateWrapper = () => {
+    wrapper = mount(DtRecipeContactCentersRow, {
+      props,
+      attrs,
+      slots,
+      global: {
+        provide,
+      },
+    });
+
+    iconType = wrapper.find('[data-qa="dt-leftbar-row-icon"]');
+    description = wrapper.find('[data-qa="dt-leftbar-row-description"]');
+    unreadBadge = wrapper.find('[data-qa="dt-leftbar-row-unread-badge"]');
+  };
+
+  beforeEach(async () => {
+    props = basePropsData;
+    slots = {};
+    updateWrapper();
+  });
+
+  // Teardown
+  afterEach(() => {
+    props = basePropsData;
+    attrs = {};
+    slots = {};
+    provide = {};
+  });
+
+  describe('Presentation Tests', () => {
+    describe('When the leftbar renders', () => {
+      // Test Setup
+      beforeEach(() => {
+        updateWrapper();
+      });
+
+      it('should exist', () => {
+        expect(wrapper.exists()).toBeTruthy();
+      });
+
+      it('should render the icon', () => {
+        expect(iconType.exists()).toBe(true);
+      });
+
+      it('should render the description', () => {
+        expect(description.text()).toBe(basePropsData.description);
+      });
+    });
+
+    describe('When a unreadCount is provided', () => {
+      // Test Environment
+      const unreadCount = 25;
+
+      // Test Setup
+      beforeEach(async () => {
+        props = { ...props, unreadCount };
+        updateWrapper();
+      });
+
+      it('should render the unreadCount', () => {
+        expect(unreadBadge.text()).toBe(`${unreadCount}`);
+      });
+    });
+  });
+});

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.vue
@@ -1,0 +1,222 @@
+<template>
+  <div
+    :class="[
+      'dt-leftbar-row__container',
+      { 'dt-leftbar-row__container--off-duty': $slots.timer },
+    ]"
+  >
+    <div
+      :class="leftbarContactCentersRowClasses"
+      data-qa="dt-recipe-contact-centers-row"
+    >
+      <a
+        class="dt-leftbar-row__primary"
+        :data-qa="$attrs['data-qa'] ?? 'dt-leftbar-row-link'"
+        :aria-label="getAriaLabel"
+        :title="description"
+        :href="$attrs.href ?? 'javascript:void(0)'"
+        v-bind="$attrs"
+        v-on="contactRowListeners"
+        @click="$emit('click', $event)"
+      >
+        <div class="dt-leftbar-row__alpha">
+          <dt-icon-headphones
+            size="300"
+            data-qa="dt-leftbar-row-icon"
+          />
+        </div>
+        <div
+          class="dt-leftbar-row__label"
+          :style="`flex-basis: ${labelWidth}`"
+        >
+          <dt-emoji-text-wrapper
+            class="dt-leftbar-row__description"
+            data-qa="dt-leftbar-row-description"
+            size="200"
+          >
+            {{ description }}
+          </dt-emoji-text-wrapper>
+        </div>
+      </a>
+      <div class="dt-leftbar-row__omega">
+        <slot name="right" />
+        <div class="dt-leftbar-row__action-container">
+          <dt-badge
+            v-if="showUnreadCount"
+            class="dt-leftbar-row__unread-badge"
+            data-qa="dt-leftbar-row-unread-badge"
+            kind="count"
+            type="bulletin"
+          >
+            {{ unreadCount }}
+          </dt-badge>
+          <dt-button
+            class="dt-leftbar-row__action"
+            data-qa="dt-leftbar-row-action-button"
+            :aria-label="menuButtonAriaLabel"
+            importance="clear"
+            size="xs"
+            circle
+            @click.stop="$emit('click-menu', $event)"
+          >
+            <template #icon>
+              <dt-icon-chevron-down size="100" />
+            </template>
+          </dt-button>
+        </div>
+      </div>
+    </div>
+    <div class="dt-leftbar-row__bottom">
+      <slot name="timer" />
+    </div>
+  </div>
+</template>
+
+<script>
+import { DtBadge } from '@/components/badge';
+import { DtButton } from '@/components/button';
+import DtIconHeadphones from '@dialpad/dialtone-icons/vue3/headphones';
+import DtIconChevronDown from '@dialpad/dialtone-icons/vue3/chevron-down';
+import DtEmojiTextWrapper from '@/components/emoji_text_wrapper/emoji_text_wrapper.vue';
+import { safeConcatStrings, extractVueListeners } from '@/common/utils';
+
+export default {
+  name: 'DtRecipeGeneralRow',
+
+  components: {
+    DtButton,
+    DtBadge,
+    DtEmojiTextWrapper,
+    DtIconHeadphones,
+    DtIconChevronDown,
+  },
+
+  inheritAttrs: false,
+
+  props: {
+    /**
+     * Will be read out by a screen reader upon focus of this row. If not defined "description" will be read.
+     */
+    ariaLabel: {
+      type: String,
+      default: '',
+    },
+
+    /**
+     * Text displayed next to the icon. Required.
+     */
+    description: {
+      type: String,
+      required: true,
+    },
+
+    /**
+     * Determines if the row is selected
+     */
+    selected: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Number of unread messages
+     */
+    unreadCount: {
+      type: Number,
+      default: 0,
+    },
+
+    /**
+     * Aria label for the menu button.
+     */
+    menuButtonAriaLabel: {
+      type: String,
+      required: true,
+    },
+  },
+
+  emits: [
+    /**
+     * Native click event on the row itself
+     *
+     * @event click
+     * @type {PointerEvent | KeyboardEvent}
+     */
+    'click',
+
+    /**
+     * Menu button clicked
+     *
+     * @event call
+     * @type {PointerEvent | KeyboardEvent}
+     */
+    'click-menu',
+  ],
+
+  data () {
+    return {
+      labelWidth: 'auto',
+    };
+  },
+
+  computed: {
+    leftbarContactCentersRowClasses () {
+      return [
+        'dt-leftbar-row',
+        'dt-leftbar-row--contact-centers',
+        {
+          'dt-leftbar-row--unread-count': this.showUnreadCount,
+          'dt-leftbar-row--selected': this.selected,
+        },
+      ];
+    },
+
+    getAriaLabel () {
+      return this.ariaLabel
+        ? this.ariaLabel
+        : safeConcatStrings([this.description, this.unreadCountTooltip]);
+    },
+
+    contactRowListeners () {
+      return extractVueListeners(this.$attrs);
+    },
+
+    showUnreadCount () {
+      return this.unreadCount > 0;
+    },
+  },
+
+  watch: {
+    $props: {
+      deep: true,
+      handler () {
+        this.adjustLabelWidth();
+      },
+    },
+  },
+
+  mounted () {
+    this.resizeObserver = new ResizeObserver(this.adjustLabelWidth);
+    this.resizeObserver.observe(this.$el);
+    this.adjustLabelWidth();
+  },
+
+  beforeUnmount: function () {
+    this.resizeObserver.disconnect();
+  },
+
+  methods: {
+    adjustLabelWidth () {
+      const labelWidth = this.$el?.querySelector('.dt-leftbar-row__primary')?.clientWidth || 0;
+      const omegaWidth = this.$el?.querySelector('.dt-leftbar-row__omega')?.clientWidth || 0;
+      const alphaWidth = this.$el?.querySelector('.dt-leftbar-row__alpha')?.clientWidth || 0;
+      const paddings = 12;
+      this.labelWidth = labelWidth - (omegaWidth + alphaWidth + paddings) + 'px';
+    },
+  },
+};
+</script>
+
+<style lang="less" scoped>
+@import "../style/leftbar_row.less";
+</style>

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row_default.story.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row_default.story.vue
@@ -1,0 +1,52 @@
+<template>
+  <dt-recipe-contact-centers-row
+    :description="$attrs.description"
+    :unread-count="$attrs.unreadCount"
+    :aria-label="$attrs.ariaLabel"
+    :menu-button-aria-label="$attrs.menuButtonAriaLabel"
+    :selected="$attrs.selected"
+    @click="$attrs.click"
+    @click-menu="$attrs.clickMenu"
+  >
+    <template
+      v-if="$attrs.right"
+      #right
+    >
+      <span v-html="$attrs.right" />
+    </template>
+    <template
+      v-else
+      #right
+    >
+      <dt-button
+        size="sm"
+        kind="muted"
+        importance="clear"
+        class="d-bar-pill d-py4 d-fc-success d-to-ellipsis"
+      >
+        <template #icon>
+          <dt-icon-bell-ring size="100" />
+        </template>
+        <span class="d-truncate d-wmx128">
+          Available
+        </span>
+      </dt-button>
+    </template>
+  </dt-recipe-contact-centers-row>
+</template>
+
+<script>
+import { DtButton } from '@/components/button';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
+import DtIconBellRing from '@dialpad/dialtone-icons/vue3/bell-ring';
+
+export default {
+  name: 'DtRecipeContactCentersRowDefault',
+
+  components: {
+    DtButton,
+    DtRecipeContactCentersRow,
+    DtIconBellRing,
+  },
+};
+</script>

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row_off_duty.story.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row_off_duty.story.vue
@@ -1,0 +1,66 @@
+<template>
+  <dt-recipe-contact-centers-row
+    :description="$attrs.description"
+    :unread-count="$attrs.unreadCount"
+    :aria-label="$attrs.ariaLabel"
+    :menu-button-aria-label="$attrs.menuButtonAriaLabel"
+    :selected="$attrs.selected"
+    @click="$attrs.click"
+    @click-menu="$attrs.clickMenu"
+  >
+    <template
+      v-if="$attrs.right"
+      #right
+    >
+      <span v-html="$attrs.right" />
+    </template>
+    <template
+      v-else
+      #right
+    >
+      <dt-button
+        size="sm"
+        kind="muted"
+        importance="clear"
+        class="d-bar-pill d-py4 d-fc-error d-to-ellipsis"
+      >
+        <template #icon>
+          <dt-icon-bell-ring size="100" />
+        </template>
+        <span class="d-truncate d-wmx128">
+          Off duty
+        </span>
+      </dt-button>
+    </template>
+    <template #timer>
+      <div class="d-d-flex d-jc-space-between d-ai-center d-p8">
+        <div class="d-headline--xl">
+          01:15
+        </div>
+        <dt-button
+          size="sm"
+          kind="muted"
+          importance="outlined"
+        >
+          I'm back
+        </dt-button>
+      </div>
+    </template>
+  </dt-recipe-contact-centers-row>
+</template>
+
+<script>
+import { DtButton } from '@/components/button';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
+import DtIconBellRing from '@dialpad/dialtone-icons/vue3/bell-ring';
+
+export default {
+  name: 'DtRecipeContactCentersRowDefault',
+
+  components: {
+    DtButton,
+    DtRecipeContactCentersRow,
+    DtIconBellRing,
+  },
+};
+</script>

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row_variants.story.vue
@@ -1,0 +1,153 @@
+<template>
+  <dt-stack gap="600">
+    <div>
+      <h3 class="d-mb8">
+        Ai Contact Centers leftbar
+      </h3>
+      <dt-recipe-contact-centers-row
+        description="Ai Contact Centers"
+        menu-button-aria-label="Menu button"
+      >
+        <template #right>
+          <dt-button
+            importance="clear"
+            kind="muted"
+            :class="[
+              'leftbar-call-centers-duty-status__button',
+              'd-bar-pill',
+              'd-py4',
+              'd-fc-success',
+            ]"
+            class="d-to-ellipsis"
+            size="sm"
+            data-qa="leftbar-call-centers-duty-value"
+            aria-label="Available"
+          >
+            <template #icon>
+              <dt-icon-bell-ring size="100" />
+            </template>
+            <span class="d-truncate d-wmx128">
+              Available
+            </span>
+          </dt-button>
+        </template>
+      </dt-recipe-contact-centers-row>
+    </div>
+    <div>
+      <h3 class="d-mb8">
+        Ai Contact Centers selected
+      </h3>
+      <dt-recipe-contact-centers-row
+        description="Ai Contact Centers"
+        menu-button-aria-label="Menu button"
+        selected
+      >
+        <template #right>
+          <dt-button
+            importance="clear"
+            kind="muted"
+            :class="[
+              'leftbar-call-centers-duty-status__button',
+              'd-bar-pill',
+              'd-py4',
+              'd-fc-success',
+            ]"
+            class="d-to-ellipsis"
+            size="sm"
+            data-qa="leftbar-call-centers-duty-value"
+            aria-label="Available"
+          >
+            <template #icon>
+              <dt-icon-bell-ring size="100" />
+            </template>
+            <span class="d-truncate d-wmx128">
+              Available
+            </span>
+          </dt-button>
+        </template>
+      </dt-recipe-contact-centers-row>
+    </div>
+    <div>
+      <h3 class="d-mb8">
+        Ai Contact Centers with unread messages
+      </h3>
+      <dt-recipe-contact-centers-row
+        description="Ai Contact Centers"
+        menu-button-aria-label="Menu button"
+        unread-count="7"
+        unread-count-tooltip="7 unread messages"
+      >
+        <template #right>
+          <dt-button
+            importance="clear"
+            kind="muted"
+            :class="[
+              'leftbar-call-centers-duty-status__button',
+              'd-bar-pill',
+              'd-py4',
+              'd-fc-success',
+            ]"
+            class="d-to-ellipsis"
+            size="sm"
+            data-qa="leftbar-call-centers-duty-value"
+            aria-label="Available"
+          >
+            <template #icon>
+              <dt-icon-bell-ring size="100" />
+            </template>
+            <span class="d-truncate d-wmx128">
+              Available
+            </span>
+          </dt-button>
+        </template>
+      </dt-recipe-contact-centers-row>
+    </div>
+    <div>
+      <h3 class="d-mb8">
+        Ai Contact Centers selected with unread messages
+      </h3>
+      <dt-recipe-contact-centers-row
+        description="Ai Contact Centers"
+        menu-button-aria-label="Menu button"
+        selected
+        unread-count="7"
+      >
+        <template #right>
+          <dt-button
+            importance="clear"
+            kind="muted"
+            :class="[
+              'leftbar-call-centers-duty-status__button',
+              'd-bar-pill',
+              'd-py4',
+              'd-fc-success',
+            ]"
+            class="d-to-ellipsis"
+            size="sm"
+            data-qa="leftbar-call-centers-duty-value"
+            aria-label="Available"
+          >
+            <template #icon>
+              <dt-icon-bell-ring size="100" />
+            </template>
+            <span class="d-truncate d-wmx128">
+              Available
+            </span>
+          </dt-button>
+        </template>
+      </dt-recipe-contact-centers-row>
+    </div>
+  </dt-stack>
+</template>
+
+<script>
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
+import { DtStack } from '@/components/stack';
+import { DtButton } from '@/components/button';
+import DtIconBellRing from '@dialpad/dialtone-icons/vue3/bell-ring';
+
+export default {
+  name: 'DtRecipeContactCentersRowVariants',
+  components: { DtRecipeContactCentersRow, DtStack, DtButton, DtIconBellRing },
+};
+</script>

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/index.js
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/index.js
@@ -1,0 +1,1 @@
+export { default as DtRecipeContactCentersRow } from './contact_centers_row.vue';

--- a/packages/dialtone-vue3/recipes/leftbar/general_row/general_row.test.js
+++ b/packages/dialtone-vue3/recipes/leftbar/general_row/general_row.test.js
@@ -26,13 +26,6 @@ describe('DtRecipeGeneralRow Tests', () => {
   let provide = {};
 
   // Helpers
-  const _setChildWrappers = async () => {
-    await vi.dynamicImportSettled();
-    iconType = wrapper.find('[data-qa="dt-leftbar-row-icon"]');
-    description = wrapper.find('.dt-leftbar-row__description');
-    unreadBadge = wrapper.find('[data-qa="dt-leftbar-row-unread-badge"]');
-  };
-
   const _setWrappers = async () => {
     wrapper = mount(DtRecipeGeneralRow, {
       props,
@@ -40,7 +33,10 @@ describe('DtRecipeGeneralRow Tests', () => {
       slots,
       provide,
     });
-    await _setChildWrappers();
+
+    iconType = wrapper.find('[data-qa="dt-leftbar-row-icon"]');
+    description = wrapper.find('.dt-leftbar-row__description');
+    unreadBadge = wrapper.find('[data-qa="dt-leftbar-row-unread-badge"]');
   };
 
   beforeEach(async () => {

--- a/packages/dialtone-vue3/recipes/leftbar/style/leftbar_row.less
+++ b/packages/dialtone-vue3/recipes/leftbar/style/leftbar_row.less
@@ -238,6 +238,31 @@
     font-weight: var(--dt-font-weight-medium);
   }
 
+  &__container--off-duty {
+      border-radius: var(--dt-size-radius-500);
+      background-color: var(--dt-badge-color-background-critical);
+      border: var(--dt-size-100) solid var(--dt-color-border-subtle);
+
+     &:deep(.dt-leftbar-row__primary) {
+       margin: calc(var(--dt-size-100) * -1);
+     }
+  }
+
+  &--contact-centers {
+    &:deep(.dt-leftbar-row__alpha) {
+      padding-right: var(--dt-space-450);
+      padding-left: var(--dt-space-450);
+    }
+
+    .dt-leftbar-row__action-container {
+      display: inline-flex;
+      align-items: center;
+      justify-content: flex-end;
+      min-width: var(--dt-size-600);
+      height: var(--dt-size-500);
+    }
+  }
+
   //  ============================================================================
   //  $   LABEL'S ELEMENTS
   //  ----------------------------------------------------------------------------


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

[DP-91907](https://dialpad.atlassian.net/browse/DP-91907)

## :book: Description

Adding a new recipe for the new section Ai Contact Centers in the leftbar.

## :bulb: Context

This new component is highly inspired on the `DtGeneralRow` recipe. The reason behind creating a new component instead of extending the existing `DtGeneralRow`, is that this component is planned to add more functionality specific for Ai Contact Centers.

Here is an example of what it might look like on the leftbar for an specific use case:

![image](https://github.com/dialpad/dialtone/assets/547211/dcedef2d-9ae3-4afb-a529-a297666ba628)

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

If new component:

- I am exporting any new components or constants:
  - [x] from the index.js in the component directory.
  - [x] from the index.js in the root (either `packages/dialtone-vue2` or `packages/dialtone-vue3`).
- [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
- [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
- [ ] I have added the new component to `common/components_list.cjs`
- [x] I have created a component story in storybook
- [x] I have created story / stories for any relevant component variants in storybook
- [x] I have created a docs page for the component in storybook.
- [ ] I have checked that changing all props/slots via the UI in storybook works as expected.

## :link: Sources

Figma designs for the new Ai Contact Centers leftbar item.

https://www.figma.com/file/pBHnsczKRLyZhx5TgR0N6g/%5BDP-72221%5D-Redesign-How-Contact-Centers-Appear-In-Dialpad?type=design&node-id=1490-13251&mode=design&t=BPH1BoPJCfsWwjfD-4

Figma link to a preliminary version of the Ai Contact Centers leftbar item variants (future work, not included in this PR).

https://www.figma.com/file/oV7c9s0EHj6QCLKFm1Jl4i/%5BDP-88690%5D-Display-time-in-status-to-agent?type=design&t=U5AybOGzRvd6GMuB-6

[DP-91907]: https://dialpad.atlassian.net/browse/DP-91907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ