### PR TITLE
fix(tooltip): DP-99352 correct offsets, trim empty check

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/client.js
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/client.js
@@ -4,6 +4,7 @@ import NotFound from './layouts/NotFound.vue';
 
 // CSS
 import '@dialpad/dialtone-css/lib/dist/dialtone.css';
+import '@dialpad/dialtone/vue3/css';
 import './assets/less/dialtone-docs.less';
 import './assets/less/dialtone-syntax.less';
 import { onBeforeMount, provide, ref } from 'vue';

--- a/packages/dialtone-vue2/components/tooltip/tooltip.test.js
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.test.js
@@ -107,6 +107,15 @@ describe('DtTooltip tests', () => {
         expect(tooltip.textContent).toBe('Test message');
       });
 
+      describe('When tooltip content is a space character', () => {
+        it('should not render the content', async () => {
+          wrapper.destroy();
+          mockProps = { show: true, message: ' ' };
+          updateWrapper();
+          expect(tippyContent.getAttribute('data-state')).not.toBe('visible');
+        });
+      });
+
       describe('When inverted is true', () => {
         it('should have the inverted class set', async () => {
           await wrapper.setProps({ show: true, inverted: true });

--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -478,7 +478,7 @@ export default {
 
     onShow (tooltipInstance) {
       // don't show tooltip when no content
-      if (tooltipInstance.props.content.textContent.length === 0) {
+      if (tooltipInstance.props.content.textContent.trim().length === 0) {
         return false;
       }
     },

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button/callbar_button.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button/callbar_button.vue
@@ -1,7 +1,7 @@
 <template>
   <dt-tooltip
     :id="id"
-    :offset="[0, 8]"
+    :offset="[0, 24]"
   >
     <template #anchor>
       <span

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -53,7 +53,7 @@
           v-if="showImagePicker"
           placement="top-start"
           :message="showImagePicker.tooltipLabel"
-          :offset="[-4, -4]"
+          :offset="[-4, 12]"
         >
           <template #anchor>
             <dt-button
@@ -141,7 +141,7 @@
           placement="top-end"
           :enabled="characterLimitTooltipEnabled"
           :message="showCharacterLimit.message"
-          :offset="[10, -8]"
+          :offset="[10, 8]"
         >
           <template #anchor>
             <p
@@ -170,12 +170,12 @@
 
         <!-- Send button -->
         <dt-tooltip
-          v-if="showSend"
+          v-if="true"
           placement="top-end"
           :enabled="!showSend"
           :message="showSend.tooltipLabel"
-          :show="!isSendDisabled && sendButtonFocus"
-          :offset="[6, -8]"
+          :show="true"
+          :offset="[6, 8]"
         >
           <template #anchor>
             <!-- Right positioned UI - send button -->

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -170,11 +170,11 @@
 
         <!-- Send button -->
         <dt-tooltip
-          v-if="true"
+          v-if="showSend"
           placement="top-end"
           :enabled="!showSend"
           :message="showSend.tooltipLabel"
-          :show="true"
+          :show="!isSendDisabled && sendButtonFocus"
           :offset="[6, 8]"
         >
           <template #anchor>

--- a/packages/dialtone-vue3/components/tooltip/tooltip.test.js
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.test.js
@@ -93,6 +93,15 @@ describe('DtTooltip tests', () => {
         expect(tooltip.textContent).toBe('Test message');
       });
 
+      describe('When tooltip content is a space character', () => {
+        it('should not render the content', async () => {
+          wrapper.unmount();
+          mockProps = { show: true, message: ' ' };
+          updateWrapper();
+          expect(tippyContent.getAttribute('data-state')).not.toBe('visible');
+        });
+      });
+
       describe('When inverted is true', () => {
         it('should have the inverted class set', async () => {
           await wrapper.setProps({ show: true, inverted: true });

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -478,7 +478,7 @@ export default {
 
     onShow (tooltipInstance) {
       // don't show tooltip when no content
-      if (tooltipInstance.props.content.textContent.length === 0) {
+      if (tooltipInstance.props.content.textContent.trim().length === 0) {
         return false;
       }
     },

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button/callbar_button.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button/callbar_button.vue
@@ -1,7 +1,7 @@
 <template>
   <dt-tooltip
     :id="id"
-    :offset="[0, 8]"
+    :offset="[0, 24]"
   >
     <template #anchor>
       <span

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -53,7 +53,7 @@
           v-if="showImagePicker"
           placement="top-start"
           :message="showImagePicker.tooltipLabel"
-          :offset="[-4, -4]"
+          :offset="[-4, 12]"
         >
           <template #anchor>
             <dt-button
@@ -141,7 +141,7 @@
           placement="top-end"
           :enabled="characterLimitTooltipEnabled"
           :message="showCharacterLimit.message"
-          :offset="[10, -8]"
+          :offset="[10, 8]"
         >
           <template #anchor>
             <p
@@ -170,12 +170,12 @@
 
         <!-- Send button -->
         <dt-tooltip
-          v-if="showSend"
+          v-if="true"
           placement="top-end"
           :enabled="!showSend"
           :message="showSend.tooltipLabel"
-          :show="!isSendDisabled && sendButtonFocus"
-          :offset="[6, -8]"
+          :show="true"
+          :offset="[6, 8]"
         >
           <template #anchor>
             <!-- Right positioned UI - send button -->

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -170,11 +170,11 @@
 
         <!-- Send button -->
         <dt-tooltip
-          v-if="true"
+          v-if="showSend"
           placement="top-end"
           :enabled="!showSend"
           :message="showSend.tooltipLabel"
-          :show="true"
+          :show="!isSendDisabled && sendButtonFocus"
           :offset="[6, 8]"
         >
           <template #anchor>


### PR DESCRIPTION
# fix(tooltip): correct offsets, trim empty check

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExamtrd3d1ZXdsa2trN2RzZXZvdzYwY3J0eHZmNjB2dmVvNjZ1ZWcwdSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l0Iy1W6Y5I9pMFUyc/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-99352

## :book: Description

- Fixed offsets in Dialtone after the recent tooltip changes
- Added trim to the tooltip empty check

## :bulb: Context

Default offset changed after the recent tooltip change, so manual offsets had to be fixed. This was done in product but not in dialtone itself. Fixed the few that were in here.

Empty check was not trimmed so spaces and newlines were getting marked as "not empty" when they should have been causing blank tooltips to show.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

CP this into beta to fix reported issues.

## :camera: Screenshots / GIFs

before:
![Screenshot 2024-05-21 at 1 35 46 PM](https://github.com/dialpad/dialtone/assets/64808812/53f2b2d9-6ebb-409a-8967-ae0d54551d2c)

after:
![Screenshot 2024-05-21 at 1 36 02 PM](https://github.com/dialpad/dialtone/assets/64808812/db9e1078-19ea-456d-a216-f6f908f1a66d)
