### PR TITLE
feat(multiselect): DP-106266 add maxListWidth prop

### DIFF
--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
@@ -23,6 +23,7 @@ export const argsData = {
   onSelect: action('select'),
   onRemove: action('remove'),
   onMaxSelected: action('maxSelected'),
+  onComboboxHighlight: action('comboboxHighlight'),
   visuallyHiddenCloseLabel: 'Close Combobox',
 };
 
@@ -121,6 +122,12 @@ export const argTypesData = {
     description: 'Select item event',
     table: {
       type: { summary: 'event' },
+    },
+  },
+
+  onComboboxHighlight: {
+    table: {
+      disable: true,
     },
   },
 };

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -4,6 +4,7 @@
     :label="label"
     :show-list="showList"
     :max-height="listMaxHeight"
+    :max-width="listMaxWidth"
     :popover-offset="popoverOffset"
     :has-suggestion-list="hasSuggestionList"
     :visually-hidden-close-label="visuallyHiddenCloseLabel"
@@ -302,6 +303,15 @@ export default {
     collapseOnFocusOut: {
       type: Boolean,
       default: false,
+    },
+
+    /**
+     * Determines maximum width for the popover before overflow.
+     * Possible units rem|px|em
+     */
+    listMaxWidth: {
+      type: String,
+      default: '',
     },
   },
 

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -13,6 +13,7 @@
     :append-to="appendTo"
     :transition="transition"
     @select="onComboboxSelect"
+    @highlight="comboboxHighlight"
   >
     <template #input="{ onInput }">
       <span
@@ -355,6 +356,14 @@ export default {
      * @type {KeyboardEvent}
       */
     'keyup',
+
+    /**
+     * Event fired when combobox item is highlighted
+     *
+     * @event combobox-highlight
+     * @type {Object}
+     */
+    'combobox-highlight',
   ],
 
   data () {
@@ -469,6 +478,10 @@ export default {
   },
 
   methods: {
+    comboboxHighlight (highlightIndex) {
+      this.$emit('combobox-highlight', highlightIndex);
+    },
+
     async initSelectedItems () {
       await this.$nextTick();
       this.setInputPadding();

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
@@ -14,7 +14,7 @@
     :selected-items="$attrs.selectedItems"
     :max-selected="$attrs.maxSelected"
     :list-max-height="$attrs.listMaxHeight"
-    :collapse-on-focus-out="$attrs.collapseOnFocusOut"
+    :list-max-width="$attrs.listMaxWidth"
     :max-selected-message="$attrs.maxSelectedMessage"
     :has-suggestion-list="$attrs.hasSuggestionList"
     :visually-hidden-close="$attrs.visuallyHiddenClose"

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
@@ -15,6 +15,7 @@
     :max-selected="$attrs.maxSelected"
     :list-max-height="$attrs.listMaxHeight"
     :list-max-width="$attrs.listMaxWidth"
+    :collapse-on-focus-out="$attrs.collapseOnFocusOut"
     :max-selected-message="$attrs.maxSelectedMessage"
     :has-suggestion-list="$attrs.hasSuggestionList"
     :visually-hidden-close="$attrs.visuallyHiddenClose"

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
@@ -25,6 +25,7 @@
     @select="onComboboxSelect"
     @remove="onComboboxRemove"
     @max-selected="$attrs.onMaxSelected"
+    @combobox-highlight="$attrs.onComboboxHighlight"
   >
     <template
       v-if="$attrs.header"

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
@@ -23,6 +23,7 @@ export const argsData = {
   onSelect: action('select'),
   onRemove: action('remove'),
   onMaxSelected: action('maxSelected'),
+  onComboboxHighlight: action('comboboxHighlight'),
   visuallyHiddenCloseLabel: 'Close Combobox',
 };
 
@@ -121,6 +122,12 @@ export const argTypesData = {
     description: 'Select item event',
     table: {
       type: { summary: 'event' },
+    },
+  },
+
+  onComboboxHighlight: {
+    table: {
+      disable: true,
     },
   },
 };

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -4,6 +4,7 @@
     :label="label"
     :show-list="showList"
     :max-height="listMaxHeight"
+    :max-width="listMaxWidth"
     :popover-offset="popoverOffset"
     :has-suggestion-list="hasSuggestionList"
     :visually-hidden-close-label="visuallyHiddenCloseLabel"
@@ -302,6 +303,15 @@ export default {
     collapseOnFocusOut: {
       type: Boolean,
       default: false,
+    },
+
+    /**
+     * Determines maximum width for the popover before overflow.
+     * Possible units rem|px|em
+     */
+    listMaxWidth: {
+      type: String,
+      default: '',
     },
   },
 

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -13,6 +13,7 @@
     :append-to="appendTo"
     :transition="transition"
     @select="onComboboxSelect"
+    @highlight="comboboxHighlight"
   >
     <template #input="{ onInput }">
       <span
@@ -355,6 +356,14 @@ export default {
      * @type {KeyboardEvent}
       */
     'keyup',
+
+    /**
+     * Event fired when combobox item is highlighted
+     *
+     * @event combobox-highlight
+     * @type {Object}
+     */
+    'combobox-highlight',
   ],
 
   data () {
@@ -462,6 +471,10 @@ export default {
   },
 
   methods: {
+    comboboxHighlight (highlightIndex) {
+      this.$emit('combobox-highlight', highlightIndex);
+    },
+
     async initSelectedItems () {
       await this.$nextTick();
       this.setInputPadding();

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
@@ -14,6 +14,7 @@
     :selected-items="$attrs.selectedItems"
     :max-selected="$attrs.maxSelected"
     :list-max-height="$attrs.listMaxHeight"
+    :list-max-width="$attrs.listMaxWidth"
     :collapse-on-focus-out="$attrs.collapseOnFocusOut"
     :max-selected-message="$attrs.maxSelectedMessage"
     :has-suggestion-list="$attrs.hasSuggestionList"

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
@@ -26,6 +26,7 @@
     @select="onComboboxSelect"
     @remove="onComboboxRemove"
     @max-selected="$attrs.onMaxSelected"
+    @combobox-highlight="$attrs.onComboboxHighlight"
   >
     <template
       v-if="$attrs.header"


### PR DESCRIPTION
# feat(multiselect): DP-106266 add maxListWidth prop

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWJubjhsbG9oZXE3b2VpZ2kxeXM1OHc1aG1pMXpienN0ZDJlN3c0NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/vLveIIhBvEhrkWYZkV/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DP-106266
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adds `maxListWidth` prop in Multiselect component to allow to set a max width on product side.
<!--- Describe specifically what the changes are -->

## :bulb: Context
To follow the designs, we need to define a maxWidth for the multiselect on the bulk SMS page.
![image](https://github.com/user-attachments/assets/904d8a78-3aa8-45f8-ac98-e9fa07773bed)
