### PR TITLE
fix(emoji-picker): NO-JIRA fix keyboard proposal

### DIFF
--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
@@ -10,9 +10,8 @@
         :scroll-into-tab="scrollIntoTab"
         :tab-set-labels="tabSetLabels"
         :is-scrolling="isScrolling"
-        @tab-key-pressed="focusNextSectionFromEmojiTabSet"
-        @shift-tab-key-pressed="$refs.skinSelectorRef.focusSkinSelector()"
-        @arrow-down-key-pressed="focusNextSectionFromEmojiTabSet"
+        @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
+        @focus-search-input="showSearch ? $refs.searchInputRef.focusSearchInput() : $refs.emojiSelectorRef.focusEmojiSelector()"
         @selected-tabset="scrollToSelectedTabset"
         @keydown.esc.native="$emit('close')"
       />
@@ -43,7 +42,7 @@
         @highlighted-emoji="updateHighlightedEmoji"
         @selected-emoji="$emit('selected-emoji', $event)"
         @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
-        @shift-tab-key-pressed="focusNextSectionFromEmojiSelector"
+        @focus-search-input="showSearch ? $refs.searchInputRef.focusSearchInput() : $refs.tabsetRef.focusTabset()"
         @keydown.esc.native="$emit('close')"
       />
     </div>
@@ -233,22 +232,6 @@ export default {
 
     updateHighlightedEmoji (emoji) {
       this.highlightedEmoji = emoji;
-    },
-
-    focusNextSectionFromEmojiTabSet () {
-      if (this.showSearch) {
-        this.$refs.searchInputRef.focusSearchInput();
-      } else {
-        this.$refs.emojiSelectorRef.focusEmojiSelector();
-      }
-    },
-
-    focusNextSectionFromEmojiSelector () {
-      if (this.showSearch) {
-        this.$refs.searchInputRef.focusSearchInput();
-      } else {
-        this.$refs.tabsetRef.focusTabset();
-      }
     },
   },
 };

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -482,7 +482,7 @@ export default {
           this.scrollToTab(indexTab, true);
         } else {
           this.scrollToTab(1, false);
-          this.$emit('shift-tab-key-pressed');
+          this.$emit('focus-search-input');
         }
       }
 

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
@@ -158,14 +158,14 @@ export default {
       if (event.key === 'Tab') {
         event.preventDefault();
         if (event.shiftKey) {
-          this.$emit('shift-tab-key-pressed');
+          this.$emit('focus-skin-selector');
         } else {
-          this.$emit('tab-key-pressed');
+          this.$emit('focus-search-input');
         }
       }
 
       if (event.key === 'ArrowDown') {
-        this.$emit('arrow-down-key-pressed');
+        this.$emit('focus-search-input');
       }
     },
   },

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
@@ -10,9 +10,8 @@
         :scroll-into-tab="scrollIntoTab"
         :tabset-labels="tabSetLabels"
         :is-scrolling="isScrolling"
-        @tab-key-pressed="focusNextSectionFromEmojiTabSet"
-        @shift-tab-key-pressed="$refs.skinSelectorRef.focusSkinSelector()"
-        @arrow-down-key-pressed="focusNextSectionFromEmojiTabSet"
+        @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
+        @focus-search-input="showSearch ? $refs.searchInputRef.focusSearchInput() : $refs.emojiSelectorRef.focusEmojiSelector()"
         @selected-tabset="scrollToSelectedTabset"
         @keydown.esc="emits('close')"
       />
@@ -42,7 +41,7 @@
         @highlighted-emoji="updateHighlightedEmoji"
         @selected-emoji="emits('selected-emoji', $event)"
         @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
-        @shift-tab-key-pressed="focusNextSectionFromEmojiSelector"
+        @focus-search-input="showSearch ? $refs.searchInputRef.focusSearchInput() : $refs.tabsetRef.focusTabset()"
         @keydown.esc="emits('close')"
       />
     </div>
@@ -216,10 +215,6 @@ const selectedTabset = ref({});
 const scrollIntoTab = ref(0);
 const isScrolling = ref(false);
 
-const searchInputRef = ref(null);
-const emojiSelectorRef = ref(null);
-const tabsetRef = ref(null);
-
 const showRecentlyUsedTab = computed(() => props.recentlyUsedEmojis.length > 0);
 
 watch(
@@ -253,21 +248,5 @@ function updateIsScrolling (value) {
 }
 function updateHighlightedEmoji (emoji) {
   highlightedEmoji.value = emoji;
-}
-
-function focusNextSectionFromEmojiTabSet () {
-  if (props.showSearch) {
-    searchInputRef.value.focusSearchInput();
-  } else {
-    emojiSelectorRef.value.focusEmojiSelector();
-  }
-}
-
-function focusNextSectionFromEmojiSelector () {
-  if (props.showSearch) {
-    searchInputRef.value.focusSearchInput();
-  } else {
-    tabsetRef.value.focusTabset();
-  }
 }
 </script>

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
@@ -205,9 +205,9 @@ const emits = defineEmits([
 
   /**
    * Emitted when the user shift tab in first tab of emoji selector
-   * @event shift-tab-key-pressed
+   * @event focus-search-input
     */
-  'shift-tab-key-pressed',
+  'focus-search-input',
 ]);
 
 const {
@@ -541,7 +541,7 @@ const handleKeyDown = (event, indexTab, indexEmoji, emoji) => {
           scrollToTab(indexTab, true);
         } else {
           scrollToTab(1, false);
-          emits('shift-tab-key-pressed');
+          emits('focus-search-input');
         }
       } else {
         if (focusEmoji(indexTab + 1, 0)) {

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
@@ -78,9 +78,8 @@ const emits = defineEmits([
    */
   'selected-tabset',
 
-  'shift-tab-key-pressed',
-  'tab-key-pressed',
-  'arrow-down-key-pressed',
+  'focus-search-input',
+  'focus-skin-selector',
 ]);
 
 const TABS_DATA = [
@@ -160,15 +159,15 @@ function handleKeyDown (event, tabId) {
   if (event.key === 'Tab') {
     event.preventDefault();
     if (event.shiftKey) {
-      emits('shift-tab-key-pressed');
+      emits('focus-skin-selector');
     } else {
-      emits('tab-key-pressed');
+      emits('focus-search-input');
     }
   }
 
   if (event.key === 'ArrowDown') {
     // Jump to search input
-    emits('arrow-down-key-pressed');
+    emits('focus-search-input');
   }
 }
 


### PR DESCRIPTION
# Emoji picker fix keyboard - proposal

I late in my review to https://github.com/dialpad/dialtone/pull/389 .
I was doing it but then I freezed it, then the PR was already merge.

This PR just revert the previous PR changes (tests are ok) and just add a ternary to the events.

`@focus-search-input="showSearch ? $refs.searchInputRef.focusSearchInput() : $refs.emojiSelectorRef.focusEmojiSelector()"`

`@focus-search-input="showSearch ? $refs.searchInputRef.focusSearchInput() : $refs.tabsetRef.focusTabset()"`

Im not fan of logic in template but tbh I see this more clear, less code, less complex and it does not modify any component section.

---------

Some explanation:

I have some concerns of the addition of this methods and the names.

On 
```
<emoji-tabset
 @tab-key-pressed="focusNextSectionFromEmojiTabSet"
@shift-tab-key-pressed="$refs.skinSelectorRef.focusSkinSelector()"
@arrow-down-key-pressed="focusNextSectionFromEmojiTabSet"
```
These event names `tab` `shift-tab` `arrow-down` are being pressed in others sections as well so it sounds off that they does not have it.
It also repeat event with `tab-key-pressed` and `arrow-down-key-pressed`

This addition can be a little bit confusing, since in our code, events are attached to the structure,
`focus-search-input` `focus-skin-selector` `focus-tabset` `focus-emoji-selector`.


On 
```
<emoji-selector
@shift-tab-key-pressed="focusNextSectionFromEmojiSelector"
```
This has the `shift-tab` but not the others events (I would expect them).
It also says focus**Next**SectionFromEmojiSelector. But it goes to the previous one. Next should be `skin-selector`.


I would prefer to keep the previous code and just go with a ternary on the events.



