### PR TITLE
fix(tooltip): NO-JIRA do not display when empty, general cleanup

### DIFF
--- a/packages/dialtone-vue2/components/tooltip/tooltip.stories.js
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.stories.js
@@ -13,7 +13,6 @@ export const argsData = {
   message: 'This is a Tooltip',
   anchor: 'Hover over me to see a tooltip',
   default: `This is a simple tooltip. You can set the position of the tooltip using the placement prop!`,
-  sticky: false,
   onShown: action('shown'),
   showTooltip: null,
 };
@@ -58,11 +57,6 @@ export const argTypesData = {
     options: TOOLTIP_STICKY_VALUES,
     control: {
       type: 'select',
-    },
-    table: {
-      defaultValue: {
-        summary: 'false',
-      },
     },
   },
 

--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -433,11 +433,12 @@ export default {
       if (!this.tooltipHasContent(tooltipInstance)) {
         return false;
       }
-      if (this.transition && callingMethod !== 'onShow') {
-        this.$emit('shown', true);
-        if (this.show !== null) {
-          this.$emit('update:show', true);
-        }
+      if (this.transition && callingMethod === 'onShow') {
+        return;
+      }
+      this.$emit('shown', true);
+      if (this.show !== null) {
+        this.$emit('update:show', true);
       }
     },
 

--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -29,7 +29,7 @@
         },
         contentClass,
       ]"
-      v-on="tooltipListeners"
+      v-on="$listeners"
     >
       <!-- In case when transitionend event doesn't work correct (for ex. tooltip component with custom trigger) -->
       <!-- after-leave event can be used instead of transitionend -->
@@ -159,7 +159,7 @@ export default {
      */
     sticky: {
       type: [Boolean, String],
-      default: false,
+      default: true,
       validator: (sticky) => {
         return TOOLTIP_STICKY_VALUES.includes(sticky);
       },
@@ -220,7 +220,7 @@ export default {
     },
 
     /**
-     * Whether the tooltip should have a transition effect.
+     * Whether the tooltip should have a transition effect (fade).
      */
     transition: {
       type: Boolean,
@@ -272,7 +272,7 @@ export default {
 
       // Internal state for whether the tooltip is shown. Changing the prop
       // will update this.
-      isShown: false,
+      internalShow: false,
 
       // this is where the placement currently is, this can be different than
       // the placement prop when there is not enough available room for the tip
@@ -282,23 +282,6 @@ export default {
   },
 
   computed: {
-    // whether the tooltip is visible or not.
-    isVisible () {
-      const hasMessage = !!this.message?.trim();
-      const hasDefaultSlot = !!this.$slots?.default;
-      const isDeviceCompatible = !this.isTouchDevice;
-
-      const shouldBeVisible = this.isShown && this.enabled && (hasMessage || hasDefaultSlot);
-
-      return shouldBeVisible && isDeviceCompatible;
-    },
-
-    tooltipListeners () {
-      return {
-        ...this.$listeners,
-      };
-    },
-
     // eslint-disable-next-line complexity
     tippyProps () {
       return {
@@ -308,10 +291,11 @@ export default {
         sticky: this.sticky,
         theme: this.inverted ? 'inverted' : undefined,
         animation: this.transition ? 'fade' : false,
-        // onShown only triggers when transition is truthy, otherwise use onShow
-        onShown: this.transition ? this.onEnterTransitionComplete : () => {},
-        onShow: this.transition ? () => {} : this.onEnterTransitionComplete,
-        onHidden: this.onLeaveTransitionComplete,
+        // onShown only triggers when transition is truthy
+        onShown: (tooltipInstance) => this.onShow(tooltipInstance, 'onShown'),
+        // onShown will always be called, but it will be called before the animation is complete
+        onShow: (tooltipInstance) => this.onShow(tooltipInstance, 'onShow'),
+        onHidden: this.onHide,
 
         popperOptions: getPopperOptions({
           fallbackPlacements: this.fallbackPlacements,
@@ -336,15 +320,15 @@ export default {
     show: {
       handler: function (show) {
         if (show !== null) {
-          this.isShown = show;
+          this.internalShow = show;
         }
       },
 
       immediate: true,
     },
 
-    isShown (isShown) {
-      if (isShown) {
+    internalShow (value) {
+      if (value) {
         this.setProps();
         this.tip.show();
       } else {
@@ -366,12 +350,6 @@ export default {
     }
     this.externalAnchor && this.addExternalAnchorEventListeners();
     this.tip = createTippy(this.anchor, this.initOptions());
-
-    // immediate watcher fires before mounted, so have this here in case
-    // show prop was initially set to true.
-    if (this.isShown) {
-      this.tip.show();
-    }
   },
 
   beforeDestroy () {
@@ -420,10 +398,10 @@ export default {
         // closing it with the mouse would trigger the tooltip to display as
         // the anchor is focused on close. Not what we want.
         if (this.show === null && this.hasVisibleFocus()) {
-          this.isShown = true;
+          this.internalShow = true;
         }
       } else {
-        if (this.show === null) this.isShown = true;
+        if (this.show === null) this.internalShow = true;
       }
     },
 
@@ -436,14 +414,14 @@ export default {
     },
 
     triggerHide () {
-      if (this.show === null) this.isShown = false;
+      if (this.show === null) this.internalShow = false;
     },
 
     onChangePlacement (placement) {
       this.currentPlacement = placement;
     },
 
-    onLeaveTransitionComplete () {
+    onHide () {
       this.tip?.unmount();
       this.$emit('shown', false);
       if (this.show !== null) {
@@ -451,10 +429,15 @@ export default {
       }
     },
 
-    onEnterTransitionComplete () {
-      this.$emit('shown', true);
-      if (this.show !== null) {
-        this.$emit('update:show', true);
+    onShow (tooltipInstance, callingMethod) {
+      if (!this.tooltipHasContent(tooltipInstance)) {
+        return false;
+      }
+      if (this.transition && callingMethod !== 'onShow') {
+        this.$emit('shown', true);
+        if (this.show !== null) {
+          this.$emit('update:show', true);
+        }
       }
     },
 
@@ -473,11 +456,12 @@ export default {
       this.setProps();
     },
 
-    onShow (tooltipInstance) {
+    tooltipHasContent (tooltipInstance) {
       // don't show tooltip when no content
       if (tooltipInstance.props.content.textContent.trim().length === 0) {
         return false;
       }
+      return true;
     },
 
     // set initial options here. If any of the options need to dynamically change, they should be put in
@@ -495,7 +479,7 @@ export default {
         // disable tooltip from displaying on touch devices
         touch: false,
         onMount: this.onMount,
-        onShow: this.onShow,
+        showOnCreate: this.internalShow,
         popperOptions: getPopperOptions({
           hasHideModifierEnabled: true,
         }),

--- a/packages/dialtone-vue3/components/tooltip/tooltip.stories.js
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.stories.js
@@ -13,7 +13,6 @@ export const argsData = {
   message: 'This is a Tooltip',
   anchor: 'Hover over me to see a tooltip',
   default: `This is a simple tooltip. You can set the position of the tooltip using the placement prop!`,
-  sticky: false,
   onShown: action('shown'),
   showTooltip: null,
 };
@@ -58,11 +57,6 @@ export const argTypesData = {
     options: TOOLTIP_STICKY_VALUES,
     control: {
       type: 'select',
-    },
-    table: {
-      defaultValue: {
-        summary: 'false',
-      },
     },
   },
 

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -434,11 +434,12 @@ export default {
       if (!this.tooltipHasContent(tooltipInstance)) {
         return false;
       }
-      if (this.transition && callingMethod !== 'onShow') {
-        this.$emit('shown', true);
-        if (this.show !== null) {
-          this.$emit('update:show', true);
-        }
+      if (this.transition && callingMethod === 'onShow') {
+        return;
+      }
+      this.$emit('shown', true);
+      if (this.show !== null) {
+        this.$emit('update:show', true);
       }
     },
 

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -158,7 +158,7 @@ export default {
      */
     sticky: {
       type: [Boolean, String],
-      default: false,
+      default: true,
       validator: (sticky) => {
         return TOOLTIP_STICKY_VALUES.includes(sticky);
       },
@@ -219,7 +219,7 @@ export default {
     },
 
     /**
-     * Whether the tooltip should have a transition effect.
+     * Whether the tooltip should have a transition effect (fade).
      */
     transition: {
       type: Boolean,
@@ -272,7 +272,7 @@ export default {
 
       // Internal state for whether the tooltip is shown. Changing the prop
       // will update this.
-      isShown: false,
+      internalShow: false,
 
       // this is where the placement currently is, this can be different than
       // the placement prop when there is not enough available room for the tip
@@ -282,17 +282,6 @@ export default {
   },
 
   computed: {
-    // whether the tooltip is visible or not.
-    isVisible () {
-      const hasMessage = !!this.message?.trim();
-      const hasDefaultSlot = !!this.$slots?.default;
-      const isDeviceCompatible = !this.isTouchDevice;
-
-      const shouldBeVisible = this.isShown && this.enabled && (hasMessage || hasDefaultSlot);
-
-      return shouldBeVisible && isDeviceCompatible;
-    },
-
     // eslint-disable-next-line complexity
     tippyProps () {
       return {
@@ -302,10 +291,11 @@ export default {
         sticky: this.sticky,
         theme: this.inverted ? 'inverted' : undefined,
         animation: this.transition ? 'fade' : false,
-        // onShown only triggers when transition is truthy, otherwise use onShow
-        onShown: this.transition ? this.onEnterTransitionComplete : () => {},
-        onShow: this.transition ? () => {} : this.onEnterTransitionComplete,
-        onHidden: this.onLeaveTransitionComplete,
+        // onShown only triggers when transition is truthy
+        onShown: (tooltipInstance) => this.onShow(tooltipInstance, 'onShown'),
+        // onShown will always be called, but it will be called before the animation is complete
+        onShow: (tooltipInstance) => this.onShow(tooltipInstance, 'onShow'),
+        onHidden: this.onHide,
 
         popperOptions: getPopperOptions({
           fallbackPlacements: this.fallbackPlacements,
@@ -330,15 +320,15 @@ export default {
     show: {
       handler: function (show) {
         if (show !== null) {
-          this.isShown = show;
+          this.internalShow = show;
         }
       },
 
       immediate: true,
     },
 
-    isShown (isShown) {
-      if (isShown) {
+    internalShow (value) {
+      if (value) {
         this.setProps();
         this.tip.show();
       } else {
@@ -361,12 +351,6 @@ export default {
 
     this.externalAnchor && this.addExternalAnchorEventListeners();
     this.tip = createTippy(this.anchor, this.initOptions());
-
-    // immediate watcher fires before mounted, so have this here in case
-    // show prop was initially set to true.
-    if (this.isShown) {
-      this.tip.show();
-    }
   },
 
   beforeUnmount () {
@@ -415,10 +399,10 @@ export default {
         // closing it with the mouse would trigger the tooltip to display as
         // the anchor is focused on close. Not what we want.
         if (this.show === null && this.hasVisibleFocus()) {
-          this.isShown = true;
+          this.internalShow = true;
         }
       } else {
-        if (this.show === null) this.isShown = true;
+        if (this.show === null) this.internalShow = true;
       }
     },
 
@@ -431,14 +415,14 @@ export default {
     },
 
     triggerHide () {
-      if (this.show === null) this.isShown = false;
+      if (this.show === null) this.internalShow = false;
     },
 
     onChangePlacement (placement) {
       this.currentPlacement = placement;
     },
 
-    onLeaveTransitionComplete () {
+    onHide () {
       this.tip?.unmount();
       this.$emit('shown', false);
       if (this.show !== null) {
@@ -446,10 +430,15 @@ export default {
       }
     },
 
-    onEnterTransitionComplete () {
-      this.$emit('shown', true);
-      if (this.show !== null) {
-        this.$emit('update:show', true);
+    onShow (tooltipInstance, callingMethod) {
+      if (!this.tooltipHasContent(tooltipInstance)) {
+        return false;
+      }
+      if (this.transition && callingMethod !== 'onShow') {
+        this.$emit('shown', true);
+        if (this.show !== null) {
+          this.$emit('update:show', true);
+        }
       }
     },
 
@@ -468,11 +457,12 @@ export default {
       this.setProps();
     },
 
-    onShow (tooltipInstance) {
+    tooltipHasContent (tooltipInstance) {
       // don't show tooltip when no content
       if (tooltipInstance.props.content.textContent.trim().length === 0) {
         return false;
       }
+      return true;
     },
 
     // set initial options here. If any of the options need to dynamically change, they should be put in
@@ -490,7 +480,7 @@ export default {
         // disable tooltip from displaying on touch devices
         touch: false,
         onMount: this.onMount,
-        onShow: this.onShow,
+        showOnCreate: this.internalShow,
         popperOptions: getPopperOptions({
           hasHideModifierEnabled: true,
         }),


### PR DESCRIPTION
# fix(tooltip): do not display when empty, general cleanup

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMG92OGxhYm8wdnNrZmRjcmRsY3Q0OGY0Z3lkMGFwYjJvbDlob3pmYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/iFU36VwXUd2O43gdcr/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

- Fixed tooltip still displaying when content was empty. 
- Did some general cleanup with unused methods and such
- Set sticky to be true by default, as we talked about yesterday

## :bulb: Context

@juliodialpad put up pr https://github.com/dialpad/dialtone/pull/341 yesterday to solve the tooltip not displaying, but the problem was actually that I broke the fix I already made by overriding the onShow method.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
