### PR TITLE
refactor(message-input): NO-JIRA remove util classes and clean up

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -129,6 +129,7 @@ export const argsData = {
   showSend: {
     icon: 'send',
     ariaLabel: 'send',
+    tooltipLabel: 'Send',
   },
   mentionSuggestion,
   channelSuggestion,

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.test.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.test.js
@@ -105,20 +105,19 @@ describe('DtRecipeMessageInput tests', () => {
     });
 
     it('should not have border applied on message-input when not focused', () => {
-      expect(messageInputEl.classes('d-bc-default')).toBe(true);
-      expect(messageInputEl.classes('d-bc-bold')).toBe(false);
+      expect(messageInputEl.classes('dt-message-input--focused')).toBe(false);
     });
 
     describe('When we focus anywhere on the message input', () => {
       it('should focus and add the border for the message input', async () => {
         await editor.trigger('focus');
-        expect(messageInputEl.classes('d-bc-bold')).toBe(true);
+        expect(messageInputEl.classes('dt-message-input--focused')).toBe(true);
       });
 
       it('should programmatically focus to input', async () => {
         wrapper.vm.onFocus();
         await wrapper.vm.$nextTick();
-        expect(messageInputEl.classes('d-bc-bold')).toBe(true);
+        expect(messageInputEl.classes('dt-message-input--focused')).toBe(true);
       });
     });
 

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -800,9 +800,11 @@ export default {
   &__bottom-section-left {
     display: flex;
   }
+
   &__bottom-section-right {
     display: flex;
   }
+
   &__image-input {
     position: absolute;
   }

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -753,7 +753,7 @@ export default {
   display: flex;
   flex-direction: column;
   border-radius: var(--dt-size-radius-400);
-  border: var(--dt-space-100) solid;
+  border: var(--dt-size-border-100) solid;
   border-color: var(--dt-color-border-default);
   cursor: text;
 
@@ -764,10 +764,7 @@ export default {
 
   &__editor-wrapper {
     overflow: auto;
-    margin-left: var(--dt-space-500);
-    margin-right: var(--dt-space-500);
-    margin-top: var(--dt-space-400);
-    margin-bottom: var(--dt-space-300);
+    padding: var(--dt-space-400) var(--dt-space-500) var(--dt-space-300);
   }
 
   &__remaining-char-tooltip {
@@ -794,7 +791,7 @@ export default {
   &__bottom-section {
     display: flex;
     justify-content: space-between;
-    margin: var(--dt-space-300) var(--dt-space-400);
+    padding: var(--dt-space-300) var(--dt-space-400);
   }
 
   &__bottom-section-left {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -3,8 +3,7 @@
   <div
     data-qa="dt-message-input"
     role="presentation"
-    :class="['d-d-flex', 'd-fd-column', 'd-bar8', 'd-baw1', 'd-ba', 'd-c-text',
-             { 'd-bc-bold d-bs-sm': hasFocus, 'd-bc-default': !hasFocus }]"
+    :class="['dt-message-input', { 'dt-message-input--focused': hasFocus }]"
     @click="$refs.richTextEditor?.focusEditor()"
     @drag-enter="onDrag"
     @drag-over="onDrag"
@@ -14,7 +13,7 @@
   >
     <!-- Some wrapper to restrict the height and show the scrollbar -->
     <div
-      class="d-of-auto d-mx16 d-mt8 d-mb4"
+      class="dt-message-input__editor-wrapper"
       :style="{ 'max-height': maxHeight }"
     >
       <dt-rich-text-editor
@@ -47,48 +46,41 @@
     <!-- @slot Slot for attachment carousel -->
     <slot name="middle" />
     <!-- Section for the bottom UI -->
-    <section class="d-d-flex d-jc-space-between d-mx8 d-my4">
+    <section class="dt-message-input__bottom-section">
       <!-- Left content -->
-      <div class="d-d-flex">
-        <dt-tooltip
+      <div class="dt-message-input__bottom-section-left">
+        <dt-button
           v-if="showImagePicker"
-          placement="top-start"
-          :message="showImagePicker.tooltipLabel"
-          :offset="[-4, 12]"
+          v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
+          data-qa="dt-message-input-image-btn"
+          size="sm"
+          circle
+          :kind="imagePickerFocus ? 'default' : 'muted'"
+          importance="clear"
+          :aria-label="showImagePicker.ariaLabel"
+          @click="onSelectImage"
+          @mouseenter="imagePickerFocus = true"
+          @mouseleave="imagePickerFocus = false"
+          @focus="imagePickerFocus = true"
+          @blur="imagePickerFocus = false"
         >
-          <template #anchor>
-            <dt-button
-              data-qa="dt-message-input-image-btn"
-              size="sm"
-              circle
-              :kind="imagePickerFocus ? 'default' : 'muted'"
-              importance="clear"
-              :aria-label="showImagePicker.ariaLabel"
-              @click="onSelectImage"
-              @mouseenter="imagePickerFocus = true"
-              @mouseleave="imagePickerFocus = false"
-              @focus="imagePickerFocus = true"
-              @blur="imagePickerFocus = false"
-            >
-              <template #icon>
-                <dt-icon
-                  name="image"
-                  size="300"
-                />
-              </template>
-            </dt-button>
-            <dt-input
-              ref="messageInputImageUpload"
-              data-qa="dt-message-input-image-input"
-              accept="image/*, video/*"
-              type="file"
-              class="d-ps-absolute"
-              multiple
-              hidden
-              @input="onImageUpload"
+          <template #icon>
+            <dt-icon
+              name="image"
+              size="300"
             />
           </template>
-        </dt-tooltip>
+        </dt-button>
+        <dt-input
+          ref="messageInputImageUpload"
+          data-qa="dt-message-input-image-input"
+          accept="image/*, video/*"
+          type="file"
+          class="dt-message-input__image-input"
+          multiple
+          hidden
+          @input="onImageUpload"
+        />
         <dt-popover
           v-if="showEmojiPicker"
           data-qa="dt-message-input-emoji-picker-popover"
@@ -134,11 +126,11 @@
         <slot name="emojiGiphyPicker" />
       </div>
       <!-- Right content -->
-      <div class="d-d-flex">
+      <div class="dt-message-input__bottom-section-right">
         <!-- Optionally displayed remaining character counter -->
         <dt-tooltip
           v-if="Boolean(showCharacterLimit)"
-          class="dt-message-input--remaining-char-tooltip"
+          class="dt-message-input__remaining-char-tooltip"
           placement="top-end"
           :enabled="characterLimitTooltipEnabled"
           :message="showCharacterLimit.message"
@@ -147,7 +139,7 @@
           <template #anchor>
             <p
               v-show="displayCharacterLimitWarning"
-              class="d-fc-error d-mr16 dt-message-input--remaining-char"
+              class="dt-message-input__remaining-char"
               data-qa="dt-message-input-character-limit"
             >
               {{ showCharacterLimit.count - inputLength }}
@@ -159,7 +151,7 @@
         <dt-button
           v-if="showCancel"
           data-qa="dt-message-input-cancel-button"
-          class="dt-message-input--cancel-button"
+          class="dt-message-input__cancel-button"
           size="sm"
           kind="muted"
           importance="clear"
@@ -170,52 +162,39 @@
         </dt-button>
 
         <!-- Send button -->
-        <dt-tooltip
+        <!-- Right positioned UI - send button -->
+        <dt-button
           v-if="showSend"
-          placement="top-end"
-          :enabled="!showSend"
-          :message="showSend.tooltipLabel"
-          :show="!isSendDisabled && sendButtonFocus"
-          :offset="[6, 8]"
+          v-dt-tooltip:top-end="showSend?.tooltipLabel"
+          data-qa="dt-message-input-send-btn"
+          size="sm"
+          kind="default"
+          importance="primary"
+          :class="[
+            {
+              'dt-message-input__send-button--disabled': isSendDisabled,
+              'd-btn--circle': showSend.icon,
+            },
+          ]"
+          :aria-label="showSend.ariaLabel"
+          :aria-disabled="isSendDisabled"
+          @click="onSend"
         >
-          <template #anchor>
-            <!-- Right positioned UI - send button -->
-            <dt-button
-              data-qa="dt-message-input-send-btn"
-              size="sm"
-              kind="default"
-              importance="primary"
-              :class="[
-                {
-                  'message-input-button__disabled d-fc-muted': isSendDisabled,
-                  'd-btn--circle': showSend.icon,
-                },
-              ]"
-              :aria-label="showSend.ariaLabel"
-              :aria-disabled="isSendDisabled"
-              @click="onSend"
-              @mouseenter="sendButtonFocus = true"
-              @mouseleave="sendButtonFocus = false"
-              @focus="sendButtonFocus = true"
-              @blur="sendButtonFocus = false"
-            >
-              <template
-                v-if="showSend.icon"
-                #icon
-              >
-                <dt-icon
-                  :name="showSend.icon"
-                  size="300"
-                />
-              </template>
-              <template
-                v-if="showSend.text"
-              >
-                <p>{{ showSend.text }}</p>
-              </template>
-            </dt-button>
+          <template
+            v-if="showSend.icon"
+            #icon
+          >
+            <dt-icon
+              :name="showSend.icon"
+              size="300"
+            />
           </template>
-        </dt-tooltip>
+          <template
+            v-if="showSend.text"
+          >
+            <p>{{ showSend.text }}</p>
+          </template>
+        </dt-button>
       </div>
     </section>
   </div>
@@ -634,7 +613,6 @@ export default {
       hasFocus: false,
       imagePickerFocus: false,
       emojiPickerFocus: false,
-      sendButtonFocus: false,
       emojiPickerOpened: false,
     };
   },
@@ -771,21 +749,62 @@ export default {
 </script>
 
 <style lang="less">
-.dt-message-input--remaining-char-tooltip {
-  margin-top: auto;
-  margin-bottom: auto;
-}
-.dt-message-input--remaining-char {
-  font-size: 1.2rem;
-}
+.dt-message-input {
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--dt-size-radius-400);
+  border: var(--dt-space-100) solid;
+  border-color: var(--dt-color-border-default);
+  cursor: text;
 
-.message-input-button__disabled {
-  background-color: unset;
-  color: var(--theme-sidebar-icon-color);
-  cursor: default;
-}
+  &--focused {
+    border-color: var(--dt-color-border-bold);
+    box-shadow: var(--dt-shadow-small);
+  }
 
-.dt-message-input--cancel-button {
-  margin-right: var(--dt-space-300);
+  &__editor-wrapper {
+    overflow: auto;
+    margin-left: var(--dt-space-500);
+    margin-right: var(--dt-space-500);
+    margin-top: var(--dt-space-400);
+    margin-bottom: var(--dt-space-300);
+  }
+
+  &__remaining-char-tooltip {
+    margin-top: auto;
+    margin-bottom: auto;
+  }
+
+  &__remaining-char {
+    color: var(--dt-color-foreground-critical);
+    font-size: var(--dt-font-size-100);
+    margin-right: var(--dt-space-500);
+  }
+
+  &__send-button--disabled {
+    background-color: unset;
+    color: var(--dt-color-foreground-muted);
+    cursor: default;
+  }
+
+  &__cancel-button {
+    margin-right: var(--dt-space-300);
+  }
+
+  &__bottom-section {
+    display: flex;
+    justify-content: space-between;
+    margin: var(--dt-space-300) var(--dt-space-400);
+  }
+
+  &__bottom-section-left {
+    display: flex;
+  }
+  &__bottom-section-right {
+    display: flex;
+  }
+  &__image-input {
+    position: absolute;
+  }
 }
 </style>

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -129,6 +129,7 @@ export const argsData = {
   showSend: {
     icon: 'send',
     ariaLabel: 'send',
+    tooltipLabel: 'Send',
   },
   mentionSuggestion,
   channelSuggestion,

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.test.js
@@ -105,20 +105,19 @@ describe('DtRecipeMessageInput tests', () => {
     });
 
     it('should not have border applied on message-input when not focused', () => {
-      expect(messageInputEl.classes('d-bc-default')).toBe(true);
-      expect(messageInputEl.classes('d-bc-bold')).toBe(false);
+      expect(messageInputEl.classes('dt-message-input--focused')).toBe(false);
     });
 
     describe('When we focus anywhere on the message input', () => {
       it('should focus and add the border for the message input', async () => {
         await editor.trigger('focus');
-        expect(messageInputEl.classes('d-bc-bold')).toBe(true);
+        expect(messageInputEl.classes('dt-message-input--focused')).toBe(true);
       });
 
       it('should programmatically focus to input', async () => {
         wrapper.vm.onFocus();
         await wrapper.vm.$nextTick();
-        expect(messageInputEl.classes('d-bc-bold')).toBe(true);
+        expect(messageInputEl.classes('dt-message-input--focused')).toBe(true);
       });
     });
 

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -3,8 +3,7 @@
   <div
     data-qa="dt-message-input"
     role="presentation"
-    :class="['d-d-flex', 'd-fd-column', 'd-bar8', 'd-baw1', 'd-ba', 'd-c-text',
-             { 'd-bc-bold d-bs-sm': hasFocus, 'd-bc-default': !hasFocus }]"
+    :class="['dt-message-input', { 'dt-message-input--focused': hasFocus }]"
     @click="$refs.richTextEditor?.focusEditor()"
     @drag-enter="onDrag"
     @drag-over="onDrag"
@@ -14,7 +13,7 @@
   >
     <!-- Some wrapper to restrict the height and show the scrollbar -->
     <div
-      class="d-of-auto d-mx16 d-mt8 d-mb4"
+      class="dt-message-input__editor-wrapper"
       :style="{ 'max-height': maxHeight }"
     >
       <dt-rich-text-editor
@@ -47,48 +46,41 @@
     <!-- @slot Slot for attachment carousel -->
     <slot name="middle" />
     <!-- Section for the bottom UI -->
-    <section class="d-d-flex d-jc-space-between d-mx8 d-my4">
+    <section class="dt-message-input__bottom-section">
       <!-- Left content -->
-      <div class="d-d-flex">
-        <dt-tooltip
+      <div class="dt-message-input__bottom-section-left">
+        <dt-button
           v-if="showImagePicker"
-          placement="top-start"
-          :message="showImagePicker.tooltipLabel"
-          :offset="[-4, 12]"
+          v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
+          data-qa="dt-message-input-image-btn"
+          size="sm"
+          circle
+          :kind="imagePickerFocus ? 'default' : 'muted'"
+          importance="clear"
+          :aria-label="showImagePicker.ariaLabel"
+          @click="onSelectImage"
+          @mouseenter="imagePickerFocus = true"
+          @mouseleave="imagePickerFocus = false"
+          @focus="imagePickerFocus = true"
+          @blur="imagePickerFocus = false"
         >
-          <template #anchor>
-            <dt-button
-              data-qa="dt-message-input-image-btn"
-              size="sm"
-              circle
-              :kind="imagePickerFocus ? 'default' : 'muted'"
-              importance="clear"
-              :aria-label="showImagePicker.ariaLabel"
-              @click="onSelectImage"
-              @mouseenter="imagePickerFocus = true"
-              @mouseleave="imagePickerFocus = false"
-              @focus="imagePickerFocus = true"
-              @blur="imagePickerFocus = false"
-            >
-              <template #icon>
-                <dt-icon
-                  name="image"
-                  size="300"
-                />
-              </template>
-            </dt-button>
-            <dt-input
-              ref="messageInputImageUpload"
-              data-qa="dt-message-input-image-input"
-              accept="image/*, video/*"
-              type="file"
-              class="d-ps-absolute"
-              multiple
-              hidden
-              @input="onImageUpload"
+          <template #icon>
+            <dt-icon
+              name="image"
+              size="300"
             />
           </template>
-        </dt-tooltip>
+        </dt-button>
+        <dt-input
+          ref="messageInputImageUpload"
+          data-qa="dt-message-input-image-input"
+          accept="image/*, video/*"
+          type="file"
+          class="dt-message-input__image-input"
+          multiple
+          hidden
+          @input="onImageUpload"
+        />
         <dt-popover
           v-if="showEmojiPicker"
           v-model:open="emojiPickerOpened"
@@ -134,11 +126,11 @@
         <slot name="emojiGiphyPicker" />
       </div>
       <!-- Right content -->
-      <div class="d-d-flex">
+      <div class="dt-message-input__bottom-section-right">
         <!-- Optionally displayed remaining character counter -->
         <dt-tooltip
           v-if="Boolean(showCharacterLimit)"
-          class="dt-message-input--remaining-char-tooltip"
+          class="dt-message-input__remaining-char-tooltip"
           placement="top-end"
           :enabled="characterLimitTooltipEnabled"
           :message="showCharacterLimit.message"
@@ -147,7 +139,7 @@
           <template #anchor>
             <p
               v-show="displayCharacterLimitWarning"
-              class="d-fc-error d-mr16 dt-message-input--remaining-char"
+              class="dt-message-input__remaining-char"
               data-qa="dt-message-input-character-limit"
             >
               {{ showCharacterLimit.count - inputLength }}
@@ -159,7 +151,7 @@
         <dt-button
           v-if="showCancel"
           data-qa="dt-message-input-cancel-button"
-          class="dt-message-input--cancel-button"
+          class="dt-message-input__cancel-button"
           size="sm"
           kind="muted"
           importance="clear"
@@ -170,52 +162,39 @@
         </dt-button>
 
         <!-- Send button -->
-        <dt-tooltip
+        <!-- Right positioned UI - send button -->
+        <dt-button
           v-if="showSend"
-          placement="top-end"
-          :enabled="!showSend"
-          :message="showSend.tooltipLabel"
-          :show="!isSendDisabled && sendButtonFocus"
-          :offset="[6, 8]"
+          v-dt-tooltip:top-end="showSend?.tooltipLabel"
+          data-qa="dt-message-input-send-btn"
+          size="sm"
+          kind="default"
+          importance="primary"
+          :class="[
+            {
+              'dt-message-input__send-button--disabled': isSendDisabled,
+              'd-btn--circle': showSend.icon,
+            },
+          ]"
+          :aria-label="showSend.ariaLabel"
+          :aria-disabled="isSendDisabled"
+          @click="onSend"
         >
-          <template #anchor>
-            <!-- Right positioned UI - send button -->
-            <dt-button
-              data-qa="dt-message-input-send-btn"
-              size="sm"
-              kind="default"
-              importance="primary"
-              :class="[
-                {
-                  'message-input-button__disabled d-fc-muted': isSendDisabled,
-                  'd-btn--circle': showSend.icon,
-                },
-              ]"
-              :aria-label="showSend.ariaLabel"
-              :aria-disabled="isSendDisabled"
-              @click="onSend"
-              @mouseenter="sendButtonFocus = true"
-              @mouseleave="sendButtonFocus = false"
-              @focus="sendButtonFocus = true"
-              @blur="sendButtonFocus = false"
-            >
-              <template
-                v-if="showSend.icon"
-                #icon
-              >
-                <dt-icon
-                  :name="showSend.icon"
-                  size="300"
-                />
-              </template>
-              <template
-                v-if="showSend.text"
-              >
-                <p>{{ showSend.text }}</p>
-              </template>
-            </dt-button>
+          <template
+            v-if="showSend.icon"
+            #icon
+          >
+            <dt-icon
+              :name="showSend.icon"
+              size="300"
+            />
           </template>
-        </dt-tooltip>
+          <template
+            v-if="showSend.text"
+          >
+            <p>{{ showSend.text }}</p>
+          </template>
+        </dt-button>
       </div>
     </section>
   </div>
@@ -634,7 +613,6 @@ export default {
       hasFocus: false,
       imagePickerFocus: false,
       emojiPickerFocus: false,
-      sendButtonFocus: false,
       emojiPickerOpened: false,
     };
   },
@@ -771,21 +749,62 @@ export default {
 </script>
 
 <style lang="less">
-.dt-message-input--remaining-char-tooltip {
-  margin-top: auto;
-  margin-bottom: auto;
-}
-.dt-message-input--remaining-char {
-  font-size: 1.2rem;
-}
+.dt-message-input {
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--dt-size-radius-400);
+  border: var(--dt-space-100) solid;
+  border-color: var(--dt-color-border-default);
+  cursor: text;
 
-.message-input-button__disabled {
-  background-color: unset;
-  color: var(--theme-sidebar-icon-color);
-  cursor: default;
-}
+  &--focused {
+    border-color: var(--dt-color-border-bold);
+    box-shadow: var(--dt-shadow-small);
+  }
 
-.dt-message-input--cancel-button {
-  margin-right: var(--dt-space-300);
+  &__editor-wrapper {
+    overflow: auto;
+    margin-left: var(--dt-space-500);
+    margin-right: var(--dt-space-500);
+    margin-top: var(--dt-space-400);
+    margin-bottom: var(--dt-space-300);
+  }
+
+  &__remaining-char-tooltip {
+    margin-top: auto;
+    margin-bottom: auto;
+  }
+
+  &__remaining-char {
+    color: var(--dt-color-foreground-critical);
+    font-size: var(--dt-font-size-100);
+    margin-right: var(--dt-space-500);
+  }
+
+  &__send-button--disabled {
+    background-color: unset;
+    color: var(--dt-color-foreground-muted);
+    cursor: default;
+  }
+
+  &__cancel-button {
+    margin-right: var(--dt-space-300);
+  }
+
+  &__bottom-section {
+    display: flex;
+    justify-content: space-between;
+    margin: var(--dt-space-300) var(--dt-space-400);
+  }
+
+  &__bottom-section-left {
+    display: flex;
+  }
+  &__bottom-section-right {
+    display: flex;
+  }
+  &__image-input {
+    position: absolute;
+  }
 }
 </style>

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -800,9 +800,11 @@ export default {
   &__bottom-section-left {
     display: flex;
   }
+
   &__bottom-section-right {
     display: flex;
   }
+
   &__image-input {
     position: absolute;
   }

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -753,7 +753,7 @@ export default {
   display: flex;
   flex-direction: column;
   border-radius: var(--dt-size-radius-400);
-  border: var(--dt-space-100) solid;
+  border: var(--dt-size-border-100) solid;
   border-color: var(--dt-color-border-default);
   cursor: text;
 
@@ -764,10 +764,7 @@ export default {
 
   &__editor-wrapper {
     overflow: auto;
-    margin-left: var(--dt-space-500);
-    margin-right: var(--dt-space-500);
-    margin-top: var(--dt-space-400);
-    margin-bottom: var(--dt-space-300);
+    padding: var(--dt-space-400) var(--dt-space-500) var(--dt-space-300);
   }
 
   &__remaining-char-tooltip {
@@ -794,7 +791,7 @@ export default {
   &__bottom-section {
     display: flex;
     justify-content: space-between;
-    margin: var(--dt-space-300) var(--dt-space-400);
+    padding: var(--dt-space-300) var(--dt-space-400);
   }
 
   &__bottom-section-left {


### PR DESCRIPTION
# refactor(message-input): remove util classes and clean up

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTE2ZnB4N2c2cDh6ZGE0bmdpNDFocW9qbzg5eHk1ZDVuZWtmcDdmYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/hor7W22LilvnttSTAl/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Refactor

## :book: Description

- Removed all util classes from message-input and converted to css with tokens.
- replaced dt-tooltips that could be directives

## :bulb: Context

Juanchi asked if he could remove the border from message-input and I noticed it was using tons of util classes preventing overrides.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

For all CSS changes:

- [x] I have used design tokens whenever possible.
