### PR TITLE
ci(semantic-release): NO-JIRA prevent GitHub rate limit

### DIFF
--- a/packages/dialtone-css/release-ci.config.cjs
+++ b/packages/dialtone-css/release-ci.config.cjs
@@ -34,7 +34,10 @@ module.exports = {
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],
-    '@semantic-release/github',
+    ['@semantic-release/github', {
+      successComment: false,
+      failTitle: false,
+    }],
   ],
   branches: [
     'staging',

--- a/packages/dialtone-emojis/release-ci.config.cjs
+++ b/packages/dialtone-emojis/release-ci.config.cjs
@@ -40,7 +40,10 @@ module.exports = {
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],
-    '@semantic-release/github',
+    ['@semantic-release/github', {
+      successComment: false,
+      failTitle: false,
+    }],
   ],
   branches: [
     'staging',

--- a/packages/dialtone-icons/release-ci.config.cjs
+++ b/packages/dialtone-icons/release-ci.config.cjs
@@ -40,7 +40,10 @@ module.exports = {
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],
-    '@semantic-release/github',
+    ['@semantic-release/github', {
+      successComment: false,
+      failTitle: false,
+    }],
   ],
   branches: [
     'staging',

--- a/packages/dialtone-tokens/release-ci.config.cjs
+++ b/packages/dialtone-tokens/release-ci.config.cjs
@@ -38,7 +38,10 @@ module.exports = {
       prepareCmd: './gradlew setProperties -Pversion=${nextRelease.version} && echo \'${nextRelease.version}\' > ./dist_ios/VERSION && git add -A && git commit -m \'chore(release): NO-JIRA ' + name + '/v${nextRelease.version} gradle\' && git push',
       execCwd: srcRoot,
     }],
-    '@semantic-release/github',
+    ['@semantic-release/github', {
+      successComment: false,
+      failTitle: false,
+    }],
   ],
   branches: [
     'staging',

--- a/packages/dialtone-vue2/release-ci.config.cjs
+++ b/packages/dialtone-vue2/release-ci.config.cjs
@@ -34,7 +34,10 @@ module.exports = {
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],
-    '@semantic-release/github',
+    ['@semantic-release/github', {
+      successComment: false,
+      failTitle: false,
+    }],
   ],
   branches: [
     'staging',

--- a/packages/dialtone-vue3/release-ci.config.cjs
+++ b/packages/dialtone-vue3/release-ci.config.cjs
@@ -34,7 +34,10 @@ module.exports = {
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],
-    '@semantic-release/github',
+    ['@semantic-release/github', {
+      successComment: false,
+      failTitle: false,
+    }],
   ],
   branches: [
     'staging',

--- a/packages/eslint-plugin-dialtone/release-ci.config.cjs
+++ b/packages/eslint-plugin-dialtone/release-ci.config.cjs
@@ -34,7 +34,10 @@ module.exports = {
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],
-    '@semantic-release/github',
+    ['@semantic-release/github', {
+      successComment: false,
+      failTitle: false,
+    }],
   ],
   branches: [
     'staging',

--- a/packages/stylelint-plugin-dialtone/release-ci.config.cjs
+++ b/packages/stylelint-plugin-dialtone/release-ci.config.cjs
@@ -34,7 +34,10 @@ module.exports = {
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],
-    '@semantic-release/github',
+    ['@semantic-release/github', {
+      successComment: false,
+      failTitle: false,
+    }],
   ],
   branches: [
     'staging',

--- a/release-ci.config.cjs
+++ b/release-ci.config.cjs
@@ -35,7 +35,10 @@ module.exports = {
       message: `chore(release): NO-JIRA ${name}` +
         '/v${nextRelease.version}\n\n${nextRelease.notes}',
     }],
-    '@semantic-release/github',
+    ['@semantic-release/github', {
+      successComment: false,
+      failTitle: false,
+    }],
   ],
   branches: [
     'staging',


### PR DESCRIPTION
# Semantic Release - Prevent GitHub rate limit

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/hGUsHFdmERpc1VpoCA/giphy.gif?cid=790b76118fwi9s800sx0syvlzp8wl58zs9uqm0t4z1lwj6y2&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] CI

## :book: Description

- Disabled `successComment` and `failTitle` on `@semantic-release/github` to avoid hitting the rate-limit.

## :bulb: Context

Our releases were hitting a secondary rate limit, looks like it is a common issue on `@semantic-release/github` as you can see on this [open issue](https://github.com/semantic-release/semantic-release/issues/2204).

Applied the suggested solution [here](https://github.com/semantic-release/semantic-release/issues/2204#issuecomment-1486299917)

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.