### PR TITLE
chore: DLT-1748 promote dialtone 9 to latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,7 +99,6 @@ jobs:
     env:
       BRANCH_NAME: ${{ needs.get-branch-name.outputs.current_branch }}
       RELEASE_TAG: ${{ needs.get-branch-name.outputs.current_branch == 'production' && 'latest' || needs.get-branch-name.outputs.current_branch }}
-      DIALTONE_RELEASE_TAG: ${{ needs.get-branch-name.outputs.current_branch == 'production' && 'next' || needs.get-branch-name.outputs.current_branch }}
       DIALTONE_VUE3_RELEASE_TAG: ${{ needs.get-branch-name.outputs.current_branch == 'production' && 'vue3' || needs.get-branch-name.outputs.current_branch }}
     steps:
       - name: Checkout
@@ -135,9 +134,9 @@ jobs:
       - name: Set npm token
         run: pnpm config set //registry.npmjs.org/:_authToken=${{ secrets.DIALTONE_NPM_TOKEN }}
 
-      - name: Publish dialtone ${{ env.DIALTONE_RELEASE_TAG }}
+      - name: Publish dialtone ${{ env.RELEASE_TAG }}
         if: ${{ needs.filter-actions.outputs.dialtone == 'true' || github.event.inputs.package == 'all' || github.event.inputs.package == 'dialtone' }}
-        run: pnpm nx publish dialtone --publish-branch=${{ env.BRANCH_NAME }} --tag=${{ env.DIALTONE_RELEASE_TAG }}
+        run: pnpm nx publish dialtone --publish-branch=${{ env.BRANCH_NAME }} --tag=${{ env.RELEASE_TAG }}
 
       - name: Publish dialtone css ${{ env.RELEASE_TAG }}
         if: ${{ needs.filter-actions.outputs.css == 'true' || github.event.inputs.package == 'all' || github.event.inputs.package == 'css' }}
@@ -177,7 +176,6 @@ jobs:
     env:
       BRANCH_NAME: ${{ needs.get-branch-name.outputs.current_branch }}
       RELEASE_TAG: ${{ needs.get-branch-name.outputs.current_branch == 'production' && 'latest' || needs.get-branch-name.outputs.current_branch }}
-      DIALTONE_RELEASE_TAG: ${{ needs.get-branch-name.outputs.current_branch == 'production' && 'next' || needs.get-branch-name.outputs.current_branch }}
       DIALTONE_VUE3_RELEASE_TAG: ${{ needs.get-branch-name.outputs.current_branch == 'production' && 'vue3' || needs.get-branch-name.outputs.current_branch }}
     steps:
       - name: Checkout
@@ -216,9 +214,9 @@ jobs:
       - name: Set GitHub auth token
         run: pnpm config set //npm.pkg.github.com/:_authToken=${{ env.GITHUB_TOKEN }}
 
-      - name: Publish dialtone ${{ env.DIALTONE_RELEASE_TAG }}
+      - name: Publish dialtone ${{ env.RELEASE_TAG }}
         if: ${{ needs.filter-actions.outputs.dialtone == 'true' || github.event.inputs.package == 'all' || github.event.inputs.package == 'dialtone' }}
-        run: pnpm nx publish dialtone --publish-branch=${{ env.BRANCH_NAME }} --tag=${{ env.DIALTONE_RELEASE_TAG }}
+        run: pnpm nx publish dialtone --publish-branch=${{ env.BRANCH_NAME }} --tag=${{ env.RELEASE_TAG }}
 
       - name: Publish dialtone css ${{ env.RELEASE_TAG }}
         if: ${{ needs.filter-actions.outputs.css == 'true' || github.event.inputs.package == 'all' || github.event.inputs.package == 'css' }}

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ All packages of the monorepo are combined into a single Dialtone package for eas
 #### Vue 3
 
 ```shell
-npm install @dialpad/dialtone@next @tiptap/vue-3
+npm install @dialpad/dialtone@latest @tiptap/vue-3
 ```
 
 #### Vue 2
 
 ```shell
-npm install @dialpad/dialtone@next @linusborg/vue-simple-portal @tiptap/vue-2
+npm install @dialpad/dialtone@latest @linusborg/vue-simple-portal @tiptap/vue-2
 ```
 
 ### Import packages:
@@ -98,6 +98,32 @@ import { DtButton } from "@dialpad/dialtone/vue3"
 
 // Default import (Prefered if using webpack as it is tree-shakeable by default)
 import { DtButton } from "@dialpad/dialtone/vue3/lib/button"
+```
+
+#### Dialtone Tokens
+
+Dialtone tokens doesn't have a default export, so you need to access
+the files directly as following:
+
+- CSS
+
+```css
+@import "@dialpad/dialtone/tokens/variables-light.css" // Light tokens
+@import "@dialpad/dialtone/tokens/variables-dark.css" // Dark tokens
+```
+
+- LESS
+
+```less
+@import "@dialpad/dialtone/tokens/variables-light.less" // Light tokens
+@import "@dialpad/dialtone/tokens/variables-dark.less" // Dark tokens
+```
+
+- JSON
+
+```js
+import "@dialpad/dialtone/tokens/tokens-light.json" // Light tokens
+import "@dialpad/dialtone/tokens/tokens-dark.json" // Dark tokens
 ```
 
 ## About this repo
@@ -370,118 +396,3 @@ This will trigger the [release action](.github/workflows/release.yml), release c
 
 1. Run the `nx release` on selected packages (all if `package` is empty).
 2. An [action](https://github.com/dialpad/dialtone/actions/workflows/publish.yml) will publish the packages with its corresponding tag.
-
-## Usage
-
-### Install it via NPM:
-
-#### Vue 3
-
-```shell
-npm install @dialpad/dialtone@next @tiptap/vue-3
-```
-
-#### Vue 2
-
-```shell
-npm install @dialpad/dialtone@next @linusborg/vue-simple-portal @tiptap/vue-2
-```
-
-### Import packages:
-
-#### Dialtone CSS
-
-- CSS
-
-```css
-@import "@dialpad/dialtone/css";
-```
-
-- Javascript
-
-```js
-import "@dialpad/dialtone/css";
-```
-
-#### Dialtone eslint-plugin
-
-```js
-import dialtone from "@dialpad/dialtone/eslint-plugin"
-```
-
-#### Dialtone icons
-
-- Importing for Vue 2:
-
-```js
-// Named import
-import { DtIconArrowUp } from '@dialpad/dialtone-icons/vue2'; 
-
-// Default import (Prefered if using webpack as it is tree-shakeable by default)
-import DtIconArrowUp from '@dialpad/dialtone-icons/vue2/arrow-up';
-```
-
-- Importing for Vue 3:
-
-```js
-// Named import
-import { DtIconArrowUp } from '@dialpad/dialtone-icons/vue3'; 
-
-// Default import (Prefered if using webpack as it is tree-shakeable by default)
-import DtIconArrowUp from '@dialpad/dialtone-icons/vue3/arrow-up';
-```
-
-- Importing json files
-
-```js
-import keywords from '@dialpad/dialtone-icons/keywords.json';
-import iconsList from '@dialpad/dialtone-icons/icons.json';
-```
-
-#### Dialtone Vue
-
-- Vue 2
-
-```js
-// Named import
-import { DtButton } from "@dialpad/dialtone/vue2" 
-
-// Default import (Prefered if using webpack as it is tree-shakeable by default)
-import { DtButton } from "@dialpad/dialtone/vue2/lib/button"
-```
-
-- Vue 3
-
-```js
-// Named import
-import { DtButton } from "@dialpad/dialtone/vue3" 
-
-// Default import (Prefered if using webpack as it is tree-shakeable by default)
-import { DtButton } from "@dialpad/dialtone/vue3/lib/button"
-```
-
-#### Dialtone Tokens
-
-Dialtone tokens doesn't have a default export, so you need to access
-the files directly as following:
-
-- CSS
-
-```css
-@import "@dialpad/dialtone/tokens/variables-light.css" // Light tokens
-@import "@dialpad/dialtone/tokens/variables-dark.css" // Dark tokens
-```
-
-- LESS
-
-```less
-@import "@dialpad/dialtone/tokens/variables-light.less" // Light tokens
-@import "@dialpad/dialtone/tokens/variables-dark.less" // Dark tokens
-```
-
-- JSON
-
-```js
-import "@dialpad/dialtone/tokens/tokens-light.json" // Light tokens
-import "@dialpad/dialtone/tokens/tokens-dark.json" // Dark tokens
-```

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-5-15.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-5-15.md
@@ -1,0 +1,36 @@
+---
+heading: Promoted Dialtone 9 to latest
+author: Tico Ortega
+posted: '2024-5-15'
+---
+
+<BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">
+
+**👋 Hey there,** we're excited to share some updates.
+
+## Dialtone 9 promoted to latest
+
+Now that all our core apps have been migrated from Dialtone 8 to Dialtone 9.
+We are promoting Dialtone 9 to latest.
+
+### How this will affect you?
+
+From now on, you should install Dialtone with `npm install @dialpad/dialtone@latest --save-exact`.
+
+### Still not fully migrated?
+
+If you're using our library and haven't fully migrated to Dialtone 9, please refer to this
+[blog post](https://dialtone.dialpad.com/about/whats-new/posts/2023-12-28.html) for the migration reference.
+
+## Got questions?
+
+We're here to help! Reach out us in the `#dialtone` channel for any assistance you need.
+
+Thanks for your patience and understanding,
+Dialtone Team 💜
+</BlogPost>
+
+<script setup>
+import BlogPost from '@baseComponents/BlogPost.vue';
+import { parse } from 'date-fns';
+</script>


### PR DESCRIPTION
# Promote dialtone 9 to latest

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/gKHGnB1ml0moQdjhEJ/giphy.gif?cid=82a1493bbfh9iqruj9op92s6fpq8svub41hxgpdvqe0apqrq&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1748

## :book: Description

- Removed the `next` from dialtone releases
- Removed duplicated info on README.md
- Added a blog post

## :bulb: Context

All our core products are already migrated to Dialtone 9 so having it as `next` doesn't makes sense anymore.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.