### PR TITLE
fix(emoji-picker): DLT-1864 tabs not focusing properly

### DIFF
--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -101,6 +101,7 @@
 </template>
 
 <script>
+/* eslint-disable max-len */
 /* eslint-disable max-lines */
 import { emojisGrouped as emojisImported } from '@dialpad/dialtone-emojis';
 import { CDN_URL, EMOJIS_PER_ROW } from '@/components/emoji_picker';
@@ -159,6 +160,7 @@ export default {
   },
 
   computed: {
+    /* eslint-disable-next-line complexity */
     currentEmojis () {
       return [
         ...this.emojis[`People${this.skinTone}`] || [],
@@ -338,6 +340,7 @@ export default {
         let prevScrollTop = container.scrollTop;
         vm.$emit('is-scrolling', true);
 
+        /* eslint-disable-next-line complexity */
         container.addEventListener('scroll', function () {
           if (isScrolling) {
             const scrollTop = container.scrollTop;
@@ -491,6 +494,7 @@ export default {
       }
     },
 
+    /* eslint-disable-next-line complexity */
     handleHorizontalNavigation: function (direction, indexTab, indexEmoji) {
       if (this.isFiltering) {
         if (direction === 'left') {
@@ -537,6 +541,7 @@ export default {
       }
     },
 
+    /* eslint-disable-next-line complexity */
     handleKeyDownFilteredEmojis (event, indexEmoji, emoji) {
       event.preventDefault();
       this.hoverFirstEmoji = false;
@@ -586,6 +591,8 @@ export default {
 
     setTabLabelObserver () {
       this.tabLabelObserver = new IntersectionObserver(entries => {
+        this.$emit('is-scrolling', false);
+        /* eslint-disable-next-line complexity */
         entries.forEach(entry => {
           const { target } = entry;
           const index = parseInt(target.dataset.index);

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
@@ -101,7 +101,8 @@
 </template>
 
 <script setup>
-// eslint-disable max-len
+/* eslint-disable max-len */
+/* eslint-disable max-lines */
 import { emojisGrouped as emojis } from '@dialpad/dialtone-emojis';
 import { computed, onMounted, onUnmounted, ref, watch, nextTick } from 'vue';
 import { CDN_URL, ARROW_KEYS } from '@/components/emoji_picker/emoji_picker_constants';
@@ -425,6 +426,7 @@ function scrollToTab (tabIndex, focusFirstEmoji = true) {
      * position (scrollTop <= offsetTop),or if the scrollToTab function is scrolling from top to bottom and has
      * passed the desired position(scrollTop >= offsetTop), then isScrolling is set to false.
      */
+    /* eslint-disable-next-line complexity */
     container.addEventListener('scroll', () => {
       if (isScrolling) {
         const scrollTop = container.scrollTop;
@@ -463,7 +465,9 @@ function setTabLabelObserver () {
    * The code extracts the target element and its index from the IntersectionObserverEntry object,
    * and checks whether the target intersects with the root and is positioned above or below it.
    */
-  tabLabelObserver.value = new IntersectionObserver(entries => {
+  tabLabelObserver.value = new IntersectionObserver(async (entries) => {
+    emits('is-scrolling', false);
+    // eslint-disable-next-line complexity
     entries.forEach(entry => {
       const { target } = entry;
       const index = parseInt(target.dataset.index);
@@ -526,6 +530,7 @@ const handleKeyDownFilteredEmojis = (event, indexEmoji, emoji) => {
   }
 };
 
+/* eslint-disable-next-line complexity */
 const handleKeyDown = (event, indexTab, indexEmoji, emoji) => {
   event.preventDefault();
 


### PR DESCRIPTION
# Emoji Picker - Tabs not focusing properly

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/RRxHEAxxQUQ0jd4YmD/giphy.gif?cid=790b7611hx8k1ibmnjrvbbk8pcu84av0gm82r97sg3n7eae7&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1864

## :book: Description

- Emit `is-scrolling: false` before selecting emoji tabset through 'tab' key.

## :bulb: Context

- Some tabs on the emoji tabset weren't being selected properly.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

- Before

https://github.com/dialpad/dialtone/assets/87546543/3a079d56-3939-4075-9720-c82f23d93a9f

-After

https://github.com/dialpad/dialtone/assets/87546543/c6c6ee56-5104-41cd-a2eb-52ce13f399f0


