### PR TITLE
feat(message-input): DLT-1947 add slot for sms count badge

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -56,6 +56,14 @@ export const argTypesData = {
       type: 'text',
     },
   },
+  smsCount: {
+    table: {
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'text',
+    },
+  },
 
   // Events
   onSubmit: {
@@ -144,6 +152,7 @@ export const argsData = {
   middle: '',
   emojiGiphyPicker: '',
   sendButton: '',
+  smsCount: '',
   placeholder: 'New message',
   inputAriaLabel: 'Input text field',
   maxHeight: '40vh',

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -132,7 +132,9 @@
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
         <!-- @slot Slot for sms count -->
-        <slot name="smsCount" />
+        <div class="d-d-flex d-ai-center">
+          <slot name="smsCount" />
+        </div>
 
         <!-- Optionally displayed remaining character counter -->
         <dt-tooltip

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -131,6 +131,8 @@
       </div>
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
+        <slot name="smsCount" />
+
         <!-- Optionally displayed remaining character counter -->
         <dt-tooltip
           v-if="Boolean(showCharacterLimit)"

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -131,6 +131,7 @@
       </div>
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
+        <!-- @slot Slot for sms count -->
         <slot name="smsCount" />
 
         <!-- Optionally displayed remaining character counter -->

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -70,6 +70,12 @@
         >
           <span v-html="$attrs.sendButton" />
         </template>
+        <template
+          v-if="$attrs.smsCount"
+          #smsCount
+        >
+          <span v-html="$attrs.smsCount" />
+        </template>
       </dt-recipe-message-input>
     </div>
   </div>

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -56,6 +56,14 @@ export const argTypesData = {
       type: 'text',
     },
   },
+  smsCount: {
+    table: {
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'text',
+    },
+  },
 
   // Events
   onSubmit: {
@@ -144,6 +152,7 @@ export const argsData = {
   middle: '',
   emojiGiphyPicker: '',
   sendButton: '',
+  smsCount: '',
   placeholder: 'New message',
   inputAriaLabel: 'Input text field',
   maxHeight: '40vh',

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -130,7 +130,9 @@
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
         <!-- @slot Slot for sms count -->
-        <slot name="smsCount" />
+        <div class="d-d-flex d-ai-center">
+          <slot name="smsCount" />
+        </div>
 
         <!-- Optionally displayed remaining character counter -->
         <dt-tooltip

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -129,6 +129,8 @@
       </div>
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
+        <slot name="smsCount" />
+
         <!-- Optionally displayed remaining character counter -->
         <dt-tooltip
           v-if="Boolean(showCharacterLimit)"

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -129,6 +129,7 @@
       </div>
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
+        <!-- @slot Slot for sms count -->
         <slot name="smsCount" />
 
         <!-- Optionally displayed remaining character counter -->

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -69,6 +69,12 @@
       >
         <span v-html="$attrs.sendButton" />
       </template>
+      <template
+        v-if="$attrs.smsCount"
+        #smsCount
+      >
+        <span v-html="$attrs.smsCount" />
+      </template>
     </dt-recipe-message-input>
   </div>
 </template>


### PR DESCRIPTION
# feat(message-input): DLT-1947 add slot for sms count badge

## Obligatory GIF (super important!)

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExeWtrbHk0Yzk3amFtcThpZWR3eGVoNnFkeWZ4bjFudmRuenZyOTEyciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/iibH5ymW6LFvSIVyUc/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-1947
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Add a slot that will be used on the product side to display the amount of SMS/segments that the user is sending.
<!--- Describe exactly what the changes are -->

## :bulb: Context
As part of the SMS Count project, we need to add a badge to the message input that displays the amount of SMS/segments the user is sending. The logic for this will be calculated on firespotter side, so I think the best way to handle this is with a slot.
![image](https://github.com/user-attachments/assets/26d290df-addc-4990-8bf0-9ed79ef02759)
