### PR TITLE
fix(message-input): NO-JIRA small issues with slash commands

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -319,7 +319,6 @@ export default {
   data () {
     return {
       editor: null,
-      lastValue: this.value,
     };
   },
 
@@ -535,13 +534,12 @@ export default {
       // The content has changed.
       this.editor.on('update', () => {
         const value = this.getOutput();
-        if (this.preventTyping && value.length > this.lastValue.length) {
-          this.editor.commands.setContent(this.lastValue, false);
+        if (this.preventTyping && value.length > this.value.length) {
+          this.editor.commands.setContent(this.value, false);
           return;
         }
         this.$emit('input', value);
         this.$emit('update:value', value);
-        this.lastValue = value;
       });
 
       // The editor is focused.

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -590,6 +590,14 @@ export default {
     'selected-command',
 
     /**
+     * Fires when meeting pill is closed
+     *
+     * @event meeting-pill-close
+     * @type {String}
+     */
+    'meeting-pill-close',
+
+    /**
      * Event to sync the value with the parent
      * @event update:value
      * @type {String|JSON}

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -319,7 +319,6 @@ export default {
   data () {
     return {
       editor: null,
-      lastValue: this.modelValue,
     };
   },
 
@@ -535,13 +534,12 @@ export default {
       // The content has changed.
       this.editor.on('update', () => {
         const value = this.getOutput();
-        if (this.preventTyping && value.length > this.lastValue.length) {
-          this.editor.commands.setContent(this.lastValue, false);
+        if (this.preventTyping && value.length > this.value.length) {
+          this.editor.commands.setContent(this.value, false);
           return;
         }
         this.$emit('input', value);
         this.$emit('update:modelValue', value);
-        this.lastValue = value;
       });
 
       // The editor is focused.

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -589,6 +589,14 @@ export default {
     'selected-command',
 
     /**
+     * Fires when meeting pill is closed
+     *
+     * @event meeting-pill-close
+     * @type {String}
+     */
+    'meeting-pill-close',
+
+    /**
      * Event to sync the value with the parent
      * @event update:modelValue
      * @type {String|JSON}


### PR DESCRIPTION
# fix(message-input): NO-JIRA small issues with slash commands

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdHd6aGc0NHpzYTdicHJobjY2MjdjbHZtNzFreXpsb2w2MzZ4Y2Y0eCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l4JyJHAF8blvfplf2/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

While i was integrating pills on new message input, I come up with two small issues.

1. It seems that lastValue prop was not being updated correctly. I replaced that to use value isntead; not sure if that going to work on product side tbh, but nothing else came to my mind. Let me know what you think. Seems to be still working on dialtone side.
![image](https://github.com/dialpad/dialtone/assets/144126346/e55dcdea-cbe4-4380-8606-8a42c818d40c)

2. `meeting-pill-close` was not being triggered. I added it and know should work.

## :bulb: Context
Here's the work I had already made on product side for this: https://github.com/dialpad/firespotter/pull/43603
