### PR TITLE
feat(rich-text-editor): DLT-1835 add undo behaviour

### DIFF
--- a/packages/dialtone-icons/src/keywords-icons.json
+++ b/packages/dialtone-icons/src/keywords-icons.json
@@ -1889,10 +1889,6 @@
         "disk",
         "hard disk"
       ],
-      "token": [
-        "symbol",
-        "figma"
-      ],
       "import": [
         "save"
       ],
@@ -1989,6 +1985,10 @@
         "forbidden",
         "prohibited",
         "error"
+      ],
+      "token": [
+        "symbol",
+        "figma"
       ],
       "toy-brick": [
         "lego",

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -26,6 +26,7 @@ import Strike from '@tiptap/extension-strike';
 import Underline from '@tiptap/extension-underline';
 import Text from '@tiptap/extension-text';
 import TextAlign from '@tiptap/extension-text-align';
+import History from '@tiptap/extension-history';
 import Emoji from './extensions/emoji';
 import CustomLink from './extensions/custom_link';
 import { MentionPlugin } from './extensions/mentions/mention';
@@ -335,7 +336,7 @@ export default {
     // eslint-disable-next-line complexity
     extensions () {
       // These are the default extensions needed just for plain text.
-      const extensions = [Document, Paragraph, Text];
+      const extensions = [Document, Paragraph, Text, History];
       if (this.link) {
         extensions.push(TipTapLink.extend({ inclusive: false }).configure({
           HTMLAttributes: {

--- a/packages/dialtone-vue2/package.json
+++ b/packages/dialtone-vue2/package.json
@@ -38,6 +38,7 @@
     "@tiptap/extension-code-block": "2.3.0",
     "@tiptap/extension-document": "2.3.0",
     "@tiptap/extension-hard-break": "2.3.0",
+    "@tiptap/extension-history": "2.3.0",
     "@tiptap/extension-italic": "2.3.0",
     "@tiptap/extension-link": "2.3.0",
     "@tiptap/extension-list-item": "2.3.0",

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -26,6 +26,7 @@ import Strike from '@tiptap/extension-strike';
 import Underline from '@tiptap/extension-underline';
 import Text from '@tiptap/extension-text';
 import TextAlign from '@tiptap/extension-text-align';
+import History from '@tiptap/extension-history';
 import Emoji from './extensions/emoji';
 import CustomLink from './extensions/custom_link';
 import { MentionPlugin } from './extensions/mentions/mention';
@@ -335,7 +336,7 @@ export default {
     // eslint-disable-next-line complexity
     extensions () {
       // These are the default extensions needed just for plain text.
-      const extensions = [Document, Paragraph, Text];
+      const extensions = [Document, Paragraph, Text, History];
       if (this.link) {
         extensions.push(TipTapLink.extend({ inclusive: false }).configure({
           HTMLAttributes: {

--- a/packages/dialtone-vue3/package.json
+++ b/packages/dialtone-vue3/package.json
@@ -37,6 +37,7 @@
     "@tiptap/extension-code-block": "2.3.0",
     "@tiptap/extension-document": "2.3.0",
     "@tiptap/extension-hard-break": "2.3.0",
+    "@tiptap/extension-history": "2.3.0",
     "@tiptap/extension-italic": "2.3.0",
     "@tiptap/extension-link": "2.3.0",
     "@tiptap/extension-list-item": "2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,9 @@ importers:
       '@tiptap/extension-hard-break':
         specifier: 2.3.0
         version: 2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))
+      '@tiptap/extension-history':
+        specifier: 2.3.0
+        version: 2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(@tiptap/pm@2.3.0)
       '@tiptap/extension-italic':
         specifier: 2.3.0
         version: 2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))
@@ -805,6 +808,9 @@ importers:
       '@tiptap/extension-hard-break':
         specifier: 2.3.0
         version: 2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))
+      '@tiptap/extension-history':
+        specifier: 2.3.0
+        version: 2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(@tiptap/pm@2.3.0)
       '@tiptap/extension-italic':
         specifier: 2.3.0
         version: 2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))
@@ -4340,6 +4346,12 @@ packages:
     resolution: {integrity: sha512-9pXi69SzLabbjY5KZ54UKzu7HAHTla9aYZKH56VatOAiJOPKJppFbU2/NfJwGzDrEtfOiDqr3dYbUDF3RuCFoQ==}
     peerDependencies:
       '@tiptap/core': ^2.0.0
+
+  '@tiptap/extension-history@2.3.0':
+    resolution: {integrity: sha512-EF5Oq9fe/VBzU1Lsow2ubOlx1e1r4OQT1WUPGsRnL7pr94GH1Skpk7/hs9COJ9K6kP3Ebt42XjP0JEQodR58YA==}
+    peerDependencies:
+      '@tiptap/core': ^2.0.0
+      '@tiptap/pm': ^2.0.0
 
   '@tiptap/extension-italic@2.3.0':
     resolution: {integrity: sha512-jdFjLjdt5JtPlGMpoS6TEq5rznjbAYVlPwcw5VkYENVIYIGIR1ylIw2JwK1nUEsQ+OgYwVxHLejcUXWG1dCi2g==}
@@ -20251,6 +20263,11 @@ snapshots:
   '@tiptap/extension-hard-break@2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))':
     dependencies:
       '@tiptap/core': 2.3.0(@tiptap/pm@2.3.0)
+
+  '@tiptap/extension-history@2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))(@tiptap/pm@2.3.0)':
+    dependencies:
+      '@tiptap/core': 2.3.0(@tiptap/pm@2.3.0)
+      '@tiptap/pm': 2.3.0
 
   '@tiptap/extension-italic@2.3.0(@tiptap/core@2.3.0(@tiptap/pm@2.3.0))':
     dependencies:


### PR DESCRIPTION
# feat(rich-text-editor): DLT-1835 add undo behaviour

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2tjNWY3aXIwaHY1ejRxbnM2YWFvdmd6Njdkemh6N29kZ3ptd2kxNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/WS6CDvvyNDrhZRFBtT/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1835

## :book: Description

Add undo behaviour to rich-text-editor as a default

## :bulb: Context

The ability to undo was missing from our inputs.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

Test in product

## :link: Sources

https://tiptap.dev/docs/editor/extensions/functionality/undo-redo
