### PR TITLE
feat(button): DLT-1779 add link-inverted prop

### DIFF
--- a/packages/dialtone-vue2/components/button/button.stories.js
+++ b/packages/dialtone-vue2/components/button/button.stories.js
@@ -19,6 +19,7 @@ export const argsData = {
   onFocusOut: action('focusout'),
   size: 'md',
   link: false,
+  linkInverted: false,
 };
 
 const iconsList = getIconNames();
@@ -82,6 +83,9 @@ export const argTypesData = {
   linkKind: {
     control: 'select',
     options: Object.keys(LINK_KIND_MODIFIERS),
+  },
+  linkInverted: {
+    control: 'boolean',
   },
   loading: {
     control: 'boolean',

--- a/packages/dialtone-vue2/components/button/button.vue
+++ b/packages/dialtone-vue2/components/button/button.vue
@@ -52,7 +52,7 @@ import {
   INVALID_COMBINATION,
 } from './button_constants';
 
-import { LINK_KIND_MODIFIERS } from '@/components/link';
+import { LINK_KIND_MODIFIERS, getLinkKindModifier } from '@/components/link';
 
 /**
  * A button is a UI element which allows users to take an action throughout the app.
@@ -105,13 +105,23 @@ export default {
 
     /**
      * The color of the link and button if the button is styled as a link.
-     * @values default, warning, danger, success, muted, inverted
+     * @values default, warning, danger, success, muted
      * @see DtLink
      */
     linkKind: {
       type: String,
       default: 'default',
       validator: (lk) => Object.keys(LINK_KIND_MODIFIERS).includes(lk),
+    },
+
+    /**
+     * Determines whether the link should have inverted styling if the button is styled as a link.
+     * @values true, false
+     * @see DtLink
+     */
+    linkInverted: {
+      type: Boolean,
+      default: false,
     },
 
     /**
@@ -300,7 +310,7 @@ export default {
       if (this.link) {
         return [
           'd-link',
-          LINK_KIND_MODIFIERS[this.linkKind],
+          getLinkKindModifier(this.linkKind, this.linkInverted),
           BUTTON_SIZE_MODIFIERS[this.size],
         ];
       }

--- a/packages/dialtone-vue2/components/button/button_default.story.vue
+++ b/packages/dialtone-vue2/components/button/button_default.story.vue
@@ -10,6 +10,7 @@
     :assertive-on-focus="$attrs.assertiveOnFocus"
     :link="$attrs.link"
     :link-kind="$attrs.linkKind"
+    :link-inverted="$attrs.linkInverted"
     :icon-position="$attrs.iconPosition"
     :disabled="$attrs.disabled"
     :width="$attrs.width"

--- a/packages/dialtone-vue2/components/link/index.js
+++ b/packages/dialtone-vue2/components/link/index.js
@@ -1,2 +1,2 @@
 export { default as DtLink } from './link.vue';
-export { LINK_VARIANTS, LINK_KIND_MODIFIERS } from './link_constants';
+export { LINK_VARIANTS, LINK_KIND_MODIFIERS, getLinkKindModifier } from './link_constants';

--- a/packages/dialtone-vue3/components/button/button.stories.js
+++ b/packages/dialtone-vue3/components/button/button.stories.js
@@ -19,6 +19,7 @@ export const argsData = {
   onFocusOut: action('focusout'),
   size: 'md',
   link: false,
+  linkInverted: false,
 };
 
 const iconsList = getIconNames();
@@ -82,6 +83,9 @@ export const argTypesData = {
   linkKind: {
     control: 'select',
     options: Object.keys(LINK_KIND_MODIFIERS),
+  },
+  linkInverted: {
+    control: 'boolean',
   },
   loading: {
     control: 'boolean',

--- a/packages/dialtone-vue3/components/button/button.vue
+++ b/packages/dialtone-vue3/components/button/button.vue
@@ -54,7 +54,7 @@ import {
   INVALID_COMBINATION,
 } from './button_constants';
 
-import { LINK_KIND_MODIFIERS } from '@/components/link';
+import { LINK_KIND_MODIFIERS, getLinkKindModifier } from '@/components/link';
 
 /**
  * A button is a UI element which allows users to take an action throughout the app.
@@ -109,13 +109,23 @@ export default {
 
     /**
      * The color of the link and button if the button is styled as a link.
-     * @values default, warning, danger, success, muted, inverted
+     * @values default, warning, danger, success, muted
      * @see DtLink
      */
     linkKind: {
       type: String,
       default: 'default',
       validator: (lk) => Object.keys(LINK_KIND_MODIFIERS).includes(lk),
+    },
+
+    /**
+     * Determines whether the link should have inverted styling if the button is styled as a link.
+     * @values true, false
+     * @see DtLink
+     */
+    linkInverted: {
+      type: Boolean,
+      default: false,
     },
 
     /**
@@ -295,7 +305,7 @@ export default {
       if (this.link) {
         return [
           'd-link',
-          LINK_KIND_MODIFIERS[this.linkKind],
+          getLinkKindModifier(this.linkKind, this.linkInverted),
           BUTTON_SIZE_MODIFIERS[this.size],
         ];
       }

--- a/packages/dialtone-vue3/components/button/button_default.story.vue
+++ b/packages/dialtone-vue3/components/button/button_default.story.vue
@@ -10,6 +10,7 @@
     :assertive-on-focus="$attrs.assertiveOnFocus"
     :link="$attrs.link"
     :link-kind="$attrs.linkKind"
+    :link-inverted="$attrs.linkInverted"
     :icon-position="$attrs.iconPosition"
     :disabled="$attrs.disabled"
     :width="$attrs.width"

--- a/packages/dialtone-vue3/components/link/index.js
+++ b/packages/dialtone-vue3/components/link/index.js
@@ -1,2 +1,2 @@
 export { default as DtLink } from './link.vue';
-export { LINK_VARIANTS, LINK_KIND_MODIFIERS } from './link_constants';
+export { LINK_VARIANTS, LINK_KIND_MODIFIERS, getLinkKindModifier } from './link_constants';


### PR DESCRIPTION
# feat(button): DLT-1779 add link-inverted prop

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/3NtY188QaxDdC/giphy.gif?cid=82a1493bicbcyptt9r58661t76iekfhkcmkifcifpiotx9hn&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DLT-1779]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adds the prop `linkInverted` to DtButton to be consistent with the changes made in https://github.com/dialpad/dialtone/pull/321
<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps
Update Firespotter to use the new prop
<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs
![button-link](https://github.com/dialpad/dialtone/assets/24460973/3c79e771-1f08-4f19-b01d-49983847fd7a)

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

<!--- Add any links to external reference material -->


[DLT-1779]: https://dialpad.atlassian.net/browse/DLT-1779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ