### PR TITLE
[NO-MERGE] DLT-1689 add overlay scrollbars example

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/emoji-picker.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji-picker.less
@@ -35,11 +35,11 @@
   }
 
   &__alignment {
+    // !important to default value to override popover dialog box-sizing: border-box style
+    box-sizing: content-box !important;
     width: auto;
     max-width: calc(var(--dt-size-925) + var(--dt-size-400));
     margin: 0 var(--dt-space-500);
-    // !important to default value to override popover dialog box-sizing: border-box style
-    box-sizing: content-box !important;
   }
 
   &--footer {
@@ -149,7 +149,10 @@
     padding-bottom: calc(var(--dt-space-300) + var(--dt-space-100));
     overflow: hidden auto;
 
-    div:not(:first-child) {
+    // when using the custom scrollbars element, the actual scrollable
+    // element ends up being the second child of the element where the
+    // scrollbars are added
+    div:nth-child(2) div:not(:first-child) {
       p {
         margin-top: calc(var(--dt-space-525) + var(--dt-space-200));
       }

--- a/packages/dialtone-css/lib/build/less/components/scrollbars.less
+++ b/packages/dialtone-css/lib/build/less/components/scrollbars.less
@@ -1,0 +1,25 @@
+.custom-scrollbars {
+  .os-theme-dark {
+    // main color for the scrollbars handle
+    --os-handle-color: var(--dt-color-black-800);
+    --os-handle-bg: var(--os-handle-color);
+    --os-handle-bg-hover: var(--os-handle-color);
+    --os-handle-bg-active: var(--os-handle-color);
+  }
+
+  .os-scrollbar {
+    .os-scrollbar-handle {
+      cursor: auto;
+      opacity: 0.44;
+
+      &:hover {
+        width: calc(var(--os-handle-perpendicular-size) + var(--dt-size-200));
+        opacity: 0.55;
+      }
+
+      &:active {
+        opacity: 0.66;
+      }
+    }
+  }
+}

--- a/packages/dialtone-css/lib/build/less/dialtone.less
+++ b/packages/dialtone-css/lib/build/less/dialtone.less
@@ -51,6 +51,7 @@
 @import 'components/toggle';
 @import 'components/presence';
 @import 'components/icon';
+@import 'components/scrollbars';
 
 //  --  UTILITIES
 @import 'utilities/backgrounds';

--- a/packages/dialtone-vue2/.storybook/preview.jsx
+++ b/packages/dialtone-vue2/.storybook/preview.jsx
@@ -1,5 +1,6 @@
 import '../css/dialtone-globals.less';
 import '@dialpad/dialtone-css/lib/dist/dialtone.css';
+import 'overlayscrollbars/overlayscrollbars.css';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { DocsContainer } from '@storybook/addon-docs';
 import { useDarkMode } from "storybook-dark-mode";
@@ -9,6 +10,7 @@ import { setEmojiAssetUrlSmall, setEmojiAssetUrlLarge, setCustomEmojiUrl, setCus
 import customEmojiJson from '@/common/custom-emoji.json';
 import { dialtoneDarkTheme, dialtoneLightTheme } from './dialtone-themes.js';
 import { DtTooltipDirective } from "@/directives/tooltip";
+import { DtScrollbarsDirective } from "@/directives/scrollbars";
 
 setEmojiAssetUrlSmall('https://static.dialpadcdn.com/joypixels/png/unicode/32/', '.png');
 setEmojiAssetUrlLarge('https://static.dialpadcdn.com/joypixels/svg/unicode/', '.svg');
@@ -16,6 +18,7 @@ setCustomEmojiUrl('https://github.githubassets.com/images/icons/emoji/');
 setCustomEmojiJson(customEmojiJson);
 
 Vue.use(DtTooltipDirective);
+Vue.use(DtScrollbarsDirective);
 
 // Fixes method "toJSON" is not defined on click event in Sb 6.5.11
 // See https://github.com/storybookjs/storybook/issues/14933#issuecomment-920578274

--- a/packages/dialtone-vue2/.storybook/preview.jsx
+++ b/packages/dialtone-vue2/.storybook/preview.jsx
@@ -1,6 +1,5 @@
 import '../css/dialtone-globals.less';
 import '@dialpad/dialtone-css/lib/dist/dialtone.css';
-import 'overlayscrollbars/overlayscrollbars.css';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { DocsContainer } from '@storybook/addon-docs';
 import { useDarkMode } from "storybook-dark-mode";

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -102,6 +102,8 @@
 </template>
 
 <script>
+/* eslint-disable complexity */
+/* eslint-disable max-lines */
 import { emojisGrouped as emojisImported } from '@dialpad/dialtone-emojis';
 import { CDN_URL, EMOJIS_PER_ROW } from '@/components/emoji_picker';
 
@@ -331,7 +333,10 @@ export default {
       const tabElement = tabLabel.ref[0];
 
       vm.$nextTick(function () {
-        const container = vm.$refs.listRef;
+        // when using the custom scrollbars element, the actual scrollable
+        // element ends up being the second child of the element where the
+        // scrollbars are added
+        const container = vm.$refs.listRef.children[1];
         const offsetTop = tabIndex === '1' ? 0 : tabElement.offsetTop - 20;
 
         let isScrolling = true;
@@ -604,7 +609,10 @@ export default {
 
       this.tabLabelObserver.observe(this.$refs.tabCategoryRef);
 
-      Array.from(this.$refs.listRef.children).forEach((child, index) => {
+      // when using the custom scrollbars element, the actual scrollable
+      // element ends up being the second child of the element where the
+      // scrollbars are added. That is the reason for the .children[1]
+      Array.from(this.$refs.listRef.children[1].children).forEach((child, index) => {
         this.tabLabelObserver.observe(child);
         child.dataset.index = index;
       });

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -5,6 +5,7 @@
     <div
       id="d-emoji-picker-list"
       ref="listRef"
+      v-dt-scrollbars
       class="d-emoji-picker__list"
     >
       <p

--- a/packages/dialtone-vue2/directives/scrollbars/index.js
+++ b/packages/dialtone-vue2/directives/scrollbars/index.js
@@ -1,0 +1,1 @@
+export { default as DtScrollbarsDirective } from './scrollbars.js';

--- a/packages/dialtone-vue2/directives/scrollbars/scrollbars.js
+++ b/packages/dialtone-vue2/directives/scrollbars/scrollbars.js
@@ -1,0 +1,15 @@
+import { OverlayScrollbars } from 'overlayscrollbars';
+
+export const DtScrollbarsDirective = {
+  name: 'dt-scrollbars-directive',
+  install (Vue) {
+    Vue.directive('dt-scrollbars', {
+      inserted (el) {
+        OverlayScrollbars(el, {});
+        el.setAttribute('data-overlayscrollbars-initialize', true);
+      },
+    });
+  },
+};
+
+export default DtScrollbarsDirective;

--- a/packages/dialtone-vue2/directives/scrollbars/scrollbars.js
+++ b/packages/dialtone-vue2/directives/scrollbars/scrollbars.js
@@ -1,12 +1,14 @@
 import { OverlayScrollbars } from 'overlayscrollbars';
+import 'overlayscrollbars/overlayscrollbars.css';
 
 export const DtScrollbarsDirective = {
   name: 'dt-scrollbars-directive',
   install (Vue) {
     Vue.directive('dt-scrollbars', {
       inserted (el) {
-        OverlayScrollbars(el, {});
+        OverlayScrollbars(el, { scrollbars: { autoHide: 'scroll' } });
         el.setAttribute('data-overlayscrollbars-initialize', true);
+        el.classList.add('custom-scrollbars');
       },
     });
   },

--- a/packages/dialtone-vue2/index.js
+++ b/packages/dialtone-vue2/index.js
@@ -68,6 +68,7 @@ export * from './components/validation_messages';
 
 // Directives
 export * from './directives/tooltip';
+export * from './directives/scrollbars';
 
 /// Recipes
 export * from './recipes/buttons/callbar_button';

--- a/packages/dialtone-vue2/package.json
+++ b/packages/dialtone-vue2/package.json
@@ -56,7 +56,6 @@
     "emoji-toolkit": "8.0.0",
     "regex-combined-emojis": "1.6.0",
     "overlayscrollbars": "2.8.3",
-    "overlayscrollbars-vue": "0.5.9",
     "tippy.js": "6.3.7"
   },
   "devDependencies": {

--- a/packages/dialtone-vue2/package.json
+++ b/packages/dialtone-vue2/package.json
@@ -55,6 +55,8 @@
     "date-fns": "2.30.0",
     "emoji-toolkit": "8.0.0",
     "regex-combined-emojis": "1.6.0",
+    "overlayscrollbars": "2.8.3",
+    "overlayscrollbars-vue": "0.5.9",
     "tippy.js": "6.3.7"
   },
   "devDependencies": {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -99,7 +99,30 @@ export const argTypesData = {
 
 // Set default values at the story level here.
 export const argsData = {
-  value: 'Always the Padawan, never the Jedi.',
+  value: `Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.`,
   placeholder: 'New message',
   inputAriaLabel: 'Input text field',
   maxHeight: '40vh',

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -14,7 +14,8 @@
   >
     <!-- Some wrapper to restrict the height and show the scrollbar -->
     <div
-      class="d-of-auto d-mx16 d-mt8 d-mb4"
+      v-dt-scrollbars
+      class="d-mx16 d-mt8 d-mb4"
       :style="{ 'max-height': maxHeight }"
     >
       <dt-rich-text-editor

--- a/packages/dialtone-vue3/.storybook/preview.jsx
+++ b/packages/dialtone-vue3/.storybook/preview.jsx
@@ -1,6 +1,5 @@
 import '../css/dialtone-globals.less';
 import '@dialpad/dialtone-css/lib/dist/dialtone.css';
-import 'overlayscrollbars/overlayscrollbars.css';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { setup } from '@storybook/vue3';
 import React from 'react';

--- a/packages/dialtone-vue3/.storybook/preview.jsx
+++ b/packages/dialtone-vue3/.storybook/preview.jsx
@@ -1,5 +1,6 @@
 import '../css/dialtone-globals.less';
 import '@dialpad/dialtone-css/lib/dist/dialtone.css';
+import 'overlayscrollbars/overlayscrollbars.css';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { setup } from '@storybook/vue3';
 import React from 'react';
@@ -10,6 +11,7 @@ import { setEmojiAssetUrlSmall, setEmojiAssetUrlLarge, setCustomEmojiUrl, setCus
 import customEmojiJson from '@/common/custom-emoji.json';
 import { dialtoneDarkTheme, dialtoneLightTheme } from './dialtone-themes.js';
 import { DtTooltipDirective } from "@/directives/tooltip";
+import { DtScrollbarsDirective } from "@/directives/scrollbars";
 
 setEmojiAssetUrlSmall('https://static.dialpadcdn.com/joypixels/png/unicode/32/', '.png');
 setEmojiAssetUrlLarge('https://static.dialpadcdn.com/joypixels/svg/unicode/', '.svg');
@@ -19,6 +21,7 @@ setCustomEmojiJson(customEmojiJson);
 setup((app) => {
   app.use(fixDefaultSlot)
   app.use(DtTooltipDirective);
+  app.use(DtScrollbarsDirective);
 });
 
 export default {

--- a/packages/dialtone-vue3/directives/scrollbars/index.js
+++ b/packages/dialtone-vue3/directives/scrollbars/index.js
@@ -1,0 +1,1 @@
+export { default as DtScrollbarsDirective } from './scrollbars.js';

--- a/packages/dialtone-vue3/directives/scrollbars/scrollbars.js
+++ b/packages/dialtone-vue3/directives/scrollbars/scrollbars.js
@@ -1,0 +1,15 @@
+import { OverlayScrollbars } from 'overlayscrollbars';
+
+export const DtScrollbarsDirective = {
+  name: 'dt-scrollbars-directive',
+  install (app) {
+    app.directive('dt-scrollbars', {
+      mounted (el) {
+        OverlayScrollbars(el, {});
+        el.setAttribute('data-overlayscrollbars-initialize', true);
+      },
+    });
+  },
+};
+
+export default DtScrollbarsDirective;

--- a/packages/dialtone-vue3/directives/scrollbars/scrollbars.js
+++ b/packages/dialtone-vue3/directives/scrollbars/scrollbars.js
@@ -1,12 +1,14 @@
 import { OverlayScrollbars } from 'overlayscrollbars';
+import 'overlayscrollbars/overlayscrollbars.css';
 
 export const DtScrollbarsDirective = {
   name: 'dt-scrollbars-directive',
   install (app) {
     app.directive('dt-scrollbars', {
       mounted (el) {
-        OverlayScrollbars(el, {});
+        OverlayScrollbars(el, { scrollbars: { autoHide: 'scroll' } });
         el.setAttribute('data-overlayscrollbars-initialize', true);
+        el.classList.add('custom-scrollbars');
       },
     });
   },

--- a/packages/dialtone-vue3/index.js
+++ b/packages/dialtone-vue3/index.js
@@ -69,6 +69,7 @@ export * from './components/validation_messages';
 
 // Directives
 export * from './directives/tooltip';
+export * from './directives/scrollbars';
 
 /// Recipes
 export * from './recipes/buttons/callbar_button';

--- a/packages/dialtone-vue3/package.json
+++ b/packages/dialtone-vue3/package.json
@@ -54,6 +54,8 @@
     "date-fns": "2.30.0",
     "emoji-toolkit": "8.0.0",
     "regex-combined-emojis": "1.6.0",
+    "overlayscrollbars": "2.8.3",
+    "overlayscrollbars-vue": "0.5.9",
     "tippy.js": "6.3.7"
   },
   "devDependencies": {

--- a/packages/dialtone-vue3/package.json
+++ b/packages/dialtone-vue3/package.json
@@ -55,7 +55,6 @@
     "emoji-toolkit": "8.0.0",
     "regex-combined-emojis": "1.6.0",
     "overlayscrollbars": "2.8.3",
-    "overlayscrollbars-vue": "0.5.9",
     "tippy.js": "6.3.7"
   },
   "devDependencies": {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -99,7 +99,31 @@ export const argTypesData = {
 
 // Set default values at the story level here.
 export const argsData = {
-  modelValue: 'Always the Padawan, never the Jedi.',
+  modelValue: `Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  Always the Padawan, never the Jedi.
+  `,
   placeholder: 'New message',
   inputAriaLabel: 'Input text field',
   maxHeight: '40vh',

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -14,7 +14,8 @@
   >
     <!-- Some wrapper to restrict the height and show the scrollbar -->
     <div
-      class="d-of-auto d-mx16 d-mt8 d-mb4"
+      v-dt-scrollbars
+      class="d-mx16 d-mt8 d-mb4"
       :style="{ 'max-height': maxHeight }"
     >
       <dt-rich-text-editor

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,6 +618,12 @@ importers:
       emoji-toolkit:
         specifier: 8.0.0
         version: 8.0.0
+      overlayscrollbars:
+        specifier: 2.8.3
+        version: 2.8.3
+      overlayscrollbars-vue:
+        specifier: 0.5.9
+        version: 0.5.9(overlayscrollbars@2.8.3)(vue@2.7.15)
       regex-combined-emojis:
         specifier: 1.6.0
         version: 1.6.0
@@ -29260,6 +29266,11 @@ snapshots:
     dependencies:
       domino: 2.1.6
       validator: 13.11.0
+
+  overlayscrollbars-vue@0.5.9(overlayscrollbars@2.8.3)(vue@2.7.15):
+    dependencies:
+      overlayscrollbars: 2.8.3
+      vue: 2.7.15
 
   overlayscrollbars-vue@0.5.9(overlayscrollbars@2.8.3)(vue@3.3.8(typescript@5.3.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,9 +621,6 @@ importers:
       overlayscrollbars:
         specifier: 2.8.3
         version: 2.8.3
-      overlayscrollbars-vue:
-        specifier: 0.5.9
-        version: 0.5.9(overlayscrollbars@2.8.3)(vue@2.7.15)
       regex-combined-emojis:
         specifier: 1.6.0
         version: 1.6.0
@@ -853,9 +850,6 @@ importers:
       overlayscrollbars:
         specifier: 2.8.3
         version: 2.8.3
-      overlayscrollbars-vue:
-        specifier: 0.5.9
-        version: 0.5.9(overlayscrollbars@2.8.3)(vue@3.3.8(typescript@5.3.3))
       regex-combined-emojis:
         specifier: 1.6.0
         version: 1.6.0
@@ -11571,12 +11565,6 @@ packages:
   oslllo-validator@3.1.0:
     resolution: {integrity: sha512-eqaVuDxnxDO55+pncqTTphbeq6O5XHMyrSfWQoL48mG2rUjr2ZBzvkFkcxIiG3l7IaIY6/L1oX1AJIDdZyzuPQ==}
     engines: {node: '>= 10.0'}
-
-  overlayscrollbars-vue@0.5.9:
-    resolution: {integrity: sha512-zZEcsb6llnKaRwXTP44E4RrmwuH+eAi70mgCdiiPwcPBE2H99Vs2V0q7sWnEanqU3462ch38e4SmIMnuH906DQ==}
-    peerDependencies:
-      overlayscrollbars: ^2.0.0
-      vue: ^3.2.25
 
   overlayscrollbars@2.8.3:
     resolution: {integrity: sha512-7JHA1oWm3Gru3RF5wwaeBdgk4keGtc56HMWEQRQi/RdLdY3pZTUDlSfUk1jyv1yQN12otr828n52rT6VNzYO4w==}
@@ -29266,16 +29254,6 @@ snapshots:
     dependencies:
       domino: 2.1.6
       validator: 13.11.0
-
-  overlayscrollbars-vue@0.5.9(overlayscrollbars@2.8.3)(vue@2.7.15):
-    dependencies:
-      overlayscrollbars: 2.8.3
-      vue: 2.7.15
-
-  overlayscrollbars-vue@0.5.9(overlayscrollbars@2.8.3)(vue@3.3.8(typescript@5.3.3)):
-    dependencies:
-      overlayscrollbars: 2.8.3
-      vue: 3.3.8(typescript@5.3.3)
 
   overlayscrollbars@2.8.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,6 +844,12 @@ importers:
       emoji-toolkit:
         specifier: 8.0.0
         version: 8.0.0
+      overlayscrollbars:
+        specifier: 2.8.3
+        version: 2.8.3
+      overlayscrollbars-vue:
+        specifier: 0.5.9
+        version: 0.5.9(overlayscrollbars@2.8.3)(vue@3.3.8(typescript@5.3.3))
       regex-combined-emojis:
         specifier: 1.6.0
         version: 1.6.0
@@ -5243,7 +5249,7 @@ packages:
     peerDependencies:
       '@types/inquirer': ^9.0.3
       inquirer: '*'
-      mem-fs: ^3.0.0 || ^4.0.0
+      mem-fs: ^3.0.0
       mem-fs-editor: ^10.0.2
     peerDependenciesMeta:
       inquirer:
@@ -11559,6 +11565,15 @@ packages:
   oslllo-validator@3.1.0:
     resolution: {integrity: sha512-eqaVuDxnxDO55+pncqTTphbeq6O5XHMyrSfWQoL48mG2rUjr2ZBzvkFkcxIiG3l7IaIY6/L1oX1AJIDdZyzuPQ==}
     engines: {node: '>= 10.0'}
+
+  overlayscrollbars-vue@0.5.9:
+    resolution: {integrity: sha512-zZEcsb6llnKaRwXTP44E4RrmwuH+eAi70mgCdiiPwcPBE2H99Vs2V0q7sWnEanqU3462ch38e4SmIMnuH906DQ==}
+    peerDependencies:
+      overlayscrollbars: ^2.0.0
+      vue: ^3.2.25
+
+  overlayscrollbars@2.8.3:
+    resolution: {integrity: sha512-7JHA1oWm3Gru3RF5wwaeBdgk4keGtc56HMWEQRQi/RdLdY3pZTUDlSfUk1jyv1yQN12otr828n52rT6VNzYO4w==}
 
   p-any@2.1.0:
     resolution: {integrity: sha512-JAERcaMBLYKMq+voYw36+x5Dgh47+/o7yuv2oQYuSSUml4YeqJEFznBrY2UeEkoSHqBua6hz518n/PsowTYLLg==}
@@ -21642,12 +21657,12 @@ snapshots:
   '@vuepress/shared@2.0.0-beta.53':
     dependencies:
       '@mdit-vue/types': 0.11.0
-      '@vue/shared': 3.4.15
+      '@vue/shared': 3.3.8
 
   '@vuepress/shared@2.0.0-beta.60':
     dependencies:
       '@mdit-vue/types': 0.11.0
-      '@vue/shared': 3.4.15
+      '@vue/shared': 3.3.8
 
   '@vuepress/theme-default@2.0.0-beta.60(typescript@5.3.3)':
     dependencies:
@@ -29246,6 +29261,13 @@ snapshots:
       domino: 2.1.6
       validator: 13.11.0
 
+  overlayscrollbars-vue@0.5.9(overlayscrollbars@2.8.3)(vue@3.3.8(typescript@5.3.3)):
+    dependencies:
+      overlayscrollbars: 2.8.3
+      vue: 3.3.8(typescript@5.3.3)
+
+  overlayscrollbars@2.8.3: {}
+
   p-any@2.1.0:
     dependencies:
       p-cancelable: 2.1.1
@@ -29937,11 +29959,11 @@ snapshots:
     dependencies:
       postcss: 7.0.39
 
-  postcss-html@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39):
+  postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39):
     dependencies:
       htmlparser2: 3.10.1
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss@8.4.33)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39)
 
   postcss-image-set-function@3.0.1:
     dependencies:
@@ -29952,11 +29974,11 @@ snapshots:
     dependencies:
       postcss: 7.0.39
 
-  postcss-jsx@0.36.4(postcss-syntax@0.36.2)(postcss@7.0.39):
+  postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39):
     dependencies:
       '@babel/core': 7.23.2
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss@8.4.33)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39)
     transitivePeerDependencies:
       - supports-color
 
@@ -30000,10 +30022,10 @@ snapshots:
     dependencies:
       postcss: 7.0.39
 
-  postcss-markdown@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39):
+  postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39):
     dependencies:
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss@8.4.33)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39)
       remark: 10.0.1
       unist-util-find-all-after: 1.0.5
 
@@ -30497,9 +30519,15 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 3.0.2
 
-  postcss-syntax@0.36.2(postcss@8.4.33):
+  postcss-syntax@0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39):
     dependencies:
-      postcss: 8.4.33
+      postcss: 7.0.39
+    optionalDependencies:
+      postcss-html: 0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39)
+      postcss-jsx: 0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39)
+      postcss-less: 3.1.4
+      postcss-markdown: 0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39)
+      postcss-scss: 2.1.1
 
   postcss-unique-selectors@5.1.1(postcss@8.4.32):
     dependencies:
@@ -32574,10 +32602,10 @@ snapshots:
       normalize-selector: 0.2.0
       pify: 4.0.1
       postcss: 7.0.39
-      postcss-html: 0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39)
-      postcss-jsx: 0.36.4(postcss-syntax@0.36.2)(postcss@7.0.39)
+      postcss-html: 0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39)
+      postcss-jsx: 0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39)
       postcss-less: 3.1.4
-      postcss-markdown: 0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39)
+      postcss-markdown: 0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39)
       postcss-media-query-parser: 0.2.3
       postcss-reporter: 6.0.1
       postcss-resolve-nested-selector: 0.1.1
@@ -32585,7 +32613,7 @@ snapshots:
       postcss-sass: 0.3.5
       postcss-scss: 2.1.1
       postcss-selector-parser: 3.1.2
-      postcss-syntax: 0.36.2(postcss@8.4.33)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-scss@2.1.1)(postcss@7.0.39)
       postcss-value-parser: 3.3.1
       resolve-from: 4.0.0
       signal-exit: 3.0.7


### PR DESCRIPTION
# Custom scrollbars POC

Jira: [DLT-1689]

Adds the dependency [Overlay Scrollbars](https://kingsora.github.io/OverlayScrollbars/) to Dialtone to see how it works and what functionality it allows.

I created and exported a new directive `DtScrollbarsDirective`, that can be used similar to the `DtTooltipDirective`, just adding `v-dt-scrollbars` to the component that would normally have `overflow: auto` to allow scroll.

The Vue wrapper that this library offers is only available for Vue 3, so it's not an option to use that for now.

Notice that when there are listeners to the scroll event in the element where we are adding the custom scrollbars, some changes would have to be made (see Emoji Picker).

I tested in:
- Message input
- Leftbar (Ubervoice)
- Emoji Picker
- Conversation View (failed)

### Message Input ✅

| With custom scrollbars | Native scrollbars | 
|-----|------|
| ![custom-scroll-mi](https://github.com/dialpad/dialtone/assets/24460973/4393d8cc-7bfd-4f21-bc1a-0acc8821957f) | ![native-scroll-mi](https://github.com/dialpad/dialtone/assets/24460973/519e1450-1977-4fce-8305-d8d1491de1a2) |

### Leftbar ✅

| With custom scrollbars | Native scrollbars | 
|-----|------|
| ![custom-scroll-leftbar](https://github.com/dialpad/dialtone/assets/24460973/4cd56af7-145e-4019-861b-4e5a1455775e) | ![native-scroll-leftbar](https://github.com/dialpad/dialtone/assets/24460973/462fe331-cb51-44ff-93ff-354e10573d3f) |

Check the code for Ubervoice [here](https://github.com/dialpad/firespotter/pull/42752).

### Emoji Picker ✅

| With custom scrollbars | Native scrollbars | 
|-----|------|
| ![emoji-custom](https://github.com/dialpad/dialtone/assets/24460973/1b4f949f-ff65-43ef-ad03-fdb1f3dcdbd6) | ![ep-native](https://github.com/dialpad/dialtone/assets/24460973/f674ef36-e742-4c49-9237-7804c4c65122) |

Some changes were needed to make it work with the emoji picker, because the overlay scrollbars library adds some new elements to the DOM, and this component was using refs and attaching event handlers to the scrollable element.
When using this directive, the scrollable element is the second child of the element you attach the custom scrollbar to. 

### Conversation View ❌
When adding `v-dt-scrollbars` directive in the `InfiniteList` the render gets stuck in an infinite loop, so the conversation is never rendered. I tried debugging this with no success, so this one might be a component where we can't add this directive for now.

### Advantages of using Overlays Scrollbars over native scrollbars

- Allows custom styling and ensures that the look and feel will be the same across browsers and platforms. Everything can be customizable: the size, color, border, transitions, etc.
- Allows overlay scrollbars (in fact there is no option for not overlay scrollbars)
- Offer a lot of options to customize them, like when they should appear (on scroll, on hover or all the time)
- It would be very simple for developers to use them in simple components (below there's a note on the Conversation View component*)

### Disadvantages
- The DOM structure ends up a little different than what you see in the template, because 4 divs are added inside the element to which the scrollbars are attached to. This might make it more difficult to use with components that add event listeners to the scrollable element.

**Previous**
<img width="550" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/a48c0de0-5e4d-4b1b-9601-e61bf00d007c">

Without the directive, the element with id `d-emoji-picker-list` is the scrollable element

**With custom scrollbars**
<img width="786" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/f439bed3-1a9e-4907-b6de-c35f59c58fe8">

The element with id `d-emoji-picker-list` now has four divs inside:
- One with the class "os-size-observer""
- The second one is the actual scrollable element
- The horizontal scrollbar
- The vertical scrollbar

### Accessibility
- They give control over the contrast and can work both in light and dark mode. 

- The size can increase on hover (imitating the native behavior) for better accessibility. This is customizable too. 

- Keyboard navigation: the native behavior is supported. These are the guidelines (from https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role):
> When focus is within the viewport controlled by a scrollbar, the Up Arrow and Down Arrow (or Left Arrow and Right Arrow for a horizontal scroll bar) should move the scroll bar thumb proportionally. Additionally, the Page Up, Page Down, Space, and Shift + Space keys must move the content and the scroll thumb the height (or width) of the viewport for each key press until the bottom or top (or left or right) of the content is in view.

- Aria role: scrollbar
> Because native scroll bar styling has historically been limited, you may come across a scrollbar implemented in JavaScript that you need to support and make fully accessible. For this, you can use the scrollbar role to inform assistive technologies that a UI control is an interactive scrollbar.

I don't think this role is added, and I didn't find a way to add it so this might be a problem for screen readers.


### Next Steps

- Test in different browsers and platforms, and different inputs, like touch on a mobile device
- Decide if the overlay is the style we want for the scrollbar
- Decide if we want to go with this solution even if it can't be used in every component

[DLT-1689]: https://dialpad.atlassian.net/browse/DLT-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ