### PR TITLE
feat(message-input): NO-JIRA add keydown event

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -145,6 +145,7 @@ export const argsData = {
   onNoticeClose: action('notice-close'),
   onSkinTone: action('skin-tone'),
   onCancel: action('cancel'),
+  onHandleKeydown: action('keydown'),
 };
 
 // Story Collection

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -10,6 +10,7 @@
     @drag-over="onDrag"
     @drop="onDrop"
     @keydown.enter.exact="onSend"
+    @keydown="handleKeydown"
     @paste="onPaste"
   >
     <!-- Some wrapper to restrict the height and show the scrollbar -->
@@ -598,6 +599,13 @@ export default {
     'focus',
 
     /**
+     * Native handleKeydown event
+     * @event event
+     * @type {String|JSON}
+     */
+    'keydown',
+
+    /**
      * Native blur event
      * @event input
      * @type {String|JSON}
@@ -673,6 +681,10 @@ export default {
   },
 
   methods: {
+    handleKeydown (e) {
+      this.$emit('keydown', e);
+    },
+
     onDrag (e) {
       e.stopPropagation();
       e.preventDefault();

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -42,6 +42,7 @@
         @paste-media="$attrs.onPasteMedia"
         @notice-close="$attrs.onNoticeClose"
         @cancel="$attrs.onCancel"
+        @keydown="$attrs.onHandleKeydown"
       />
     </div>
   </div>

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -136,6 +136,7 @@ export const argsData = {
   onNoticeClose: action('notice-close'),
   onSkinTone: action('skin-tone'),
   onCancel: action('cancel'),
+  onHandleKeydown: action('keydown'),
 };
 
 // Story Collection

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -10,6 +10,7 @@
     @drag-over="onDrag"
     @drop="onDrop"
     @keydown.enter.exact="onSend"
+    @keydown="handleKeydown"
     @paste="onPaste"
   >
     <!-- Some wrapper to restrict the height and show the scrollbar -->
@@ -570,6 +571,13 @@ export default {
     'focus',
 
     /**
+     * Native handleKeydown event
+     * @event event
+     * @type {String|JSON}
+     */
+    'keydown',
+
+    /**
      * Native blur event
      * @event input
      * @type {String|JSON}
@@ -645,6 +653,10 @@ export default {
   },
 
   methods: {
+    handleKeydown (e) {
+      this.$emit('keydown', e);
+    },
+
     onDrag (e) {
       e.stopPropagation();
       e.preventDefault();

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -39,6 +39,7 @@
       @paste-media="$attrs.onPasteMedia"
       @notice-close="$attrs.onNoticeClose"
       @cancel="$attrs.onCancel"
+      @keydown="$attrs.onHandleKeydown"
     />
   </div>
 </template>


### PR DESCRIPTION
# feat(message-input): NO-JIRA add keydown event

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaXpjMG5vdzc1MDYyaXc2M29kZGtkeXhmczRvM292c2R4OWZrcW1pcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3NtY188QaxDdC/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor


## :book: Jira Ticket

NO-JIRA

## :book: Description

This pull request adds keydown event on message input component.

## :bulb: Context
We need to prevent the backspace key default event when using the input component on the new message flow because if not it moves to the previous input and in this case is not the expected behavior.
Example of current behavior:

https://github.com/dialpad/dialtone/assets/144126346/e0933c12-1d5a-4b76-b068-10311c27a47c


## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
