### PR TITLE
fix(rich-text-editor): NO-JIRA output emojis in text as unicode rather than shortname

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
@@ -1,7 +1,7 @@
 import { mergeAttributes, Node, nodeInputRule, nodePasteRule } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-2';
 import EmojiComponent from './EmojiComponent.vue';
-import { codeToEmojiData, emojiShortCodeRegex, emojiRegex } from '@/common/emoji';
+import { codeToEmojiData, emojiShortCodeRegex, emojiRegex, stringToUnicode } from '@/common/emoji';
 import { PluginKey } from '@tiptap/pm/state';
 
 import Suggestion from '@tiptap/suggestion';
@@ -75,7 +75,10 @@ export const Emoji = Node.create({
   },
 
   renderText ({ node }) {
-    return node.attrs.code;
+    // output emoji in text as unicode character rather than shortname for backwards compatibility with
+    // our backend.
+    const unicodeEmoji = stringToUnicode(codeToEmojiData(node.attrs.code).unicode_output);
+    return unicodeEmoji;
   },
 
   renderHTML ({ HTMLAttributes }) {

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
@@ -13,7 +13,7 @@ import slashCommandSuggestion from './slash_command_suggestion';
 
 // Default Prop Values
 export const argsData = {
-  value: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:"></emoji-component><emoji-component code=":robot:"></emoji-component>!</p>',
+  value: '<p>I am not a standalone component, please use Message Input instead <emoji-component code=":v_tone3:"></emoji-component><emoji-component code=":robot:"></emoji-component>!</p>',
   editable: true,
   inputAriaLabel: 'This is a descriptive label',
   autoFocus: false,

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/emoji.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/emoji.js
@@ -1,7 +1,7 @@
 import { mergeAttributes, Node, nodeInputRule, nodePasteRule } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-3';
 import EmojiComponent from './EmojiComponent.vue';
-import { codeToEmojiData, emojiShortCodeRegex, emojiRegex } from '@/common/emoji';
+import { codeToEmojiData, emojiShortCodeRegex, emojiRegex, stringToUnicode } from '@/common/emoji';
 import { PluginKey } from '@tiptap/pm/state';
 
 import Suggestion from '@tiptap/suggestion';
@@ -75,7 +75,10 @@ export const Emoji = Node.create({
   },
 
   renderText ({ node }) {
-    return node.attrs.code;
+    // output emoji in text as unicode character rather than shortname for backwards compatibility with
+    // our backend.
+    const unicodeEmoji = stringToUnicode(codeToEmojiData(node.attrs.code).unicode_output);
+    return unicodeEmoji;
   },
 
   renderHTML ({ HTMLAttributes }) {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -13,7 +13,7 @@ import slashCommandSuggestion from './slash_command_suggestion';
 
 // Default Prop Values
 export const argsData = {
-  modelValue: '<p>I am not a standalone component, please use Message Input instead<emoji-component code=":v_tone3:"></emoji-component><emoji-component code=":robot:"></emoji-component>!</p>',
+  modelValue: '<p>I am not a standalone component, please use Message Input instead <emoji-component code=":v_tone3:"></emoji-component><emoji-component code=":robot:"></emoji-component>!</p>',
   editable: true,
   inputAriaLabel: 'This is a descriptive label',
   autoFocus: false,


### PR DESCRIPTION
# fix(rich-text-editor): out emojis in text as unicode rather than shortname

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExemxvMTJtMGR5ajh3ZTZmZWgwbTg0aTUyOWF2dTM1bzZwaWd1dnRvYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Pn1h5Un3LZD9uq3u07/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Output emojis when in outputType "text" as unicode rather than shortname.

## :bulb: Context

Our backend just passes through the shortname text, which is fine on web because we can just convert it to an emoji again on the other side, however mobile will show the actual string `:smile:` for example without converting it to emoji.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
