### PR TITLE
fix(tooltip): DLT-1758 add legacy styles back

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/tooltip.less
+++ b/packages/dialtone-css/lib/build/less/components/tooltip.less
@@ -56,6 +56,12 @@
   text-align: center;
   background-color: var(--tooltip-color-background);
   border-radius: var(--tooltip-border-radius);
+
+  &::after {
+    position: absolute;
+    border: var(--dt-size-350) solid transparent;
+    content: '';
+  }
 }
 
 //  ============================================================================

--- a/packages/dialtone-css/lib/build/less/components/tooltip.less
+++ b/packages/dialtone-css/lib/build/less/components/tooltip.less
@@ -98,13 +98,164 @@
 //  ----------------------------------------------------------------------------
 .d-tooltip--hover {
   .d-tooltip {
-    &:extend(.d-tooltip--hide);
+      &:extend(.d-tooltip--hide);
   }
 
   &:hover,
   &:focus-visible {
-    .d-tooltip {
-      &:extend(.d-tooltip--show);
-    }
+      .d-tooltip {
+          &:extend(.d-tooltip--show);
+      }
   }
+}
+
+//  ============================================================================
+//  $   TOOLTIP DIRECTIONS
+//  ============================================================================
+//  $$  TOP
+//  ----------------------------------------------------------------------------
+.d-tooltip__arrow-tippy--bottom-start,
+.d-tooltip__arrow-tippy--bottom,
+.d-tooltip__arrow-tippy--bottom-end,
+.d-tooltip__arrow--top-left,
+.d-tooltip__arrow--top-center,
+.d-tooltip__arrow--top-right {
+top: calc(100% + var(--dt-space-450)); // 100% + 12
+transform: translateY(var(--dt-space-500)); // 16
+
+&::after {
+  top: calc(var(--dt-space-350-negative) - var(--dt-space-50-negative)); // -5.5
+  border-top-width: 0;
+  border-bottom-color: var(--tooltip-color-background);
+}
+}
+
+//  $$  BOTTOM
+//  ----------------------------------------------------------------------------
+.d-tooltip__arrow-tippy--top-start,
+.d-tooltip__arrow-tippy--top,
+.d-tooltip__arrow-tippy--top-end,
+.d-tooltip__arrow--bottom-left,
+.d-tooltip__arrow--bottom-center,
+.d-tooltip__arrow--bottom-right {
+bottom: calc(100% + var(--dt-space-450)); // 100% + 12
+transform: translateY(var(--dt-space-500-negative)); // -16
+
+&::after {
+  bottom: calc(var(--dt-space-350-negative) - var(--dt-space-50-negative)); // -5.5
+  border-top-color: var(--tooltip-color-background);
+  border-bottom-width: 0;
+}
+}
+
+//  $$  TOP / BOTTOM LEFT
+//  ----------------------------------------------------------------------------
+.d-tooltip__arrow-tippy--bottom-start,
+.d-tooltip__arrow-tippy--top-start,
+.d-tooltip__arrow--top-left,
+.d-tooltip__arrow--bottom-left {
+left: var(--dt-space-200-negative); // -2
+
+&::after {
+  left: var(--dt-space-500); // 16
+}
+}
+
+//  $$  TOP / BOTTOM CENTER
+//  ----------------------------------------------------------------------------
+.d-tooltip__arrow-tippy--bottom,
+.d-tooltip__arrow-tippy--top,
+.d-tooltip__arrow--top-center,
+.d-tooltip__arrow--bottom-center {
+&::after {
+  left: 50%;
+  margin-left: var(--dt-space-350-negative); // -6
+}
+}
+
+//  $$  TOP / BOTTOM RIGHT
+//  ----------------------------------------------------------------------------
+.d-tooltip__arrow-tippy--bottom-end,
+.d-tooltip__arrow-tippy--top-end,
+.d-tooltip__arrow--top-right,
+.d-tooltip__arrow--bottom-right {
+right: var(--dt-space-200-negative); // -2
+
+&::after {
+  right: var(--dt-space-500); // 16
+}
+}
+
+//  $$  RIGHT
+//  ----------------------------------------------------------------------------
+.d-tooltip__arrow-tippy--left-start,
+.d-tooltip__arrow-tippy--left,
+.d-tooltip__arrow-tippy--left-end,
+.d-tooltip__arrow--right-top,
+.d-tooltip__arrow--right-center,
+.d-tooltip__arrow--right-bottom {
+right: calc(100% + var(--dt-space-450)); // 100% + 12
+transform: translateX(var(--dt-space-500-negative)); // -16
+
+&::after {
+  right: calc(var(--dt-space-350-negative) - var(--dt-space-50-negative)); // -5.5
+  border-right-width: 0;
+  border-left-color: var(--tooltip-color-background);
+}
+}
+
+//  $$  LEFT
+//  ----------------------------------------------------------------------------
+.d-tooltip__arrow-tippy--right-start,
+.d-tooltip__arrow-tippy--right,
+.d-tooltip__arrow-tippy--right-end,
+.d-tooltip__arrow--left-top,
+.d-tooltip__arrow--left-center,
+.d-tooltip__arrow--left-bottom {
+left: calc(100% + var(--dt-space-450)); // 100% + 12
+transform: translateX(var(--dt-space-500)); // 16
+
+&::after {
+  left: calc(var(--dt-space-350-negative) - var(--dt-space-50-negative)); // -5.5
+  border-right-color: var(--tooltip-color-background);
+  border-left-width: 0;
+}
+}
+
+//  $$  RIGHT / LEFT TOP
+//  ----------------------------------------------------------------------------
+.d-tooltip__arrow-tippy--right-start,
+.d-tooltip__arrow-tippy--left-start,
+.d-tooltip__arrow--right-top,
+.d-tooltip__arrow--left-top {
+top: var(--dt-space-100-negative); // -1
+
+&::after {
+  top: var(--dt-space-400); // 8
+}
+}
+
+//  $$  RIGHT / LEFT CENTER
+//  ----------------------------------------------------------------------------
+.d-tooltip__arrow-tippy--right,
+.d-tooltip__arrow-tippy--left,
+.d-tooltip__arrow--right-center,
+.d-tooltip__arrow--left-center {
+&::after {
+  top: 50%;
+  margin-top: var(--dt-space-350-negative); // -6
+}
+}
+
+//  $$  RIGHT / LEFT BOTTOM
+//  ----------------------------------------------------------------------------
+.d-tooltip__arrow-tippy--right-end,
+.d-tooltip__arrow-tippy--left-end,
+.d-tooltip__arrow--right-bottom,
+.d-tooltip__arrow--left-bottom {
+bottom: var(--dt-space-100-negative); // -1
+
+&::after {
+  bottom: var(--dt-space-400); // 8
+}
 }


### PR DESCRIPTION
# fix(tooltip): add legacy styles back

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNGpjN204b2FwejdkdGtlOWI3dHZybmR0ZzhsOTFsbGVmMHo5M3U2ayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/AfUi1HtHga1LdQuqwS/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1758

## :book: Description

Adding legacy tooltip styles back in, even though they are not used in the vue component anymore, DPM still uses them. Shouldn't hurt anything to keep them.

Also fixes the issues on tooltip docs page.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
