### PR TITLE
feat(link): DLT-1631 add inverted utility classes

### DIFF
--- a/apps/dialtone-documentation/docs/components/link.md
+++ b/apps/dialtone-documentation/docs/components/link.md
@@ -45,35 +45,65 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 
 ## Variants and examples
 
+### Default
+
 <code-well-header>
   <a href="#link" class="d-link">Base link</a>
   <a href="#link" class="d-link d-link--danger">Danger link</a>
   <a href="#link" class="d-link d-link--muted">Muted link</a>
   <a href="#link" class="d-link d-link--success">Success link</a>
   <a href="#link" class="d-link d-link--warning">Warning link</a>
-  <a href="#link" class="d-link d-link--disabled">Disabled link</a>
   <a href="#link" class="d-link d-link--mention">Mention link</a>
 </code-well-header>
 
-```html
-<a href="#link" class="d-link">...</a>
-<a href="#link" class="d-link d-link--danger">...</a>
-<a href="#link" class="d-link d-link--muted">...</a>
-<a href="#link" class="d-link d-link--success">...</a>
-<a href="#link" class="d-link d-link--warning">...</a>
-<a href="#link" class="d-link d-link--disabled">...</a>
-<a href="#link" class="d-link d-link--mention">...</a>
-```
+<code-example-tabs
+htmlCode='
+<a href="#link" class="d-link">Link</a>
+<a href="#link" class="d-link d-link--danger">Danger link</a>
+<a href="#link" class="d-link d-link--muted">Muted link</a>
+<a href="#link" class="d-link d-link--success">Success link</a>
+<a href="#link" class="d-link d-link--warning">Warning link</a>
+<a href="#link" class="d-link d-link--mention">Mention link</a>
+'
+vueCode='
+<dt-link :href="#link">Link</dt-link>
+<dt-link :href="#link" kind="danger">Danger link</dt-link>
+<dt-link :href="#link" kind="muted">Muted link</dt-link>
+<dt-link :href="#link" kind="success">Success link</dt-link>
+<dt-link :href="#link" kind="warning">Warning link</dt-link>
+<dt-link :href="#link" kind="mention">Mention link</dt-link>
+'
+showHtmlWarning />
+
+### Inverted
 
 <code-well-header bgclass="d-bgc-contrast">
   <a href="#link" class="d-link d-link--inverted">Inverted base link</a>
-  <a href="#link" class="d-link d-link--inverted-disabled">Inverted disabled link</a>
+  <a href="#link" class="d-link d-link--inverted-danger">Inverted danger link</a>
+  <a href="#link" class="d-link d-link--inverted-success">Inverted success link</a>
+  <a href="#link" class="d-link d-link--inverted-warning">Inverted warning link</a>
+  <a href="#link" class="d-link d-link--inverted-muted">Inverted muted link</a>
+  <a href="#link" class="d-link d-link--inverted-mention">Inverted mention link</a>
 </code-well-header>
 
-```html
-<a href="#link" class="d-link d-link--inverted">...</a>
-<a href="#link" class="d-link d-link--inverted-disabled">Inverted disabled link</a>
-```
+<code-example-tabs
+htmlCode='
+<a href="#link" class="d-link d-link--inverted">Inverted link</a>
+<a href="#link" class="d-link d-link--inverted-danger">Inverted danger link</a>
+<a href="#link" class="d-link d-link--inverted-success">Inverted success link</a>
+<a href="#link" class="d-link d-link--inverted-warning">Inverted warning link</a>
+<a href="#link" class="d-link d-link--inverted-muted">Inverted muted link</a>
+<a href="#link" class="d-link d-link--inverted-mention">Inverted muted link</a>
+'
+vueCode='
+<dt-link :href="#link" inverted>Inverted link</dt-link>
+<dt-link :href="#link" kind="danger" inverted>Inverted danger link</dt-link>
+<dt-link :href="#link" kind="success" inverted>Inverted success link</dt-link>
+<dt-link :href="#link" kind="warning" inverted>Inverted warning link</dt-link>
+<dt-link :href="#link" kind="muted" inverted>Inverted muted link</dt-link>
+<dt-link :href="#link" kind="mention" inverted>Inverted mention link</dt-link>
+'
+showHtmlWarning />
 
 ## Vue API
 

--- a/packages/dialtone-css/lib/build/less/components/link.less
+++ b/packages/dialtone-css/lib/build/less/components/link.less
@@ -130,6 +130,47 @@
         }
     }
 
+    //  $$  INVERTED DANGER
+    //  ----------------------------------------------------------------------------
+    &--inverted-danger {
+        --link-color-default: var(--dt-color-link-critical-inverted);
+        --link-color-default-hover: var(--dt-color-link-critical-inverted-hover);
+    }
+
+    //  $$  INVERTED SUCCESS
+    //  ----------------------------------------------------------------------------
+    &--inverted-success {
+        --link-color-default: var(--dt-color-link-success-inverted);
+        --link-color-default-hover: var(--dt-color-link-success-inverted-hover);
+    }
+
+    //  $$  INVERTED WARNING
+    //  ----------------------------------------------------------------------------
+    &--inverted-warning {
+        --link-color-default: var(--dt-color-link-warning-inverted);
+        --link-color-default-hover: var(--dt-color-link-warning-inverted-hover);
+    }
+
+    //  $$  INVERTED MUTED
+    //  ----------------------------------------------------------------------------
+    &--inverted-muted {
+        --link-color-default: var(--dt-color-link-muted-inverted);
+        --link-color-default-hover: var(--dt-color-link-muted-inverted-hover);
+    }
+
+    //  $$  INVERTED MENTION
+    //  ----------------------------------------------------------------------------
+    &--inverted-mention {
+        --link-color-default: var(--dt-color-link-primary-inverted);
+        --link-color-default-hover: var(--dt-color-link-primary-inverted-hover);
+        --link-text-decoration: none;
+        --link-padding: 0 var(--dt-space-200);
+        --link-background-color: hsl(var(--dt-color-purple-400-hsl) / 0.2);
+
+        line-height: var(--dt-font-line-height-200);
+        border-radius: var(--dt-size-radius-200);
+    }
+
     //  $$  MENTION
     //  ----------------------------------------------------------------------------
     // Styling specific to mentions such as @brad.paugh. The underline highlighting

--- a/packages/dialtone-vue2/components/breadcrumbs/breadcrumb_item.vue
+++ b/packages/dialtone-vue2/components/breadcrumbs/breadcrumb_item.vue
@@ -8,6 +8,7 @@
   >
     <dt-link
       :kind="linkKind"
+      :inverted="linkInverted"
       :aria-current="ariaCurrent"
       data-qa="breadcrumb-item"
       v-bind="$attrs"
@@ -23,7 +24,7 @@
 <script>
 import { BREADCRUMB_ITEM_SELECTED_MODIFIER } from './breadcrumbs_constants';
 import { DtLink } from '../link';
-import { INVERTED, MUTED } from '../link/link_constants';
+import { MUTED } from '../link/link_constants';
 
 export default {
   name: 'DtBreadcrumbItem',
@@ -68,7 +69,11 @@ export default {
 
   computed: {
     linkKind () {
-      return this.inverted ? INVERTED : MUTED;
+      return this.inverted ? '' : MUTED;
+    },
+
+    linkInverted () {
+      return !!this.inverted;
     },
 
     ariaCurrent () {

--- a/packages/dialtone-vue2/components/link/link.stories.js
+++ b/packages/dialtone-vue2/components/link/link.stories.js
@@ -10,6 +10,7 @@ import { LINK_VARIANTS } from './link_constants';
 export const argsData = {
   default: 'Default link',
   href: '#',
+  inverted: false,
   kind: '',
   rel: undefined,
   onClick: action('click'),
@@ -35,6 +36,9 @@ export const argTypesData = {
     control: {
       type: 'select',
     },
+  },
+  inverted: {
+    control: 'boolean',
   },
 
   // HTML attributes

--- a/packages/dialtone-vue2/components/link/link.test.js
+++ b/packages/dialtone-vue2/components/link/link.test.js
@@ -6,7 +6,7 @@ import {
   SUCCESS,
   WARNING,
   MUTED,
-  INVERTED,
+  getLinkKindModifier,
 } from './link_constants';
 
 const baseProps = {
@@ -72,16 +72,6 @@ describe('DtLink tests', () => {
       });
     });
 
-    describe('When kind is inverted', () => {
-      it('should have correct class', async () => {
-        mockProps = { kind: INVERTED };
-
-        updateWrapper();
-
-        expect(nativeLink.classes(LINK_KIND_MODIFIERS[INVERTED])).toBe(true);
-      });
-    });
-
     describe('When kind is success', () => {
       it('should have correct class', async () => {
         mockProps = { kind: SUCCESS };
@@ -109,6 +99,56 @@ describe('DtLink tests', () => {
         updateWrapper();
 
         expect(nativeLink.classes(LINK_KIND_MODIFIERS[MUTED])).toBe(true);
+      });
+    });
+
+    describe('When inverted is true', () => {
+      it('should have correct class', async () => {
+        mockProps = { inverted: true };
+
+        updateWrapper();
+
+        expect(nativeLink.classes(getLinkKindModifier('', true))).toBe(true);
+      });
+    });
+
+    describe('When kind is danger and inverted is true', () => {
+      it('should have correct class', async () => {
+        mockProps = { kind: DANGER, inverted: true };
+
+        updateWrapper();
+
+        expect(nativeLink.classes(getLinkKindModifier(DANGER, true))).toBe(true);
+      });
+    });
+
+    describe('When kind is success and inverted is true', () => {
+      it('should have correct class', async () => {
+        mockProps = { kind: SUCCESS, inverted: true };
+
+        updateWrapper();
+
+        expect(nativeLink.classes(getLinkKindModifier(SUCCESS, true))).toBe(true);
+      });
+    });
+
+    describe('When kind is warning and inverted is true', () => {
+      it('should have correct class', async () => {
+        mockProps = { kind: WARNING, inverted: true };
+
+        updateWrapper();
+
+        expect(nativeLink.classes(getLinkKindModifier(WARNING, true))).toBe(true);
+      });
+    });
+
+    describe('When kind is muted and inverted is true', () => {
+      it('should have correct class', async () => {
+        mockProps = { kind: MUTED, inverted: true };
+
+        updateWrapper();
+
+        expect(nativeLink.classes(getLinkKindModifier(MUTED, true))).toBe(true);
       });
     });
   });

--- a/packages/dialtone-vue2/components/link/link.vue
+++ b/packages/dialtone-vue2/components/link/link.vue
@@ -1,9 +1,6 @@
 <template>
   <a
-    :class="[
-      'd-link',
-      LINK_KIND_MODIFIERS[kind],
-    ]"
+    :class="getLinkClasses()"
     data-qa="dt-link"
     :href="'href' in $attrs ? $attrs.href : 'javascript:void(0)'"
     v-on="$listeners"
@@ -14,7 +11,7 @@
 </template>
 
 <script>
-import { LINK_VARIANTS, LINK_KIND_MODIFIERS } from './link_constants';
+import { LINK_VARIANTS, LINK_KIND_MODIFIERS, getLinkKindModifier } from './link_constants';
 
 /**
  * A link is a navigational element that can be found on its own, within other text, or directly following content.
@@ -28,7 +25,7 @@ export default {
   props: {
     /**
      * Applies the link variant styles
-     * @values null, danger, warning, success, muted, inverted, mention
+     * @values null, danger, warning, success, muted, mention
      */
     kind: {
       type: String,
@@ -36,6 +33,16 @@ export default {
       validator (kind) {
         return LINK_VARIANTS.includes(kind);
       },
+    },
+
+    /**
+     * Determines whether the link should have inverted styling
+     * default is false.
+     * @values true, false
+     */
+    inverted: {
+      type: Boolean,
+      default: false,
     },
   },
 
@@ -69,6 +76,15 @@ export default {
     return {
       LINK_KIND_MODIFIERS,
     };
+  },
+
+  methods: {
+    getLinkClasses () {
+      return [
+        'd-link',
+        getLinkKindModifier(this.kind, this.inverted),
+      ];
+    },
   },
 };
 </script>

--- a/packages/dialtone-vue2/components/link/link_constants.js
+++ b/packages/dialtone-vue2/components/link/link_constants.js
@@ -2,9 +2,8 @@ export const DANGER = 'danger';
 export const WARNING = 'warning';
 export const SUCCESS = 'success';
 export const MUTED = 'muted';
-export const INVERTED = 'inverted';
 export const MENTION = 'mention';
-export const LINK_VARIANTS = ['', DANGER, WARNING, SUCCESS, MUTED, INVERTED, MENTION];
+export const LINK_VARIANTS = ['', DANGER, WARNING, SUCCESS, MUTED, MENTION];
 
 export const LINK_KIND_MODIFIERS = {
   default: '',
@@ -12,11 +11,27 @@ export const LINK_KIND_MODIFIERS = {
   danger: 'd-link--danger',
   success: 'd-link--success',
   muted: 'd-link--muted',
-  inverted: 'd-link--inverted',
   mention: 'd-link--mention',
+};
+
+const LINK_KIND_MODIFIERS_INVERTED = {
+  default: 'd-link--inverted',
+  warning: 'd-link--inverted-warning',
+  danger: 'd-link--inverted-danger',
+  success: 'd-link--inverted-success',
+  muted: 'd-link--inverted-muted',
+  mention: 'd-link--inverted-mention',
+};
+
+export const getLinkKindModifier = (kind, inverted) => {
+  if (inverted) {
+    return LINK_KIND_MODIFIERS_INVERTED[kind || 'default'];
+  }
+  return LINK_KIND_MODIFIERS[kind];
 };
 
 export default {
   LINK_VARIANTS,
   LINK_KIND_MODIFIERS,
+  getLinkKindModifier,
 };

--- a/packages/dialtone-vue2/components/link/link_default.story.vue
+++ b/packages/dialtone-vue2/components/link/link_default.story.vue
@@ -3,6 +3,7 @@
     <dt-link
       :href="$attrs.href"
       :kind="$attrs.kind"
+      :inverted="$attrs.inverted"
       :rel="$attrs.rel"
       @click="$attrs.onClick"
       @focusin="$attrs.onFocusIn"

--- a/packages/dialtone-vue2/components/link/link_variants.story.vue
+++ b/packages/dialtone-vue2/components/link/link_variants.story.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <dt-link
-      v-for="kind in filteredKindClasses"
+      v-for="kind in LINK_VARIANTS"
       :key="kind"
       href="#"
       :kind="kind"
@@ -11,11 +11,14 @@
     </dt-link>
     <div class="d-bgc-purple-600">
       <dt-link
-        kind="inverted"
+        v-for="kind in LINK_VARIANTS"
+        :key="kind"
+        inverted
         href="#"
-        class="d-tt-capitalize"
+        :kind="kind"
+        class="d-tt-capitalize d-mr8"
       >
-        Inverted link
+        Inverted {{ kind }} link
       </dt-link>
     </div>
   </div>
@@ -23,7 +26,7 @@
 
 <script>
 import DtLink from './link.vue';
-import { LINK_VARIANTS, INVERTED } from './link_constants';
+import { LINK_VARIANTS } from './link_constants';
 
 export default {
   name: 'DtLinkVariants',
@@ -32,12 +35,6 @@ export default {
     return {
       LINK_VARIANTS,
     };
-  },
-
-  computed: {
-    filteredKindClasses () {
-      return LINK_VARIANTS.filter(kind => kind !== INVERTED);
-    },
   },
 };
 </script>

--- a/packages/dialtone-vue3/components/breadcrumbs/breadcrumb_item.vue
+++ b/packages/dialtone-vue3/components/breadcrumbs/breadcrumb_item.vue
@@ -8,6 +8,7 @@
   >
     <dt-link
       :kind="linkKind"
+      :inverted="linkInverted"
       :aria-current="ariaCurrent"
       data-qa="breadcrumb-item"
       v-bind="$attrs"
@@ -23,7 +24,7 @@
 <script>
 import { BREADCRUMB_ITEM_SELECTED_MODIFIER } from './breadcrumbs_constants';
 import { DtLink } from '../link';
-import { INVERTED, MUTED } from '../link/link_constants';
+import { MUTED } from '../link/link_constants';
 
 export default {
   name: 'DtBreadcrumbItem',
@@ -68,7 +69,11 @@ export default {
 
   computed: {
     linkKind () {
-      return this.inverted ? INVERTED : MUTED;
+      return this.inverted ? '' : MUTED;
+    },
+
+    linkInverted () {
+      return !!this.inverted;
     },
 
     ariaCurrent () {

--- a/packages/dialtone-vue3/components/link/link.stories.js
+++ b/packages/dialtone-vue3/components/link/link.stories.js
@@ -10,6 +10,7 @@ import { LINK_VARIANTS } from './link_constants';
 export const argsData = {
   default: 'Default link',
   href: '#',
+  inverted: false,
   kind: '',
   rel: undefined,
   onClick: action('click'),
@@ -35,6 +36,9 @@ export const argTypesData = {
     control: {
       type: 'select',
     },
+  },
+  inverted: {
+    control: 'boolean',
   },
 
   // HTML attributes

--- a/packages/dialtone-vue3/components/link/link.test.js
+++ b/packages/dialtone-vue3/components/link/link.test.js
@@ -6,7 +6,7 @@ import {
   SUCCESS,
   WARNING,
   MUTED,
-  INVERTED,
+  getLinkKindModifier,
 } from './link_constants';
 
 const baseProps = {
@@ -66,16 +66,6 @@ describe('DtLink tests', () => {
       });
     });
 
-    describe('When kind is inverted', () => {
-      it('should have correct class', async () => {
-        mockProps = { kind: INVERTED };
-
-        updateWrapper();
-
-        expect(nativeLink.classes(LINK_KIND_MODIFIERS[INVERTED])).toBe(true);
-      });
-    });
-
     describe('When kind is success', () => {
       it('should have correct class', async () => {
         mockProps = { kind: SUCCESS };
@@ -103,6 +93,56 @@ describe('DtLink tests', () => {
         updateWrapper();
 
         expect(nativeLink.classes(LINK_KIND_MODIFIERS[MUTED])).toBe(true);
+      });
+    });
+
+    describe('When inverted is true', () => {
+      it('should have correct class', async () => {
+        mockProps = { inverted: true };
+
+        updateWrapper();
+
+        expect(nativeLink.classes(getLinkKindModifier('', true))).toBe(true);
+      });
+    });
+
+    describe('When kind is danger and inverted is true', () => {
+      it('should have correct class', async () => {
+        mockProps = { kind: DANGER, inverted: true };
+
+        updateWrapper();
+
+        expect(nativeLink.classes(getLinkKindModifier(DANGER, true))).toBe(true);
+      });
+    });
+
+    describe('When kind is success and inverted is true', () => {
+      it('should have correct class', async () => {
+        mockProps = { kind: SUCCESS, inverted: true };
+
+        updateWrapper();
+
+        expect(nativeLink.classes(getLinkKindModifier(SUCCESS, true))).toBe(true);
+      });
+    });
+
+    describe('When kind is warning and inverted is true', () => {
+      it('should have correct class', async () => {
+        mockProps = { kind: WARNING, inverted: true };
+
+        updateWrapper();
+
+        expect(nativeLink.classes(getLinkKindModifier(WARNING, true))).toBe(true);
+      });
+    });
+
+    describe('When kind is muted and inverted is true', () => {
+      it('should have correct class', async () => {
+        mockProps = { kind: MUTED, inverted: true };
+
+        updateWrapper();
+
+        expect(nativeLink.classes(getLinkKindModifier(MUTED, true))).toBe(true);
       });
     });
   });

--- a/packages/dialtone-vue3/components/link/link.vue
+++ b/packages/dialtone-vue3/components/link/link.vue
@@ -1,9 +1,6 @@
 <template>
   <a
-    :class="[
-      'd-link',
-      LINK_KIND_MODIFIERS[kind],
-    ]"
+    :class="getLinkClasses()"
     data-qa="dt-link"
     :href="'href' in $attrs ? $attrs.href : 'javascript:void(0)'"
   >
@@ -13,7 +10,7 @@
 </template>
 
 <script>
-import { LINK_VARIANTS, LINK_KIND_MODIFIERS } from './link_constants';
+import { LINK_VARIANTS, LINK_KIND_MODIFIERS, getLinkKindModifier } from './link_constants';
 
 /**
  * A link is a navigational element that can be found on its own, within other text, or directly following content.
@@ -27,7 +24,7 @@ export default {
   props: {
     /**
      * Applies the link variant styles
-     * @values null, danger, warning, success, muted, inverted, mention
+     * @values null, danger, warning, success, muted, mention
      */
     kind: {
       type: String,
@@ -36,12 +33,31 @@ export default {
         return LINK_VARIANTS.includes(kind);
       },
     },
+
+    /**
+     * Determines whether the link should have inverted styling
+     * default is false.
+     * @values true, false
+     */
+    inverted: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data () {
     return {
       LINK_KIND_MODIFIERS,
     };
+  },
+
+  methods: {
+    getLinkClasses () {
+      return [
+        'd-link',
+        getLinkKindModifier(this.kind, this.inverted),
+      ];
+    },
   },
 };
 </script>

--- a/packages/dialtone-vue3/components/link/link_constants.js
+++ b/packages/dialtone-vue3/components/link/link_constants.js
@@ -2,9 +2,8 @@ export const DANGER = 'danger';
 export const WARNING = 'warning';
 export const SUCCESS = 'success';
 export const MUTED = 'muted';
-export const INVERTED = 'inverted';
 export const MENTION = 'mention';
-export const LINK_VARIANTS = ['', DANGER, WARNING, SUCCESS, MUTED, INVERTED, MENTION];
+export const LINK_VARIANTS = ['', DANGER, WARNING, SUCCESS, MUTED, MENTION];
 
 export const LINK_KIND_MODIFIERS = {
   default: '',
@@ -12,11 +11,27 @@ export const LINK_KIND_MODIFIERS = {
   danger: 'd-link--danger',
   success: 'd-link--success',
   muted: 'd-link--muted',
-  inverted: 'd-link--inverted',
   mention: 'd-link--mention',
+};
+
+const LINK_KIND_MODIFIERS_INVERTED = {
+  default: 'd-link--inverted',
+  warning: 'd-link--inverted-warning',
+  danger: 'd-link--inverted-danger',
+  success: 'd-link--inverted-success',
+  muted: 'd-link--inverted-muted',
+  mention: 'd-link--inverted-mention',
+};
+
+export const getLinkKindModifier = (kind, inverted) => {
+  if (inverted) {
+    return LINK_KIND_MODIFIERS_INVERTED[kind || 'default'];
+  }
+  return LINK_KIND_MODIFIERS[kind];
 };
 
 export default {
   LINK_VARIANTS,
   LINK_KIND_MODIFIERS,
+  getLinkKindModifier,
 };

--- a/packages/dialtone-vue3/components/link/link_default.story.vue
+++ b/packages/dialtone-vue3/components/link/link_default.story.vue
@@ -3,6 +3,7 @@
     <dt-link
       :href="$attrs.href"
       :kind="$attrs.kind"
+      :inverted="$attrs.inverted"
       :rel="$attrs.rel"
       @click="$attrs.onClick"
       @focusin="$attrs.onFocusIn"

--- a/packages/dialtone-vue3/components/link/link_variants.story.vue
+++ b/packages/dialtone-vue3/components/link/link_variants.story.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <dt-link
-      v-for="kind in filteredKindClasses"
+      v-for="kind in LINK_VARIANTS"
       :key="kind"
       href="#"
       :kind="kind"
@@ -11,11 +11,14 @@
     </dt-link>
     <div class="d-bgc-purple-600">
       <dt-link
-        kind="inverted"
+        v-for="kind in LINK_VARIANTS"
+        :key="kind"
+        inverted
         href="#"
-        class="d-tt-capitalize"
+        :kind="kind"
+        class="d-tt-capitalize d-mr8"
       >
-        Inverted link
+        Inverted {{ kind }} link
       </dt-link>
     </div>
   </div>
@@ -23,7 +26,7 @@
 
 <script>
 import DtLink from './link.vue';
-import { LINK_VARIANTS, INVERTED } from './link_constants';
+import { LINK_VARIANTS } from './link_constants';
 
 export default {
   name: 'DtLinkVariants',
@@ -32,12 +35,6 @@ export default {
     return {
       LINK_VARIANTS,
     };
-  },
-
-  computed: {
-    filteredKindClasses () {
-      return LINK_VARIANTS.filter(kind => kind !== INVERTED);
-    },
   },
 };
 </script>


### PR DESCRIPTION
# feat(link): DLT-1631 add inverted utility classes

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNDB4eGsyb3cyNHI0a21ra3lwZ3FiMGpibTk1MGQ5OXVvYXZia2gweiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l0HlVJmZTI3Tn94c0/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DLT-1631]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adds inverted styles for all kinds of links.
This is a breaking change since it adds the boolean property "inverted" and removes the "inverted" kind from the component to allow for all combinations between "inverted" and "kind". I checked firespotter and found no uses of `kind="inverted"` for the DtLink component.
Figma file: https://www.figma.com/design/2adf7JhZOncRyjYiy2joil/DT9-Component-Library?node-id=8919-21226&m=dev
<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.


## :crystal_ball: Next Steps
- [ ] Add change to Vue 3 after code review
<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<img width="966" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/f67e7abc-e31d-4b9f-8dfc-d49af9f9652d">

<img width="559" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/5f41a6f9-dddc-461e-b18d-6dea857b42a0">


<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->



[DLT-1631]: https://dialpad.atlassian.net/browse/DLT-1631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ