### PR TITLE
feat(stack): DLT-1805 add responsive gap prop

### DIFF
--- a/apps/dialtone-documentation/docs/components/stack.md
+++ b/apps/dialtone-documentation/docs/components/stack.md
@@ -156,6 +156,22 @@ vueCode='
 '
 showHtmlWarning />
 
+Set gap to 600 at extra large screen size, 500 for large screen size, 400 for medium screen size, and 300 for small screen size
+
+<code-well-header>
+    <dt-stack :gap="{ xl: '600', lg: '500', md: '400', sm: '300' }">
+      <div class="d-bgc-magenta-100">
+        Stack item 1
+      </div>
+      <div class="d-bgc-magenta-100">
+        Stack item 2
+      </div>
+      <div class="d-bgc-magenta-100">
+        Stack item 3
+      </div>
+    </dt-stack>
+</code-well-header>
+
 Stacks row with gap 300 and stacks in row reverse the second element with gap 600
 
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/stack.md
+++ b/apps/dialtone-documentation/docs/components/stack.md
@@ -156,7 +156,7 @@ vueCode='
 '
 showHtmlWarning />
 
-Set gap to 300 at default size, 600 at extra large screen size, 500 for large screen size, 400 for medium screen size, and 300 for small screen size. Check how our breakpoints work [here](/utilities/responsive/breakpoints.html).
+Set 300 as the default gap, 600 at <= XL, 500 at <= L, 400 at <= M, and 300 at <= SM. Check how our breakpoints work [here](/utilities/responsive/breakpoints.html).
 
 <code-well-header>
   <dt-stack :gap="{ default: '300', xl: '600', lg: '500', md: '400', sm: '300' }">

--- a/apps/dialtone-documentation/docs/components/stack.md
+++ b/apps/dialtone-documentation/docs/components/stack.md
@@ -156,10 +156,10 @@ vueCode='
 '
 showHtmlWarning />
 
-Set gap to 600 at extra large screen size, 500 for large screen size, 400 for medium screen size, and 300 for small screen size
+Set gap to 300 at default size, 600 at extra large screen size, 500 for large screen size, 400 for medium screen size, and 300 for small screen size. Check how our breakpoints work [here](/utilities/responsive/breakpoints.html).
 
 <code-well-header>
-  <dt-stack :gap="{ xl: '600', lg: '500', md: '400', sm: '300' }">
+  <dt-stack :gap="{ default: '300', xl: '600', lg: '500', md: '400', sm: '300' }">
     <div class="d-bgc-magenta-100">
       Stack item 1
     </div>
@@ -174,14 +174,14 @@ Set gap to 600 at extra large screen size, 500 for large screen size, 400 for me
 
 <code-example-tabs
 htmlCode='
-<div class="d-stack d-stack--sm-gap-300 d-stack--md-gap-400 d-stack--lg-gap-500 d-stack--xl-gap-600">
+<div class="d-stack d-stack--gap-300 d-stack--sm-gap-300 d-stack--md-gap-400 d-stack--lg-gap-500 d-stack--xl-gap-600">
   <div class="d-bgc-magenta-100">Stack item 1</div>
   <div class="d-bgc-magenta-100">Stack item 2</div>
   <div class="d-bgc-magenta-100">Stack item 3</div>
 </div>
 '
 vueCode='
-<dt-stack :gap="{ xl: `600`, lg: `500`, md: `400`, sm: `300` }">
+<dt-stack :gap="{ default: `300`, xl: `600`, lg: `500`, md: `400`, sm: `300` }">
   <div class="d-bgc-magenta-100">
     Stack item 1
   </div>

--- a/apps/dialtone-documentation/docs/components/stack.md
+++ b/apps/dialtone-documentation/docs/components/stack.md
@@ -118,7 +118,7 @@ showHtmlWarning />
 Stacks column at small screen size and column reverse at large screen
 
 <code-well-header>
-    <div class="d-stack d-stack--row d-stack--sm--column d-stack--lg--column-reverse d-stack--gap-100">
+    <div class="d-stack d-stack--row d-stack--sm-column d-stack--lg-column-reverse d-stack--gap-100">
       <div class="d-bgc-magenta-100">
         Stack item 1
       </div>
@@ -133,7 +133,7 @@ Stacks column at small screen size and column reverse at large screen
 
 <code-example-tabs
 htmlCode='
-<div class="d-stack d-stack--row d-stack--sm--column d-stack--lg--column-reverse d-stack--gap-0">
+<div class="d-stack d-stack--row d-stack--sm-column d-stack--lg-column-reverse d-stack--gap-0">
   <div class="d-bgc-magenta-100">Stack item 1</div>
   <div class="d-bgc-magenta-100">Stack item 2</div>
   <div class="d-bgc-magenta-100">Stack item 3</div>
@@ -159,18 +159,41 @@ showHtmlWarning />
 Set gap to 600 at extra large screen size, 500 for large screen size, 400 for medium screen size, and 300 for small screen size
 
 <code-well-header>
-    <dt-stack :gap="{ xl: '600', lg: '500', md: '400', sm: '300' }">
-      <div class="d-bgc-magenta-100">
-        Stack item 1
-      </div>
-      <div class="d-bgc-magenta-100">
-        Stack item 2
-      </div>
-      <div class="d-bgc-magenta-100">
-        Stack item 3
-      </div>
-    </dt-stack>
+  <dt-stack :gap="{ xl: '600', lg: '500', md: '400', sm: '300' }">
+    <div class="d-bgc-magenta-100">
+      Stack item 1
+    </div>
+    <div class="d-bgc-magenta-100">
+      Stack item 2
+    </div>
+    <div class="d-bgc-magenta-100">
+      Stack item 3
+    </div>
+  </dt-stack>
 </code-well-header>
+
+<code-example-tabs
+htmlCode='
+<div class="d-stack d-stack--sm-gap-300 d-stack--md-gap-400 d-stack--lg-gap-500 d-stack--xl-gap-600">
+  <div class="d-bgc-magenta-100">Stack item 1</div>
+  <div class="d-bgc-magenta-100">Stack item 2</div>
+  <div class="d-bgc-magenta-100">Stack item 3</div>
+</div>
+'
+vueCode='
+<dt-stack :gap="{ xl: `600`, lg: `500`, md: `400`, sm: `300` }">
+  <div class="d-bgc-magenta-100">
+    Stack item 1
+  </div>
+  <div class="d-bgc-magenta-100">
+    Stack item 2
+  </div>
+  <div class="d-bgc-magenta-100">
+    Stack item 3
+  </div>
+</dt-stack>
+'
+/>
 
 Stacks row with gap 300 and stacks in row reverse the second element with gap 600
 

--- a/packages/dialtone-css/lib/build/less/components/stack.less
+++ b/packages/dialtone-css/lib/build/less/components/stack.less
@@ -15,26 +15,26 @@
 //  ----------------------------------------------------------------------------
 
 .direction-options() {
-  &--column {
+  &-column {
     --stack-direction: column;
 
     justify-content: flex-start;
   }
 
-  &--column-reverse {
+  &-column-reverse {
     --stack-direction: column-reverse;
 
     justify-content: flex-start;
   }
 
-  &--row {
+  &-row {
     --stack-direction: row;
 
     align-items: center;
     justify-content: normal;
   }
 
-  &--row-reverse {
+  &-row-reverse {
     --stack-direction: row-reverse;
 
     align-items: center;
@@ -43,31 +43,31 @@
 }
 
 .gap-options() {
-  &--gap-100 {
+  &-gap-100 {
     .d-stack--gap-100();
   }
 
-  &--gap-200 {
+  &-gap-200 {
     .d-stack--gap-200();
   }
 
-  &--gap-300 {
+  &-gap-300 {
     .d-stack--gap-300();
   }
 
-  &--gap-400 {
+  &-gap-400 {
     .d-stack--gap-400();
   }
 
-  &--gap-450 {
+  &-gap-450 {
     .d-stack--gap-450();
   }
 
-  &--gap-500 {
+  &-gap-500 {
     .d-stack--gap-500();
   }
 
-  &--gap-600 {
+  &-gap-600 {
     .d-stack--gap-600();
   }
 }

--- a/packages/dialtone-css/lib/build/less/components/stack.less
+++ b/packages/dialtone-css/lib/build/less/components/stack.less
@@ -8,8 +8,8 @@
 //  TABLE OF CONTENTS
 //  • BASE STYLE
 //  • VISUAL STYLES
-//  • RESPONSIVE STYLE
 //  • SIZES
+//  • RESPONSIVE STYLE
 
 //  @@  BASE STYLE
 //  ----------------------------------------------------------------------------
@@ -39,6 +39,36 @@
 
     align-items: center;
     justify-content: normal;
+  }
+}
+
+.gap-options() {
+  &--gap-100 {
+    .d-stack--gap-100();
+  }
+
+  &--gap-200 {
+    .d-stack--gap-200();
+  }
+
+  &--gap-300 {
+    .d-stack--gap-300();
+  }
+
+  &--gap-400 {
+    .d-stack--gap-400();
+  }
+
+  &--gap-450 {
+    .d-stack--gap-450();
+  }
+
+  &--gap-500 {
+    .d-stack--gap-500();
+  }
+
+  &--gap-600 {
+    .d-stack--gap-600();
   }
 }
 
@@ -84,41 +114,6 @@
 }
 
 //  ============================================================================
-//  $   RESPONSIVE
-//  ----------------------------------------------------------------------------
-//  $$  EXTRA LARGE
-//  ----------------------------------------------------------------------------
-.d-stack--xl {
-  @media screen and (max-width: 1264px) {
-    .direction-options();
-  }
-}
-
-//  $$  LARGE
-//  ----------------------------------------------------------------------------
-.d-stack--lg {
-  @media screen and (max-width: 980px) {
-    .direction-options();
-  }
-}
-
-//  $$  MEDIUM
-//  ----------------
-.d-stack--md {
-  @media screen and (max-width: 640px) {
-    .direction-options();
-  }
-}
-
-//  $$ SMALL
-//  ----------------------------------------------------------------------------
-.d-stack--sm {
-  @media screen and (max-width: 480px) {
-    .direction-options();
-  }
-}
-
-//  ============================================================================
 //  $   SIZES
 //  ----------------------------------------------------------------------------
 .d-stack--gap-100 { --stack-gap: var(--dt-space-100); }
@@ -128,3 +123,43 @@
 .d-stack--gap-450 { --stack-gap: var(--dt-space-450); }
 .d-stack--gap-500 { --stack-gap: var(--dt-space-500); }
 .d-stack--gap-600 { --stack-gap: var(--dt-space-600); }
+
+
+//  ============================================================================
+//  $   RESPONSIVE
+//  ----------------------------------------------------------------------------
+//  $$  EXTRA LARGE
+//  ----------------------------------------------------------------------------
+.d-stack--xl {
+  @media screen and (max-width: 1264px) {
+    .direction-options();
+    .gap-options();
+  }
+}
+
+//  $$  LARGE
+//  ----------------------------------------------------------------------------
+.d-stack--lg {
+  @media screen and (max-width: 980px) {
+    .direction-options();
+    .gap-options();
+  }
+}
+
+//  $$  MEDIUM
+//  ----------------
+.d-stack--md {
+  @media screen and (max-width: 640px) {
+    .direction-options();
+    .gap-options();
+  }
+}
+
+//  $$ SMALL
+//  ----------------------------------------------------------------------------
+.d-stack--sm {
+  @media screen and (max-width: 480px) {
+    .direction-options();
+    .gap-options();
+  }
+}

--- a/packages/dialtone-css/lib/build/less/components/stack.less
+++ b/packages/dialtone-css/lib/build/less/components/stack.less
@@ -128,19 +128,11 @@
 //  ============================================================================
 //  $   RESPONSIVE
 //  ----------------------------------------------------------------------------
-//  $$  EXTRA LARGE
-//  ----------------------------------------------------------------------------
-.d-stack--xl {
-  @media screen and (max-width: 1264px) {
-    .direction-options();
-    .gap-options();
-  }
-}
 
-//  $$  LARGE
+//  $$ SMALL
 //  ----------------------------------------------------------------------------
-.d-stack--lg {
-  @media screen and (max-width: 980px) {
+.d-stack--sm {
+  @media screen and (min-width: 0) and (max-width: 480px) {
     .direction-options();
     .gap-options();
   }
@@ -149,16 +141,25 @@
 //  $$  MEDIUM
 //  ----------------
 .d-stack--md {
-  @media screen and (max-width: 640px) {
+  @media screen and (min-width: 480px) and (max-width: 640px) {
     .direction-options();
     .gap-options();
   }
 }
 
-//  $$ SMALL
+//  $$  LARGE
 //  ----------------------------------------------------------------------------
-.d-stack--sm {
-  @media screen and (max-width: 480px) {
+.d-stack--lg {
+  @media screen and (min-width: 640px) and (max-width: 980px) {
+    .direction-options();
+    .gap-options();
+  }
+}
+
+//  $$  EXTRA LARGE
+//  ----------------------------------------------------------------------------
+.d-stack--xl {
+  @media screen and (min-width: 980px) {
     .direction-options();
     .gap-options();
   }

--- a/packages/dialtone-css/lib/build/less/components/stack.less
+++ b/packages/dialtone-css/lib/build/less/components/stack.less
@@ -128,20 +128,10 @@
 //  ============================================================================
 //  $   RESPONSIVE
 //  ----------------------------------------------------------------------------
-
-//  $$ SMALL
+//  $$  EXTRA LARGE
 //  ----------------------------------------------------------------------------
-.d-stack--sm {
-  @media screen and (min-width: 0) and (max-width: 480px) {
-    .direction-options();
-    .gap-options();
-  }
-}
-
-//  $$  MEDIUM
-//  ----------------
-.d-stack--md {
-  @media screen and (min-width: 480px) and (max-width: 640px) {
+.d-stack--xl {
+  @media screen and (max-width: 1264px) {
     .direction-options();
     .gap-options();
   }
@@ -150,16 +140,25 @@
 //  $$  LARGE
 //  ----------------------------------------------------------------------------
 .d-stack--lg {
-  @media screen and (min-width: 640px) and (max-width: 980px) {
+  @media screen and (max-width: 980px) {
     .direction-options();
     .gap-options();
   }
 }
 
-//  $$  EXTRA LARGE
+//  $$  MEDIUM
+//  ----------------
+.d-stack--md {
+  @media screen and (max-width: 640px) {
+    .direction-options();
+    .gap-options();
+  }
+}
+
+//  $$ SMALL
 //  ----------------------------------------------------------------------------
-.d-stack--xl {
-  @media screen and (min-width: 980px) {
+.d-stack--sm {
+  @media screen and (max-width: 480px) {
     .direction-options();
     .gap-options();
   }

--- a/packages/dialtone-icons/src/keywords-icons.json
+++ b/packages/dialtone-icons/src/keywords-icons.json
@@ -683,15 +683,14 @@
       "park": [
         "call"
       ],
-      "pause-circle": [
+      "pause-circle-filled": [
         "music",
         "audio",
         "stop",
         "video",
         "media"
-
       ],
-      "pause-circle-filled": [
+      "pause-circle": [
         "music",
         "audio",
         "stop",
@@ -716,6 +715,13 @@
         "miniature",
         "window"
       ],
+      "pin-filled": [
+        "save",
+        "location",
+        "map",
+        "lock",
+        "fix"
+      ],
       "pin-off": [
         "unpin",
         "unsave",
@@ -729,20 +735,13 @@
         "lock",
         "fix"
       ],
-      "pin-filled": [
-        "save",
-        "location",
-        "map",
-        "lock",
-        "fix"
-      ],
-      "play-circle": [
+      "play-circle-filled": [
         "music",
         "start",
         "video",
         "media"
       ],
-      "play-circle-filled": [
+      "play-circle": [
         "music",
         "start",
         "video",
@@ -758,16 +757,15 @@
         "music",
         "start"
       ],
-      "plus-circle": [
-        "add",
-        "new",
-        "maths"
-      ],
       "plus-circle-filled": [
         "add",
         "new",
         "maths"
-
+      ],
+      "plus-circle": [
+        "add",
+        "new",
+        "maths"
       ],
       "plus": [
         "add",
@@ -869,11 +867,11 @@
       "sticker": [
         "label"
       ],
-      "stop-circle": [
+      "stop-circle-filled": [
         "media",
         "music"
       ],
-      "stop-circle-filled": [
+      "stop-circle": [
         "media",
         "music"
       ],
@@ -1461,6 +1459,12 @@
         "magazine",
         "library"
       ],
+      "bookmark-filled": [
+        "read",
+        "clip",
+        "marker",
+        "tag"
+      ],
       "bookmark-minus": [
         "delete",
         "remove"
@@ -1469,12 +1473,6 @@
         "add"
       ],
       "bookmark": [
-        "read",
-        "clip",
-        "marker",
-        "tag"
-      ],
-      "bookmark-filled": [
         "read",
         "clip",
         "marker",
@@ -1547,9 +1545,6 @@
         "payment",
         "cc"
       ],
-      "dissatisfied": [
-        "unhappy"
-      ],
       "dissatisfied-filled": [
         "unhappy",
         "rating",
@@ -1557,6 +1552,9 @@
         "vote",
         "voting",
         "review"
+      ],
+      "dissatisfied": [
+        "unhappy"
       ],
       "double-check": [
         "read"
@@ -1688,6 +1686,18 @@
         "version",
         "science"
       ],
+      "satisfied-filled": [
+        "happy",
+        "pleased",
+        "smile",
+        "great",
+        "good",
+        "rating",
+        "rate",
+        "vote",
+        "voting",
+        "review"
+      ],
       "satisfied": [
         "happy",
         "pleased",
@@ -1700,17 +1710,6 @@
         "voting",
         "review"
       ],
-      "satisfied-filled": [
-        "happy",
-        "pleased",
-        "smile",
-        "great",
-        "good",
-        "rating",
-        "rate",
-        "vote",
-        "voting",
-        "review"      ],
       "scroll": [
         "paper",
         "log",
@@ -1755,7 +1754,27 @@
         "security",
         "secure"
       ],
+      "somewhat-dissatisfied-filled": [
+        "face",
+        "rating",
+        "rate",
+        "vote",
+        "voting",
+        "review"
+      ],
       "somewhat-dissatisfied": [
+        "face",
+        "rating",
+        "rate",
+        "vote",
+        "voting",
+        "review"
+      ],
+      "somewhat-satisfied-filled": [
+        "smile",
+        "happy",
+        "pleased",
+        "good",
         "face",
         "rating",
         "rate",
@@ -1775,33 +1794,13 @@
         "voting",
         "review"
       ],
-      "somewhat-dissatisfied-filled": [
-        "face",
-        "rating",
-        "rate",
-        "vote",
-        "voting",
-        "review"
-      ],
-      "somewhat-satisfied-filled": [
-        "smile",
-        "happy",
-        "pleased",
-        "good",
-        "face",
-        "rating",
-        "rate",
-        "vote",
-        "voting",
-        "review"
-            ],
-      "sparkle": [
+      "sparkle-filled": [
         "stars",
         "magic",
         "help",
         "ai"
       ],
-      "sparkle-filled": [
+      "sparkle": [
         "stars",
         "magic",
         "help",
@@ -1879,22 +1878,6 @@
         "delta",
         "shape"
       ],
-      "very-dissatisfied": [
-        "sad",
-        "frown",
-        "unhappy",
-        "bad",
-        "poor",
-        "face"
-      ],
-      "very-satisfied": [
-        "happy",
-        "smile",
-        "face",
-        "great",
-        "pleased",
-        "good"
-      ],
       "very-dissatisfied-filled": [
         "sad",
         "frown",
@@ -1903,7 +1886,23 @@
         "poor",
         "face"
       ],
+      "very-dissatisfied": [
+        "sad",
+        "frown",
+        "unhappy",
+        "bad",
+        "poor",
+        "face"
+      ],
       "very-satisfied-filled": [
+        "happy",
+        "smile",
+        "face",
+        "great",
+        "pleased",
+        "good"
+      ],
+      "very-satisfied": [
         "happy",
         "smile",
         "face",
@@ -2209,13 +2208,13 @@
         "house",
         "living"
       ],
-      "map-pin": [
+      "map-pin-filled": [
         "location",
         "navigation",
         "travel",
         "marker"
       ],
-      "map-pin-filled": [
+      "map-pin": [
         "location",
         "navigation",
         "travel",

--- a/packages/dialtone-vue2/components/stack/stack.stories.js
+++ b/packages/dialtone-vue2/components/stack/stack.stories.js
@@ -11,7 +11,7 @@ import {
 export const argsData = {
   direction: { default: 'column' },
   as: 'div',
-  gap: '400',
+  gap: { default: '400' },
 };
 
 export const argTypesData = {
@@ -50,9 +50,15 @@ Object: { "default": "row", "sm": "column", "lg": "column-reverse" }`,
     control: 'text',
   },
   gap: {
-    options: DT_STACK_GAP,
-    control: {
-      type: 'select',
+    control: 'object',
+    table: {
+      type: {
+        detail: `
+        Gaps: "${DT_STACK_GAP}"
+Breakpoints: "${DT_STACK_RESPONSIVE_BREAKPOINTS}"
+String: "400"
+Object: { "default": "400", "sm": "200", "lg": "450" }`,
+      },
     },
   },
 };

--- a/packages/dialtone-vue2/components/stack/stack.test.js
+++ b/packages/dialtone-vue2/components/stack/stack.test.js
@@ -75,10 +75,10 @@ describe('DtStack Tests', () => {
         });
 
         expect(wrapper.classes(
-          'd-stack--sm--column',
-          'd-stack--md--row-reverse',
-          'd-stack--lg--column-reverse',
-          'd-stack--xl--row',
+          'd-stack--sm-column',
+          'd-stack--md-row-reverse',
+          'd-stack--lg-column-reverse',
+          'd-stack--xl-row',
         )).toBe(true);
       });
 
@@ -96,7 +96,7 @@ describe('DtStack Tests', () => {
         it('should do not add inexistent breakpoint class', async () => {
           await wrapper.setProps({ direction: { invalid: 'column' } });
 
-          expect(wrapper.classes().includes('d-stack--invalid--column')).toBe(false);
+          expect(wrapper.classes().includes('d-stack--invalid-column')).toBe(false);
         });
       });
 
@@ -147,10 +147,10 @@ describe('DtStack Tests', () => {
         });
 
         expect(wrapper.classes(
-          'd-stack--sm--gap-200',
-          'd-stack--md--gap-400',
-          'd-stack--lg--gap-500',
-          'd-stack--xl--gap-600',
+          'd-stack--sm-gap-200',
+          'd-stack--md-gap-400',
+          'd-stack--lg-gap-500',
+          'd-stack--xl-gap-600',
         )).toBe(true);
       });
 
@@ -168,7 +168,7 @@ describe('DtStack Tests', () => {
         it('should do not add inexistent breakpoint class', async () => {
           await wrapper.setProps({ gap: { invalid: '400' } });
 
-          expect(wrapper.classes().includes('d-stack--invalid--gap-400')).toBe(false);
+          expect(wrapper.classes().includes('d-stack--invalid-gap-400')).toBe(false);
         });
       });
 

--- a/packages/dialtone-vue2/components/stack/stack.test.js
+++ b/packages/dialtone-vue2/components/stack/stack.test.js
@@ -118,8 +118,8 @@ describe('DtStack Tests', () => {
     });
   });
 
-  describe('When `gap` prop is provided as', () => {
-    describe('valid value', () => {
+  describe('When `gap` prop is provided with', () => {
+    describe('valid string value', () => {
       it('should set proper gap class', async () => {
         await wrapper.setProps({ gap: '300' });
 
@@ -127,11 +127,57 @@ describe('DtStack Tests', () => {
       });
     });
 
-    describe('non valid value', () => {
+    describe('non valid string value', () => {
       it('should not set gap class', async () => {
         await wrapper.setProps({ gap: '123' });
 
         expect(wrapper.classes().includes('d-stack--gap-123')).toBe(false);
+      });
+    });
+
+    describe('expected object value', () => {
+      it('should set proper responsive classes', async () => {
+        await wrapper.setProps({
+          gap: {
+            sm: '200',
+            md: '400',
+            lg: '500',
+            xl: '600',
+          },
+        });
+
+        expect(wrapper.classes(
+          'd-stack--sm--gap-200',
+          'd-stack--md--gap-400',
+          'd-stack--lg--gap-500',
+          'd-stack--xl--gap-600',
+        )).toBe(true);
+      });
+
+      describe('When `default` is provided', () => {
+        it('should override the default value', async () => {
+          await wrapper.setProps({ gap: { default: '500' } });
+
+          expect(wrapper.classes('d-stack', 'd-stack--gap-500')).toBe(true);
+        });
+      });
+    });
+
+    describe('non expected object value', () => {
+      describe('When is provided with non expected breakpoint value', () => {
+        it('should do not add inexistent breakpoint class', async () => {
+          await wrapper.setProps({ gap: { invalid: '400' } });
+
+          expect(wrapper.classes().includes('d-stack--invalid--gap-400')).toBe(false);
+        });
+      });
+
+      describe('When `default` is provided with non expected direction value', () => {
+        it('should do not add inexistent direction class', async () => {
+          await wrapper.setProps({ gap: { default: '900' } });
+
+          expect(wrapper.classes().includes('d-stack--gap-900')).toBe(false);
+        });
       });
     });
   });

--- a/packages/dialtone-vue2/components/stack/stack.vue
+++ b/packages/dialtone-vue2/components/stack/stack.vue
@@ -4,8 +4,8 @@
     :class="[
       'd-stack',
       defaultDirection,
+      defaultGap,
       stackResponsive,
-      stackGap,
     ]"
   >
     <!-- @slot Slot for main content -->
@@ -16,7 +16,7 @@
 <script>
 import { DT_STACK_DIRECTION, DT_STACK_GAP, DT_STACK_RESPONSIVE_BREAKPOINTS } from './stack_constants';
 import { directionValidator, gapValidator } from './validators';
-import { getDefaultDirectionClass, getResponsiveClasses, getGapClass } from './utils';
+import { getDefaultDirectionClass, getResponsiveClasses, getDefaultGapClass } from './utils';
 
 export default {
   name: 'DtStack',
@@ -45,11 +45,15 @@ export default {
     },
 
     /**
-     * Set this prop to have the space between each stack item
-     * @values 0, 100, 200, 300, 400, 500, 600
+     * The gap property controls the spacing between items in the stack.
+     * The gap can be set to a string, or object with breakpoints.
+     * All the undefined breakpoints will have the 'default' value.
+     * You can override the default gap with 'default' key.
+     * In case of string, it will be applied to all the breakpoints.
+     * Valid values are '0', '100', '200', '300', '400', '450', '500', '600'.
      */
     gap: {
-      type: String,
+      type: [String, Object],
       default: '0',
       validator: (gap) => gapValidator(gap),
     },
@@ -64,8 +68,8 @@ export default {
   },
 
   computed: {
-    stackGap () {
-      return getGapClass(this.gap);
+    defaultGap () {
+      return getDefaultGapClass(this.gap);
     },
 
     defaultDirection () {
@@ -73,7 +77,7 @@ export default {
     },
 
     stackResponsive () {
-      return getResponsiveClasses(this.direction);
+      return getResponsiveClasses(this.direction, this.gap);
     },
   },
 };

--- a/packages/dialtone-vue2/components/stack/utils.js
+++ b/packages/dialtone-vue2/components/stack/utils.js
@@ -17,7 +17,7 @@ function _getValidDirection (direction) {
 function _getValidGap (gap) {
   if (typeof gap === 'string') {
     return gap;
-  } else if (directionPropType(gap) === 'object') {
+  } else if (typeof gap === 'object') {
     return gap.default;
   } else { return null; }
 }
@@ -36,7 +36,7 @@ function getResposiveDirectionClasses (direction) {
   if (directionPropType(direction) === 'object') {
     return [
       ...DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
-        return DT_STACK_DIRECTION.includes(direction[breakpoint])
+        return direction[breakpoint]
           ? `d-stack--${breakpoint}-${direction[breakpoint]}`
           : null;
       })];
@@ -44,7 +44,7 @@ function getResposiveDirectionClasses (direction) {
 }
 
 function getResposiveGapClasses (gap) {
-  if (directionPropType(gap) === 'object') {
+  if (typeof gap === 'object') {
     return [
       ...DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
         return DT_STACK_GAP.includes(gap[breakpoint])

--- a/packages/dialtone-vue2/components/stack/utils.js
+++ b/packages/dialtone-vue2/components/stack/utils.js
@@ -14,6 +14,14 @@ function _getValidDirection (direction) {
   } else { return null; }
 }
 
+function _getValidGap (gap) {
+  if (typeof gap === 'string') {
+    return gap;
+  } else if (directionPropType(gap) === 'object') {
+    return gap.default;
+  } else { return null; }
+}
+
 export function directionPropType (value) {
   return typeof value;
 }
@@ -24,17 +32,36 @@ export function getDefaultDirectionClass (direction) {
     : null;
 }
 
-export function getResponsiveClasses (direction) {
+function getResposiveDirectionClasses (direction) {
   if (directionPropType(direction) === 'object') {
     return [
       ...DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
         return direction[breakpoint]
-          ? `d-stack--${breakpoint}--${direction[breakpoint]}`
+          ? `d-stack--${breakpoint}--${DT_STACK_DIRECTION[direction[breakpoint]]}`
           : null;
       })];
-  } else { return null; }
+  } else { return []; }
 }
 
-export function getGapClass (gap) {
-  return DT_STACK_GAP.includes(gap) ? `d-stack--gap-${gap}` : null;
+function getResposiveGapClasses (gap) {
+  if (directionPropType(gap) === 'object') {
+    return [
+      ...DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
+        return DT_STACK_GAP.includes(gap[breakpoint])
+          ? `d-stack--${breakpoint}--gap-${gap[breakpoint]}`
+          : null;
+      })];
+  } else { return []; }
+}
+
+export function getResponsiveClasses (direction, gap) {
+  return [
+    ...getResposiveDirectionClasses(direction),
+    ...getResposiveGapClasses(gap),
+  ];
+}
+
+export function getDefaultGapClass (gap) {
+  const validGap = _getValidGap(gap);
+  return DT_STACK_GAP.includes(validGap) ? `d-stack--gap-${validGap}` : null;
 }

--- a/packages/dialtone-vue2/components/stack/utils.js
+++ b/packages/dialtone-vue2/components/stack/utils.js
@@ -36,8 +36,8 @@ function getResposiveDirectionClasses (direction) {
   if (directionPropType(direction) === 'object') {
     return [
       ...DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
-        return direction[breakpoint]
-          ? `d-stack--${breakpoint}--${DT_STACK_DIRECTION[direction[breakpoint]]}`
+        return DT_STACK_DIRECTION.includes(direction[breakpoint])
+          ? `d-stack--${breakpoint}-${direction[breakpoint]}`
           : null;
       })];
   } else { return []; }
@@ -48,7 +48,7 @@ function getResposiveGapClasses (gap) {
     return [
       ...DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
         return DT_STACK_GAP.includes(gap[breakpoint])
-          ? `d-stack--${breakpoint}--gap-${gap[breakpoint]}`
+          ? `d-stack--${breakpoint}-gap-${gap[breakpoint]}`
           : null;
       })];
   } else { return []; }

--- a/packages/dialtone-vue2/components/stack/validators.js
+++ b/packages/dialtone-vue2/components/stack/validators.js
@@ -12,5 +12,12 @@ export function directionValidator (direction) {
 }
 
 export function gapValidator (gap) {
-  return DT_STACK_GAP.includes(gap);
+  if (typeof gap === 'string') {
+    return DT_STACK_GAP.includes(gap);
+  }
+  if (typeof gap === 'object') {
+    const { default: defaultStyle } = gap;
+
+    return DT_STACK_GAP.includes(defaultStyle);
+  }
 }

--- a/packages/dialtone-vue3/components/stack/stack.stories.js
+++ b/packages/dialtone-vue3/components/stack/stack.stories.js
@@ -11,7 +11,7 @@ import {
 export const argsData = {
   direction: { default: 'column' },
   as: 'div',
-  gap: '400',
+  gap: { default: '400' },
 };
 
 export const argTypesData = {
@@ -50,9 +50,15 @@ Object: { "default": "row", "sm": "column", "lg": "column-reverse" }`,
     control: 'text',
   },
   gap: {
-    options: DT_STACK_GAP,
-    control: {
-      type: 'select',
+    control: 'object',
+    table: {
+      type: {
+        detail: `
+        Gaps: "${DT_STACK_GAP}"
+Breakpoints: "${DT_STACK_RESPONSIVE_BREAKPOINTS}"
+String: "400"
+Object: { "default": "400", "sm": "200", "lg": "450" }`,
+      },
     },
   },
 };

--- a/packages/dialtone-vue3/components/stack/stack.test.js
+++ b/packages/dialtone-vue3/components/stack/stack.test.js
@@ -112,8 +112,8 @@ describe('DtStack Tests', () => {
     });
   });
 
-  describe('When `gap` prop is provided as', () => {
-    describe('valid value', () => {
+  describe('When `gap` prop is provided with', () => {
+    describe('valid string value', () => {
       it('should set proper gap class', async () => {
         await wrapper.setProps({ gap: '300' });
 
@@ -121,11 +121,57 @@ describe('DtStack Tests', () => {
       });
     });
 
-    describe('non valid value', () => {
+    describe('non valid string value', () => {
       it('should not set gap class', async () => {
         await wrapper.setProps({ gap: '123' });
 
         expect(wrapper.classes().includes('d-stack--gap-123')).toBe(false);
+      });
+    });
+
+    describe('expected object value', () => {
+      it('should set proper responsive classes', async () => {
+        await wrapper.setProps({
+          gap: {
+            sm: '200',
+            md: '400',
+            lg: '500',
+            xl: '600',
+          },
+        });
+
+        expect(wrapper.classes(
+          'd-stack--sm--gap-200',
+          'd-stack--md--gap-400',
+          'd-stack--lg--gap-500',
+          'd-stack--xl--gap-600',
+        )).toBe(true);
+      });
+
+      describe('When `default` is provided', () => {
+        it('should override the default value', async () => {
+          await wrapper.setProps({ gap: { default: '500' } });
+
+          expect(wrapper.classes('d-stack', 'd-stack--gap-500')).toBe(true);
+        });
+      });
+    });
+
+    describe('non expected object value', () => {
+      describe('When is provided with non expected breakpoint value', () => {
+        it('should do not add inexistent breakpoint class', async () => {
+          await wrapper.setProps({ gap: { invalid: '400' } });
+
+          expect(wrapper.classes().includes('d-stack--invalid--gap-400')).toBe(false);
+        });
+      });
+
+      describe('When `default` is provided with non expected direction value', () => {
+        it('should do not add inexistent direction class', async () => {
+          await wrapper.setProps({ gap: { default: '900' } });
+
+          expect(wrapper.classes().includes('d-stack--gap-900')).toBe(false);
+        });
       });
     });
   });

--- a/packages/dialtone-vue3/components/stack/stack.test.js
+++ b/packages/dialtone-vue3/components/stack/stack.test.js
@@ -69,10 +69,10 @@ describe('DtStack Tests', () => {
         });
 
         expect(wrapper.classes(
-          'd-stack--sm--column',
-          'd-stack--md--row-reverse',
-          'd-stack--lg--column-reverse',
-          'd-stack--xl--row',
+          'd-stack--sm-column',
+          'd-stack--md-row-reverse',
+          'd-stack--lg-column-reverse',
+          'd-stack--xl-row',
         )).toBe(true);
       });
 
@@ -90,7 +90,7 @@ describe('DtStack Tests', () => {
         it('should do not add inexistent breakpoint class', async () => {
           await wrapper.setProps({ direction: { invalid: 'column' } });
 
-          expect(wrapper.classes().includes('d-stack--invalid--column')).toBe(false);
+          expect(wrapper.classes().includes('d-stack--invalid-column')).toBe(false);
         });
       });
 
@@ -141,10 +141,10 @@ describe('DtStack Tests', () => {
         });
 
         expect(wrapper.classes(
-          'd-stack--sm--gap-200',
-          'd-stack--md--gap-400',
-          'd-stack--lg--gap-500',
-          'd-stack--xl--gap-600',
+          'd-stack--sm-gap-200',
+          'd-stack--md-gap-400',
+          'd-stack--lg-gap-500',
+          'd-stack--xl-gap-600',
         )).toBe(true);
       });
 
@@ -162,7 +162,7 @@ describe('DtStack Tests', () => {
         it('should do not add inexistent breakpoint class', async () => {
           await wrapper.setProps({ gap: { invalid: '400' } });
 
-          expect(wrapper.classes().includes('d-stack--invalid--gap-400')).toBe(false);
+          expect(wrapper.classes().includes('d-stack--invalid-gap-400')).toBe(false);
         });
       });
 

--- a/packages/dialtone-vue3/components/stack/stack.vue
+++ b/packages/dialtone-vue3/components/stack/stack.vue
@@ -4,8 +4,8 @@
     :class="[
       'd-stack',
       defaultDirection,
+      defaultGap,
       stackResponsive,
-      stackGap,
     ]"
   >
     <!-- @slot Slot for main content -->
@@ -16,7 +16,7 @@
 <script>
 import { DT_STACK_DIRECTION, DT_STACK_GAP, DT_STACK_RESPONSIVE_BREAKPOINTS } from './stack_constants';
 import { directionValidator, gapValidator } from './validators';
-import { getDefaultDirectionClass, getResponsiveClasses, getGapClass } from './utils';
+import { getDefaultDirectionClass, getResponsiveClasses, getDefaultGapClass } from './utils';
 
 export default {
   name: 'DtStack',
@@ -45,11 +45,15 @@ export default {
     },
 
     /**
-     * Set this prop to have the space between each stack item
-     * @values 0, 100, 200, 300, 400, 500, 600
+     * The gap property controls the spacing between items in the stack.
+     * The gap can be set to a string, or object with breakpoints.
+     * All the undefined breakpoints will have the 'default' value.
+     * You can override the default gap with 'default' key.
+     * In case of string, it will be applied to all the breakpoints.
+     * Valid values are '0', '100', '200', '300', '400', '450', '500', '600'.
      */
     gap: {
-      type: String,
+      type: [String, Object],
       default: '0',
       validator: (gap) => gapValidator(gap),
     },
@@ -64,8 +68,8 @@ export default {
   },
 
   computed: {
-    stackGap () {
-      return getGapClass(this.gap);
+    defaultGap () {
+      return getDefaultGapClass(this.gap);
     },
 
     defaultDirection () {
@@ -73,7 +77,7 @@ export default {
     },
 
     stackResponsive () {
-      return getResponsiveClasses(this.direction);
+      return getResponsiveClasses(this.direction, this.gap);
     },
   },
 };

--- a/packages/dialtone-vue3/components/stack/utils.js
+++ b/packages/dialtone-vue3/components/stack/utils.js
@@ -48,7 +48,7 @@ function getResposiveGapClasses (gap) {
     return [
       ...DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
         return DT_STACK_GAP.includes(gap[breakpoint])
-          ? `d-stack--${breakpoint}--gap-${gap[breakpoint]}`
+          ? `d-stack--${breakpoint}-gap-${gap[breakpoint]}`
           : null;
       })];
   } else { return []; }

--- a/packages/dialtone-vue3/components/stack/utils.js
+++ b/packages/dialtone-vue3/components/stack/utils.js
@@ -14,6 +14,14 @@ function _getValidDirection (direction) {
   } else { return null; }
 }
 
+function _getValidGap (gap) {
+  if (typeof gap === 'string') {
+    return gap;
+  } else if (directionPropType(gap) === 'object') {
+    return gap.default;
+  } else { return null; }
+}
+
 export function directionPropType (value) {
   return typeof value;
 }
@@ -24,17 +32,36 @@ export function getDefaultDirectionClass (direction) {
     : null;
 }
 
-export function getResponsiveClasses (direction) {
+function getResposiveDirectionClasses (direction) {
   if (directionPropType(direction) === 'object') {
     return [
       ...DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
         return direction[breakpoint]
-          ? `d-stack--${breakpoint}--${direction[breakpoint]}`
+          ? `d-stack--${breakpoint}--${DT_STACK_DIRECTION[direction[breakpoint]]}`
           : null;
       })];
-  } else { return null; }
+  } else { return []; }
 }
 
-export function getGapClass (gap) {
-  return DT_STACK_GAP.includes(gap) ? `d-stack--gap-${gap}` : null;
+function getResposiveGapClasses (gap) {
+  if (directionPropType(gap) === 'object') {
+    return [
+      ...DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
+        return DT_STACK_GAP.includes(gap[breakpoint])
+          ? `d-stack--${breakpoint}--gap-${gap[breakpoint]}`
+          : null;
+      })];
+  } else { return []; }
+}
+
+export function getResponsiveClasses (direction, gap) {
+  return [
+    ...getResposiveDirectionClasses(direction),
+    ...getResposiveGapClasses(gap),
+  ];
+}
+
+export function getDefaultGapClass (gap) {
+  const validGap = _getValidGap(gap);
+  return DT_STACK_GAP.includes(validGap) ? `d-stack--gap-${validGap}` : null;
 }

--- a/packages/dialtone-vue3/components/stack/utils.js
+++ b/packages/dialtone-vue3/components/stack/utils.js
@@ -17,7 +17,7 @@ function _getValidDirection (direction) {
 function _getValidGap (gap) {
   if (typeof gap === 'string') {
     return gap;
-  } else if (directionPropType(gap) === 'object') {
+  } else if (typeof gap === 'object') {
     return gap.default;
   } else { return null; }
 }
@@ -37,14 +37,14 @@ function getResposiveDirectionClasses (direction) {
     return [
       ...DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
         return direction[breakpoint]
-          ? `d-stack--${breakpoint}--${DT_STACK_DIRECTION[direction[breakpoint]]}`
+          ? `d-stack--${breakpoint}-${direction[breakpoint]}`
           : null;
       })];
   } else { return []; }
 }
 
 function getResposiveGapClasses (gap) {
-  if (directionPropType(gap) === 'object') {
+  if (typeof gap === 'object') {
     return [
       ...DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
         return DT_STACK_GAP.includes(gap[breakpoint])

--- a/packages/dialtone-vue3/components/stack/validators.js
+++ b/packages/dialtone-vue3/components/stack/validators.js
@@ -12,5 +12,12 @@ export function directionValidator (direction) {
 }
 
 export function gapValidator (gap) {
-  return DT_STACK_GAP.includes(gap);
+  if (typeof gap === 'string') {
+    return DT_STACK_GAP.includes(gap);
+  }
+  if (typeof gap === 'object') {
+    const { default: defaultStyle } = gap;
+
+    return DT_STACK_GAP.includes(defaultStyle);
+  }
 }


### PR DESCRIPTION
# feat(gap): DLT-1805 enable responsive gap prop

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/4Iw2OzgiiTc4M/giphy.gif?cid=790b7611qc24u96qr1h08oj9ix3bi8b1ry95wundt0sz7dsx&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
[DLT-1805]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Allows setting the gap as an object with breakpoints and values.

<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps
Add Vue 3
<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs
![stack-gap](https://github.com/user-attachments/assets/e7855ffa-ea41-429e-8073-f597791fa941)

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

<!--- Add any links to external reference material -->


[DLT-1805]: https://dialpad.atlassian.net/browse/DLT-1805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ