### PR TITLE
fix(input): NO-JIRA add identifier classes

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/input.less
+++ b/packages/dialtone-css/lib/build/less/components/input.less
@@ -114,33 +114,6 @@
     }
 }
 
-.d-input__label-text {
-    display: flex;
-    flex: 1 0%;
-    align-items: baseline;
-    justify-content: space-between;
-    box-sizing: border-box;
-    margin-bottom: var(--dt-space-300);
-    color: var(--dt-color-foreground-secondary);
-    font-weight: var(--dt-font-weight-semi-bold);
-    font-size: var(--dt-font-size-200);
-    font-family: inherit;
-    line-height: var(--dt-font-line-height-300);
-    word-break: break-word;
-    overflow-wrap: break-word;
-}
-
-.d-input__description {
-    display: flex;
-    flex-direction: column;
-    box-sizing: border-box;
-    color: var(--dt-color-foreground-tertiary);
-    font-size: var(--dt-font-size-100);
-    font-family: inherit;
-    line-height: var(--dt-font-line-height-400);
-    fill: currentColor;
-}
-
 .d-input__length-description {
     margin-bottom: var(--dt-space-200);
 }

--- a/packages/dialtone-css/lib/build/less/components/input.less
+++ b/packages/dialtone-css/lib/build/less/components/input.less
@@ -270,18 +270,15 @@
 
 //  $$  VALIDATION STATES
 //  ----------------------------------------------------------------------------
-.d-input--warning,
-.d-textarea--warning {
+.d-input--warning {
     --input-color-border: var(--dt-inputs-color-border-warning) !important;
 }
 
-.d-input--error,
-.d-textarea--error {
+.d-input--error {
     --input-color-border: var(--dt-inputs-color-border-critical) !important;
 }
 
-.d-input--success,
-.d-textarea--success {
+.d-input--success {
     --input-color-border: var(--dt-inputs-color-border-success) !important;
 }
 
@@ -290,7 +287,7 @@
 //  ----------------------------------------------------------------------------
 .d-input-icon {
     display: none;
-    
+
     &:not(:empty) {
         display: inline-flex;
         align-items: center;
@@ -299,8 +296,8 @@
     &--right:not(:empty) {
         margin-right: var(--dt-space-400);
     }
-    
+
     &--left:not(:empty) {
         margin-left: var(--dt-space-400);
     }
-} 
+}

--- a/packages/dialtone-vue2/components/input/input.vue
+++ b/packages/dialtone-vue2/components/input/input.vue
@@ -1,10 +1,11 @@
 <template>
   <div
     ref="container"
-    :class="{ 'd-input--hidden': hidden }"
+    :class="['d-input__root', { 'd-input--hidden': hidden }]"
     data-qa="dt-input"
   >
     <label
+      class="d-input__label"
       :aria-details="$slots.description || description ? descriptionKey : undefined"
       data-qa="dt-input-label-wrapper"
     >
@@ -15,6 +16,7 @@
           ref="label"
           data-qa="dt-input-label"
           :class="[
+            'd-input__label-text',
             'd-label',
             labelSizeClasses[size],
           ]"
@@ -27,6 +29,7 @@
         :id="descriptionKey"
         ref="description"
         :class="[
+          'd-input__description',
           'd-description',
           descriptionSizeClasses[size],
         ]"
@@ -483,7 +486,7 @@ export default {
     },
 
     stateClass () {
-      return [INPUT_STATE_CLASSES[this.inputComponent][this.inputState]];
+      return [INPUT_STATE_CLASSES[this.inputState]];
     },
   },
 
@@ -514,6 +517,7 @@ export default {
   methods: {
     inputClasses () {
       return [
+        'd-input__input',
         this.inputComponent === 'input' ? 'd-input' : 'd-textarea',
         {
           [this.stateClass]: this.showInputState,

--- a/packages/dialtone-vue2/components/input/input_constants.js
+++ b/packages/dialtone-vue2/components/input/input_constants.js
@@ -45,17 +45,9 @@ export const INPUT_SIZE_CLASSES = {
 };
 
 export const INPUT_STATE_CLASSES = {
-  input: {
-    error: 'd-input--error',
-    warning: 'd-input--warning',
-    success: 'd-input--success',
-  },
-
-  textarea: {
-    error: 'd-textarea--error',
-    warning: 'd-textarea--warning',
-    success: 'd-textarea--success',
-  },
+  error: 'd-input--error',
+  warning: 'd-input--warning',
+  success: 'd-input--success',
 };
 
 export const DESCRIPTION_SIZE_CLASSES = {

--- a/packages/dialtone-vue3/components/input/input.vue
+++ b/packages/dialtone-vue3/components/input/input.vue
@@ -1,10 +1,11 @@
 <template>
   <div
     ref="container"
-    :class="{ 'd-input--hidden': hidden }"
+    :class="['d-input__root', { 'd-input--hidden': hidden }]"
     data-qa="dt-input"
   >
     <label
+      class="d-input__label"
       :aria-details="$slots.description || description ? descriptionKey : undefined"
       data-qa="dt-input-label-wrapper"
     >
@@ -15,6 +16,7 @@
           ref="label"
           data-qa="dt-input-label"
           :class="[
+            'd-input__label-text',
             'd-label',
             labelSizeClasses[size],
           ]"
@@ -27,6 +29,7 @@
         :id="descriptionKey"
         ref="description"
         :class="[
+          'd-input__description',
           'd-description',
           descriptionSizeClasses[size],
         ]"
@@ -497,7 +500,7 @@ export default {
     },
 
     stateClass () {
-      return [INPUT_STATE_CLASSES[this.inputComponent][this.inputState]];
+      return [INPUT_STATE_CLASSES[this.inputState]];
     },
   },
 
@@ -528,6 +531,7 @@ export default {
   methods: {
     inputClasses () {
       return [
+        'd-input__input',
         this.inputComponent === 'input' ? 'd-input' : 'd-textarea',
         {
           [this.stateClass]: this.showInputState,

--- a/packages/dialtone-vue3/components/input/input_constants.js
+++ b/packages/dialtone-vue3/components/input/input_constants.js
@@ -45,17 +45,9 @@ export const INPUT_SIZE_CLASSES = {
 };
 
 export const INPUT_STATE_CLASSES = {
-  input: {
-    error: 'd-input--error',
-    warning: 'd-input--warning',
-    success: 'd-input--success',
-  },
-
-  textarea: {
-    error: 'd-textarea--error',
-    warning: 'd-textarea--warning',
-    success: 'd-textarea--success',
-  },
+  error: 'd-input--error',
+  warning: 'd-input--warning',
+  success: 'd-input--success',
 };
 
 export const DESCRIPTION_SIZE_CLASSES = {


### PR DESCRIPTION
# fix(input): NO-JIRA add identifier classes

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZjZmbWM0Y2NvMnlxbWcwdTNvbnp6Yjlmb2p6Y281anpvcnR0M2trbCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/775UhhzsSkZd8d81jp/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Added identifier classes in the input component. Removed unnecessary class definitions.

I will leave some comments for explanation of some things I did.

## :bulb: Context

Follow up to https://github.com/dialpad/dialtone/pull/392

We removed some deprecated classes / naming conventions above, however it is still good practice to have unique identifiers for important elements within the component, and a lot of overrides in product were using the old deprecated classes. This will also make it much easier to migrate the deprecated classes to the new ones since most of them will be 1-1 mappings. The migration mapping is below:

```
base-input -> d-input__root
base-input__label -> d-input__label
base-input__label-text -> d-input__label-text
base-input__description -> d-input__description
base-input__input -> d-input__input

base-input__icon--left -> d-input-icon--left
base-input__icon--right -> d-input-icon--right

base-input__input--error -> d-input--error
base-input__input--warning -> d-input--warning
base-input__input--success -> d-input--success

d-textarea--success -> d-input--success
d-textarea--warning -> d-input--warning
d-textarea--error -> d-input--error
```

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

migrate product side
