### PR TITLE
feat(callbar-button-with-popover): NO-JIRA add offset as passthrough prop

### DIFF
--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -31,7 +31,7 @@
       :placement="placement"
       :initial-focus-element="initialFocusElement"
       :show-close-button="showCloseButton"
-      :offset="[0, 16]"
+      :offset="offset"
       padding="none"
       class="dt-recipe--callbar-button-with-popover--popover-wrapper"
       :dialog-class="['dt-recipe--callbar-button-with-popover--popover', contentClass]"
@@ -139,6 +139,22 @@ export default {
     placement: {
       type: String,
       default: 'top',
+    },
+
+    /**
+     *  Displaces the content box from its anchor element
+     *  by the specified number of pixels.
+     *  <a
+     *    class="d-link"
+     *    href="https://atomiks.github.io/tippyjs/v6/all-props/#offset"
+     *    target="_blank"
+     *  >
+     *    Tippy.js docs
+     *  </a>
+     */
+    offset: {
+      type: Array,
+      default: () => [0, 16],
     },
 
     /**

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
@@ -7,6 +7,7 @@
     :initial-focus-element="$attrs.initialFocusElement"
     :show-close-button="$attrs.showCloseButton"
     :disabled="$attrs.disabled"
+    :offset="$attrs.offset"
     :force-show-arrow="$attrs.forceShowArrow"
     :active="$attrs.active"
     :danger="$attrs.danger"

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -29,7 +29,7 @@
       :placement="placement"
       :initial-focus-element="initialFocusElement"
       :show-close-button="showCloseButton"
-      :offset="[0, 16]"
+      :offset="offset"
       padding="none"
       class="dt-recipe--callbar-button-with-popover--popover-wrapper"
       :dialog-class="['dt-recipe--callbar-button-with-popover--popover', contentClass]"
@@ -134,6 +134,22 @@ export default {
     placement: {
       type: String,
       default: 'top',
+    },
+
+    /**
+     *  Displaces the content box from its anchor element
+     *  by the specified number of pixels.
+     *  <a
+     *    class="d-link"
+     *    href="https://atomiks.github.io/tippyjs/v6/all-props/#offset"
+     *    target="_blank"
+     *  >
+     *    Tippy.js docs
+     *  </a>
+     */
+    offset: {
+      type: Array,
+      default: () => [0, 16],
     },
 
     /**

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_default.story.vue
@@ -7,6 +7,7 @@
     :initial-focus-element="$attrs.initialFocusElement"
     :show-close-button="$attrs.showCloseButton"
     :disabled="$attrs.disabled"
+    :offset="$attrs.offset"
     :force-show-arrow="$attrs.forceShowArrow"
     :active="$attrs.active"
     :danger="$attrs.danger"


### PR DESCRIPTION
# feat(callbar-button-with-popover): add offset as passthrough prop

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

- [x] Feature

## :book: Description

Quickly adding this in for Mo, allows to change offset on the callbar butotn

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
