### PR TITLE
feat(multi-select): DLT-1845 allow duplicated names on multiselect

### DIFF
--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
@@ -170,3 +170,12 @@ export const WithMaxSelectValidation = {
     },
   },
 };
+
+export const DuplicatedNames = {
+  render: (argsData) =>
+    createRenderConfig(DtRecipeComboboxMultiSelect, DtRecipeComboboxMultiSelectDefaultTemplate, argsData),
+
+  args: {
+    selectedItems: ['item12', 'item12', 'item12'],
+  },
+};

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.test.js
@@ -4,6 +4,7 @@ import { VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 import DtPopover from '@/components/popover/popover.vue';
 import { cleanSpy, initializeSpy } from '@/tests/shared_examples/validation';
 import { itBehavesLikeVisuallyHiddenCloseLabelIsNull } from '@/tests/shared_examples/sr_only_close_button';
+import * as utils from '@/common/utils';
 
 // Constants
 const basePropsData = {
@@ -213,6 +214,10 @@ describe('DtRecipeComboboxMultiSelect Tests', () => {
     });
 
     describe('Should navigate between last chip and input', () => {
+      beforeAll(() => {
+        vi.spyOn(utils, 'getUniqueString').mockImplementation((item) => `mockedUniqueString-${item}`);
+      });
+
       let lastChip;
       beforeEach(async () => {
         await wrapper.setProps({ selectedItems: ['1'] });

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -23,9 +23,9 @@
           class="combobox__chip-wrapper"
         >
           <dt-chip
-            v-for="item in selectedItems"
+            v-for="({ item, key }) in selectedItemsWithKeys"
             ref="chips"
-            :key="getMultiSelectItemKey(item)"
+            :key="key"
             :label-class="['d-chip__label']"
             class="combobox__chip"
             :close-button-props="{ ariaLabel: 'close' }"
@@ -116,7 +116,7 @@ import {
   CHIP_TOP_POSITION,
 } from './combobox_multi_select_constants';
 import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
-import utils from '@/common/utils';
+import { getUniqueString } from '@/common/utils';
 
 export default {
   name: 'DtRecipeComboboxMultiSelect',
@@ -384,6 +384,13 @@ export default {
         },
       };
     },
+
+    selectedItemsWithKeys () {
+      return this.selectedItems.map(selectedItem => ({
+        item: selectedItem,
+        key: getUniqueString(selectedItem),
+      }));
+    },
   },
 
   watch: {
@@ -605,10 +612,6 @@ export default {
       } else {
         this.showValidationMessages = false;
       }
-    },
-
-    getMultiSelectItemKey (item) {
-      return `${item}-${utils.getUniqueString()}`;
     },
   },
 };

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -23,9 +23,9 @@
           class="combobox__chip-wrapper"
         >
           <dt-chip
-            v-for="item in selectedItems"
+            v-for="(item, index) in selectedItems"
             ref="chips"
-            :key="item"
+            :key="`${item}-${index}`"
             :label-class="['d-chip__label']"
             class="combobox__chip"
             :close-button-props="{ ariaLabel: 'close' }"

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -23,9 +23,9 @@
           class="combobox__chip-wrapper"
         >
           <dt-chip
-            v-for="(item, index) in selectedItems"
+            v-for="item in selectedItems"
             ref="chips"
-            :key="`${item}-${index}`"
+            :key="getMultiSelectItemKey(item)"
             :label-class="['d-chip__label']"
             class="combobox__chip"
             :close-button-props="{ ariaLabel: 'close' }"
@@ -116,6 +116,7 @@ import {
   CHIP_TOP_POSITION,
 } from './combobox_multi_select_constants';
 import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
+import utils from '@/common/utils';
 
 export default {
   name: 'DtRecipeComboboxMultiSelect',
@@ -604,6 +605,10 @@ export default {
       } else {
         this.showValidationMessages = false;
       }
+    },
+
+    getMultiSelectItemKey (item) {
+      return `${item}-${utils.getUniqueString()}`;
     },
   },
 };

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
@@ -176,3 +176,11 @@ export const WithMaxSelectValidation = {
     },
   },
 };
+
+export const DuplicatedNames = {
+  render: Template,
+
+  args: {
+    selectedItems: ['item12', 'item12', 'item12'],
+  },
+};

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -23,9 +23,9 @@
           class="combobox__chip-wrapper"
         >
           <dt-chip
-            v-for="(item, index) in selectedItems"
+            v-for="item in selectedItems"
             ref="chips"
-            :key="`${item}-${index}`"
+            :key="getMultiSelectItemKey(item)"
             :label-class="['d-chip__label']"
             class="combobox__chip"
             :close-button-props="{ ariaLabel: 'close' }"
@@ -107,7 +107,7 @@ import DtInput from '@/components/input/input.vue';
 import DtChip from '@/components/chip/chip.vue';
 import DtValidationMessages from '@/components/validation_messages/validation_messages.vue';
 import { validationMessageValidator } from '@/common/validators';
-import { hasSlotContent } from '@/common/utils';
+import utils, { hasSlotContent } from '@/common/utils';
 import {
   POPOVER_APPEND_TO_VALUES,
 } from '@/components/popover/popover_constants';
@@ -605,6 +605,10 @@ export default {
       } else {
         this.showValidationMessages = false;
       }
+    },
+
+    getMultiSelectItemKey (item) {
+      return `${item}-${utils.getUniqueString()}`;
     },
   },
 };

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -25,7 +25,7 @@
           <dt-chip
             v-for="item in selectedItems"
             ref="chips"
-            :key="getMultiSelectItemKey(item)"
+            :key="item"
             :label-class="['d-chip__label']"
             class="combobox__chip"
             :close-button-props="{ ariaLabel: 'close' }"
@@ -107,7 +107,7 @@ import DtInput from '@/components/input/input.vue';
 import DtChip from '@/components/chip/chip.vue';
 import DtValidationMessages from '@/components/validation_messages/validation_messages.vue';
 import { validationMessageValidator } from '@/common/validators';
-import utils, { hasSlotContent } from '@/common/utils';
+import { hasSlotContent } from '@/common/utils';
 import {
   POPOVER_APPEND_TO_VALUES,
 } from '@/components/popover/popover_constants';
@@ -605,10 +605,6 @@ export default {
       } else {
         this.showValidationMessages = false;
       }
-    },
-
-    getMultiSelectItemKey (item) {
-      return `${item}-${utils.getUniqueString()}`;
     },
   },
 };

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -23,9 +23,9 @@
           class="combobox__chip-wrapper"
         >
           <dt-chip
-            v-for="item in selectedItems"
+            v-for="(item, index) in selectedItems"
             ref="chips"
-            :key="item"
+            :key="`${item}-${index}`"
             :label-class="['d-chip__label']"
             class="combobox__chip"
             :close-button-props="{ ariaLabel: 'close' }"


### PR DESCRIPTION
# feat(DLT-1845): allow duplicated names on multiselect

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTllMnRmbHUycTB4dDY2bzQ0a3UwcTA5OHRveDZqdjBkemhiamtpdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/J0BqmcZi9zmnlYTDKs/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-1845

## :book: Description
We need to find a way to avoid console errors when we have duplicate values on the items. Since we are using the same strings that we rendered as keys (which are usually not ids or keys, they can be names) we can have duplicate values. What I have done to allow duplicate names is to convert the key to `{value}-{index}`.
Please feel free to suggest other ideas to achieve this behaviour.

## :bulb: Context
We use the multi-select component to select users for the bulk SMS feature. Sometimes we have more than one user with the same name and in these cases the multi-select component returned an error.