### PR TITLE
fix: DLT-1899 page TOC persisting from page to page

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/AllTokens.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/AllTokens.vue
@@ -90,7 +90,7 @@ const noSearchResults = computed(() => filteredTokens.value === null);
 const updateHeaders = () => {
   if (filteredTokens.value === null) return [];
   filteredHeaders.value = updateHeadersRecursively(filteredTokens.value, null);
-  localStorage.setItem('filteredHeaders', JSON.stringify(filteredHeaders.value));
+  window.filteredHeaders = filteredHeaders.value;
 };
 
 const updateHeadersRecursively = (node, category) => {
@@ -116,6 +116,6 @@ onBeforeMount(() => {
 });
 
 onBeforeRouteLeave(() => {
-  localStorage.removeItem('filteredHeaders');
+  window.filteredHeaders = null;
 });
 </script>

--- a/apps/dialtone-documentation/docs/.vuepress/theme/client.js
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/client.js
@@ -47,6 +47,9 @@ export default defineClientConfig({
 
       provide('currentTheme', currentTheme);
       provide('systemPrefersDark', systemPrefersDark);
+
+      // reset the filtered headers when the page is reloaded
+      localStorage.removeItem('filteredHeaders');
     });
   },
   layouts: {

--- a/apps/dialtone-documentation/docs/.vuepress/theme/client.js
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/client.js
@@ -47,9 +47,6 @@ export default defineClientConfig({
 
       provide('currentTheme', currentTheme);
       provide('systemPrefersDark', systemPrefersDark);
-
-      // reset the filtered headers when the page is reloaded
-      localStorage.removeItem('filteredHeaders');
     });
   },
   layouts: {

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Page.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Page.vue
@@ -106,6 +106,7 @@ const includeToc = computed(() => {
 });
 
 watch(route, async () => {
+  // waits for the filteredHeaders to be set in the child page
   await nextTick();
   const filteredHeaders = JSON.parse(localStorage.getItem('filteredHeaders'));
   const pageHeaders = usePageData().value.headers;

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Page.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Page.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="d-d-grid d-jc-center"
-    :class="[gridClass, tokensPageClass]"
+    :class="gridClass"
   >
     <div class="d-p24 lg:d-pr24 lg:d-pt64">
       <page-header />
@@ -55,7 +55,7 @@
       </footer>
     </div>
     <div class="d-ps-relative d-ga-toc">
-      <page-toc v-if="!isMobile && includeToc" />
+      <page-toc v-if="!isMobile && includeToc" :headers="headers" />
     </div>
   </div>
 </template>
@@ -63,7 +63,7 @@
 <script setup>
 import PageHeader from '../components/PageHeader.vue';
 import PageToc from '../components/PageToc.vue';
-import { computed } from 'vue';
+import { computed, watch, ref, nextTick } from 'vue';
 import { useRoute } from 'vue-router';
 import { usePageData } from '@vuepress/client';
 import { useThemeLocaleData } from '@vuepress/plugin-theme-data/client';
@@ -84,6 +84,9 @@ const props = defineProps({
     required: true,
   },
 });
+
+const headers = ref(null);
+
 const lastUpdated = computed(() => {
   const date = new Date(usePageData().value.git.updatedTime);
   return new Intl.DateTimeFormat('en-US', { dateStyle: 'full' }).format(date);
@@ -99,12 +102,13 @@ const includeToc = computed(() => {
   // get the item that matches the current route from site-nav without cosidering the last '/'
   const key = Object.keys(items).filter(item => route.path.includes(item.replace(/\/$/, '')));
   if (!items[key] || !Array.isArray(items[key])) return false;
-  const headers = usePageData().value.headers;
-  return headers?.length > 0 || localStorage.getItem('filteredHeaders');
+  return headers.value && headers.value.length > 0;
 });
 
-const tokensPageClass = computed(() => {
-  if (route.path.includes('tokens')) return 'tokens-page';
-  return '';
-});
+watch(route, async () => {
+  await nextTick();
+  const filteredHeaders = JSON.parse(localStorage.getItem('filteredHeaders'));
+  const pageHeaders = usePageData().value.headers;
+  headers.value = filteredHeaders ?? pageHeaders;
+}, { flush: 'pre', immediate: true, deep: true });
 </script>

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Page.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Page.vue
@@ -108,7 +108,7 @@ const includeToc = computed(() => {
 watch(route, async () => {
   // waits for the filteredHeaders to be set in the child page
   await nextTick();
-  const filteredHeaders = JSON.parse(localStorage.getItem('filteredHeaders'));
+  const { filteredHeaders } = window;
   const pageHeaders = usePageData().value.headers;
   headers.value = filteredHeaders ?? pageHeaders;
 }, { flush: 'pre', immediate: true, deep: true });

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/PageToc.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/PageToc.vue
@@ -57,13 +57,17 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
-import { usePageData } from '@vuepress/client';
 import { useRoute } from 'vue-router';
 import TocItem from './TocItem.vue';
 
+defineProps({
+  headers: {
+    type: Array,
+    default: null,
+  },
+});
+
 const route = useRoute();
-const headers = ref(null);
 
 function isHeaderActive (header) {
   const links = [header.link, ...header.children.map(child => child.link)];
@@ -73,12 +77,6 @@ function isHeaderActive (header) {
 function isItemActive (item) {
   return item.link === route.hash;
 }
-
-watch(route, () => {
-  const filteredHeaders = JSON.parse(localStorage.getItem('filteredHeaders'));
-  const pageHeaders = usePageData().value.headers;
-  headers.value = filteredHeaders ?? pageHeaders;
-}, { flush: 'pre', immediate: true, deep: true });
 </script>
 
 <style lang="less" scoped>


### PR DESCRIPTION
# fix: DLT-1899 page TOC persisting from page to page

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMm1ndnhkdjV5YjVuN2UxY2xidWN0a3RyOTc1d2YybHp3a2Q5cnVncyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/mlvseq9yvZhba/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket
[DLT-1899]

<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
After visiting the Tokens page and reloading, the key `filteredHeaders` remained in the Local Storage, so `Page.vue` would use those for the TOC.
I am reseting the `filteredHeaders` when the page is reloaded.

Also:
- fixes another bug where going to https://dialtone.dialpad.com/tokens/ with the local storage empty would not show the Table of Contents
- removes Tokens page custom class for the grid since it's no longer needed

<!--- Describe specifically what the changes are -->

## :camera: Screenshots / GIFs

## Before
![toc](https://github.com/user-attachments/assets/7e0bb834-5a2d-495b-a9cb-9dad91420199)

## Now
![toc-now](https://github.com/user-attachments/assets/e438911a-c06f-4616-8ad1-f84c2cb4ec4d)


<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->



[DLT-1899]: https://dialpad.atlassian.net/browse/DLT-1899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ