### PR TITLE
fix: DLT-1738 phone number regex lookahead

### DIFF
--- a/packages/dialtone-vue2/common/utils/index.js
+++ b/packages/dialtone-vue2/common/utils/index.js
@@ -288,18 +288,22 @@ export function getPhoneNumberRegex (minLength = 7, maxLength = 15) {
   // Some older browser versions don't support lookbehind, so provide a RegExp
   // version without it. It fails just one test case, so IMO it's still good
   // enough to use. https://caniuse.com/js-regexp-lookbehind
-  let canUseLookBehind = true;
   try {
-    // eslint-disable-next-line prefer-regex-literals
-    RegExp('(?<=\\W)');
+    return new RegExp(
+      '(?:^|(?<=\\W))' +
+      '(?![\\s\\-])\\+?(?:[0-9()\\- \\t]' +
+      `{${minLength},${maxLength}}` +
+      ')(?=\\b)(?=\\W(?=\\W|$)|\\s|$)',
+    );
   } catch (e) {
-    canUseLookBehind = false;
+    // eslint-disable-next-line no-console
+    console.warn('This browser doesn\'t support regex lookahead/lookbehind');
   }
+
   return new RegExp(
-    `${canUseLookBehind ? '(?:^|(?<=\\W))' : ''}` +
     '(?![\\s\\-])\\+?(?:[0-9()\\- \\t]' +
-    `{${minLength},${maxLength}}` +
-    ')(?=\\b)(?=\\W(?=\\W|$)|\\s|$)',
+      `{${minLength},${maxLength}}` +
+      ')(?=\\b)(?=\\W(?=\\W|$)|\\s|$)',
   );
 }
 

--- a/packages/dialtone-vue3/common/utils/index.js
+++ b/packages/dialtone-vue3/common/utils/index.js
@@ -309,18 +309,22 @@ export function getPhoneNumberRegex (minLength = 7, maxLength = 15) {
   // Some older browser versions don't support lookbehind, so provide a RegExp
   // version without it. It fails just one test case, so IMO it's still good
   // enough to use. https://caniuse.com/js-regexp-lookbehind
-  let canUseLookBehind = true;
   try {
-    // eslint-disable-next-line prefer-regex-literals
-    RegExp('(?<=\\W)');
+    return new RegExp(
+      '(?:^|(?<=\\W))' +
+      '(?![\\s\\-])\\+?(?:[0-9()\\- \\t]' +
+      `{${minLength},${maxLength}}` +
+      ')(?=\\b)(?=\\W(?=\\W|$)|\\s|$)',
+    );
   } catch (e) {
-    canUseLookBehind = false;
+    // eslint-disable-next-line no-console
+    console.warn('This browser doesn\'t support regex lookahead/lookbehind');
   }
+
   return new RegExp(
-    `${canUseLookBehind ? '(?:^|(?<=\\W))' : ''}` +
     '(?![\\s\\-])\\+?(?:[0-9()\\- \\t]' +
-    `{${minLength},${maxLength}}` +
-    ')(?=\\b)(?=\\W(?=\\W|$)|\\s|$)',
+      `{${minLength},${maxLength}}` +
+      ')(?=\\b)(?=\\W(?=\\W|$)|\\s|$)',
   );
 }
 


### PR DESCRIPTION
# Fix phone number regex lookahead

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOG5jazFiY2Y1c2h1ZDlkc2M3NXJqZXgwbGRsaTNicTZoeWZnNGxnMyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/YqMF4AHYlGEWk/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1738

## :book: Description

- Moved the actual output to the try-catch so tree-shaking doesn't remove it because it's not really doing anything inside the try-catch.

## :bulb: Context

Problems reported with older browsers on UC

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.