### PR TITLE
docs(tokens): NO-JIRA add border example for border-ai

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenExample.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenExample.vue
@@ -115,6 +115,7 @@ const getBorderStyle = () => {
       background: `linear-gradient(var(--dt-color-neutral-white), var(--dt-color-neutral-white)) padding-box,
       ${props.value} border-box`,
       borderWidth: 'var(--dt-size-border-200)',
+      borderColor: 'transparent',
     };
   }
   return { border: `var(--dt-size-200) solid ${props.value}` };

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenExample.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenExample.vue
@@ -102,14 +102,23 @@ const getColorStyle = computed(() => {
   if (props.name.includes('opacity')) {
     return { background: `rgba(0, 0, 0, ${props.value})` };
   }
-  if (props.name.includes('border')) {
-    return { border: `var(--dt-size-200) solid ${props.value}` };
-  }
+  if (props.name.includes('border')) return getBorderStyle();
   if (isForeground.value || isLink.value) {
     return { backgroundColor: foregroundBackgroundColor.value, color: props.value };
   }
   return { background: props.value };
 });
+
+const getBorderStyle = () => {
+  if (props.name.includes('border-ai')) {
+    return {
+      background: `linear-gradient(var(--dt-color-neutral-white), var(--dt-color-neutral-white)) padding-box,
+      ${props.value} border-box`,
+      borderWidth: 'var(--dt-size-border-200)',
+    };
+  }
+  return { border: `var(--dt-size-200) solid ${props.value}` };
+};
 
 const foregroundBackgroundColor = computed(() => {
   if (props.theme === 'light') {


### PR DESCRIPTION
# docs(tokens): NO-JIRA add border example for border-ai

## :hammer_and_wrench: Type Of Change
The example for the token `var(--dt-color-border-ai)` was empty. This PR adds the example of the border with a gradient.
<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
No Jira
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :camera: Screenshots / GIFs

| Before | Now |
|------|------|
| <img width="400" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/31fc8ec2-4bc1-4b36-a6bc-326156d9a6a9"> | <img width="399" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/26fe0601-d5f9-4bca-8035-b4f4d8a9d51a"> |


