### PR TITLE
fix(badge): DP-102533 mention only color

### DIFF
--- a/packages/dialtone-vue2/recipes/leftbar/general_row/general_row.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/general_row/general_row.vue
@@ -101,6 +101,7 @@
             data-qa="dt-leftbar-row-unread-mention-badge"
             :class="['dt-leftbar-row__unread-badge',
                      { 'dt-leftbar-row__unread-mention-count-badge': shouldApplyCustomStyleForCountBadge },
+                     { 'dt-leftbar-row__unread-mention-only-count-badge': shouldApplyCustomStyleForMentionOnly },
             ]"
           >
             {{ unreadMentionCount }}
@@ -211,6 +212,14 @@ export default {
       validator: (color) => {
         return Object.keys(LEFTBAR_GENERAL_ROW_CONTACT_CENTER_COLORS).includes(color);
       },
+    },
+
+    /**
+     * The channel setting, either 'mention' or 'always'.
+     */
+    channelSetting: {
+      type: String,
+      default: null,
     },
 
     /**
@@ -404,6 +413,15 @@ export default {
 
     shouldApplyCustomStyleForCountBadge () {
       return this.hasUnreadCount && this.hasUnreadMentionCount;
+    },
+
+    /**
+     * When a channel in 'always' setting, meaning the user should see both unread count and unread mention count,
+     * if there are only mention messages, we should apply the custom background with var(--dt-color-purple-500).
+     * @returns {boolean}
+     */
+    shouldApplyCustomStyleForMentionOnly () {
+      return this.channelSetting === 'always' && !this.hasUnreadCount && this.hasUnreadMentionCount;
     },
   },
 

--- a/packages/dialtone-vue2/recipes/leftbar/general_row/general_row.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/general_row/general_row.vue
@@ -216,6 +216,7 @@ export default {
 
     /**
      * The channel setting, either 'mention' or 'always'.
+     * @values 'mention', 'always', null.
      */
     channelSetting: {
       type: String,

--- a/packages/dialtone-vue2/recipes/leftbar/general_row/general_row_default.story.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/general_row/general_row_default.story.vue
@@ -5,6 +5,7 @@
     :description="$attrs.description"
     :unread-count="$attrs.unreadCount"
     :has-unreads="$attrs.hasUnreads"
+    :channel-setting="$attrs.channelSetting"
     :unread-mention-count="$attrs.unreadMentionCount"
     :aria-label="$attrs.ariaLabel"
     :unread-count-tooltip="$attrs.unreadCountTooltip"

--- a/packages/dialtone-vue2/recipes/leftbar/general_row/general_row_variants.story.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/general_row/general_row_variants.story.vue
@@ -47,11 +47,24 @@
     </div>
     <div>
       <h3>
-        Channel only show unread mentioned count
+        Channel only show unread mentioned count with 'always' setting
       </h3>
       <dt-recipe-general-row
         type="channels"
         unread-mention-count="1"
+        channel-setting="always"
+        :has-unreads="true"
+        description="Channel name"
+      />
+    </div>
+    <div>
+      <h3>
+        Channel show unread mentioned count with other than 'always' setting
+      </h3>
+      <dt-recipe-general-row
+        type="channels"
+        unread-mention-count="1"
+        channel-setting="mention"
         :has-unreads="true"
         description="Channel name"
       />

--- a/packages/dialtone-vue2/recipes/leftbar/style/leftbar_row.less
+++ b/packages/dialtone-vue2/recipes/leftbar/style/leftbar_row.less
@@ -94,6 +94,7 @@
 
   &__unread-mention-only-count-badge {
     background-color: var(--dt-color-purple-500);
+    color: var(--dt-color-foreground-primary-inverted);
   }
 
   &--muted {

--- a/packages/dialtone-vue2/recipes/leftbar/style/leftbar_row.less
+++ b/packages/dialtone-vue2/recipes/leftbar/style/leftbar_row.less
@@ -92,6 +92,10 @@
     background-color: var(--dt-color-purple-500);
   }
 
+  &__unread-mention-only-count-badge {
+    background-color: var(--dt-color-purple-500);
+  }
+
   &--muted {
     --leftbar-row-opacity: 60%;
   }

--- a/packages/dialtone-vue3/recipes/leftbar/general_row/general_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/general_row/general_row.vue
@@ -101,6 +101,7 @@
             data-qa="dt-leftbar-row-unread-mention-badge"
             :class="['dt-leftbar-row__unread-badge',
                      { 'dt-leftbar-row__unread-mention-count-badge': shouldApplyCustomStyleForCountBadge },
+                     { 'dt-leftbar-row__unread-mention-only-count-badge': shouldApplyCustomStyleForMentionOnly },
             ]"
           >
             {{ unreadMentionCount }}
@@ -211,6 +212,14 @@ export default {
       validator: (color) => {
         return Object.keys(LEFTBAR_GENERAL_ROW_CONTACT_CENTER_COLORS).includes(color);
       },
+    },
+
+    /**
+     * The channel setting, either 'mention' or 'always'.
+     */
+    channelSetting: {
+      type: String,
+      default: null,
     },
 
     /**
@@ -400,6 +409,15 @@ export default {
 
     shouldApplyCustomStyleForCountBadge () {
       return this.hasUnreadCount && this.hasUnreadMentionCount;
+    },
+
+    /**
+     * When a channel in 'always' setting, meaning the user should see both unread count and unread mention count,
+     * if there are only mention messages, we should apply the custom background with var(--dt-color-purple-500).
+     * @returns {boolean}
+     */
+    shouldApplyCustomStyleForMentionOnly () {
+      return this.channelSetting === 'always' && !this.hasUnreadCount && this.hasUnreadMentionCount;
     },
   },
 

--- a/packages/dialtone-vue3/recipes/leftbar/general_row/general_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/general_row/general_row.vue
@@ -216,6 +216,7 @@ export default {
 
     /**
      * The channel setting, either 'mention' or 'always'.
+     * @values 'mention', 'always', null.
      */
     channelSetting: {
       type: String,

--- a/packages/dialtone-vue3/recipes/leftbar/general_row/general_row_default.story.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/general_row/general_row_default.story.vue
@@ -5,6 +5,7 @@
     :description="$attrs.description"
     :unread-count="$attrs.unreadCount"
     :has-unreads="$attrs.hasUnreads"
+    :channel-setting="$attrs.channelSetting"
     :unread-mention-count="$attrs.unreadMentionCount"
     :aria-label="$attrs.ariaLabel"
     :unread-count-tooltip="$attrs.unreadCountTooltip"

--- a/packages/dialtone-vue3/recipes/leftbar/general_row/general_row_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/general_row/general_row_variants.story.vue
@@ -47,11 +47,24 @@
     </div>
     <div>
       <h3>
-        Channel only show unread mentioned count
+        Channel only show unread mentioned count with 'always' setting
       </h3>
       <dt-recipe-general-row
         type="channels"
         unread-mention-count="1"
+        channel-setting="always"
+        :has-unreads="true"
+        description="Channel name"
+      />
+    </div>
+    <div>
+      <h3>
+        Channel show unread mentioned count with other than 'always' setting
+      </h3>
+      <dt-recipe-general-row
+        type="channels"
+        unread-mention-count="1"
+        channel-setting="mention"
         :has-unreads="true"
         description="Channel name"
       />

--- a/packages/dialtone-vue3/recipes/leftbar/style/leftbar_row.less
+++ b/packages/dialtone-vue3/recipes/leftbar/style/leftbar_row.less
@@ -94,6 +94,7 @@
 
   &__unread-mention-only-count-badge {
     background-color: var(--dt-color-purple-500);
+    color: var(--dt-color-foreground-primary-inverted);
   }
 
   &--muted {

--- a/packages/dialtone-vue3/recipes/leftbar/style/leftbar_row.less
+++ b/packages/dialtone-vue3/recipes/leftbar/style/leftbar_row.less
@@ -92,6 +92,10 @@
     background-color: var(--dt-color-purple-500);
   }
 
+  &__unread-mention-only-count-badge {
+    background-color: var(--dt-color-purple-500);
+  }
+
   &--muted {
     --leftbar-row-opacity: 60%;
   }


### PR DESCRIPTION
# PR Title

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](path/to/gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-102533


## :book: Description

<!--- Describe specifically what the changes are -->

## :bulb: Context

<!--- Describe the purpose of the changes -->
This is a change is necessary for a corner case missed in the design. 
This corner case is:
The user has the channel setting set as 'All Messages'. There is a situation where the user only receives  MENTION messages. It was assumed that the color should be #7C52FF. As pointed out by QA and after discussing with the designer, in this situation, the color should be #3A1D95.

Since we are not changing the current behavior of badge count when the channel setting is Mention only or Muted, I had to add a new prop 'channelSetting' to count for this situation. When the channel setting is 'All message' and there is unread mention count and NO unread count, the color will set to be #3A1D95

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [ ] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [ ] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

If new component:

<!--- There are lots of things to remember when adding a new component to the system! This is so you don't forget any of them. -->

- I am exporting any new components or constants:
  - [ ] from the index.js in the component directory.
  - [ ] from the index.js in the root (either `packages/dialtone-vue2` or `packages/dialtone-vue3`).
- [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
- [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
- [ ] I have added the new component to `common/components_list.cjs`
- [ ] I have created a component story in storybook
- [ ] I have created story / stories for any relevant component variants in storybook
- [ ] I have created a docs page for the component in storybook.
- [ ] I have checked that changing all props/slots via the UI in storybook works as expected.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
