### PR TITLE
feat(leftbar): DLT-1929 add scheduled icon

### DIFF
--- a/packages/dialtone-vue2/recipes/leftbar/general_row/general_row_constants.js
+++ b/packages/dialtone-vue2/recipes/leftbar/general_row/general_row_constants.js
@@ -12,6 +12,7 @@ export const LEFTBAR_GENERAL_ROW_TYPES = {
   DIALBOT: 'dialbot',
   ASSIGNED: 'assigned',
   DIGITAL: 'digital',
+  SCHEDULED: 'scheduled',
 };
 
 export const LEFTBAR_GENERAL_ROW_ICON_MAPPING = {
@@ -28,6 +29,7 @@ export const LEFTBAR_GENERAL_ROW_ICON_MAPPING = {
   'channel unread': 'hash-bold',
   [LEFTBAR_GENERAL_ROW_TYPES.ASSIGNED]: 'at-sign',
   [LEFTBAR_GENERAL_ROW_TYPES.DIGITAL]: 'laptop-2',
+  [LEFTBAR_GENERAL_ROW_TYPES.SCHEDULED]: 'calendar-clock',
 };
 
 export const LEFTBAR_GENERAL_ROW_CONTACT_CENTER_COLORS = {

--- a/packages/dialtone-vue3/recipes/leftbar/general_row/general_row_constants.js
+++ b/packages/dialtone-vue3/recipes/leftbar/general_row/general_row_constants.js
@@ -12,6 +12,7 @@ export const LEFTBAR_GENERAL_ROW_TYPES = {
   DIALBOT: 'dialbot',
   ASSIGNED: 'assigned',
   DIGITAL: 'digital',
+  SCHEDULED: 'scheduled',
 };
 
 export const LEFTBAR_GENERAL_ROW_ICON_MAPPING = {
@@ -28,6 +29,7 @@ export const LEFTBAR_GENERAL_ROW_ICON_MAPPING = {
   'channel unread': 'hash-bold',
   [LEFTBAR_GENERAL_ROW_TYPES.ASSIGNED]: 'at-sign',
   [LEFTBAR_GENERAL_ROW_TYPES.DIGITAL]: 'laptop-2',
+  [LEFTBAR_GENERAL_ROW_TYPES.SCHEDULED]: 'calendar-clock',
 };
 
 export const LEFTBAR_GENERAL_ROW_CONTACT_CENTER_COLORS = {


### PR DESCRIPTION
# feat(leftbar): DLT-1929 add scheduled icon

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->
![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmpoc2FvZHM3N2owYzQyYTZoa2Y3ZzZzczc2a2N3ZnAwcm56NHZnMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/oF5oUYTOhvFnO/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-1929
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adding a new type inside LEFTBAR_GENERAL_ROW_TYPES to support Scheduled item on leftbar.
<!--- Describe specifically what the changes are -->

## :bulb: Context
As a part of Bulk WhatsApp and Bulk SMS, we will add a new section on the left bar to see scheduled messages.

![image](https://github.com/user-attachments/assets/4ee2ac30-21c4-4066-a933-4b15f06d1b57)

To achieve this goal we should add this icon as a type in the left bar component.

Designs: https://www.figma.com/design/R5tER3J8fCg9VhpN9zpmow/%5BDP-XXXXX%5D-Bulk-WhatsApp-V2?node-id=6793-56981&m=dev