### PR TITLE
feat(message-input): DLT-1912 add slot for split button

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -48,6 +48,14 @@ export const argTypesData = {
       type: 'text',
     },
   },
+  button: {
+    table: {
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'text',
+    },
+  },
 
   // Events
   onSubmit: {
@@ -135,6 +143,7 @@ export const argsData = {
   top: '',
   middle: '',
   emojiGiphyPicker: '',
+  button: '',
   placeholder: 'New message',
   inputAriaLabel: 'Input text field',
   maxHeight: '40vh',

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -48,7 +48,7 @@ export const argTypesData = {
       type: 'text',
     },
   },
-  button: {
+  sendButton: {
     table: {
       type: { summary: 'VNode' },
     },
@@ -143,7 +143,7 @@ export const argsData = {
   top: '',
   middle: '',
   emojiGiphyPicker: '',
-  button: '',
+  sendButton: '',
   placeholder: 'New message',
   inputAriaLabel: 'Input text field',
   maxHeight: '40vh',

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -200,8 +200,8 @@
           </template>
         </dt-button>
 
-        <!-- @slot Slot for button picker -->
-        <slot name="button" />
+        <!-- @slot Slot for sendButton picker -->
+        <slot name="sendButton" />
       </div>
     </section>
   </div>

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -199,6 +199,9 @@
             <p>{{ showSend.text }}</p>
           </template>
         </dt-button>
+
+        <!-- @slot Slot for button picker -->
+        <slot name="button" />
       </div>
     </section>
   </div>

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -165,43 +165,43 @@
           <p>{{ showCancel.text }}</p>
         </dt-button>
 
-        <!-- Send button -->
-        <!-- Right positioned UI - send button -->
-        <dt-button
-          v-if="showSend"
-          v-dt-tooltip:top-end="showSend?.tooltipLabel"
-          data-qa="dt-message-input-send-btn"
-          size="sm"
-          kind="default"
-          importance="primary"
-          :class="[
-            {
-              'dt-message-input__send-button--disabled': isSendDisabled,
-              'd-btn--circle': showSend.icon,
-            },
-          ]"
-          :aria-label="showSend.ariaLabel"
-          :aria-disabled="isSendDisabled"
-          @click="onSend"
-        >
-          <template
-            v-if="showSend.icon"
-            #icon
-          >
-            <dt-icon
-              :name="showSend.icon"
-              size="300"
-            />
-          </template>
-          <template
-            v-if="showSend.text"
-          >
-            <p>{{ showSend.text }}</p>
-          </template>
-        </dt-button>
-
         <!-- @slot Slot for sendButton picker -->
-        <slot name="sendButton" />
+        <slot name="sendButton">
+          <!-- Send button -->
+          <!-- Right positioned UI - send button -->
+          <dt-button
+            v-if="showSend"
+            v-dt-tooltip:top-end="showSend?.tooltipLabel"
+            data-qa="dt-message-input-send-btn"
+            size="sm"
+            kind="default"
+            importance="primary"
+            :class="[
+              {
+                'dt-message-input__send-button--disabled': isSendDisabled,
+                'd-btn--circle': showSend.icon,
+              },
+            ]"
+            :aria-label="showSend.ariaLabel"
+            :aria-disabled="isSendDisabled"
+            @click="onSend"
+          >
+            <template
+              v-if="showSend.icon"
+              #icon
+            >
+              <dt-icon
+                :name="showSend.icon"
+                size="300"
+              />
+            </template>
+            <template
+              v-if="showSend.text"
+            >
+              <p>{{ showSend.text }}</p>
+            </template>
+          </dt-button>
+        </slot>
       </div>
     </section>
   </div>

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -65,10 +65,10 @@
           <span v-html="$attrs.top" />
         </template>
         <template
-          v-if="$attrs.button"
-          #button
+          v-if="$attrs.sendButton"
+          #sendButton
         >
-          <span v-html="$attrs.button" />
+          <span v-html="$attrs.sendButton" />
         </template>
       </dt-recipe-message-input>
     </div>

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -64,6 +64,12 @@
         >
           <span v-html="$attrs.top" />
         </template>
+        <template
+          v-if="$attrs.button"
+          #button
+        >
+          <span v-html="$attrs.button" />
+        </template>
       </dt-recipe-message-input>
     </div>
   </div>

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -48,6 +48,14 @@ export const argTypesData = {
       type: 'text',
     },
   },
+  button: {
+    table: {
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'text',
+    },
+  },
 
   // Events
   onSubmit: {
@@ -135,6 +143,7 @@ export const argsData = {
   top: '',
   middle: '',
   emojiGiphyPicker: '',
+  button: '',
   placeholder: 'New message',
   inputAriaLabel: 'Input text field',
   maxHeight: '40vh',

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -48,7 +48,7 @@ export const argTypesData = {
       type: 'text',
     },
   },
-  button: {
+  sendButton: {
     table: {
       type: { summary: 'VNode' },
     },
@@ -143,7 +143,7 @@ export const argsData = {
   top: '',
   middle: '',
   emojiGiphyPicker: '',
-  button: '',
+  sendButton: '',
   placeholder: 'New message',
   inputAriaLabel: 'Input text field',
   maxHeight: '40vh',

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -163,42 +163,43 @@
           <p>{{ showCancel.text }}</p>
         </dt-button>
 
-        <!-- Send button -->
-        <!-- Right positioned UI - send button -->
-        <dt-button
-          v-if="showSend"
-          v-dt-tooltip:top-end="showSend?.tooltipLabel"
-          data-qa="dt-message-input-send-btn"
-          size="sm"
-          kind="default"
-          importance="primary"
-          :class="[
-            {
-              'dt-message-input__send-button--disabled': isSendDisabled,
-              'd-btn--circle': showSend.icon,
-            },
-          ]"
-          :aria-label="showSend.ariaLabel"
-          :aria-disabled="isSendDisabled"
-          @click="onSend"
-        >
-          <template
-            v-if="showSend.icon"
-            #icon
-          >
-            <dt-icon
-              :name="showSend.icon"
-              size="300"
-            />
-          </template>
-          <template
-            v-if="showSend.text"
-          >
-            <p>{{ showSend.text }}</p>
-          </template>
-        </dt-button>
         <!-- @slot Slot for sendButton picker -->
-        <slot name="sendButton" />
+        <slot name="sendButton">
+          <!-- Send button -->
+          <!-- Right positioned UI - send button -->
+          <dt-button
+            v-if="showSend"
+            v-dt-tooltip:top-end="showSend?.tooltipLabel"
+            data-qa="dt-message-input-send-btn"
+            size="sm"
+            kind="default"
+            importance="primary"
+            :class="[
+              {
+                'dt-message-input__send-button--disabled': isSendDisabled,
+                'd-btn--circle': showSend.icon,
+              },
+            ]"
+            :aria-label="showSend.ariaLabel"
+            :aria-disabled="isSendDisabled"
+            @click="onSend"
+          >
+            <template
+              v-if="showSend.icon"
+              #icon
+            >
+              <dt-icon
+                :name="showSend.icon"
+                size="300"
+              />
+            </template>
+            <template
+              v-if="showSend.text"
+            >
+              <p>{{ showSend.text }}</p>
+            </template>
+          </dt-button>
+        </slot>
       </div>
     </section>
   </div>

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -197,8 +197,8 @@
             <p>{{ showSend.text }}</p>
           </template>
         </dt-button>
-        <!-- @slot Slot for button picker -->
-        <slot name="button" />
+        <!-- @slot Slot for sendButton picker -->
+        <slot name="sendButton" />
       </div>
     </section>
   </div>

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -197,6 +197,8 @@
             <p>{{ showSend.text }}</p>
           </template>
         </dt-button>
+        <!-- @slot Slot for button picker -->
+        <slot name="button" />
       </div>
     </section>
   </div>

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -64,10 +64,10 @@
         <span v-html="$attrs.top" />
       </template>
       <template
-        v-if="$attrs.button"
-        #button
+        v-if="$attrs.sendButton"
+        #sendButton
       >
-        <span v-html="$attrs.button" />
+        <span v-html="$attrs.sendButton" />
       </template>
     </dt-recipe-message-input>
   </div>

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -63,6 +63,12 @@
       >
         <span v-html="$attrs.top" />
       </template>
+      <template
+        v-if="$attrs.button"
+        #button
+      >
+        <span v-html="$attrs.button" />
+      </template>
     </dt-recipe-message-input>
   </div>
 </template>


### PR DESCRIPTION
# feat(message-input): DLT-1912 add slot for split button

## Obligatory GIF (super important!)

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZGx3OXhsOHV5ajZoODN0eXFuN3RweDh3MTd0M2NjOGg1czZnMTZvdSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Ok4HaWlYrewuY/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-1912
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Add a slot that will be used on the product side to display a split button instead of a button.
<!--- Describe exactly what the changes are -->

## :bulb: Context
On the product side, we have a page that needs to have a split button instead of a button on the news input. To achieve this goal, we should have a slot so we can add it when needed.

Designs: https://www.figma.com/design/PZ8VMSupLJtdE9kb74K61K/%5BDP-86884%5D-Bulk-SMS%2FMMS?node-id=5945-155374&t=zvkFWohTgJ7K9yth-0