### PR TITLE
feat(badge): DLT-1777 subtle and outlined variants

### DIFF
--- a/apps/dialtone-documentation/docs/components/badge.md
+++ b/apps/dialtone-documentation/docs/components/badge.md
@@ -25,10 +25,12 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 - To flag and draw awareness to a specific element or feature of focus. For example, something is unique about that separates it from other like content.
 - As a notification system with minimal footprint.
 </template>
+
 <template #dont>
 
 - To indicate that interaction by the user is required.
 </template>
+
 </dialtone-usage>
 
 ### Best practices
@@ -52,7 +54,7 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 htmlCode='
 <span class="d-badge"><span class="d-badge__label">Label</span></span>'
 vueCode='
-<dt-badge type="default" kind="label" text="Label" />
+<dt-badge text="Label" />
 '
 showHtmlWarning />
 
@@ -66,7 +68,7 @@ showHtmlWarning />
 htmlCode='
 <span class="d-badge d-badge--count"><span class="d-badge__label">1</span></span>'
 vueCode='
-<dt-badge type="default" kind="count" default="1" />
+<dt-badge kind="count" text="1" />
 '
 showHtmlWarning />
 
@@ -180,7 +182,7 @@ htmlCode='
 <span class="d-badge d-badge--count d-badge--bulletin"><span class="d-badge__label">6</span></span>
 '
 vueCode='
-<dt-badge type="default" kind="label" text="Label" />
+<dt-badge kind="label" text="Label" />
 <dt-badge type="info" kind="label" text="Label" />
 <dt-badge type="success" kind="label" text="Label" />
 <dt-badge type="warning" kind="label" text="Label" />
@@ -188,11 +190,11 @@ vueCode='
 <dt-badge type="bulletin" kind="label" text="Label" />
 <dt-badge type="ai" text="Label" kind="label" icon-left="dialpad-ai" />
 <dt-badge type="default" text="1" kind="count" />
-<dt-badge type="info" text="1" kind="count" />
-<dt-badge type="success" text="1" kind="count" />
-<dt-badge type="warning" text="1" kind="count" />
-<dt-badge type="critical" text="1" kind="count" />
-<dt-badge type="bulletin" text="1" kind="count" />
+<dt-badge type="info" text="2" kind="count" />
+<dt-badge type="success" text="3" kind="count" />
+<dt-badge type="warning" text="4" kind="count" />
+<dt-badge type="critical" text="5" kind="count" />
+<dt-badge type="bulletin" text="6" kind="count" />
 '
 showHtmlWarning />
 
@@ -227,7 +229,16 @@ htmlCode='
 <span class="d-badge d-badge--critical d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
 '
 vueCode='
-(TBD)
+<dt-badge text="Label" outlined />
+<dt-badge text="Label" type="info" outlined />
+<dt-badge text="Label" type="success" outlined />
+<dt-badge text="Label" type="warning" outlined />
+<dt-badge text="Label" type="critical" outlined />
+<dt-badge text="1" kind="count" outlined />
+<dt-badge text="1" type="info" kind="count" outlined />
+<dt-badge text="1" type="success" kind="count" outlined />
+<dt-badge text="1" type="warning" kind="count" outlined />
+<dt-badge text="1" type="critical" kind="count" outlined />
 '
 showHtmlWarning />
 
@@ -252,7 +263,10 @@ htmlCode='
 <span class="d-badge d-badge--bulletin d-badge--subtle d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
 '
 vueCode='
-(TBD)
+<dt-badge text="Label" type="bulletin" subtle />
+<dt-badge text="Label" type="bulletin" subtle outlined />
+<dt-badge text="1" type="bulletin" subtle kind="count" />
+<dt-badge text="1" type="bulletin" subtle kind="count" outlined />
 '
 showHtmlWarning />
 
@@ -387,6 +401,7 @@ showHtmlWarning />
 
 - Use for categories of items with a limited number of options (eg. call categories, AI moments).
 </template>
+
 <template #dont>
 
 - Use for categories of items with an unlimited or unknown number of options (eg. user-defined contact labels, RTA cards, contact centers).
@@ -397,6 +412,7 @@ showHtmlWarning />
 - Change the customize the Badge's background color text style,
 - Extend the decorative slot color beyond what Dialtone provides.
 </template>
+
 </dialtone-usage>
 
 ### Best practices

--- a/apps/dialtone-documentation/docs/components/badge.md
+++ b/apps/dialtone-documentation/docs/components/badge.md
@@ -196,6 +196,66 @@ vueCode='
 '
 showHtmlWarning />
 
+## Outlined
+
+<code-well-header bgclass="d-bgc-primary">
+  <dt-stack direction="row" gap="400">
+    <span class="d-badge d-badge--outlined"><span class="d-badge__label">Label</span></span>
+    <span class="d-badge d-badge--info d-badge--outlined"><span class="d-badge__label">Label</span></span>
+    <span class="d-badge d-badge--success d-badge--outlined"><span class="d-badge__label">Label</span></span>
+    <span class="d-badge d-badge--warning d-badge--outlined"><span class="d-badge__label">Label</span></span>
+    <span class="d-badge d-badge--critical d-badge--outlined"><span class="d-badge__label">Label</span></span>
+    <span class="d-badge d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
+    <span class="d-badge d-badge--info d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
+    <span class="d-badge d-badge--success d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
+    <span class="d-badge d-badge--warning d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
+    <span class="d-badge d-badge--critical d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
+  </dt-stack>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-badge d-badge--outlined"><span class="d-badge__label">Label</span></span>
+<span class="d-badge d-badge--info d-badge--outlined"><span class="d-badge__label">Label</span></span>
+<span class="d-badge d-badge--success d-badge--outlined"><span class="d-badge__label">Label</span></span>
+<span class="d-badge d-badge--warning d-badge--outlined"><span class="d-badge__label">Label</span></span>
+<span class="d-badge d-badge--critical d-badge--outlined"><span class="d-badge__label">Label</span></span>
+<span class="d-badge d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
+<span class="d-badge d-badge--info d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
+<span class="d-badge d-badge--success d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
+<span class="d-badge d-badge--warning d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
+<span class="d-badge d-badge--critical d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
+'
+vueCode='
+(TBD)
+'
+showHtmlWarning />
+
+## Subtle
+
+At the moment, only the `bulletin` type has a subtle variant.
+
+<code-well-header>
+  <dt-stack direction="row" gap="400">
+    <span class="d-badge d-badge--bulletin d-badge--subtle"><span class="d-badge__label">Label</span></span>
+    <span class="d-badge d-badge--bulletin d-badge--subtle d-badge--outlined"><span class="d-badge__label">Label</span></span>
+    <span class="d-badge d-badge--bulletin d-badge--subtle d-badge--count"><span class="d-badge__label">1</span></span>
+    <span class="d-badge d-badge--bulletin d-badge--subtle d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
+  </dt-stack>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-badge d-badge--bulletin d-badge--subtle"><span class="d-badge__label">Label</span></span>
+<span class="d-badge d-badge--bulletin d-badge--subtle d-badge--outlined"><span class="d-badge__label">Label</span></span>
+<span class="d-badge d-badge--bulletin d-badge--subtle d-badge--count"><span class="d-badge__label">1</span></span>
+<span class="d-badge d-badge--bulletin d-badge--subtle d-badge--count d-badge--outlined"><span class="d-badge__label">1</span></span>
+'
+vueCode='
+(TBD)
+'
+showHtmlWarning />
+
 ## Icon
 
 <code-well-header bgclass="d-bgc-primary">

--- a/packages/dialtone-css/lib/build/less/components/badge.less
+++ b/packages/dialtone-css/lib/build/less/components/badge.less
@@ -22,6 +22,7 @@
   //  --------------------------------------------------------------------------
   --badge-color-text: var(--dt-badge-color-foreground-default);
   --badge-color-background: var(--dt-badge-color-background-default);
+  --badge-color-outline: var(--dt-color-border-subtle);
   --badge-radius: var(--dt-size-300);
   --badge-line-height: calc(var(--dt-size-500) + var(--dt-size-200));
   --badge-font-size: var(--dt-font-size-100);
@@ -82,6 +83,17 @@
   &--bulletin {
     --badge-color-text: var(--dt-badge-color-foreground-bulletin);
     --badge-color-background: var(--dt-badge-color-background-bulletin);
+
+    &.d-badge--subtle {
+      --badge-color-text: hsl(var(--primary-color-h) var(--primary-color-s) calc(var(--primary-color-l) - 40%));
+      --badge-color-background: hsla(var(--primary-color-hsl) / 0.1);
+      --badge-color-outline: hsla(var(--primary-color-hsl) / 0.5);
+
+      .dialtone-theme-dark & {
+        --badge-color-text: var(--dt-color-foreground-primary);
+        --badge-color-background: hsla(var(--primary-color-hsl) / 0.6);
+      }
+    }
   }
 
   &--ai {
@@ -91,6 +103,12 @@
     background-image: var(--dt-badge-color-background-ai);
   }
 
+  &--outlined {
+    box-shadow: 0 0 0 var(--dt-size-border-150) var(--badge-color-outline) inset;
+  }
+
+  //  DECORATIVE
+  //  --------------------------------------------------------------------------
   &--decorate-black-400 { --badge-decorative-color: var(--dt-color-black-400); }
   &--decorate-black-500 { --badge-decorative-color: var(--dt-color-black-500); }
   &--decorate-black-900 { --badge-decorative-color: var(--dt-color-black-900); }

--- a/packages/dialtone-vue2/components/badge/badge.vue
+++ b/packages/dialtone-vue2/components/badge/badge.vue
@@ -5,6 +5,8 @@
       BADGE_TYPE_MODIFIERS[type],
       BADGE_KIND_MODIFIERS[kind],
       BADGE_DECORATION_MODIFIERS[decoration],
+      { 'd-badge--subtle': subtle },
+      { 'd-badge--outlined': outlined },
     ]"
     data-qa="dt-badge"
   >
@@ -123,6 +125,23 @@ export default {
       type: [String, Array, Object],
       default: '',
     },
+
+    /**
+     * Shows a subtle appearance for the badge
+     * Currently only affects the badge when type is bulletin.
+     */
+    subtle: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Outlines the badge with a border
+     */
+    outlined: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data () {
@@ -158,6 +177,9 @@ export default {
     validateTypePropCombination () {
       if (this.type === 'ai' && this.kind === 'count') {
         console.error('DtBadge error: type: \'ai\' with kind: \'count\' is an invalid combination.');
+      }
+      if (this.type !== 'bulletin' && this.subtle) {
+        console.error('DtBadge error: subtle can only be used with type \'bulletin\'');
       }
     },
 

--- a/packages/dialtone-vue2/components/badge/badge_default.story.vue
+++ b/packages/dialtone-vue2/components/badge/badge_default.story.vue
@@ -7,6 +7,8 @@
     :icon-left="$attrs.iconLeft"
     :icon-right="$attrs.iconRight"
     :label-class="$attrs.labelClass"
+    :subtle="$attrs.subtle"
+    :outlined="$attrs.outlined"
   >
     <template v-if="$attrs.default">
       {{ $attrs.default }}

--- a/packages/dialtone-vue3/components/badge/badge.vue
+++ b/packages/dialtone-vue3/components/badge/badge.vue
@@ -5,6 +5,8 @@
       BADGE_TYPE_MODIFIERS[type],
       BADGE_KIND_MODIFIERS[kind],
       BADGE_DECORATION_MODIFIERS[decoration],
+      { 'd-badge--subtle': subtle },
+      { 'd-badge--outlined': outlined },
     ]"
     data-qa="dt-badge"
   >
@@ -123,6 +125,23 @@ export default {
       type: [String, Array, Object],
       default: '',
     },
+
+    /**
+     * Shows a subtle appearance for the badge
+     * Currently only affects the badge when type is bulletin.
+     */
+    subtle: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Outlines the badge with a border
+     */
+    outlined: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data () {
@@ -158,6 +177,9 @@ export default {
     validateTypePropCombination () {
       if (this.type === 'ai' && this.kind === 'count') {
         console.error('DtBadge error: type: \'ai\' with kind: \'count\' is an invalid combination.');
+      }
+      if (this.type !== 'bulletin' && this.subtle) {
+        console.error('DtBadge error: subtle can only be used with type \'bulletin\'');
       }
     },
 

--- a/packages/dialtone-vue3/components/badge/badge_default.story.vue
+++ b/packages/dialtone-vue3/components/badge/badge_default.story.vue
@@ -7,6 +7,8 @@
     :icon-left="$attrs.iconLeft"
     :icon-right="$attrs.iconRight"
     :label-class="$attrs.labelClass"
+    :subtle="$attrs.subtle"
+    :outlined="$attrs.outlined"
   >
     <template v-if="defaultSlot">
       {{ defaultSlot }}


### PR DESCRIPTION
# Badge: subtle and outlined variants

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1777

## :book: Description

* `subtle` variant of `bulletin` type
* `outlined` variants for each type.

## :bulb: Context

https://dialpad.atlassian.net/browse/DP-100133

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

Add to `vue` component.

## :camera: Screenshots / GIFs

<img width="787" alt="image" src="https://github.com/dialpad/dialtone/assets/1165933/1a35e36b-5361-48f2-aac4-80c416cafdc1">