### PR TITLE
fix(scrollbar): NO-JIRA fix to explicitly set the viewport

### DIFF
--- a/apps/dialtone-documentation/docs/components/scrollbar.md
+++ b/apps/dialtone-documentation/docs/components/scrollbar.md
@@ -71,6 +71,7 @@ Vue.use(DtScrollbarDirective);
 ```
 
 To add a custom overlay scrollbar to a scrollable region, apply the `v-dt-scrollbar` directive to the parent element of the desired region.
+This parent element should have one and only one child. In the case where there are siblings, the scrollable element should be wrapped inside a new `<div>` tag with the directive attached by adding `<div v-dt-scrollbar></div>` around the element.
 There is no need to explicitly add an `overflow` property. If the section overflows the available vertical space, a vertical scrollbar will be present. Similarly, if it exceeds the horizontal space, a horizontal scrollbar will appear.
 
 ## Characteristics

--- a/apps/dialtone-documentation/docs/components/scrollbar.md
+++ b/apps/dialtone-documentation/docs/components/scrollbar.md
@@ -70,7 +70,7 @@ Install the directive into vue instance
 Vue.use(DtScrollbarDirective);
 ```
 
-To add a custom overlay scrollbar to a scrollable region, apply the `v-dt-scrollbar` directive to the desired region.
+To add a custom overlay scrollbar to a scrollable region, apply the `v-dt-scrollbar` directive to the parent element of the desired region.
 There is no need to explicitly add an `overflow` property. If the section overflows the available vertical space, a vertical scrollbar will be present. Similarly, if it exceeds the horizontal space, a horizontal scrollbar will appear.
 
 ## Characteristics
@@ -95,11 +95,13 @@ Show the scrollbar when the mouse enters the scrollable area. This is the defaul
 ```
 
 <code-well-header>
-  <dt-stack class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar>
-    <div v-for="item in items" class="item">
-      {{ item}}
-    </div>
-  </dt-stack>
+  <div class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar>
+    <dt-stack>
+      <div v-for="item in items" class="item">
+        {{ item}}
+      </div>
+    </dt-stack>
+  </div>
 </code-well-header>
 
 ### Always
@@ -111,11 +113,13 @@ Always show the scrollbar if the region is overflowing the available space.
 ```
 
 <code-well-header>
-  <dt-stack class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar:never>
-    <div v-for="item in items" class="item">
-      {{ item}}
-    </div>
-  </dt-stack>
+  <div class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar:never>
+    <dt-stack>
+      <div v-for="item in items" class="item">
+        {{ item}}
+      </div>
+    </dt-stack>
+  </div>
 </code-well-header>
 
 ### Scroll
@@ -127,11 +131,13 @@ Show the scrollbar on scroll.
 ```
 
 <code-well-header>
-  <dt-stack class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar:scroll>
-    <div v-for="item in items" class="item">
-      {{ item}}
-    </div>
-  </dt-stack>
+  <div class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar:scroll>
+    <dt-stack>
+      <div v-for="item in items" class="item">
+        {{ item}}
+      </div>
+    </dt-stack>
+  </div>
 </code-well-header>
 
 ### Move
@@ -143,22 +149,23 @@ Show the scrollbar when the mouse moves inside the scrollable area.
 ```
 
 <code-well-header>
-  <dt-stack class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar:move>
-    <div v-for="item in items" class="item">
-      {{ item}}
-    </div>
-  </dt-stack>
+  <div class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar:move>
+    <dt-stack>
+      <div v-for="item in items" class="item">
+        {{ item}}
+      </div>
+    </dt-stack>
+  </div>
 </code-well-header>
 
 ## Limitations
 
-Adding this directive to a DOM element or a Vue component will alter the DOM structure, by adding four elements inside the one that the directive was attached to. If the scrollable region is a Vue component, it's recommended to wrap it in a `<div v-dt-scrollbar></div>`, to avoid altering the structure
-that the component needs.
+Adding this directive to a DOM element or a Vue component will alter the DOM structure, by adding four elements inside the one that the directive was attached to. If the scrollable region is a Vue component, it's recommended to wrap it in a `<div v-dt-scrollbar></div>`, to avoid altering the structure that the component needs.
 
 The added elements are:
 
 * One with the class `os-size-observer`
-* The second one is the actual scrollable element
+* The second one is the scrollable viewport
 * The horizontal scrollbar
 * The vertical scrollbar
 

--- a/packages/dialtone-vue2/directives/scrollbar/scrollbar.js
+++ b/packages/dialtone-vue2/directives/scrollbar/scrollbar.js
@@ -7,7 +7,12 @@ export const DtScrollbarDirective = {
     OverlayScrollbars.plugin(ClickScrollPlugin);
     Vue.directive('dt-scrollbar', {
       inserted (el, binding) {
-        OverlayScrollbars(el, {
+        OverlayScrollbars({
+          target: el,
+          elements: {
+            viewport: el.children[0],
+          },
+        }, {
           scrollbars: {
             autoHide: `${binding.arg || 'leave'}`,
             clickScroll: true,

--- a/packages/dialtone-vue2/directives/scrollbar/scrollbar.test.js
+++ b/packages/dialtone-vue2/directives/scrollbar/scrollbar.test.js
@@ -5,7 +5,7 @@ import { OverlayScrollbars } from 'overlayscrollbars';
 const WrapperComponent = {
   name: 'wrapper-component',
   template: `
-    <div v-dt-scrollbar></div>
+    <div v-dt-scrollbar><div id="viewport"></div></div>
   `,
 };
 
@@ -13,12 +13,15 @@ const testContext = {};
 
 describe('DtScrollbarDirective Tests', () => {
   let wrapper;
+  let viewportElement;
 
   const updateWrapper = () => {
     wrapper = mount(WrapperComponent, {
       localVue: testContext.localVue,
       attachTo: document.body,
     });
+
+    viewportElement = wrapper.find('#viewport').element;
   };
 
   afterEach(() => {
@@ -56,7 +59,14 @@ describe('DtScrollbarDirective Tests', () => {
       });
 
       it('should setup directive', () => {
-        expect(OverlayScrollbars).toHaveBeenCalledWith(wrapper.element, { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: '0' } });
+        expect(OverlayScrollbars).toHaveBeenCalledWith(
+          {
+            target: wrapper.element,
+            elements: {
+              viewport: viewportElement,
+            },
+          },
+          { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: '0' } });
         expect(OverlayScrollbars).toHaveBeenCalledTimes(1);
         expect(wrapper.element.getAttribute('data-overlayscrollbars-initialize')).toBe('true');
         expect(wrapper.element.classList.contains('scrollbar')).toBe(true);

--- a/packages/dialtone-vue3/directives/scrollbar/scrollbar.js
+++ b/packages/dialtone-vue3/directives/scrollbar/scrollbar.js
@@ -7,7 +7,12 @@ export const DtScrollbarDirective = {
     OverlayScrollbars.plugin(ClickScrollPlugin);
     app.directive('dt-scrollbar', {
       mounted (el, binding) {
-        OverlayScrollbars(el, {
+        OverlayScrollbars({
+          target: el,
+          elements: {
+            viewport: el.children[0],
+          },
+        }, {
           scrollbars: {
             autoHide: `${binding.arg || 'leave'}`,
             clickScroll: true,

--- a/packages/dialtone-vue3/directives/scrollbar/scrollbar.test.js
+++ b/packages/dialtone-vue3/directives/scrollbar/scrollbar.test.js
@@ -5,12 +5,13 @@ import { OverlayScrollbars } from 'overlayscrollbars';
 const WrapperComponent = {
   name: 'wrapper-component',
   template: `
-    <div v-dt-scrollbar></div>
+    <div v-dt-scrollbar><div id="viewport"></div></div>
   `,
 };
 
 describe('DtScrollbarDirective Tests', () => {
   let wrapper;
+  let viewportElement;
 
   const updateWrapper = () => {
     wrapper = mount(WrapperComponent, {
@@ -19,6 +20,8 @@ describe('DtScrollbarDirective Tests', () => {
       },
       attachTo: document.body,
     });
+
+    viewportElement = wrapper.find('#viewport').element;
   };
 
   afterEach(() => {
@@ -53,7 +56,14 @@ describe('DtScrollbarDirective Tests', () => {
       });
 
       it('should setup directive', () => {
-        expect(OverlayScrollbars).toHaveBeenCalledWith(wrapper.element, { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: '0' } });
+        expect(OverlayScrollbars).toHaveBeenCalledWith(
+          {
+            target: wrapper.element,
+            elements: {
+              viewport: viewportElement,
+            },
+          },
+          { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: '0' } });
         expect(OverlayScrollbars).toHaveBeenCalledTimes(1);
         expect(wrapper.element.getAttribute('data-overlayscrollbars-initialize')).toBe('true');
         expect(wrapper.element.classList.contains('scrollbar')).toBe(true);


### PR DESCRIPTION
# Fix scrollbar directive to explicitly set the viewport

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
NO-JIRA
Related to: https://dialpad.atlassian.net/browse/DP-103842
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Changes the way that OverlayScrollbars are initialized. Instead of passing just the element, it passes an object. This object has `target` (the element to which the plugin will be attached) and `viewport`. This way we are explicitly setting the scrollable viewport and this way all the scroll event listeners can work as expected. 
From the library's docs:

> In the initialization object you can specify how the library handles generated elements. For example, you can specify an existing element as the `viewport' element. Then the library won't generate it, but use the specified element instead

More info: https://github.com/KingSora/OverlayScrollbars/tree/master?tab=readme-ov-file#initialization-with-an-object

This allows for the directive to work in the leftbar of the Dialpad app without having to change the references or how the listeners are attached. The only difference is that the directive has to be attached to the parent `div` (setting `target` and `viewport` to the same element brings problems with the keyboard events).

<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.
