### PR TITLE
fix: NO-JIRA define "Segoe UI Adjusted" font

### DIFF
--- a/packages/dialtone-css/lib/build/less/dialtone-globals.less
+++ b/packages/dialtone-css/lib/build/less/dialtone-globals.less
@@ -39,6 +39,14 @@
   src: url('../fonts/Archivo-SemiBold.woff2') format('woff2');
 }
 
+// Define custom font: "Segoe UI Adjusted" to fix some visual issues with the Segoe UI font
+@font-face {
+  font-family: "Segoe UI Adjusted";
+  src: local(Segoe UI);
+  ascent-override: 95%;
+}
+
+
 html,
 body {
     margin: 0;


### PR DESCRIPTION
# fix: NO-JIRA define "Segoe UI Adjusted" font

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

We were not outputting Segoe UI Adjusted with Dialtone even though it was defined in our tokens. This should fix issues with Segoe UI font overflow on windows.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
