### PR TITLE
fix(multi-select): NO-JIRA update input padding when focus out

### DIFF
--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -650,8 +650,9 @@ export default {
     async handleInputFocusOut () {
       this.inputFocused = false;
       if (this.collapseOnFocusOut) {
-        await this.$nextTick();
-        this.setInputPadding();
+        const input = this.getInput();
+        if (!input) return;
+        this.revertInputPadding(input);
       }
     },
   },

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -643,8 +643,9 @@ export default {
     async handleInputFocusOut () {
       this.inputFocused = false;
       if (this.collapseOnFocusOut) {
-        await this.$nextTick();
-        this.setInputPadding();
+        const input = this.getInput();
+        if (!input) return;
+        this.revertInputPadding(input);
       }
     },
   },


### PR DESCRIPTION
# fix(multi-select): NO-JIRA update input padding when focus out

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZWhiOWI1djZ3aDI5aml0anRjY2kxOW52cWM1aGh0endhaWk0cXdxZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/BYoRqTmcgzHcL9TCy1/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

NO-JIRA

## :book: Description
When the input has `collapseOnFocusOut` prop set as _true_, we need to collapse both chips and input when losing focus. That was not working fine on product side.
After some debugging we realized with @ninamarina that we can avoid calling `setInputPadding` when input lose focus and we can just revert input padding.

## :bulb: Context
When using the `collapseOnFocusOut` prop on firespotter side, I noticed that the input padding was not being updated when the input loses the focus (it was working fine on Dialtone side, but this change it should work fine on both). 
Video with the issue:

https://github.com/user-attachments/assets/d1f2f23c-59ac-4a08-aba6-7236e47a6619

