### PR TITLE
fix(rich-text-editor): DLT-1822 inputs with line breaks are not working for editor

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -396,6 +396,8 @@ export default {
             },
           }),
         );
+      } else {
+        extensions.push(HardBreak);
       }
 
       if (this.mentionSuggestion) {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -396,6 +396,8 @@ export default {
             },
           }),
         );
+      } else {
+        extensions.push(HardBreak);
       }
 
       if (this.mentionSuggestion) {


### PR DESCRIPTION
# fix(rich-text-editor): DLT-1822 inputs with line breaks are not working for editor

## Obligatory GIF

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExem52Y2pwOTBxNnVnaThtdmY4dHp1eTRtMmI3bTFrZThzemxxdGNsYSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/toXKzaJP3WIgM/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

[Jira ticket ](https://dialpad.atlassian.net/browse/DLT-1822)

## :book: Description

Inputs with `<br>` for the rich text editor used to work, but now they don't anymore. To fix it I had to add the `HardBreak` extension manually to the rich text editor component's extensions (only when line breaks enabled via `allowLineBreaks` prop), whereas before it was working by default. Not sure if it was something in the tip-tap plugin defaults that changed or if some of the other changes that have been recently made to the editor is what caused this.

## :bulb: Context

Original bug reported [here](https://dialpad.atlassian.net/browse/DP-102153)
Users need the line breaks to work because most of them appear to use longish/multiline quick replies for emails, which usually include line breaks. 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

<img width="1229" alt="Screenshot 2024-06-18 at 09 29 21" src="https://github.com/dialpad/dialtone/assets/12575023/61b8ff07-b86c-4f98-97d7-2d99c9db9d12">

## :link: Sources

[tip-tap hard break extension docs](https://tiptap.dev/docs/editor/api/nodes/hard-break)
