### PR TITLE
fix(datepicker): DP-89398 change tooltip fallback positions

### DIFF
--- a/packages/dialtone-vue2/components/datepicker/modules/month-year-picker.vue
+++ b/packages/dialtone-vue2/components/datepicker/modules/month-year-picker.vue
@@ -13,6 +13,7 @@
       <dt-tooltip
         :message="prevYearLabel"
         placement="top"
+        :fallback-placements="['top-start', 'auto']"
       >
         <template #anchor>
           <dt-button
@@ -38,6 +39,7 @@
       <dt-tooltip
         :message="prevMonthLabel"
         placement="top"
+        :fallback-placements="['top-end', 'auto']"
       >
         <template #anchor>
           <dt-button
@@ -78,6 +80,7 @@
       <dt-tooltip
         :message="nextMonthLabel"
         placement="top"
+        :fallback-placements="['top-start', 'auto']"
       >
         <template #anchor>
           <dt-button
@@ -103,6 +106,7 @@
       <dt-tooltip
         :message="nextYearLabel"
         placement="top"
+        :fallback-placements="['top-end', 'auto']"
       >
         <template #anchor>
           <dt-button

--- a/packages/dialtone-vue3/components/datepicker/modules/month-year-picker.vue
+++ b/packages/dialtone-vue3/components/datepicker/modules/month-year-picker.vue
@@ -13,6 +13,7 @@
       <dt-tooltip
         :message="prevYearLabel"
         placement="top"
+        :fallback-placements="['top-start', 'auto']"
       >
         <template #anchor>
           <dt-button
@@ -38,6 +39,7 @@
       <dt-tooltip
         :message="prevMonthLabel"
         placement="top"
+        :fallback-placements="['top-end', 'auto']"
       >
         <template #anchor>
           <dt-button
@@ -80,6 +82,7 @@
       <dt-tooltip
         :message="nextMonthLabel"
         placement="top"
+        :fallback-placements="['top-start', 'auto']"
       >
         <template #anchor>
           <dt-button
@@ -107,6 +110,7 @@
       <dt-tooltip
         :message="nextYearLabel"
         placement="top"
+        :fallback-placements="['top-end', 'auto']"
       >
         <template #anchor>
           <dt-button


### PR DESCRIPTION
# fix(datepicker): change tooltip fallback positions

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbjlvaWNoaHRnMG9pazU1Ymxna3c3Nml6NnV0b250dm54ZnkwOGF1NSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l41YtzJmMgEyOWBKU/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-89398

## :book: Description

Tooltip was overlapping the month name when there was not enough horizontal space for it to display on top. Added custom fallbackPlacements to remedy this.

## :bulb: Context

See Jira ticket, datepicker implementation within integrations iframe.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

Release and notify in jira ticket
