### PR TITLE
docs(button): NO-JIRA add disabled class docs back into examples

### DIFF
--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -290,17 +290,32 @@ All button styles and variations appear the same when disabled.
 <code-well-header>
   <div class="d-d-flex d-flow8">
     <div>
-      <button type="button" disabled="disabled" class="base-button__button d-btn d-btn--primary"><span class="d-btn__label base-button__label">Place call</span></button>
+      <button type="button" disabled="disabled" class="base-button__button d-btn d-btn--primary"><span class="d-btn__label base-button__label">Place call (disabled attribute)</span></button>
+    </div>
+    <div>
+      <span class="d-c-not-allowed">
+        <button type="button" class="base-button__button d-btn d-btn--primary d-btn--disabled"><span class="d-btn__label base-button__label">Place call (disabled class)</span></button>
+      </span>
     </div>
   </div>
 </code-well-header>
 
 <code-example-tabs
 htmlCode='
+<!-- disabled attribute -->
 <button class="d-btn" type="button" disabled><span class="d-btn__label">...</span></button>
+<!-- disabled class -->
+<span class="d-c-not-allowed">
+  <button type="button" class="base-button__button d-btn d-btn--primary d-btn--disabled"><span class="d-btn__label base-button__label">...</span></button>
+</span>
 '
 vueCode='
-<dt-button disabled> Place call </dt-button>
+<!-- disabled attribute -->
+<dt-button disabled>Place call</dt-button>
+<!-- disabled class -->
+<span class="d-c-not-allowed">
+  <dt-button class="d-btn--disabled">Place call</dt-button>
+</span>
 '
 showHtmlWarning />
 
@@ -495,7 +510,7 @@ htmlCode='
 </button>
 '
 vueCode='
-<!-- icon-position can be "right/top/bottom" , 
+<!-- icon-position can be "right/top/bottom" ,
      no icon-position will be left -->
 <dt-button importance="outlined" icon-position="right">
   <template #icon>


### PR DESCRIPTION
# docs(button): NO-JIRA add disabled class docs back into examples

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcDlqNXNtdzRia2wyZnFleG1nbmNkem0xa2Iwcm5ycjZ3ZXR6NnVldSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/nNxT5qXR02FOM/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Description

We removed the disabled class example on our docs page update of button component. Adding it back in as this is commonly used and we get a lot of questions about it (how to trigger a tooltip on a disabled button)

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
