### PR TITLE
fix(rich-text-editor): DLT-1822 fix hard break default configuration for rich text editor

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -411,7 +411,15 @@ export default {
           }),
         );
       } else {
-        extensions.push(HardBreak);
+        extensions.push(HardBreak.extend({
+          addKeyboardShortcuts () {
+            return {
+              Enter: () => {
+                this.editor.commands.setHardBreak();
+              },
+            };
+          },
+        }));
       }
 
       if (this.mentionSuggestion) {

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.test.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.test.js
@@ -580,6 +580,18 @@ describe('DtRecipeEditor tests', () => {
       });
     });
 
+    describe('When enter key is pressed', () => {
+      it('editor should add br tag html content', async () => {
+        let editorHtmlOutput = editor.html();
+        expect(editorHtmlOutput).not.toContain('<br>');
+        await editor.trigger('keydown.enter');
+        await wrapper.vm.$nextTick();
+
+        editorHtmlOutput = editor.html();
+        expect(editorHtmlOutput).toContain('<br>');
+      });
+    });
+
     describe('When quick replies button is clicked', () => {
       it('quick replies clicked event should be fired', async () => {
         await quickRepliesBtn.trigger('click');

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -411,7 +411,15 @@ export default {
           }),
         );
       } else {
-        extensions.push(HardBreak);
+        extensions.push(HardBreak.extend({
+          addKeyboardShortcuts () {
+            return {
+              Enter: () => {
+                this.editor.commands.setHardBreak();
+              },
+            };
+          },
+        }));
       }
 
       if (this.mentionSuggestion) {

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.test.js
@@ -546,5 +546,20 @@ describe('DtRecipeEditor tests', () => {
         expect('quick-replies-click' in wrapper.emitted()).toBeTruthy();
       });
     });
+
+    describe('When enter key is pressed', () => {
+      beforeEach(async () => {
+        wrapper.vm.$refs.richTextEditor?.editor.commands.focus('end');
+      });
+
+      it('editor should add br tag html content', async () => {
+        let editorHtmlOutput = editor.html();
+        expect(editorHtmlOutput).not.toContain('<br>');
+        await wrapper.vm.$refs.richTextEditor?.editor.commands.enter();
+        await wrapper.vm.$nextTick();
+        editorHtmlOutput = editor.html();
+        expect(editorHtmlOutput).toContain('<br>');
+      });
+    });
   });
 });


### PR DESCRIPTION
# fix(rich-text-editor): DLT-1822 fix hard break default configuration for rich text editor

## Obligatory GIF (super important!)

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ21zNmhlaDByMDhqNHN3MTU4eWh6bG0ydGc2Ymp1d2ZycjFnaWY1YSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/sTczweWUTxLqg/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1949

## :book: Description

Add configuration to tip tap Hard Break extension so that when enter key is pressed, the <br> tag will be added to the content.

## :bulb: Context

Editor default Hard Break configuration not adding <br> tags. This is the reason why when the agent when using the Editor component to write emails can enter one or multiple line breaks, but when the email is sent they are not being rendered because the <br> are not being added.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

<img width="1261" alt="Screenshot 2024-08-09 at 10 50 05" src="https://github.com/user-attachments/assets/7b509a79-4511-4e2c-a0e1-6179c20ef031">

## :link: Sources

[Tip-Tap Hard Break extension docs](https://tiptap.dev/docs/editor/extensions/nodes/hard-break)