### PR TITLE
docs: DLT-1764 update to new Dialpad logo in doc site header

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/DialtoneLogo.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/DialtoneLogo.vue
@@ -4,18 +4,11 @@
     title="Go back to the homepage"
     to="/"
   >
-    <img
-      class="d-h42"
-      :alt="brandLogoAlt"
-      :src="brandLogo"
-    >
+    <svg-loader :illustration="true" name="dialpad-logo" />
   </router-link>
 </template>
 
 <script setup>
-import { useThemeLocaleData } from '@vuepress/plugin-theme-data/client';
-import { useSiteLocaleData } from '@vuepress/client';
+import SvgLoader from '../../baseComponents/SvgLoader.vue';
 
-const brandLogo = useThemeLocaleData().value.logo;
-const brandLogoAlt = useSiteLocaleData().value.title;
 </script>

--- a/packages/dialtone-vue2/.storybook/dialtone-themes.js
+++ b/packages/dialtone-vue2/.storybook/dialtone-themes.js
@@ -7,13 +7,13 @@ import { create } from '@storybook/theming/create';
 const _baseThemeVariables = {
   brandTitle: 'Dialpad storybook',
   brandUrl: 'https://dialtone.dialpad.com',
-  brandImage: 'https://static.dialpadcdn.com/dialtone/dialpad_logo.svg',
   fontBase: '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
 }
 
 export const dialtoneDarkTheme = create({
   base: 'dark',
   ..._baseThemeVariables,
+  brandImage: 'https://static.dialpadcdn.com/dialtone/dialpad-logo-white.svg',
   appBg: '#1B1B1B', // --dt-color-surface-secondary
   appContentBg: '#080808', // --dt-color-surface-primary
 
@@ -27,6 +27,7 @@ export const dialtoneDarkTheme = create({
 export const dialtoneLightTheme = create({
   base: 'light',
   ..._baseThemeVariables,
+  brandImage: 'https://static.dialpadcdn.com/dialtone/dialpad-logo-black.svg',
   appBg: '#F9F9F9', // --dt-color-surface-secondary
   appContentBg: '#FFFFFF', // --dt-color-surface-primary
 

--- a/packages/dialtone-vue2/docs/welcome.mdx
+++ b/packages/dialtone-vue2/docs/welcome.mdx
@@ -1,11 +1,12 @@
 import { Meta } from '@storybook/blocks';
 import { version } from '../package.json';
+import { useDarkMode } from "storybook-dark-mode";
 import { LogoContainer, Logo } from './components';
 
 <Meta title="Welcome" id="welcome" />
 
 <LogoContainer>
-  <Logo className="example-doc__image" src="https://static.dialpadcdn.com/dialtone/dialpad_logo.svg" />
+  <Logo className="example-doc__image" src={`https://static.dialpadcdn.com/dialtone/dialpad-logo-${useDarkMode() ? 'white' : 'black'}.svg`} />
 </LogoContainer>
 
 # Dialtone Vue 📞

--- a/packages/dialtone-vue3/.storybook/dialtone-themes.js
+++ b/packages/dialtone-vue3/.storybook/dialtone-themes.js
@@ -7,13 +7,13 @@ import { create } from '@storybook/theming/create';
 const _baseThemeVariables = {
   brandTitle: 'Dialpad storybook',
   brandUrl: 'https://dialtone.dialpad.com',
-  brandImage: 'https://static.dialpadcdn.com/dialtone/dialpad_logo.svg',
   fontBase: '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
 }
 
 export const dialtoneDarkTheme = create({
   base: 'dark',
   ..._baseThemeVariables,
+  brandImage: 'https://static.dialpadcdn.com/dialtone/dialpad-logo-white.svg',
   appBg: '#1B1B1B', // --dt-color-surface-secondary
   appContentBg: '#080808', // --dt-color-surface-primary
 
@@ -27,6 +27,7 @@ export const dialtoneDarkTheme = create({
 export const dialtoneLightTheme = create({
   base: 'light',
   ..._baseThemeVariables,
+  brandImage: 'https://static.dialpadcdn.com/dialtone/dialpad-logo-black.svg',
   appBg: '#F9F9F9', // --dt-color-surface-secondary
   appContentBg: '#FFFFFF', // --dt-color-surface-primary
 

--- a/packages/dialtone-vue3/docs/welcome.mdx
+++ b/packages/dialtone-vue3/docs/welcome.mdx
@@ -1,11 +1,12 @@
 import { Meta } from '@storybook/blocks';
 import { version } from '../package.json';
+import { useDarkMode } from "storybook-dark-mode";
 import { LogoContainer, Logo } from './components';
 
 <Meta title="Welcome" id="welcome" />
 
 <LogoContainer>
-  <Logo className="example-doc__image" src="https://static.dialpadcdn.com/dialtone/dialpad_logo.svg" />
+  <Logo className="example-doc__image" src={`https://static.dialpadcdn.com/dialtone/dialpad-logo-${useDarkMode() ? 'white' : 'black'}.svg`} />
 </LogoContainer>
 
 # Dialtone Vue 📞


### PR DESCRIPTION
# Update to new Dialpad logo in doc site header

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :book: Jira Ticket
[DLT-1764]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :camera: Screenshots / GIFs

## Doc site

<img width="1168" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/0ad38174-4b69-4516-b994-020208398d80">
<img width="1170" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/de55e86d-d085-4f6e-b705-8bc960f84d23">

## Storybook

<img width="1225" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/cb0c9379-f87f-4ea4-9784-2ecfa6703a8a">

<img width="1239" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/67e2471a-60cc-4bd9-85bb-d9b99b5af6bb">



<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->


[DLT-1764]: https://dialpad.atlassian.net/browse/DLT-1764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ