### PR TITLE
feat(popover): DLT-1826 appendTo root

### DIFF
--- a/packages/dialtone-vue2/components/popover/popover.stories.js
+++ b/packages/dialtone-vue2/components/popover/popover.stories.js
@@ -243,3 +243,21 @@ export const Variants = {
     },
   },
 };
+
+export const IframeTest = {
+  render: (argsData) => createRenderConfig(DtPopover, PopoverDefault, argsData),
+
+  args: {
+    appendTo: window.parent.document.body,
+    placement: 'top-start',
+    fallbackPlacements: [],
+  },
+
+  decorators: [
+    () => ({
+      template: `<div class="d-d-flex d-jc-center d-ai-center d-h332"><story /></div>`,
+    }),
+  ],
+
+  parameters: {},
+};

--- a/packages/dialtone-vue2/components/popover/popover.stories.js
+++ b/packages/dialtone-vue2/components/popover/popover.stories.js
@@ -249,8 +249,6 @@ export const IframeTest = {
   render: (argsData) => createRenderConfig(DtPopover, PopoverIframe, argsData),
 
   args: {
-    appendTo: window.parent.document.body,
-    placement: 'top-start',
-    fallbackPlacements: [],
+    placement: 'top-end',
   },
 };

--- a/packages/dialtone-vue2/components/popover/popover.stories.js
+++ b/packages/dialtone-vue2/components/popover/popover.stories.js
@@ -7,6 +7,7 @@ import {
 } from './';
 import PopoverDefault from './popover_default.story.vue';
 import PopoverVariants from './popover_variants.story.vue';
+import PopoverIframe from './popover_iframe.story.vue';
 import { createRenderConfig } from '@/common/storybook_utils';
 
 import { action } from '@storybook/addon-actions';
@@ -245,19 +246,11 @@ export const Variants = {
 };
 
 export const IframeTest = {
-  render: (argsData) => createRenderConfig(DtPopover, PopoverDefault, argsData),
+  render: (argsData) => createRenderConfig(DtPopover, PopoverIframe, argsData),
 
   args: {
     appendTo: window.parent.document.body,
     placement: 'top-start',
     fallbackPlacements: [],
   },
-
-  decorators: [
-    () => ({
-      template: `<div class="d-d-flex d-jc-center d-ai-center d-h332"><story /></div>`,
-    }),
-  ],
-
-  parameters: {},
 };

--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -948,7 +948,12 @@ export default {
       }
     },
 
-    getReferenceClientRect (appendTo, error) {
+    /**
+     * Return's the anchor ClientRect object relative to the window.
+     * Refer to: https://atomiks.github.io/tippyjs/v6/all-props/#getreferenceclientrect for more information
+     * @param error
+     */
+    getReferenceClientRect (error) {
       const anchorReferenceRect = this.anchorEl?.getBoundingClientRect();
 
       if (this.appendTo !== 'root' || error) return anchorReferenceRect;
@@ -1005,7 +1010,7 @@ export default {
         appendTo: internalAppendTo,
         interactive: true,
         trigger: 'manual',
-        getReferenceClientRect: () => this.getReferenceClientRect(internalAppendTo, iFrameError),
+        getReferenceClientRect: () => this.getReferenceClientRect(iFrameError),
         // We have to manage hideOnClick functionality manually to handle
         // popover within popover situations.
         hideOnClick: false,

--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -947,22 +947,25 @@ export default {
     },
 
     getReferenceClientRect (appendTo, error) {
-      const anchorReferenceRect = this.anchorEl.getBoundingClientRect();
+      const anchorReferenceRect = this.anchorEl?.getBoundingClientRect();
 
       if (this.appendTo !== 'root' || error) return anchorReferenceRect;
 
-      const iframe = appendTo.getElementsByTagName('iframe');
-      const iframeReferenceRect = iframe[0].getBoundingClientRect();
+      const anchorOwnerDocument = this.anchorEl?.ownerDocument;
+      const anchorParentWindow = anchorOwnerDocument?.defaultView || anchorOwnerDocument?.parentWindow;
+      const anchorIframe = anchorParentWindow?.frameElement;
 
-      if (!iframe || this.anchorEl.ownerDocument === iframe[0].ownerDocument) return anchorReferenceRect;
+      if (!anchorIframe) return anchorReferenceRect;
+
+      const iframeReferenceRect = anchorIframe.getBoundingClientRect();
 
       return {
-        width: anchorReferenceRect.width,
-        height: anchorReferenceRect.height,
-        top: iframeReferenceRect.top + anchorReferenceRect.top,
-        left: iframeReferenceRect.left + anchorReferenceRect.left,
-        right: iframeReferenceRect.right + anchorReferenceRect.right,
-        bottom: iframeReferenceRect.bottom + anchorReferenceRect.bottom,
+        width: anchorReferenceRect?.width,
+        height: anchorReferenceRect?.height,
+        top: iframeReferenceRect?.top + anchorReferenceRect?.top,
+        left: iframeReferenceRect?.left + anchorReferenceRect?.left,
+        right: iframeReferenceRect?.right + anchorReferenceRect?.right,
+        bottom: iframeReferenceRect?.bottom + anchorReferenceRect?.bottom,
       };
     },
 

--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -492,6 +492,8 @@ export default {
     /**
      * Sets the element to which the popover is going to append to.
      * 'body' will append to the nearest body (supports shadow DOM).
+     * 'root' will try append to the iFrame's parent body if it is contained in an iFrame
+     * and has permissions to access it, else, it'd default to 'parent'.
      * @values 'body', 'parent', 'root', HTMLElement
      */
     appendTo: {

--- a/packages/dialtone-vue2/components/popover/popover_constants.js
+++ b/packages/dialtone-vue2/components/popover/popover_constants.js
@@ -15,7 +15,7 @@ export const POPOVER_HEADER_FOOTER_PADDING_CLASSES = {
 export const POPOVER_ROLES = ['dialog', 'menu', 'listbox', 'tree', 'grid'];
 export const POPOVER_CONTENT_WIDTHS = ['', 'anchor'];
 export const POPOVER_INITIAL_FOCUS_STRINGS = ['none', 'dialog', 'first'];
-export const POPOVER_APPEND_TO_VALUES = ['parent', 'body'];
+export const POPOVER_APPEND_TO_VALUES = ['parent', 'body', 'root'];
 export const POPOVER_STICKY_VALUES = [
   ...TIPPY_STICKY_VALUES,
 ];

--- a/packages/dialtone-vue2/components/popover/popover_iframe.story.vue
+++ b/packages/dialtone-vue2/components/popover/popover_iframe.story.vue
@@ -1,0 +1,65 @@
+<!-- eslint-disable max-lines -->
+<template>
+  <div class="d-d-flex d-jc-space-between d-fw-wrap d-w100p d-flg12 d-fl-col2">
+    <dt-button
+      id="anchor"
+      @click="toggleOpen(!internalOpen)"
+    >
+      popover anchor
+    </dt-button>
+    <dt-popover
+      :open="internalOpen"
+      :modal="true"
+      width-content="anchor"
+      :placement="$attrs.placement"
+      initial-focus-element="first"
+      class="d-mb128"
+      external-anchor="anchor"
+      :append-to="$attrs.appendTo"
+      sticky="popper"
+      @update:open="toggleOpen"
+    >
+      <template
+        slot="content"
+        slot-scope="{ close }"
+      >
+        <div>
+          <p class="d-mb4">
+            I will be displayed in the popover!
+          </p>
+          <dt-button
+            @click="close"
+          >
+            Click to close
+          </dt-button>
+        </div>
+      </template>
+    </dt-popover>
+  </div>
+</template>
+
+<script>
+import { DtPopover } from '.';
+import { DtButton } from '@/components/button';
+
+export default {
+  name: 'PopoverVariantsStory',
+
+  components: {
+    DtPopover,
+    DtButton,
+  },
+
+  data () {
+    return {
+      internalOpen: this.$attrs.open,
+    };
+  },
+
+  methods: {
+    toggleOpen (value) {
+      this.internalOpen = value;
+    },
+  },
+};
+</script>

--- a/packages/dialtone-vue2/components/popover/popover_iframe.story.vue
+++ b/packages/dialtone-vue2/components/popover/popover_iframe.story.vue
@@ -1,24 +1,24 @@
 <!-- eslint-disable max-lines -->
 <template>
-  <div class="d-d-flex d-jc-space-between d-fw-wrap d-w100p d-flg12 d-fl-col2">
-    <dt-button
-      id="anchor"
-      @click="toggleOpen(!internalOpen)"
-    >
-      popover anchor
-    </dt-button>
+  <div class="d-ml128">
     <dt-popover
-      :open="internalOpen"
+      :open="$attrs.open"
       :modal="true"
       width-content="anchor"
       :placement="$attrs.placement"
       initial-focus-element="first"
-      class="d-mb128"
-      external-anchor="anchor"
-      :append-to="$attrs.appendTo"
-      sticky="popper"
-      @update:open="toggleOpen"
+      append-to="root"
     >
+      <template
+        slot="anchor"
+        slot-scope="{ attrs }"
+      >
+        <dt-button
+          v-bind="attrs"
+        >
+          popover anchor
+        </dt-button>
+      </template>
       <template
         slot="content"
         slot-scope="{ close }"
@@ -48,18 +48,6 @@ export default {
   components: {
     DtPopover,
     DtButton,
-  },
-
-  data () {
-    return {
-      internalOpen: this.$attrs.open,
-    };
-  },
-
-  methods: {
-    toggleOpen (value) {
-      this.internalOpen = value;
-    },
   },
 };
 </script>

--- a/packages/dialtone-vue2/components/popover/popover_variants.story.vue
+++ b/packages/dialtone-vue2/components/popover/popover_variants.story.vue
@@ -109,7 +109,7 @@
     </dt-popover>
     <dt-popover
       :open="$attrs.open"
-      :modal="modal || false"
+      :modal="false"
       :hide-on-click="$attrs.hideOnClick"
       :transition="$attrs.transition"
       width-content="anchor"
@@ -421,7 +421,7 @@
     </dt-popover>
 
     <dt-popover
-      :modal="modal || false"
+      :modal="false"
       :hide-on-click="$attrs.hideOnClick"
       :transition="$attrs.transition"
       content-class="d-pl12 d-pr16"
@@ -446,6 +446,11 @@
         </p>
       </template>
     </dt-popover>
+
+    <iframe
+      title="iframe popover example"
+      src="http://localhost:9010/iframe.html?args=&id=components-popover--iframe-test&viewMode=story"
+    />
   </div>
 </template>
 
@@ -459,6 +464,7 @@ import { DtIcon } from '@/components/icon';
 
 export default {
   name: 'PopoverVariantsStory',
+
   components: {
     DtPopover,
     DtButton,

--- a/packages/dialtone-vue2/components/popover/popover_variants.story.vue
+++ b/packages/dialtone-vue2/components/popover/popover_variants.story.vue
@@ -449,12 +449,12 @@
 
     <iframe
       title="iframe popover example"
-      src="/iframe.html?args=&id=components-popover--iframe-test&viewMode=story"
+      :src="withURLprefix('?args=&id=components-popover--iframe-test&viewMode=story')"
     />
 
     <iframe
       title="iframe popover example 2"
-      src="/iframe.html?args=&id=components-popover--iframe-test&viewMode=story"
+      :src="withURLprefix('?args=&id=components-popover--iframe-test&viewMode=story')"
     />
   </div>
 </template>
@@ -497,6 +497,10 @@ export default {
 
     onMouseOut () {
       this.openPopoverWithTriggerOverride = false;
+    },
+
+    withURLprefix (query) {
+      return window.location.origin + window.location.pathname + query;
     },
   },
 };

--- a/packages/dialtone-vue2/components/popover/popover_variants.story.vue
+++ b/packages/dialtone-vue2/components/popover/popover_variants.story.vue
@@ -449,7 +449,7 @@
 
     <iframe
       title="iframe popover example"
-      src="http://localhost:9010/iframe.html?args=&id=components-popover--iframe-test&viewMode=story"
+      src="/iframe.html?args=&id=components-popover--iframe-test&viewMode=story"
     />
   </div>
 </template>

--- a/packages/dialtone-vue2/components/popover/popover_variants.story.vue
+++ b/packages/dialtone-vue2/components/popover/popover_variants.story.vue
@@ -451,6 +451,11 @@
       title="iframe popover example"
       src="/iframe.html?args=&id=components-popover--iframe-test&viewMode=story"
     />
+
+    <iframe
+      title="iframe popover example 2"
+      src="/iframe.html?args=&id=components-popover--iframe-test&viewMode=story"
+    />
   </div>
 </template>
 

--- a/packages/dialtone-vue2/components/popover/tippy_utils.js
+++ b/packages/dialtone-vue2/components/popover/tippy_utils.js
@@ -35,7 +35,6 @@ export const getPopperOptions = ({
   tether = true,
 } = {}) => {
   return {
-    strategy: 'fixed',
     modifiers: [
       {
         name: 'flip',

--- a/packages/dialtone-vue2/components/popover/tippy_utils.js
+++ b/packages/dialtone-vue2/components/popover/tippy_utils.js
@@ -35,6 +35,7 @@ export const getPopperOptions = ({
   tether = true,
 } = {}) => {
   return {
+    strategy: 'fixed',
     modifiers: [
       {
         name: 'flip',


### PR DESCRIPTION
# Add appendTo root to popover

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/PZ1yRtwjc1wLAvfMJZ/giphy.gif?cid=790b7611ol3hsjeu9yhvl7cpwyanxcftcgnbo6qrw5ssxl0n&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1826

## :book: Description

- Added 'root' to appendTo prop options

## :bulb: Context

If a popover were used inside an iFrame, it'd cut off as the tippy instance was being attached to the body (which still inside the iFrame). 

Setting the `appendTo` prop to 'root' will try to attach the popover to the iFrame parent's body, this will trigger a console error and fallback to 'parent' if the iFrame doesn't have the same origin as per mentioned here: https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

- Migrate changes to Vue 3
- Add tests
- Add documentation

## :camera: Screenshots / GIFs

![image](https://github.com/dialpad/dialtone/assets/87546543/a3a9fcc4-4d88-40a3-a175-e0129d8474b9)

\* The styles are lost on the example story that we're using for the iFrame as the popover is being attached to the storybooks 
iFrame parent body which is not including the dialtone styles.

![Screenshot 2024-06-19 at 2 18 15 p m](https://github.com/dialpad/dialtone/assets/87546543/d01f8f21-d572-4922-beda-278e342532e8)

https://dialtone.dialpad.com/vue/deploy-previews/pr-379/?path=/story/components-popover--variants
https://dialtone.dialpad.com/vue/deploy-previews/pr-379/?path=/story/components-popover--iframe-test