### PR TITLE
feat(emoji-picker): DLT-1781 allow hiding of search and setting searchQuery via prop

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/emoji-picker.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji-picker.less
@@ -35,11 +35,11 @@
   }
 
   &__alignment {
+    // !important to default value to override popover dialog box-sizing: border-box style
+    box-sizing: content-box !important;
     width: auto;
     max-width: calc(var(--dt-size-925) + var(--dt-size-400));
     margin: 0 var(--dt-space-500);
-    // !important to default value to override popover dialog box-sizing: border-box style
-    box-sizing: content-box !important;
   }
 
   &--footer {
@@ -217,7 +217,7 @@
 
   &__data {
     display: flex;
-    gap: var(--dt-space-100);
+    gap: var(--dt-space-400);
     align-items: center;
     width: 100%;
     max-width: calc(var(--dt-size-905) + var(--dt-size-550) + var(--dt-size-200));

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.stories.js
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.stories.js
@@ -81,6 +81,12 @@ export const argTypesData = {
     options: ['Default', 'Light', 'MediumLight', 'Medium', 'MediumDark', 'Dark'],
     control: 'select',
   },
+  searchQuery: {
+    control: 'text',
+  },
+  showSearch: {
+    control: 'boolean',
+  },
   onSkinTone: {
     table: {
       disable: true,
@@ -92,6 +98,11 @@ export const argTypesData = {
     },
   },
   onClose: {
+    table: {
+      disable: true,
+    },
+  },
+  showPopover: {
     table: {
       disable: true,
     },

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
@@ -156,6 +156,7 @@ export default {
      */
     skinTone: {
       type: String,
+      default: 'Default',
     },
 
     /**

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
@@ -81,44 +81,112 @@ export default {
   },
 
   props: {
+    /**
+     * The array with recently used  emoji object
+     * This list is necessary to fill the recently used tab
+     * @type {Array}
+     * @default []
+     * @example
+     * <dt-emoji-picker :recentlyUsedEmojis="[emojiObject, emojiObject]" />
+     */
+    // TODO try to simplify this to achieve an array of unicode characters and not an entire emoji data object
     recentlyUsedEmojis: {
       type: Array,
     },
 
+    /**
+     * The placeholder text for the search input
+     * @type {String}
+     * @required
+     * @example
+     * <dt-emoji-picker :searchPlaceholderLabel="'Search...'" />
+     */
     searchPlaceholderLabel: {
       type: String,
       required: true,
     },
 
+    /**
+     * The label for the search results tab
+     * @type {String}
+     * @required
+     * @example
+     * <dt-emoji-picker :searchResultsLabel="'Search results'" />
+     */
     searchResultsLabel: {
       type: String,
       required: true,
     },
 
+    /**
+     * The label for the search no results
+     * @type {String}
+     * @required
+     * @example
+     * <dt-emoji-picker :searchNoResultsLabel="'No results'" />
+     */
     searchNoResultsLabel: {
       type: String,
       required: true,
     },
 
+    /**
+     * The list of tabsets to show, it is necessary to be updated with the correct language
+     * It must respect the provided order.
+     * @type {Array}
+     * @required
+     * @example
+     * <dt-emoji-picker
+     *  :tabSetLabels="['Most recently used', 'Smileys and people', 'Nature',
+     *    'Food', 'Activity', 'Travel', 'Objects', 'Symbols', 'Flags']" />
+     */
     tabSetLabels: {
       type: Array,
       required: true,
     },
 
+    /**
+     * The skin tone to show the emojis
+     * This prop gives the possibility to use the skin tone selected by the user previously
+     * @type {String}
+     * @default 'Default'
+     * @values 'Default', 'Light', 'MediumLight', 'Medium', 'MediumDark', 'Dark'
+     * @example
+     * <dt-emoji-picker :skinTone="'Default'" />
+     */
     skinTone: {
       type: String,
     },
 
+    /**
+     * Tooltip shown when skin selector button is hovered.
+     * @type {String}
+     * @required
+     * @example
+     * <dt-emoji-picker :skin-selector-button-tooltip-label="'Change default skin tone'" />
+     */
     skinSelectorButtonTooltipLabel: {
       type: String,
       required: true,
     },
 
+    /**
+     * Sets the search query that filters emojis.
+     * @type {String}
+     * @example
+     * <dt-emoji-picker search-query="smile" />
+     */
     searchQuery: {
       type: String,
       default: '',
     },
 
+    /**
+     * Shows the search input
+     * @type {String}
+     * @example
+     * <dt-emoji-picker :show-search="false" />
+     */
     showSearch: {
       type: Boolean,
       default: true,

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
@@ -183,7 +183,7 @@ export default {
 
     /**
      * Shows the search input
-     * @type {String}
+     * @type {Boolean}
      * @example
      * <dt-emoji-picker :show-search="false" />
      */

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
@@ -5,7 +5,7 @@
     <div class="d-emoji-picker--header">
       <emoji-tabset
         ref="tabsetRef"
-        :emoji-filter="searchQuery"
+        :emoji-filter="internalSearchQuery"
         :show-recently-used-tab="showRecentlyUsedTab"
         :scroll-into-tab="scrollIntoTab"
         :tab-set-labels="tabSetLabels"
@@ -18,10 +18,11 @@
     </div>
     <div class="d-emoji-picker--body">
       <emoji-search
+        v-if="showSearch"
         ref="searchInputRef"
-        :model-value="searchQuery"
+        :model-value="internalSearchQuery"
         :search-placeholder-label="searchPlaceholderLabel"
-        @update:model-value="newValue => searchQuery = newValue"
+        @update:model-value="newValue => internalSearchQuery = newValue"
         @select-first-emoji="$emit('selected-emoji', highlightedEmoji)"
         @focus-tabset="$refs.tabsetRef.focusTabset()"
         @focus-emoji-selector="$refs.emojiSelectorRef.focusEmojiSelector()"
@@ -29,7 +30,7 @@
       />
       <emoji-selector
         ref="emojiSelectorRef"
-        :emoji-filter="searchQuery"
+        :emoji-filter="internalSearchQuery"
         :skin-tone="skinTone"
         :tab-set-labels="tabSetLabels"
         :search-results-label="searchResultsLabel"
@@ -112,11 +113,21 @@ export default {
       type: String,
       required: true,
     },
+
+    searchQuery: {
+      type: String,
+      default: '',
+    },
+
+    showSearch: {
+      type: Boolean,
+      default: true,
+    },
   },
 
   data () {
     return {
-      searchQuery: '',
+      internalSearchQuery: this.searchQuery,
       highlightedEmoji: null,
       selectedTabset: {},
       scrollIntoTab: 0,
@@ -130,9 +141,15 @@ export default {
     },
   },
 
+  watch: {
+    searchQuery (value) {
+      this.internalSearchQuery = value;
+    },
+  },
+
   methods: {
     scrollToSelectedTabset (tabId) {
-      this.searchQuery = '';
+      this.internalSearchQuery = '';
       this.selectedTabset = { ...this.selectedTabset, tabId };
     },
 

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker_default.story.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker_default.story.vue
@@ -7,6 +7,8 @@
     :search-results-label="$attrs.searchResultsLabel"
     :search-no-results-label="$attrs.searchNoResultsLabel"
     :search-placeholder-label="$attrs.searchPlaceholderLabel"
+    :search-query="$attrs.searchQuery"
+    :show-search="$attrs.showSearch"
     @skin-tone="isSkinTone = $event; $attrs.onSkinTone($event)"
     @close="$attrs.onClose($event)"
     @selected-emoji="$attrs.onSelectedEmoji($event)"

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_description.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_description.vue
@@ -8,7 +8,7 @@
       :title="emoji.name"
       :src="`${CDN_URL + emoji.unicode_character}.png`"
     >
-    {{ emoji?.name }}
+    <div>{{ emoji?.name }}</div>
   </div>
 </template>
 

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_search.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_search.vue
@@ -20,13 +20,18 @@
         v-if="modelValue.length > 0"
         #rightIcon
       >
-        <button
-          class="d-emoji-picker__search-button"
+        <dt-button
+          importance="clear"
+          kind="muted"
           @click="clearSearch"
-          @keydown.enter="clearSearch"
         >
-          <dt-icon name="close" />
-        </button>
+          <template #icon>
+            <dt-icon
+              name="x-circle"
+              size="200"
+            />
+          </template>
+        </dt-button>
       </template>
     </dt-input>
   </div>
@@ -35,6 +40,7 @@
 <script>
 import { DtInput } from '@/components/input';
 import { DtIcon } from '@/components/icon';
+import { DtButton } from '@/components/button';
 
 export default {
   name: 'EmojiSearch',
@@ -42,6 +48,7 @@ export default {
   components: {
     DtInput,
     DtIcon,
+    DtButton,
   },
 
   props: {

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.stories.js
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.stories.js
@@ -81,6 +81,12 @@ export const argTypesData = {
     options: ['Default', 'Light', 'MediumLight', 'Medium', 'MediumDark', 'Dark'],
     control: 'select',
   },
+  searchQuery: {
+    control: 'text',
+  },
+  showSearch: {
+    control: 'boolean',
+  },
   onSkinTone: {
     table: {
       disable: true,
@@ -92,6 +98,11 @@ export const argTypesData = {
     },
   },
   onClose: {
+    table: {
+      disable: true,
+    },
+  },
+  showPopover: {
     table: {
       disable: true,
     },

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
@@ -5,7 +5,7 @@
     <div class="d-emoji-picker--header">
       <emoji-tabset
         ref="tabsetRef"
-        :emoji-filter="searchQuery"
+        :emoji-filter="internalSearchQuery"
         :show-recently-used-tab="showRecentlyUsedTab"
         :scroll-into-tab="scrollIntoTab"
         :tabset-labels="tabSetLabels"
@@ -18,8 +18,9 @@
     </div>
     <div class="d-emoji-picker--body">
       <emoji-search
+        v-if="showSearch"
         ref="searchInputRef"
-        v-model="searchQuery"
+        v-model="internalSearchQuery"
         :search-placeholder-label="searchPlaceholderLabel"
         @select-first-emoji="emits('selected-emoji', highlightedEmoji)"
         @focus-tabset="$refs.tabsetRef.focusTabset()"
@@ -28,7 +29,7 @@
       />
       <emoji-selector
         ref="emojiSelectorRef"
-        :emoji-filter="searchQuery"
+        :emoji-filter="internalSearchQuery"
         :skin-tone="skinTone"
         :tabset-labels="tabSetLabels"
         :search-results-label="searchResultsLabel"
@@ -66,7 +67,7 @@ import EmojiTabset from './modules/emoji_tabset.vue';
 import EmojiSelector from './modules/emoji_selector.vue';
 import EmojiSkinSelector from './modules/emoji_skin_selector.vue';
 import EmojiDescription from './modules/emoji_description.vue';
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 const props = defineProps({
   /**
@@ -159,6 +160,28 @@ const props = defineProps({
     type: String,
     required: true,
   },
+
+  /**
+   * Sets the search query that filters emojis.
+   * @type {String}
+   * @example
+   * <dt-emoji-picker search-query="smile" />
+   */
+  searchQuery: {
+    type: String,
+    default: '',
+  },
+
+  /**
+   * Shows the search input
+   * @type {String}
+   * @example
+   * <dt-emoji-picker :show-search="false" />
+   */
+  showSearch: {
+    type: Boolean,
+    default: true,
+  },
 });
 
 const emits = defineEmits(
@@ -185,7 +208,7 @@ const emits = defineEmits(
   ],
 );
 
-const searchQuery = ref('');
+const internalSearchQuery = ref(props.searchQuery.value);
 const highlightedEmoji = ref(null);
 const selectedTabset = ref({});
 
@@ -193,6 +216,13 @@ const scrollIntoTab = ref(0);
 const isScrolling = ref(false);
 
 const showRecentlyUsedTab = computed(() => props.recentlyUsedEmojis.length > 0);
+
+watch(
+  () => props.searchQuery,
+  (newValue) => {
+    internalSearchQuery.value = newValue;
+  },
+);
 
 /**
  * Handle the selected tabset event
@@ -204,7 +234,7 @@ const showRecentlyUsedTab = computed(() => props.recentlyUsedEmojis.length > 0);
  * @param tabName {String} - The name of the tab that was selected
  */
 function scrollToSelectedTabset (tabId) {
-  searchQuery.value = '';
+  internalSearchQuery.value = '';
   selectedTabset.value = tabId;
   selectedTabset.value = { ...selectedTabset.value, tabId };
 }

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
@@ -174,7 +174,7 @@ const props = defineProps({
 
   /**
    * Shows the search input
-   * @type {String}
+   * @type {Boolean}
    * @example
    * <dt-emoji-picker :show-search="false" />
    */

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker_default.story.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker_default.story.vue
@@ -7,6 +7,8 @@
     :search-results-label="$attrs.searchResultsLabel"
     :search-no-results-label="$attrs.searchNoResultsLabel"
     :search-placeholder-label="$attrs.searchPlaceholderLabel"
+    :search-query="$attrs.searchQuery"
+    :show-search="$attrs.showSearch"
     @skin-tone="skinTone = $event"
     @selected-emoji="$attrs.selectedEmoji"
   />

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_description.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_description.vue
@@ -8,7 +8,7 @@
       :title="emoji.name"
       :src="`${CDN_URL + emoji.unicode_character}.png`"
     >
-    {{ emoji?.name }}
+    <div>{{ emoji?.name }}</div>
   </div>
 </template>
 

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_search.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_search.vue
@@ -20,13 +20,18 @@
         v-if="modelValue.length > 0"
         #rightIcon
       >
-        <button
-          class="d-emoji-picker__search-button"
+        <dt-button
+          importance="clear"
+          kind="muted"
           @click="clearSearch"
-          @keydown.enter="clearSearch"
         >
-          <dt-icon name="close" />
-        </button>
+          <template #icon>
+            <dt-icon
+              name="x-circle"
+              size="200"
+            />
+          </template>
+        </dt-button>
       </template>
     </dt-input>
   </div>
@@ -35,6 +40,7 @@
 <script setup>
 import { DtInput } from '@/components/input';
 import { DtIcon } from '@/components/icon';
+import { DtButton } from '@/components/button';
 import { onMounted, ref } from 'vue';
 
 defineProps({


### PR DESCRIPTION
# feat(emoji-picker): DLT-1781 allow hiding of search and setting searchQuery via prop

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExaTc2NHdvemh0aWtkd3Nua2thdnJlYjVzYnFkMzZxaGtzYnFiYWtpNyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/26n6WywJyh39n1pBu/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1781

## :book: Description

- New prop searchQuery: allows setting of the search query via prop
- New prop showSearch: shows or hides the search input

## :bulb: Context

Needed for message input emoji picker implementation since it needs to integrate with gif / sticker pickers search

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

attempt to put in message input.
