### PR TITLE
ci: DLT-1744 add --skip-tag flag to avoid creating the tag

### DIFF
--- a/packages/dialtone-css/project.json
+++ b/packages/dialtone-css/project.json
@@ -16,7 +16,7 @@
     "release-local": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-css/release-local.config.cjs"
+        "command": "pnpm semantic-release-plus --skip-tag --extends ./packages/dialtone-css/release-local.config.cjs"
       }
     },
     "start": {

--- a/packages/dialtone-css/release-ci.config.cjs
+++ b/packages/dialtone-css/release-ci.config.cjs
@@ -2,6 +2,9 @@
 const name = 'dialtone-css';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
   pkgRoot: srcRoot,

--- a/packages/dialtone-css/release-local.config.cjs
+++ b/packages/dialtone-css/release-local.config.cjs
@@ -2,8 +2,12 @@
 const name = 'dialtone-css';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
+  ci: false,
   pkgRoot: srcRoot,
   tagFormat: name + '/v${version}',
   commitPaths: [`${srcRoot}/*`],
@@ -29,7 +33,6 @@ module.exports = {
     ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
-      /* eslint-disable-next-line no-template-curly-in-string */
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],

--- a/packages/dialtone-emojis/project.json
+++ b/packages/dialtone-emojis/project.json
@@ -16,7 +16,7 @@
     "release-local": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-emojis/release-local.config.cjs"
+        "command": "pnpm semantic-release-plus --skip-tag --extends ./packages/dialtone-emojis/release-local.config.cjs"
       }
     }
   }

--- a/packages/dialtone-emojis/release-ci.config.cjs
+++ b/packages/dialtone-emojis/release-ci.config.cjs
@@ -1,6 +1,10 @@
+/* eslint-disable no-template-curly-in-string */
 const name = 'dialtone-emojis';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
   pkgRoot: srcRoot,
@@ -10,7 +14,7 @@ module.exports = {
     ['@semantic-release/commit-analyzer', {
       preset: 'angular',
       releaseRules: [
-        {type: 'refactor', release: 'patch'},
+        { type: 'refactor', release: 'patch' },
       ],
     }],
     ['@semantic-release/release-notes-generator', {

--- a/packages/dialtone-emojis/release-local.config.cjs
+++ b/packages/dialtone-emojis/release-local.config.cjs
@@ -2,6 +2,9 @@
 const name = 'dialtone-emojis';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
   pkgRoot: srcRoot,
@@ -10,19 +13,19 @@ module.exports = {
   assets: [
     `${srcRoot}/CHANGELOG.md`,
     `${srcRoot}/CHANGELOG.json`,
-    `${srcRoot}/package.json`
+    `${srcRoot}/package.json`,
   ],
   plugins: [
     ['@semantic-release/commit-analyzer', {
       preset: 'angular',
       releaseRules: [
-        {type: 'build', release: 'patch'},
-        {type: 'chore', release: 'patch'},
-        {type: 'ci', release: 'patch'},
-        {type: 'docs', release: 'patch'},
-        {type: 'refactor', release: 'patch'},
-        {type: 'style', release: 'patch'},
-        {type: 'test', release: 'patch'},
+        { type: 'build', release: 'patch' },
+        { type: 'chore', release: 'patch' },
+        { type: 'ci', release: 'patch' },
+        { type: 'docs', release: 'patch' },
+        { type: 'refactor', release: 'patch' },
+        { type: 'style', release: 'patch' },
+        { type: 'test', release: 'patch' },
       ],
     }],
     ['@semantic-release/release-notes-generator', {
@@ -35,7 +38,6 @@ module.exports = {
     ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
-      /* eslint-disable-next-line no-template-curly-in-string */
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],

--- a/packages/dialtone-icons/project.json
+++ b/packages/dialtone-icons/project.json
@@ -33,7 +33,7 @@
     "release-local": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-icons/release-local.config.cjs"
+        "command": "pnpm semantic-release-plus --skip-tag --extends ./packages/dialtone-icons/release-local.config.cjs"
       }
     }
   }

--- a/packages/dialtone-icons/release-ci.config.cjs
+++ b/packages/dialtone-icons/release-ci.config.cjs
@@ -1,6 +1,10 @@
+/* eslint-disable no-template-curly-in-string */
 const name = 'dialtone-icons';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
   pkgRoot: srcRoot,
@@ -10,7 +14,7 @@ module.exports = {
     ['@semantic-release/commit-analyzer', {
       preset: 'angular',
       releaseRules: [
-        {type: 'refactor', release: 'patch'},
+        { type: 'refactor', release: 'patch' },
       ],
     }],
     ['@semantic-release/release-notes-generator', {

--- a/packages/dialtone-icons/release-local.config.cjs
+++ b/packages/dialtone-icons/release-local.config.cjs
@@ -2,8 +2,12 @@
 const name = 'dialtone-icons';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
+  ci: false,
   pkgRoot: srcRoot,
   tagFormat: name + '/v${version}',
   commitPaths: [`${srcRoot}/*`],
@@ -16,13 +20,13 @@ module.exports = {
     ['@semantic-release/commit-analyzer', {
       preset: 'angular',
       releaseRules: [
-        {type: 'build', release: 'patch'},
-        {type: 'chore', release: 'patch'},
-        {type: 'ci', release: 'patch'},
-        {type: 'docs', release: 'patch'},
-        {type: 'refactor', release: 'patch'},
-        {type: 'style', release: 'patch'},
-        {type: 'test', release: 'patch'},
+        { type: 'build', release: 'patch' },
+        { type: 'chore', release: 'patch' },
+        { type: 'ci', release: 'patch' },
+        { type: 'docs', release: 'patch' },
+        { type: 'refactor', release: 'patch' },
+        { type: 'style', release: 'patch' },
+        { type: 'test', release: 'patch' },
       ],
     }],
     ['@semantic-release/release-notes-generator', {
@@ -35,7 +39,6 @@ module.exports = {
     ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
-      /* eslint-disable-next-line no-template-curly-in-string */
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],

--- a/packages/dialtone-tokens/project.json
+++ b/packages/dialtone-tokens/project.json
@@ -26,7 +26,7 @@
     "release-local": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-tokens/release-local.config.cjs"
+        "command": "pnpm semantic-release-plus --skip-tag --extends ./packages/dialtone-tokens/release-local.config.cjs"
       }
     }
   }

--- a/packages/dialtone-tokens/release-ci.config.cjs
+++ b/packages/dialtone-tokens/release-ci.config.cjs
@@ -1,6 +1,10 @@
+/* eslint-disable no-template-curly-in-string */
 const name = 'dialtone-tokens';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
   pkgRoot: srcRoot,
@@ -10,7 +14,7 @@ module.exports = {
     ['@semantic-release/commit-analyzer', {
       preset: 'angular',
       releaseRules: [
-        {type: 'refactor', release: 'patch'},
+        { type: 'refactor', release: 'patch' },
       ],
     }],
     ['@semantic-release/release-notes-generator', {

--- a/packages/dialtone-tokens/release-local.config.cjs
+++ b/packages/dialtone-tokens/release-local.config.cjs
@@ -1,8 +1,13 @@
+/* eslint-disable no-template-curly-in-string */
 const name = 'dialtone-tokens';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
+  ci: false,
   pkgRoot: srcRoot,
   tagFormat: name + '/v${version}',
   commitPaths: [`${srcRoot}/*`],
@@ -21,13 +26,12 @@ module.exports = {
     ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
-      /* eslint-disable-next-line no-template-curly-in-string */
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],
-    ["@semantic-release/exec", {
-      "prepareCmd": "./gradlew setProperties -Pversion=${nextRelease.version} && echo '${nextRelease.version}' > ./dist_ios/VERSION && git add -A && git commit -m 'chore(release): NO-JIRA " + name + "/v${nextRelease.version} gradle' && git push",
-      "execCwd": srcRoot,
+    ['@semantic-release/exec', {
+      prepareCmd: './gradlew setProperties -Pversion=${nextRelease.version} && echo \'${nextRelease.version}\' > ./dist_ios/VERSION && git add -A && git commit -m \'chore(release): NO-JIRA ' + name + '/v${nextRelease.version} gradle\' && git push',
+      execCwd: srcRoot,
     }],
   ],
   branches: [

--- a/packages/dialtone-vue2/project.json
+++ b/packages/dialtone-vue2/project.json
@@ -24,7 +24,7 @@
     "release-local": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-vue2/release-local.config.cjs"
+        "command": "pnpm semantic-release-plus --skip-tag --extends ./packages/dialtone-vue2/release-local.config.cjs"
       }
     },
     "test": {

--- a/packages/dialtone-vue2/release-ci.config.cjs
+++ b/packages/dialtone-vue2/release-ci.config.cjs
@@ -2,6 +2,9 @@
 const name = 'dialtone-vue2';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
   pkgRoot: srcRoot,

--- a/packages/dialtone-vue2/release-local.config.cjs
+++ b/packages/dialtone-vue2/release-local.config.cjs
@@ -2,8 +2,12 @@
 const name = 'dialtone-vue2';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
+  ci: false,
   pkgRoot: srcRoot,
   tagFormat: name + '/v${version}',
   commitPaths: [`${srcRoot}/*`],
@@ -29,7 +33,6 @@ module.exports = {
     ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
-      /* eslint-disable-next-line no-template-curly-in-string */
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],

--- a/packages/dialtone-vue3/project.json
+++ b/packages/dialtone-vue3/project.json
@@ -24,7 +24,7 @@
     "release-local": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/dialtone-vue3/release-local.config.cjs"
+        "command": "pnpm semantic-release-plus --skip-tag --extends ./packages/dialtone-vue3/release-local.config.cjs"
       }
     },
     "test": {

--- a/packages/dialtone-vue3/release-ci.config.cjs
+++ b/packages/dialtone-vue3/release-ci.config.cjs
@@ -2,6 +2,9 @@
 const name = 'dialtone-vue3';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
   pkgRoot: srcRoot,

--- a/packages/dialtone-vue3/release-local.config.cjs
+++ b/packages/dialtone-vue3/release-local.config.cjs
@@ -2,8 +2,12 @@
 const name = 'dialtone-vue3';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
+  ci: false,
   pkgRoot: srcRoot,
   tagFormat: name + '/v${version}',
   commitPaths: [`${srcRoot}/*`],
@@ -29,7 +33,6 @@ module.exports = {
     ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
-      /* eslint-disable-next-line no-template-curly-in-string */
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],

--- a/packages/eslint-plugin-dialtone/project.json
+++ b/packages/eslint-plugin-dialtone/project.json
@@ -18,7 +18,7 @@
     "release-local": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/eslint-plugin-dialtone/release-local.config.cjs",
+        "command": "pnpm semantic-release-plus --skip-tag --extends ./packages/eslint-plugin-dialtone/release-local.config.cjs",
         "parallel": false
       }
     }

--- a/packages/eslint-plugin-dialtone/release-ci.config.cjs
+++ b/packages/eslint-plugin-dialtone/release-ci.config.cjs
@@ -1,6 +1,10 @@
+/* eslint-disable no-template-curly-in-string */
 const name = 'eslint-plugin-dialtone';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
   pkgRoot: srcRoot,

--- a/packages/eslint-plugin-dialtone/release-local.config.cjs
+++ b/packages/eslint-plugin-dialtone/release-local.config.cjs
@@ -1,8 +1,13 @@
+/* eslint-disable no-template-curly-in-string */
 const name = 'eslint-plugin-dialtone';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
+  ci: false,
   pkgRoot: srcRoot,
   tagFormat: name + '/v${version}',
   commitPaths: [`${srcRoot}/*`],
@@ -21,8 +26,7 @@ module.exports = {
     ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
-      /* eslint-disable-next-line no-template-curly-in-string */
-      message: `chore(release): NO-JIRA ${name}` +
+        message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],
   ],

--- a/packages/stylelint-plugin-dialtone/project.json
+++ b/packages/stylelint-plugin-dialtone/project.json
@@ -18,7 +18,7 @@
     "release-local": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./packages/stylelint-plugin-dialtone/release-local.config.cjs",
+        "command": "pnpm semantic-release-plus --skip-tag --extends ./packages/stylelint-plugin-dialtone/release-local.config.cjs",
         "parallel": false
       }
     }

--- a/packages/stylelint-plugin-dialtone/release-ci.config.cjs
+++ b/packages/stylelint-plugin-dialtone/release-ci.config.cjs
@@ -1,6 +1,10 @@
+/* eslint-disable no-template-curly-in-string */
 const name = 'stylelint-plugin-dialtone';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
   pkgRoot: srcRoot,

--- a/packages/stylelint-plugin-dialtone/release-local.config.cjs
+++ b/packages/stylelint-plugin-dialtone/release-local.config.cjs
@@ -1,8 +1,12 @@
 const name = 'stylelint-plugin-dialtone';
 const srcRoot = `packages/${name}`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
+  ci: false,
   pkgRoot: srcRoot,
   tagFormat: name + '/v${version}',
   commitPaths: [`${srcRoot}/*`],
@@ -21,8 +25,7 @@ module.exports = {
     ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
-      /* eslint-disable-next-line no-template-curly-in-string */
-      message: `chore(release): NO-JIRA ${name}` +
+            message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],
   ],

--- a/project.json
+++ b/project.json
@@ -32,7 +32,7 @@
     "release-local": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm semantic-release-plus --no-ci --extends ./release-local.config.cjs",
+        "command": "pnpm semantic-release-plus --skip-tag --extends ./release-local.config.cjs",
         "parallel": false
       }
     },

--- a/release-ci.config.cjs
+++ b/release-ci.config.cjs
@@ -2,6 +2,9 @@
 const name = 'dialtone';
 const srcRoot = '.';
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
   pkgRoot: srcRoot,

--- a/release-local.config.cjs
+++ b/release-local.config.cjs
@@ -2,8 +2,12 @@
 const name = 'dialtone';
 const srcRoot = `.`;
 
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 module.exports = {
   extends: 'release.config.base.js',
+  ci: false,
   pkgRoot: srcRoot,
   tagFormat: name + '/v${version}',
   commitPaths: [`${srcRoot}/*`],
@@ -30,7 +34,6 @@ module.exports = {
     ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
-      /* eslint-disable-next-line no-template-curly-in-string */
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],


### PR DESCRIPTION
# Add --skip-tag flag to avoid creating the tag

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/QWjFSsvUPCUncq6ItU/giphy.gif?cid=790b7611hslce9px6b3k1ch3fgey1ny2pij3w6qljlv299j1&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] CI

## :book: Jira Ticket

- https://dialpad.atlassian.net/browse/DLT-1744

## :book: Description

- Added --skip-tag flag to semantic release to avoid creating the tag locally.

## :bulb: Context

We were creating the tag locally so when `release-github` command was running, the tag was already created so it will not detect any changes so no release would be created.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

## :link: Sources

https://semantic-release-plus.gitbook.io/semantic-release-plus/v/beta/usage/configuration#skiptag
https://github.com/dialpad/dialtone/actions/runs/8900104791/job/24440928949#step:35:74