### PR TITLE
fix: DLT-1668 message input bullet lists

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -357,6 +357,7 @@ export default {
       // make sure that this is defined before any other extensions
       // where Enter and Shift+Enter should have its own interaction. otherwise it will be ignored
       if (!this.allowLineBreaks) {
+        const self = this;
         extensions.push(
           HardBreak.extend({
             addKeyboardShortcuts () {
@@ -364,7 +365,7 @@ export default {
                 Enter: () => true,
                 'Shift-Enter': () => this.editor.commands.first(({ commands }) => [
                   () => commands.newlineInCode(),
-                  () => commands.splitListItem('listItem'),
+                  () => self.allowBulletList && commands.splitListItem('listItem'),
                   () => commands.createParagraphNear(),
                   () => commands.liftEmptyBlock(),
                   () => commands.splitBlock(),

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -335,9 +335,7 @@ export default {
       if (this.allowBulletList) {
         extensions.push(BulletList);
         extensions.push(ListItem);
-        extensions.push(OrderedList.configure({
-          itemTypeName: 'listItem',
-        }));
+        extensions.push(OrderedList);
       }
       if (this.allowItalic) {
         extensions.push(Italic);
@@ -366,6 +364,7 @@ export default {
                 Enter: () => true,
                 'Shift-Enter': () => this.editor.commands.first(({ commands }) => [
                   () => commands.newlineInCode(),
+                  () => commands.splitListItem('listItem'),
                   () => commands.createParagraphNear(),
                   () => commands.liftEmptyBlock(),
                   () => commands.splitBlock(),
@@ -621,34 +620,40 @@ export default {
 </script>
 
 <style lang="less">
-  .ProseMirror p.is-editor-empty:first-child::before {
-    content: attr(data-placeholder);
-    float: left;
-    color: var(--dt-color-foreground-placeholder);
-    pointer-events: none;
-    height: 0;
-  }
-
-  .ProseMirror ul > li {
-    list-style-type: disc;
-  }
-
-  .ProseMirror ol > li {
-    list-style-type: decimal;
-  }
-
-  .ProseMirror blockquote {
-    padding-left: var(--dt-space-400);
-    border-left: var(--dt-size-border-300) solid var(--dt-color-foreground-muted-inverted);
-    margin-left: 0;
-  }
-
-  .dt-rich-text-editor--code-block {
-    background: var(--dt-color-surface-secondary);
-    padding: var(--dt-space-400);
-  }
-
   .dt-rich-text-editor {
-    overflow: hidden;
+    &--code-block {
+      background: var(--dt-color-surface-secondary);
+      padding: var(--dt-space-400);
+    }
+
+    > .ProseMirror {
+      box-shadow: none;
+
+      p.is-editor-empty:first-child::before {
+        content: attr(data-placeholder);
+        float: left;
+        color: var(--dt-color-foreground-placeholder);
+        pointer-events: none;
+        height: 0;
+      }
+
+      ul, ol {
+        padding-left: var(--dt-space-525);
+      }
+
+      ul > li {
+        list-style-type: disc;
+      }
+
+      ol > li {
+        list-style-type: decimal;
+      }
+
+      blockquote {
+        padding-left: var(--dt-space-400);
+        border-left: var(--dt-size-border-300) solid var(--dt-color-foreground-muted-inverted);
+        margin-left: 0;
+      }
+    }
   }
 </style>

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -357,6 +357,7 @@ export default {
       // make sure that this is defined before any other extensions
       // where Enter and Shift+Enter should have its own interaction. otherwise it will be ignored
       if (!this.allowLineBreaks) {
+        const self = this;
         extensions.push(
           HardBreak.extend({
             addKeyboardShortcuts () {
@@ -364,7 +365,7 @@ export default {
                 Enter: () => true,
                 'Shift-Enter': () => this.editor.commands.first(({ commands }) => [
                   () => commands.newlineInCode(),
-                  () => commands.splitListItem('listItem'),
+                  () => self.allowBulletList && commands.splitListItem('listItem'),
                   () => commands.createParagraphNear(),
                   () => commands.liftEmptyBlock(),
                   () => commands.splitBlock(),

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -335,9 +335,7 @@ export default {
       if (this.allowBulletList) {
         extensions.push(BulletList);
         extensions.push(ListItem);
-        extensions.push(OrderedList.configure({
-          itemTypeName: 'listItem',
-        }));
+        extensions.push(OrderedList);
       }
       if (this.allowItalic) {
         extensions.push(Italic);
@@ -366,6 +364,7 @@ export default {
                 Enter: () => true,
                 'Shift-Enter': () => this.editor.commands.first(({ commands }) => [
                   () => commands.newlineInCode(),
+                  () => commands.splitListItem('listItem'),
                   () => commands.createParagraphNear(),
                   () => commands.liftEmptyBlock(),
                   () => commands.splitBlock(),
@@ -620,34 +619,40 @@ export default {
 </script>
 
 <style lang="less">
-  .ProseMirror p.is-editor-empty:first-child::before {
-    content: attr(data-placeholder);
-    float: left;
-    color: var(--dt-color-foreground-placeholder);
-    pointer-events: none;
-    height: 0;
-  }
-
-  .ProseMirror ul > li {
-    list-style-type: disc;
-  }
-
-  .ProseMirror ol > li {
-    list-style-type: decimal;
-  }
-
-  .ProseMirror blockquote {
-    padding-left: var(--dt-space-400);
-    border-left: var(--dt-size-border-300) solid var(--dt-color-foreground-muted-inverted);
-    margin-left: 0;
-  }
-
-  .dt-rich-text-editor--code-block {
-    background: var(--dt-color-surface-secondary);
-    padding: var(--dt-space-400);
-  }
-
   .dt-rich-text-editor {
-    overflow: hidden;
+    &--code-block {
+      background: var(--dt-color-surface-secondary);
+      padding: var(--dt-space-400);
+    }
+
+    > .ProseMirror {
+      box-shadow: none;
+
+      p.is-editor-empty:first-child::before {
+        content: attr(data-placeholder);
+        float: left;
+        color: var(--dt-color-foreground-placeholder);
+        pointer-events: none;
+        height: 0;
+      }
+
+      ul, ol {
+        padding-left: var(--dt-space-525);
+      }
+
+      ul > li {
+        list-style-type: disc;
+      }
+
+      ol > li {
+        list-style-type: decimal;
+      }
+
+      blockquote {
+        padding-left: var(--dt-space-400);
+        border-left: var(--dt-size-border-300) solid var(--dt-color-foreground-muted-inverted);
+        margin-left: 0;
+      }
+    }
   }
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15227,8 +15227,8 @@ packages:
   vue-component-type-helpers@1.8.24:
     resolution: {integrity: sha512-lqWs/7fdRXoSBAlbouHBX+LNuaY6gI9xWW34m/ZIz9zVPYHEyw0b2/zaCBwlKx0NtKTeF/6pOpvrxVkh7nhIYg==}
 
-  vue-component-type-helpers@2.0.16:
-    resolution: {integrity: sha512-qisL/iAfdO++7w+SsfYQJVPj6QKvxp4i1MMxvsNO41z/8zu3KuAw9LkhKUfP/kcOWGDxESp+pQObWppXusejCA==}
+  vue-component-type-helpers@2.0.19:
+    resolution: {integrity: sha512-cN3f1aTxxKo4lzNeQAkVopswuImUrb5Iurll9Gaw5cqpnbTAxtEMM1mgi6ou4X79OCyqYv1U1mzBHJkzmiK82w==}
 
   vue-demi@0.14.7:
     resolution: {integrity: sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==}
@@ -20079,7 +20079,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.3.8(typescript@5.3.3)
-      vue-component-type-helpers: 2.0.16
+      vue-component-type-helpers: 2.0.19
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -33691,7 +33691,7 @@ snapshots:
 
   vue-component-type-helpers@1.8.24: {}
 
-  vue-component-type-helpers@2.0.16: {}
+  vue-component-type-helpers@2.0.19: {}
 
   vue-demi@0.14.7(vue@3.4.15(typescript@5.3.3)):
     dependencies:


### PR DESCRIPTION
# Fix Message input bullet and ordered lists

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/j5cdi0E1fdGasOsgP4/giphy.gif?cid=790b7611z1zs0ak1kx311mimf1ukdaq46rcqlv9ksc2squ4q&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1668

## :book: Description

- Added left padding to list items to prevent overflow.
- Removed `overflow: hidden` from `DtRichTextEditor` as it was causing overflowing issues.
- Fixed `Shift+Enter` behavior to create a list item instead of just going down.

## :bulb: Context

Bullet and ordered lists were not working properly.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.

## :camera: Screenshots / GIFs

https://github.com/dialpad/dialtone/assets/87546543/fee5acfa-7cb3-41ef-b5de-10d5d953853f