### PR TITLE
fix: NO-JIRA empty state update

### DIFF
--- a/packages/dialtone-vue2/components/empty_state/empty_state.test.js
+++ b/packages/dialtone-vue2/components/empty_state/empty_state.test.js
@@ -65,7 +65,7 @@ describe('DtIllustration Tests', () => {
     });
 
     it('Should render size classes in wrapper', () => {
-      expect(wrapper.classes().includes('d-empty-state', 'd-empty-state--size--lg')).toBe(true);
+      expect(wrapper.classes().includes('d-empty-state', 'd-empty-state--size-lg')).toBe(true);
     });
 
     it('Should render correct headline classes in header text', () => {
@@ -84,7 +84,7 @@ describe('DtIllustration Tests', () => {
 
         updateWrapper();
 
-        expect(wrapper.classes().includes('d-empty-state--size--md')).toBe(true);
+        expect(wrapper.classes().includes('d-empty-state--size-md')).toBe(true);
       });
 
       it('Should update headline classes in header text', () => {

--- a/packages/dialtone-vue2/components/empty_state/empty_state_constants.js
+++ b/packages/dialtone-vue2/components/empty_state/empty_state_constants.js
@@ -1,7 +1,7 @@
 export const EMPTY_STATE_SIZE_MODIFIERS = {
-  sm: 'd-empty-state--size--sm',
-  md: 'd-empty-state--size--md',
-  lg: 'd-empty-state--size--lg',
+  sm: 'd-empty-state--size-sm',
+  md: 'd-empty-state--size-md',
+  lg: 'd-empty-state--size-lg',
 };
 
 export default {

--- a/packages/dialtone-vue3/components/empty_state/empty_state.test.js
+++ b/packages/dialtone-vue3/components/empty_state/empty_state.test.js
@@ -65,7 +65,7 @@ describe('DtIllustration Tests', () => {
     });
 
     it('Should render size classes in wrapper', () => {
-      expect(wrapper.classes().includes('d-empty-state', 'd-empty-state--size--lg')).toBe(true);
+      expect(wrapper.classes().includes('d-empty-state', 'd-empty-state--size-lg')).toBe(true);
     });
 
     it('Should render correct headline classes in header text', () => {
@@ -82,7 +82,7 @@ describe('DtIllustration Tests', () => {
       it('Should update size classes in wrapper', () => {
         wrapper.setProps({ size: 'md' });
 
-        expect(wrapper.classes().includes('d-empty-state', 'd-empty-state--size--md')).toBe(true);
+        expect(wrapper.classes().includes('d-empty-state', 'd-empty-state--size-md')).toBe(true);
       });
 
       it('Should update headline classes in header text', () => {


### PR DESCRIPTION
Following @francisrupert latest change

https://github.com/dialpad/dialtone/pull/347/files#diff-5ac682276f1dad13ee004246335598d7378d7838261efe17e225e5a950bf5a69

Im updating `empty_state_constants.js` to match this change

Vue3 looks good.