### PR TITLE
feat(combobox-multiselect): NO-JIRA add collapse on focus out

### DIFF
--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
@@ -4,6 +4,7 @@ import DtRecipeComboboxMultiSelect from './combobox_multi_select.vue';
 
 import DtRecipeComboboxMultiSelectDefaultTemplate from './combobox_multi_select_default.story.vue';
 import { MULTI_SELECT_SIZES } from './combobox_multi_select_constants';
+import { ITEMS_LIST_DATA } from './combobox_multi_select_story_constants';
 
 // Default Prop Values
 export const argsData = {
@@ -177,5 +178,15 @@ export const DuplicatedNames = {
 
   args: {
     selectedItems: ['item12', 'item12', 'item12'],
+  },
+};
+
+export const WithCollapseOnFocusOut = {
+  render: (argsData) =>
+    createRenderConfig(DtRecipeComboboxMultiSelect, DtRecipeComboboxMultiSelectDefaultTemplate, argsData),
+
+  args: {
+    selectedItems: ITEMS_LIST_DATA.map(item => item.value),
+    collapseOnFocusOut: true,
   },
 };

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
@@ -14,6 +14,7 @@
     :selected-items="$attrs.selectedItems"
     :max-selected="$attrs.maxSelected"
     :list-max-height="$attrs.listMaxHeight"
+    :collapse-on-focus-out="$attrs.collapseOnFocusOut"
     :max-selected-message="$attrs.maxSelectedMessage"
     :has-suggestion-list="$attrs.hasSuggestionList"
     :visually-hidden-close="$attrs.visuallyHiddenClose"

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
@@ -4,6 +4,7 @@ import DtRecipeComboboxMultiSelect from './combobox_multi_select.vue';
 
 import DtRecipeComboboxMultiSelectDefaultTemplate from './combobox_multi_select_default.story.vue';
 import { MULTI_SELECT_SIZES } from './combobox_multi_select_constants';
+import { ITEMS_LIST_DATA } from './combobox_multi_select_story_constants';
 
 // Default Prop Values
 export const argsData = {
@@ -182,5 +183,14 @@ export const DuplicatedNames = {
 
   args: {
     selectedItems: ['item12', 'item12', 'item12'],
+  },
+};
+
+export const WithCollapseOnFocusOut = {
+  render: Template,
+
+  args: {
+    selectedItems: ITEMS_LIST_DATA.map(item => item.value),
+    collapseOnFocusOut: true,
   },
 };

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -17,10 +17,12 @@
       <span
         ref="inputSlotWrapper"
         class="combobox__input-wrapper"
+        @focusin="handleInputFocusIn"
+        @focusout="handleInputFocusOut"
       >
         <span
           ref="chipsWrapper"
-          class="combobox__chip-wrapper"
+          :class="['combobox__chip-wrapper', chipWrapperClass]"
         >
           <dt-chip
             v-for="item in selectedItems"
@@ -102,6 +104,7 @@
 </template>
 
 <script>
+/* eslint-disable max-lines */
 import DtRecipeComboboxWithPopover from '@/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue';
 import DtInput from '@/components/input/input.vue';
 import DtChip from '@/components/chip/chip.vue';
@@ -291,6 +294,15 @@ export default {
       type: String,
       default: 'fade',
     },
+
+    /**
+     * Determines whether the combobox should collapse to a single when losing focus.
+     * @type {boolean}
+     */
+    collapseOnFocusOut: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   emits: [
@@ -340,11 +352,11 @@ export default {
       value: '',
       popoverOffset: [0, 4],
       showValidationMessages: false,
-      initialInputPadding: {},
       resizeWindowObserver: null,
-      originalInputSize: null,
+      initialInputHeight: null,
       CHIP_SIZES,
       hasSlotContent,
+      inputFocused: false,
     };
   },
 
@@ -383,6 +395,12 @@ export default {
         },
       };
     },
+
+    chipWrapperClass () {
+      return {
+        [`combobox__chip-wrapper-${this.size}--collapsed`]: !this.inputFocused && this.collapseOnFocusOut,
+      };
+    },
   },
 
   watch: {
@@ -410,7 +428,7 @@ export default {
         await this.$nextTick();
         const input = this.getInput();
         this.revertInputPadding(input);
-        this.originalInputSize = input.getBoundingClientRect().height;
+        this.initialInputHeight = input.getBoundingClientRect().height;
         this.setInputPadding();
         this.setChipsTopPosition();
       },
@@ -418,6 +436,7 @@ export default {
   },
 
   mounted () {
+    this.setInitialInputHeight();
     // Recalculate chip position and input padding when resizing window
     this.resizeWindowObserver = new ResizeObserver(async () => {
       this.setChipsTopPosition();
@@ -568,7 +587,7 @@ export default {
       const top = lastChip.offsetTop + 2;
 
       // Add padding to Top only if the chips need more space
-      if (chipsSize > this.originalInputSize) {
+      if (chipsSize > this.initialInputHeight) {
         input.style.paddingTop = `${top}px`;
       }
     },
@@ -606,6 +625,28 @@ export default {
         this.showValidationMessages = false;
       }
     },
+
+    setInitialInputHeight () {
+      const input = this.getInput();
+      if (!input) return;
+      this.initialInputHeight = input.getBoundingClientRect().height;
+    },
+
+    async handleInputFocusIn () {
+      this.inputFocused = true;
+      if (this.collapseOnFocusOut) {
+        await this.$nextTick();
+        this.setInputPadding();
+      }
+    },
+
+    async handleInputFocusOut () {
+      this.inputFocused = false;
+      if (this.collapseOnFocusOut) {
+        await this.$nextTick();
+        this.setInputPadding();
+      }
+    },
   },
 };
 </script>
@@ -622,6 +663,19 @@ export default {
   margin-right: var(--dt-space-200);
   padding-left: var(--dt-space-100);
   max-width: calc(var(--dt-size-100-percent) - var(--dt-space-400));
+  max-height: initial;
+  overflow-y: visible;
+}
+
+.combobox__chip-wrapper-md--collapsed {
+  max-height: 2.8rem;
+  overflow-y: hidden;
+}
+
+.combobox__chip-wrapper-sm--collapsed,
+.combobox__chip-wrapper-xs--collapsed {
+  max-height: 2.5rem;
+  overflow-y: hidden;
 }
 
 .combobox__chip {

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
@@ -14,6 +14,7 @@
     :selected-items="$attrs.selectedItems"
     :max-selected="$attrs.maxSelected"
     :list-max-height="$attrs.listMaxHeight"
+    :collapse-on-focus-out="$attrs.collapseOnFocusOut"
     :max-selected-message="$attrs.maxSelectedMessage"
     :has-suggestion-list="$attrs.hasSuggestionList"
     :visually-hidden-close="$attrs.visuallyHiddenClose"


### PR DESCRIPTION
# Add collapseOnFocusOut property to combobox with multi select

https://dialtone.dialpad.com/vue/deploy-previews/pr-399/?path=/story/recipes-comboboxes-combobox-multi-select--with-input-max-height
<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
NO-JIRA
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
The idea is to avoid situations like this one:
<img width="1060" alt="image" src="https://github.com/dialpad/dialtone/assets/24460973/bde69fd6-d7e3-4731-a7c3-207f237fbfb8">

For this I added the property `collapseOnFocusOut` that when present will:
On focus out:
- set a maxHeight for the chips wrapper
- set the corresponding padding-top for the input

<!--- Describe specifically what the changes are -->

## :bulb: Context
This is a proposal for a feature required by a messaging dev in this thread: https://dialpad.com/app/messages/agxzfnViZXItdm9pY2VyGAsSC1RleHRNZXNzYWdlGICApcLGy9gJDA
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps
Add Vue 3
<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs
![input-max-height](https://github.com/dialpad/dialtone/assets/24460973/b6063e48-5565-4052-8f5e-1af7bf478c21)

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->


<!--- Add any links to external reference material -->
