### PR TITLE
fix: DLT-1731 skin tone emojis

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/AllTokens.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/AllTokens.vue
@@ -14,7 +14,7 @@
       &OpenCurlyDoubleQuote;{{ searchCriteria }}&CloseCurlyDoubleQuote;
     </strong>
   </div>
-  <token-tree v-else :node="filteredTokens" :category="null" :level="2" />
+  <token-tree v-else :node="filteredTokens" :category="null" :level="2" :theme="theme" />
 </template>
 
 <script setup>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenExample.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenExample.vue
@@ -1,23 +1,29 @@
 <template>
   <div
     v-if="category === 'color'"
-    class="d-bar-circle d-w42 d-h42"
+    class="d-bar4 d-w128 d-h32 d-d-flex d-jc-center d-ai-center colorRectangle"
     :style="getColorStyle"
-  />
-  <p
-    v-if="category === 'typography'"
-    :style="getTypographyStyle"
   >
-    Aa
-  </p>
+    <div v-if="isForeground || isLink" :class="['d-headline--lg', { 'link-example': isLink }]">
+      Aa
+    </div>
+  </div>
+  <div
+    v-if="category === 'typography'"
+    class="d-w128 d-h32 d-d-flex d-jc-center d-ai-center"
+  >
+    <div :style="getTypographyStyle">
+      Aa
+    </div>
+  </div>
   <div
     v-if="category === 'shadow'"
-    class="d-bar2 d-w42 d-h42"
+    class="d-bar4 d-w128 d-h32"
     :style="getShadowStyle"
   />
   <div
     v-if="category === 'size'"
-    class="rectangle"
+    class="sizeRectangle"
     :style="getSizeStyle"
   />
   <div v-if="category === 'space'" class="space">
@@ -25,7 +31,7 @@
       A
     </div>
     <div
-      class="rectangle"
+      class="spaceRectangle"
       :style="getSizeStyle"
     />
     <div
@@ -57,7 +63,7 @@ const isFont = (name, key) => name.includes(`--dt-font-${key}`);
 const getRectSizeStyle = (value) => {
   if (value.endsWith('%')) return { width: value };
   const size = parseFloat(value.replace('rem', ''));
-  if (size < 12.8 && size >= 0) return { width: value };
+  if (size < 12.8 && size > -12.8) return { width: `${Math.abs(size)}rem` };
   return null;
 };
 
@@ -77,21 +83,45 @@ const props = defineProps({
     type: String,
     default: '',
   },
+
+  theme: {
+    type: String,
+    required: true,
+  },
+});
+
+const isForeground = computed(() => {
+  return props.name.includes('foreground');
+});
+
+const isLink = computed(() => {
+  return props.name.includes('link');
 });
 
 const getColorStyle = computed(() => {
-  const property = props.name.split('--dt-')[1]?.split('-')[0];
-  switch (property) {
-    case 'color':
-    case 'theme':
-      return { background: props.value };
-
-    case 'opacity':
-      return { background: `rgba(0, 0, 0, ${props.value})` };
-
-    default:
-      return null;
+  if (props.name.includes('opacity')) {
+    return { background: `rgba(0, 0, 0, ${props.value})` };
   }
+  if (props.name.includes('border')) {
+    return { border: `var(--dt-size-200) solid ${props.value}` };
+  }
+  if (isForeground.value || isLink.value) {
+    return { backgroundColor: foregroundBackgroundColor.value, color: props.value };
+  }
+  return { background: props.value };
+});
+
+const foregroundBackgroundColor = computed(() => {
+  if (props.theme === 'light') {
+    if (props.name.includes('inverted')) {
+      return 'var(--dt-color-neutral-black)';
+    }
+    return 'var(--dt-color-neutral-white)';
+  }
+  if (props.name.includes('inverted')) {
+    return 'var(--dt-color-neutral-white)';
+  }
+  return 'var(--dt-color-neutral-black)';
 });
 
 const getTypographyStyle = computed(() => {
@@ -115,11 +145,14 @@ const getShadowStyle = computed(() => {
 
 const getSizeStyle = computed(() => {
   if (props.name.includes('radius')) {
-    return { width: 'var(--dt-size-625)', borderRadius: props.value };
+    if (props.name.includes('circle')) {
+      return { width: 'var(--dt-size-600)', borderRadius: props.value };
+    }
+    return { width: 'var(--dt-size-100-percent)', borderRadius: props.value };
   }
   if (props.name.includes('border')) {
     return {
-      width: 'var(--dt-size-625)',
+      width: 'var(--dt-size-100-percent)',
       backgroundColor: 'var(--dt-color-neutral-transparent)',
       border: `${props.value} solid var(--dt-color-border-brand)`,
     };
@@ -130,7 +163,7 @@ const getSizeStyle = computed(() => {
 const displaySpaceReference = computed(() => {
   if (props.value.endsWith('%')) return true;
   const value = parseFloat(props.value.replace('rem', ''));
-  return (value < 12.8 && value >= 0);
+  return (value < 12.8 && value > -12.8);
 });
 
 const getSpaceAfterStyle = computed(() => {
@@ -141,24 +174,50 @@ const isPercentage = computed(() => props.value.endsWith('%'));
 </script>
 
 <style scoped lang="less">
-.rectangle {
-  height: var(--dt-size-625);
-  background-color: var(--dt-color-brand-purple);
+.colorRectangle {
+  border: var(--dt-size-border-100) dashed var(--dt-color-border-subtle)
+}
+
+.link-example {
+  border-bottom: var(--dt-size-200) solid;
+  line-height: initial;
+}
+
+.sizeRectangle {
+  height: var(--dt-size-600);
+  background-color: var(--dt-color-purple-400);
+  border-radius: var(--dt-size-radius-300);
   width: 0;
 }
+
+.spaceRectangle {
+  height: var(--dt-size-600);
+  background-color: var(--dt-color-purple-400);
+  width: 0;
+}
+
 .space {
   display: flex;
   position: relative;
 }
+
 .spaceReference {
-  height: var(--dt-size-625);
+  height: var(--dt-size-600);
   width: var(--dt-size-500);
-  background-color: var(--dt-color-black-200);
+  background-color: var(--dt-color-surface-moderate);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: var(--dt-font-size-100);
-  color: var(--dt-color-black-500);
+  font: var(--dt-typography-body-sm);
+  color: var(--dt-color-foreground-muted);
+  padding: var(--dt-space-400) var(--dt-space-200);
+  border-top-right-radius: var(--dt-size-radius-300);
+  border-bottom-right-radius: var(--dt-size-radius-300);
+  &.spaceBefore {
+    border-radius: var(--dt-size-radius-0);
+    border-top-left-radius: var(--dt-size-radius-300);
+    border-bottom-left-radius: var(--dt-size-radius-300);
+  }
 }
 
 .spaceReference.percentage {

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenTable.vue
@@ -40,7 +40,12 @@
         @focusout="onLeaveRow()"
       >
         <td>
-          <token-example :category="category" :name="exampleName || name" :value="exampleValue.toString()" />
+          <token-example
+            :category="category"
+            :name="exampleName || name"
+            :value="exampleValue.toString()"
+            :theme="theme"
+          />
         </td>
         <th scope="row">
           <dt-stack
@@ -64,7 +69,7 @@
             {{ description }}
           </div>
         </th>
-        <td class="d-code--sm d-fc-purple-400 d-ta-right d-wmx264">
+        <td class="d-code--sm d-fc-purple-400 d-ta-right d-wmx164">
           <div v-if="isCompositionToken(tokenValue)">
             <span v-for="value in tokenValue" :key="value">
               <span v-if="valueIsDivided(value)">
@@ -126,6 +131,11 @@ export default {
     tokenList: {
       type: Boolean,
       default: false,
+    },
+
+    theme: {
+      type: String,
+      required: true,
     },
   },
 
@@ -189,5 +199,9 @@ export default {
 .d-table th {
   color: var(--color-foreground-tertiary);
   font-weight: var(--dt-font-weight-semi-bold);
+}
+
+.d-table tr th:first-child {
+  width: 16rem;
 }
 </style>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenTree.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenTree.vue
@@ -4,6 +4,7 @@
       v-if="isChild(subNodeKey) && hasContent(subNodeKey)"
       :category="category"
       :tokens="node[subNodeKey]"
+      :theme="props.theme"
     />
     <div v-else-if="!isChild(subNodeKey)">
       <component
@@ -22,6 +23,7 @@
         :node="node[subNodeKey]"
         :category="category === null ? subNodeKey : category"
         :level="level + 1"
+        :theme="props.theme"
       />
     </div>
   </div>
@@ -43,6 +45,11 @@ const props = defineProps({
 
   level: {
     type: Number,
+    required: true,
+  },
+
+  theme: {
+    type: String,
     required: true,
   },
 });

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -290,17 +290,32 @@ All button styles and variations appear the same when disabled.
 <code-well-header>
   <div class="d-d-flex d-flow8">
     <div>
-      <button type="button" disabled="disabled" class="base-button__button d-btn d-btn--primary"><span class="d-btn__label base-button__label">Place call</span></button>
+      <button type="button" disabled="disabled" class="base-button__button d-btn d-btn--primary"><span class="d-btn__label base-button__label">Place call (disabled attribute)</span></button>
+    </div>
+    <div>
+      <span class="d-c-not-allowed">
+        <button type="button" class="base-button__button d-btn d-btn--primary d-btn--disabled"><span class="d-btn__label base-button__label">Place call (disabled class)</span></button>
+      </span>
     </div>
   </div>
 </code-well-header>
 
 <code-example-tabs
 htmlCode='
+<!-- disabled attribute -->
 <button class="d-btn" type="button" disabled><span class="d-btn__label">...</span></button>
+<!-- disabled class -->
+<span class="d-c-not-allowed">
+  <button type="button" class="base-button__button d-btn d-btn--primary d-btn--disabled"><span class="d-btn__label base-button__label">...</span></button>
+</span>
 '
 vueCode='
-<dt-button disabled> Place call </dt-button>
+<!-- disabled attribute -->
+<dt-button disabled>Place call</dt-button>
+<!-- disabled class -->
+<span class="d-c-not-allowed">
+  <dt-button class="d-btn--disabled">Place call</dt-button>
+</span>
 '
 showHtmlWarning />
 
@@ -495,7 +510,7 @@ htmlCode='
 </button>
 '
 vueCode='
-<!-- icon-position can be "right/top/bottom" , 
+<!-- icon-position can be "right/top/bottom" ,
      no icon-position will be left -->
 <dt-button importance="outlined" icon-position="right">
   <template #icon>

--- a/packages/dialtone-vue2/common/emoji/index.js
+++ b/packages/dialtone-vue2/common/emoji/index.js
@@ -1,6 +1,7 @@
-import emojiRegex from 'emoji-regex';
+import { emojiPattern } from 'regex-combined-emojis';
 import emojiJsonLocal from 'emoji-toolkit/emoji_strategy.json';
 
+export const emojiRegex = new RegExp(emojiPattern, 'g');
 export const emojiVersion = '8.0';
 export const defaultEmojiAssetUrl = 'https://cdn.jsdelivr.net/joypixels/assets/' + emojiVersion + '/png/unicode/32/';
 export let customEmojiAssetUrl = null;
@@ -174,7 +175,6 @@ export function codeToEmojiData (code) {
     return shortcodeToEmojiData(code);
   } else {
     const unicodeString = unicodeToString(code);
-
     const result = emojiJson[unicodeString];
     if (result) result.key = unicodeString;
     return result;
@@ -201,7 +201,7 @@ export function filterValidShortCodes (shortcodes) {
 // removes duplicates
 // @returns {string[]}
 export function findEmojis (textContent) {
-  const matches = [...textContent.matchAll(emojiRegex())];
+  const matches = [...textContent.matchAll(emojiRegex)];
   const emojis = matches.length ? matches.map(match => match[0]) : [];
   return new Set(emojis);
 }

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/channels/channel.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/channels/channel.js
@@ -1,44 +1,13 @@
 import Mention from '@tiptap/extension-mention';
-import { mergeAttributes, nodeInputRule, nodePasteRule } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-2';
 import { PluginKey } from '@tiptap/pm/state';
 
 // Channel Mention component
 import ChannelComponent from './ChannelComponent.vue';
 
-export const channelRegex = /#([\w-]+)[^\w-]?/g;
-
-const channelPasteMatch = (text, suggestions) => {
-  const matches = [...text.matchAll(channelRegex)];
-
-  return matches
-    .filter(match => suggestions.some(({ id }) => id === match[1].trim()))
-    .map(match => {
-      let channel = match[1];
-      if (!channel.endsWith(' ')) channel += ' ';
-      return {
-        index: match.index,
-        text: channel,
-        match,
-      };
-    });
-};
-
-const channelInputMatch = (text, suggestions) => {
-  const match = text.match(/#([\w-]+)[^\w-]$/);
-  if (!match || !suggestions.some(({ id }) => id === match[1])) return;
-
-  return {
-    index: match.index,
-    text: match[0],
-    match,
-  };
-};
-
 export const ChannelPlugin = Mention.extend({
   name: 'channel',
-  group: 'inline',
-  inline: true,
 
   addNodeView () {
     return VueNodeViewRenderer(ChannelComponent);
@@ -71,34 +40,9 @@ export const ChannelPlugin = Mention.extend({
   },
 
   renderHTML ({ HTMLAttributes }) {
-    return ['channel-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)];
+    return ['channel-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
   },
 
-  addInputRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodeInputRule({
-        find: (text) => channelInputMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].replace('#', '').trim());
-        },
-      }),
-    ];
-  },
-
-  addPasteRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodePasteRule({
-        find: (text) => channelPasteMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].trim());
-        },
-      }),
-    ];
-  },
 }).configure({
   suggestion: {
     char: '#',

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
@@ -1,19 +1,17 @@
 import { mergeAttributes, Node, nodeInputRule, nodePasteRule } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-2';
 import EmojiComponent from './EmojiComponent.vue';
-import { codeToEmojiData, emojiShortCodeRegex } from '@/common/emoji';
+import { codeToEmojiData, emojiShortCodeRegex, emojiRegex } from '@/common/emoji';
 import { PluginKey } from '@tiptap/pm/state';
 
 import Suggestion from '@tiptap/suggestion';
 import suggestionOptions from './suggestion';
+import { emojiPattern } from 'regex-combined-emojis';
 
 export const EmojiPluginKey = new PluginKey('emoji');
 
 const inputShortCodeRegex = /(^| |(?<=:))(:\w+:)$/;
-/* eslint-disable max-len */
-const inputUnicodeRegex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])$/;
-const pasteUnicodeRegex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
-/* eslint-enable max-len */
+const inputUnicodeRegex = new RegExp(emojiPattern + '$');
 
 const inputRuleMatch = (match) => {
   if (match && codeToEmojiData(match[0])) {
@@ -109,11 +107,9 @@ export const Emoji = Node.create({
         },
         type: this.type,
         getAttributes (attrs) {
-          const unicode = codeToEmojiData(attrs[0]).unicode_output;
-          const emoji = String.fromCodePoint(parseInt(unicode, 16));
+          const emoji = codeToEmojiData(attrs[0]).shortname;
           return {
             code: emoji,
-            label: 'emoji',
           };
         },
       }),
@@ -132,7 +128,7 @@ export const Emoji = Node.create({
         },
       }),
       nodePasteRule({
-        find: pasteUnicodeRegex,
+        find: emojiRegex,
         type: this.type,
         getAttributes (attrs) {
           return {

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
@@ -1,19 +1,17 @@
 import { mergeAttributes, Node, nodeInputRule, nodePasteRule } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-2';
 import EmojiComponent from './EmojiComponent.vue';
-import { codeToEmojiData, emojiShortCodeRegex } from '@/common/emoji';
+import { codeToEmojiData, emojiShortCodeRegex, emojiRegex } from '@/common/emoji';
 import { PluginKey } from '@tiptap/pm/state';
 
 import Suggestion from '@tiptap/suggestion';
 import suggestionOptions from './suggestion';
+import { emojiPattern } from 'regex-combined-emojis';
 
 export const EmojiPluginKey = new PluginKey('emoji');
 
 const inputShortCodeRegex = /(^| |(?<=:))(:\w+:)$/;
-/* eslint-disable max-len */
-const inputUnicodeRegex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])$/;
-const pasteUnicodeRegex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
-/* eslint-enable max-len */
+const inputUnicodeRegex = new RegExp(emojiPattern + '$');
 
 const inputRuleMatch = (match) => {
   if (match && codeToEmojiData(match[0])) {
@@ -113,11 +111,9 @@ export const Emoji = Node.create({
         },
         type: this.type,
         getAttributes (attrs) {
-          const unicode = codeToEmojiData(attrs[0]).unicode_output;
-          const emoji = String.fromCodePoint(parseInt(unicode, 16));
+          const emoji = codeToEmojiData(attrs[0]).shortname;
           return {
             code: emoji,
-            label: 'emoji',
           };
         },
       }),
@@ -136,7 +132,7 @@ export const Emoji = Node.create({
         },
       }),
       nodePasteRule({
-        find: pasteUnicodeRegex,
+        find: emojiRegex,
         type: this.type,
         getAttributes (attrs) {
           return {

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
@@ -65,10 +65,6 @@ export const Emoji = Node.create({
       code: {
         default: null,
       },
-
-      id: {
-        default: null,
-      },
     };
   },
 

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/suggestion.js
@@ -18,7 +18,7 @@ export default {
       }
       return false;
     });
-    return filteredEmoji.map(item => { return { id: item.unicode_character, code: item.shortname }; });
+    return filteredEmoji.map(item => { return { code: item.shortname }; });
   },
 
   command: ({ editor, range, props }) => {
@@ -77,7 +77,6 @@ export default {
           interactive: true,
           trigger: 'manual',
           placement: 'top-start',
-          contentElement: null,
           zIndex: 650,
         });
       },

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/mention.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/mention.js
@@ -1,44 +1,12 @@
 import Mention from '@tiptap/extension-mention';
-import { mergeAttributes, nodeInputRule, nodePasteRule } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-2';
 import { PluginKey } from '@tiptap/pm/state';
 
 // Mention component
 import MentionComponent from './MentionComponent.vue';
 
-export const mentionRegex = /@([\w.-]+)[^\w.-]?/g;
-
-const mentionPasteMatch = (text, suggestions) => {
-  const matches = [...text.matchAll(mentionRegex)];
-
-  return matches
-    .filter(match => suggestions.some(({ id }) => id === match[1].trim()))
-    .map(match => {
-      let mention = match[1];
-      if (!mention.endsWith(' ')) mention += ' ';
-      return {
-        index: match.index,
-        text: mention,
-        match,
-      };
-    });
-};
-
-const mentionInputMatch = (text, suggestions) => {
-  const match = text.match(/@([\w.-]+)[^\w.-]$/);
-  if (!match || !suggestions.some(({ id }) => id === match[1])) return;
-
-  return {
-    index: match.index,
-    text: match[0],
-    match,
-  };
-};
-
 export const MentionPlugin = Mention.extend({
-  name: 'mention',
-  group: 'inline',
-  inline: true,
 
   addNodeView () {
     return VueNodeViewRenderer(MentionComponent);
@@ -71,34 +39,9 @@ export const MentionPlugin = Mention.extend({
   },
 
   renderHTML ({ HTMLAttributes }) {
-    return ['mention-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)];
+    return ['mention-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
   },
 
-  addInputRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodeInputRule({
-        find: (text) => mentionInputMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].replace('@', '').trim());
-        },
-      }),
-    ];
-  },
-
-  addPasteRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodePasteRule({
-        find: (text) => mentionPasteMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].trim());
-        },
-      }),
-    ];
-  },
 }).configure({
   suggestion: {
     char: '@',

--- a/packages/dialtone-vue2/components/rich_text_editor/mention_suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/mention_suggestion.js
@@ -1,26 +1,53 @@
 /* eslint-disable max-len */
+const CONTACT_LIST = [
+  {
+    id: 'test.person',
+    name: 'Test Person',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'test.person2',
+    name: 'Test Person 2',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'test.person3',
+    name: 'Test Person 3',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'brad.paugh',
+    name: 'Brad Paugh',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'bradley.hawkins',
+    name: 'Bradley Hawkins',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'julio.ortega',
+    name: 'Tico Ortega',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'ignacio.ropolo',
+    name: 'Ignacio Ropolo',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'nina.repetto',
+    name: 'Nina Repetto',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+];
+
 export default {
-  items ({ query }) {
-    const CONTACT_LIST = [
-      {
-        id: 'test.person',
-        name: 'Test Person',
-        avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
-      },
-      {
-        id: 'test.person2',
-        name: 'Test Person 2',
-        avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
-      },
-      {
-        id: 'test.person3',
-        name: 'Test Person 3',
-        avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
-      },
-    ];
+  async items ({ query }) {
+    // simulate an API call by waiting 1000 seconds.
+    await new Promise(resolve => setTimeout(resolve, 1000));
 
     if (query.length === 0) return CONTACT_LIST;
-
     return CONTACT_LIST.filter((contact) => { return contact.name.toLowerCase().startsWith(query.toLowerCase()); });
   },
 };

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
@@ -13,10 +13,9 @@ import slashCommandSuggestion from './slash_command_suggestion';
 
 // Default Prop Values
 export const argsData = {
-  value: `I am not a standalone component, please use Message Input instead :v_tone3::robot:!`,
+  value: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:"></emoji-component><emoji-component code=":robot:"></emoji-component>!</p>',
   editable: true,
   inputAriaLabel: 'This is a descriptive label',
-  outputFormat: 'text',
   autoFocus: false,
   placeholder: 'Type here...',
   link: true,
@@ -106,15 +105,14 @@ export const WithLinks = {
   render: (argsData) => createRenderConfig(DtRichTextEditor, DtRichTextEditorDefaultTemplate, argsData),
   args: {
     link: true,
-    value: 'The editor can autolink URLs: dialpad.com, https://www.dialpad.com/about-us/, ' +
-    'IP addresses: 192.158.1.38, email addresses: noreply@dialpad.com and phone numbers: (778) 765-8813, +17787658813!',
+    value: '<p>The editor can autolink URLs: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="http://dialpad.com">dialpad.com</a>, <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="https://www.dialpad.com/about-us/">https://www.dialpad.com/about-us/</a>, email addresses: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="mailto:noreply@dialpad.com">noreply@dialpad.com</a></p>',
   },
 };
 
 export const WithMentionSuggestions = {
   render: (argsData) => createRenderConfig(DtRichTextEditor, DtRichTextEditorDefaultTemplate, argsData),
   args: {
-    value: 'The editor can also suggest mentions: @test.person, @test.person2! and channel suggestions: #dialpad.',
+    value: '<p>The editor can also suggest mentions: <mention-component name="Test Person" avatarsrc="" id="test.person"></mention-component>, <mention-component name="Test Person 2" avatarsrc="" id="test.person2"></mention-component>! and channel suggestions: <channel-component name="dialpad" id="dialpad" locked="false"></channel-component>. The suggestions dropdown will wait 1000ms to simulate an API call.</p>',
     mentionSuggestion,
     channelSuggestion,
     slashCommandSuggestion,

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -40,8 +40,7 @@ import {
 import mentionSuggestion from './extensions/mentions/suggestion';
 import channelSuggestion from './extensions/channels/suggestion';
 import slashCommandSuggestion from './extensions/slash_command/suggestion';
-import emojiRegex from 'emoji-regex';
-import { codeToEmojiData, emojiShortCodeRegex } from '@/common/emoji';
+import { codeToEmojiData, emojiShortCodeRegex, emojiRegex } from '@/common/emoji';
 
 export default {
   name: 'DtRichTextEditor',
@@ -513,7 +512,7 @@ export default {
 
     parseEmojis () {
       const matches = new Set(
-        [...this.value.matchAll(emojiRegex()), ...this.value.matchAll(emojiShortCodeRegex)]
+        [...this.value.matchAll(emojiRegex), ...this.value.matchAll(emojiShortCodeRegex)]
           .map(match => match[0].trim()),
       );
 

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -28,8 +28,8 @@ import Text from '@tiptap/extension-text';
 import TextAlign from '@tiptap/extension-text-align';
 import Emoji from './extensions/emoji';
 import CustomLink from './extensions/custom_link';
-import { MentionPlugin, mentionRegex } from './extensions/mentions/mention';
-import { ChannelPlugin, channelRegex } from './extensions/channels/channel';
+import { MentionPlugin } from './extensions/mentions/mention';
+import { ChannelPlugin } from './extensions/channels/channel';
 import { SlashCommandPlugin } from './extensions/slash_command/slash_command';
 import {
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
@@ -40,8 +40,6 @@ import {
 import mentionSuggestion from './extensions/mentions/suggestion';
 import channelSuggestion from './extensions/channels/suggestion';
 import slashCommandSuggestion from './extensions/slash_command/suggestion';
-import emojiRegex from 'emoji-regex';
-import { codeToEmojiData, emojiShortCodeRegex } from '@/common/emoji';
 
 export default {
   name: 'DtRichTextEditor',
@@ -124,7 +122,7 @@ export default {
      */
     outputFormat: {
       type: String,
-      default: 'text',
+      default: 'html',
       validator (outputFormat) {
         return RICH_TEXT_EDITOR_OUTPUT_FORMATS.includes(outputFormat);
       },
@@ -472,9 +470,8 @@ export default {
         // through the parent, so don't do anything here.
         return;
       }
-
-      this.internalValue = newValue;
-      this.insertContent();
+      // Otherwise replace the content (resets the cursor position).
+      this.editor.commands.setContent(newValue, false);
     },
   },
 
@@ -495,6 +492,7 @@ export default {
       // For all available options, see https://tiptap.dev/api/editor#settings
       this.editor = new Editor({
         autofocus: this.autoFocus,
+        content: this.value,
         editable: this.editable,
         extensions: this.extensions,
         editorProps: {
@@ -504,73 +502,7 @@ export default {
           },
         },
       });
-      this.insertContent();
       this.addEditorListeners();
-    },
-
-    /**
-     * This function is necessary as tiptap doesn't render the content passed
-     * directly through `editor.commands.setContent` the content passed down to it
-     * should be already parsed. So We're parsing the elements into it's corresponding
-     * HTML version before setting it.
-     */
-    insertContent () {
-      this.parseMentions();
-      this.parseChannels();
-      this.parseEmojis();
-      this.editor.commands.setContent(this.internalValue, true);
-    },
-
-    parseEmojis () {
-      const matches = new Set(
-        [...this.value.matchAll(emojiRegex()), ...this.value.matchAll(emojiShortCodeRegex)]
-          .map(match => match[0].trim()),
-      );
-
-      if (!matches) return;
-
-      matches
-        .forEach(match => {
-          const emoji = codeToEmojiData(match);
-          if (!emoji) return;
-          this.internalValue = this.internalValue.replace(new RegExp(`${match}`, 'g'), `<emoji-component code="${emoji.shortname}"></emoji-component>`);
-        });
-    },
-
-    parseChannels () {
-      if (!this.channelSuggestion) return;
-
-      const suggestions = this.channelSuggestion.items({ query: '' });
-      const matches = [...this.value.matchAll(channelRegex)]
-        .filter(match => suggestions.some(({ id }) => id === match[1]));
-
-      if (!matches) return;
-
-      matches.forEach(match => {
-        const channel = suggestions.find(({ id }) => id === match[1]);
-        this.internalValue = this.internalValue.replace(
-          `#${match[1]}`,
-          /** The space at the beginning is important as tiptap removes that while rendering.
-           *  So if multiple mentions, channels or emojis are next to each other it will fail
-           */
-          ` <channel-component name="${channel.name}" id="${channel.id}"></channel-component>`,
-        );
-      });
-    },
-
-    parseMentions () {
-      if (!this.mentionSuggestion) return;
-
-      const suggestions = this.mentionSuggestion.items({ query: '' });
-      const matches = [...this.value.matchAll(mentionRegex)]
-        .filter(match => suggestions.some(({ id }) => id === match[1]));
-
-      if (!matches) return;
-
-      matches.forEach(match => {
-        const mention = suggestions.find(({ id }) => id === match[1]);
-        this.internalValue = this.internalValue.replace(`@${match[1]}`, ` <mention-component name="${mention.name}" id="${mention.id}"></mention-component>`);
-      });
     },
 
     destroyEditor () {

--- a/packages/dialtone-vue2/package.json
+++ b/packages/dialtone-vue2/package.json
@@ -53,8 +53,8 @@
     "@tiptap/suggestion": "2.3.0",
     "@tiptap/vue-2": "2.3.0",
     "date-fns": "2.30.0",
-    "emoji-regex": "10.3.0",
     "emoji-toolkit": "8.0.0",
+    "regex-combined-emojis": "1.6.0",
     "tippy.js": "6.3.7"
   },
   "devDependencies": {

--- a/packages/dialtone-vue3/common/emoji/index.js
+++ b/packages/dialtone-vue3/common/emoji/index.js
@@ -1,6 +1,7 @@
-import emojiRegex from 'emoji-regex';
+import { emojiPattern } from 'regex-combined-emojis';
 import { emojisIndexed } from '@dialpad/dialtone-emojis';
 
+export const emojiRegex = new RegExp(emojiPattern, 'g');
 export const emojiVersion = '8.0';
 export const defaultEmojiAssetUrl = 'https://cdn.jsdelivr.net/joypixels/assets/' + emojiVersion + '/png/unicode/32/';
 export let customEmojiAssetUrl = null;
@@ -174,7 +175,6 @@ export function codeToEmojiData (code) {
     return shortcodeToEmojiData(code);
   } else {
     const unicodeString = unicodeToString(code);
-
     const result = emojiJson[unicodeString];
     if (result) result.key = unicodeString;
     return result;
@@ -201,7 +201,7 @@ export function filterValidShortCodes (shortcodes) {
 // removes duplicates
 // @returns {string[]}
 export function findEmojis (textContent) {
-  const matches = [...textContent.matchAll(emojiRegex())];
+  const matches = [...textContent.matchAll(emojiRegex)];
   const emojis = matches.length ? matches.map(match => match[0]) : [];
   return new Set(emojis);
 }

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/channels/channel.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/channels/channel.js
@@ -1,44 +1,13 @@
 import Mention from '@tiptap/extension-mention';
-import { mergeAttributes, nodeInputRule, nodePasteRule } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-3';
 import { PluginKey } from '@tiptap/pm/state';
 
 // Channel Mention component
 import ChannelComponent from './ChannelComponent.vue';
 
-export const channelRegex = /#([\w-]+)[^\w-]?/g;
-
-const channelPasteMatch = (text, suggestions) => {
-  const matches = [...text.matchAll(channelRegex)];
-
-  return matches
-    .filter(match => suggestions.some(({ id }) => id === match[1].trim()))
-    .map(match => {
-      let channel = match[1];
-      if (!channel.endsWith(' ')) channel += ' ';
-      return {
-        index: match.index,
-        text: channel,
-        match,
-      };
-    });
-};
-
-const channelInputMatch = (text, suggestions) => {
-  const match = text.match(/#([\w-]+)[^\w-]$/);
-  if (!match || !suggestions.some(({ id }) => id === match[1])) return;
-
-  return {
-    index: match.index,
-    text: match[0],
-    match,
-  };
-};
-
 export const ChannelPlugin = Mention.extend({
   name: 'channel',
-  group: 'inline',
-  inline: true,
 
   addNodeView () {
     return VueNodeViewRenderer(ChannelComponent);
@@ -71,34 +40,9 @@ export const ChannelPlugin = Mention.extend({
   },
 
   renderHTML ({ HTMLAttributes }) {
-    return ['channel-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)];
+    return ['channel-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
   },
 
-  addInputRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodeInputRule({
-        find: (text) => channelInputMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].replace('#', '').trim());
-        },
-      }),
-    ];
-  },
-
-  addPasteRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodePasteRule({
-        find: (text) => channelPasteMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].trim());
-        },
-      }),
-    ];
-  },
 }).configure({
   suggestion: {
     char: '#',

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/emoji.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/emoji.js
@@ -1,19 +1,17 @@
 import { mergeAttributes, Node, nodeInputRule, nodePasteRule } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-3';
 import EmojiComponent from './EmojiComponent.vue';
-import { codeToEmojiData, emojiShortCodeRegex } from '@/common/emoji';
+import { codeToEmojiData, emojiShortCodeRegex, emojiRegex } from '@/common/emoji';
 import { PluginKey } from '@tiptap/pm/state';
 
 import Suggestion from '@tiptap/suggestion';
 import suggestionOptions from './suggestion';
+import { emojiPattern } from 'regex-combined-emojis';
 
 export const EmojiPluginKey = new PluginKey('emoji');
 
 const inputShortCodeRegex = /(^| |(?<=:))(:\w+:)$/;
-/* eslint-disable max-len */
-const inputUnicodeRegex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])$/;
-const pasteUnicodeRegex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
-/* eslint-enable max-len */
+const inputUnicodeRegex = new RegExp(emojiPattern + '$');
 
 const inputRuleMatch = (match) => {
   if (match && codeToEmojiData(match[0])) {
@@ -113,11 +111,9 @@ export const Emoji = Node.create({
         },
         type: this.type,
         getAttributes (attrs) {
-          const unicode = codeToEmojiData(attrs[0]).unicode_output;
-          const emoji = String.fromCodePoint(parseInt(unicode, 16));
+          const emoji = codeToEmojiData(attrs[0]).shortname;
           return {
             code: emoji,
-            label: 'emoji',
           };
         },
       }),
@@ -136,7 +132,7 @@ export const Emoji = Node.create({
         },
       }),
       nodePasteRule({
-        find: pasteUnicodeRegex,
+        find: emojiRegex,
         type: this.type,
         getAttributes (attrs) {
           return {

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/emoji.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/emoji.js
@@ -1,19 +1,17 @@
 import { mergeAttributes, Node, nodeInputRule, nodePasteRule } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-3';
 import EmojiComponent from './EmojiComponent.vue';
-import { codeToEmojiData, emojiShortCodeRegex } from '@/common/emoji';
+import { codeToEmojiData, emojiShortCodeRegex, emojiRegex } from '@/common/emoji';
 import { PluginKey } from '@tiptap/pm/state';
 
 import Suggestion from '@tiptap/suggestion';
 import suggestionOptions from './suggestion';
+import { emojiPattern } from 'regex-combined-emojis';
 
 export const EmojiPluginKey = new PluginKey('emoji');
 
 const inputShortCodeRegex = /(^| |(?<=:))(:\w+:)$/;
-/* eslint-disable max-len */
-const inputUnicodeRegex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])$/;
-const pasteUnicodeRegex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
-/* eslint-enable max-len */
+const inputUnicodeRegex = new RegExp(emojiPattern + '$');
 
 const inputRuleMatch = (match) => {
   if (match && codeToEmojiData(match[0])) {
@@ -109,11 +107,9 @@ export const Emoji = Node.create({
         },
         type: this.type,
         getAttributes (attrs) {
-          const unicode = codeToEmojiData(attrs[0]).unicode_output;
-          const emoji = String.fromCodePoint(parseInt(unicode, 16));
+          const emoji = codeToEmojiData(attrs[0]).shortname;
           return {
             code: emoji,
-            label: 'emoji',
           };
         },
       }),
@@ -132,7 +128,7 @@ export const Emoji = Node.create({
         },
       }),
       nodePasteRule({
-        find: pasteUnicodeRegex,
+        find: emojiRegex,
         type: this.type,
         getAttributes (attrs) {
           return {

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/emoji.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/emoji.js
@@ -65,10 +65,6 @@ export const Emoji = Node.create({
       code: {
         default: null,
       },
-
-      id: {
-        default: null,
-      },
     };
   },
 

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/suggestion.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/suggestion.js
@@ -19,7 +19,7 @@ export default {
       }
       return false;
     });
-    return filteredEmoji.map(item => { return { id: item.unicode_character, code: item.shortname }; });
+    return filteredEmoji.map(item => { return { code: item.shortname }; });
   },
 
   command: ({ editor, range, props }) => {
@@ -77,7 +77,6 @@ export default {
           interactive: true,
           trigger: 'manual',
           placement: 'top-start',
-          contentElement: null,
           zIndex: 650,
         });
       },

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/mention.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/mention.js
@@ -1,39 +1,10 @@
 import Mention from '@tiptap/extension-mention';
-import { mergeAttributes, nodeInputRule, nodePasteRule } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-3';
 import { PluginKey } from '@tiptap/pm/state';
 
 // Mention component
 import MentionComponent from './MentionComponent.vue';
-
-export const mentionRegex = /@([\w.-]+)[^\w.-]?/g;
-
-const mentionPasteMatch = (text, suggestions) => {
-  const matches = [...text.matchAll(mentionRegex)];
-
-  return matches
-    .filter(match => suggestions.some(({ id }) => id === match[1].trim()))
-    .map(match => {
-      let mention = match[1];
-      if (!mention.endsWith(' ')) mention += ' ';
-      return {
-        index: match.index,
-        text: mention,
-        match,
-      };
-    });
-};
-
-const mentionInputMatch = (text, suggestions) => {
-  const match = text.match(/@([\w.-]+)[^\w.-]$/);
-  if (!match || !suggestions.some(({ id }) => id === match[1])) return;
-
-  return {
-    index: match.index,
-    text: match[0],
-    match,
-  };
-};
 
 export const MentionPlugin = Mention.extend({
 
@@ -68,34 +39,9 @@ export const MentionPlugin = Mention.extend({
   },
 
   renderHTML ({ HTMLAttributes }) {
-    return ['mention-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)];
+    return ['mention-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
   },
 
-  addInputRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodeInputRule({
-        find: (text) => mentionInputMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].replace('@', '').trim());
-        },
-      }),
-    ];
-  },
-
-  addPasteRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodePasteRule({
-        find: (text) => mentionPasteMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].trim());
-        },
-      }),
-    ];
-  },
 }).configure({
   suggestion: {
     char: '@',

--- a/packages/dialtone-vue3/components/rich_text_editor/mention_suggestion.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/mention_suggestion.js
@@ -1,26 +1,53 @@
 /* eslint-disable max-len */
+const CONTACT_LIST = [
+  {
+    id: 'test.person',
+    name: 'Test Person',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'test.person2',
+    name: 'Test Person 2',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'test.person3',
+    name: 'Test Person 3',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'brad.paugh',
+    name: 'Brad Paugh',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'bradley.hawkins',
+    name: 'Bradley Hawkins',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'julio.ortega',
+    name: 'Tico Ortega',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'ignacio.Ropolo',
+    name: 'Ignacio Ropolo',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'nina.repetto',
+    name: 'Nina Repetto',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+];
+
 export default {
-  items ({ query }) {
-    const CONTACT_LIST = [
-      {
-        id: 'test.person',
-        name: 'Test Person',
-        avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
-      },
-      {
-        id: 'test.person2',
-        name: 'Test Person 2',
-        avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
-      },
-      {
-        id: 'test.person3',
-        name: 'Test Person 3',
-        avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
-      },
-    ];
+  async items ({ query }) {
+    // simulate an API call by waiting 1000 seconds.
+    await new Promise(resolve => setTimeout(resolve, 1000));
 
     if (query.length === 0) return CONTACT_LIST;
-
     return CONTACT_LIST.filter((contact) => { return contact.name.toLowerCase().startsWith(query.toLowerCase()); });
   },
 };

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -13,10 +13,9 @@ import slashCommandSuggestion from './slash_command_suggestion';
 
 // Default Prop Values
 export const argsData = {
-  modelValue: `I am not a standalone component, please use Message Input instead :v_tone3::robot:!`,
+  modelValue: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:"></emoji-component><emoji-component code=":robot:"></emoji-component>!</p>',
   editable: true,
   inputAriaLabel: 'This is a descriptive label',
-  outputFormat: 'text',
   autoFocus: false,
   placeholder: 'Type here...',
   link: true,
@@ -113,15 +112,14 @@ export const WithLinks = {
   ...Default,
   args: {
     link: true,
-    modelValue: 'The editor can autolink URLs: dialpad.com, https://www.dialpad.com/about-us/, ' +
-    'IP addresses: 192.158.1.38, email addresses: noreply@dialpad.com and phone numbers: (778) 765-8813, +17787658813!',
+    modelValue: '<p>The editor can autolink URLs: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="http://dialpad.com">dialpad.com</a>, <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="https://www.dialpad.com/about-us/">https://www.dialpad.com/about-us/</a>, email addresses: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="mailto:noreply@dialpad.com">noreply@dialpad.com</a></p>',
   },
 };
 
 export const WithMentionSuggestions = {
   ...Default,
   args: {
-    modelValue: 'The editor can also suggest mentions: @test.person, @test.person2! and channel suggestions: #dialpad.',
+    modelValue: '<p>The editor can also suggest mentions: <mention-component name="Test Person" avatarsrc="" id="test.person"></mention-component>, <mention-component name="Test Person 2" avatarsrc="" id="test.person2"></mention-component>! and channel suggestions: <channel-component name="dialpad" id="dialpad" locked="false"></channel-component>. The suggestions dropdown will wait 1000ms to simulate an API call.</p>',
     mentionSuggestion,
     channelSuggestion,
     slashCommandSuggestion,

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -40,8 +40,7 @@ import {
 import mentionSuggestion from './extensions/mentions/suggestion';
 import channelSuggestion from './extensions/channels/suggestion';
 import slashCommandSuggestion from './extensions/slash_command/suggestion';
-import emojiRegex from 'emoji-regex';
-import { codeToEmojiData, emojiShortCodeRegex } from '@/common/emoji';
+import { codeToEmojiData, emojiShortCodeRegex, emojiRegex } from '@/common/emoji';
 
 export default {
   name: 'DtRichTextEditor',
@@ -513,9 +512,10 @@ export default {
 
     parseEmojis () {
       const matches = new Set(
-        [...this.modelValue.matchAll(emojiRegex()), ...this.modelValue.matchAll(emojiShortCodeRegex)]
+        [...this.modelValue.matchAll(emojiRegex), ...this.modelValue.matchAll(emojiShortCodeRegex)]
           .map(match => match[0].trim()),
       );
+
       if (!matches) return;
 
       matches

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -28,8 +28,8 @@ import Text from '@tiptap/extension-text';
 import TextAlign from '@tiptap/extension-text-align';
 import Emoji from './extensions/emoji';
 import CustomLink from './extensions/custom_link';
-import { MentionPlugin, mentionRegex } from './extensions/mentions/mention';
-import { ChannelPlugin, channelRegex } from './extensions/channels/channel';
+import { MentionPlugin } from './extensions/mentions/mention';
+import { ChannelPlugin } from './extensions/channels/channel';
 import { SlashCommandPlugin } from './extensions/slash_command/slash_command';
 import {
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
@@ -40,8 +40,6 @@ import {
 import mentionSuggestion from './extensions/mentions/suggestion';
 import channelSuggestion from './extensions/channels/suggestion';
 import slashCommandSuggestion from './extensions/slash_command/suggestion';
-import emojiRegex from 'emoji-regex';
-import { codeToEmojiData, emojiShortCodeRegex } from '@/common/emoji';
 
 export default {
   name: 'DtRichTextEditor',
@@ -124,7 +122,7 @@ export default {
      */
     outputFormat: {
       type: String,
-      default: 'text',
+      default: 'html',
       validator (outputFormat) {
         return RICH_TEXT_EDITOR_OUTPUT_FORMATS.includes(outputFormat);
       },
@@ -472,9 +470,8 @@ export default {
         // through the parent, so don't do anything here.
         return;
       }
-
-      this.internalValue = newValue;
-      this.insertContent();
+      // Otherwise replace the content (resets the cursor position).
+      this.editor.commands.setContent(newValue, false);
     },
   },
 
@@ -495,6 +492,7 @@ export default {
       // For all available options, see https://tiptap.dev/api/editor#settings
       this.editor = new Editor({
         autofocus: this.autoFocus,
+        content: this.modelValue,
         editable: this.editable,
         extensions: this.extensions,
         editorProps: {
@@ -504,72 +502,7 @@ export default {
           },
         },
       });
-      this.insertContent();
       this.addEditorListeners();
-    },
-
-    /**
-     * This function is necessary as tiptap doesn't render the content passed
-     * directly through `editor.commands.setContent` the content passed down to it
-     * should be already parsed. So We're parsing the elements into it's corresponding
-     * HTML version before setting it.
-     */
-    insertContent () {
-      this.parseMentions();
-      this.parseChannels();
-      this.parseEmojis();
-      this.editor.commands.setContent(this.internalValue, true);
-    },
-
-    parseEmojis () {
-      const matches = new Set(
-        [...this.modelValue.matchAll(emojiRegex()), ...this.modelValue.matchAll(emojiShortCodeRegex)]
-          .map(match => match[0].trim()),
-      );
-      if (!matches) return;
-
-      matches
-        .forEach(match => {
-          const emoji = codeToEmojiData(match);
-          if (!emoji) return;
-          this.internalValue = this.internalValue.replace(new RegExp(`${match}`, 'g'), `<emoji-component code="${emoji.shortname}"></emoji-component>`);
-        });
-    },
-
-    parseChannels () {
-      if (!this.channelSuggestion) return;
-
-      const suggestions = this.channelSuggestion.items({ query: '' });
-      const matches = [...this.modelValue.matchAll(channelRegex)]
-        .filter(match => suggestions.some(({ id }) => id === match[1]));
-
-      if (!matches) return;
-
-      matches.forEach(match => {
-        const channel = suggestions.find(({ id }) => id === match[1]);
-        this.internalValue = this.internalValue.replace(
-          `#${match[1]}`,
-          /** The space at the beginning is important as tiptap removes that while rendering.
-           *  So if multiple mentions, channels or emojis are next to each other it will fail
-           */
-          ` <channel-component name="${channel.name}" id="${channel.id}"></channel-component>`,
-        );
-      });
-    },
-
-    parseMentions () {
-      if (!this.mentionSuggestion) return;
-
-      const suggestions = this.mentionSuggestion.items({ query: '' });
-      const matches = [...this.modelValue.matchAll(mentionRegex)]
-        .filter(match => suggestions.some(({ id }) => id === match[1]));
-
-      if (!matches) return;
-
-      matches.forEach(match => {
-        const mention = suggestions.find(({ id }) => id === match[1]);
-        this.internalValue = this.internalValue.replace(`@${match[1]}`, ` <mention-component name="${mention.name}" id="${mention.id}"></mention-component>`);
-      });
     },
 
     destroyEditor () {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
@@ -1,6 +1,6 @@
 <template>
   <dt-rich-text-editor
-    v-model="$attrs.modelValue"
+    v-model="value"
     :editable="$attrs.editable"
     :input-aria-label="$attrs.inputAriaLabel"
     :input-class="$attrs.inputClass"
@@ -32,6 +32,18 @@ export default {
 
   components: {
     DtRichTextEditor,
+  },
+
+  data () {
+    return {
+      value: this.$attrs.modelValue,
+    };
+  },
+
+  watch: {
+    '$attrs.modelValue' (value) {
+      this.value = value;
+    },
   },
 };
 </script>

--- a/packages/dialtone-vue3/package.json
+++ b/packages/dialtone-vue3/package.json
@@ -52,8 +52,8 @@
     "@tiptap/suggestion": "2.3.0",
     "@tiptap/vue-3": "2.3.0",
     "date-fns": "2.30.0",
-    "emoji-regex": "10.3.0",
     "emoji-toolkit": "8.0.0",
+    "regex-combined-emojis": "1.6.0",
     "tippy.js": "6.3.7"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -841,12 +841,12 @@ importers:
       date-fns:
         specifier: 2.30.0
         version: 2.30.0
-      emoji-regex:
-        specifier: 10.3.0
-        version: 10.3.0
       emoji-toolkit:
         specifier: 8.0.0
         version: 8.0.0
+      regex-combined-emojis:
+        specifier: 1.6.0
+        version: 1.6.0
       tippy.js:
         specifier: 6.3.7
         version: 6.3.7
@@ -15962,7 +15962,7 @@ snapshots:
       '@babel/traverse': 7.23.2
       '@babel/types': 7.23.0
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -16017,7 +16017,7 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -16696,7 +16696,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.9
       '@babel/types': 7.23.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -21920,7 +21920,7 @@ snapshots:
 
   agent-base@7.1.0:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22323,7 +22323,7 @@ snapshots:
 
   axios@1.6.2:
     dependencies:
-      follow-redirects: 1.15.3
+      follow-redirects: 1.15.3(debug@4.3.4)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -23752,10 +23752,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.3.4:
-    dependencies:
-      ms: 2.1.2
-
   debug@4.3.4(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
@@ -23930,7 +23926,7 @@ snapshots:
   detect-port@1.5.1:
     dependencies:
       address: 1.2.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -24321,7 +24317,7 @@ snapshots:
 
   esbuild-register@3.5.0(esbuild@0.18.20):
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
@@ -24991,7 +24987,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -25157,7 +25153,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 5.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -25277,8 +25273,6 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
       - supports-color
-
-  follow-redirects@1.15.3: {}
 
   follow-redirects@1.15.3(debug@4.3.4):
     optionalDependencies:
@@ -26134,7 +26128,7 @@ snapshots:
   http-proxy-agent@7.0.0:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26185,7 +26179,7 @@ snapshots:
   https-proxy-agent@4.0.0:
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26199,7 +26193,7 @@ snapshots:
   https-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26272,7 +26266,7 @@ snapshots:
 
   import-from-esm@1.3.3:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       import-meta-resolve: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -26788,7 +26782,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.1
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -28394,7 +28388,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.11
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -30879,7 +30873,7 @@ snapshots:
   puppeteer-core@2.1.1:
     dependencies:
       '@types/mime-types': 2.1.4
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -31962,7 +31956,7 @@ snapshots:
   socks-proxy-agent@8.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       socks: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -33035,7 +33029,7 @@ snapshots:
   tuf-js@2.2.0:
     dependencies:
       '@tufjs/models': 2.0.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
@@ -34058,7 +34052,7 @@ snapshots:
     dependencies:
       chalk: 2.4.2
       commander: 3.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -34570,7 +34564,7 @@ snapshots:
       arrify: 3.0.0
       chalk: 5.3.0
       commander: 11.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       execa: 8.0.1
       fly-import: 0.4.0
       globby: 14.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -615,12 +615,12 @@ importers:
       date-fns:
         specifier: 2.30.0
         version: 2.30.0
-      emoji-regex:
-        specifier: 10.3.0
-        version: 10.3.0
       emoji-toolkit:
         specifier: 8.0.0
         version: 8.0.0
+      regex-combined-emojis:
+        specifier: 1.6.0
+        version: 1.6.0
       tippy.js:
         specifier: 6.3.7
         version: 6.3.7
@@ -13163,6 +13163,9 @@ packages:
   regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
 
+  regex-combined-emojis@1.6.0:
+    resolution: {integrity: sha512-pkQZHqM8M00hN0Md5e6Fag5mjxseDyjzB2gXmawdX0aoZzx5I9on/Eg77di1+ahPcPrCXkvT7Br5eJUp+BaeoA==}
+
   regex-not@1.0.2:
     resolution: {integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==}
     engines: {node: '>=0.10.0'}
@@ -15959,7 +15962,7 @@ snapshots:
       '@babel/traverse': 7.23.2
       '@babel/types': 7.23.0
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -16014,7 +16017,7 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -16693,7 +16696,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.9
       '@babel/types': 7.23.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -21917,7 +21920,7 @@ snapshots:
 
   agent-base@7.1.0:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -22320,7 +22323,7 @@ snapshots:
 
   axios@1.6.2:
     dependencies:
-      follow-redirects: 1.15.3(debug@4.3.4)
+      follow-redirects: 1.15.3
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -23749,6 +23752,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
+
   debug@4.3.4(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
@@ -23923,7 +23930,7 @@ snapshots:
   detect-port@1.5.1:
     dependencies:
       address: 1.2.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -24314,7 +24321,7 @@ snapshots:
 
   esbuild-register@3.5.0(esbuild@0.18.20):
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
@@ -24984,7 +24991,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -25150,7 +25157,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 5.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -25270,6 +25277,8 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
       - supports-color
+
+  follow-redirects@1.15.3: {}
 
   follow-redirects@1.15.3(debug@4.3.4):
     optionalDependencies:
@@ -26125,7 +26134,7 @@ snapshots:
   http-proxy-agent@7.0.0:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -26176,7 +26185,7 @@ snapshots:
   https-proxy-agent@4.0.0:
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -26190,7 +26199,7 @@ snapshots:
   https-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -26263,7 +26272,7 @@ snapshots:
 
   import-from-esm@1.3.3:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       import-meta-resolve: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -26779,7 +26788,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.1
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -28385,7 +28394,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.11
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -30870,7 +30879,7 @@ snapshots:
   puppeteer-core@2.1.1:
     dependencies:
       '@types/mime-types': 2.1.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -31159,6 +31168,8 @@ snapshots:
   regenerator-transform@0.15.2:
     dependencies:
       '@babel/runtime': 7.23.2
+
+  regex-combined-emojis@1.6.0: {}
 
   regex-not@1.0.2:
     dependencies:
@@ -31951,7 +31962,7 @@ snapshots:
   socks-proxy-agent@8.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       socks: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -33024,7 +33035,7 @@ snapshots:
   tuf-js@2.2.0:
     dependencies:
       '@tufjs/models': 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
@@ -34047,7 +34058,7 @@ snapshots:
     dependencies:
       chalk: 2.4.2
       commander: 3.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -34559,7 +34570,7 @@ snapshots:
       arrify: 3.0.0
       chalk: 5.3.0
       commander: 11.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       execa: 8.0.1
       fly-import: 0.4.0
       globby: 14.0.1


### PR DESCRIPTION
# Detect skin tone emojis on rich text editor emoji plugin

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/xUPGcz2H1TXdCz4suY/giphy.gif?cid=ecf05e47x36z6k65oojazqkjsfztpl2gggobuvy7n9cae2ch&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1731

## :book: Description

- Changed [emoji-regex](https://github.com/mathiasbynens/emoji-regex) dependency to [regex-combined-emojis](https://github.com/sweaver2112/Regex-combined-emojis) that seems to be more maintained and up-to-date.
- Updated emoji input rule to return shortcode instead of emoji, if we already found the emoji and know that it is valid, why we would need to send unicode and having to transform it again?

## :bulb: Context

Skin tone emojis were not being detected correctly.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :camera: Screenshots / GIFs

### Before

https://github.com/dialpad/dialtone/assets/87546543/7f9ddcd6-139e-42fe-9860-3b0ef5f7aa24

### After

https://github.com/dialpad/dialtone/assets/87546543/cf510018-0286-407a-b3ce-31918e9aab44