### PR TITLE
fix(multi-select): NO-JIRA update input padding when resizing

### DIFF
--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -581,6 +581,8 @@ export default {
       this.revertInputPadding(input);
       this.popoverOffset = [0, 4];
       if (!lastChip) return;
+      // Avoid adding extra padding when the input is not focused if collapseOnFocusOut is true
+      // This ensures the input returns to its original state when resizing
       if (this.collapseOnFocusOut && !this.inputFocused) return;
 
       // Get the position of the last chip

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -581,6 +581,7 @@ export default {
       this.revertInputPadding(input);
       this.popoverOffset = [0, 4];
       if (!lastChip) return;
+      if (this.collapseOnFocusOut && !this.inputFocused) return;
 
       // Get the position of the last chip
       // The input cursor should be the same "top" as that chip and next besides it

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -574,6 +574,7 @@ export default {
       this.revertInputPadding(input);
       this.popoverOffset = [0, 4];
       if (!lastChip) return;
+      if (this.collapseOnFocusOut && !this.inputFocused) return;
 
       // Get the position of the last chip
       // The input cursor should be the same "top" as that chip and next besides it

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -574,6 +574,8 @@ export default {
       this.revertInputPadding(input);
       this.popoverOffset = [0, 4];
       if (!lastChip) return;
+      // Avoid adding extra padding when the input is not focused if collapseOnFocusOut is true
+      // This ensures the input returns to its original state when resizing
       if (this.collapseOnFocusOut && !this.inputFocused) return;
 
       // Get the position of the last chip


### PR DESCRIPTION
# [fix(multi-select): NO-JIRA update input padding when resizing](https://github.com/dialpad/dialtone/commit/7cbba705933f0a89ef6bd86357774739ce21bb3d)

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMzByamJzMnpkZWRsMnFzdzJoeDBsYjN6bDJtZzRnemxmNWljYzFobSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3NtY188QaxDdC/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket
NO-JIRA
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
This pull request is trying to fix an issue that's only reproducible on firespotter side.
When resizing the screen and having a multi-select we have the following listener:
```
 this.resizeWindowObserver = new ResizeObserver(async () => {
      this.setChipsTopPosition();
      this.setInputPadding();
    });
```
So `setInputPadding` is called every time the page is resized. For some reason, the following condition always returns true on the firespotter side and false on the dialtone side:
```
 if (chipsSize > this.initialInputHeight) { input.style.paddingTop
        input.style.paddingTop = `${top}px`;
      }
```
Because this condition is executed on the firespotter side, the input padding is updated each time the user resizes the page. If we have the collapseOnFocusOut prop set to true and the input is not in focus, we shou

## :bulb: Context
When using the collapse-on-focus-out prop on the Firespotter page, I noticed that the input padding was not updated when the window was resized.  I cannot reproduce this bug on the dialtone side, but I think the changes I have made should do the trick, as `setInputPadding` seems to be the function called on resizing.