### PR TITLE
fix(emoji-picker): DP-102475 fix keyboard navigation

### DIFF
--- a/packages/dialtone-icons/src/keywords-icons.json
+++ b/packages/dialtone-icons/src/keywords-icons.json
@@ -1889,10 +1889,6 @@
         "disk",
         "hard disk"
       ],
-      "token": [
-        "symbol",
-        "figma"
-      ],
       "import": [
         "save"
       ],
@@ -1989,6 +1985,10 @@
         "forbidden",
         "prohibited",
         "error"
+      ],
+      "token": [
+        "symbol",
+        "figma"
       ],
       "toy-brick": [
         "lego",

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.test.js
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.test.js
@@ -363,5 +363,19 @@ describe('DtEmojiPicker Tests', () => {
 
       expect(document.activeElement).toBe(searchInput.element);
     });
+
+    it('Should jump to the first emoji from tabset if showSearch is false', async () => {
+      mockProps = { showSearch: false };
+
+      updateWrapper();
+
+      const firstTab = wrapper.find('.d-tablist button');
+      const firstEmoji = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(2) button');
+
+      await firstTab.element.focus();
+      await firstTab.trigger('keydown.tab');
+
+      expect(document.activeElement).toBe(firstEmoji.element);
+    });
   });
 });

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
@@ -10,8 +10,9 @@
         :scroll-into-tab="scrollIntoTab"
         :tab-set-labels="tabSetLabels"
         :is-scrolling="isScrolling"
-        @focus-search-input="$refs.searchInputRef.focusSearchInput()"
-        @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
+        @tab-key-pressed="focusNextSectionFromEmojiTabSet"
+        @shift-tab-key-pressed="$refs.skinSelectorRef.focusSkinSelector()"
+        @arrow-down-key-pressed="focusNextSectionFromEmojiTabSet"
         @selected-tabset="scrollToSelectedTabset"
         @keydown.esc.native="$emit('close')"
       />
@@ -42,7 +43,7 @@
         @highlighted-emoji="updateHighlightedEmoji"
         @selected-emoji="$emit('selected-emoji', $event)"
         @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
-        @focus-search-input="$refs.searchInputRef.focusSearchInput()"
+        @shift-tab-key-pressed="focusNextSectionFromEmojiSelector"
         @keydown.esc.native="$emit('close')"
       />
     </div>
@@ -232,6 +233,22 @@ export default {
 
     updateHighlightedEmoji (emoji) {
       this.highlightedEmoji = emoji;
+    },
+
+    focusNextSectionFromEmojiTabSet () {
+      if (this.showSearch) {
+        this.$refs.searchInputRef.focusSearchInput();
+      } else {
+        this.$refs.emojiSelectorRef.focusEmojiSelector();
+      }
+    },
+
+    focusNextSectionFromEmojiSelector () {
+      if (this.showSearch) {
+        this.$refs.searchInputRef.focusSearchInput();
+      } else {
+        this.$refs.tabsetRef.focusTabset();
+      }
     },
   },
 };

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -101,6 +101,7 @@
 </template>
 
 <script>
+/* eslint-disable max-lines */
 import { emojisGrouped as emojisImported } from '@dialpad/dialtone-emojis';
 import { CDN_URL, EMOJIS_PER_ROW } from '@/components/emoji_picker';
 
@@ -396,6 +397,7 @@ export default {
       return false;
     },
 
+    // eslint-disable-next-line complexity
     handleKeyDown: function (event, indexTab, indexEmoji, emoji) {
       event.preventDefault();
 
@@ -480,7 +482,7 @@ export default {
           this.scrollToTab(indexTab, true);
         } else {
           this.scrollToTab(1, false);
-          this.$emit('focus-search-input');
+          this.$emit('shift-tab-key-pressed');
         }
       }
 

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
@@ -146,6 +146,7 @@ export default {
       }
     },
 
+    // eslint-disable-next-line complexity
     handleKeyDown (event, tabId) {
       if (event.key === 'Enter') {
         this.selectTabset(tabId);
@@ -157,14 +158,14 @@ export default {
       if (event.key === 'Tab') {
         event.preventDefault();
         if (event.shiftKey) {
-          this.$emit('focus-skin-selector');
+          this.$emit('shift-tab-key-pressed');
         } else {
-          this.$emit('focus-search-input');
+          this.$emit('tab-key-pressed');
         }
       }
 
       if (event.key === 'ArrowDown') {
-        this.$emit('focus-search-input');
+        this.$emit('arrow-down-key-pressed');
       }
     },
   },

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.test.js
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.test.js
@@ -404,5 +404,19 @@ describe('DtEmojiPicker Tests', () => {
 
       expect(document.activeElement).toBe(searchInput.element);
     });
+
+    it('Should jump to the first emoji from tabset if showSearch is false', async () => {
+      mockProps = { showSearch: false };
+
+      updateWrapper();
+
+      const firstTab = wrapper.find('.d-tablist button');
+      const firstEmoji = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(2) button');
+
+      await firstTab.element.focus();
+      await firstTab.trigger('keydown.Tab');
+
+      expect(document.activeElement).toBe(firstEmoji.element);
+    });
   });
 });

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
@@ -10,8 +10,9 @@
         :scroll-into-tab="scrollIntoTab"
         :tabset-labels="tabSetLabels"
         :is-scrolling="isScrolling"
-        @focus-search-input="$refs.searchInputRef.focusSearchInput()"
-        @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
+        @tab-key-pressed="focusNextSectionFromEmojiTabSet"
+        @shift-tab-key-pressed="$refs.skinSelectorRef.focusSkinSelector()"
+        @arrow-down-key-pressed="focusNextSectionFromEmojiTabSet"
         @selected-tabset="scrollToSelectedTabset"
         @keydown.esc="emits('close')"
       />
@@ -41,7 +42,7 @@
         @highlighted-emoji="updateHighlightedEmoji"
         @selected-emoji="emits('selected-emoji', $event)"
         @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
-        @focus-search-input="$refs.searchInputRef.focusSearchInput()"
+        @shift-tab-key-pressed="focusNextSectionFromEmojiSelector"
         @keydown.esc="emits('close')"
       />
     </div>
@@ -215,6 +216,10 @@ const selectedTabset = ref({});
 const scrollIntoTab = ref(0);
 const isScrolling = ref(false);
 
+const searchInputRef = ref(null);
+const emojiSelectorRef = ref(null);
+const tabsetRef = ref(null);
+
 const showRecentlyUsedTab = computed(() => props.recentlyUsedEmojis.length > 0);
 
 watch(
@@ -248,5 +253,21 @@ function updateIsScrolling (value) {
 }
 function updateHighlightedEmoji (emoji) {
   highlightedEmoji.value = emoji;
+}
+
+function focusNextSectionFromEmojiTabSet () {
+  if (props.showSearch) {
+    searchInputRef.value.focusSearchInput();
+  } else {
+    emojiSelectorRef.value.focusEmojiSelector();
+  }
+}
+
+function focusNextSectionFromEmojiSelector () {
+  if (props.showSearch) {
+    searchInputRef.value.focusSearchInput();
+  } else {
+    tabsetRef.value.focusTabset();
+  }
 }
 </script>

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
@@ -205,9 +205,9 @@ const emits = defineEmits([
 
   /**
    * Emitted when the user shift tab in first tab of emoji selector
-   * @event focus-search-input
+   * @event shift-tab-key-pressed
     */
-  'focus-search-input',
+  'shift-tab-key-pressed',
 ]);
 
 const {
@@ -541,7 +541,7 @@ const handleKeyDown = (event, indexTab, indexEmoji, emoji) => {
           scrollToTab(indexTab, true);
         } else {
           scrollToTab(1, false);
-          emits('focus-search-input');
+          emits('shift-tab-key-pressed');
         }
       } else {
         if (focusEmoji(indexTab + 1, 0)) {

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
@@ -78,8 +78,9 @@ const emits = defineEmits([
    */
   'selected-tabset',
 
-  'focus-search-input',
-  'focus-skin-selector',
+  'shift-tab-key-pressed',
+  'tab-key-pressed',
+  'arrow-down-key-pressed',
 ]);
 
 const TABS_DATA = [
@@ -159,15 +160,15 @@ function handleKeyDown (event, tabId) {
   if (event.key === 'Tab') {
     event.preventDefault();
     if (event.shiftKey) {
-      emits('focus-skin-selector');
+      emits('shift-tab-key-pressed');
     } else {
-      emits('focus-search-input');
+      emits('tab-key-pressed');
     }
   }
 
   if (event.key === 'ArrowDown') {
     // Jump to search input
-    emits('focus-search-input');
+    emits('arrow-down-key-pressed');
   }
 }
 


### PR DESCRIPTION
# Fix Emoji Picker keyboard navigation when there is no search input

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/hhgAbqQpm49vW/giphy.gif?cid=790b7611ze9fbgbzcoq1840q8rfh3ztjzh5rqxfftwvnke6y&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
[DP-102475]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
When the prop `showSearch` is false, hitting tab from the emoji tab set would fail with the error `Cannot read properties of undefined (reading 'focusSearchInput')` because the ref to the search input was not there.

To solve this, I changed the emitted event from `'focus-search-input'` to `'tab-key-pressed'` so that the parent component can handle the event and decide to which section should the focus move.

<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs
Remember that to reproduce this you must set `showSearch` to false.

### Before
![emoji-picker-error](https://github.com/dialpad/dialtone/assets/24460973/1750ea1d-1f16-40b0-8dd0-5cc510727cfb)


### Now

![emoji-picker-fixed](https://github.com/dialpad/dialtone/assets/24460973/15baf330-ad0b-4e4c-9956-379a61c9d218)


## Next Steps
Add changes to Vue 3 once approved

[DP-102475]: https://dialpad.atlassian.net/browse/DP-102475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ