### PR TITLE
feat(input): DLT-1808 icon scoped slot

### DIFF
--- a/apps/dialtone-documentation/docs/components/input.md
+++ b/apps/dialtone-documentation/docs/components/input.md
@@ -217,13 +217,13 @@ showHtmlWarning />
 <code-well-header>
   <div class="d-stack16 d-w100p">
     <dt-input label="Left icon" type="text" placeholder="Placeholder">
-      <template #leftIcon>
-        <dt-icon name="send" size="200" />
+      <template #leftIcon="{ iconSize }">
+        <dt-icon name="send" :size="iconSize" />
       </template>
     </dt-input>
     <dt-input label="Right icon" type="text" placeholder="Placeholder">
-      <template #rightIcon>
-        <dt-icon name="lock" size="200" />
+      <template #rightIcon="{ iconSize }">
+        <dt-icon name="lock" :size="iconSize" />
       </template>
     </dt-input>
   </div>
@@ -234,27 +234,31 @@ htmlCode='
 <div>
   <label class="d-label" for="Dialtone--InputExample--IconLeft">Label</label>
   <div class="d-input__wrapper">
-    <span class="d-input-icon d-input-icon--left"><dt-icon name="send" size="200" /></span>
-    <input class="d-input d-input-icon--left" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+    <span class="d-input-icon d-input-icon--left">
+      <svg class="d-icon d-icon--size-200">...</svg>
+    </span>
+    <input class="d-input" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
   </div>
 </div>
 <div>
   <label class="d-label" for="Dialtone--InputExample--IconRight">Label</label>
   <div class="d-input__wrapper">
-    <input class="d-input d-input-icon--right" id="Dialtone--InputExample--IconRight" type="text" placeholder="Placeholder" />
-    <span class="d-input-icon d-input-icon--right"><dt-icon name="lock" size="200" /></span>
+    <input class="d-input" id="Dialtone--InputExample--IconRight" type="text" placeholder="Placeholder" />
+    <span class="d-input-icon d-input-icon--right">
+      <svg class="d-icon d-icon--size-200">...</svg>
+    </span>
   </div>
 </div>
 '
 vueCode='
 <dt-input label="Left icon" type="text" placeholder="Placeholder">
-  <template #leftIcon>
-    <dt-icon name="send" size="200" />
+  <template #leftIcon="{ iconSize }">
+    <dt-icon name="send" :size="iconSize" />
   </template>
 </dt-input>
 <dt-input label="Right icon" type="text" placeholder="Placeholder">
-  <template #rightIcon>
-    <dt-icon name="lock" size="200" />
+  <template #rightIcon="{ iconSize }">
+    <dt-icon name="lock" :size="iconSize" />
   </template>
 </dt-input>
 '
@@ -263,13 +267,13 @@ showHtmlWarning />
 <code-well-header>
   <div class="d-stack16 d-w100p">
     <dt-input label="Left icon" type="textarea" placeholder="Placeholder">
-      <template #leftIcon>
-        <dt-icon name="send" size="200" />
+      <template #leftIcon="{ iconSize }">
+        <dt-icon name="send" :size="iconSize" />
       </template>
     </dt-input>
     <dt-input label="Right icon" type="textarea" placeholder="Placeholder">
-      <template #rightIcon>
-        <dt-icon name="lock" size="200" />
+      <template #rightIcon="{ iconSize }">
+        <dt-icon name="lock" :size="iconSize" />
       </template>
     </dt-input>
   </div>
@@ -280,20 +284,22 @@ htmlCode='
 <div>
   <label class="d-label" for="Dialtone--InputExample--IconLeft">...</label>
   <div class="d-input__wrapper">
-    <span class="d-input-icon d-input-icon--left">...</span>
-    <textarea class="d-textarea d-input-icon--left" id="Dialtone--InputExample--IconLeft" type="text" placeholder="..."></textarea>
+    <span class="d-input-icon d-input-icon--left">
+      <svg class="d-icon d-icon--size-200">...</svg>
+    </span>
+    <textarea class="d-textarea" id="Dialtone--InputExample--IconLeft" type="text" placeholder="..."></textarea>
   </div>
 </div>
 '
 vueCode='
 <dt-input label="Left icon" type="textarea" placeholder="Placeholder">
-  <template #leftIcon>
-    <dt-icon name="send" size="200" />
+  <template #leftIcon="{ iconSize }">
+    <dt-icon name="send" :size="iconSize" />
   </template>
 </dt-input>
 <dt-input label="Right icon" type="textarea" placeholder="Placeholder">
-  <template #rightIcon>
-    <dt-icon name="lock" size="200" />
+  <template #rightIcon="{ iconSize }">
+    <dt-icon name="lock" :size="iconSize" />
   </template>
 </dt-input>
 '
@@ -318,8 +324,8 @@ showHtmlWarning />
       placeholder="Search Items"
       type="text"
     >
-      <template #leftIcon>
-        <dt-icon name="search" size="300" />
+      <template #leftIcon="{ iconSize }">
+        <dt-icon name="search" :size="iconSize" />
       </template>
       <template #rightIcon>
         <dt-button
@@ -329,8 +335,8 @@ showHtmlWarning />
           circle
           aria-label="Clear search"
         >
-          <template #icon>
-            <dt-icon name="close" size="200" />
+        <template #icon="{ iconSize }">
+            <dt-icon name="close" :size="iconSize" />
           </template>
         </dt-button>
       </template>
@@ -356,8 +362,8 @@ vueCode='
   placeholder="Search Items"
   type="text"
 >
-  <template #leftIcon>
-    <dt-icon name="search" size="300" />
+  <template #leftIcon="{ iconSize }">
+    <dt-icon name="search" :size="iconSize" />
   </template>
   <template #rightIcon>
     <dt-button
@@ -367,8 +373,8 @@ vueCode='
       circle
       aria-label="Clear search"
     >
-      <template #icon>
-        <dt-icon name="close" size="200" />
+      <template #icon="{ iconSize }">
+        <dt-icon name="close" :size="iconSize" />
       </template>
     </dt-button>
   </template>
@@ -510,17 +516,17 @@ You may use different icon sizes in different sized inputs
 
 <code-well-header>
   <div class="d-stack16 d-w100p">
-    <dt-input label="Small input with large icon" type="text" placeholder="Placeholder" icon-size="lg" size="sm">
+    <dt-input label="Small input with large icon" type="text" placeholder="Placeholder" size="sm">
       <template #leftIcon>
-        <dt-icon name="send" size="200" />
+        <dt-icon name="send" size="400" />
       </template>
     </dt-input>
-    <dt-input label="Medium input with extra large icon" type="text" placeholder="Placeholder" icon-size="xl">
+    <dt-input label="Medium input with extra large icon" type="text" placeholder="Placeholder">
       <template #leftIcon>
-        <dt-icon name="send" size="200" />
+        <dt-icon name="send" size="500" />
       </template>
     </dt-input>
-    <dt-input label="Extra large input with medium icon" type="text" placeholder="Placeholder" icon-size="md" size="xl">
+    <dt-input label="Extra large input with medium icon" type="text" placeholder="Placeholder" size="xl">
       <template #leftIcon>
         <dt-icon name="send" size="200" />
       </template>
@@ -540,8 +546,10 @@ htmlCode='
     <label class="d-label" for="Dialtone--InputExample--IconLeft">Input:sm Icon:lg</label>
   </div>
   <div class="d-input__wrapper">
-    <span class="d-input-icon d-input-icon--left d-input--sm d-input-icon--lg"><dt-icon name="send" /></span>
-    <input class="d-input d-input-icon--left d-input--sm" id="Dialtone--InputExample--IconLeft-sm-lg" type="text" placeholder="Placeholder" />
+    <span class="d-input-icon d-input-icon--left">
+      <svg class="d-icon d-icon--size-400">...</svg>
+    </span>
+    <input class="d-input d-input--sm" id="Dialtone--InputExample--IconLeft-sm-lg" type="text" placeholder="Placeholder" />
   </div>
 </div>
 <div>
@@ -549,8 +557,10 @@ htmlCode='
     <label class="d-label" for="Dialtone--InputExample--IconLeft">Input:md(default), Icon:xl</label>
   </div>
   <div class="d-input__wrapper">
-    <span class="d-input-icon d-input-icon--left d-input-icon--xl"><dt-icon name="send" /></span>
-    <input class="d-input d-input-icon--left" id="Dialtone--InputExample--IconLeft-md-xl" type="text" placeholder="Placeholder" />
+    <span class="d-input-icon d-input-icon--left">
+      <svg class="d-icon d-icon--size-500">...</svg>
+    </span>
+    <input class="d-input" id="Dialtone--InputExample--IconLeft-md-xl" type="text" placeholder="Placeholder" />
   </div>
 </div>
 <div>
@@ -558,8 +568,10 @@ htmlCode='
     <label class="d-label" for="Dialtone--InputExample--IconLeft">Input:xl Icon:md(default)</label>
   </div>
   <div class="d-input__wrapper">
-    <span class="d-input-icon d-input-icon--left d-input--xl"><dt-icon name="send" /></span>
-    <input class="d-input d-input-icon--left d-input--xl" id="Dialtone--InputExample--IconLeft-xl-md" type="text" placeholder="Placeholder" />
+    <span class="d-input-icon d-input-icon--left">
+      <svg class="d-icon d-icon--size-200">...</svg>
+    </span>
+    <input class="d-input d-input--xl" id="Dialtone--InputExample--IconLeft-xl-md" type="text" placeholder="Placeholder" />
   </div>
 </div>
 <div>
@@ -567,28 +579,30 @@ htmlCode='
     <label class="d-label" for="Dialtone--InputExample--IconLeft">Textarea:lg Icon:md(default)</label>
   </div>
   <div class="d-input__wrapper">
-    <span class="d-input-icon d-input-icon--left d-input--lg"><dt-icon name="send" /></span>
-    <textarea class="d-textarea d-input-icon--left d-textarea--lg" id="Dialtone--TextareaExample--IconLeft-lg-md" type="text" placeholder="Placeholder"></textarea>
+    <span class="d-input-icon d-input-icon--left">
+      <svg class="d-icon d-icon--size-200">...</svg>
+    </span>
+    <textarea class="d-textarea d-textarea--lg" id="Dialtone--TextareaExample--IconLeft-lg-md" type="text" placeholder="Placeholder"></textarea>
   </div>
 </div>
 '
 vueCode='
-<dt-input label="Small input with large icon" type="text" placeholder="Placeholder" icon-size="lg" size="sm">
+<dt-input label="Small input with large icon" type="text" placeholder="Placeholder" size="sm">
+  <template #leftIcon>
+    <dt-icon name="send" size="400" />
+  </template>
+</dt-input>
+<dt-input label="Medium input with extra large icon" type="text" placeholder="Placeholder">
+  <template #leftIcon>
+    <dt-icon name="send" size="500" />
+  </template>
+</dt-input>
+<dt-input label="Extra large input with medium icon" type="text" placeholder="Placeholder" size="xl">
   <template #leftIcon>
     <dt-icon name="send" size="200" />
   </template>
 </dt-input>
-<dt-input label="Medium input with extra large icon" type="text" placeholder="Placeholder" icon-size="xl">
-  <template #leftIcon>
-    <dt-icon name="send" size="200" />
-  </template>
-</dt-input>
-<dt-input label="Extra large input with medium icon" type="text" placeholder="Placeholder" icon-size="md" size="xl">
-  <template #leftIcon>
-    <dt-icon name="send" size="200" />
-  </template>
-</dt-input>
-<dt-input label="Large textarea with medium icon" type="textarea" placeholder="Placeholder" icon-size="md" size="lg">
+<dt-input label="Large textarea with medium icon" type="textarea" placeholder="Placeholder" size="lg">
   <template #leftIcon>
     <dt-icon name="send" size="200" />
   </template>

--- a/packages/dialtone-css/lib/build/less/components/input.less
+++ b/packages/dialtone-css/lib/build/less/components/input.less
@@ -145,6 +145,10 @@
     margin-bottom: var(--dt-space-200);
 }
 
+.d-input--hidden {
+    visibility: hidden;
+}
+
 //  $$  INPUT WRAPPER
 //  ----------------------------------------------------------------------------
 .d-input__wrapper {

--- a/packages/dialtone-css/lib/build/less/components/input.less
+++ b/packages/dialtone-css/lib/build/less/components/input.less
@@ -151,17 +151,46 @@
     padding: 0;
     overflow-y: auto;
 
-    .d-input-icon.d-input-icon--right {
-        margin-right: var(--dt-space-400);
-    }
-
-    .d-input-icon.d-input-icon--left {
-        margin-left: var(--dt-space-400);
-    }
-
-    .d-textarea + .d-input-icon.d-input-icon--right {
+    .d-textarea + .d-input-icon--right {
       position: absolute;
       right: var(--dt-space-450);
+    }
+
+    .d-input-icon--left:has(+ .d-textarea) {
+        align-items: flex-start;
+    }
+
+    .d-input-icon:has(+ .d-textarea),
+    .d-textarea+.d-input-icon {
+        padding-top: calc(var(--input-padding-y) + var(--dt-space-200));
+    }
+
+    .d-input-icon:has(+ .d-textarea--xs),
+    .d-textarea--xs + .d-input-icon {
+        #d-internal__input-and-select-xs();
+
+        padding-top: calc(var(--input-padding-y) + var(--dt-space-100));
+    }
+
+    .d-input-icon:has(+ .d-textarea--sm),
+    .d-textarea--sm+.d-input-icon {
+        #d-internal__input-and-select-sm();
+
+        padding-top: calc(var(--input-padding-y) + var(--dt-space-100));
+    }
+
+    .d-input-icon:has(+ .d-textarea--lg),
+    .d-textarea--lg+.d-input-icon {
+        #d-internal__input-and-select-lg();
+
+        padding-top: calc(var(--input-padding-y) + var(--dt-space-100));
+    }
+
+    .d-input-icon:has(+ .d-textarea--xl),
+    .d-textarea--xl+.d-input-icon {
+        #d-internal__input-and-select-xl();
+
+        padding-top: calc(var(--input-padding-y) + (var(--dt-space-350) - var(--dt-space-100)));
     }
 
     .d-input,
@@ -176,20 +205,6 @@
             outline: 0;
             box-shadow: none !important;
         }
-
-        &.d-input-icon--right {
-            padding-right: var(--dt-space-350);
-        }
-
-        &.d-input-icon--left {
-            padding-left: var(--dt-space-350);
-        }
-    }
-
-    .d-textarea {
-      &.d-input-icon--right {
-        padding-right: var(--dt-space-625);
-      }
     }
 }
 
@@ -270,54 +285,14 @@
 //  $  INPUT ICONS
 //  ----------------------------------------------------------------------------
 .d-input-icon {
-    //  Component CSS Vars
-    //  ------------------------------------------------------------------------
-    --input-icon-size: var(--dt-size-500);
-    --input-icon-container-height: var(--dt-size-600);
-
-    z-index: var(--zi-base1);
     display: inline-flex;
     align-items: center;
-    height: var(--input-icon-container-height);
-    margin: 0;
-}
 
-
-
-//  $$ SIZES
-//  ----------------------------------------------------------------------------
-.d-input-icon.d-input--xs {
-    --input-icon-container-height: calc(var(--dt-size-600) - var(--dt-size-300));
-}
-
-.d-input-icon--xs {
-    // Backwards-compatible to DT6 icons
-    --input-icon-size: var(--dt-icon-size-100);
-}
-
-.d-input-icon.d-input--sm {
-    --input-icon-container-height: var(--dt-size-600);
-}
-
-.d-input-icon--sm {
-    // Backwards-compatible to DT6 icons
-    --input-icon-size: var(--dt-icon-size-200);
-}
-
-.d-input-icon.d-input--lg {
-    --input-icon-container-height: calc(var(--dt-size-300) * 10);
-}
-
-.d-input-icon--lg {
-    // Backwards-compatible to DT6 icons
-    --input-icon-size: var(--dt-icon-size-400);
-}
-
-.d-input-icon.d-input--xl {
-    --input-icon-container-height: calc(var(--dt-size-300) * 14);
-}
-
-.d-input-icon--xl {
-    // Backwards-compatible to DT6 icons
-    --input-icon-size: var(--dt-icon-size-500);
-}
+    &--right > svg {
+        margin-right: var(--dt-space-400);
+    }
+    
+    &--left > svg {
+        margin-left: var(--dt-space-400);
+    }
+} 

--- a/packages/dialtone-css/lib/build/less/components/input.less
+++ b/packages/dialtone-css/lib/build/less/components/input.less
@@ -285,14 +285,18 @@
 //  $  INPUT ICONS
 //  ----------------------------------------------------------------------------
 .d-input-icon {
-    display: inline-flex;
+    display: none;
     align-items: center;
 
-    &--right > svg {
+    &:has( > svg) {
+        display: inline-flex;
+    }
+
+    &--right:has( > svg) {
         margin-right: var(--dt-space-400);
     }
     
-    &--left > svg {
+    &--left:has(> svg) {
         margin-left: var(--dt-space-400);
     }
 } 

--- a/packages/dialtone-vue2/components/input/input.mdx
+++ b/packages/dialtone-vue2/components/input/input.mdx
@@ -78,8 +78,11 @@ import { DtInput, DtIcon } from '@dialpad/dialtone-vue';
   v-model="text"
   placeholder="placeholder"
 >
-  <template #leftIcon>
-    <dt-icon name="send" />
+  <template #leftIcon="{ size }">
+    <dt-icon
+      name="send"
+      :size="size"
+    />
   </template>
 </dt-input>
 ```
@@ -103,8 +106,11 @@ import { DtInput, DtIcon } from '@dialpad/dialtone-vue';
   v-model="text"
   placeholder="placeholder"
 >
-  <template #rightIcon>
-    <dt-icon name="lock" />
+  <template #rightIcon="{ attrs }">
+    <dt-icon
+      name="lock"
+      v-bind="attrs"
+    />
   </template>
 </dt-input>
 ```
@@ -128,11 +134,17 @@ import { DtInput } from '@dialpad/dialtone-vue';
   v-model="text"
   placeholder="placeholder"
 >
-  <template #leftIcon>
-    <dt-icon name="send" />
+  <template #leftIcon="{ size }">
+    <dt-icon
+      name="send"
+      :size="size"
+    />
   </template>
-  <template #rightIcon>
-    <dt-icon name="lock" />
+  <template #rightIcon="{ size }">
+    <dt-icon
+      name="lock"
+      :size="size"
+    />
   </template>
 </dt-input>
 ```

--- a/packages/dialtone-vue2/components/input/input.mdx
+++ b/packages/dialtone-vue2/components/input/input.mdx
@@ -78,10 +78,10 @@ import { DtInput, DtIcon } from '@dialpad/dialtone-vue';
   v-model="text"
   placeholder="placeholder"
 >
-  <template #leftIcon="{ size }">
+  <template #leftIcon="{ iconSize }">
     <dt-icon
       name="send"
-      :size="size"
+      :size="iconSize"
     />
   </template>
 </dt-input>
@@ -134,16 +134,16 @@ import { DtInput } from '@dialpad/dialtone-vue';
   v-model="text"
   placeholder="placeholder"
 >
-  <template #leftIcon="{ size }">
+  <template #leftIcon="{ iconSize }">
     <dt-icon
       name="send"
-      :size="size"
+      :size="iconSize"
     />
   </template>
-  <template #rightIcon="{ size }">
+  <template #rightIcon="{ iconSize }">
     <dt-icon
       name="lock"
-      :size="size"
+      :size="iconSize"
     />
   </template>
 </dt-input>

--- a/packages/dialtone-vue2/components/input/input.stories.js
+++ b/packages/dialtone-vue2/components/input/input.stories.js
@@ -11,7 +11,7 @@ const iconsList = getIconNames();
 export const argsData = {
   type: DtInput.props.type.default,
   size: INPUT_SIZES.DEFAULT,
-  placeholder: 'Placeholder',
+  placeholder: 'placeholder',
   label: 'Label',
   onBlur: action('blur'),
   onInput: action('input'),

--- a/packages/dialtone-vue2/components/input/input.stories.js
+++ b/packages/dialtone-vue2/components/input/input.stories.js
@@ -11,9 +11,8 @@ const iconsList = getIconNames();
 export const argsData = {
   type: DtInput.props.type.default,
   size: INPUT_SIZES.DEFAULT,
-  placeholder: 'placeholder',
+  placeholder: 'Placeholder',
   label: 'Label',
-  iconSize: null,
   onBlur: action('blur'),
   onInput: action('input'),
   onClear: action('clear'),
@@ -28,7 +27,6 @@ export const argsData = {
 export const argTypesData = {
   // Slots
   description: {
-    description: 'slot for description, defaults to description prop',
     table: {
       type: { summary: 'VNode' },
     },
@@ -91,17 +89,6 @@ export const argTypesData = {
     table: {
       defaultValue: {
         summary: INPUT_SIZES.DEFAULT,
-      },
-    },
-  },
-  iconSize: {
-    options: [null, ...Object.values(INPUT_SIZES)],
-    control: {
-      type: 'select',
-    },
-    table: {
-      defaultValue: {
-        summary: 'null',
       },
     },
   },

--- a/packages/dialtone-vue2/components/input/input.test.js
+++ b/packages/dialtone-vue2/components/input/input.test.js
@@ -227,54 +227,20 @@ describe('DtInput tests', () => {
         updateWrapper();
       });
 
-      describe('When a size is not provided', () => {
-        it('should render the icon wrapper', () => {
-          expect(leftIconWrapper.exists()).toBe(true);
-        });
-
-        it('should have input icon class', () => {
-          expect(leftIconWrapper.classes().includes('d-input-icon')).toBe(true);
-        });
-
-        it('should have input icon side class', () => {
-          expect(leftIconWrapper.classes().includes('d-input-icon--left')).toBe(true);
-        });
-
-        it('should have input icon size class', () => {
-          expect(leftIconWrapper.classes().includes(`d-input-icon--${INPUT_SIZES.DEFAULT}`)).toBe(false);
-        });
-
-        it('should render the provided icon', () => {
-          expect(wrapper.findComponent(DtIcon).exists()).toBe(true);
-        });
+      it('should render the icon wrapper', () => {
+        expect(leftIconWrapper.exists()).toBe(true);
       });
 
-      describe('When a size is provided', () => {
-        beforeEach(() => {
-          mockProps = { size: INPUT_SIZES.EXTRA_LARGE };
+      it('should have input icon class', () => {
+        expect(leftIconWrapper.classes().includes('d-input-icon')).toBe(true);
+      });
 
-          updateWrapper();
-        });
+      it('should have input icon side class', () => {
+        expect(leftIconWrapper.classes().includes('d-input-icon--left')).toBe(true);
+      });
 
-        it('should render the icon wrapper', () => {
-          expect(leftIconWrapper.exists()).toBe(true);
-        });
-
-        it('should have input icon class', () => {
-          expect(leftIconWrapper.classes().includes('d-input-icon')).toBe(true);
-        });
-
-        it('should have input icon side class', () => {
-          expect(leftIconWrapper.classes().includes('d-input-icon--left')).toBe(true);
-        });
-
-        it('should have input icon size class', () => {
-          expect(leftIconWrapper.classes().includes(`d-input-icon--${INPUT_SIZES.EXTRA_LARGE}`)).toBe(true);
-        });
-
-        it('should render the provided icon', () => {
-          expect(wrapper.findComponent(DtIcon).exists()).toBe(true);
-        });
+      it('should render the provided icon', () => {
+        expect(wrapper.findComponent(DtIcon).exists()).toBe(true);
       });
     });
 
@@ -285,54 +251,20 @@ describe('DtInput tests', () => {
         updateWrapper();
       });
 
-      describe('When a size is not provided', () => {
-        it('should render the icon wrapper', () => {
-          expect(rightIconWrapper.exists()).toBe(true);
-        });
-
-        it('should have input icon class', () => {
-          expect(rightIconWrapper.classes().includes('d-input-icon')).toBe(true);
-        });
-
-        it('should have input icon side class', () => {
-          expect(rightIconWrapper.classes().includes('d-input-icon--right')).toBe(true);
-        });
-
-        it('should have input icon size class', () => {
-          expect(rightIconWrapper.classes().includes(`d-input-icon--${INPUT_SIZES.DEFAULT}`)).toBe(false);
-        });
-
-        it('should render the provided icon', () => {
-          expect(wrapper.findComponent(DtIcon).exists()).toBe(true);
-        });
+      it('should render the icon wrapper', () => {
+        expect(rightIconWrapper.exists()).toBe(true);
       });
 
-      describe('When a size is provided', () => {
-        beforeEach(() => {
-          mockProps = { size: INPUT_SIZES.EXTRA_LARGE };
+      it('should have input icon class', () => {
+        expect(rightIconWrapper.classes().includes('d-input-icon')).toBe(true);
+      });
 
-          updateWrapper();
-        });
+      it('should have input icon side class', () => {
+        expect(rightIconWrapper.classes().includes('d-input-icon--right')).toBe(true);
+      });
 
-        it('should render the icon wrapper', () => {
-          expect(rightIconWrapper.exists()).toBe(true);
-        });
-
-        it('should have input icon class', () => {
-          expect(rightIconWrapper.classes().includes('d-input-icon')).toBe(true);
-        });
-
-        it('should have input icon side class', () => {
-          expect(rightIconWrapper.classes().includes('d-input-icon--right')).toBe(true);
-        });
-
-        it('should have input icon size class', () => {
-          expect(rightIconWrapper.classes().includes(`d-input-icon--${INPUT_SIZES.EXTRA_LARGE}`)).toBe(true);
-        });
-
-        it('should render the provided icon', () => {
-          expect(wrapper.findComponent(DtIcon).exists()).toBe(true);
-        });
+      it('should render the provided icon', () => {
+        expect(wrapper.findComponent(DtIcon).exists()).toBe(true);
       });
     });
 

--- a/packages/dialtone-vue2/components/input/input.vue
+++ b/packages/dialtone-vue2/components/input/input.vue
@@ -585,9 +585,3 @@ export default {
   },
 };
 </script>
-
-<style lang="less">
-.d-input--hidden {
-  visibility: hidden;
-}
-</style>

--- a/packages/dialtone-vue2/components/input/input.vue
+++ b/packages/dialtone-vue2/components/input/input.vue
@@ -58,7 +58,7 @@
           <!-- @slot Slot for left icon -->
           <slot
             name="leftIcon"
-            :size="iconSize"
+            :icon-size="iconSize"
           />
         </span>
         <textarea
@@ -120,6 +120,8 @@ import {
   INPUT_SIZE_CLASSES,
   INPUT_ICON_SIZES,
   INPUT_STATE_CLASSES,
+  DESCRIPTION_SIZE_CLASSES,
+  LABEL_SIZE_CLASSES,
 } from './input_constants';
 import {
   getUniqueString,
@@ -209,11 +211,11 @@ export default {
 
     /**
      * Size of the input, one of `xs`, `sm`, `md`, `lg`, `xl`
-     * @values null, xs, sm, md, lg, xl
+     * @values xs, sm, md, lg, xl
      */
     size: {
       type: String,
-      default: null,
+      default: 'md',
       validator: (t) => Object.values(INPUT_SIZES).includes(t),
     },
 
@@ -343,19 +345,6 @@ export default {
 
   data () {
     return {
-      descriptionSizeClasses: {
-        lg: 'd-description--lg',
-        xl: 'd-description--xl',
-      },
-
-      labelSizeClasses: {
-        xs: 'd-label--xs',
-        sm: 'd-label--sm',
-        md: 'd-label--md',
-        lg: 'd-label--lg',
-        xl: 'd-label--xl',
-      },
-
       isInputFocused: false,
       isInvalid: false,
       defaultLength: 0,
@@ -515,6 +504,11 @@ export default {
         }
       },
     },
+  },
+
+  beforeMount () {
+    this.descriptionSizeClasses = DESCRIPTION_SIZE_CLASSES;
+    this.labelSizeClasses = LABEL_SIZE_CLASSES;
   },
 
   methods: {

--- a/packages/dialtone-vue2/components/input/input.vue
+++ b/packages/dialtone-vue2/components/input/input.vue
@@ -1,23 +1,20 @@
-<!-- eslint-disable vue/no-restricted-class -->
 <template>
   <div
     ref="container"
-    :class="['base-input', { 'd-vi-hidden': hidden }]"
+    :class="{ 'd-input--hidden': hidden }"
     data-qa="dt-input"
   >
     <label
-      class="base-input__label"
       :aria-details="$slots.description || description ? descriptionKey : undefined"
       data-qa="dt-input-label-wrapper"
     >
-      <!-- @slot slot for label, defaults to label prop -->
+      <!-- @slot Slot for label, defaults to label prop -->
       <slot name="labelSlot">
         <div
           v-if="labelVisible && label"
           ref="label"
           data-qa="dt-input-label"
           :class="[
-            'base-input__label-text',
             'd-label',
             labelSizeClasses[size],
           ]"
@@ -30,7 +27,6 @@
         :id="descriptionKey"
         ref="description"
         :class="[
-          'base-input__description',
           'd-description',
           descriptionSizeClasses[size],
         ]"
@@ -39,7 +35,7 @@
         <div
           v-if="$slots.description || description"
         >
-          <!-- @slot slot for description, defaults to description prop -->
+          <!-- @slot Slot for description, defaults to description prop -->
           <slot name="description">{{ description }}</slot>
         </div>
         <div
@@ -55,13 +51,15 @@
         :read-only="disabled"
       >
         <span
-          v-if="$slots.leftIcon"
-          :class="inputIconClasses('left')"
+          class="d-input-icon d-input-icon--left"
           data-qa="dt-input-left-icon-wrapper"
           @focusout="onBlur"
         >
           <!-- @slot Slot for left icon -->
-          <slot name="leftIcon" />
+          <slot
+            name="leftIcon"
+            :size="iconSize"
+          />
         </span>
         <textarea
           v-if="isTextarea"
@@ -91,13 +89,15 @@
           v-on="inputListeners"
         >
         <span
-          v-if="$slots.rightIcon"
-          :class="inputIconClasses('right')"
+          class="d-input-icon d-input-icon--right"
           data-qa="dt-input-right-icon-wrapper"
           @focusout="onBlur"
         >
           <!-- @slot Slot for right icon -->
-          <slot name="rightIcon" />
+          <slot
+            name="rightIcon"
+            :icon-size="iconSize"
+          />
         </span>
       </div>
     </label>
@@ -112,8 +112,15 @@
 </template>
 
 <script>
+/* eslint-disable max-lines */
 import { DESCRIPTION_SIZE_TYPES, VALIDATION_MESSAGE_TYPES } from '@/common/constants';
-import { INPUT_TYPES, INPUT_SIZES } from './input_constants';
+import {
+  INPUT_TYPES,
+  INPUT_SIZES,
+  INPUT_SIZE_CLASSES,
+  INPUT_ICON_SIZES,
+  INPUT_STATE_CLASSES,
+} from './input_constants';
 import {
   getUniqueString,
   getValidationState,
@@ -205,17 +212,6 @@ export default {
      * @values null, xs, sm, md, lg, xl
      */
     size: {
-      type: String,
-      default: null,
-      validator: (t) => Object.values(INPUT_SIZES).includes(t),
-    },
-
-    /**
-     * Size of the icon. One of `xs`, `sm`, `md`, `lg`, `xl`. If you do not set this the icon will size relative
-     * to the input size
-     * @values null, xs, sm, md, lg, xl
-     */
-    iconSize: {
       type: String,
       default: null,
       validator: (t) => Object.values(INPUT_SIZES).includes(t),
@@ -376,12 +372,8 @@ export default {
       return this.size === INPUT_SIZES.DEFAULT;
     },
 
-    isDefaultIconSize () {
-      return this.iconSizeComputed === INPUT_SIZES.DEFAULT;
-    },
-
-    iconSizeComputed () {
-      return this.iconSize ? this.iconSize : this.size;
+    iconSize () {
+      return INPUT_ICON_SIZES[this.size];
     },
 
     isValidSize () {
@@ -498,40 +490,11 @@ export default {
         return '';
       }
 
-      const sizeClasses = {
-        input: {
-          xs: 'd-input--xs',
-          sm: 'd-input--sm',
-          lg: 'd-input--lg',
-          xl: 'd-input--xl',
-        },
-
-        textarea: {
-          xs: 'd-textarea--xs',
-          sm: 'd-textarea--sm',
-          lg: 'd-textarea--lg',
-          xl: 'd-textarea--xl',
-        },
-      };
-
-      return sizeClasses[this.inputComponent][this.size];
+      return INPUT_SIZE_CLASSES[this.inputComponent][this.size];
     },
 
     stateClass () {
-      const inputStateClasses = {
-        input: {
-          error: 'd-input--error base-input__input--error',
-          warning: 'd-input--warning base-input__input--warning',
-          success: 'd-input--success base-input__input--success',
-        },
-
-        textarea: {
-          error: 'd-textarea--error base-input__input--error',
-          warning: 'd-textarea--warning base-input__input--warning',
-          success: 'd-textarea--success base-input__input--success',
-        },
-      };
-      return [inputStateClasses[this.inputComponent][this.inputState]];
+      return [INPUT_STATE_CLASSES[this.inputComponent][this.inputState]];
     },
   },
 
@@ -557,7 +520,6 @@ export default {
   methods: {
     inputClasses () {
       return [
-        'base-input__input',
         this.inputComponent === 'input' ? 'd-input' : 'd-textarea',
         {
           [this.stateClass]: this.showInputState,
@@ -595,26 +557,6 @@ export default {
       };
     },
 
-    inputIconClasses (side) {
-      const iconSizeClasses = {
-        xs: 'd-input-icon--xs',
-        sm: 'd-input-icon--sm',
-        lg: 'd-input-icon--lg',
-        xl: 'd-input-icon--xl',
-      };
-      const iconOrientationClasses = {
-        left: 'base-input__icon--left d-input-icon--left',
-        right: 'base-input__icon--right d-input-icon--right',
-      };
-
-      return [
-        iconOrientationClasses[side],
-        'd-input-icon',
-        { [iconSizeClasses[this.iconSizeComputed]]: !this.isDefaultIconSize },
-        this.sizeModifierClass,
-      ];
-    },
-
     onBlur (e) {
       // Do not emit a blur event if the target element is a child of this component
       if (!this.$refs.container?.contains(e.relatedTarget)) {
@@ -649,3 +591,9 @@ export default {
   },
 };
 </script>
+
+<style lang="less">
+.d-input--hidden {
+  visibility: hidden;
+}
+</style>

--- a/packages/dialtone-vue2/components/input/input_constants.js
+++ b/packages/dialtone-vue2/components/input/input_constants.js
@@ -20,7 +20,48 @@ export const INPUT_SIZES = {
   EXTRA_LARGE: 'xl',
 };
 
+export const INPUT_ICON_SIZES = {
+  xs: '100',
+  sm: '200',
+  md: '200',
+  lg: '400',
+  xl: '500',
+};
+
+export const INPUT_SIZE_CLASSES = {
+  input: {
+    xs: 'd-input--xs',
+    sm: 'd-input--sm',
+    lg: 'd-input--lg',
+    xl: 'd-input--xl',
+  },
+
+  textarea: {
+    xs: 'd-textarea--xs',
+    sm: 'd-textarea--sm',
+    lg: 'd-textarea--lg',
+    xl: 'd-textarea--xl',
+  },
+};
+
+export const INPUT_STATE_CLASSES = {
+  input: {
+    error: 'd-input--error',
+    warning: 'd-input--warning',
+    success: 'd-input--success',
+  },
+
+  textarea: {
+    error: 'd-textarea--error',
+    warning: 'd-textarea--warning',
+    success: 'd-textarea--success',
+  },
+};
+
 export default {
   INPUT_TYPES,
   INPUT_SIZES,
+  INPUT_ICON_SIZES,
+  INPUT_SIZE_CLASSES,
+  INPUT_STATE_CLASSES,
 };

--- a/packages/dialtone-vue2/components/input/input_constants.js
+++ b/packages/dialtone-vue2/components/input/input_constants.js
@@ -58,10 +58,25 @@ export const INPUT_STATE_CLASSES = {
   },
 };
 
+export const DESCRIPTION_SIZE_CLASSES = {
+  lg: 'd-description--lg',
+  xl: 'd-description--xl',
+};
+
+export const LABEL_SIZE_CLASSES = {
+  xs: 'd-label--xs',
+  sm: 'd-label--sm',
+  md: 'd-label--md',
+  lg: 'd-label--lg',
+  xl: 'd-label--xl',
+};
+
 export default {
   INPUT_TYPES,
   INPUT_SIZES,
   INPUT_ICON_SIZES,
   INPUT_SIZE_CLASSES,
   INPUT_STATE_CLASSES,
+  DESCRIPTION_SIZE_CLASSES,
+  LABEL_SIZE_CLASSES,
 };

--- a/packages/dialtone-vue2/components/input/input_default.story.vue
+++ b/packages/dialtone-vue2/components/input/input_default.story.vue
@@ -5,7 +5,6 @@
     :type="$attrs.type"
     :messages="$attrs.messages"
     :size="$attrs.size"
-    :icon-size="$attrs.iconSize"
     :label="$attrs.label"
     :messages-child-props="$attrs.messagesChildProps"
     :name="$attrs.name"
@@ -39,17 +38,17 @@
     >
       <span v-html="$attrs.description" />
     </template>
-    <template
-      v-if="$attrs.leftIcon"
-      slot="leftIcon"
-    >
-      <dt-icon :name="$attrs.leftIcon" />
+    <template #leftIcon="{ size }">
+      <dt-icon
+        :name="$attrs.leftIcon"
+        :size="size"
+      />
     </template>
-    <template
-      v-if="$attrs.rightIcon"
-      slot="rightIcon"
-    >
-      <dt-icon :name="$attrs.rightIcon" />
+    <template #rightIcon="{ size }">
+      <dt-icon
+        :name="$attrs.rightIcon"
+        :size="size"
+      />
     </template>
   </dt-input>
 </template>

--- a/packages/dialtone-vue2/components/input/input_default.story.vue
+++ b/packages/dialtone-vue2/components/input/input_default.story.vue
@@ -38,16 +38,16 @@
     >
       <span v-html="$attrs.description" />
     </template>
-    <template #leftIcon="{ size }">
+    <template #leftIcon="{ iconSize }">
       <dt-icon
         :name="$attrs.leftIcon"
-        :size="size"
+        :size="iconSize"
       />
     </template>
-    <template #rightIcon="{ size }">
+    <template #rightIcon="{ iconSize }">
       <dt-icon
         :name="$attrs.rightIcon"
-        :size="size"
+        :size="iconSize"
       />
     </template>
   </dt-input>

--- a/packages/dialtone-vue3/components/input/input.mdx
+++ b/packages/dialtone-vue3/components/input/input.mdx
@@ -78,8 +78,11 @@ import { DtInput, DtIcon } from '@dialpad/dialtone-vue';
   v-model="text"
   placeholder="placeholder"
 >
-  <template #leftIcon>
-    <dt-icon name="send" />
+  <template #leftIcon="{ iconSize }">
+    <dt-icon
+      name="send"
+      :size="iconSize"
+    />
   </template>
 </dt-input>
 ```
@@ -103,8 +106,11 @@ import { DtInput, DtIcon } from '@dialpad/dialtone-vue';
   v-model="text"
   placeholder="placeholder"
 >
-  <template #rightIcon>
-    <dt-icon name="lock" />
+  <template #rightIcon="{ attrs }">
+    <dt-icon
+      name="lock"
+      v-bind="attrs"
+    />
   </template>
 </dt-input>
 ```
@@ -128,11 +134,17 @@ import { DtInput } from '@dialpad/dialtone-vue';
   v-model="text"
   placeholder="placeholder"
 >
-  <template #leftIcon>
-    <dt-icon name="send" />
+  <template #leftIcon="{ iconSize }">
+    <dt-icon
+      name="send"
+      :size="iconSize"
+    />
   </template>
-  <template #rightIcon>
-    <dt-icon name="lock" />
+  <template #rightIcon="{ iconSize }">
+    <dt-icon
+      name="lock"
+      :size="iconSize"
+    />
   </template>
 </dt-input>
 ```

--- a/packages/dialtone-vue3/components/input/input.stories.js
+++ b/packages/dialtone-vue3/components/input/input.stories.js
@@ -11,7 +11,7 @@ const iconsList = getIconNames();
 export const argsData = {
   type: DtInput.props.type.default,
   size: INPUT_SIZES.DEFAULT,
-  placeholder: 'Placeholder',
+  placeholder: 'placeholder',
   label: 'Label',
   onBlur: action('blur'),
   onInput: action('input'),

--- a/packages/dialtone-vue3/components/input/input.stories.js
+++ b/packages/dialtone-vue3/components/input/input.stories.js
@@ -11,9 +11,8 @@ const iconsList = getIconNames();
 export const argsData = {
   type: DtInput.props.type.default,
   size: INPUT_SIZES.DEFAULT,
-  placeholder: 'placeholder',
+  placeholder: 'Placeholder',
   label: 'Label',
-  iconSize: null,
   onBlur: action('blur'),
   onInput: action('input'),
   onClear: action('clear'),
@@ -28,7 +27,6 @@ export const argsData = {
 export const argTypesData = {
   // Slots
   description: {
-    description: 'slot for description, defaults to description prop',
     table: {
       type: { summary: 'VNode' },
     },
@@ -91,17 +89,6 @@ export const argTypesData = {
     table: {
       defaultValue: {
         summary: INPUT_SIZES.DEFAULT,
-      },
-    },
-  },
-  iconSize: {
-    options: [null, ...Object.values(INPUT_SIZES)],
-    control: {
-      type: 'select',
-    },
-    table: {
-      defaultValue: {
-        summary: 'null',
       },
     },
   },

--- a/packages/dialtone-vue3/components/input/input.test.js
+++ b/packages/dialtone-vue3/components/input/input.test.js
@@ -221,54 +221,24 @@ describe('DtInput tests', () => {
         updateWrapper();
       });
 
-      describe('When a size is not provided', () => {
-        it('should render the icon wrapper', () => {
-          expect(leftIconWrapper.exists()).toBe(true);
-        });
-
-        it('should have input icon class', () => {
-          expect(leftIconWrapper.classes().includes('d-input-icon')).toBe(true);
-        });
-
-        it('should have input icon side class', () => {
-          expect(leftIconWrapper.classes().includes('d-input-icon--left')).toBe(true);
-        });
-
-        it('should have input icon size class', () => {
-          expect(leftIconWrapper.classes().includes(`d-input-icon--${INPUT_SIZES.DEFAULT}`)).toBe(false);
-        });
-
-        it('should render the provided icon', () => {
-          expect(wrapper.findComponent(DtIcon).exists()).toBe(true);
-        });
+      it('should render the icon wrapper', () => {
+        expect(leftIconWrapper.exists()).toBe(true);
       });
 
-      describe('When a size is provided', () => {
-        beforeEach(() => {
-          mockProps = { size: INPUT_SIZES.EXTRA_LARGE };
+      it('should have input icon class', () => {
+        expect(leftIconWrapper.classes().includes('d-input-icon')).toBe(true);
+      });
 
-          updateWrapper();
-        });
+      it('should have input icon side class', () => {
+        expect(leftIconWrapper.classes().includes('d-input-icon--left')).toBe(true);
+      });
 
-        it('should render the icon wrapper', () => {
-          expect(leftIconWrapper.exists()).toBe(true);
-        });
+      it('should have input icon size class', () => {
+        expect(leftIconWrapper.classes().includes(`d-input-icon--${INPUT_SIZES.DEFAULT}`)).toBe(false);
+      });
 
-        it('should have input icon class', () => {
-          expect(leftIconWrapper.classes().includes('d-input-icon')).toBe(true);
-        });
-
-        it('should have input icon side class', () => {
-          expect(leftIconWrapper.classes().includes('d-input-icon--left')).toBe(true);
-        });
-
-        it('should have input icon size class', () => {
-          expect(leftIconWrapper.classes().includes(`d-input-icon--${INPUT_SIZES.EXTRA_LARGE}`)).toBe(true);
-        });
-
-        it('should render the provided icon', () => {
-          expect(wrapper.findComponent(DtIcon).exists()).toBe(true);
-        });
+      it('should render the provided icon', () => {
+        expect(wrapper.findComponent(DtIcon).exists()).toBe(true);
       });
     });
 
@@ -279,54 +249,24 @@ describe('DtInput tests', () => {
         updateWrapper();
       });
 
-      describe('When a size is not provided', () => {
-        it('should render the icon wrapper', () => {
-          expect(rightIconWrapper.exists()).toBe(true);
-        });
-
-        it('should have input icon class', () => {
-          expect(rightIconWrapper.classes().includes('d-input-icon')).toBe(true);
-        });
-
-        it('should have input icon side class', () => {
-          expect(rightIconWrapper.classes().includes('d-input-icon--right')).toBe(true);
-        });
-
-        it('should have input icon size class', () => {
-          expect(rightIconWrapper.classes().includes(`d-input-icon--${INPUT_SIZES.DEFAULT}`)).toBe(false);
-        });
-
-        it('should render the provided icon', () => {
-          expect(wrapper.findComponent(DtIcon).exists()).toBe(true);
-        });
+      it('should render the icon wrapper', () => {
+        expect(rightIconWrapper.exists()).toBe(true);
       });
 
-      describe('When a size is provided', () => {
-        beforeEach(() => {
-          mockProps = { size: INPUT_SIZES.EXTRA_LARGE };
+      it('should have input icon class', () => {
+        expect(rightIconWrapper.classes().includes('d-input-icon')).toBe(true);
+      });
 
-          updateWrapper();
-        });
+      it('should have input icon side class', () => {
+        expect(rightIconWrapper.classes().includes('d-input-icon--right')).toBe(true);
+      });
 
-        it('should render the icon wrapper', () => {
-          expect(rightIconWrapper.exists()).toBe(true);
-        });
+      it('should have input icon size class', () => {
+        expect(rightIconWrapper.classes().includes(`d-input-icon--${INPUT_SIZES.DEFAULT}`)).toBe(false);
+      });
 
-        it('should have input icon class', () => {
-          expect(rightIconWrapper.classes().includes('d-input-icon')).toBe(true);
-        });
-
-        it('should have input icon side class', () => {
-          expect(rightIconWrapper.classes().includes('d-input-icon--right')).toBe(true);
-        });
-
-        it('should have input icon size class', () => {
-          expect(rightIconWrapper.classes().includes(`d-input-icon--${INPUT_SIZES.EXTRA_LARGE}`)).toBe(true);
-        });
-
-        it('should render the provided icon', () => {
-          expect(wrapper.findComponent(DtIcon).exists()).toBe(true);
-        });
+      it('should render the provided icon', () => {
+        expect(wrapper.findComponent(DtIcon).exists()).toBe(true);
       });
     });
 

--- a/packages/dialtone-vue3/components/input/input.vue
+++ b/packages/dialtone-vue3/components/input/input.vue
@@ -1,23 +1,20 @@
-<!-- eslint-disable vue/no-restricted-class -->
 <template>
   <div
     ref="container"
-    :class="['base-input', { 'd-vi-hidden': hidden }]"
+    :class="{ 'd-input--hidden': hidden }"
     data-qa="dt-input"
   >
     <label
-      class="base-input__label"
       :aria-details="$slots.description || description ? descriptionKey : undefined"
       data-qa="dt-input-label-wrapper"
     >
-      <!-- @slot slot for label, defaults to label prop -->
+      <!-- @slot Slot for label, defaults to label prop -->
       <slot name="labelSlot">
         <div
           v-if="labelVisible && label"
           ref="label"
           data-qa="dt-input-label"
           :class="[
-            'base-input__label-text',
             'd-label',
             labelSizeClasses[size],
           ]"
@@ -30,7 +27,6 @@
         :id="descriptionKey"
         ref="description"
         :class="[
-          'base-input__description',
           'd-description',
           descriptionSizeClasses[size],
         ]"
@@ -39,7 +35,7 @@
         <div
           v-if="hasSlotContent($slots.description) || description"
         >
-          <!-- @slot slot for description, defaults to description prop -->
+          <!-- @slot Slot for description, defaults to description prop -->
           <slot name="description">{{ description }}</slot>
         </div>
         <div
@@ -55,13 +51,15 @@
         :read-only="disabled === true ? true : undefined"
       >
         <span
-          v-if="hasSlotContent($slots.leftIcon)"
-          :class="inputIconClasses('left')"
+          class="d-input-icon d-input-icon--left"
           data-qa="dt-input-left-icon-wrapper"
           @focusout="onBlur"
         >
           <!-- @slot Slot for left icon -->
-          <slot name="leftIcon" />
+          <slot
+            name="leftIcon"
+            :icon-size="iconSize"
+          />
         </span>
         <textarea
           v-if="isTextarea"
@@ -91,13 +89,15 @@
           v-on="inputListeners"
         >
         <span
-          v-if="hasSlotContent($slots.rightIcon)"
-          :class="inputIconClasses('right')"
+          class="d-input-icon d-input-icon--right"
           data-qa="dt-input-right-icon-wrapper"
           @focusout="onBlur"
         >
           <!-- @slot Slot for right icon -->
-          <slot name="rightIcon" />
+          <slot
+            name="rightIcon"
+            :icon-size="iconSize"
+          />
         </span>
       </div>
     </label>
@@ -112,8 +112,17 @@
 </template>
 
 <script>
+/* eslint-disable max-lines */
 import { DESCRIPTION_SIZE_TYPES, VALIDATION_MESSAGE_TYPES } from '@/common/constants';
-import { INPUT_TYPES, INPUT_SIZES } from './input_constants';
+import {
+  INPUT_TYPES,
+  INPUT_SIZES,
+  INPUT_SIZE_CLASSES,
+  INPUT_ICON_SIZES,
+  INPUT_STATE_CLASSES,
+  DESCRIPTION_SIZE_CLASSES,
+  LABEL_SIZE_CLASSES,
+} from './input_constants';
 import {
   getUniqueString,
   getValidationState,
@@ -203,22 +212,11 @@ export default {
 
     /**
      * Size of the input, one of `xs`, `sm`, `md`, `lg`, `xl`
-     * @values null, xs, sm, md, lg, xl
+     * @values xs, sm, md, lg, xl
      */
     size: {
       type: String,
-      default: null,
-      validator: (t) => Object.values(INPUT_SIZES).includes(t),
-    },
-
-    /**
-     * Size of the icon. One of `xs`, `sm`, `md`, `lg`, `xl`. If you do not set this the icon will size relative
-     * to the input size
-     * @values null, xs, sm, md, lg, xl
-     */
-    iconSize: {
-      type: String,
-      default: null,
+      default: 'md',
       validator: (t) => Object.values(INPUT_SIZES).includes(t),
     },
 
@@ -354,19 +352,6 @@ export default {
 
   data () {
     return {
-      descriptionSizeClasses: {
-        lg: 'd-description--lg',
-        xl: 'd-description--xl',
-      },
-
-      labelSizeClasses: {
-        xs: 'd-label--xs',
-        sm: 'd-label--sm',
-        md: 'd-label--md',
-        lg: 'd-label--lg',
-        xl: 'd-label--xl',
-      },
-
       isInputFocused: false,
       isInvalid: false,
       defaultLength: 0,
@@ -384,12 +369,8 @@ export default {
       return this.size === INPUT_SIZES.DEFAULT;
     },
 
-    isDefaultIconSize () {
-      return this.iconSizeComputed === INPUT_SIZES.DEFAULT;
-    },
-
-    iconSizeComputed () {
-      return this.iconSize ? this.iconSize : this.size;
+    iconSize () {
+      return INPUT_ICON_SIZES[this.size];
     },
 
     isValidSize () {
@@ -512,40 +493,11 @@ export default {
         return '';
       }
 
-      const sizeClasses = {
-        input: {
-          xs: 'd-input--xs',
-          sm: 'd-input--sm',
-          lg: 'd-input--lg',
-          xl: 'd-input--xl',
-        },
-
-        textarea: {
-          xs: 'd-textarea--xs',
-          sm: 'd-textarea--sm',
-          lg: 'd-textarea--lg',
-          xl: 'd-textarea--xl',
-        },
-      };
-
-      return sizeClasses[this.inputComponent][this.size];
+      return INPUT_SIZE_CLASSES[this.inputComponent][this.size];
     },
 
     stateClass () {
-      const inputStateClasses = {
-        input: {
-          error: 'd-input--error base-input__input--error',
-          warning: 'd-input--warning base-input__input--warning',
-          success: 'd-input--success base-input__input--success',
-        },
-
-        textarea: {
-          error: 'd-textarea--error base-input__input--error',
-          warning: 'd-textarea--warning base-input__input--warning',
-          success: 'd-textarea--success base-input__input--success',
-        },
-      };
-      return [inputStateClasses[this.inputComponent][this.inputState]];
+      return [INPUT_STATE_CLASSES[this.inputComponent][this.inputState]];
     },
   },
 
@@ -568,10 +520,14 @@ export default {
     },
   },
 
+  beforeMount () {
+    this.descriptionSizeClasses = DESCRIPTION_SIZE_CLASSES;
+    this.labelSizeClasses = LABEL_SIZE_CLASSES;
+  },
+
   methods: {
     inputClasses () {
       return [
-        'base-input__input',
         this.inputComponent === 'input' ? 'd-input' : 'd-textarea',
         {
           [this.stateClass]: this.showInputState,
@@ -609,26 +565,6 @@ export default {
       };
     },
 
-    inputIconClasses (side) {
-      const iconSizeClasses = {
-        xs: 'd-input-icon--xs',
-        sm: 'd-input-icon--sm',
-        lg: 'd-input-icon--lg',
-        xl: 'd-input-icon--xl',
-      };
-      const iconOrientationClasses = {
-        left: 'base-input__icon--left d-input-icon--left',
-        right: 'base-input__icon--right d-input-icon--right',
-      };
-
-      return [
-        iconOrientationClasses[side],
-        'd-input-icon',
-        { [iconSizeClasses[this.iconSizeComputed]]: !this.isDefaultIconSize },
-        this.sizeModifierClass,
-      ];
-    },
-
     onBlur (e) {
       // Do not emit a blur event if the target element is a child of this component
       if (!this.$refs.container?.contains(e.relatedTarget)) {
@@ -663,3 +599,9 @@ export default {
   },
 };
 </script>
+
+<style lang="less">
+.d-input--hidden {
+  visibility: hidden;
+}
+</style>

--- a/packages/dialtone-vue3/components/input/input.vue
+++ b/packages/dialtone-vue3/components/input/input.vue
@@ -599,9 +599,3 @@ export default {
   },
 };
 </script>
-
-<style lang="less">
-.d-input--hidden {
-  visibility: hidden;
-}
-</style>

--- a/packages/dialtone-vue3/components/input/input_constants.js
+++ b/packages/dialtone-vue3/components/input/input_constants.js
@@ -20,7 +20,63 @@ export const INPUT_SIZES = {
   EXTRA_LARGE: 'xl',
 };
 
+export const INPUT_ICON_SIZES = {
+  xs: '100',
+  sm: '200',
+  md: '200',
+  lg: '400',
+  xl: '500',
+};
+
+export const INPUT_SIZE_CLASSES = {
+  input: {
+    xs: 'd-input--xs',
+    sm: 'd-input--sm',
+    lg: 'd-input--lg',
+    xl: 'd-input--xl',
+  },
+
+  textarea: {
+    xs: 'd-textarea--xs',
+    sm: 'd-textarea--sm',
+    lg: 'd-textarea--lg',
+    xl: 'd-textarea--xl',
+  },
+};
+
+export const INPUT_STATE_CLASSES = {
+  input: {
+    error: 'd-input--error',
+    warning: 'd-input--warning',
+    success: 'd-input--success',
+  },
+
+  textarea: {
+    error: 'd-textarea--error',
+    warning: 'd-textarea--warning',
+    success: 'd-textarea--success',
+  },
+};
+
+export const DESCRIPTION_SIZE_CLASSES = {
+  lg: 'd-description--lg',
+  xl: 'd-description--xl',
+};
+
+export const LABEL_SIZE_CLASSES = {
+  xs: 'd-label--xs',
+  sm: 'd-label--sm',
+  md: 'd-label--md',
+  lg: 'd-label--lg',
+  xl: 'd-label--xl',
+};
+
 export default {
   INPUT_TYPES,
   INPUT_SIZES,
+  INPUT_ICON_SIZES,
+  INPUT_SIZE_CLASSES,
+  INPUT_STATE_CLASSES,
+  DESCRIPTION_SIZE_CLASSES,
+  LABEL_SIZE_CLASSES,
 };

--- a/packages/dialtone-vue3/components/input/input_default.story.vue
+++ b/packages/dialtone-vue3/components/input/input_default.story.vue
@@ -5,7 +5,6 @@
     :type="$attrs.type"
     :messages="$attrs.messages"
     :size="$attrs.size"
-    :icon-size="$attrs.iconSize"
     :label="$attrs.label"
     :messages-child-props="$attrs.messagesChildProps"
     :name="$attrs.name"
@@ -39,17 +38,17 @@
     >
       <span v-html="$attrs.description" />
     </template>
-    <template
-      v-if="$attrs.leftIcon"
-      #leftIcon
-    >
-      <dt-icon :name="$attrs.leftIcon" />
+    <template #leftIcon="{ iconSize }">
+      <dt-icon
+        :name="$attrs.leftIcon"
+        :size="iconSize"
+      />
     </template>
-    <template
-      v-if="$attrs.rightIcon"
-      #rightIcon
-    >
-      <dt-icon :name="$attrs.rightIcon" />
+    <template #rightIcon="{ iconSize }">
+      <dt-icon
+        :name="$attrs.rightIcon"
+        :size="iconSize"
+      />
     </template>
   </dt-input>
 </template>


### PR DESCRIPTION
# Add icon scoped slot to input

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/TEOBMqak2vubSdGi1I/giphy.gif?cid=6c09b952zv1jszfvnzpdzmncln8qgvy6r2uvbrzdrht9usnh&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1808

## :book: Description

- Added iconSize scope to icon slot to be able to keep the icon size in sync with the input.
- General CSS cleanup of input.less

## :bulb: Context

- A while ago when we changed the way we were handling icons, forgot to update input accordingly, so the icon sizes where not being handled correctly.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

For all CSS changes:

- [x] I have used design tokens whenever possible.

## :camera: Screenshots / GIFs

<table>
  <tr>
    <th>Size</th>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>XS</td>
    <td>
      <img src="https://github.com/dialpad/dialtone/assets/87546543/d068bfbc-fd13-4586-9c41-bb0e888ae6ab" />
    </td>
    <td>
      <img src="https://github.com/dialpad/dialtone/assets/87546543/dc3f6dd6-dd74-4c3a-8d40-8285010e7db2" />
    </td>
  </tr>
  <tr>
    <td>SM</td>
    <td>
      <img src="https://github.com/dialpad/dialtone/assets/87546543/d671cd7d-2f1d-49d4-8d82-2990b5b01b60" />
    </td>
    <td>
      <img src="https://github.com/dialpad/dialtone/assets/87546543/42a5d42c-d8bc-40c8-aac9-c77f558bcd2f" />
    </td>
  </tr>
  <tr>
    <td>MD</td>
    <td>
      <img src="https://github.com/dialpad/dialtone/assets/87546543/7e2b8f90-986f-42b1-a57a-3cae9aae881f" />
    </td>
    <td>
      <img src="https://github.com/dialpad/dialtone/assets/87546543/dc3f6dd6-dd74-4c3a-8d40-8285010e7db2" />
    </td>
  </tr>
  <tr>
    <td>LG</td>
    <td>
      <img src="https://github.com/dialpad/dialtone/assets/87546543/704ced35-40b9-475f-9ef0-f74ea57f7c39" />
    </td>
    <td>
      <img src="https://github.com/dialpad/dialtone/assets/87546543/f3ac414b-8ea1-4d4d-a1ef-51be03d57c9b" />
    </td>
  </tr>
  <tr>
    <td>XL</td>
    <td>
      <img src="https://github.com/dialpad/dialtone/assets/87546543/a5427681-61e0-43c6-ba2b-7cec8ee9d7f6" />
    </td>
    <td>
      <img src="https://github.com/dialpad/dialtone/assets/87546543/fb93547f-ae2f-40b5-b23f-2322d49dc705" />
    </td>
  </tr>
</table>

## Links
- [Input component - Dialtone docs](https://dialtone.dialpad.com/deploy-previews/pr-392/components/input.html)
- [DtInput - Dialtone Vue 2](https://dialtone.dialpad.com/vue/deploy-previews/pr-392/?path=/story/components-input--with-both-icons)
- [DtInput - Dialtone Vue 3](https://dialtone.dialpad.com/vue3/deploy-previews/pr-392/?path=/story/components-input--with-both-icons)
