### PR TITLE
ci: NO-JIRA escape double quotes

### DIFF
--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -32,7 +32,7 @@ jobs:
         run: >
           echo "RELEASE_NOTES=$(
             echo ${EXTRACTED_NOTES//$'\n'/\\n} |
-            sed 's/[(][^)]*[)]//g' |
+            sed -e 's/[(][^)]*[)]//g' -e 's/"/\\"/g' |
             tr -d '()'
           )" >> $GITHUB_ENV;
 


### PR DESCRIPTION
# Escape double quotes

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWpjbzBuNjh2amthdjJwMWJlMHFod256MXQ0cHZobzY1eWc2NDF3diZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l41YmgdpcJwUngcXm/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] CI

## :book: Description

Escape double quotes to avoid issues with JSON string format.

## :bulb: Context

The release notification failed due to the changelog including `"` 
https://github.com/dialpad/dialtone/actions/runs/9020875851