### PR TITLE
fix: NO-JIRA empty tooltip displaying

### DIFF
--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -282,13 +282,12 @@ export default {
   },
 
   computed: {
-    // whether the tooltip is visible or not.
-    isVisible () {
+    shouldDisplay () {
       const hasMessage = !!this.message?.trim();
       const hasDefaultSlot = !!this.$slots?.default;
       const isDeviceCompatible = !this.isTouchDevice;
 
-      const shouldBeVisible = this.isShown && this.enabled && (hasMessage || hasDefaultSlot);
+      const shouldBeVisible = this.enabled && (hasMessage || hasDefaultSlot);
 
       return shouldBeVisible && isDeviceCompatible;
     },
@@ -401,6 +400,7 @@ export default {
     },
 
     onEnterAnchor (e) {
+      if (!this.shouldDisplay) return;
       if (this.delay && this.inTimer === null) {
         this.inTimer = setTimeout(() => {
           this.triggerShow(e);

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -282,13 +282,12 @@ export default {
   },
 
   computed: {
-    // whether the tooltip is visible or not.
-    isVisible () {
+    shouldDisplay () {
       const hasMessage = !!this.message?.trim();
       const hasDefaultSlot = !!this.$slots?.default;
       const isDeviceCompatible = !this.isTouchDevice;
 
-      const shouldBeVisible = this.isShown && this.enabled && (hasMessage || hasDefaultSlot);
+      const shouldBeVisible = this.enabled && (hasMessage || hasDefaultSlot);
 
       return shouldBeVisible && isDeviceCompatible;
     },
@@ -396,6 +395,7 @@ export default {
     },
 
     onEnterAnchor (e) {
+      if (!this.shouldDisplay) return;
       if (this.delay && this.inTimer === null) {
         this.inTimer = setTimeout(() => {
           this.triggerShow(e);


### PR DESCRIPTION
# Empty tooltip displaying

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/ez1QgBv3LAzwcYiGDK/giphy.gif?cid=790b7611iymo39nclinyi7cfvz7hx9kfqaqkkrdegsimoh4n&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Description

- Refactored unused function `isVisible` to `shouldDisplay` to disable displaying empty tooltips.

## :bulb: Context

Empty tooltips were displaying and I think they should not but we were not even using the method created to achieve that.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :camera: Screenshots / GIFs

- Before
![Screenshot 2024-05-30 at 5 27 00 p m](https://github.com/dialpad/dialtone/assets/87546543/89bcce9d-17ce-4dc2-9ede-da9a94ff3751)

- After
![Screenshot 2024-05-30 at 5 28 26 p m](https://github.com/dialpad/dialtone/assets/87546543/ba51cda7-2a5e-4b98-9402-a9c5f0092238)
