### PR TITLE
docs(input): DLT-1782 add search input example

### DIFF
--- a/apps/dialtone-documentation/docs/components/input.md
+++ b/apps/dialtone-documentation/docs/components/input.md
@@ -299,7 +299,7 @@ vueCode='
 '
 showHtmlWarning />
 
-### With left icon and clear button
+### Search input
 
 <code-well-header>
   <div class="d-w100p">

--- a/apps/dialtone-documentation/docs/components/input.md
+++ b/apps/dialtone-documentation/docs/components/input.md
@@ -301,6 +301,16 @@ showHtmlWarning />
 
 ### Search input
 
+<dt-notice
+  kind="warning"
+  hideClose="true"
+  class="d-wmx100p d-mb24"
+>
+  <template #default>
+  Note: The usage of <code>type="search"</code> is not recommended for this component as it may cause unintended styling issues in Chrome. Instead, refer to the provided example code if you need to implement a search input.
+  </template>
+</dt-notice>
+
 <code-well-header>
   <div class="d-w100p">
     <dt-input

--- a/apps/dialtone-documentation/docs/components/input.md
+++ b/apps/dialtone-documentation/docs/components/input.md
@@ -299,6 +299,73 @@ vueCode='
 '
 showHtmlWarning />
 
+### With left icon and clear button
+
+<code-well-header>
+  <div class="d-w100p">
+    <dt-input
+      aria-label="Search items"
+      placeholder="Search Items"
+      type="text"
+    >
+      <template #leftIcon>
+        <dt-icon name="search" size="300" />
+      </template>
+      <template #rightIcon>
+        <dt-button
+          kind="muted"
+          importance="clear"
+          size="xs"
+          circle
+          aria-label="Clear search"
+        >
+          <template #icon>
+            <dt-icon name="close" size="200" />
+          </template>
+        </dt-button>
+      </template>
+    </dt-input>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<div class="d-input__wrapper">
+  <span class="base-input__icon--left d-input-icon--left d-input-icon">...</span>
+  <input type="text" autocomplete="off" class="base-input__input d-input d-input-icon--left d-input-icon--right" placeholder="Search Items">
+  <span class="base-input__icon--right d-input-icon--right d-input-icon undefined" data-qa="dt-input-right-icon-wrapper">
+    <button class="base-button__button d-btn d-btn--muted d-btn--xs d-btn--circle d-btn--icon-only" data-qa="dt-button" type="button" aria-label="Clear search">
+      <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+    </button>
+  </span>
+</div>
+'
+vueCode='
+<dt-input
+  aria-label="Search items"
+  placeholder="Search Items"
+  type="text"
+>
+  <template #leftIcon>
+    <dt-icon name="search" size="300" />
+  </template>
+  <template #rightIcon>
+    <dt-button
+      kind="muted"
+      importance="clear"
+      size="xs"
+      circle
+      aria-label="Clear search"
+    >
+      <template #icon>
+        <dt-icon name="close" size="200" />
+      </template>
+    </dt-button>
+  </template>
+</dt-input>
+'
+showHtmlWarning />
+
 ### Input sizes
 
 We offer different sizes for instances in which the interface requires a smaller or larger input. In general, though, use the base (medium) size input as much as possible, especially in forms.

--- a/packages/dialtone-vue2/components/input/input.vue
+++ b/packages/dialtone-vue2/components/input/input.vue
@@ -147,9 +147,10 @@ export default {
     },
 
     /**
-     * Type of the input, one of: `text`, `password`, `email`, `number`, `textarea`, 'date', 'time'.
+     * Type of the input.
      * When `textarea` a `<textarea>` element will be rendered instead of an `<input>` element.
-     * @values text, password, email, number, textarea, date, time
+     * @values text, password, email, number, textarea, date, time, file, tel
+     * @default 'text'
      */
     type: {
       type: String,
@@ -471,6 +472,7 @@ export default {
     },
 
     shouldValidateLength () {
+      // eslint-disable-next-line max-lines
       return !!(
         this.validationProps.length.description &&
         this.validationProps.length.max

--- a/packages/dialtone-vue2/components/input/input_constants.js
+++ b/packages/dialtone-vue2/components/input/input_constants.js
@@ -9,6 +9,7 @@ export const INPUT_TYPES = {
   DATE: 'date',
   TIME: 'time',
   FILE: 'file',
+  TEL: 'tel',
 };
 
 export const INPUT_SIZES = {

--- a/packages/dialtone-vue3/components/input/input.vue
+++ b/packages/dialtone-vue3/components/input/input.vue
@@ -148,9 +148,10 @@ export default {
     },
 
     /**
-     * Type of the input, one of: `text`, `password`, `email`, `number`, `textarea`, 'date', 'time'.
+     * Type of the input.
      * When `textarea` a `<textarea>` element will be rendered instead of an `<input>` element.
-     * @values text, password, email, number, textarea, date, time
+     * @values text, password, email, number, textarea, date, time, file, tel
+     * @default 'text'
      */
     type: {
       type: String,

--- a/packages/dialtone-vue3/components/input/input_constants.js
+++ b/packages/dialtone-vue3/components/input/input_constants.js
@@ -9,6 +9,7 @@ export const INPUT_TYPES = {
   DATE: 'date',
   TIME: 'time',
   FILE: 'file',
+  TEL: 'tel',
 };
 
 export const INPUT_SIZES = {


### PR DESCRIPTION
# docs(input): DLT-1782 add search input example

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/5xtDarztR1rCyfIpMDS/giphy.gif?cid=790b7611q67lk42mpltopqt9938h2bgusdmplje1wwvkviff&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

- [x] Documentation

## :book: Jira Ticket
[DLT-1782]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adds an example showing a typical search input in the doc site.

I resolved not to add the type `search` as a valid type because even though the functionality is the same as `type="text"`, Chrome adds a clear button, and if I hide it, I would be braking what they are already using in some cases in the product:
<img width="266" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/73f9fab3-3002-4417-ad00-1b525348d1b2">

Also, added type `tel` since it's documented.

<!--- Describe specifically what the changes are -->

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :crystal_ball: Next Steps
We could add the type `search` after the remaining uses of `<input type="search"></input>` are migrated to DtInput.
<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<img width="1205" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/b7a8ce89-1882-4651-8c63-3cefadc38c4d">



[DLT-1782]: https://dialpad.atlassian.net/browse/DLT-1782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ