### PR TITLE
feat(badge): DLT-1930 spacing refinement

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/DialtoneUsage.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/DialtoneUsage.vue
@@ -3,7 +3,9 @@
     <div class="dialtone-usage__item dialtone-usage__item--do">
       <h3 class="dialtone-usage__hd dialtone-usage__hd--do">
         <dt-icon name="check" size="200" />
-        Do
+        <div class="dialtone-usage__label">
+          Do
+        </div>
       </h3>
       <div class="dialtone-usage__bd">
         <slot name="do" />
@@ -12,7 +14,9 @@
     <div class="dialtone-usage__item dialtone-usage__item--dont">
       <h3 class="dialtone-usage__hd dialtone-usage__hd--dont">
         <dt-icon name="close" size="200" />
-        Don’t
+        <div class="dialtone-usage__label">
+          Don’t
+        </div>
       </h3>
       <div class="dialtone-usage__bd">
         <slot name="dont" />

--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -748,10 +748,10 @@ a.header-anchor {
 
   &__hd {
     display: flex;
-    gap: var(--dt-space-200);
+    gap: var(--dt-space-100);
     align-items: center;
     align-self: baseline;
-    padding: var(--dt-space-100) var(--dt-space-400);
+    padding: var(--dt-space-100) var(--dt-space-350);
     color: var(--dt-color-foreground-primary-inverted);
     font-size: var(--dt-font-size-100);
     background-color: var(--usage-item-background-hd);
@@ -764,6 +764,10 @@ a.header-anchor {
     &--dont {
       --usage-item-background-hd: var(--dt-color-surface-critical-strong);
     }
+  }
+
+  &__label {
+    padding-inline: var(--dt-space-200);
   }
 
   &__item {

--- a/packages/dialtone-css/lib/build/less/components/badge.less
+++ b/packages/dialtone-css/lib/build/less/components/badge.less
@@ -42,7 +42,7 @@
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
-  min-width: var(--dt-size-550);
+  min-inline-size: var(--dt-size-550);
   padding: var(--badge-padding-y) var(--badge-padding-x);
   color: var(--badge-color-text);
   font-weight: var(--badge-font-weight);

--- a/packages/dialtone-css/lib/build/less/components/badge.less
+++ b/packages/dialtone-css/lib/build/less/components/badge.less
@@ -27,10 +27,11 @@
   --badge-line-height: calc(var(--dt-size-500) + var(--dt-size-200));
   --badge-font-size: var(--dt-font-size-100);
   --badge-font-weight: var(--dt-font-weight-semi-bold);
-  --badge-gap: var(--dt-space-300);
+  --badge-gap: var(--dt-space-200);
   --badge-letter-spacing: var(--dt-size-50);
   --badge-padding-y: var(--dt-space-100);
-  --badge-padding-x: var(--dt-space-350);
+  --badge-padding-x: var(--dt-space-300);
+  --badge-label-padding-x: var(--dt-space-200);
   --badge-text-case: none;
   --badge-decorative-color: var(--dt-color-black-900);
 
@@ -60,6 +61,8 @@
     --badge-padding-x: calc(var(--dt-space-400) - var(--dt-space-100));
     --badge-padding-y: var(--dt-space-300);
     --badge-line-height: var(--dt-size-500);
+    --badge-label-padding-x: var(--dt-space-0);
+    --badge-gap: var(--dt-space-300);
   }
 
   //  TYPE
@@ -135,11 +138,13 @@
     height: var(--dt-size-400);
     background-color: var(--badge-decorative-color);
     border-radius: var(--dt-size-200);
+    margin-inline-start: var(--dt-space-200);
   }
 
   &__label {
     display: flex;
     align-items: center;
+    padding-inline: var(--badge-label-padding-x);
   }
 
   &__icon-left,

--- a/packages/dialtone-css/lib/build/less/components/badge.less
+++ b/packages/dialtone-css/lib/build/less/components/badge.less
@@ -151,4 +151,12 @@
   &__icon-right {
     display: flex;
   }
+
+  &__icon-left {
+    padding-inline-start: var(--dt-space-100);
+  }
+
+  &__icon-right {
+    padding-inline-end: var(--dt-space-100);
+  }
 }


### PR DESCRIPTION
# Badge Spacing Refinement

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1930

## :book: Description

The Spacing approach for Badge is currently too simplistic, resulting in the space on the icon sides to feel out of proportion. 

This distributes `padding` and `gap` more intentionally for both the icon and label parts, resulting in a better balanced Badge when icon is present. 

I will probably adopt this approach for Buttons too.

## :bulb: Context

Francis was annoyed by the spacing around icon and he likes to push pixels.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

99% confident this will not introduce breaking or negative effects. Keep an eye on it though.

## :camera: Screenshots / GIFs

![image](https://github.com/user-attachments/assets/b0eb2cd6-7c26-4375-baa7-1df606899d40)