### PR TITLE
docs: NO-JIRA update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,6 @@ All separate packages of dialtone are also deployed individually.
 If you would like to use an individual package rather than the combined Dialtone package,
 you can find documentation for each package in the following table.
 
-## Available packages
-
-| Name                                                             | Description                                                                                                                                        | Version                                                                                                   |
-|------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
-| [Dialtone](README.md)                                            | Combined package containing the latest versions of the libraries for ease of use                                                                   | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone?logo=npm&color=7C52FF)                  |
-| [Dialtone CSS](packages/dialtone-css/README.md)                  | Classes or styles used within Dialtone should be stored here and documented on our site under `apps/dialtone-documentation`                        | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-css?logo=npm&color=7C52FF)              |
-| [Dialtone emojis](packages/dialtone-emojis/README.md)            | Emoji assets                                                                                                                                       | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-emojis?logo=npm&color=7C52FF)           |
-| [Dialtone icons](packages/dialtone-icons/README.md)              | Resources needed to implement icons on your application that conform to Dialpad’s design principles and best practices                             | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-icons?logo=npm&color=7C52FF)            |
-| [Dialtone tokens](packages/dialtone-tokens/README.md)            | Design tokens for Dialpad's design system Dialtone and everything related to building and publishing them                                          | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-tokens?logo=npm&color=7C52FF)           |
-| [Dialtone vue 2](packages/dialtone-vue2/README.md)               | Vue components library to simplify and standardize the use of common UI patterns and behaviour across all Dialpad projects (compatible with Vue 2) | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-vue?logo=npm&color=7C52FF)              |
-| [Dialtone vue 3](packages/dialtone-vue3/README.md)               | Vue components library to simplify and standardize the use of common UI patterns and behaviour across all Dialpad projects (compatible with Vue 3) | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-vue/vue3?logo=npm&color=7C52FF)         |
-| [ESlint plugin](packages/eslint-plugin-dialtone/README.md)       | ESLint plugin containing rules to help developers maintain dialtone recommended practices                                                          | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Feslint-plugin-dialtone?logo=npm&color=7C52FF)    |
-| [Stylelint plugin](packages/stylelint-plugin-dialtone/README.md) | StyleLint plugin containing rules to help developers maintain dialtone recommended practices for CSS                                               | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fstylelint-plugin-dialtone?logo=npm&color=7C52FF) |
-
 ## Usage
 
 The below usage instructions are for the combined package.
@@ -167,6 +153,20 @@ dialtone/
   |--- stylelint-plugin-dialtone  # Custom Stylelint rules for Dialtone users
 |--- scripts                      # Shared scripts
 ```
+
+### Available packages
+
+| Name                                                             | Description                                                                                                                                        | Version                                                                                                   |
+|------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| [Dialtone](README.md)                                            | Combined package containing the latest versions of the libraries for ease of use                                                                   | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone?logo=npm&color=7C52FF)                  |
+| [Dialtone CSS](packages/dialtone-css/README.md)                  | Classes or styles used within Dialtone should be stored here and documented on our site under `apps/dialtone-documentation`                        | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-css?logo=npm&color=7C52FF)              |
+| [Dialtone emojis](packages/dialtone-emojis/README.md)            | Emoji assets                                                                                                                                       | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-emojis?logo=npm&color=7C52FF)           |
+| [Dialtone icons](packages/dialtone-icons/README.md)              | Resources needed to implement icons on your application that conform to Dialpad’s design principles and best practices                             | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-icons?logo=npm&color=7C52FF)            |
+| [Dialtone tokens](packages/dialtone-tokens/README.md)            | Design tokens for Dialpad's design system Dialtone and everything related to building and publishing them                                          | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-tokens?logo=npm&color=7C52FF)           |
+| [Dialtone vue 2](packages/dialtone-vue2/README.md)               | Vue components library to simplify and standardize the use of common UI patterns and behaviour across all Dialpad projects (compatible with Vue 2) | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-vue?logo=npm&color=7C52FF)              |
+| [Dialtone vue 3](packages/dialtone-vue3/README.md)               | Vue components library to simplify and standardize the use of common UI patterns and behaviour across all Dialpad projects (compatible with Vue 3) | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-vue/vue3?logo=npm&color=7C52FF)         |
+| [ESlint plugin](packages/eslint-plugin-dialtone/README.md)       | ESLint plugin containing rules to help developers maintain dialtone recommended practices                                                          | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Feslint-plugin-dialtone?logo=npm&color=7C52FF)    |
+| [Stylelint plugin](packages/stylelint-plugin-dialtone/README.md) | StyleLint plugin containing rules to help developers maintain dialtone recommended practices for CSS                                               | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fstylelint-plugin-dialtone?logo=npm&color=7C52FF) |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,27 @@
 
 The monorepo for Dialpad's design system Dialtone.
 
-All packages of the monorepo are combined into a single Dialtone package for ease of use, however all separate packages of dialtone are also deployed individually. If you would like to use an individual package rather than the combined Dialtone package, you can find documentation for each package in the readme under the respective packages folder. The below usage instructions are for the combined package.
+All separate packages of dialtone are also deployed individually.
+If you would like to use an individual package rather than the combined Dialtone package,
+you can find documentation for each package in the following table.
+
+## Available packages
+
+| Name                                                             | Description                                                                                                                                        | Version                                                                                                   |
+|------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| [Dialtone](README.md)                                            | Combined package containing the latest versions of the libraries for ease of use                                                                   | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone?logo=npm&color=7C52FF)                  |
+| [Dialtone CSS](packages/dialtone-css/README.md)                  | Classes or styles used within Dialtone should be stored here and documented on our site under `apps/dialtone-documentation`                        | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-css?logo=npm&color=7C52FF)              |
+| [Dialtone emojis](packages/dialtone-emojis/README.md)            | Emoji assets                                                                                                                                       | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-emojis?logo=npm&color=7C52FF)           |
+| [Dialtone icons](packages/dialtone-icons/README.md)              | Resources needed to implement icons on your application that conform to Dialpad’s design principles and best practices                             | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-icons?logo=npm&color=7C52FF)            |
+| [Dialtone tokens](packages/dialtone-tokens/README.md)            | Design tokens for Dialpad's design system Dialtone and everything related to building and publishing them                                          | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-tokens?logo=npm&color=7C52FF)           |
+| [Dialtone vue 2](packages/dialtone-vue2/README.md)               | Vue components library to simplify and standardize the use of common UI patterns and behaviour across all Dialpad projects (compatible with Vue 2) | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-vue?logo=npm&color=7C52FF)              |
+| [Dialtone vue 3](packages/dialtone-vue3/README.md)               | Vue components library to simplify and standardize the use of common UI patterns and behaviour across all Dialpad projects (compatible with Vue 3) | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fdialtone-vue/vue3?logo=npm&color=7C52FF)         |
+| [ESlint plugin](packages/eslint-plugin-dialtone/README.md)       | ESLint plugin containing rules to help developers maintain dialtone recommended practices                                                          | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Feslint-plugin-dialtone?logo=npm&color=7C52FF)    |
+| [Stylelint plugin](packages/stylelint-plugin-dialtone/README.md) | StyleLint plugin containing rules to help developers maintain dialtone recommended practices for CSS                                               | ![NPM Version](https://img.shields.io/npm/v/%40dialpad%2Fstylelint-plugin-dialtone?logo=npm&color=7C52FF) |
 
 ## Usage
+
+The below usage instructions are for the combined package.
 
 ### Install it via NPM:
 

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Home.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Home.vue
@@ -10,95 +10,16 @@
           Documented styles, components, and utility classes to help you quickly design and build unified experiences
           across Dialpad experiences.
         </p>
-        <div class="d-mb32 d-d-flex d-jc-center d-gg8 d-w100p d-fw-wrap">
-          <!-- Dialtone -->
+        <div class="d-mb32 d-d-flex d-jc-flex-start">
           <a
             class="d-td-unset d-d-inline-flex"
-            href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone"
+            href="https://github.com/dialpad/dialtone"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             <img
               alt="Dialtone version number"
               src="https://img.shields.io/npm/v/@dialpad/dialtone?color=D3BCFF&label=Dialtone"
-            >
-          </a>
-          <!-- Dialtone CSS -->
-          <a
-            class="d-td-unset d-d-inline-flex"
-            href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone-css"
-          >
-            <img
-              alt="Dialtone CSS version number"
-              src="https://img.shields.io/npm/v/@dialpad/dialtone-css?color=D3BCFF&label=CSS"
-            >
-          </a>
-          <!-- Dialtone Emojis -->
-          <a
-            class="d-td-unset d-d-inline-flex"
-            href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone-emojis"
-          >
-            <img
-              alt="Dialtone Emojis version number"
-              src="https://img.shields.io/npm/v/@dialpad/dialtone-emojis?color=D3BCFF&label=Emojis"
-            >
-          </a>
-          <!-- Dialtone Icons -->
-          <a
-            class="d-td-unset d-d-inline-flex"
-            href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone-icons"
-          >
-            <img
-              alt="Dialtone Icons version number"
-              src="https://img.shields.io/npm/v/@dialpad/dialtone-icons?color=D3BCFF&label=Icons"
-            >
-          </a>
-          <!-- Dialtone Tokens -->
-          <a
-            class="d-td-unset d-d-inline-flex"
-            href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone-tokens"
-          >
-            <img
-              alt="Dialtone Tokens version number"
-              src="https://img.shields.io/npm/v/@dialpad/dialtone-tokens?color=D3BCFF&label=Tokens"
-            >
-          </a>
-          <!-- Dialtone Vue@latest -->
-          <a
-            class="d-td-unset d-d-inline-flex"
-            href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone-vue2"
-          >
-            <img
-              alt="Dialtone Vue version number"
-              src="https://img.shields.io/npm/v/@dialpad/dialtone-vue?color=D3BCFF&label=Vue"
-            >
-          </a>
-          <!-- Dialtone Vue@3 -->
-          <a
-            class="d-td-unset d-d-inline-flex"
-            href="https://github.com/dialpad/dialtone/tree/packages/dialtone-vue3"
-          >
-            <img
-              alt="Dialtone Vue version number"
-              src="https://img.shields.io/npm/v/%40dialpad/dialtone-vue/vue3?color=D3BCFF&label=Vue 3"
-            >
-          </a>
-          <!-- Dialtone ESlint plugin -->
-          <a
-            class="d-td-unset d-d-inline-flex"
-            href="https://github.com/dialpad/dialtone/tree/staging/packages/eslint-plugin-dialtone"
-          >
-            <img
-              alt="Dialtone ESlint plugin version number"
-              src="https://img.shields.io/npm/v/@dialpad/eslint-plugin-dialtone?color=D3BCFF&label=ESlint%20plugin"
-            >
-          </a>
-          <!-- Dialtone Stylelint plugin -->
-          <a
-            class="d-td-unset d-d-inline-flex"
-            href="https://github.com/dialpad/dialtone/tree/staging/packages/stylelint-plugin-dialtone"
-          >
-            <img
-              alt="Dialtone Stylelint plugin version number"
-              src="https://img.shields.io/npm/v/@dialpad/stylelint-plugin-dialtone?color=D3BCFF&label=Stylelint%20plugin"
             >
           </a>
         </div>

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Home.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Home.vue
@@ -10,32 +10,95 @@
           Documented styles, components, and utility classes to help you quickly design and build unified experiences
           across Dialpad experiences.
         </p>
-        <div class="d-mb32 d-d-flex d-jc-center d-flow8">
+        <div class="d-mb32 d-d-flex d-jc-center d-gg8 d-w100p d-fw-wrap">
+          <!-- Dialtone -->
           <a
             class="d-td-unset d-d-inline-flex"
-            href="https://github.com/dialpad/dialtone/"
+            href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone"
+          >
+            <img
+              alt="Dialtone version number"
+              src="https://img.shields.io/npm/v/@dialpad/dialtone?color=D3BCFF&label=Dialtone"
+            >
+          </a>
+          <!-- Dialtone CSS -->
+          <a
+            class="d-td-unset d-d-inline-flex"
+            href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone-css"
           >
             <img
               alt="Dialtone CSS version number"
-              src="https://img.shields.io/github/package-json/v/dialpad/dialtone?color=D3BCFF&label=CSS"
+              src="https://img.shields.io/npm/v/@dialpad/dialtone-css?color=D3BCFF&label=CSS"
             >
           </a>
+          <!-- Dialtone Emojis -->
           <a
             class="d-td-unset d-d-inline-flex"
-            href="https://github.com/dialpad/dialtone-vue"
+            href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone-emojis"
+          >
+            <img
+              alt="Dialtone Emojis version number"
+              src="https://img.shields.io/npm/v/@dialpad/dialtone-emojis?color=D3BCFF&label=Emojis"
+            >
+          </a>
+          <!-- Dialtone Icons -->
+          <a
+            class="d-td-unset d-d-inline-flex"
+            href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone-icons"
+          >
+            <img
+              alt="Dialtone Icons version number"
+              src="https://img.shields.io/npm/v/@dialpad/dialtone-icons?color=D3BCFF&label=Icons"
+            >
+          </a>
+          <!-- Dialtone Tokens -->
+          <a
+            class="d-td-unset d-d-inline-flex"
+            href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone-tokens"
+          >
+            <img
+              alt="Dialtone Tokens version number"
+              src="https://img.shields.io/npm/v/@dialpad/dialtone-tokens?color=D3BCFF&label=Tokens"
+            >
+          </a>
+          <!-- Dialtone Vue@latest -->
+          <a
+            class="d-td-unset d-d-inline-flex"
+            href="https://github.com/dialpad/dialtone/tree/staging/packages/dialtone-vue2"
           >
             <img
               alt="Dialtone Vue version number"
-              src="https://img.shields.io/github/package-json/v/dialpad/dialtone-vue?color=D3BCFF&label=Vue"
+              src="https://img.shields.io/npm/v/@dialpad/dialtone-vue?color=D3BCFF&label=Vue"
             >
           </a>
+          <!-- Dialtone Vue@3 -->
           <a
             class="d-td-unset d-d-inline-flex"
-            href="https://github.com/dialpad/dialtone-vue/tree/vue3"
+            href="https://github.com/dialpad/dialtone/tree/packages/dialtone-vue3"
           >
             <img
               alt="Dialtone Vue version number"
-              src="https://img.shields.io/github/package-json/v/dialpad/dialtone-vue/vue3?color=D3BCFF&label=Vue 3"
+              src="https://img.shields.io/npm/v/%40dialpad/dialtone-vue/vue3?color=D3BCFF&label=Vue 3"
+            >
+          </a>
+          <!-- Dialtone ESlint plugin -->
+          <a
+            class="d-td-unset d-d-inline-flex"
+            href="https://github.com/dialpad/dialtone/tree/staging/packages/eslint-plugin-dialtone"
+          >
+            <img
+              alt="Dialtone ESlint plugin version number"
+              src="https://img.shields.io/npm/v/@dialpad/eslint-plugin-dialtone?color=D3BCFF&label=ESlint%20plugin"
+            >
+          </a>
+          <!-- Dialtone Stylelint plugin -->
+          <a
+            class="d-td-unset d-d-inline-flex"
+            href="https://github.com/dialpad/dialtone/tree/staging/packages/stylelint-plugin-dialtone"
+          >
+            <img
+              alt="Dialtone Stylelint plugin version number"
+              src="https://img.shields.io/npm/v/@dialpad/stylelint-plugin-dialtone?color=D3BCFF&label=Stylelint%20plugin"
             >
           </a>
         </div>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start:dialtone-vue3": "nx run-many --target=start --projects=dialtone-css,dialtone-vue3",
     "start:dialtone-vue2": "nx run-many --target=start --projects=dialtone-css,dialtone-vue2",
     "prepare": "husky install",
+    "prepack": "nx build",
     "test:vue": "vitest run --test-timeout=10000"
   },
   "pnpm": {

--- a/packages/dialtone-emojis/README.md
+++ b/packages/dialtone-emojis/README.md
@@ -1,0 +1,3 @@
+# Dialtone Emojis
+
+This is the home for Dialtone emojis.


### PR DESCRIPTION
# Update badges

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/zWoUfSLyygqPegeoMJ/giphy.gif?cid=ecf05e47437dx9uckb01tj9ki6sx33sd9j0bajq0vxgrbg3v&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Description

- Updated dialtone badge on Homepage.
- Updated README to include a table with links to packages documentation, description and latest version badge.
- Added `prepack` script to build the packages with `nx build` before packing with `pnpm pack`.
- Added basic README to packages/dialtone-emojis

## :bulb: Context

Found outdated badges on Homepage

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.