### PR TITLE
fix(tooltip): DLT-1747 tooltip staying open over overlay

### DIFF
--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -421,10 +421,10 @@ export default {
       //       as when triggered by click or touch, the relatedTarget property of MouseEvent is null
       if (this.isTouchDevice && !e.relatedTarget) return;
 
-      if (this.delay) {
-        this.inTimer = setTimeout(function (event) {
-          this.triggerShow(event);
-        }.bind(this, e), TOOLTIP_DELAY_MS);
+      if (this.delay && this.inTimer === null) {
+        this.inTimer = setTimeout(() => {
+          this.triggerShow(e);
+        }, TOOLTIP_DELAY_MS);
       } else {
         this.triggerShow(e);
       }
@@ -454,6 +454,7 @@ export default {
       if (e.type === 'keydown' && e.code !== 'Escape') return;
 
       clearTimeout(this.inTimer);
+      this.inTimer = null;
       this.triggerHide();
     },
 

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -430,10 +430,10 @@ export default {
       //       as when triggered by click or touch, the relatedTarget property of MouseEvent is null
       if (this.isTouchDevice && !e.relatedTarget) return;
 
-      if (this.delay) {
-        this.inTimer = setTimeout(function (event) {
-          this.triggerShow(event);
-        }.bind(this, e), TOOLTIP_DELAY_MS);
+      if (this.delay && this.inTimer === null) {
+        this.inTimer = setTimeout(() => {
+          this.triggerShow(e);
+        }, TOOLTIP_DELAY_MS);
       } else {
         this.triggerShow(e);
       }
@@ -463,6 +463,7 @@ export default {
       if (e.type === 'keydown' && e.code !== 'Escape') return;
 
       clearTimeout(this.inTimer);
+      this.inTimer = null;
       this.triggerHide();
     },
 


### PR DESCRIPTION
# fix(tooltip): DLT-1747 tooltip staying open over overlay

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGVocmVuMjc5OHIwMzlyaWh2czl5Zm1xemE5NTBwZW1semZtdXVleSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/wXnmM6hHFtz3IulO36/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1747

## :book: Description

FINALLY figured this one out. It's been a problem for a very long time.

Because there are two events on tooltip (mouseover and focus) they both get triggered on click. Only one timer's handle was stored in `this.inTimer` so only that timer was cancelled on mouseout causing the other to still trigger. Added protection to not add another timer if one already exists and it has fixed the issue.

## :bulb: Context

Tooltip will sometimes stay open when you open a modal overlay

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script.
