### PR TITLE
fix: NO-JIRA dark mode in storybook

### DIFF
--- a/packages/dialtone-vue2/.storybook/preview.jsx
+++ b/packages/dialtone-vue2/.storybook/preview.jsx
@@ -1,10 +1,12 @@
 import '../css/dialtone-globals.less';
 import '@dialpad/dialtone-css/lib/dist/dialtone.css';
+import { addons } from '@storybook/preview-api';
 import { setTheme } from '@/../../common/themes/config';
 import DpLight from '@/../../common/themes/dp-light.js';
+import DpDark from '@/../../common/themes/dp-dark.js';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { DocsContainer } from '@storybook/addon-docs';
-import { useDarkMode } from "storybook-dark-mode";
+import { useDarkMode, DARK_MODE_EVENT_NAME } from "storybook-dark-mode";
 import Vue from 'vue';
 import React from 'react';
 import { setEmojiAssetUrlSmall, setEmojiAssetUrlLarge, setCustomEmojiUrl, setCustomEmojiJson } from '@/common/emoji';
@@ -14,7 +16,11 @@ import { DtTooltipDirective } from "@/directives/tooltip";
 import { faker } from '@faker-js/faker';
 import { DtScrollbarDirective } from "@/directives/scrollbar";
 
-setTheme(DpLight);
+const channel = addons.getChannel();
+
+channel.on(DARK_MODE_EVENT_NAME, (isDark) => {
+  setTheme(isDark ? DpDark : DpLight);
+});
 
 setEmojiAssetUrlSmall('https://static.dialpadcdn.com/joypixels/png/unicode/32/', '.png');
 setEmojiAssetUrlLarge('https://static.dialpadcdn.com/joypixels/svg/unicode/', '.svg');
@@ -86,13 +92,6 @@ export default {
       },
     },
     backgrounds: { disable: true },
-    darkMode: {
-      darkClass: 'dialtone-theme-dark',
-      lightClass: 'dialtone-theme-light',
-      dark: dialtoneDarkTheme,
-      light: dialtoneLightTheme,
-      stylePreview: true,
-    },
     docs: {
       container: ({ children, ...props }) => {
         const isDark = useDarkMode();

--- a/packages/dialtone-vue2/.storybook/preview.jsx
+++ b/packages/dialtone-vue2/.storybook/preview.jsx
@@ -7,6 +7,7 @@ import DpDark from '@/../../common/themes/dp-dark.js';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { DocsContainer } from '@storybook/addon-docs';
 import { useDarkMode, DARK_MODE_EVENT_NAME } from "storybook-dark-mode";
+import React from 'react';
 import Vue from 'vue';
 import { setEmojiAssetUrlSmall, setEmojiAssetUrlLarge, setCustomEmojiUrl, setCustomEmojiJson } from '@/common/emoji';
 import customEmojiJson from '@/common/custom-emoji.json';

--- a/packages/dialtone-vue2/.storybook/preview.jsx
+++ b/packages/dialtone-vue2/.storybook/preview.jsx
@@ -8,7 +8,6 @@ import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { DocsContainer } from '@storybook/addon-docs';
 import { useDarkMode, DARK_MODE_EVENT_NAME } from "storybook-dark-mode";
 import Vue from 'vue';
-import React from 'react';
 import { setEmojiAssetUrlSmall, setEmojiAssetUrlLarge, setCustomEmojiUrl, setCustomEmojiJson } from '@/common/emoji';
 import customEmojiJson from '@/common/custom-emoji.json';
 import { dialtoneDarkTheme, dialtoneLightTheme } from './dialtone-themes.js';

--- a/packages/dialtone-vue3/.storybook/preview.jsx
+++ b/packages/dialtone-vue3/.storybook/preview.jsx
@@ -1,12 +1,14 @@
 import '../css/dialtone-globals.less';
 import '@dialpad/dialtone-css/lib/dist/dialtone.css';
+import { addons } from '@storybook/preview-api';
 import { setTheme } from '@/../../common/themes/config';
 import DpLight from '@/../../common/themes/dp-light.js';
+import DpDark from '@/../../common/themes/dp-dark.js';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { setup } from '@storybook/vue3';
 import React from 'react';
 import { DocsContainer } from '@storybook/addon-docs';
-import { useDarkMode } from "storybook-dark-mode";
+import { useDarkMode, DARK_MODE_EVENT_NAME } from "storybook-dark-mode";
 import fixDefaultSlot from '../components/plugins/fixDefaultSlot';
 import { setEmojiAssetUrlSmall, setEmojiAssetUrlLarge, setCustomEmojiUrl, setCustomEmojiJson } from '@/common/emoji';
 import customEmojiJson from '@/common/custom-emoji.json';
@@ -15,7 +17,11 @@ import { DtTooltipDirective } from "@/directives/tooltip";
 import { faker } from '@faker-js/faker';
 import { DtScrollbarDirective } from "@/directives/scrollbar";
 
-setTheme(DpLight);
+const channel = addons.getChannel();
+
+channel.on(DARK_MODE_EVENT_NAME, (isDark) => {
+  setTheme(isDark ? DpDark : DpLight);
+});
 
 setEmojiAssetUrlSmall('https://static.dialpadcdn.com/joypixels/png/unicode/32/', '.png');
 setEmojiAssetUrlLarge('https://static.dialpadcdn.com/joypixels/svg/unicode/', '.svg');
@@ -86,13 +92,6 @@ export default {
       },
     },
     backgrounds: { disable: true },
-    darkMode: {
-      darkClass: 'dialtone-theme-dark',
-      lightClass: 'dialtone-theme-light',
-      dark: dialtoneDarkTheme,
-      light: dialtoneLightTheme,
-      stylePreview: true,
-    },
     docs: {
       container: ({ children, ...props }) => {
         const isDark = useDarkMode();


### PR DESCRIPTION
# fix: NO-JIRA dark mode in storybook

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Fixing the storybook dark mode that I broke. Using the dark mode event to set the theme.