### PR TITLE
ci: NO-JIRA improve release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Filter actions by path
         if: ${{ github.event.inputs.base || github.event_name == 'push' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
 
       - name: Filter actions by path
         if: ${{ github.event.inputs.base || github.event_name == 'push' }}
@@ -60,22 +58,31 @@ jobs:
           filters: |
             dialtone:
               - 'package.json'
+              - 'CHANGELOG.md'
             css:
               - 'packages/dialtone-css/package.json'
+              - 'packages/dialtone-css/CHANGELOG.md'
             emojis:
               - 'packages/dialtone-emojis/package.json'
+              - 'packages/dialtone-emojis/CHANGELOG.md'
             icons:
               - 'packages/dialtone-icons/package.json'
+              - 'packages/dialtone-icons/CHANGELOG.md'
             tokens:
               - 'packages/dialtone-tokens/package.json'
+              - 'packages/dialtone-tokens/CHANGELOG.md'
             vue2:
               - 'packages/dialtone-vue2/package.json'
+              - 'packages/dialtone-vue2/CHANGELOG.md'
             vue3:
               - 'packages/dialtone-vue3/package.json'
+              - 'packages/dialtone-vue3/CHANGELOG.md'
             eslint-plugin:
               - 'packages/eslint-plugin-dialtone/package.json'
+              - 'packages/eslint-plugin-dialtone/CHANGELOG.md'
             stylelint-plugin:
               - 'packages/stylelint-plugin-dialtone/package.json'
+              - 'packages/stylelint-plugin-dialtone/CHANGELOG.md'
 
   get-branch-name:
     runs-on: ubuntu-latest
@@ -98,6 +105,7 @@ jobs:
 
   release:
     needs: [get-branch-name, check-dialpad-member, filter-actions]
+    if: needs.filter-actions.outputs.changes != '[]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -112,6 +120,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/gulpfile.cjs
+++ b/gulpfile.cjs
@@ -28,7 +28,7 @@ const paths = {
     tokens: [
       './packages/dialtone-tokens/dist/**',
       '!./packages/dialtone-tokens/dist/android/**',
-      '!./packages/dialtone-tokens/dist/ios/**'
+      '!./packages/dialtone-tokens/dist/ios/**',
     ],
     vue2: './packages/dialtone-vue2/dist/**',
     vue3: './packages/dialtone-vue3/dist/**',

--- a/nx.json
+++ b/nx.json
@@ -22,24 +22,6 @@
         "^build"
       ]
     },
-    "release": {
-      "dependsOn": [
-        "build",
-        "^build"
-      ]
-    },
-    "release-local": {
-      "dependsOn": [
-        "build",
-        "^build"
-      ]
-    },
-    "release-github": {
-      "dependsOn": [
-        "build",
-        "^build"
-      ]
-    },
     "start": {
       "dependsOn": [
         "^build"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,9 +24,9 @@ git merge --ff-only "$current_branch";
 
 echo "Running release-local on affected projects";
 if [[ "$release_branch" == "alpha" || "$release_branch" == "beta" ]]; then
-  pnpm nx release-local --base=staging dialtone;
+  pnpm nx affected --target=release-local --base=staging --parallel=false;
 else
-  pnpm nx release-local --base=production dialtone;
+  pnpm nx affected --target=release-local --base=production --parallel=false;
 fi
 
 echo "Pushing changes to $release_branch";

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,48 +1,40 @@
 #!/usr/bin/env bash
 set -e
 
-current_branch="$(git rev-parse --abbrev-ref HEAD)"
-release_branch="${1:-production}"
+current_branch="$(git rev-parse --abbrev-ref HEAD)";
+release_branch="${1:-production}";
 
 if [[ "$release_branch" == "production" && "$current_branch" != "staging" ]]; then
-  echo "Releasing production can only be done while on staging branch"
+  echo "Releasing production can only be done while on staging branch";
   exit 1;
 elif [[ "$release_branch" == "$current_branch" ]]; then
-  echo "Releasing $release_branch can't be done while on $current_branch branch"
-  echo "Make sure to checkout to your feature branch"
+  echo "Releasing $release_branch can't be done while on $current_branch branch";
+  echo "Make sure to checkout to your feature branch";
   exit 1;
 fi
 
+echo "Checking out to $release_branch";
+git checkout "$release_branch";
+
+echo "Updating branch";
+git pull;
+
+echo "Merging changes";
+git merge --ff-only "$current_branch";
+
+echo "Running release-local on affected projects";
 if [[ "$release_branch" == "alpha" || "$release_branch" == "beta" ]]; then
-  echo "Deleting local and remote $release_branch branch"
-  git branch -D "$release_branch" || true
-  git push origin --delete "$release_branch" || true
-
-  echo "Checking out and pushing a clean $release_branch branch"
-  git checkout -b "$release_branch";
-  git push origin "$release_branch"
+  pnpm nx release-local --base=staging dialtone;
+else
+  pnpm nx release-local --base=production dialtone;
 fi
 
-echo "Running build in parallel to improve performance"
-pnpm nx affected --target=build --parallel=6;
+echo "Pushing changes to $release_branch";
+git push origin "$release_branch";
 
-echo "Running release-local on affected projects"
-pnpm nx affected --target=release-local --parallel=false;
+echo "Merge changes back to $current_branch";
+git checkout "$current_branch";
+git merge --ff-only "$release_branch";
 
-if [[ "$release_branch" == "production" && "$current_branch" == "staging" ]]; then
-  echo "Checking out to $release_branch"
-  git checkout "$release_branch";
-
-  echo "Updating branch"
-  git pull;
-
-  echo "Merging changes"
-  git merge --ff-only "$current_branch";
-fi
-
-echo "Pushing changes to $release_branch"
-git push -u origin "$release_branch";
-
-echo "Merge changes back to $current_branch"
-git checkout "$current_branch"
-git merge --ff-only "$release_branch"
+echo "Pushing changes to $current_branch";
+git push origin "$current_branch";


### PR DESCRIPTION
# Improve release script

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/l0MYu38R0PPhIXe36/giphy.gif?cid=790b7611rb10xzuw4k2vj611godbxlkhsk8fjzul05rnlipy&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] CI

## :book: Description

- Added `CHANGELOG.md` to path filter change detection.
- Added `fetch-depth: 0` to fetch all the git history.
- Removed the `build` dependency of `release-local` script, it's not necessary actually and it's just making it take longer than it should.
- Improved release script to stop deleting alpha/beta, it was causing issues with git tags.

## :bulb: Context

I was testing releasing alpha/beta versions with the new `--skip-tag` flag and it was failing due to alpha/beta branches were behind the current one as it was deleted and recreated.

I think having the alpha/beta releases on staging/production should not make any damage, but please think about it and let me know if having any concern.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.