### PR TITLE
fix(tooltip): DLT-1921 enabled prop not working - vue 3

### DIFF
--- a/packages/dialtone-vue3/components/tooltip/tooltip.test.js
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.test.js
@@ -181,5 +181,20 @@ describe('DtTooltip tests', () => {
         });
       });
     });
+
+    describe('When enabled prop is false', () => {
+      describe('When mouseenter on anchor', () => {
+        it('should not display tooltip', async () => {
+          mockProps = { enabled: false };
+          updateWrapper();
+
+          await anchor.trigger('mouseenter');
+          await flushPromises();
+          tippyContent = document.body.querySelector('.tippy-content');
+
+          expect(tippyContent).toBeNull();
+        });
+      });
+    });
   });
 });

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -327,7 +327,7 @@ export default {
 
     show: {
       handler: function (show) {
-        if (show !== null) {
+        if (show !== null && this.enabled) {
           this.internalShow = show;
         }
       },
@@ -388,6 +388,7 @@ export default {
     },
 
     onEnterAnchor (e) {
+      if (!this.enabled) return;
       if (this.delay && this.inTimer === null) {
         this.inTimer = setTimeout(() => {
           this.triggerShow(e);


### PR DESCRIPTION
Vue 3 for [this PR](https://github.com/dialpad/dialtone/pull/424)