### PR TITLE
feat(popover): DLT-1826 appendTo root

### DIFF
--- a/packages/dialtone-vue2/components/popover/popover.stories.js
+++ b/packages/dialtone-vue2/components/popover/popover.stories.js
@@ -251,4 +251,16 @@ export const IframeTest = {
   args: {
     placement: 'top-end',
   },
+
+  parameters: {
+    options: {
+      showPanel: false,
+    },
+
+    percy: {
+      args: {
+        open: true,
+      },
+    },
+  },
 };

--- a/packages/dialtone-vue2/percy.config.cjs
+++ b/packages/dialtone-vue2/percy.config.cjs
@@ -4,7 +4,7 @@ module.exports = {
   ...baseConfig,
   storybook: {
     exclude: [
-      ...baseConfig.storybook.exclude
+      ...baseConfig.storybook.exclude,
       // Add specific dialtone-vue 2 stories to exclude
     ],
   },

--- a/packages/dialtone-vue3/components/popover/popover.stories.js
+++ b/packages/dialtone-vue3/components/popover/popover.stories.js
@@ -7,6 +7,7 @@ import {
 } from './';
 import PopoverDefault from './popover_default.story.vue';
 import PopoverVariants from './popover_variants.story.vue';
+import PopoverIframe from './popover_iframe.story.vue';
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
 
 import { action } from '@storybook/addon-actions';
@@ -164,6 +165,7 @@ export default {
 
 const Template = (args, { argTypes }) => createTemplateFromVueFile(args, argTypes, PopoverDefault);
 const TemplateVariants = (args, { argTypes }) => createTemplateFromVueFile(args, argTypes, PopoverVariants);
+const TemplateIFrame = (args, { argTypes }) => createTemplateFromVueFile(args, argTypes, PopoverIframe);
 
 export const Default = {
   render: Template,
@@ -195,6 +197,26 @@ export const Variants = {
           },
         ],
       },
+    },
+
+    percy: {
+      args: {
+        open: true,
+      },
+    },
+  },
+};
+
+export const IframeTest = {
+  render: TemplateIFrame,
+
+  args: {
+    placement: 'top-end',
+  },
+
+  parameters: {
+    options: {
+      showPanel: false,
     },
 
     percy: {

--- a/packages/dialtone-vue3/components/popover/popover.vue
+++ b/packages/dialtone-vue3/components/popover/popover.vue
@@ -503,7 +503,9 @@ export default {
     /**
      * Sets the element to which the popover is going to append to.
      * 'body' will append to the nearest body (supports shadow DOM).
-     * @values 'body', 'parent', HTMLElement,
+     * 'root' will try append to the iFrame's parent body if it is contained in an iFrame
+     * and has permissions to access it, else, it'd default to 'parent'.
+     * @values 'body', 'parent', 'root', HTMLElement
      */
     appendTo: {
       type: [HTMLElement, String],
@@ -982,16 +984,69 @@ export default {
       }
     },
 
+    /**
+     * Return's the anchor ClientRect object relative to the window.
+     * Refer to: https://atomiks.github.io/tippyjs/v6/all-props/#getreferenceclientrect for more information
+     * @param error
+     */
+    getReferenceClientRect (error) {
+      const anchorReferenceRect = this.anchorEl?.getBoundingClientRect();
+
+      if (this.appendTo !== 'root' || error) return anchorReferenceRect;
+
+      const anchorOwnerDocument = this.anchorEl?.ownerDocument;
+      const anchorParentWindow = anchorOwnerDocument?.defaultView || anchorOwnerDocument?.parentWindow;
+      const anchorIframe = anchorParentWindow?.frameElement;
+
+      if (!anchorIframe) return anchorReferenceRect;
+
+      const iframeReferenceRect = anchorIframe.getBoundingClientRect();
+
+      return {
+        width: anchorReferenceRect?.width,
+        height: anchorReferenceRect?.height,
+        top: iframeReferenceRect?.top + anchorReferenceRect?.top,
+        left: iframeReferenceRect?.left + anchorReferenceRect?.left,
+        right: iframeReferenceRect?.right + anchorReferenceRect?.right,
+        bottom: iframeReferenceRect?.bottom + anchorReferenceRect?.bottom,
+      };
+    },
+
     initTippyInstance () {
+      let internalAppendTo = null;
+      let iFrameError = false;
+
+      switch (this.appendTo) {
+        case 'body':
+          internalAppendTo = this.anchorEl?.getRootNode()?.querySelector('body');
+          break;
+
+        case 'root':
+          // Try to attach the popover to root document, fallback to parent is fail
+          try {
+            internalAppendTo = window.parent.document.body;
+          } catch (err) {
+            console.error('Could not attach the popover to iframe parent window: ', err);
+            internalAppendTo = 'parent';
+            iFrameError = true;
+          }
+          break;
+
+        default:
+          internalAppendTo = this.appendTo;
+          break;
+      }
+
       this.tip = createTippyPopover(this.anchorEl, {
         popperOptions: this.popperOptions(),
         contentElement: this.popoverContentEl,
         placement: this.placement,
         offset: this.offset,
         sticky: this.sticky,
-        appendTo: this.appendTo === 'body' ? this.anchorEl?.getRootNode()?.querySelector('body') : this.appendTo,
+        appendTo: internalAppendTo,
         interactive: true,
         trigger: 'manual',
+        getReferenceClientRect: () => this.getReferenceClientRect(iFrameError),
         // We have to manage hideOnClick functionality manually to handle
         // popover within popover situations.
         hideOnClick: false,

--- a/packages/dialtone-vue3/components/popover/popover_constants.js
+++ b/packages/dialtone-vue3/components/popover/popover_constants.js
@@ -15,7 +15,7 @@ export const POPOVER_HEADER_FOOTER_PADDING_CLASSES = {
 export const POPOVER_ROLES = ['dialog', 'menu', 'listbox', 'tree', 'grid'];
 export const POPOVER_CONTENT_WIDTHS = ['', 'anchor'];
 export const POPOVER_INITIAL_FOCUS_STRINGS = ['none', 'dialog', 'first'];
-export const POPOVER_APPEND_TO_VALUES = ['parent', 'body'];
+export const POPOVER_APPEND_TO_VALUES = ['parent', 'body', 'root'];
 export const POPOVER_STICKY_VALUES = [
   ...TIPPY_STICKY_VALUES,
 ];

--- a/packages/dialtone-vue3/components/popover/popover_iframe.story.vue
+++ b/packages/dialtone-vue3/components/popover/popover_iframe.story.vue
@@ -1,0 +1,47 @@
+<!-- eslint-disable max-lines -->
+<template>
+  <div class="d-ml128">
+    <dt-popover
+      :open="$attrs.open"
+      :modal="true"
+      width-content="anchor"
+      :placement="$attrs.placement"
+      initial-focus-element="first"
+      append-to="root"
+    >
+      <template #anchor="{ attrs }">
+        <dt-button
+          v-bind="attrs"
+        >
+          popover anchor
+        </dt-button>
+      </template>
+      <template #content="{ close }">
+        <div>
+          <p class="d-mb4">
+            I will be displayed in the popover!
+          </p>
+          <dt-button
+            @click="close"
+          >
+            Click to close
+          </dt-button>
+        </div>
+      </template>
+    </dt-popover>
+  </div>
+</template>
+
+<script>
+import { DtPopover } from '.';
+import { DtButton } from '@/components/button';
+
+export default {
+  name: 'PopoverVariantsStory',
+
+  components: {
+    DtPopover,
+    DtButton,
+  },
+};
+</script>

--- a/packages/dialtone-vue3/components/popover/popover_variants.story.vue
+++ b/packages/dialtone-vue3/components/popover/popover_variants.story.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-deprecated-v-bind-sync -->
 <!-- eslint-disable max-lines -->
 <template>
   <div class="d-d-flex d-jc-space-between d-fw-wrap d-w100p d-flg12 d-fl-col2">
@@ -98,7 +97,7 @@
     </dt-popover>
     <dt-popover
       :open="$attrs.open"
-      :modal="$attrs.modal || false"
+      :modal="false"
       :hide-on-click="$attrs.hideOnClick"
       :transition="$attrs.transition"
       width-content="anchor"
@@ -400,8 +399,7 @@
     </dt-popover>
 
     <dt-popover
-      v-model:open="openPopoverWithTriggerOverride"
-      :modal="$attrs.modal || false"
+      :modal="false"
       :hide-on-click="$attrs.hideOnClick"
       :transition="$attrs.transition"
       content-class="d-pl12 d-pr16"
@@ -425,6 +423,16 @@
         </p>
       </template>
     </dt-popover>
+
+    <iframe
+      title="iframe popover example"
+      :src="withURLprefix('?args=&id=components-popover--iframe-test&viewMode=story')"
+    />
+
+    <iframe
+      title="iframe popover example 2"
+      :src="withURLprefix('?args=&id=components-popover--iframe-test&viewMode=story')"
+    />
   </div>
 </template>
 
@@ -438,6 +446,7 @@ import { DtIcon } from '@/components/icon';
 
 export default {
   name: 'PopoverVariantsStory',
+
   components: {
     DtPopover,
     DtButton,
@@ -465,6 +474,10 @@ export default {
 
     onMouseLeave () {
       this.openPopoverWithTriggerOverride = false;
+    },
+
+    withURLprefix (query) {
+      return window.location.origin + window.location.pathname + query;
     },
   },
 };

--- a/percy.base_config.cjs
+++ b/percy.base_config.cjs
@@ -29,6 +29,7 @@ module.exports = {
       'Components/Link: Default',
       'Components/Pagination: Default',
       'Components/Popover: Default',
+      'Components/Popover: Iframe Test',
       'Components/Presence: Default',
       'Components/Radio: Default',
       'Components/Radio Group: Default',


### PR DESCRIPTION
# Add appendTo root to popover - Vue 3

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExN3hiMTdoMTZ5cWllMXRrbmN3OTdqcHhtMXowdDdpbHdyYTJ4OHhzYyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/cYblQbWbVCtdMVH7tZ/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Feature

## :book: Description

Vue 3 version of #379

## :bulb: Context

- Migrated changes to Vue 3
- Added open argument to percy on Vue 2 version to open the iFrame popover by default
- Added iFrame test story to percy's exclusion

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)