### PR TITLE
fix(message-input): NO-JIRA preventTyping not working with pills

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -534,7 +534,9 @@ export default {
       // The content has changed.
       this.editor.on('update', () => {
         const value = this.getOutput();
-        if (this.preventTyping && value.length > this.value.length) {
+        // When preventTyping is true and user wants to type, we revert to last value
+        // If Backspace (keyCode = 8) is pressed, we allow updating the text
+        if (this.preventTyping && this.editor.view?.input?.lastKeyCode !== 8) {
           this.editor.commands.setContent(this.value, false);
           return;
         }

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -196,5 +196,6 @@ export const WithMeetingPill = {
       },
     },
     value: '<meeting-pill text="Start a meeting" close-button-aria-label="Delete meeting pill"/>',
+    preventTyping: true,
   },
 };

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -534,7 +534,9 @@ export default {
       // The content has changed.
       this.editor.on('update', () => {
         const value = this.getOutput();
-        if (this.preventTyping && value.length > this.value.length) {
+        // When preventTyping is true and user wants to type, we revert to last value
+        // If Backspace (keyCode = 8) is pressed, we allow updating the text
+        if (this.preventTyping && this.editor.view?.input?.lastKeyCode !== 8) {
           this.editor.commands.setContent(this.value, false);
           return;
         }

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -204,5 +204,6 @@ export const WithMeetingPill = {
       },
     },
     modelValue: '<meeting-pill text="Start a meeting" close-button-aria-label="Delete meeting pill"/>',
+    preventTyping: true,
   },
 };


### PR DESCRIPTION
# fix(message-input): NO-JIRA preventTyping not working with pills

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbm1nanhmcDloZXZmOWp5b3RoazBrY2d4aXIxOG9kNHFubzFyejFidiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/UWovEBGTAjFra/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description
We need to disallow typing when a pill is selected.

## :bulb: Context
The fix I introduced to prevent users typing https://github.com/dialpad/dialtone/pull/371 when a pill is present did not work. 
The problem seems to be that the old value (`this.value`) is something like this `<meeting-pill text="Start a meeting" close-button-aria-label="Delete meeting pill"/>` while `value` is something like `/dpm{newCharacter}`, so when we did `value.length > this.value.length` the first time, it returned false and the value was updated.
So the fix I made this time was to disallow typing if keyCode is different from 8 (backspace key), so we don't need to register the length of the old and new values. If you come up with something better, please let me know, but so far this is the best I have found.