### PR TITLE
docs: NO-JIRA github doc update

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -126,7 +126,7 @@ After you have discussed your change with the Dialtone team, follow these steps 
    - 'visual-test-ready' if your PR includes visual UI changes.
    - 'no-visual-test' if no UI changes.
 
-8. If it's a Vue change, you need to update both dialtone-vue2 and dialtone-vue3 packages. You may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
+8. If it's a Vue change, you need to update both dialtone-vue2 and dialtone-vue3 packages. You may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Please see the section in the Dialtone Vue contributing guide: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script) for details on usage of the script.
 9. Once your changes have been approved, you may squash your branch into staging.
 
 Once your change is in `staging` it will go live with the next Dialtone Vue release.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -96,7 +96,7 @@ This is why it is important to evaluate the change carefully and asses its impac
 Any new components or updates to existing components require the following:
 
 - Unit tests covering the entire change.
-- Storybook documentation including a live rendered component via controls and MDX. See [the documentation](https://dialtone.dialpad.com/vue/?path=/story/docs-storybook-getting-started--page)
+- Storybook documentation including a live rendered component via controls and MDX. See [the documentation](https://dialtone.dialpad.com/vue/?path=/docs/docs-storybook-getting-started--docs)
 - Component is accessible according to requirements.
   - Navigable by keyboard.
   - Read by a screen reader.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,10 @@
 # Contributing
 
+Thanks for your interest in contributing to Dialtone! Please take a moment to review this document before submitting a pull request.
+
 Dialtone exists as a monorepo containing multiple packages. Libraries are stored in the packages folder, and deployable documentation sites are stored in the apps folder. Currently the Dialtone Vue storybook documentation sites are stored in the same folder as their libraries due to a limitation of storybook, however this may change in the future as it makes more logical sense for them to be stored in the apps folder.
 
-Each package has its own contributing guide, please follow the links to find the actual contributing guide you might need.
+This contributing guide contains guidelines and processes that apply to all packages of the Dialtone monorepo. There are also contributing guides specific to each package, so make sure to also read the contributing guide for the package you are contributing to in addition to this one:
 
 ## Dialtone CSS
 
@@ -19,3 +21,219 @@ Each package has its own contributing guide, please follow the links to find the
 ## Dialtone Icons
 
 [CONTRIBUTING.md](../packages/dialtone-icons/.github/CONTRIBUTING.md)
+
+## Dialtone Documentation Site
+
+[CONTRIBUTING.md](../apps/dialtone-documentation/.github/CONTRIBUTING.md)
+
+## Overview
+
+### What is Dialtone?
+
+Dialtone is a design system by Dialpad comprised of CSS components and utility classes, [Vue components](https://dialtone.dialpad.com/vue), visual assets, documentation and examples which strives to:
+
+- Create a consistent design language between all Dialpad products.
+- Create a suite of well-documented, flexible and intuitive UI components that are easy for designers, developers and users to use.
+- Document and promote accessible development and design across Dialpad.
+
+### What is a contribution?
+
+A contribution is any proposal, design, code, or documentation completed by someone not on the core Dialtone team, and released through Dialtone for other people to use. It can be created by anyone who'd like to help make Dialtone better.
+
+Types of contributions:
+
+- **Fix:** fixes a technical defect, documentation typo, or Figma symbol defect.
+- **Enhancement:** extends an existing style or component without changing the underlying architecture or behavior.
+- **New feature:** adds something new, like a component.
+
+### What belongs in Dialtone?
+
+There are a couple important considerations when thinking about contributing to Dialtone. The first is to remember that Dialtone strives to offer styles, components, or patterns intended to be shared by multiple teams or features. Generally, one-off or first-time elements (i.e. snowflakes) aren't a great fit, though there may be the occasional exception.
+
+The second is to check with the Dialtone team (in the #dialtone Dialpad channel) to ensure the contribution isn't already requested, planned, or even complete. You may also see our [Jira backlog](https://dialpad.atlassian.net/jira/software/c/projects/DLT/boards/548/backlog) for upcoming work, and our [Jira timeline](https://dialpad.atlassian.net/jira/software/c/projects/DLT/boards/548/timeline) for our long term quarterly roadmap.
+
+### Roles
+
+- **Contributor:** Has the ability to create PRs and merge their change into `staging` after at least one approving review.
+- **Maintainer:** A trusted contributor with the ability to release Dialtone.
+- **Admin:** Has the ability to change any configuration on the Dialtone repository and release Dialtone. Usually for members of the Dialtone team.
+
+## How to contribute
+
+### Feature request
+
+To request a new Dialtone feature or enhancement, submit a [feature request](https://dialpad.atlassian.net/secure/CreateIssue.jspa?issuetype=10975&pid=12508) to our Jira.
+
+### Bug report
+
+If you would like to report a bug, please post it in the #dialtone Dialpad channel. We will assist you in determining whether it is a Dialtone bug. Please give us a working example of the bug on a private beta or deploy preview link. A branch we can checkout is also helpful. If we have determined that this is a bug in Dialtone, then you may create a [bug report](https://dialpad.atlassian.net/secure/CreateIssue.jspa?issuetype=1&pid=12508) on Jira for the bug. We will get to fixing the bug in the future, or you can fix the bug yourself by [Making a Pull Request](#making-a-pull-request)
+
+## Making a Pull Request
+
+### Before Submitting
+
+Before submitting a pull request, make sure to communicate what you wish to change to the Dialtone team.
+The easiest way to do this is via the #dialtone Dialpad channel.
+It's possible your change is already being worked on, has already been fixed, or maybe we just need to discuss the best solution to the problem.
+This prevents you from having to re-write your entire change, or even having to scrap it entirely.
+
+The Dialtone library exists to serve multiple teams, so it is important to ensure that your PR does not introduce any unnecessary breaking changes.
+Breaking changes will require extra steps that may prolong the submission review process.
+If breaking changes are absolutely necessary for your use case, then you must communicate them to the Dialtone team in advance to allow for a smooth migration strategy for all dependant projects.
+
+Examples of breaking include the following:
+
+- **Changing or removing the component API**: renaming or removing props and emits, or changing their expected types
+
+Examples of non-breaking changes:
+
+- **Making new additions to the component API**: for example, adding a new prop to a component that triggers a different flow of behaviour or output, or adding a new emit event to detect specific changes.
+- **Refactoring**: changing the internal code of a component without changing any external behaviour.
+
+Some updates can unintentionally cause breaking changes, or cause changes to a component's output behaviour or functionality without necessary breaking it.
+This is why it is important to evaluate the change carefully and asses its impact on existing usage.
+
+Any new components or updates to existing components require the following:
+
+- Unit tests covering the entire change.
+- Storybook documentation including a live rendered component via controls and MDX. See [the documentation](https://dialtone.dialpad.com/vue/?path=/story/docs-storybook-getting-started--page)
+- Component is accessible according to requirements.
+  - Navigable by keyboard.
+  - Read by a screen reader.
+  - Minimum contrast ratio.
+- Changes must be made for Vue 2 as well as Vue 3, `dialtone-vue2` and `dialtone-vue3` package folders respectively
+- Unit tests are passing locally.
+  - `nx test dialtone-vue2` or `nx test dialtone-vue3`
+- Linters are passing locally.
+  - `nx lint dialtone-vue2` or `nx lint dialtone-vue3`
+- Library builds locally.
+  - `nx build dialtone-vue2` or `nx build dialtone-vue3`
+- Documentation builds locally.
+  - `nx storybook:build dialtone-vue2` or `nx storybook:build dialtone-vue3`
+
+### How to Submit
+
+After you have discussed your change with the Dialtone team, follow these steps to submit it:
+
+1. See [README.md](../README.md) for instructions on how to initially clone and run the project.
+2. First make sure you are on the `staging` branch with `git checkout staging`, and that it is up-to-date with `git pull`.
+3. Create a personal branch to make your change off of `staging` with `git checkout -b my-change-branch`. We use kebab-case for branch names.
+4. Make and commit your changes. Note our commit message conventions in [COMMIT_CONVENTION.md].
+5. Push your branch to remote. `git push -u origin my-change-branch`.
+6. Create a pull request into the `staging` branch, reviewers will be automatically added and notified of your PR.
+7. Set the label on your PR:
+
+- 'visual-test-ready' if your PR includes visual UI changes.
+- 'no-visual-test' if no UI changes.
+
+<!-- markdownlint-disable MD029 -->
+8. If it's a Vue change, you need to update both dialtone-vue2 and dialtone-vue3 packages. You may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
+9. Once your changes have been approved, you may squash your branch into staging.
+
+Once your change is in `staging` it will go live with the next Dialtone Vue release.
+Releases are done on demand by the Dialtone team, and are done fairly regularly.
+
+## Commit Message Convention
+
+Dialtone uses [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) to have commit messages that can be used as part of the semantic release process. For more information, see [COMMIT_CONVENTION.md].
+
+### A11y standards
+
+Dialtone adopts the [WCAG 2.1 AA](https://www.w3.org/WAI/standards-guidelines/wcag/glance/) Web Content Accessibility Guidelines.
+
+### Git Hooks
+
+To enforce your commit message on the release branches (`production`, `staging`, `alpha` and `beta`) are correct according to the Conventional Commits specification, there is a `commit-msg` git hook that will be invoked by `git commit`.
+`pre-commit` git hook will lint your code.
+
+## Versioning
+
+Dialtone follows [SemVer](https://semver.org/) for versioning and the commit message convention used in the project is aligned with SemVer by describing the features, fixes, and breaking changes made in commit messages.
+
+## How we manage work
+
+We use Jira to manage our work and you can visit the [Dialtone board and backlog](https://dialpad.atlassian.net/jira/software/c/projects/DLT/boards/548/backlog) assuming you are an authenticated Dialpad employee. Below we will define how we use our Jira board so team members and external contriubutors are all on the same page.
+
+### Issue Types
+
+#### Dev Story
+
+A "Dev Story" is a small portion of work estimated and completed by the development team.
+
+#### Design Story
+
+A "Design Story" is a small portion of work estimated and completed by the design team.
+
+#### Proposal
+
+Proposals can be submitted by anyone with access to the jira board. Each proposal will be discussed in a grooming meeting with the Design System team and if accepted will be turned into a story (or multiple).
+
+#### Epic
+
+Epics are a collection of multiple stories, and always have a start and end length of one quarter. They should map to our quarterly OKRs. If a single feature will take multiple quarters to complete it should be split up into separate quarterly epics. If a story does not belong in any epic it can be put into the "Future work" epic, which holds all "uncategorized" stories.
+
+#### Bug
+
+A Bug is an unintentional defect in code that we have written that does not need any intended functionality to change in order to fix it. Bugs are not assigned a story point estimate.
+
+#### Spike
+
+The spike type refers to a "technical spike" in which we are not actually writing any code but instead performing research to find the best solution to our problem. Upon completion of a spike a resulting story will be created and groomed. Spikes are not assigned a story point estimate.
+
+#### Subtasks
+
+Subtasks are only created within a sprint after it has started and are individual technical tasks that need to be completed for the story to be finished. It may not make sense to split simpler stories into subtasks, for example if there would only be 1 task. By creating subtasks it prevents certain work from being forgotten and potentially allows multiple developers to work on different parts of the same story. It is possible for multiple developers to be working on the same story but it should only be possible for one developer to work on an individual subtask.
+
+### Estimation
+
+We estimate on an 8 point fibonacci scale of complexity during our grooming sessions. We only estimate work that gives explicit business value, so that means that only "Dev Stories" and "Design Stories" are estimated. Every sprint we should only be allocating story points for about 70% of developer work time. The other 30% is allocated to everything else a developer has to do: participate in meetings, fix bugs, support users, research technical spikes, review etc...
+
+### Prioritization
+
+Each Jira ticket has a priority which can be defined as the following:
+
+- **urgent**: we immediately pull it into the current sprint and begin working on it.
+- **high**: is quite important but not so important it is immediately pulled into the sprint.
+- **medium**: of moderate importance, the default priority level, the majority of our stories will probably be this.
+- **low**: not a priority, it is unlikely we will pull these into a sprint unless they are very low effort, or become a higher priority at a later time.
+
+Just because an item is high priority does not necessarily mean it will be pulled into the sprint before a medium item. The priority is how much business value this particular task will provide, however the rank (sort order) of the backlog is the order in which items will be pulled into the sprint. The rank is determined manually by the product owner (@braddialpad / @francisrupert in this case) and can be based on factors other than just priority, effort for example.
+
+#### Order / Rank
+
+In the backlog we always try to keep our jira items sorted in this order from top to bottom:
+
+- Bugs
+- Spikes
+- Stories / Proposals
+
+Within each of these categories, items marked 'backlog' should always be above items marked 'needs definition'. The top items of 'needs defintion' are next to be groomed, and the top items of 'backlog' are next to be pulled into the sprint. Once a story is assigned to someone it can be moved to 'todo' status.
+
+Proposals are mixed in and ranked with stories as they will eventually be turned into stories.
+
+### Component Categories
+
+"Components" are a feature of Jira that allows you to categorize your tickets in any way you wish. We use these to categorize our tickets in the long term. Unlike epics, components never have a start or end date. Multiple components can be applied to a single ticket. Try to use just one if you can, but if necessary multiple can be used.
+
+- `[Component]`: this story changes all components or multiple components.
+- `[Dropdown(or any component name)]`: this story includes change to only the dropdown component. Exclude Dt prefix and use [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case) format.
+- `[Utility]`: this story includes changes to a single or multiple utility classes.
+- `[Docs]`: this story only changes the documentation site or the storybook, it does not affect anything in our published library.
+- `[Figma]`: this is work specific to figma
+- `[Style]`: a css/less change that does not change a specific component or utility class.
+- `[Tokens]`: a change specific to Dialtone tokens.
+- `[Icons]`: a change specific to the Dialtone icons repo.
+- `[Storybook]`: a problem specific to the dialtone vue storybook documentation.
+- `[Architecture]`: a change to technical architecture such as GHA, gulp, webpack, npm, docsite config etc.
+
+### What about outside contributions?
+
+If you are developer contributing to Dialtone but are not on the Dialtone team your work will be added to the Dialtone board as normal and groomed with the Dialtone team. The main difference is that we will not be including your story in a Dialtone team sprint. The Dialtone ticket can be pulled into your own team's sprint, or just updated within our backlog if you prefer.
+
+### GitHub Actions
+
+[GitHub Actions](https://docs.github.com/en/actions) is what we use for our CI/CD solution.
+All GHA workflows are in the `.github/workflows` directory.
+Currently, we use GitHub Actions to run a number of CI process releated to releasing, deploying, and running checks on PRs.
+
+[COMMIT_CONVENTION.md]: ./COMMIT_CONVENTION.md

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -123,10 +123,9 @@ After you have discussed your change with the Dialtone team, follow these steps 
 6. Create a pull request into the `staging` branch, reviewers will be automatically added and notified of your PR.
 7. Set the label on your PR:
 
-- 'visual-test-ready' if your PR includes visual UI changes.
-- 'no-visual-test' if no UI changes.
+   - 'visual-test-ready' if your PR includes visual UI changes.
+   - 'no-visual-test' if no UI changes.
 
-<!-- markdownlint-disable MD029 -->
 8. If it's a Vue change, you need to update both dialtone-vue2 and dialtone-vue3 packages. You may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
 9. Once your changes have been approved, you may squash your branch into staging.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -58,7 +58,7 @@ For all PRs:
 For all Vue changes:
 
 - [ ] I have added / updated unit tests.
-- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
+- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
 - [ ] I have validated components with a screen reader.
 - [ ] I have validated components keyboard navigation.
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ nx build
 ##### Run all Vue unit tests
 
 ```bash
-nx test:vue
+nx test
 ```
 
 ##### Run Vue 2 tests

--- a/README.md
+++ b/README.md
@@ -2,6 +2,86 @@
 
 The monorepo for Dialpad's design system Dialtone.
 
+All packages of the monorepo are combined into a single Dialtone package for ease of use, however all separate packages of dialtone are also deployed individually. If you would like to use an individual package rather than the combined Dialtone package, you can find documentation for each package in the readme under the respective packages folder. The below usage instructions are for the combined package.
+
+## Usage
+
+### Install it via NPM:
+
+#### Vue 3
+
+```shell
+npm install @dialpad/dialtone@next @tiptap/vue-3
+```
+
+#### Vue 2
+
+```shell
+npm install @dialpad/dialtone@next @linusborg/vue-simple-portal @tiptap/vue-2
+```
+
+### Import packages:
+
+#### Dialtone CSS
+
+Dialtone CSS includes all utility classes as well as tokens.
+
+- CSS
+
+```css
+@import "@dialpad/dialtone/css";
+```
+
+- Javascript
+
+```js
+import "@dialpad/dialtone/css";
+```
+
+#### Dialtone icons
+
+- Vue 2:
+
+```js
+// Named import
+import { DtIconArrowUp } from '@dialpad/dialtone-icons/vue2';
+
+// Default import (Prefered if using webpack as it is tree-shakeable by default)
+import DtIconArrowUp from '@dialpad/dialtone-icons/vue2/arrow-up';
+```
+
+- Vue 3:
+
+```js
+// Named import
+import { DtIconArrowUp } from '@dialpad/dialtone-icons/vue3';
+
+// Default import (Prefered if using webpack as it is tree-shakeable by default)
+import DtIconArrowUp from '@dialpad/dialtone-icons/vue3/arrow-up';
+```
+
+#### Dialtone Vue components
+
+- Vue 2
+
+```js
+// Named import
+import { DtButton } from "@dialpad/dialtone/vue2"
+
+// Default import (Prefered if using webpack as it is tree-shakeable by default)
+import { DtButton } from "@dialpad/dialtone/vue2/lib/button"
+```
+
+- Vue 3
+
+```js
+// Named import
+import { DtButton } from "@dialpad/dialtone/vue3"
+
+// Default import (Prefered if using webpack as it is tree-shakeable by default)
+import { DtButton } from "@dialpad/dialtone/vue3/lib/button"
+```
+
 ## About this repo
 
 The @dialpad/dialtone repository is a monorepo composed of Dialtone NPM packages and apps.
@@ -16,6 +96,7 @@ dialtone/
   |--- dialtone-documentation     # Documentation site
 |--- packages                     # NPM packages
   |--- dialtone-css               # CSS library
+  |--- dialtone-emojis            # Emoji assets
   |--- dialtone-vue2              # Vue component library compatible with vue@2
   |--- dialtone-vue3              # Vue component library compatible with vue@3
   |--- dialtone-icons             # SVG icons library
@@ -25,33 +106,55 @@ dialtone/
 |--- scripts                      # Shared scripts
 ```
 
-## Tooling
+## Contributing
 
-### PNPM
+Please read our [contributing guide](.github/CONTRIBUTING.md) **before submitting a pull request**.
+
+### Quick start
+
+If you would like to contribute to Dialtone without having to do any local environment setup, you can use GitHub
+Codespaces. You can initialize a new Codespace by clicking the green "Code" button at the top right of the Dialtone
+GitHub page.
+
+![Creating a codespace](./.github/new_codespace.png)
+
+Please see the [Codespaces docs](./.github/codespaces.md) for more information.
+
+### Local development
+
+#### PNPM
 
 PNPM (Performant NPM) is a package management solution designed to address the challenges posed by
 traditional package managers.
 
 We use PNPM to manage everything related to NPM, **adding, installing, removing and publishing packages**.
 
-#### Do
+You will need to install PNPM locally to contribute to this project. <https://pnpm.io/installation>
 
-Use PNPM to manage packages dependencies
+##### Installation
+
+```bash
+npm install -g pnpm
+```
+
+##### Do
+
+Use PNPM to manage package dependencies
 
 ```bash
 pnpm add eslint --filter dialtone-icons
 ```
 
-#### Don't
+##### Don't
 
 Run package scripts with PNPM, this will not use NX cache and pipelines,
 so you might end up missing dependencies that needed to be built before.
 
 ```bash
-pnpm run --filter packages/dialtone-css build
+pnpm run --filter dialtone-css build
 ```
 
-### NX
+#### NX
 
 Nx is a build system with built-in tooling and advanced CI capabilities.
 It helps you maintain and scale monorepos, both locally and on CI.
@@ -74,7 +177,15 @@ if they need to run before a specific command.
 
 For more information, check [setup a monorepo with PNPM workspaces and NX](https://blog.nrwl.io/setup-a-monorepo-with-pnpm-workspaces-and-speed-it-up-with-nx-bc5d97258a7e#d69f)
 
-#### Do
+##### Installation
+
+It is recommended to install NX globally via:
+
+```bash
+pnpm add --global nx@latest
+```
+
+##### Do
 
 Use NX to run scripts, this will use cache, improve the performance,
 and build any dependency needed before running your command.
@@ -83,7 +194,7 @@ and build any dependency needed before running your command.
 nx run dialtone-css:build
 ```
 
-#### Don't
+##### Don't
 
 Try installing packages with NX, this doesn't work at all, please use PNPM instead.
 
@@ -91,52 +202,25 @@ Try installing packages with NX, this doesn't work at all, please use PNPM inste
 nx add eslint --filter dialtone-icons
 ```
 
-## Quick start
+#### Running the projects
 
-If you would like to contribute to Dialtone without having to do any local environment setup, you can use GitHub
-Codespaces. You can initialize a new Codespace by clicking the green "Code" button at the top right of the Dialtone
-GitHub page.
-
-![Creating a codespace](./.github/new_codespace.png)
-
-Please see the [Codespaces docs](./.github/codespaces.md) for more information.
-
-### Local environment setup
-
-- We use [pnpm](https://pnpm.io) for managing dependencies, so you need to have it installed
-in order to be able to manage the packages. In order to install it, run the following command
-or follow its [installation guide](https://pnpm.io/installation):
-
-```bash
-npm install -g pnpm
-```
-
-Once pnpm is installed, install nx globally to make sure you can run commands such as `nx run build`
-without having to prefix them with `pnpm` or `pnpm exec`:
-
-```bash
-pnpm add --global nx@latest
-```
-
-Then, install the dependencies for all the monorepo packages and apps.
+First, install the dependencies for all the monorepo packages and apps.
 
 ```bash
 pnpm install
 ```
 
-### Running the projects
-
-#### Dialtone
+##### Dialtone documentation site
 
 ```bash
 nx start:dialtone
 ```
 
-This will start the documentation site and watch the library changes, so it is live updated.
+This will start the documentation site and watch the library for changes, it will be live updated with any changes.
 
 Access the local server at `http://localhost:4000`
 
-#### Dialtone Vue 2:
+##### Dialtone Vue 2 storybook
 
 ```bash
 nx start:dialtone-vue2
@@ -144,7 +228,7 @@ nx start:dialtone-vue2
 
 Access the local storybook server for Dialtone Vue 2 via `http://localhost:9010/`
 
-#### Dialtone Vue 3:
+##### Dialtone Vue 3 storybook
 
 ```bash
 nx start:dialtone-vue3
@@ -152,26 +236,61 @@ nx start:dialtone-vue3
 
 Access the local storybook server for Dialtone Vue 3 via `http://localhost:9011/`
 
-## Local development
+#### Common Commands
 
-Use the `--filter` flag to run commands
-for a specific package or app.
-
-### Adding dependencies for individual packages
+##### Production build the root project
 
 ```bash
-pnpm add <dependency> --filter <package/app>
+nx build
+```
+
+##### Run all Vue unit tests
+
+```bash
+nx test:vue
+```
+
+##### Run Vue 2 tests
+
+```bash
+nx test dialtone-vue2
+```
+
+##### Run Vue 3 tests
+
+```bash
+nx test dialtone-vue3
+```
+
+Use the `--filter` flag to run commands for a specific package or app.
+
+##### Adding dependencies for individual packages
+
+```bash
+pnpm add <dependency> --filter <package or app name>
+```
+
+Example:
+
+```bash
+pnpm add eslint --filter dialtone-icons
 ```
 
 To install a local dependency, just add the `--workspace` flag
 
 ```bash
-pnpm add <dependency> --filter <package/app> --workspace
+pnpm add <dependency> --filter <package or app name> --workspace
 ```
 
-### Running commands for individual packages
+Example:
 
-You can run commands like `build`, `test`, `start` from
+```bash
+pnpm add @dialpad/dialtone-tokens --filter dialtone-icons --workspace
+```
+
+##### Running commands for individual packages
+
+You can run commands like `build`, `test`, `start` for individual packages from
 the root of the project with:
 
 ```bash
@@ -210,7 +329,7 @@ This can only be run while on **staging** branch. After running the command, it 
 5. Merge changes from `production` back to `staging`
 
 ```bash
-nx run dialtone:release
+nx run release
 ```
 
 #### Alpha/Beta
@@ -231,125 +350,4 @@ nx run dialtone:release:alpha
 
 ```bash
 nx run dialtone:release:beta
-```
-
-## Usage
-
-### Install it via NPM:
-
-#### Vue 3
-
-```shell
-npm install @dialpad/dialtone@next @tiptap/vue-3
-```
-
-#### Vue 2
-
-```shell
-npm install @dialpad/dialtone@next @linusborg/vue-simple-portal @tiptap/vue-2
-```
-
-### Import packages:
-
-#### Dialtone CSS
-
-- CSS
-
-```css
-@import "@dialpad/dialtone/css";
-```
-
-- Javascript
-
-```js
-import "@dialpad/dialtone/css";
-```
-
-#### Dialtone eslint-plugin
-
-```js
-import dialtone from "@dialpad/dialtone/eslint-plugin"
-```
-
-#### Dialtone icons
-
-- Importing for Vue 2:
-
-```js
-// Named import
-import { DtIconArrowUp } from '@dialpad/dialtone-icons/vue2'; 
-
-// Default import (Prefered if using webpack as it is tree-shakeable by default)
-import DtIconArrowUp from '@dialpad/dialtone-icons/vue2/arrow-up';
-```
-
-- Importing for Vue 3:
-
-```js
-// Named import
-import { DtIconArrowUp } from '@dialpad/dialtone-icons/vue3'; 
-
-// Default import (Prefered if using webpack as it is tree-shakeable by default)
-import DtIconArrowUp from '@dialpad/dialtone-icons/vue3/arrow-up';
-```
-
-- In case you are not using vue, import the svg's directly as following:
-
-```js
-import IconArrowUp from '@dialpad/dialtone-icons/arrow-up.svg';
-```
-
-- Importing json files
-
-```js
-import keywords from '@dialpad/dialtone-icons/keywords.json';
-import iconsList from '@dialpad/dialtone-icons/icons.json';
-```
-
-#### Dialtone Vue
-
-- Vue 2
-
-```js
-// Named import
-import { DtButton } from "@dialpad/dialtone/vue2" 
-
-// Default import (Prefered if using webpack as it is tree-shakeable by default)
-import { DtButton } from "@dialpad/dialtone/vue2/lib/button"
-```
-
-- Vue 3
-
-```js
-// Named import
-import { DtButton } from "@dialpad/dialtone/vue3" 
-
-// Default import (Prefered if using webpack as it is tree-shakeable by default)
-import { DtButton } from "@dialpad/dialtone/vue3/lib/button"
-```
-
-#### Dialtone Tokens
-
-Dialtone tokens doesn't have a default export, so you need to access
-the files directly as following:
-
-- CSS
-
-```css
-@import "@dialpad/dialtone/tokens/variables-light.css" // Light tokens
-@import "@dialpad/dialtone/tokens/variables-dark.css" // Dark tokens
-```
-
-- LESS
-
-```less
-@import "@dialpad/dialtone/tokens/variables-light.less" // Light tokens
-@import "@dialpad/dialtone/tokens/variables-dark.less" // Dark tokens
-```
-
-- JSON
-
-```js
-import "@dialpad/dialtone/tokens/tokens-light.json" // Light tokens
-import "@dialpad/dialtone/tokens/tokens-dark.json" // Dark tokens
 ```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ Dialtone CSS includes all utility classes as well as tokens.
 import "@dialpad/dialtone/css";
 ```
 
+If you are using the Vue components, then import either Vue 2 or Vue 3 css:
+
+- CSS
+
+```css
+@import "@dialpad/dialtone/vue2/css";
+/* Or */
+@import "@dialpad/dialtone/vue3/css";
+```
+
+- Javascript
+
+```js
+import "@dialpad/dialtone/vue2/css";
+/* Or */
+import "@dialpad/dialtone/vue3/css";
+```
+
 #### Dialtone icons
 
 - Vue 2:

--- a/apps/dialtone-documentation/.github/CONTRIBUTING.md
+++ b/apps/dialtone-documentation/.github/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Dialtone Documentation Site Contributing
+
+## VuePress
+
+[VuePress](https://v2.vuepress.vuejs.org/) Vue-powered static site generator, is used as a static site generator for our documentation site.
+VuePress's root folder is within the folder `docs` in the Dialtone repository.
+Here are some short descriptions of the folders within `docs` and what they are responsible for:
+
+- `docs/.vuepress`: This is where all VuePress-specific files are placed.
+  - `baseComponents`: These are components that might be reused across the documentation site.
+  - `exampleComponents`: These are example components to be used in the `docs/components` section.
+  - `public`: Contains public assets like images.
+  - `styles`: Contains VuePress specific styling files.
+    - `palette.scss`: This file should be used to override VuePress specific values like breakpoints and to unset undesired margins, paddings, etc... It has higher priority than any other styling file.
+  - `theme`: Contains customized dialtone vuepress theme configurations, layouts and components.
+    - `components`:  Contains Theme specific components like Navbar, Sidebar, etc.
+    - `layouts`: Contains Theme specific [Layouts](https://vuepress.github.io/reference/theme-api.html#layouts).
+  - `views`: Contains complex views that couldn't be created with Markdown only.
+  - `client.js`: Contains VuePress [client configuration](https://vuepress.github.io/advanced/cookbook/usage-of-client-config.html).
+  - `config.ts`: Contains VuePress [global configuration](https://vuepress.github.io/reference/config.html).
+- `docs/_data`: Contains json files with data to populate tables, examples and the sidebar items.
+- `doc/about`: Contains templates for the "About" section of the website. (About dialtone, Contributing).
+- `docs/assets`: Contains doc site specific LESS/CSS and Fonts **Note:** the css and fonts folders within `docs/assets` are output by the Dialtone build and any manual changes will be overwritten.
+  - `less/overrides.less`: This file should be used to override styling on documentation site, if you need to unset specific value, please add it to `docs/.vuepress/styles/palette.scss`.
+  - `less/hljs-dialpad.less`: Contains code blocks styling rules.
+- `docs/components`: Contains templates for the "Components" section of the website. (Form inputs, Avatar, Banner etc).
+- `docs/design`: Contains templates for the "Design" section of the website. (Colors, Icons, etc).
+- `docs/getting-started`: Contains templates for the "Getting started" section of the website. (Installation, Usage).
+- `docs/utilities`: Contains templates for the "Utilities" section of the website. (Utility classes).
+
+We use markdown frontmatter to add metadata to the pages, and we have several functions to extract such data and manipulate it.
+Here's an overview of important properties and the values they need/can have:
+
+- title `(required)`: Used as the page title, and also as the component name for [Components overview page].
+- shortTitle `(optional)`: This property is used to fix linking issues on [Components overview page] when the title is different from the component name.
+- description `(optional)`: Used as the page subtitle and in the page metadata.
+- status `(optional)`: CSS Component status, used to display a badge on [Components overview page] and
+also to define the component status on [Components status page],
+  - Status options available: `['wip', 'planned', 'new', 'ready', null]`
+  if status is not defined, the component will have a "N/A" CSS status on [Components status page].
+- thumb `(optional)`: Boolean to define if the component in [Components overview page] will have a thumbnail
+  - ***Note:*** The thumbnail must exist on `/docs/.vuepress/public/assets/images/components` and the name should be the `component title` in kebab-case in `png` format. e.g. `Button Group` component -> button-group.png
+- storybook `(optional)`: It can be a storybook URL or a status.
+  - Status options available: `['wip', 'planned', null]`
+  if storybook is not defined, the component will have a "N/A" Vue status on [Components status page].
+- figma `(optional)`: It can be a figma URL or a status.
+  - Status options available: `['wip', 'planned', null]`
+  if figma is not defined, the component will have a "N/A" Figma status on [Components status page].
+- no_preview `(optional)`: If defined, the page will have no preview section at the top.
+
+[Components overview page]: https://dialtone.dialpad.com/components/
+[Components status page]: https://dialtone.dialpad.com/components/status/

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "release": "./scripts/release.sh",
     "release:alpha": "./scripts/release.sh alpha",
     "release:beta": "./scripts/release.sh beta",
-    "test:vitest": "vitest run --test-timeout=10000"
+    "test:vue": "vitest run --test-timeout=10000"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/packages/dialtone-css/.github/CONTRIBUTING.md
+++ b/packages/dialtone-css/.github/CONTRIBUTING.md
@@ -1,66 +1,5 @@
-# Contributing
 
-Thanks for your interest in contributing to Dialtone! Please take a moment to review this document before submitting a pull request.
-
-## Overview
-
-### What is Dialtone?
-
-Dialtone is a design system by Dialpad comprised of CSS components, [Vue components](https://dialtone.dialpad.com/vue), utility classes, visual assets, documentation and examples which strives to:
-
-- Create a consistent design language between all Dialpad products.
-- Create a suite of well-documented, flexible and intuitive UI components that are easy for designers, developers and users to use.
-- Document and promote accessible development and design across Dialpad.
-
-### What is a contribution?
-
-A contribution is any proposal, design, code, or documentation completed by someone not on the core Dialtone team, and released through Dialtone for other people to use. It can be created by anyone who'd like to help make Dialtone better.
-
-Types of contributions:
-
-- **Fix:** fixes a technical defect, documentation typo, or Figma symbol defect.
-- **Enhancement:** extends an existing style or component without changing the underlying architecture or behavior.
-- **New feature:** adds something new, like a component.
-
-### What belongs in Dialtone?
-
-There are a couple important considerations when thinking about contributing to Dialtone. The first is to remember that Dialtone strives to offer styles, components, or patterns intended to be shared by multiple teams or features. Generally, one-off or first-time elements (i.e. snowflakes) aren't a great fit, though there may be the occasional exception.
-
-The second is to check with the Dialtone team (in the #dialtone Dialpad channel) to ensure the contribution isn't already requested, planned, or even complete. You may also see our [Jira backlog](https://dialpad.atlassian.net/jira/software/c/projects/DLT/boards/548/backlog) for upcoming work, and our [Jira timeline](https://dialpad.atlassian.net/jira/software/c/projects/DLT/boards/548/timeline) for our long term quarterly roadmap.
-
-### Roles
-
-- **Contributor:** Has the ability to create PRs and merge their change into `staging` after at least one approving review.
-- **Maintainer:** A trusted contributor with the ability to release Dialtone.
-- **Admin:** Has the ability to change any configuration on the Dialtone repository and release Dialtone. Usually for members of the Dialtone team.
-
-## How to contribute
-
-### Feature request
-
-To request a new Dialtone feature or enhancement, submit a [feature request](https://dialpad.atlassian.net/secure/CreateIssue.jspa?issuetype=10975&pid=12508) to our Jira.
-
-### Bug report
-
-If you would like to report a bug, please post it in the #dialtone Dialpad channel. We will assist you in determining whether it is a Dialtone bug. Please give us a working example of the bug on a private beta or deploy preview link. A branch we can checkout is also helpful. If we have determined that this is a bug in Dialtone, then you may create a [bug report](https://dialpad.atlassian.net/secure/CreateIssue.jspa?issuetype=1&pid=12508) on Jira for the bug. We will get to fixing the bug in the future, or you can fix the bug yourself by [Making a Pull Request](#making-a-pull-request)
-
-### Making a pull request
-
-Before submitting a pull request, make sure to communicate what you wish to change to the Dialtone team. The easiest way to do this is via the #dialtone Dialpad channel. It's possible your change is already being worked on, has already been fixed, or maybe we just need to discuss the best solution to the problem. This prevents you from having to re-write your entire change, or even having to scrap it entirely.
-
-After you have discussed your change with the Dialtone team, follow these steps to submit it:
-
-1. See [README.md](../README.md) for instructions on how to initially clone and run the project.
-2. First make sure you are on the `staging` branch with `git checkout staging`, and that it is up to date with `git pull`.
-3. Create a personal branch to make your change off of `staging` with `git checkout -b my-change-branch`. We use kebab-case for branch names.
-4. Make and commit your changes. Note our commit message conventions in [COMMIT_CONVENTION.md]. If you have only a single commit on your branch, then your git commit message must follow the conventions. If you have multiple commits on your branch, then the github PR title must follow the commit message conventions. Your change will be automatically linted on commit.
-5. Push your branch to remote. `git push -u origin my-change-branch`.
-6. Create a pull request into the `staging` branch, reviewers will be automatically added and notified of your PR.
-7. Once your changes have been approved, you may squash merge your branch into `staging`.
-
-Once your change is in `staging` it will go live with the next Dialtone release. Releases are done on demand by the Dialtone team, and are done fairly regularly. If you need your change to be released promptly, please ask in the #dialtone Dialpad channel.
-
-## Coding guidelines
+## Dialtone CSS Coding guidelines
 
 ### Naming conventions
 
@@ -96,11 +35,11 @@ Component class names use the [Block Element Modifier (BEM)](http://getbem.com/n
 
 ### Immutable utility classes
 
-All of our utility classes are set to `!important`. This is because they are designed to be immutable, and `!important` is the best way we have of achieving immutability in CSS. Utility classes should only be applied at the application level and not within dialtone vue components.
+All of our utility classes are set to `!important`. This is because they are designed to be immutable, and `!important` is the best way we have of achieving immutability in CSS. Utility classes should only be applied at the application level and not within Dialtone Vue components.
 
 ### CSS vars
 
-We use CSS vars, also known as [CSS Custom Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) in our component classes for better reusability. We should use tokens to apply values to properties within our CSS classes unless a relevant token does not exist. For example, we should use `var(--dt-color-black-100)` instead of `#000000` or `var(--dt-space-400)` instead of `0.8rem`.
+We use CSS vars, also known as [CSS Custom Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) in our CSS component classes for better reusability. We should use tokens to apply values to properties within our CSS classes unless a relevant token does not exist. For example, we should use `var(--dt-color-black-100)` instead of `#000000` or `var(--dt-space-400)` instead of `0.8rem`.
 
 Here we set the `--avatar--size` CSS var to the `--dt-size-450` token, and set both the width and the height to reference this variable.
 
@@ -120,7 +59,7 @@ Now in variation `d-avatar--sm`, we just set `--avatar--size`. Width and height 
 }
 ```
 
-### Linting
+## Linting
 
 Our code is linted by:
 
@@ -136,14 +75,14 @@ Configuration can be found in:
 - [.eslintrc.cjs](../.eslintrc.cjs), [.eslintignore](../.eslintignore)
 - [.markdownlintrc](apps/dialtone-documentation/.markdownlintrc), [.markdownlintignore](apps/dialtone-documentation/.markdownlintignore)
 
-Your code will be linted automatically on commit.
+Your code will be linted (and fixed if possible) automatically on commit.
 
 - **Lint manually:** `nx lint dialtone`
 - **With autofix:** `nx lint:fix dialtone`
 
 Note that we use lesshint only for the utilities folder and stylelint for everything else. Due to some unsupported syntax limitations we cannot use stylelint on our utilities folder.
 
-### Folder structure
+## Folder structure
 
 Here are some important directories to know within the Dialtone repository
 
@@ -151,178 +90,15 @@ Here are some important directories to know within the Dialtone repository
 - `lib/dist`: The compiled bundle will be output here upon `nx build dialtone-css`.
 - `lib/build/fonts`: Fonts we wish to bundle with Dialtone (woff2 format).
 - `lib/build/less`: LESS files defining our styles. they are processed and transpiled to CSS on build.
-- `lib/build/svg`: Contains only spot illustrations. Icons are stored in the dialtone-icons package. See [adding icons and illustrations](https://dialtone.dialpad.com/about/contributing.html#adding-icons-and-illustrations) for instructions on how to add icons into Dialtone.
 
-For folder structure of the doc site, see the [VuePress section](#vuepress) of this document.
-
-### Testing
+## Testing
 
 Any changes you make to Dialtone CSS that is used in Dialtone Vue components will be tested in our percy visual tests when you create a pull request. Other than that please manually test your changes on the Dialtone documentation site as well.
 
-### A11y standards
+### Building
 
-Dialtone adopts the [WCAG 2.1 AA](https://www.w3.org/WAI/standards-guidelines/wcag/glance/) Web Content Accessibility Guidelines.
-
-## Commit Message Convention
-
-Dialtone uses [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) to have commit messages that can be used as part of the [semantic release process](RELEASING.md). For more information, see [COMMIT_CONVENTION.md].
-
-### Git Hooks
-
-To enforce your commit message on the release branches (`production`, `staging`, `alpha` and `beta`) are correct according to the Conventional Commits specification, there is a `commit-msg` git hook that will be invoked by `git commit`.
-`pre-commit` git hook will lint your code.
-
-## Versioning
-
-Dialtone follows [SemVer](https://semver.org/) for versioning and the commit message convention used in the project is aligned with SemVer by describing the features, fixes, and breaking changes made in commit messages.
-
-## How we manage work
-
-We use Jira to manage our work and you can visit the [Dialtone board and backlog](https://dialpad.atlassian.net/jira/software/c/projects/DLT/boards/548/backlog) assuming you are an authenticated Dialpad employee. Below we will define how we use our Jira board so team members and external contriubutors are all on the same page.
-
-### Issue Types
-
-#### Dev Story
-
-A "Dev Story" is a small portion of work estimated and completed by the development team.
-
-#### Design Story
-
-A "Design Story" is a small portion of work estimated and completed by the design team.
-
-#### Proposal
-
-Proposals can be submitted by anyone with access to the jira board. Each proposal will be discussed in a grooming meeting with the Design System team and if accepted will be turned into a story (or multiple).
-
-#### Epic
-
-Epics are a collection of multiple stories, and always have a start and end length of one quarter. They should map to our quarterly OKRs. If a single feature will take multiple quarters to complete it should be split up into separate quarterly epics. If a story does not belong in any epic it can be put into the "Future work" epic, which holds all "uncategorized" stories.
-
-#### Bug
-
-A Bug is an unintentional defect in code that we have written that does not need any intended functionality to change in order to fix it. Bugs are not assigned a story point estimate.
-
-#### Spike
-
-The spike type refers to a "technical spike" in which we are not actually writing any code but instead performing research to find the best solution to our problem. Upon completion of a spike a resulting story will be created and groomed. Spikes are not assigned a story point estimate.
-
-#### Subtasks
-
-Subtasks are only created within a sprint after it has started and are individual technical tasks that need to be completed for the story to be finished. It may not make sense to split simpler stories into subtasks, for example if there would only be 1 task. By creating subtasks it prevents certain work from being forgotten and potentially allows multiple developers to work on different parts of the same story. It is possible for multiple developers to be working on the same story but it should only be possible for one developer to work on an individual subtask.
-
-### Estimation
-
-We estimate on an 8 point fibonacci scale of complexity during our grooming sessions. We only estimate work that gives explicit business value, so that means that only "Dev Stories" and "Design Stories" are estimated. Every sprint we should only be allocating story points for about 70% of developer work time. The other 30% is allocated to everything else a developer has to do: participate in meetings, fix bugs, support users, research technical spikes, review etc...
-
-### Prioritization
-
-Each Jira ticket has a priority which can be defined as the following:
-
-- **urgent**: we immediately pull it into the current sprint and begin working on it.
-- **high**: is quite important but not so important it is immediately pulled into the sprint.
-- **medium**: of moderate importance, the default priority level, the majority of our stories will probably be this.
-- **low**: not a priority, it is unlikely we will pull these into a sprint unless they are very low effort, or become a higher priority at a later time.
-
-Just because an item is high priority does not necessarily mean it will be pulled into the sprint before a medium item. The priority is how much business value this particular task will provide, however the rank (sort order) of the backlog is the order in which items will be pulled into the sprint. The rank is determined manually by the product owner (@braddialpad / @francisrupert in this case) and can be based on factors other than just priority, effort for example.
-
-#### Order / Rank
-
-In the backlog we always try to keep our jira items sorted in this order from top to bottom:
-
-- Bugs
-- Spikes
-- Stories / Proposals
-
-Within each of these categories, items marked 'backlog' should always be above items marked 'needs definition'. The top items of 'needs defintion' are next to be groomed, and the top items of 'backlog' are next to be pulled into the sprint. Once a story is assigned to someone it can be moved to 'todo' status.
-
-Proposals are mixed in and ranked with stories as they will eventually be turned into stories.
-
-### Component Categories
-
-"Components" are a feature of Jira that allows you to categorize your tickets in any way you wish. We use these to categorize our tickets in the long term. Unlike epics, components never have a start or end date. Multiple components can be applied to a single ticket. Try to use just one if you can, but if necessary multiple can be used.
-
-- `[Component]`: this story changes all components or multiple components.
-- `[Dropdown(or any component name)]`: this story includes change to only the dropdown component. Exclude Dt prefix and use [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case) format.
-- `[Utility]`: this story includes changes to a single or multiple utility classes.
-- `[Docs]`: this story only changes the documentation site or the storybook, it does not affect anything in our published library.
-- `[Figma]`: this is work specific to figma
-- `[Style]`: a css/less change that does not change a specific component or utility class.
-- `[Tokens]`: a change specific to Dialtone tokens.
-- `[Icons]`: a change specific to the Dialtone icons repo.
-- `[Storybook]`: a problem specific to the dialtone vue storybook documentation.
-- `[Architecture]`: a change to technical architecture such as GHA, gulp, webpack, npm, docsite config etc.
-
-### What about outside contributions?
-
-If you are developer contributing to Dialtone but are not on the Dialtone team your work will be added to the Dialtone board as normal and groomed with the Dialtone team. The main difference is that we will not be including your story in a Dialtone team sprint. The Dialtone ticket can be pulled into your own team's sprint, or just updated within our backlog if you prefer.
-
-## Tooling
-
-### VuePress
-
-[VuePress](https://v2.vuepress.vuejs.org/) Vue-powered static site generator, is used as a static site generator for our documentation site.
-VuePress's root folder is within the folder `docs` in the Dialtone repository.
-Here are some short descriptions of the folders within `docs` and what they are responsible for:
-
-- `docs/.vuepress`: This is where all VuePress-specific files are placed.
-  - `baseComponents`: These are components that might be reused across the documentation site.
-  - `exampleComponents`: These are example components to be used in the `docs/components` section.
-  - `public`: Contains public assets like images.
-  - `styles`: Contains VuePress specific styling files.
-    - `palette.scss`: This file should be used to override VuePress specific values like breakpoints and to unset undesired margins, paddings, etc... It has higher priority than any other styling file.
-  - `theme`: Contains customized dialtone vuepress theme configurations, layouts and components.
-    - `components`:  Contains Theme specific components like Navbar, Sidebar, etc.
-    - `layouts`: Contains Theme specific [Layouts](https://vuepress.github.io/reference/theme-api.html#layouts).
-  - `views`: Contains complex views that couldn't be created with Markdown only.
-  - `client.js`: Contains VuePress [client configuration](https://vuepress.github.io/advanced/cookbook/usage-of-client-config.html).
-  - `config.ts`: Contains VuePress [global configuration](https://vuepress.github.io/reference/config.html).
-- `docs/_data`: Contains json files with data to populate tables, examples and the sidebar items.
-- `doc/about`: Contains templates for the "About" section of the website. (About dialtone, Contributing).
-- `docs/assets`: Contains doc site specific LESS/CSS and Fonts **Note:** the css and fonts folders within `docs/assets` are output by the Dialtone build and any manual changes will be overwritten.
-  - `less/overrides.less`: This file should be used to override styling on documentation site, if you need to unset specific value, please add it to `docs/.vuepress/styles/palette.scss`.
-  - `less/hljs-dialpad.less`: Contains code blocks styling rules.
-- `docs/components`: Contains templates for the "Components" section of the website. (Form inputs, Avatar, Banner etc).
-- `docs/design`: Contains templates for the "Design" section of the website. (Colors, Icons, etc).
-- `docs/getting-started`: Contains templates for the "Getting started" section of the website. (Installation, Usage).
-- `docs/utilities`: Contains templates for the "Utilities" section of the website. (Utility classes).
-
-We use markdown frontmatter to add metadata to the pages, and we have several functions to extract such data and manipulate it.
-Here's an overview of important properties and the values they need/can have:
-
-- title `(required)`: Used as the page title, and also as the component name for [Components overview page].
-- shortTitle `(optional)`: This property is used to fix linking issues on [Components overview page] when the title is different from the component name.
-- description `(optional)`: Used as the page subtitle and in the page metadata.
-- status `(optional)`: CSS Component status, used to display a badge on [Components overview page] and
-also to define the component status on [Components status page],
-  - Status options available: `['wip', 'planned', 'new', 'ready', null]`
-  if status is not defined, the component will have a "N/A" CSS status on [Components status page].
-- thumb `(optional)`: Boolean to define if the component in [Components overview page] will have a thumbnail
-  - ***Note:*** The thumbnail must exist on `/docs/.vuepress/public/assets/images/components` and the name should be the `component title` in kebab-case in `png` format. e.g. `Button Group` component -> button-group.png
-- storybook `(optional)`: It can be a storybook URL or a status.
-  - Status options available: `['wip', 'planned', null]`
-  if storybook is not defined, the component will have a "N/A" Vue status on [Components status page].
-- figma `(optional)`: It can be a figma URL or a status.
-  - Status options available: `['wip', 'planned', null]`
-  if figma is not defined, the component will have a "N/A" Figma status on [Components status page].
-- no_preview `(optional)`: If defined, the page will have no preview section at the top.
-
-### Gulp
-
-[Gulp](https://gulpjs.com/) is the task runner we use to build Dialtone. It's configuration can be found in `.gulpfile.js`. The following tasks are handled within the gulp build
+[Gulp](https://gulpjs.com/) is the task runner we use to build Dialtone CSS. It's configuration can be found in `.gulpfile.js`. The following tasks are handled within the gulp build:
 
 - Compilation, minification and output of LESS to CSS.
-- Processing svg files for themability, and outputting them as vue files.
 - Bundling and output of fonts.
 - Caching for faster local build performance.
-
-### GitHub Actions
-
-[GitHub Actions](https://docs.github.com/en/actions) is what we use for our CI/CD solution. All GHA workflows are in the `.github/workflows` directory. Currently, we use GitHub Actions for the following:
-
-- Deploying to `production` `.github/workflows/deploy.yml`, See [RELEASING](RELEASING.md) for instructions on how to do this.
-- Linting our LESS files on pull request `.github/workflows/lint-pr.yml`.
-- Validating commit messages `.github/workflows/lint-commit-message.yml`, see [COMMIT_CONVENTION.md] for our commit message conventions.
-
-[Components overview page]: https://dialtone.dialpad.com/components/
-[Components status page]: https://dialtone.dialpad.com/components/status/
-[COMMIT_CONVENTION.md]: /.github/COMMIT_CONVENTION.md

--- a/packages/dialtone-icons/.github/CONTRIBUTING.md
+++ b/packages/dialtone-icons/.github/CONTRIBUTING.md
@@ -43,42 +43,11 @@ to prefix the identifiers of every icon with `dt-icon`, that way even if we have
 
 Generated Vue icons are output to the `src/icons/` folder when you do `nx build dialtone-icons`
 
-## Coding guidelines
-
-### Important Folders and Files
+## Important Folders and Files
 
 - `src/svg`: All the source SVG icon files.
 - `keywords.json`: Contains the categories on which icons are going to be included and the keywords to make the icons more discoverable while searching on [Dialtone icons documentation](https://dialpad.design/components/icon.html).
 - `icons.json`: This file is auto generated and used to list all the icons in Storybook.
 
-## Commit Message Convention
-
-Dialtone icons uses [Conventional Commits specification] to have commit messages that can be used as part of the releasing. For more information, see [COMMIT_CONVENTION.md].
-
-### Git Hooks
-
-To enforce your commit message on the release branches (`production`, `staging`, `alpha` and `beta`) are correct according to the Conventional Commits specification, there is a `commit-msg` git hook that will be invoked by `git commit`.
-`pre-commit` git hook will lint your code.
-
-## Versioning
-
-Dialtone icons follows [SemVer] for versioning and the commit message convention used in the project is aligned with SemVer by describing the features, fixes, and breaking changes made in commit messages.
-
-## Tooling
-
-### GitHub Actions
-
-[GitHub Actions] is what we use for our CI/CD solution.
-All GHA workflows are in the `.github/workflows` directory. Currently, we use GitHub Actions for the following:
-
-- Deploying to `production` `.github/workflows/deploy.yml`, See [RELEASING.md] for instructions on how to do this.
-- Linting our LESS files on pull request `.github/workflows/lint-pr.yml`.
-- Validating commit messages and Pull Request tile `.github/workflows/lint-pr.yml`, see [COMMIT_CONVENTION.md] for our commit message conventions.
-
-[RELEASING.md]: RELEASING.md
-[COMMIT_CONVENTION.md]: /.github/COMMIT_CONVENTION.md
-[GitHub Actions]: https://docs.github.com/en/actions
-[SemVer]: https://semver.org/
-[Conventional Commits specification]: https://www.conventionalcommits.org/en/v1.0.0/
 [Dialtone-vue icon]: https://vue.dialpad.design/?path=/story/components-icon--default
 [Icons Figma file]: https://www.figma.com/file/zz40wi0uW9MvaJ5RuhcRZR/DT9-Icon-Library?type=design&node-id=10023-2864&mode=design&t=MvRnRubYryeiG1az-0

--- a/packages/dialtone-icons/README.md
+++ b/packages/dialtone-icons/README.md
@@ -39,6 +39,13 @@ import * as icons from '@dialpad/dialtone-icons/vue3'; // Vue 3+
 import DtIconAccessibility from '@dialpad/dialtone-icons/accessibility.svg';
 ```
 
+- Importing icon related data
+
+```js
+import keywords from '@dialpad/dialtone-icons/keywords.json';
+import iconsList from '@dialpad/dialtone-icons/icons.json';
+```
+
 ## Committing
 
 If you need to add icons, follow the next steps to get your icons committed.

--- a/packages/dialtone-tokens/README.md
+++ b/packages/dialtone-tokens/README.md
@@ -50,6 +50,13 @@ Or
 }
 ```
 
+#### Import JSON
+
+```js
+import "@dialpad/dialtone/tokens/tokens-light.json" // Light tokens
+import "@dialpad/dialtone/tokens/tokens-dark.json" // Dark tokens
+```
+
 ### iOS (swift)
 
 1. Within your XCode project `File > Swift Packages > Add Package Dependency`

--- a/packages/dialtone-vue3/.github/CONTRIBUTING.md
+++ b/packages/dialtone-vue3/.github/CONTRIBUTING.md
@@ -144,6 +144,43 @@ except when noted below. This in particular means:
 - **No imports outside the dialtone-vue directory**
 - **Vue 2 compatibility:** Dialtone Vue components should support Vue 2 and Vue 3. Vue 2 components are in the dialtone-vue2 package, Vue 3 components are in the dialtone-vue3 package. You may copy your changes from one to the other via `<dialtone-root>/scripts/dialtone-vue-sync.sh`
 
+### Dialtone Vue Sync script
+
+This script will allow you to copy your changes from Vue 2 to Vue 3 or vice versa. to run it, you can use the following command from the root dialtone directory:
+
+```bash
+./scripts/dialtone-vue-sync.sh
+```
+
+With no parameter this will simply copy the most recent commit from Vue 2 to Vue 3. The script will prompt you to input whether you made your initial changes in Vue 2 or Vue 3.
+
+If you would like to copy more than one commit you can enter the git SHA of the commit BEFORE the first one one you would like to copy, example below:
+
+```bash
+./scripts/dialtone-vue-sync.sh 16eb2969894dd93bbb09b4baa28677fa2fa970c2
+```
+
+This will copy the first commit after the SHA you entered, up to the most recent commit.
+
+You may also enter two SHA's to copy the specified range of commits.
+
+```bash
+./scripts/dialtone-vue-sync.sh 16eb2969894dd93bbb09b4baa28677fa2fa970c2 59f4882be487d05eb20696162b14e9c7fcf5fdf5
+```
+
+When the script completes it will have created new uncommited changes in the Vue 2 or Vue 3 folder. It is possible for there to be conflicts when running the script. If this happens, you will need to resolve the conflicts manually, and then commit the resolved changes.
+
+Note that the script only copies your exact changes from one version to the other, it does not migrate your changes to Vue 3 code.
+
+Here are some of the most common changes you will need to make between Vue 2 and Vue 3:
+
+- $listeners no longer exists in Vue 3. You will have to handle your listeners within $attrs. <https://v3-migration.vuejs.org/breaking-changes/listeners-removed.html>
+- prop.sync="value" has been changed to v-model:prop="value" in Vue 3 <https://v3-migration.vuejs.org/breaking-changes/v-model.html#v-model>
+- In Vue 3 you should only use the emits option for custom events you are emitting via `this.$emit`. Emits should not contain native events like `click` or `input`, unless you are manually emitting them. <https://v3-migration.vuejs.org/breaking-changes/emits-option.html>
+- In unit tests, the "propsData" property has been renamed to just "props". You will have to rename this in your test setup. <https://v3-migration.vuejs.org/breaking-changes/props-data.html>
+
+For the full list, see the Vue 3 migration guide: <https://v3-migration.vuejs.org/>
+
 ### Exports
 
 When adding a new component, please add its exports to `index.js`, including any named exports, so they're available for import to users of Dialtone Vue:

--- a/packages/dialtone-vue3/.github/CONTRIBUTING.md
+++ b/packages/dialtone-vue3/.github/CONTRIBUTING.md
@@ -8,116 +8,18 @@ to see if there is already an issue for it and if not, add it.
 ### What Is Dialtone Vue?
 
 Dialtone is a design system by Dialpad comprised of CSS components, Vue components, utility classes, visual assets, documentation.
-Dialtone Vue is the Vue component portion of Dialtone and is distributed as a separate package.
-It is recommended that you are familiar with the [Dialtone CSS](https://github.com/dialpad/dialtone/tree/staging/packages/dialtone) package.
-as well as it's [contribution guide](../../dialtone/.github/CONTRIBUTING.md) before you contribute to Dialtone Vue.
+Dialtone Vue is the Vue component portion of Dialtone and is distributed as a separate package as well as included in the combined package.
+It is recommended that you are familiar with the [Dialtone CSS](https://github.com/dialpad/dialtone/tree/staging/packages/dialtone) package and it's [contribution guide](../../dialtone/.github/CONTRIBUTING.md),
+as well as the general [contribution guide](../../.github/CONTRIBUTING.md) before you contribute to Dialtone Vue.
 
-Dialtone is a peer dependency of Dialtone Vue.
-
-### What Is a Contribution?
-
-A contribution is any proposal, design, code, or documentation completed by someone not on the core Dialtone team,
-and released through Dialtone Vue for other people to use.
-It can be created by anyone who'd like to help make Dialtone Vue better.
-
-Types of contributions:
-
-- **Fix:** Fixes a technical or documentation defect.
-- **Enhancement:** Extends an existing component without changing the underlying architecture or behavior.
-- **New feature:** Adds something new, like a component.
-
-### What Belongs in Dialtone Vue?
-
-There are a couple important considerations when thinking about contributing to Dialtone Vue.
-The first is to remember that Dialtone Vue strives to offer components to be shared by multiple teams or features.
-Generally, one-off or first-time elements (i.e. snowflakes) aren't a great fit, though there may be the occasional exception.
-
-The second is to check with the Dialtone team (in #dialtone Dialpad channel) to ensure the contribution isn't already requested, planned, or even complete.
-
-### Roles
-
-- **Contributor:** Has the ability to create PRs and merge their change into staging after at least one approving review.
-- **Maintainer:** A trusted contributor with the ability to release Dialtone.
-- **Admin:** Has the ability to change any configuration on the Dialtone repository and release Dialtone. Usually for members of the Dialtone team.
-
-## Making a Pull Request
-
-### Before Submitting
-
-Before submitting a pull request, make sure to communicate what you wish to change to the Dialtone team.
-The easiest way to do this is via the #dialtone Dialpad channel.
-It's possible your change is already being worked on, has already been fixed, or maybe we just need to discuss the best solution to the problem.
-This prevents you from having to re-write your entire change, or even having to scrap it entirely.
-
-The Dialtone library exists to serve multiple teams, so it is important to ensure that your PR does not introduce any unnecessary breaking changes.
-Breaking changes will require extra steps that may prolong the submission review process.
-If breaking changes are absolutely necessary for your use case, then you must communicate them to the Dialtone team in advance to allow for a smooth migration strategy for all dependant projects.
-
-Examples of breaking include the following:
-
-- **Changing or removing the component API**: renaming or removing props and emits, or changing their expected types
-
-Examples of non-breaking changes:
-
-- **Making new additions to the component API**: for example, adding a new prop to a component that triggers a different flow of behaviour or output, or adding a new emit event to detect specific changes.
-- **Refactoring**: changing the internal code of a component without changing any external behaviour.
-
-Some updates can unintentionally cause breaking changes, or cause changes to a component's output behaviour or functionality without necessary breaking it.
-This is why it is important to evaluate the change carefully and asses its impact on existing usage.
-
-Any new components or updates to existing components require the following:
-
-- Unit tests covering the entire change.
-- Storybook documentation including a live rendered component via controls and MDX. See [the documentation](https://dialtone.dialpad.com/vue/?path=/story/docs-storybook-getting-started--page)
-- Component is accessible according to requirements.
-  - Navigable by keyboard.
-  - Read by a screen reader.
-  - Minimum contrast ratio.
-- Changes must be made for Vue 2 as well as Vue 3, `dialtone-vue2` and `dialtone-vue3` package folders respectively
-- Unit tests are passing locally.
-  - `nx test dialtone-vue2` or `nx test dialtone-vue3`
-- Linters are passing locally.
-  - `nx lint dialtone-vue2` or `nx lint dialtone-vue3`
-- Library builds locally.
-  - `nx build dialtone-vue2` or `nx build dialtone-vue3`
-- Documentation builds locally.
-  - `nx storybook:build dialtone-vue2` or `nx storybook:build dialtone-vue3`
-
-### How to Submit
-
-After you have discussed your change with the Dialtone team, follow these steps to submit it:
-
-1. See [README.md](../README.md) for instructions on how to initially clone and run the project.
-2. First make sure you are on the `staging` branch with `git checkout staging`, and that it is up-to-date with `git pull`.
-3. Create a personal branch to make your change off of `staging` with `git checkout -b my-change-branch`. We use kebab-case for branch names.
-4. Make and commit your changes. Note our commit message conventions in [COMMIT_CONVENTION.md].
-5. Push your branch to remote. `git push -u origin my-change-branch`.
-6. Create a pull request into the `staging` branch, reviewers will be automatically added and notified of your PR.
-7. Set the label on your PR:
-
-- 'visual-test-ready' if your PR includes visual UI changes.
-- 'no-visual-test' if not UI changes.
-
-<!-- markdownlint-disable MD029 -->
-8. If it's a Vue change, you need to update both dialtone-vue2 and dialtone-vue3 packages. You may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
-9. Once your changes have been approved, you may squash your branch into staging.
-
-Once your change is in `staging` it will go live with the next Dialtone Vue release.
-Releases are done on demand by the Dialtone team, and are done fairly regularly.
+Dialtone is a dependency of Dialtone Vue.
 
 ## Coding Guidelines
 
 ### CSS
 
-We should use [Dialtone tokens](https://dialtone.dialpad.com/tokens/) in Dialtone Vue for all component styling.
-Avoid using [utility classes](https://dialtone.dialpad.com/utilities/) in Dialtone Vue, those should be only used at the application level.
-
-### How We Use Slots
-
-Main content is the key visual content of a component.
-For example the text and the icon of a button are two different content slots.
-It is important that slots are used for this type of content as the consumer of the component can override the content with markup or vue components.
-If the button text was only a prop, the consumer could not make changes to the styling of the text.
+We should use [Dialtone tokens](https://dialtone.dialpad.com/tokens/) in Dialtone Vue for all component styling. For core components we should write CSS in a new component in the dialtone-css package. For recipe components we should write CSS in the component itself.
+Avoid using [utility classes](https://dialtone.dialpad.com/utilities/) in Dialtone Vue as they cannot be easily overidden in the product, those should be only used at the application level.
 
 ### Transparent Components
 
@@ -240,7 +142,7 @@ except when noted below. This in particular means:
 - **No custom directives:** Directives in Vue are installed globally and vary from project to project. Custom directives (such as `v-tooltip`) cannot be used in Dialtone Vue components, unless they exist in dialtone itself.
 - **No other custom global methods:** Some projects may implement custom global methods on the Vue object. Dialtone Vue components are limited to the built-in Vue methods.
 - **No imports outside the dialtone-vue directory**
-- **Vue 2 compatibility:** Dialtone Vue components should support Vue 2 and Vue 3.
+- **Vue 2 compatibility:** Dialtone Vue components should support Vue 2 and Vue 3. Vue 2 components are in the dialtone-vue2 package, Vue 3 components are in the dialtone-vue3 package. You may copy your changes from one to the other via `<dialtone-root>/scripts/dialtone-vue-sync.sh`
 
 ### Exports
 
@@ -264,8 +166,7 @@ Before you start to write tests, please follow the [Contributing Guideline - Wri
 
 ### Dialtone Usage
 
-Dialtone Vue components should utilize the global immutable CSS classes provided by Dialtone whenever possible.
-It is a requirement of any project using Dialtone Vue to include Dialtone as a dependency.
+Consumers of Dialtone Vue should utilize the global immutable CSS classes provided by Dialtone whenever possible.
 If needed, you can also write custom CSS using [Dialtone Tokens CSS variables](https://dialtone.dialpad.com/tokens/).
 
 Please **do not** use any mixins or utility classes in Dialtone Vue components.
@@ -283,31 +184,13 @@ change via a blog post on [dialtone.dialpad.com](https://dialtone.dialpad.com/ab
 - **`.storybook`:** Build time configuration files for storybook. If you need to edit the storybook webpack config for example, you would do so here.
 - **`components`:** Everything related to a specific component is stored here in a folder with the component name. This includes the component itself, tests, documentation and storybook files.
 - **`css`:** We store any global less/css in here. Right now it is only used for Dialtone overrides.
+- **`directives`:** Vue directives we output as part of the Dialtone Vue library.
 - **`dist`:** The Dialtone Vue library is output here upon `npm run build`.
 - **`docs`:** Any storybook documentation not directly related to a component.
+- **`functions`:** Contains documentation for any functions we export as part of the library.
 - **`recipes`:** Everything related to recipe components is stored here in a folder with the component name. This includes the component itself, tests, documentation and storybook files.
 - **`scripts`:** - Contains shell scripts.
 - **`tests`:** For utility/helper files to be used in multiple tests and test configuration. Actual tests are stored in the component folder.
-- **`tools`:** - Any additional tooling related to Dialtone Vue. Right now contains files related to the migration from Dialtone 5 to Dialtone 6.
-
-## Commit Message Convention
-
-Dialtone Vue uses [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
-to have commit messages that can be used as part of the [semantic release process](RELEASING.md).
-For more information, see [COMMIT_CONVENTION.md].
-
-Commit message conventions will be enforced on commit via git hook when pushing to branches (`production`, `staging`, `alpha` and `beta`).
-
-When creating a PR from your own feature branch it is enforced via GitHub actions in the following conditions:
-
-1. If you have only a single commit on your branch the commit message must follow the conventions.
-2. If you have more than one commit on your branch the commit messages do not have to follow the conventions but the title of the PR does.
-
-## Versioning
-
-Dialtone Vue follows [SemVer](https://semver.org/) for versioning and the commit message convention used in the project
-is aligned with SemVer by describing the features, fixes, and breaking changes made in commit messages.
-All versioning on release will be done automatically based on the commit messages contained in it.
 
 ## Tooling
 
@@ -348,17 +231,3 @@ We use Yeoman as our generator to scaffold new components.
 This means if you are creating a new component you can simply just run `pnpm exec yo @dialpad/dialtone:vue3` and enter the name of your component.
 All files for your component (component, tests, storybook files) will be generated with starter templates and proper naming conventions.
 For more details on how to use yeoman, see [the docs](https://dialtone.dialpad.com/vue/?path=/story/docs-component-driven-development-yeoman-generator--page).
-
-### GitHub Actions
-
-[GitHub Actions](https://docs.github.com/en/actions) is what we use for our CI/CD solution.
-All GHA workflows are in the `.github/workflows` directory.
-Currently, we use GitHub Actions for the following:
-
-- Deploying to production `.github/workflows/deploy.yml`, See [RELEASING](RELEASING.md) for instructions on how to do this.
-- Linting our files on pull request `.github/workflows/lint-pr.yml`.
-- Validating commit messages `.github/workflows/lint-commit-message.yml`, see [COMMIT_CONVENTION] for our commit message conventions.
-- Running unit tests on pull requests and pushes to staging `.github/workflows/unit_tests.yml`.
-- Running visual tests after approved pull requests and pushes to staging `.github/workflows/visual_tests.yml`.
-
-[COMMIT_CONVENTION.md]: /.github/COMMIT_CONVENTION.md

--- a/packages/dialtone-vue3/README.md
+++ b/packages/dialtone-vue3/README.md
@@ -32,6 +32,24 @@ or
 @import '@dialpad/dialtone-css';
 ```
 
+And then import Dialtone Vue css for either Vue 2 or Vue 3:
+
+- CSS
+
+```css
+@import "@dialpad/dialtone/vue2/css";
+/* Or */
+@import "@dialpad/dialtone/vue3/css";
+```
+
+- Javascript
+
+```js
+import "@dialpad/dialtone/vue2/css";
+/* Or */
+import "@dialpad/dialtone/vue3/css";
+```
+
 Dialtone Vue components can be imported directly from the package. Some components also export named constants, which can be imported as well:
 
 ```js

--- a/project.json
+++ b/project.json
@@ -39,7 +39,7 @@
     "test": {
       "executor": "nx:run-script",
       "options": {
-        "script": "test:vitest"
+        "script": "test:vue"
       }
     }
   }


### PR DESCRIPTION
# docs: NO-JIRA github doc update

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbDZmdGV2amFocHo1MjFzemYwa296eXdxNzB5M3dudjNqajNtdXlwZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/wpgYasZ0tBrP4lCgS3/giphy-downsized-large.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Description

- Moved library usage instructions to the top of the readme as that is the first thing most people would want to see
- Removed more obscure steps out of the initial readme and into the readme for that specific package, for example most users will not need to import tokens directly, they will just get them from Dialtone CSS.
- Put quick start as the first section of contributing
- Added some common commands
- Moved all contributing documentation that applied to the monorepo as a whole into the root contributing.md. The content left in the package specific contributing.md's should be specific to that package only. There was a lot of duplication here before this was done.

## :bulb: Context

Did some GitHub documentation cleanup, it has gotten a bit messy and confusing since all the changes recently.
