### PR TITLE
feat(tooltip): DLT-1793 new prop to set tippy theme

### DIFF
--- a/packages/dialtone-vue2/components/tooltip/tooltip.mdx
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.mdx
@@ -155,3 +155,30 @@ manually specify which position it will move to in what order you can do so via 
     </template>
 </dt-tooltip>
 ```
+
+### Custom theme
+
+If you want to style the tooltip background in a different color you will have to set the theme and style it yourself
+in the css using that theme, or else the tooltip arrow will not be colored.
+
+```html
+<template>
+    <dt-tooltip theme="purple" message="Message">
+        <template #anchor>
+            <dt-button importance="outlined" class="d-w128">
+                top
+            </dt-button>
+        </template>
+    </dt-tooltip>
+</template>
+
+<style>
+.tippy-box[data-theme~='purple'] > .tippy-svg-arrow {
+  fill: var(--dt-color-purple-200);
+}
+.tippy-box[data-theme~='purple'] .d-tooltip {
+  background-color: var(--dt-color-purple-200);
+  color: var(--dt-color-foreground-primary);
+}
+</style>
+```

--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -237,6 +237,14 @@ export default {
     },
 
     /**
+     * Set a custom theme on the tooltip. See https://atomiks.github.io/tippyjs/v6/themes/
+     */
+    theme: {
+      type: String,
+      default: undefined,
+    },
+
+    /**
      * External anchor id to use in those cases the anchor can't be provided via the slot.
      * For instance, using the combobox's input as the anchor for the popover.
      */
@@ -289,7 +297,7 @@ export default {
         delay: this.delay ? TOOLTIP_DELAY_MS : false,
         placement: this.placement,
         sticky: this.sticky,
-        theme: this.inverted ? 'inverted' : undefined,
+        theme: this.inverted ? 'inverted' : this.theme,
         animation: this.transition ? 'fade' : false,
         // onShown only triggers when transition is truthy
         onShown: (tooltipInstance) => this.onShow(tooltipInstance, 'onShown'),

--- a/packages/dialtone-vue2/components/tooltip/tooltip_default.story.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip_default.story.vue
@@ -13,6 +13,7 @@
         :placement="$attrs.placement"
         :inverted="$attrs.inverted"
         :message="$attrs.message"
+        :theme="$attrs.theme"
         :fallback-placements="$attrs.fallbackPlacements"
         :offset="$attrs.offset"
         :sticky="$attrs.sticky"
@@ -67,3 +68,12 @@ export default {
   },
 };
 </script>
+
+<style>
+.tippy-box[data-theme~='purple'] > .tippy-svg-arrow {
+  fill: var(--dt-color-purple-200);
+}
+.tippy-box[data-theme~='purple'] > .d-tooltip {
+  background-color: var(--dt-color-purple-200);
+}
+</style>

--- a/packages/dialtone-vue2/components/tooltip/tooltip_variants.story.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip_variants.story.vue
@@ -100,6 +100,24 @@
         </template>
       </dt-tooltip>
     </div>
+    <div class="d-d-flex d-jc-center d-w100p">
+      <!-- Custom Theme -->
+      <dt-tooltip
+        class="d-mb64 d-mt32"
+        theme="purple"
+        :transition="$attrs.transition"
+        :message="localMessage"
+        :show="$attrs.showTooltip"
+      >
+        <template #anchor>
+          <dt-button
+            importance="outlined"
+          >
+            Custom Theme
+          </dt-button>
+        </template>
+      </dt-tooltip>
+    </div>
     <div class="d-bgc-purple-600 d-pt64 d-d-flex d-jc-center">
       <div class="d-py64">
         <!-- Inverted state -->
@@ -159,3 +177,13 @@ export default {
   },
 };
 </script>
+
+<style>
+.tippy-box[data-theme~='purple'] > .tippy-svg-arrow {
+  fill: var(--dt-color-purple-200);
+}
+.tippy-box[data-theme~='purple'] .d-tooltip {
+  background-color: var(--dt-color-purple-200);
+  color: var(--dt-color-foreground-primary);
+}
+</style>

--- a/packages/dialtone-vue3/components/tooltip/tooltip.mdx
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.mdx
@@ -155,3 +155,30 @@ manually specify which position it will move to in what order you can do so via 
     </template>
 </dt-tooltip>
 ```
+
+### Custom theme
+
+If you want to style the tooltip background in a different color you will have to set the theme and style it yourself
+in the css using that theme, or else the tooltip arrow will not be colored.
+
+```html
+<template>
+    <dt-tooltip theme="purple" message="Message">
+        <template #anchor>
+            <dt-button importance="outlined" class="d-w128">
+                top
+            </dt-button>
+        </template>
+    </dt-tooltip>
+</template>
+
+<style>
+.tippy-box[data-theme~='purple'] > .tippy-svg-arrow {
+  fill: var(--dt-color-purple-200);
+}
+.tippy-box[data-theme~='purple'] .d-tooltip {
+  background-color: var(--dt-color-purple-200);
+  color: var(--dt-color-foreground-primary);
+}
+</style>
+```

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -236,6 +236,14 @@ export default {
     },
 
     /**
+     * Set a custom theme on the tooltip. See https://atomiks.github.io/tippyjs/v6/themes/
+     */
+    theme: {
+      type: String,
+      default: undefined,
+    },
+
+    /**
      * External anchor id to use in those cases the anchor can't be provided via the slot.
      * For instance, using the combobox's input as the anchor for the popover.
      */
@@ -289,7 +297,7 @@ export default {
         delay: this.delay ? TOOLTIP_DELAY_MS : false,
         placement: this.placement,
         sticky: this.sticky,
-        theme: this.inverted ? 'inverted' : undefined,
+        theme: this.inverted ? 'inverted' : this.theme,
         animation: this.transition ? 'fade' : false,
         // onShown only triggers when transition is truthy
         onShown: (tooltipInstance) => this.onShow(tooltipInstance, 'onShown'),

--- a/packages/dialtone-vue3/components/tooltip/tooltip_default.story.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip_default.story.vue
@@ -14,6 +14,7 @@
         :placement="$attrs.placement"
         :inverted="$attrs.inverted"
         :message="$attrs.message"
+        :theme="$attrs.theme"
         :fallback-placements="$attrs.fallbackPlacements"
         :offset="$attrs.offset"
         :sticky="$attrs.sticky"
@@ -66,3 +67,12 @@ export default {
   },
 };
 </script>
+
+<style>
+.tippy-box[data-theme~='purple'] > .tippy-svg-arrow {
+  fill: var(--dt-color-purple-200);
+}
+.tippy-box[data-theme~='purple'] > .d-tooltip {
+  background-color: var(--dt-color-purple-200);
+}
+</style>

--- a/packages/dialtone-vue3/components/tooltip/tooltip_variants.story.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip_variants.story.vue
@@ -100,6 +100,24 @@
         </template>
       </dt-tooltip>
     </div>
+    <div class="d-d-flex d-jc-center d-w100p">
+      <!-- Custom Theme -->
+      <dt-tooltip
+        class="d-mb64 d-mt32"
+        theme="purple"
+        :transition="$attrs.transition"
+        :message="localMessage"
+        :show="$attrs.showTooltip"
+      >
+        <template #anchor>
+          <dt-button
+            importance="outlined"
+          >
+            Custom Theme
+          </dt-button>
+        </template>
+      </dt-tooltip>
+    </div>
     <div class="d-bgc-purple-600 d-pt64 d-d-flex d-jc-center">
       <div class="d-py64">
         <!-- Inverted state -->
@@ -159,3 +177,13 @@ export default {
   },
 };
 </script>
+
+<style>
+.tippy-box[data-theme~='purple'] > .tippy-svg-arrow {
+  fill: var(--dt-color-purple-200);
+}
+.tippy-box[data-theme~='purple'] .d-tooltip {
+  background-color: var(--dt-color-purple-200);
+  color: var(--dt-color-foreground-primary);
+}
+</style>


### PR DESCRIPTION
# feat(tooltip): new prop to set tippy theme

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbjQ0MDZnY3ZxdHZ1aHhhc2xqM2Fsb3FmbXA4NmlicHhtN3VqcGZncSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/rCeIPA4u4xqk5JlU0k/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

- [x] Feature

## :book: Description

Added new prop to allow setting the tippy theme

## :bulb: Context

We have some places in the app where the tooltip content is custom styled to purple. This unfortunately doesn't style the arrow svg. You can set a custom theme on the tippy and then style it via css to get around this. This is the way tippy recommends doing it as you can see here https://atomiks.github.io/tippyjs/v6/themes/#svg-arrow. This will likely not be used often just for these special cases.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

For all CSS changes:

- [x] I have used design tokens whenever possible.

## :crystal_ball: Next Steps

Let the dev who asked for this know to try it out.

## :camera: Screenshots / GIFs

![Screenshot 2024-06-07 at 4 51 02 PM](https://github.com/dialpad/dialtone/assets/64808812/8548efe9-65b2-46a6-8134-6939e7ca4dde)

## :link: Sources

https://atomiks.github.io/tippyjs/v6/themes/#svg-arrow
