### PR TITLE
fix(utility): NO-JIRA border color opacity utility

### DIFF
--- a/packages/dialtone-css/postcss/dialtone-generators.cjs
+++ b/packages/dialtone-css/postcss/dialtone-generators.cjs
@@ -184,7 +184,7 @@ function opacityUtilities (Rule, clonedSource, declaration) {
     }));
     generatedRules.borderOpacity.push(new Rule({
       source: clonedSource,
-      selector: appendHoverFocusSelectors(`.d-bco-${opacity}`),
+      selector: appendHoverFocusSelectors(`.d-bco${opacity}`),
       nodes: [
         declaration.clone({ prop: '--bco', value: `${opacity}% !important` }),
       ],


### PR DESCRIPTION
# fix: NO-JIRA border color opacity utility

The utility `d-bco{n}` was at some point generated as `d-bco-{n}`. We think this was unintended because the docs show `d-bco{n}`, and the rest of the utilities for opacity follow that same pattern.

| Before | Now | 
|----|----|
| <img width="987" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/a146a179-7fee-44ec-9c8f-21fda79120b5"> | <img width="965" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/9d1285cf-5d40-4aa4-bc24-55202b9b6cd9"> |
