### PR TITLE
fix(rich-text-editor): DLT-1752 remove custom parsing

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/channels/channel.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/channels/channel.js
@@ -1,44 +1,13 @@
 import Mention from '@tiptap/extension-mention';
-import { mergeAttributes, nodeInputRule, nodePasteRule } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-2';
 import { PluginKey } from '@tiptap/pm/state';
 
 // Channel Mention component
 import ChannelComponent from './ChannelComponent.vue';
 
-export const channelRegex = /#([\w-]+)[^\w-]?/g;
-
-const channelPasteMatch = (text, suggestions) => {
-  const matches = [...text.matchAll(channelRegex)];
-
-  return matches
-    .filter(match => suggestions.some(({ id }) => id === match[1].trim()))
-    .map(match => {
-      let channel = match[1];
-      if (!channel.endsWith(' ')) channel += ' ';
-      return {
-        index: match.index,
-        text: channel,
-        match,
-      };
-    });
-};
-
-const channelInputMatch = (text, suggestions) => {
-  const match = text.match(/#([\w-]+)[^\w-]$/);
-  if (!match || !suggestions.some(({ id }) => id === match[1])) return;
-
-  return {
-    index: match.index,
-    text: match[0],
-    match,
-  };
-};
-
 export const ChannelPlugin = Mention.extend({
   name: 'channel',
-  group: 'inline',
-  inline: true,
 
   addNodeView () {
     return VueNodeViewRenderer(ChannelComponent);
@@ -71,34 +40,9 @@ export const ChannelPlugin = Mention.extend({
   },
 
   renderHTML ({ HTMLAttributes }) {
-    return ['channel-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)];
+    return ['channel-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
   },
 
-  addInputRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodeInputRule({
-        find: (text) => channelInputMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].replace('#', '').trim());
-        },
-      }),
-    ];
-  },
-
-  addPasteRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodePasteRule({
-        find: (text) => channelPasteMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].trim());
-        },
-      }),
-    ];
-  },
 }).configure({
   suggestion: {
     char: '#',

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
@@ -65,10 +65,6 @@ export const Emoji = Node.create({
       code: {
         default: null,
       },
-
-      id: {
-        default: null,
-      },
     };
   },
 

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/suggestion.js
@@ -18,7 +18,7 @@ export default {
       }
       return false;
     });
-    return filteredEmoji.map(item => { return { id: item.unicode_character, code: item.shortname }; });
+    return filteredEmoji.map(item => { return { code: item.shortname }; });
   },
 
   command: ({ editor, range, props }) => {

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/suggestion.js
@@ -77,7 +77,6 @@ export default {
           interactive: true,
           trigger: 'manual',
           placement: 'top-start',
-          contentElement: null,
           zIndex: 650,
         });
       },

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/mention.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/mention.js
@@ -1,44 +1,12 @@
 import Mention from '@tiptap/extension-mention';
-import { mergeAttributes, nodeInputRule, nodePasteRule } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-2';
 import { PluginKey } from '@tiptap/pm/state';
 
 // Mention component
 import MentionComponent from './MentionComponent.vue';
 
-export const mentionRegex = /@([\w.-]+)[^\w.-]?/g;
-
-const mentionPasteMatch = (text, suggestions) => {
-  const matches = [...text.matchAll(mentionRegex)];
-
-  return matches
-    .filter(match => suggestions.some(({ id }) => id === match[1].trim()))
-    .map(match => {
-      let mention = match[1];
-      if (!mention.endsWith(' ')) mention += ' ';
-      return {
-        index: match.index,
-        text: mention,
-        match,
-      };
-    });
-};
-
-const mentionInputMatch = (text, suggestions) => {
-  const match = text.match(/@([\w.-]+)[^\w.-]$/);
-  if (!match || !suggestions.some(({ id }) => id === match[1])) return;
-
-  return {
-    index: match.index,
-    text: match[0],
-    match,
-  };
-};
-
 export const MentionPlugin = Mention.extend({
-  name: 'mention',
-  group: 'inline',
-  inline: true,
 
   addNodeView () {
     return VueNodeViewRenderer(MentionComponent);
@@ -71,34 +39,9 @@ export const MentionPlugin = Mention.extend({
   },
 
   renderHTML ({ HTMLAttributes }) {
-    return ['mention-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)];
+    return ['mention-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
   },
 
-  addInputRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodeInputRule({
-        find: (text) => mentionInputMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].replace('@', '').trim());
-        },
-      }),
-    ];
-  },
-
-  addPasteRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodePasteRule({
-        find: (text) => mentionPasteMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].trim());
-        },
-      }),
-    ];
-  },
 }).configure({
   suggestion: {
     char: '@',

--- a/packages/dialtone-vue2/components/rich_text_editor/mention_suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/mention_suggestion.js
@@ -31,7 +31,7 @@ const CONTACT_LIST = [
     avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
   },
   {
-    id: 'ignacio.Ropolo',
+    id: 'ignacio.ropolo',
     name: 'Ignacio Ropolo',
     avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
   },

--- a/packages/dialtone-vue2/components/rich_text_editor/mention_suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/mention_suggestion.js
@@ -1,26 +1,53 @@
 /* eslint-disable max-len */
+const CONTACT_LIST = [
+  {
+    id: 'test.person',
+    name: 'Test Person',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'test.person2',
+    name: 'Test Person 2',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'test.person3',
+    name: 'Test Person 3',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'brad.paugh',
+    name: 'Brad Paugh',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'bradley.hawkins',
+    name: 'Bradley Hawkins',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'julio.ortega',
+    name: 'Tico Ortega',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'ignacio.Ropolo',
+    name: 'Ignacio Ropolo',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'nina.repetto',
+    name: 'Nina Repetto',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+];
+
 export default {
   items ({ query }) {
-    const CONTACT_LIST = [
-      {
-        id: 'test.person',
-        name: 'Test Person',
-        avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
-      },
-      {
-        id: 'test.person2',
-        name: 'Test Person 2',
-        avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
-      },
-      {
-        id: 'test.person3',
-        name: 'Test Person 3',
-        avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
-      },
-    ];
+    // simulate an API call by waiting 1000 seconds.
+    // new Promise(resolve => setTimeout(resolve, 1000));
 
     if (query.length === 0) return CONTACT_LIST;
-
     return CONTACT_LIST.filter((contact) => { return contact.name.toLowerCase().startsWith(query.toLowerCase()); });
   },
 };

--- a/packages/dialtone-vue2/components/rich_text_editor/mention_suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/mention_suggestion.js
@@ -43,9 +43,9 @@ const CONTACT_LIST = [
 ];
 
 export default {
-  items ({ query }) {
+  async items ({ query }) {
     // simulate an API call by waiting 1000 seconds.
-    // new Promise(resolve => setTimeout(resolve, 1000));
+    await new Promise(resolve => setTimeout(resolve, 1000));
 
     if (query.length === 0) return CONTACT_LIST;
     return CONTACT_LIST.filter((contact) => { return contact.name.toLowerCase().startsWith(query.toLowerCase()); });

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
@@ -13,7 +13,7 @@ import slashCommandSuggestion from './slash_command_suggestion';
 
 // Default Prop Values
 export const argsData = {
-  value: `I am not a standalone component, please use Message Input instead :v_tone3::robot:!`,
+  value: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:" id="270c-1f3fd"></emoji-component><emoji-component code=":robot:" id="1f916"></emoji-component> !</p>',
   editable: true,
   inputAriaLabel: 'This is a descriptive label',
   outputFormat: 'text',
@@ -106,15 +106,14 @@ export const WithLinks = {
   render: (argsData) => createRenderConfig(DtRichTextEditor, DtRichTextEditorDefaultTemplate, argsData),
   args: {
     link: true,
-    value: 'The editor can autolink URLs: dialpad.com, https://www.dialpad.com/about-us/, ' +
-    'IP addresses: 192.158.1.38, email addresses: noreply@dialpad.com and phone numbers: (778) 765-8813, +17787658813!',
+    value: '<p>The editor can autolink URLs: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="http://dialpad.com">dialpad.com</a>, <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="https://www.dialpad.com/about-us/">https://www.dialpad.com/about-us/</a>, email addresses: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="mailto:noreply@dialpad.com">noreply@dialpad.com</a></p>',
   },
 };
 
 export const WithMentionSuggestions = {
   render: (argsData) => createRenderConfig(DtRichTextEditor, DtRichTextEditorDefaultTemplate, argsData),
   args: {
-    value: 'The editor can also suggest mentions: @test.person, @test.person2! and channel suggestions: #dialpad.',
+    value: '<p>The editor can also suggest mentions: <mention-component name="Test Person" avatarsrc="" id="test.person"></mention-component>, <mention-component name="Test Person 2" avatarsrc="" id="test.person2"></mention-component>! and channel suggestions: <channel-component name="dialpad" id="dialpad" locked="false"></channel-component>. The suggestions dropdown will wait 1000ms to simulate an API call.</p>',
     mentionSuggestion,
     channelSuggestion,
     slashCommandSuggestion,

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
@@ -13,10 +13,9 @@ import slashCommandSuggestion from './slash_command_suggestion';
 
 // Default Prop Values
 export const argsData = {
-  value: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:" id="270c-1f3fd"></emoji-component><emoji-component code=":robot:" id="1f916"></emoji-component> !</p>',
+  value: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:"></emoji-component><emoji-component code=":robot:"></emoji-component>!</p>',
   editable: true,
   inputAriaLabel: 'This is a descriptive label',
-  outputFormat: 'text',
   autoFocus: false,
   placeholder: 'Type here...',
   link: true,

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -505,6 +505,10 @@ export default {
       this.addEditorListeners();
     },
 
+    destroyEditor () {
+      this.editor.destroy();
+    },
+
     /**
      * The Editor exposes event hooks that we have to map our emits into. See
      * https://tiptap.dev/api/events for all events.

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -40,8 +40,6 @@ import {
 import mentionSuggestion from './extensions/mentions/suggestion';
 import channelSuggestion from './extensions/channels/suggestion';
 import slashCommandSuggestion from './extensions/slash_command/suggestion';
-import emojiRegex from 'emoji-regex';
-import { codeToEmojiData, emojiShortCodeRegex } from '@/common/emoji';
 
 export default {
   name: 'DtRichTextEditor',

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -122,7 +122,7 @@ export default {
      */
     outputFormat: {
       type: String,
-      default: 'text',
+      default: 'html',
       validator (outputFormat) {
         return RICH_TEXT_EDITOR_OUTPUT_FORMATS.includes(outputFormat);
       },

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -28,8 +28,8 @@ import Text from '@tiptap/extension-text';
 import TextAlign from '@tiptap/extension-text-align';
 import Emoji from './extensions/emoji';
 import CustomLink from './extensions/custom_link';
-import { MentionPlugin, mentionRegex } from './extensions/mentions/mention';
-import { ChannelPlugin, channelRegex } from './extensions/channels/channel';
+import { MentionPlugin } from './extensions/mentions/mention';
+import { ChannelPlugin } from './extensions/channels/channel';
 import { SlashCommandPlugin } from './extensions/slash_command/slash_command';
 import {
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
@@ -472,9 +472,8 @@ export default {
         // through the parent, so don't do anything here.
         return;
       }
-
-      this.internalValue = newValue;
-      this.insertContent();
+      // Otherwise replace the content (resets the cursor position).
+      this.editor.commands.setContent(newValue, false);
     },
   },
 
@@ -495,6 +494,7 @@ export default {
       // For all available options, see https://tiptap.dev/api/editor#settings
       this.editor = new Editor({
         autofocus: this.autoFocus,
+        content: this.value,
         editable: this.editable,
         extensions: this.extensions,
         editorProps: {
@@ -504,77 +504,7 @@ export default {
           },
         },
       });
-      this.insertContent();
       this.addEditorListeners();
-    },
-
-    /**
-     * This function is necessary as tiptap doesn't render the content passed
-     * directly through `editor.commands.setContent` the content passed down to it
-     * should be already parsed. So We're parsing the elements into it's corresponding
-     * HTML version before setting it.
-     */
-    insertContent () {
-      this.parseMentions();
-      this.parseChannels();
-      this.parseEmojis();
-      this.editor.commands.setContent(this.internalValue, true);
-    },
-
-    parseEmojis () {
-      const matches = new Set(
-        [...this.value.matchAll(emojiRegex()), ...this.value.matchAll(emojiShortCodeRegex)]
-          .map(match => match[0].trim()),
-      );
-
-      if (!matches) return;
-
-      matches
-        .forEach(match => {
-          const emoji = codeToEmojiData(match);
-          if (!emoji) return;
-          this.internalValue = this.internalValue.replace(new RegExp(`${match}`, 'g'), `<emoji-component code="${emoji.shortname}"></emoji-component>`);
-        });
-    },
-
-    parseChannels () {
-      if (!this.channelSuggestion) return;
-
-      const suggestions = this.channelSuggestion.items({ query: '' });
-      const matches = [...this.value.matchAll(channelRegex)]
-        .filter(match => suggestions.some(({ id }) => id === match[1]));
-
-      if (!matches) return;
-
-      matches.forEach(match => {
-        const channel = suggestions.find(({ id }) => id === match[1]);
-        this.internalValue = this.internalValue.replace(
-          `#${match[1]}`,
-          /** The space at the beginning is important as tiptap removes that while rendering.
-           *  So if multiple mentions, channels or emojis are next to each other it will fail
-           */
-          ` <channel-component name="${channel.name}" id="${channel.id}"></channel-component>`,
-        );
-      });
-    },
-
-    parseMentions () {
-      if (!this.mentionSuggestion) return;
-
-      const suggestions = this.mentionSuggestion.items({ query: '' });
-      const matches = [...this.value.matchAll(mentionRegex)]
-        .filter(match => suggestions.some(({ id }) => id === match[1]));
-
-      if (!matches) return;
-
-      matches.forEach(match => {
-        const mention = suggestions.find(({ id }) => id === match[1]);
-        this.internalValue = this.internalValue.replace(`@${match[1]}`, ` <mention-component name="${mention.name}" id="${mention.id}"></mention-component>`);
-      });
-    },
-
-    destroyEditor () {
-      this.editor.destroy();
     },
 
     /**

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/channels/channel.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/channels/channel.js
@@ -1,44 +1,13 @@
 import Mention from '@tiptap/extension-mention';
-import { mergeAttributes, nodeInputRule, nodePasteRule } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-3';
 import { PluginKey } from '@tiptap/pm/state';
 
 // Channel Mention component
 import ChannelComponent from './ChannelComponent.vue';
 
-export const channelRegex = /#([\w-]+)[^\w-]?/g;
-
-const channelPasteMatch = (text, suggestions) => {
-  const matches = [...text.matchAll(channelRegex)];
-
-  return matches
-    .filter(match => suggestions.some(({ id }) => id === match[1].trim()))
-    .map(match => {
-      let channel = match[1];
-      if (!channel.endsWith(' ')) channel += ' ';
-      return {
-        index: match.index,
-        text: channel,
-        match,
-      };
-    });
-};
-
-const channelInputMatch = (text, suggestions) => {
-  const match = text.match(/#([\w-]+)[^\w-]$/);
-  if (!match || !suggestions.some(({ id }) => id === match[1])) return;
-
-  return {
-    index: match.index,
-    text: match[0],
-    match,
-  };
-};
-
 export const ChannelPlugin = Mention.extend({
   name: 'channel',
-  group: 'inline',
-  inline: true,
 
   addNodeView () {
     return VueNodeViewRenderer(ChannelComponent);
@@ -71,34 +40,9 @@ export const ChannelPlugin = Mention.extend({
   },
 
   renderHTML ({ HTMLAttributes }) {
-    return ['channel-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)];
+    return ['channel-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
   },
 
-  addInputRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodeInputRule({
-        find: (text) => channelInputMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].replace('#', '').trim());
-        },
-      }),
-    ];
-  },
-
-  addPasteRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodePasteRule({
-        find: (text) => channelPasteMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].trim());
-        },
-      }),
-    ];
-  },
 }).configure({
   suggestion: {
     char: '#',

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/emoji.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/emoji.js
@@ -65,10 +65,6 @@ export const Emoji = Node.create({
       code: {
         default: null,
       },
-
-      id: {
-        default: null,
-      },
     };
   },
 

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/suggestion.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/suggestion.js
@@ -19,7 +19,7 @@ export default {
       }
       return false;
     });
-    return filteredEmoji.map(item => { return { id: item.unicode_character, code: item.shortname }; });
+    return filteredEmoji.map(item => { return { code: item.shortname }; });
   },
 
   command: ({ editor, range, props }) => {

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/suggestion.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/suggestion.js
@@ -77,7 +77,6 @@ export default {
           interactive: true,
           trigger: 'manual',
           placement: 'top-start',
-          contentElement: null,
           zIndex: 650,
         });
       },

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/mention.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/mention.js
@@ -1,39 +1,10 @@
 import Mention from '@tiptap/extension-mention';
-import { mergeAttributes, nodeInputRule, nodePasteRule } from '@tiptap/core';
+import { mergeAttributes } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-3';
 import { PluginKey } from '@tiptap/pm/state';
 
 // Mention component
 import MentionComponent from './MentionComponent.vue';
-
-export const mentionRegex = /@([\w.-]+)[^\w.-]?/g;
-
-const mentionPasteMatch = (text, suggestions) => {
-  const matches = [...text.matchAll(mentionRegex)];
-
-  return matches
-    .filter(match => suggestions.some(({ id }) => id === match[1].trim()))
-    .map(match => {
-      let mention = match[1];
-      if (!mention.endsWith(' ')) mention += ' ';
-      return {
-        index: match.index,
-        text: mention,
-        match,
-      };
-    });
-};
-
-const mentionInputMatch = (text, suggestions) => {
-  const match = text.match(/@([\w.-]+)[^\w.-]$/);
-  if (!match || !suggestions.some(({ id }) => id === match[1])) return;
-
-  return {
-    index: match.index,
-    text: match[0],
-    match,
-  };
-};
 
 export const MentionPlugin = Mention.extend({
 
@@ -68,34 +39,9 @@ export const MentionPlugin = Mention.extend({
   },
 
   renderHTML ({ HTMLAttributes }) {
-    return ['mention-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)];
+    return ['mention-component', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
   },
 
-  addInputRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodeInputRule({
-        find: (text) => mentionInputMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].replace('@', '').trim());
-        },
-      }),
-    ];
-  },
-
-  addPasteRules () {
-    const suggestions = this.options.suggestion?.items({ query: '' });
-    return [
-      nodePasteRule({
-        find: (text) => mentionPasteMatch(text, suggestions),
-        type: this.type,
-        getAttributes (attrs) {
-          return suggestions.find(({ id }) => id === attrs[0].trim());
-        },
-      }),
-    ];
-  },
 }).configure({
   suggestion: {
     char: '@',

--- a/packages/dialtone-vue3/components/rich_text_editor/mention_suggestion.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/mention_suggestion.js
@@ -1,26 +1,53 @@
 /* eslint-disable max-len */
+const CONTACT_LIST = [
+  {
+    id: 'test.person',
+    name: 'Test Person',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'test.person2',
+    name: 'Test Person 2',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'test.person3',
+    name: 'Test Person 3',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'brad.paugh',
+    name: 'Brad Paugh',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'bradley.hawkins',
+    name: 'Bradley Hawkins',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'julio.ortega',
+    name: 'Tico Ortega',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'ignacio.Ropolo',
+    name: 'Ignacio Ropolo',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'nina.repetto',
+    name: 'Nina Repetto',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+];
+
 export default {
-  items ({ query }) {
-    const CONTACT_LIST = [
-      {
-        id: 'test.person',
-        name: 'Test Person',
-        avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
-      },
-      {
-        id: 'test.person2',
-        name: 'Test Person 2',
-        avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
-      },
-      {
-        id: 'test.person3',
-        name: 'Test Person 3',
-        avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
-      },
-    ];
+  async items ({ query }) {
+    // simulate an API call by waiting 1000 seconds.
+    await new Promise(resolve => setTimeout(resolve, 1000));
 
     if (query.length === 0) return CONTACT_LIST;
-
     return CONTACT_LIST.filter((contact) => { return contact.name.toLowerCase().startsWith(query.toLowerCase()); });
   },
 };

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -13,7 +13,7 @@ import slashCommandSuggestion from './slash_command_suggestion';
 
 // Default Prop Values
 export const argsData = {
-  modelValue: `I am not a standalone component, please use Message Input instead :v_tone3::robot:!`,
+  modelValue: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:" id="270c-1f3fd"></emoji-component><emoji-component code=":robot:" id="1f916"></emoji-component> !</p>',
   editable: true,
   inputAriaLabel: 'This is a descriptive label',
   outputFormat: 'text',
@@ -113,15 +113,14 @@ export const WithLinks = {
   ...Default,
   args: {
     link: true,
-    modelValue: 'The editor can autolink URLs: dialpad.com, https://www.dialpad.com/about-us/, ' +
-    'IP addresses: 192.158.1.38, email addresses: noreply@dialpad.com and phone numbers: (778) 765-8813, +17787658813!',
+    modelValue: '<p>The editor can autolink URLs: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="http://dialpad.com">dialpad.com</a>, <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="https://www.dialpad.com/about-us/">https://www.dialpad.com/about-us/</a>, email addresses: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="mailto:noreply@dialpad.com">noreply@dialpad.com</a></p>',
   },
 };
 
 export const WithMentionSuggestions = {
   ...Default,
   args: {
-    modelValue: 'The editor can also suggest mentions: @test.person, @test.person2! and channel suggestions: #dialpad.',
+    modelValue: '<p>The editor can also suggest mentions: <mention-component name="Test Person" avatarsrc="" id="test.person"></mention-component>, <mention-component name="Test Person 2" avatarsrc="" id="test.person2"></mention-component>! and channel suggestions: <channel-component name="dialpad" id="dialpad" locked="false"></channel-component>. The suggestions dropdown will wait 1000ms to simulate an API call.</p>',
     mentionSuggestion,
     channelSuggestion,
     slashCommandSuggestion,

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -13,7 +13,7 @@ import slashCommandSuggestion from './slash_command_suggestion';
 
 // Default Prop Values
 export const argsData = {
-  modelValue: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:" id="270c-1f3fd"></emoji-component><emoji-component code=":robot:" id="1f916"></emoji-component> !</p>',
+  value: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:" id="270c-1f3fd"></emoji-component><emoji-component code=":robot:" id="1f916"></emoji-component> !</p>',
   editable: true,
   inputAriaLabel: 'This is a descriptive label',
   outputFormat: 'text',
@@ -54,7 +54,7 @@ export const argTypesData = {
     },
   },
 
-  modelValue: {
+  value: {
     control: 'text',
   },
 
@@ -113,14 +113,14 @@ export const WithLinks = {
   ...Default,
   args: {
     link: true,
-    modelValue: '<p>The editor can autolink URLs: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="http://dialpad.com">dialpad.com</a>, <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="https://www.dialpad.com/about-us/">https://www.dialpad.com/about-us/</a>, email addresses: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="mailto:noreply@dialpad.com">noreply@dialpad.com</a></p>',
+    value: '<p>The editor can autolink URLs: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="http://dialpad.com">dialpad.com</a>, <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="https://www.dialpad.com/about-us/">https://www.dialpad.com/about-us/</a>, email addresses: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="mailto:noreply@dialpad.com">noreply@dialpad.com</a></p>',
   },
 };
 
 export const WithMentionSuggestions = {
   ...Default,
   args: {
-    modelValue: '<p>The editor can also suggest mentions: <mention-component name="Test Person" avatarsrc="" id="test.person"></mention-component>, <mention-component name="Test Person 2" avatarsrc="" id="test.person2"></mention-component>! and channel suggestions: <channel-component name="dialpad" id="dialpad" locked="false"></channel-component>. The suggestions dropdown will wait 1000ms to simulate an API call.</p>',
+    value: '<p>The editor can also suggest mentions: <mention-component name="Test Person" avatarsrc="" id="test.person"></mention-component>, <mention-component name="Test Person 2" avatarsrc="" id="test.person2"></mention-component>! and channel suggestions: <channel-component name="dialpad" id="dialpad" locked="false"></channel-component>. The suggestions dropdown will wait 1000ms to simulate an API call.</p>',
     mentionSuggestion,
     channelSuggestion,
     slashCommandSuggestion,

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -13,7 +13,7 @@ import slashCommandSuggestion from './slash_command_suggestion';
 
 // Default Prop Values
 export const argsData = {
-  value: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:" id="270c-1f3fd"></emoji-component><emoji-component code=":robot:" id="1f916"></emoji-component> !</p>',
+  modelValue: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:" id="270c-1f3fd"></emoji-component><emoji-component code=":robot:" id="1f916"></emoji-component> !</p>',
   editable: true,
   inputAriaLabel: 'This is a descriptive label',
   outputFormat: 'text',
@@ -54,7 +54,7 @@ export const argTypesData = {
     },
   },
 
-  value: {
+  modelValue: {
     control: 'text',
   },
 
@@ -113,14 +113,14 @@ export const WithLinks = {
   ...Default,
   args: {
     link: true,
-    value: '<p>The editor can autolink URLs: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="http://dialpad.com">dialpad.com</a>, <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="https://www.dialpad.com/about-us/">https://www.dialpad.com/about-us/</a>, email addresses: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="mailto:noreply@dialpad.com">noreply@dialpad.com</a></p>',
+    modelValue: '<p>The editor can autolink URLs: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="http://dialpad.com">dialpad.com</a>, <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="https://www.dialpad.com/about-us/">https://www.dialpad.com/about-us/</a>, email addresses: <a target="_blank" rel="noopener noreferrer nofollow" class="d-link d-wb-break-all" href="mailto:noreply@dialpad.com">noreply@dialpad.com</a></p>',
   },
 };
 
 export const WithMentionSuggestions = {
   ...Default,
   args: {
-    value: '<p>The editor can also suggest mentions: <mention-component name="Test Person" avatarsrc="" id="test.person"></mention-component>, <mention-component name="Test Person 2" avatarsrc="" id="test.person2"></mention-component>! and channel suggestions: <channel-component name="dialpad" id="dialpad" locked="false"></channel-component>. The suggestions dropdown will wait 1000ms to simulate an API call.</p>',
+    modelValue: '<p>The editor can also suggest mentions: <mention-component name="Test Person" avatarsrc="" id="test.person"></mention-component>, <mention-component name="Test Person 2" avatarsrc="" id="test.person2"></mention-component>! and channel suggestions: <channel-component name="dialpad" id="dialpad" locked="false"></channel-component>. The suggestions dropdown will wait 1000ms to simulate an API call.</p>',
     mentionSuggestion,
     channelSuggestion,
     slashCommandSuggestion,

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -13,10 +13,9 @@ import slashCommandSuggestion from './slash_command_suggestion';
 
 // Default Prop Values
 export const argsData = {
-  modelValue: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:" id="270c-1f3fd"></emoji-component><emoji-component code=":robot:" id="1f916"></emoji-component> !</p>',
+  modelValue: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:"></emoji-component><emoji-component code=":robot:"></emoji-component>!</p>',
   editable: true,
   inputAriaLabel: 'This is a descriptive label',
-  outputFormat: 'text',
   autoFocus: false,
   placeholder: 'Type here...',
   link: true,

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -53,7 +53,7 @@ export default {
      * Value of the input. The object format should match TipTap's JSON
      * document structure: https://tiptap.dev/guide/output#option-1-json
      */
-    value: {
+    modelValue: {
       type: [Object, String],
       default: '',
     },
@@ -459,7 +459,7 @@ export default {
       this.createEditor();
     },
 
-    value (newValue) {
+    modelValue (newValue) {
       let currentValue = this.getOutput();
       if (this.outputFormat === 'json') {
         newValue = JSON.stringify(newValue);
@@ -492,7 +492,7 @@ export default {
       // For all available options, see https://tiptap.dev/api/editor#settings
       this.editor = new Editor({
         autofocus: this.autoFocus,
-        content: this.value,
+        content: this.modelValue,
         editable: this.editable,
         extensions: this.extensions,
         editorProps: {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -505,6 +505,10 @@ export default {
       this.addEditorListeners();
     },
 
+    destroyEditor () {
+      this.editor.destroy();
+    },
+
     /**
      * The Editor exposes event hooks that we have to map our emits into. See
      * https://tiptap.dev/api/events for all events.

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -40,8 +40,6 @@ import {
 import mentionSuggestion from './extensions/mentions/suggestion';
 import channelSuggestion from './extensions/channels/suggestion';
 import slashCommandSuggestion from './extensions/slash_command/suggestion';
-import emojiRegex from 'emoji-regex';
-import { codeToEmojiData, emojiShortCodeRegex } from '@/common/emoji';
 
 export default {
   name: 'DtRichTextEditor',

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -53,7 +53,7 @@ export default {
      * Value of the input. The object format should match TipTap's JSON
      * document structure: https://tiptap.dev/guide/output#option-1-json
      */
-    modelValue: {
+    value: {
       type: [Object, String],
       default: '',
     },
@@ -459,7 +459,7 @@ export default {
       this.createEditor();
     },
 
-    modelValue (newValue) {
+    value (newValue) {
       let currentValue = this.getOutput();
       if (this.outputFormat === 'json') {
         newValue = JSON.stringify(newValue);

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -122,7 +122,7 @@ export default {
      */
     outputFormat: {
       type: String,
-      default: 'text',
+      default: 'html',
       validator (outputFormat) {
         return RICH_TEXT_EDITOR_OUTPUT_FORMATS.includes(outputFormat);
       },

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
@@ -1,6 +1,6 @@
 <template>
   <dt-rich-text-editor
-    v-model="$attrs.modelValue"
+    v-model="value"
     :editable="$attrs.editable"
     :input-aria-label="$attrs.inputAriaLabel"
     :input-class="$attrs.inputClass"
@@ -32,6 +32,18 @@ export default {
 
   components: {
     DtRichTextEditor,
+  },
+
+  data () {
+    return {
+      value: this.$attrs.value,
+    };
+  },
+
+  watch: {
+    '$attrs.value' (value) {
+      this.value = value;
+    },
   },
 };
 </script>

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
@@ -36,12 +36,12 @@ export default {
 
   data () {
     return {
-      value: this.$attrs.value,
+      value: this.$attrs.modelValue,
     };
   },
 
   watch: {
-    '$attrs.value' (value) {
+    '$attrs.modelValue' (value) {
       this.value = value;
     },
   },


### PR DESCRIPTION
# fix(rich-text-editor): DLT-1752 remove custom parsing

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXh2MXJ0bWpoem95ejZocXd0Z21qZTJnanJqenhyeGlsdno5OXBnZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ely3apij36BJhoZ234/giphy-downsized-large.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1752

## :book: Description

- Removed the code we put in previously to parse mentions on programmatic input.
- Added an async wait into the mentions example.

## :bulb: Context

What we were doing here with the parsing is not really the way TipTap is supposed to work. TipTap fully supports doing this on it's own, however you have to pass in input that it understands which is HTML or JSON input. see: https://tiptap.dev/docs/editor/guide/output

To do this properly we have to change our backend to support TipTaps html or json output and use that to populate the input. I talked to Bianca and they have agreed to update the backend to be able to handle this. For now we will just not parse links / mentions live in the input which is actually the way it works currently in production.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

Check if all TipTap formatting will work correctly after the server side changes have been made

## :link: Sources

https://tiptap.dev/docs/editor/guide/output
https://tiptap.dev/docs/editor/api/utilities/html#generate-html-from-json
