### PR TITLE
docs: DLT-1918 update do / don't usage well styles

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/DialtoneUsage.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/DialtoneUsage.vue
@@ -2,7 +2,7 @@
   <div class="dialtone-usage">
     <div class="dialtone-usage__item dialtone-usage__item--do">
       <h3 class="dialtone-usage__hd dialtone-usage__hd--do">
-        <dt-icon name="thumbs-up" size="400" />
+        <dt-icon name="check" size="200" />
         Do
       </h3>
       <div class="dialtone-usage__bd">
@@ -11,7 +11,7 @@
     </div>
     <div class="dialtone-usage__item dialtone-usage__item--dont">
       <h3 class="dialtone-usage__hd dialtone-usage__hd--dont">
-        <dt-icon name="thumbs-down" size="400" />
+        <dt-icon name="close" size="200" />
         Don’t
       </h3>
       <div class="dialtone-usage__bd">

--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -733,7 +733,8 @@ a.header-anchor {
 //  ----------------------------------------------------------------------------
 
 .dialtone-usage {
-  --usage-item-color-background: var(--dt-color-surface-secondary);
+  --usage-item-color-border: var(--dt-color-border-default);
+  --usage-item-background-hd: var(--dt-color-surface-bold-opaque);
 
   display: flex;
   flex-direction: column;
@@ -747,16 +748,21 @@ a.header-anchor {
 
   &__hd {
     display: flex;
-    gap: var(--dt-space-400);
+    gap: var(--dt-space-200);
     align-items: center;
-    font-size: var(--dt-font-size-200);
+    align-self: baseline;
+    padding: var(--dt-space-100) var(--dt-space-400);
+    color: var(--dt-color-foreground-primary-inverted);
+    font-size: var(--dt-font-size-100);
+    background-color: var(--usage-item-background-hd);
+    border-radius: var(--dt-size-radius-pill);
 
     &--do {
-      color: var(--dt-color-foreground-success);
+      --usage-item-background-hd: var(--dt-color-surface-success-strong);
     }
 
     &--dont {
-      color: var(--dt-color-foreground-critical-strong);
+      --usage-item-background-hd: var(--dt-color-surface-critical-strong);
     }
   }
 
@@ -766,15 +772,15 @@ a.header-anchor {
     flex-direction: column;
     gap: var(--dt-space-500);
     padding: var(--dt-space-500);
-    background-color: var(--usage-item-color-background);
+    border: 1px solid var(--usage-item-color-border);
     border-radius: var(--dt-size-400);
 
     &--do {
-      --usage-item-color-background: var(--dt-color-surface-success-subtle);
+      --usage-item-color-border: var(--dt-color-border-success);
     }
 
     &--dont {
-      --usage-item-color-background: var(--dt-color-surface-critical-subtle);
+      --usage-item-color-border: var(--dt-color-border-critical);
     }
 
   }

--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -772,7 +772,7 @@ a.header-anchor {
     flex-direction: column;
     gap: var(--dt-space-500);
     padding: var(--dt-space-500);
-    border: var(--dt-size-100) solid var(--usage-item-color-border);
+    border: var(--dt-size-border-100) solid var(--usage-item-color-border);
     border-radius: var(--dt-size-400);
 
     &--do {

--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -772,7 +772,7 @@ a.header-anchor {
     flex-direction: column;
     gap: var(--dt-space-500);
     padding: var(--dt-space-500);
-    border: 1px solid var(--usage-item-color-border);
+    border: var(--dt-size-100) solid var(--usage-item-color-border);
     border-radius: var(--dt-size-400);
 
     &--do {

--- a/apps/dialtone-documentation/docs/guides/content/index.md
+++ b/apps/dialtone-documentation/docs/guides/content/index.md
@@ -2,7 +2,7 @@
 title: Content guidelines
 shortTitle: content
 next: { link: "/guides/content/action-language/", text: "Action language" }
-description: These guidelines exist to unify the way we communicate with our users at Dialpad, laying out standards by which we should all adhere to as well as how to creatively consider contextual messaging throughout the user’s experience.
+description: Guidelines to unify the way we communicate with our users.
 ---
 
 <overview :pages="$page.enhancedFrontmatter" base-path="guides/content" />


### PR DESCRIPTION
# Update Do / Don't Usage Well Styles

## Obligatory GIF (super important!)

![The Good Place Rocks](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExM3NlOHpzcWRwMGo1ejdiYjEzeW90emJqZjZoZmRnaTVmODkxaHU1cSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ozdLLPz7wDaxpck9Pw/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

Full description in [Jira ticket](https://dialpad.atlassian.net/browse/DLT-1918).

## :book: Description

This PR updates the `dialtone-usage` "Do" / "Don't" wells in the following ways:
- Remove the surface color
- Add a strong border color
- Pop the header within a pill shaped strong surface color
- Change Do icon from `thumbs-up` to `check`
- Change Don’t icon from `thumbs-down` to `close`
