### PR TITLE
fix(tooltip): DLT-1846 inverted not working properly

### DIFF
--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -241,7 +241,7 @@ export default {
      */
     theme: {
       type: String,
-      default: undefined,
+      default: null,
     },
 
     /**

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -240,7 +240,7 @@ export default {
      */
     theme: {
       type: String,
-      default: undefined,
+      default: null,
     },
 
     /**


### PR DESCRIPTION
# Fix Tooltip - Inverted not working properly

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaDc0OTN5dnNpbnNvZHh0b2VhcmdwNWI2eG14YjgwOGc1M2RiaGluZyZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/sR0VkRHuVtdl4rgAOr/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1846

## :book: Description

- Change `theme` prop default value from 'undefined' to 'null'.

## :bulb: Context

- The theme was not reverting correctly after toggling `inverted` prop.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :camera: Screenshots / GIFs

- Before

https://github.com/dialpad/dialtone/assets/87546543/2e66c731-da68-43e5-9920-f0a25d8c322e

- After

https://github.com/dialpad/dialtone/assets/87546543/ee61f0a7-5595-4a71-a6e8-cc33559cb392
