### PR TITLE
docs(lists): NO-JIRA clarify list css utilities

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/layouts/Layout.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/layouts/Layout.vue
@@ -2,8 +2,10 @@
   <dt-root-layout
     :fixed="false"
     :header-sticky="true"
-    sidebar-class="dialtone-sidebar lg:d-d-none"
-    footer-class="d-text-right"
+    header-class="d-ol-none"
+    sidebar-class="dialtone-sidebar lg:d-d-none d-ol-none"
+    footer-class="d-text-right d-ol-none"
+    content-class="d-ol-none"
   >
     <template #header>
       <div class="dialtone-header">

--- a/apps/dialtone-documentation/docs/utilities/typography/lists.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/lists.md
@@ -7,67 +7,95 @@ description: Utilities for controlling list styling.
 
 Use `d-ls-reset` to reset the margin, padding, and list-style-type of a list. Reseting a list applies to the parent `ol` or `ul`, any child `li` elements, and any child `ol` or `ul` elements.
 
-<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-purple-100 d-w100p d-hmn102" custom>
-  <ul class="d-ls-reset d-fc-purple-400 d-fs-200">
+<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-secondary d-w100p d-hmn102" custom>
+  <ul class="d-ls-reset">
     <li>An unordered list item</li>
     <li>
+      An unordered list item
       <ol>
-        <li>An ordered list item</li>
-        <li>An ordered list item</li>
+        <li>A nested ordered list item</li>
+        <li>A nested ordered list item</li>
       </ol>
     </li>
     <li>An unordered list item</li>
+    <li>
+      An unordered list item
+      <ul>
+        <li>A nested unordered list item</li>
+        <li>A nested unordered list item</li>
+      </ul>
+    </li>
   </ul>
 </code-well-header>
 
 ```html
 <ul class="d-ls-reset">
-  <li>...</li>
+  <li>An unordered list item</li>
   <li>
+    An unordered list item
     <ol>
-      <li>...</li>
-      <li>...</li>
+      <li>A nested ordered list item</li>
+      <li>A nested ordered list item</li>
     </ol>
   </li>
-  <li>...</li>
+  <li>An unordered list item</li>
+  <li>
+    An unordered list item
+    <ul>
+      <li>A nested unordered list item</li>
+      <li>A nested unordered list item</li>
+    </ul>
+  </li>
 </ul>
 ```
 
 ## Changing the list style type
 
-Use `d-ls-{disc|decimal}` to change an unordered list's bullet styling.
+Use `d-lst-{none|disc|circle|decimal|content|none}` to change a list item's bullet styling.
 
-<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-green-100 d-w100p d-hmn102" custom>
-  <ul class="d-lst-disc d-fs-200 d-fc-success">
-    <li>An unordered list item</li>
-    <li>
-      <ul class="d-lst-circle">
-        <li class="d-pl4">An unordered list item</li>
-        <li class="d-pl4">An unordered list item</li>
+<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-secondary d-w100p d-hmn102" custom>
+  <ul class="d-pl16">
+    <li class="d-lst-none"><strong>none</strong> list item</li>
+    <li class="d-lst-disc"><strong>disc</strong> list item</li>
+    <li class="d-lst-circle"><strong>circle</strong> list item</li>
+    <li class="d-lst-decimal"><strong>decimal</strong> list item</li>
+    <li class="d-lst-content" style="--ls-content: '🫠'"><strong>content</strong> list item</li>
+    <li class="d-lst-disc">
+      An unordered list item
+      <ul class="d-pl16">
+        <li class="d-lst-circle">A nested unordered list item</li>
+        <li class="d-lst-circle">A nested unordered list item</li>
       </ul>
     </li>
-    <li>
-      <ul>
-        <li class="d-pl4 d-lst-content" style="--ls-content: '✅'">An unordered list item</li>
-        <li class="d-pl4 d-lst-content" style="--ls-content: '❌'">An unordered list item</li>
+    <li class="d-lst-disc">
+      An unordered list item
+      <ul class="d-pl16">
+        <li class="d-pl8 d-lst-content" style="--ls-content: '✅'">A nested unordered list item</li>
+        <li class="d-pl8 d-lst-content" style="--ls-content: '❌'">A nested unordered list item</li>
       </ul>
     </li>
   </ul>
 </code-well-header>
 
 ```html
-<ul class="d-lst-disc">
-  <li>...</li>
-  <li>
-    <ul class="d-lst-circle">
-      <li>...</li>
-      <li>...</li>
+<ul class="d-pl16">
+  <li class="d-lst-none"><strong>none</strong> list item</li>
+  <li class="d-lst-disc"><strong>disc</strong> list item</li>
+  <li class="d-lst-circle"><strong>circle</strong> list item</li>
+  <li class="d-lst-decimal"><strong>decimal</strong> list item</li>
+  <li class="d-lst-content" style="--ls-content: '🫠'"><strong>content</strong> list item</li>
+  <li class="d-lst-disc">
+    An unordered list item
+    <ul class="d-pl16">
+      <li class="d-lst-circle">A nested unordered list item</li>
+      <li class="d-lst-circle">A nested unordered list item</li>
     </ul>
   </li>
-  <li>
-    <ul>
-      <li class="d-lst-content" style="--ls-content: '✅'">...</li>
-      <li class="d-lst-content" style="--ls-content: '❌'">...</li>
+  <li class="d-lst-disc">
+    An unordered list item
+    <ul class="d-pl16">
+      <li class="d-pl8 d-lst-content" style="--ls-content: '✅'">A nested unordered list item</li>
+      <li class="d-pl8 d-lst-content" style="--ls-content: '❌'">A nested unordered list item</li>
     </ul>
   </li>
 </ul>

--- a/apps/dialtone-documentation/docs/utilities/typography/lists.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/lists.md
@@ -101,6 +101,46 @@ Use `d-lst-{none|disc|circle|decimal|content|none}` to change a list item's bull
 </ul>
 ```
 
+## Custom starting number
+
+Use the `start` attribute for an `<ol>` to set its starting number.
+
+<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-secondary d-w100p d-hmn102" custom>
+  <dt-stack gap="400">
+    <p>Paragraph of text.</p>
+    <ol class="d-pl24">
+      <li class="d-lst-decimal">Decimal list item</li>
+      <li class="d-lst-decimal">Decimal list item</li>
+      <li class="d-lst-decimal">Decimal list item</li>
+    </ol>
+    <p>Paragraph of text. The list below starts at 4.</p>
+    <ol class="d-pl24" start="4">
+      <li class="d-lst-decimal">Decimal list item</li>
+      <li class="d-lst-decimal">Decimal list item</li>
+      <li class="d-lst-decimal">Decimal list item</li>
+    </ol>
+  </dt-stack>
+</code-well-header>
+
+```html
+<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-secondary d-w100p d-hmn102" custom>
+  <dt-stack gap="400">
+    <p>Paragraph of text.</p>
+    <ol class="d-pl24">
+      <li class="d-lst-decimal">Decimal list item</li>
+      <li class="d-lst-decimal">Decimal list item</li>
+      <li class="d-lst-decimal">Decimal list item</li>
+    </ol>
+    <p>Paragraph of text. The list below starts at 4.</p>
+    <ol class="d-pl24" start="4">
+      <li class="d-lst-decimal">Decimal list item</li>
+      <li class="d-lst-decimal">Decimal list item</li>
+      <li class="d-lst-decimal">Decimal list item</li>
+    </ol>
+  </dt-stack>
+</code-well-header>
+```
+
 <script setup>
   import { lists } from '@data/type.json';
 </script>

--- a/apps/dialtone-documentation/docs/utilities/typography/lists.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/lists.md
@@ -54,12 +54,47 @@ Use `d-ls-reset` to reset the margin, padding, and list-style-type of a list. Re
 Use `d-lst-{none|disc|circle|decimal|content|none}` to change a list item's bullet styling.
 
 <code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-secondary d-w100p d-hmn102" custom>
+  <dt-stack gap="400">
+    <p>Paragraph of text.</p>
+    <ul class="d-pl16">
+      <li class="d-lst-disc"><strong>disc</strong> list item</li>
+      <li class="d-lst-circle"><strong>circle</strong> list item</li>
+      <li class="d-lst-decimal"><strong>decimal</strong> list item</li>
+      <li class="d-lst-content" style="--ls-content: '🫠'"><strong>content</strong> list item</li>
+      <li class="d-lst-none"><strong>none</strong> list item</li>
+    </ul>
+    <p>Paragraph of text.</p>
+    <ul class="d-pl16">
+      <li class="d-lst-disc">
+        An unordered list item
+        <ul class="d-pl16">
+          <li class="d-lst-circle">A nested unordered list item</li>
+          <li class="d-lst-circle">A nested unordered list item</li>
+        </ul>
+      </li>
+      <li class="d-lst-disc">
+        An unordered list item
+        <ul class="d-pl16">
+          <li class="d-pl8 d-lst-content" style="--ls-content: '✅'">A nested unordered list item</li>
+          <li class="d-pl8 d-lst-content" style="--ls-content: '❌'">A nested unordered list item</li>
+        </ul>
+      </li>
+    </ul>
+  </dt-stack>
+</code-well-header>
+
+```html
+<dt-stack gap="400">
+  <p>Paragraph of text.</p>
   <ul class="d-pl16">
-    <li class="d-lst-none"><strong>none</strong> list item</li>
     <li class="d-lst-disc"><strong>disc</strong> list item</li>
     <li class="d-lst-circle"><strong>circle</strong> list item</li>
     <li class="d-lst-decimal"><strong>decimal</strong> list item</li>
     <li class="d-lst-content" style="--ls-content: '🫠'"><strong>content</strong> list item</li>
+    <li class="d-lst-none"><strong>none</strong> list item</li>
+  </ul>
+  <p>Paragraph of text.</p>
+  <ul class="d-pl16">
     <li class="d-lst-disc">
       An unordered list item
       <ul class="d-pl16">
@@ -75,30 +110,7 @@ Use `d-lst-{none|disc|circle|decimal|content|none}` to change a list item's bull
       </ul>
     </li>
   </ul>
-</code-well-header>
-
-```html
-<ul class="d-pl16">
-  <li class="d-lst-none"><strong>none</strong> list item</li>
-  <li class="d-lst-disc"><strong>disc</strong> list item</li>
-  <li class="d-lst-circle"><strong>circle</strong> list item</li>
-  <li class="d-lst-decimal"><strong>decimal</strong> list item</li>
-  <li class="d-lst-content" style="--ls-content: '🫠'"><strong>content</strong> list item</li>
-  <li class="d-lst-disc">
-    An unordered list item
-    <ul class="d-pl16">
-      <li class="d-lst-circle">A nested unordered list item</li>
-      <li class="d-lst-circle">A nested unordered list item</li>
-    </ul>
-  </li>
-  <li class="d-lst-disc">
-    An unordered list item
-    <ul class="d-pl16">
-      <li class="d-pl8 d-lst-content" style="--ls-content: '✅'">A nested unordered list item</li>
-      <li class="d-pl8 d-lst-content" style="--ls-content: '❌'">A nested unordered list item</li>
-    </ul>
-  </li>
-</ul>
+</dt-stack>
 ```
 
 ## Custom starting number

--- a/packages/dialtone-icons/src/keywords.json
+++ b/packages/dialtone-icons/src/keywords.json
@@ -1024,6 +1024,13 @@
         "chromecast",
         "airplay"
       ],
+      "connection-api": [
+        "plug",
+        "plugin",
+        "connected",
+        "connection",
+        "connections"
+      ],
       "dect-base-station": [],
       "dect-handset": [],
       "deskphone": [
@@ -1197,13 +1204,6 @@
         "flash",
         "camera",
         "lightning"
-      ],
-      "connection-api": [
-        "plug",
-        "plugin",
-        "connected",
-        "connection",
-        "connections"
       ]
     },
     "editing": {


### PR DESCRIPTION
# Clarify list css utilities docs

<img width="385" alt="image" src="https://github.com/dialpad/dialtone/assets/1165933/2bd634d2-c19d-4dcd-ac4e-4b29fec48864">

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Description

Using CSS Utilities for lists needed clarity

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.