### PR TITLE
feat(message-input): DLT-1767 add ability to disallow codeblock

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
@@ -130,5 +130,6 @@ export const WithCustomExtensions = {
     allowItalic: false,
     allowStrike: false,
     allowUnderline: false,
+    allowCodeblock: false,
   },
 };

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -261,6 +261,14 @@ export default {
       type: Boolean,
       default: true,
     },
+
+    /**
+     * Whether the input allows codeblock to be introduced in the text.
+     */
+    allowCodeblock: {
+      type: Boolean,
+      default: true,
+    },
   },
 
   emits: [
@@ -403,11 +411,13 @@ export default {
         defaultAlignment: 'left',
       }));
 
-      extensions.push(CodeBlock.configure({
-        HTMLAttributes: {
-          class: 'dt-rich-text-editor--code-block',
-        },
-      }));
+      if (this.allowCodeblock) {
+        extensions.push(CodeBlock.configure({
+          HTMLAttributes: {
+            class: 'dt-rich-text-editor--code-block',
+          },
+        }));
+      }
 
       return extensions;
     },

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor_default.story.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor_default.story.vue
@@ -14,6 +14,7 @@
     :allow-blockquote="$attrs.allowBlockquote"
     :allow-bold="$attrs.allowBold"
     :allow-bullet-list="$attrs.allowBulletList"
+    :allow-codeblock="$attrs.allowCodeblock"
     :allow-italic="$attrs.allowItalic"
     :allow-strike="$attrs.allowStrike"
     :allow-underline="$attrs.allowUnderline"

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -170,5 +170,6 @@ export const WithoutExtensions = {
     allowItalic: false,
     allowStrike: false,
     allowUnderline: false,
+    allowCodeblock: false,
   },
 };

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -33,6 +33,7 @@
         :allow-blockquote="allowBlockquote"
         :allow-bold="allowBold"
         :allow-bullet-list="allowBulletList"
+        :allow-codeblock="allowCodeblock"
         :allow-italic="allowItalic"
         :allow-strike="allowStrike"
         :allow-underline="allowUnderline"
@@ -520,6 +521,14 @@ export default {
      * Whether the input allows for underline to be introduced in the text.
      */
     allowUnderline: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
+     * Whether the input allows codeblock to be introduced in the text.
+     */
+    allowCodeblock: {
       type: Boolean,
       default: true,
     },

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -9,6 +9,7 @@
         :allow-blockquote="$attrs.allowBlockquote"
         :allow-bold="$attrs.allowBold"
         :allow-bullet-list="$attrs.allowBulletList"
+        :allow-codeblock="$attrs.allowCodeblock"
         :allow-italic="$attrs.allowItalic"
         :allow-strike="$attrs.allowStrike"
         :allow-underline="$attrs.allowUnderline"

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -137,5 +137,6 @@ export const WithCustomExtensions = {
     allowItalic: false,
     allowStrike: false,
     allowUnderline: false,
+    allowCodeblock: false,
   },
 };

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -261,6 +261,14 @@ export default {
       type: Boolean,
       default: true,
     },
+
+    /**
+     * Whether the input allows codeblock to be introduced in the text.
+     */
+    allowCodeblock: {
+      type: Boolean,
+      default: true,
+    },
   },
 
   emits: [
@@ -403,11 +411,13 @@ export default {
         defaultAlignment: 'left',
       }));
 
-      extensions.push(CodeBlock.configure({
-        HTMLAttributes: {
-          class: 'dt-rich-text-editor--code-block',
-        },
-      }));
+      if (this.allowCodeblock) {
+        extensions.push(CodeBlock.configure({
+          HTMLAttributes: {
+            class: 'dt-rich-text-editor--code-block',
+          },
+        }));
+      }
 
       return extensions;
     },

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
@@ -14,6 +14,7 @@
     :allow-blockquote="$attrs.allowBlockquote"
     :allow-bold="$attrs.allowBold"
     :allow-bullet-list="$attrs.allowBulletList"
+    :allow-codeblock="$attrs.allowCodeblock"
     :allow-italic="$attrs.allowItalic"
     :allow-strike="$attrs.allowStrike"
     :allow-underline="$attrs.allowUnderline"

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -178,5 +178,6 @@ export const WithoutExtensions = {
     allowItalic: false,
     allowStrike: false,
     allowUnderline: false,
+    allowCodeblock: false,
   },
 };

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -23,6 +23,7 @@
         :allow-blockquote="allowBlockquote"
         :allow-bold="allowBold"
         :allow-bullet-list="allowBulletList"
+        :allow-codeblock="allowCodeblock"
         :allow-italic="allowItalic"
         :allow-strike="allowStrike"
         :allow-underline="allowUnderline"
@@ -520,6 +521,14 @@ export default {
      * Whether the input allows for underline to be introduced in the text.
      */
     allowUnderline: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
+     * Whether the input allows codeblock to be introduced in the text.
+     */
+    allowCodeblock: {
       type: Boolean,
       default: true,
     },

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -8,6 +8,7 @@
       :allow-blockquote="$attrs.allowBlockquote"
       :allow-bold="$attrs.allowBold"
       :allow-bullet-list="$attrs.allowBulletList"
+      :allow-codeblock="$attrs.allowCodeblock"
       :allow-italic="$attrs.allowItalic"
       :allow-strike="$attrs.allowStrike"
       :allow-underline="$attrs.allowUnderline"


### PR DESCRIPTION
# feat(message-input): DLT-1767 Add ability to disallow codeblock

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXdueG9uZjA3dGJocmhzaWF4bGd0cHl0bjNjanZxZXkyMXZjb2lxZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/vVzH2XY3Y0Ar6/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-1767
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
We need to add allow-codeblock prop to the current message input and rich text editor so we can allow clients to decide if used it or not.

## :bulb: Context
We need to disallow this option on firespotter because tiptap doesn't support markdown and our server does not support HTML for now.