### PR TITLE
docs(prototypes): DLT-1740 left bar prototype - vue 2

### DIFF
--- a/packages/dialtone-vue2/.eslintrc.cjs
+++ b/packages/dialtone-vue2/.eslintrc.cjs
@@ -193,5 +193,18 @@ module.exports = {
         ],
       },
     },
+    {
+      files: [
+        'prototypes/**/*.vue',
+      ],
+      rules: {
+        'vue/no-bare-strings-in-template': [
+          'off',
+        ],
+        'vue/no-restricted-class': [
+          'off',
+        ],
+      },
+    },
   ],
 };

--- a/packages/dialtone-vue2/.storybook/main.js
+++ b/packages/dialtone-vue2/.storybook/main.js
@@ -3,7 +3,7 @@ import { mergeConfig } from 'vite';
 /** @type { import('@storybook/vue-vite').StorybookConfig } */
 const config = {
   stories: [
-    '../@(components|directives|recipes)/**/*.stories.@(js|jsx|ts|tsx)',
+    '../@(components|directives|recipes|prototypes)/**/*.stories.@(js|jsx|ts|tsx)',
     '../@(components|directives|docs|functions|recipes)/**/*.mdx',
   ],
   addons: ["@storybook/addon-links", "@storybook/addon-essentials", "@storybook/addon-a11y", 'storybook-dark-mode'],

--- a/packages/dialtone-vue2/.storybook/preview.jsx
+++ b/packages/dialtone-vue2/.storybook/preview.jsx
@@ -9,6 +9,7 @@ import { setEmojiAssetUrlSmall, setEmojiAssetUrlLarge, setCustomEmojiUrl, setCus
 import customEmojiJson from '@/common/custom-emoji.json';
 import { dialtoneDarkTheme, dialtoneLightTheme } from './dialtone-themes.js';
 import { DtTooltipDirective } from "@/directives/tooltip";
+import { faker } from '@faker-js/faker';
 
 setEmojiAssetUrlSmall('https://static.dialpadcdn.com/joypixels/png/unicode/32/', '.png');
 setEmojiAssetUrlLarge('https://static.dialpadcdn.com/joypixels/svg/unicode/', '.svg');
@@ -20,6 +21,8 @@ Vue.use(DtTooltipDirective);
 // Fixes method "toJSON" is not defined on click event in Sb 6.5.11
 // See https://github.com/storybookjs/storybook/issues/14933#issuecomment-920578274
 Vue.prototype.toJSON = () => {}
+// global seed, to make sure results are reproducible on percy and don't change on every reload too.
+faker.seed(6687422389464139);
 
 export default {
   parameters: {

--- a/packages/dialtone-vue2/components/collapsible/collapsible.stories.js
+++ b/packages/dialtone-vue2/components/collapsible/collapsible.stories.js
@@ -52,6 +52,12 @@ const argTypesData = {
   },
 
   // Action Event Handlers
+  onOpened: {
+    table: {
+      disable: true,
+    },
+  },
+
   opened: {
     description: 'Emitted whenever the content is collapsed or expanded.',
     table: {

--- a/packages/dialtone-vue2/components/popover/popover_iframe.story.vue
+++ b/packages/dialtone-vue2/components/popover/popover_iframe.story.vue
@@ -9,20 +9,14 @@
       initial-focus-element="first"
       append-to="root"
     >
-      <template
-        slot="anchor"
-        slot-scope="{ attrs }"
-      >
+      <template #anchor="{ attrs }">
         <dt-button
           v-bind="attrs"
         >
           popover anchor
         </dt-button>
       </template>
-      <template
-        slot="content"
-        slot-scope="{ close }"
-      >
+      <template #content="{ close }">
         <div>
           <p class="d-mb4">
             I will be displayed in the popover!

--- a/packages/dialtone-vue2/package.json
+++ b/packages/dialtone-vue2/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@dialpad/dialtone-css": "workspace:*",
     "@dialpad/generator-dialtone": "workspace:*",
+    "@faker-js/faker": "8.4.1",
     "@percy/cli": "1.28.2",
     "@percy/storybook": "5.0.3",
     "@storybook/addon-a11y": "^7.6.1",

--- a/packages/dialtone-vue2/prototypes/dialpad/dialpad.stories.js
+++ b/packages/dialtone-vue2/prototypes/dialpad/dialpad.stories.js
@@ -1,0 +1,20 @@
+import { createRenderConfig } from '@/common/storybook_utils';
+import DialpadLayout from './dialpad_layout.vue';
+import DialpadDefaultTemplate from './dialpad_default.story.vue';
+
+// Story Collection
+export default {
+  title: 'Prototypes/Dialpad',
+  component: DialpadLayout,
+  args: {},
+  argTypes: {},
+  excludeStories: /.*Data$/,
+};
+
+export const Default = {
+  render: (argsData) => createRenderConfig(DialpadLayout, DialpadDefaultTemplate, argsData),
+  parameters: {
+    options: { showPanel: false },
+    controls: { disable: true },
+  },
+};

--- a/packages/dialtone-vue2/prototypes/dialpad/dialpad_default.story.vue
+++ b/packages/dialtone-vue2/prototypes/dialpad/dialpad_default.story.vue
@@ -1,0 +1,20 @@
+<template>
+  <dialpad-layout>
+    <template #leftbar>
+      <dialpad-leftbar />
+    </template>
+  </dialpad-layout>
+</template>
+
+<script>
+import DialpadLayout from './dialpad_layout.vue';
+import DialpadLeftbar from './leftbar/dialpad_leftbar.vue';
+
+export default {
+  name: 'DialpadDefault',
+  components: {
+    DialpadLayout,
+    DialpadLeftbar,
+  },
+};
+</script>

--- a/packages/dialtone-vue2/prototypes/dialpad/dialpad_layout.vue
+++ b/packages/dialtone-vue2/prototypes/dialpad/dialpad_layout.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="dialpad-layout">
+    <dt-root-layout
+      class="d-h100p d-hmn-auto"
+      sidebar-class="dialpad-leftbar"
+    >
+      <template #sidebar>
+        <slot name="leftbar" />
+      </template>
+    </dt-root-layout>
+  </div>
+</template>
+
+<script>
+import { DtRootLayout } from '@/components/root_layout';
+
+export default {
+  name: 'DialpadLayout',
+  components: {
+    DtRootLayout,
+  },
+};
+</script>
+
+<style lang="less">
+:root {
+  --dialpad-sidebar-width: 284px;
+  --dialpad-sidebar-background-color: #F9F9F9;
+}
+.dialpad-layout {
+  height: calc(100vh - 2rem);
+  padding: var(--dt-space-500);
+  background: var(--dt-color-surface-secondary);
+  border-radius: var(--dt-border-radius-sm);
+}
+
+.dialpad-leftbar {
+  padding: var(--dt-space-400);
+  width: var(--dialpad-sidebar-width);
+  background: var(--dt-color-surface-primary);
+}
+</style>

--- a/packages/dialtone-vue2/prototypes/dialpad/leftbar/components/leftbar_section.vue
+++ b/packages/dialtone-vue2/prototypes/dialpad/leftbar/components/leftbar_section.vue
@@ -1,0 +1,76 @@
+<template>
+  <dt-collapsible
+    class="leftbar-section"
+    :open="isOpen"
+  >
+    <template #anchor="{ attrs }">
+      <div class="d-ps-relative">
+        <dt-button
+          v-bind="attrs"
+          class="d-bar-pill d-py4 d-w100p d-baw0"
+          label-class="d-jc-flex-start d-w100p"
+          importance="clear"
+          kind="muted"
+          @click="defaultToggleOpen"
+        >
+          <template #icon="{ iconSize }">
+            <div class="d-w24 d-d-inline-flex d-ai-center">
+              <dt-icon
+                :name=" isOpen ? 'chevron-down' : 'chevron-right'"
+                :size="iconSize"
+              />
+            </div>
+          </template>
+          <span class="d-truncate d-lh12 d-headline--sm d-fc-tertiary d-us-none d-wmx128 d-ta-left">{{ title }}</span>
+        </dt-button>
+        <div class="leftbar-section-header__action">
+          <slot name="action" />
+        </div>
+      </div>
+    </template>
+    <template #content>
+      <slot name="items" />
+    </template>
+  </dt-collapsible>
+</template>
+
+<script>
+import { DtCollapsible } from '@/components/collapsible';
+import { DtButton } from '@/components/button';
+import { DtIcon } from '@/components/icon';
+
+export default {
+  name: 'LeftbarSection',
+  components: {
+    DtCollapsible,
+    DtButton,
+    DtIcon,
+  },
+
+  props: {
+    title: { type: String, required: true },
+    open: { type: Boolean, default: false },
+  },
+
+  data () {
+    return {
+      isOpen: this.open,
+    };
+  },
+
+  methods: {
+    defaultToggleOpen () {
+      this.isOpen = !this.isOpen;
+    },
+  },
+};
+</script>
+
+<style lang="less" scoped>
+.leftbar-section-header__action {
+    position: absolute;
+    right: var(--dt-size-300);
+    top: 50%;
+    transform: translateY(-50%);
+}
+</style>

--- a/packages/dialtone-vue2/prototypes/dialpad/leftbar/components/mark_all_as_read_button.vue
+++ b/packages/dialtone-vue2/prototypes/dialpad/leftbar/components/mark_all_as_read_button.vue
@@ -1,0 +1,31 @@
+<template>
+  <dt-button
+    v-dt-tooltip="'Mark all as read'"
+    :aria-label="'Mark all as read'"
+    class="d-fc-tertiary d-h24 d-w24"
+    importance="clear"
+    kind="muted"
+    size="sm"
+    circle
+  >
+    <template #icon="{ iconSize }">
+      <dt-icon
+        name="double-check"
+        :size="iconSize"
+      />
+    </template>
+  </dt-button>
+</template>
+
+<script>
+import { DtButton } from '@/components/button';
+import { DtIcon } from '@/components/icon';
+
+export default {
+  name: 'MarkAsAllReadButton',
+  components: {
+    DtButton,
+    DtIcon,
+  },
+};
+</script>

--- a/packages/dialtone-vue2/prototypes/dialpad/leftbar/components/options_dropdown.vue
+++ b/packages/dialtone-vue2/prototypes/dialpad/leftbar/components/options_dropdown.vue
@@ -1,0 +1,92 @@
+<template>
+  <dt-dropdown
+    navigation-type="arrow-keys"
+    placement="bottom-start"
+    @opened="openDropdown"
+  >
+    <template #anchor="{ attrs }">
+      <dt-button
+        ref="dropdownAnchor"
+        v-dt-tooltip="'Section options'"
+        class="d-fc-tertiary d-h24 d-w24"
+        importance="clear"
+        kind="muted"
+        size="sm"
+        circle
+        aria-label="Section Options"
+        v-bind="attrs"
+        @click.stop="openDropdown"
+      >
+        <template #icon="{ iconSize }">
+          <dt-icon
+            name="more-vertical"
+            :size="iconSize"
+          />
+        </template>
+      </dt-button>
+    </template>
+
+    <template #list="{ close }">
+      <template v-for="option in menuOptions">
+        <dt-dropdown-separator
+          v-if="option.separator"
+          :key="`${option.value}separator`"
+        />
+        <dt-list-item
+          v-else
+          :key="option.value"
+          navigation-type="arrow-keys"
+          role="menuitem"
+          @click="selectMenuOption(option, close);"
+        >
+          {{ option.name }}
+        </dt-list-item>
+      </template>
+    </template>
+  </dt-dropdown>
+</template>
+
+<script>
+import { DtDropdown, DtDropdownSeparator } from '@/components/dropdown';
+import { DtListItem } from '@/components/list_item';
+import { DtButton } from '@/components/button';
+import { DtIcon } from '@/components/icon';
+
+export default {
+  name: 'OptionsDropdown',
+  components: {
+    DtDropdown,
+    DtDropdownSeparator,
+    DtListItem,
+    DtButton,
+    DtIcon,
+  },
+
+  emits: [
+    'select-menu-option',
+    'open-dropdown',
+  ],
+
+  data () {
+    return {
+      menuOptions: [
+        { value: 0, name: 'Mark all as read' },
+        { value: 1, separator: true },
+        { value: 2, name: 'Create new channel' },
+        { value: 3, name: 'Browse channels' },
+      ],
+    };
+  },
+
+  methods: {
+    openDropdown (value) {
+      this.$emit('open-dropdown', value);
+    },
+  },
+
+  selectMenuOption (option, close) {
+    close?.();
+    this.$emit('select-menu-option', option);
+  },
+};
+</script>

--- a/packages/dialtone-vue2/prototypes/dialpad/leftbar/dialpad_leftbar.vue
+++ b/packages/dialtone-vue2/prototypes/dialpad/leftbar/dialpad_leftbar.vue
@@ -1,0 +1,261 @@
+<template>
+  <dt-stack gap="400">
+    <dt-stack gap="200">
+      <dt-recipe-general-row
+        v-for="item in mainOptions"
+        :key="item.description"
+        v-bind="item"
+      />
+    </dt-stack>
+    <dt-stack
+      gap="200"
+    >
+      <leftbar-section title="Favorites">
+        <template #items>
+          <dt-stack gap="200">
+            <dt-recipe-general-row
+              v-for="channel in favoriteChannels"
+              :key="channel.description"
+              v-bind="channel"
+            />
+            <dt-recipe-general-row
+              v-for="group in favoriteGroups"
+              :key="group.description"
+              v-bind="group"
+            />
+            <dt-recipe-contact-row
+              v-for="contact in favoriteContacts"
+              :key="contact.name"
+              v-bind="contact"
+            />
+          </dt-stack>
+        </template>
+        <template #action>
+          <mark-all-as-read-button />
+        </template>
+      </leftbar-section>
+
+      <leftbar-section title="Contact centers Contact centers">
+        <template #items>
+          <dt-stack gap="200">
+            <dt-recipe-general-row
+              v-for="contactCenter in contactCenters"
+              :key="contactCenter.description"
+              v-bind="contactCenter"
+            />
+          </dt-stack>
+        </template>
+        <template #action>
+          <dt-button
+            class="d-fc-success d-bar-pill d-h24"
+            kind="muted"
+            importance="clear"
+            size="xs"
+          >
+            <template #icon="{ iconSize }">
+              <dt-icon
+                name="bell-ring"
+                :size="iconSize"
+              />
+            </template>
+            <span>Available</span>
+          </dt-button>
+        </template>
+      </leftbar-section>
+
+      <leftbar-section title="Channels">
+        <template #items>
+          <dt-stack gap="200">
+            <dt-recipe-general-row
+              v-for="channel in channels"
+              :key="channel.description"
+              v-bind="channel"
+            />
+          </dt-stack>
+        </template>
+        <template #action>
+          <options-dropdown />
+        </template>
+      </leftbar-section>
+
+      <leftbar-section title="Recents">
+        <template #items>
+          <dt-stack gap="200">
+            <dt-recipe-general-row
+              v-for="group in groups"
+              :key="group.description"
+              v-bind="group"
+            />
+            <dt-recipe-contact-row
+              v-for="contact in contacts"
+              :key="contact.name"
+              v-bind="contact"
+            />
+          </dt-stack>
+        </template>
+        <template #action>
+          <mark-all-as-read-button />
+        </template>
+      </leftbar-section>
+    </dt-stack>
+  </dt-stack>
+</template>
+
+<script>
+import LeftbarSection from './components/leftbar_section.vue';
+import MarkAllAsReadButton from './components/mark_all_as_read_button.vue';
+import OptionsDropdown from './components/options_dropdown.vue';
+import { DtButton } from '@/components/button';
+import { DtIcon } from '@/components/icon';
+import { DtStack } from '@/components/stack';
+import { DtRecipeGeneralRow } from '@/recipes/leftbar/general_row';
+import { DtRecipeContactRow } from '@/recipes/leftbar/contact_row';
+import { faker } from '@faker-js/faker';
+
+function unreadCountMessage ({ messages, mentions }) {
+  const unreadMessages = messages && `${messages} unread messages`;
+  const unreadMentions = mentions && `${mentions} unread mentions`;
+
+  return [unreadMessages, unreadMentions].filter(item => !!item).join(' and ');
+}
+
+export default {
+  name: 'DialpadLeftbar',
+  components: {
+    LeftbarSection,
+    MarkAllAsReadButton,
+    OptionsDropdown,
+    DtButton,
+    DtIcon,
+    DtStack,
+    DtRecipeGeneralRow,
+    DtRecipeContactRow,
+  },
+
+  data () {
+    return {
+      mainOptions: [
+        { description: 'Inbox', type: 'inbox' },
+        { description: 'Contacts', type: 'contacts' },
+        {
+          description: 'All channels',
+          type: 'channels',
+          hasUnreads: true,
+          unreadMentionCount: faker.number.int({ min: 1, max: 20 }).toString(),
+          get unreadCountTooltip () {
+            return unreadCountMessage({ mentions: this.unreadMentionCount });
+          },
+        },
+
+        {
+          description: 'Threads',
+          type: 'threads',
+          hasUnreads: true,
+          unreadCount: faker.number.int({ min: 1, max: 20 }).toString(),
+          unreadMentionCount: faker.number.int({ min: 1, max: 20 }).toString(),
+          get unreadCountTooltip () {
+            return unreadCountMessage({ messages: this.unreadCount, mentions: this.unreadMentionCount });
+          },
+        },
+      ],
+
+      channels: [
+        {
+          description: faker.word.sample({ strategy: 'longest' }),
+          type: 'channels',
+          iconSize: '200',
+          unreadCount: faker.number.int({ min: 0, max: 9 }).toString(),
+          hasUnreads: true,
+          get unreadCountTooltip () {
+            return unreadCountMessage({ messages: this.unreadCount });
+          },
+        },
+
+        { description: faker.word.sample(), type: 'channels', iconSize: '200' },
+        { description: faker.word.sample({ strategy: 'longest' }), type: 'locked channel', iconSize: '200' },
+      ],
+
+      contactCenters: [
+        { description: faker.person.fullName(), type: 'contact center', color: 'magenta-200' },
+        {
+          description: faker.person.fullName(),
+          type: 'contact center',
+          color: 'gold-300',
+          unreadCount: faker.number.int({ min: 0, max: 99 }).toString(),
+          hasUnreads: true,
+          get unreadCountTooltip () {
+            return unreadCountMessage({ messages: this.unreadCount });
+          },
+        },
+
+        { description: faker.person.fullName(), type: 'contact center', color: 'purple-300' },
+      ],
+
+      contacts: [
+        {
+          name: faker.person.fullName(),
+          avatarPresence: 'active',
+          callButtonTooltip: 'Call',
+          presenceText: 'Work from home',
+          hasUnreads: true,
+          unreadCount: faker.number.int({ min: 0, max: 99 }).toString(),
+          get unreadCountTooltip () {
+            return unreadCountMessage({ messages: this.unreadCount });
+          },
+
+          get avatarSeed () {
+            return this.name;
+          },
+        },
+        {
+          name: faker.person.fullName(),
+          avatarPresence: 'away',
+          callButtonTooltip: 'Call',
+          presenceText: 'In a meeting',
+          get avatarSeed () {
+            return this.name;
+          },
+        },
+        {
+          name: faker.person.fullName(),
+          avatarPresence: 'busy',
+          callButtonTooltip: 'Call',
+          presenceText: 'DND',
+          muted: true,
+          get avatarSeed () {
+            return this.name;
+          },
+        },
+        {
+          name: faker.person.fullName(),
+          avatarPresence: 'offline',
+          callButtonTooltip: 'Call',
+          presenceText: 'DND',
+          muted: true,
+          get avatarSeed () {
+            return this.name;
+          },
+        },
+      ],
+
+      groups: [
+        {
+          description: faker.person.fullName(),
+          type: 'coaching group',
+          hasUnreads: true,
+          unreadCount: faker.number.int({ min: 0, max: 99 }).toString(),
+          get unreadCountTooltip () {
+            return unreadCountMessage({ messages: this.unreadCount });
+          },
+        },
+      ],
+    };
+  },
+
+  computed: {
+    favoriteChannels () { return this.channels.slice(0, 1); },
+    favoriteContacts () { return this.contacts.slice(0, 1); },
+    favoriteGroups () { return this.groups.slice(0, 1); },
+  },
+};
+</script>

--- a/packages/dialtone-vue3/prototypes/dialpad/leftbar/dialpad_leftbar.vue
+++ b/packages/dialtone-vue3/prototypes/dialpad/leftbar/dialpad_leftbar.vue
@@ -3,7 +3,7 @@
     <dt-stack gap="200">
       <dt-recipe-general-row
         v-for="item in mainOptions"
-        :key="item"
+        :key="item.description"
         v-bind="item"
       />
     </dt-stack>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,6 +631,9 @@ importers:
       '@dialpad/generator-dialtone':
         specifier: workspace:*
         version: link:../../generator-dialtone
+      '@faker-js/faker':
+        specifier: 8.4.1
+        version: 8.4.1
       '@percy/cli':
         specifier: 1.28.2
         version: 1.28.2(typescript@5.3.3)
@@ -15237,8 +15240,8 @@ packages:
   vue-component-type-helpers@1.8.24:
     resolution: {integrity: sha512-lqWs/7fdRXoSBAlbouHBX+LNuaY6gI9xWW34m/ZIz9zVPYHEyw0b2/zaCBwlKx0NtKTeF/6pOpvrxVkh7nhIYg==}
 
-  vue-component-type-helpers@2.0.21:
-    resolution: {integrity: sha512-3NaicyZ7N4B6cft4bfb7dOnPbE9CjLcx+6wZWAg5zwszfO4qXRh+U52dN5r5ZZfc6iMaxKCEcoH9CmxxoFZHLg==}
+  vue-component-type-helpers@2.0.22:
+    resolution: {integrity: sha512-gPr2Ba7efUwy/Vfbuf735bHSVdN4ycoZUCHfypkI33M9DUH+ieRblLLVM2eImccFYaWNWwEzURx02EgoXDBmaQ==}
 
   vue-demi@0.14.7:
     resolution: {integrity: sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==}
@@ -20091,7 +20094,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.3.8(typescript@5.3.3)
-      vue-component-type-helpers: 2.0.21
+      vue-component-type-helpers: 2.0.22
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -33711,7 +33714,7 @@ snapshots:
 
   vue-component-type-helpers@1.8.24: {}
 
-  vue-component-type-helpers@2.0.21: {}
+  vue-component-type-helpers@2.0.22: {}
 
   vue-demi@0.14.7(vue@3.4.15(typescript@5.3.3)):
     dependencies:


### PR DESCRIPTION
# Dialpad leftbar prototype - vue 2

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/GRPy8MKag9U1U88hzY/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1740

## :book: Description

Vue 2 version of #368

## :bulb: Context

Migrated the leftbar prototype to Vue 2

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.