### PR TITLE
feat(split-button): DLT-1819 vue3 version

### DIFF
--- a/apps/dialtone-documentation/docs/_data/split-button.json
+++ b/apps/dialtone-documentation/docs/_data/split-button.json
@@ -1,0 +1,39 @@
+{
+  "classes": [
+    {
+      "class": "d-split-btn",
+      "applies": "N/A",
+      "description": "Base split button style."
+    },
+    {
+      "class": "d-split-btn__alpha",
+      "applies": "N/A",
+      "description": "Alpha button style."
+    },
+    {
+      "class": "d-split-btn__omega",
+      "applies": "N/A",
+      "description": "Omega button style."
+    },
+    {
+      "class": "d-split-btn__omega--xs",
+      "applies": ".d-split-btn__omega",
+      "description": "Applies extra small size."
+    },
+    {
+      "class": "d-split-btn__omega--sm",
+      "applies": ".d-split-btn__omega",
+      "description": "Applies small size."
+    },
+    {
+      "class": "d-split-btn__omega--lg",
+      "applies": ".d-split-btn__omega",
+      "description": "Applies large size."
+    },
+    {
+      "class": "d-split-btn__omega--xl",
+      "applies": ".d-split-btn__omega",
+      "description": "Applies extra large size."
+    }
+  ]
+}

--- a/apps/dialtone-documentation/docs/components/split-button.md
+++ b/apps/dialtone-documentation/docs/components/split-button.md
@@ -4,27 +4,32 @@ description: A split button offers a default action paired with a secondary acti
 status: beta
 thumb: true
 image: assets/images/components/split-button.png
-storybook:
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-split-button--default
 ---
 
 <code-well-header>
-  <dt-split-button>
+  <dt-split-button
+    omega-tooltip-text="More calling options"
+  >
     Place call
+    <template #dropdownList>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+    </template>
   </dt-split-button>
 </code-well-header>
-
-## Usage
 
 ## Variants
 
 ### Base
 
 <code-well-header>
-  <div class="d-d-flex d-flow8">
-      <dt-split-button> Place Call </dt-split-button>
-      <dt-split-button importance="outlined"> Place Call </dt-split-button>
-      <dt-split-button importance="clear"> Place Call </dt-split-button>
-  </div>
+  <dt-stack direction="row" gap="400">
+      <dt-split-button omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+      <dt-split-button importance="outlined" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+      <dt-split-button importance="clear" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+  </dt-stack>
 </code-well-header>
 
 <code-example-tabs
@@ -55,20 +60,20 @@ htmlCode='
 </span>
 '
 vueCode='
-<dt-split-button> Place Call </dt-button>
-<dt-split-button importance="outlined"> Place Call </dt-button>
-<dt-split-button importance="clear"> Place Call </dt-button>
+<dt-split-button omega-tooltip-text="More calling options"> Place Call </dt-button>
+<dt-split-button importance="outlined" omega-tooltip-text="More calling options"> Place Call </dt-button>
+<dt-split-button importance="clear" omega-tooltip-text="More calling options"> Place Call </dt-button>
 '
 showHtmlWarning />
 
 ### Danger
 
 <code-well-header>
-  <div class="d-d-flex d-flow8">
-      <dt-split-button kind="danger"> Place Call </dt-split-button>
-      <dt-split-button importance="outlined" kind="danger"> Place Call </dt-split-button>
-      <dt-split-button importance="clear" kind="danger"> Place Call </dt-split-button>
-  </div>
+  <dt-stack direction="row" gap="400">
+      <dt-split-button kind="danger" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+      <dt-split-button importance="outlined" kind="danger" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+      <dt-split-button importance="clear" kind="danger" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+  </dt-stack>
 </code-well-header>
 
 <code-example-tabs
@@ -99,20 +104,20 @@ htmlCode='
 </span>
 '
 vueCode='
-<dt-split-button kind="danger"> Place Call </dt-button>
-<dt-split-button importance="outlined" kind="danger"> Place Call </dt-button>
-<dt-split-button importance="clear" kind="danger"> Place Call </dt-button>
+<dt-split-button kind="danger" omega-tooltip-text="More calling options"> Place Call </dt-button>
+<dt-split-button importance="outlined" kind="danger" omega-tooltip-text="More calling options"> Place Call </dt-button>
+<dt-split-button importance="clear" kind="danger" omega-tooltip-text="More calling options"> Place Call </dt-button>
 '
 showHtmlWarning />
 
 ### Inverted
 
 <code-well-header bgclass="d-bgc-contrast">
-  <div class="d-d-flex d-flow8">
-      <dt-split-button kind="inverted"> Place Call </dt-split-button>
-      <dt-split-button importance="outlined" kind="inverted"> Place Call </dt-split-button>
-      <dt-split-button importance="clear" kind="inverted"> Place Call </dt-split-button>
-  </div>
+  <dt-stack direction="row" gap="400">
+      <dt-split-button kind="inverted" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+      <dt-split-button importance="outlined" kind="inverted" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+      <dt-split-button importance="clear" kind="inverted" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+  </dt-stack>
 </code-well-header>
 
 <code-example-tabs
@@ -143,19 +148,19 @@ htmlCode='
 </span>
 '
 vueCode='
-<dt-split-button kind="inverted"> Place Call </dt-split-button>
-<dt-split-button importance="outlined" kind="inverted"> Place Call </dt-split-button>
-<dt-split-button importance="clear" kind="inverted"> Place Call </dt-split-button>
+<dt-split-button kind="inverted" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+<dt-split-button importance="outlined" kind="inverted" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+<dt-split-button importance="clear" kind="inverted" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
 '
 showHtmlWarning />
 
 ### Muted
 
 <code-well-header>
-  <div class="d-d-flex d-flow8">
-      <dt-split-button importance="outlined" kind="muted"> Place Call </dt-split-button>
-      <dt-split-button importance="clear" kind="muted"> Place Call </dt-split-button>
-  </div>
+  <dt-stack direction="row" gap="400">
+      <dt-split-button importance="outlined" kind="muted" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+      <dt-split-button importance="clear" kind="muted" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+  </dt-stack>
 </code-well-header>
 
 <code-example-tabs
@@ -178,20 +183,20 @@ htmlCode='
 </span>
 '
 vueCode='
-<dt-split-button importance="outlined" kind="muted"> Place Call </dt-split-button>
-<dt-split-button importance="clear" kind="muted"> Place Call </dt-split-button>
+<dt-split-button importance="outlined" kind="muted" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
+<dt-split-button importance="clear" kind="muted" omega-tooltip-text="More calling options"> Place Call </dt-split-button>
 '
 showHtmlWarning />
 
 ### Disabled
 
 <code-well-header>
-  <div class="d-d-flex d-flow8">
-      <dt-split-button disabled> Place Call (disable attribute)</dt-split-button>
+  <dt-stack direction="row" gap="400">
+      <dt-split-button disabled omega-tooltip-text="More calling options"> Place Call (disable attribute)</dt-split-button>
       <span class="d-c-not-allowed">
-        <dt-split-button class="d-btn--disabled"> Place Call (disabled class) </dt-split-button>
+        <dt-split-button class="d-btn--disabled" omega-tooltip-text="More calling options"> Place Call (disabled class) </dt-split-button>
       </span>
-  </div>
+  </dt-stack>
 </code-well-header>
 
 <code-example-tabs
@@ -224,11 +229,10 @@ showHtmlWarning />
 ### Active
 
 <code-well-header>
-  <div class="d-d-flex d-flow8">
-    <dt-split-button alpha-active> Alpha active </dt-split-button>
-    <dt-split-button omega-active importance="outlined"> Omega active </dt-split-button>
-    <dt-split-button alpha-active omega-active importance="clear"> Both active </dt-split-button>
-  </div>
+  <dt-stack direction="row" gap="400">
+    <dt-split-button alpha-active omega-tooltip-text="More calling options"> Alpha active </dt-split-button>
+    <dt-split-button omega-active omega-tooltip-text="More calling options"> Omega active </dt-split-button>
+  </dt-stack>
 </code-well-header>
 
 <code-example-tabs
@@ -259,22 +263,21 @@ htmlCode='
 </span>
 '
 vueCode='
-<dt-split-button alpha-active> Alpha active </dt-split-button>
-<dt-split-button omega-active importance="outlined"> Omega active </dt-split-button>
-<dt-split-button alpha-active omega-active importance="clear"> Both active </dt-split-button>
+<dt-split-button alpha-active omega-tooltip-text="More calling options"> Alpha active </dt-split-button>
+<dt-split-button omega-active omega-tooltip-text="More calling options"> Omega active </dt-split-button>
 '
 showHtmlWarning />
 
 ### Sizes
 
 <code-well-header>
-  <div class="d-d-flex d-flow8 d-ai-center">
-    <dt-split-button size="xs"> xs </dt-split-button>
-    <dt-split-button size="sm"> sm </dt-split-button>
-    <dt-split-button size="md"> md </dt-split-button>
-    <dt-split-button size="lg"> lg </dt-split-button>
-    <dt-split-button size="xl"> xl </dt-split-button>
-  </div>
+  <dt-stack direction="row" gap="400">
+    <dt-split-button size="xs" omega-tooltip-text="More calling options"> xs </dt-split-button>
+    <dt-split-button size="sm" omega-tooltip-text="More calling options"> sm </dt-split-button>
+    <dt-split-button size="md" omega-tooltip-text="More calling options"> md </dt-split-button>
+    <dt-split-button size="lg" omega-tooltip-text="More calling options"> lg </dt-split-button>
+    <dt-split-button size="xl" omega-tooltip-text="More calling options"> xl </dt-split-button>
+  </dt-stack>
 </code-well-header>
 
 <code-example-tabs
@@ -321,22 +324,22 @@ htmlCode='
 </span>
 '
 vueCode='
-<dt-split-button size="xs"> xs </dt-split-button>
-<dt-split-button size="sm"> sm </dt-split-button>
-<dt-split-button size="md"> md </dt-split-button>
-<dt-split-button size="lg"> lg </dt-split-button>
-<dt-split-button size="xl"> xl </dt-split-button>
+<dt-split-button size="xs" omega-tooltip-text="More calling options"> xs </dt-split-button>
+<dt-split-button size="sm" omega-tooltip-text="More calling options"> sm </dt-split-button>
+<dt-split-button size="md" omega-tooltip-text="More calling options"> md </dt-split-button>
+<dt-split-button size="lg" omega-tooltip-text="More calling options"> lg </dt-split-button>
+<dt-split-button size="xl" omega-tooltip-text="More calling options"> xl </dt-split-button>
 '
 showHtmlWarning />
 
 ### Loading
 
 <code-well-header>
-  <div class="d-d-flex d-flow8 d-ai-center">
-    <dt-split-button alpha-loading> Place call </dt-split-button>
-    <dt-split-button alpha-loading importance="outlined"> Place call </dt-split-button>
-    <dt-split-button alpha-loading importance="clear"> Place call </dt-split-button>
-  </div>
+  <dt-stack direction="row" gap="400">
+    <dt-split-button alpha-loading omega-tooltip-text="More calling options"> Place call </dt-split-button>
+    <dt-split-button alpha-loading importance="outlined" omega-tooltip-text="More calling options"> Place call </dt-split-button>
+    <dt-split-button alpha-loading importance="clear" omega-tooltip-text="More calling options"> Place call </dt-split-button>
+  </dt-stack>
 </code-well-header>
 
 <code-example-tabs
@@ -367,9 +370,9 @@ htmlCode='
 </span>
 '
 vueCode='
-<dt-split-button alpha-loading> Place call </dt-split-button>
-<dt-split-button alpha-loading importance="outlined"> Place call </dt-split-button>
-<dt-split-button alpha-loading importance="clear"> Place call </dt-split-button>
+<dt-split-button alpha-loading omega-tooltip-text="More calling options"> Place call </dt-split-button>
+<dt-split-button alpha-loading importance="outlined" omega-tooltip-text="More calling options"> Place call </dt-split-button>
+<dt-split-button alpha-loading importance="clear" omega-tooltip-text="More calling options"> Place call </dt-split-button>
 '
 showHtmlWarning />
 
@@ -378,32 +381,32 @@ showHtmlWarning />
 #### Icon and label
 
 <code-well-header>
-  <div class="d-d-flex d-flow8 d-ai-center">
-    <dt-split-button importance="outlined">
+  <dt-stack direction="row" gap="400">
+    <dt-split-button importance="outlined" omega-tooltip-text="More calling options">
       <template #alphaIcon="{ size }">
         <dt-icon name="phone" :size="size" />
       </template>
       Place call
     </dt-split-button>
-    <dt-split-button importance="outlined" alpha-icon-position="top">
+    <dt-split-button importance="outlined" alpha-icon-position="top" omega-tooltip-text="More calling options">
       <template #alphaIcon="{ size }">
         <dt-icon name="phone" :size="size" />
       </template>
       Place call
     </dt-split-button>
-    <dt-split-button importance="outlined" alpha-icon-position="right">
+    <dt-split-button importance="outlined" alpha-icon-position="right" omega-tooltip-text="More calling options">
       <template #alphaIcon="{ size }">
         <dt-icon name="phone" :size="size" />
       </template>
       Place call
     </dt-split-button>
-    <dt-split-button importance="outlined" alpha-icon-position="bottom">
+    <dt-split-button importance="outlined" alpha-icon-position="bottom" omega-tooltip-text="More calling options">
       <template #alphaIcon="{ size }">
         <dt-icon name="phone" :size="size" />
       </template>
       Place call
     </dt-split-button>
-  </div>
+  </dt-stack>
 </code-well-header>
 
 <code-example-tabs
@@ -454,25 +457,25 @@ htmlCode='
 </span>
 '
 vueCode='
-<dt-split-button importance="outlined">
+<dt-split-button importance="outlined" omega-tooltip-text="More calling options">
   <template #alphaIcon="{ size }">
     <dt-icon name="phone" :size="size" />
   </template>
   Place call
 </dt-split-button>
-<dt-split-button importance="outlined" alpha-icon-position="top">
+<dt-split-button importance="outlined" alpha-icon-position="top" omega-tooltip-text="More calling options">
   <template #alphaIcon="{ size }">
     <dt-icon name="phone" :size="size" />
   </template>
   Place call
 </dt-split-button>
-<dt-split-button importance="outlined" alpha-icon-position="right">
+<dt-split-button importance="outlined" alpha-icon-position="right" omega-tooltip-text="More calling options">
   <template #alphaIcon="{ size }">
     <dt-icon name="phone" :size="size" />
   </template>
   Place call
 </dt-split-button>
-<dt-split-button importance="outlined" alpha-icon-position="bottom">
+<dt-split-button importance="outlined" alpha-icon-position="bottom" omega-tooltip-text="More calling options">
   <template #alphaIcon="{ size }">
     <dt-icon name="phone" :size="size" />
   </template>
@@ -484,23 +487,23 @@ showHtmlWarning />
 #### Icon only
 
 <code-well-header>
-  <div class="d-d-flex d-flow8 d-ai-center">
-    <dt-split-button>
+  <dt-stack direction="row" gap="400">
+    <dt-split-button omega-tooltip-text="More calling options" alpha-tooltip-text="Place call">
       <template #alphaIcon="{ size }">
         <dt-icon name="phone" :size="size" />
       </template>
     </dt-split-button>
-    <dt-split-button importance="outlined" kind="muted">
+    <dt-split-button importance="outlined" kind="muted" omega-tooltip-text="More calling options" alpha-tooltip-text="Place call">
       <template #alphaIcon="{ size }">
         <dt-icon name="phone" :size="size" />
       </template>
     </dt-split-button>
-    <dt-split-button importance="clear" kind="danger">
+    <dt-split-button importance="clear" kind="danger" omega-tooltip-text="More calling options" alpha-tooltip-text="Place call">
       <template #alphaIcon="{ size }">
         <dt-icon name="phone" :size="size" />
       </template>
     </dt-split-button>
-  </div>
+  </dt-stack>
 </code-well-header>
 
 <code-example-tabs
@@ -537,17 +540,17 @@ htmlCode='
 </span>
 '
 vueCode='
-<dt-split-button>
+<dt-split-button omega-tooltip-text="More calling options" alpha-tooltip-text="Place call">
   <template #alphaIcon="{ size }">
     <dt-icon name="phone" :size="size" />
   </template>
 </dt-split-button>
-<dt-split-button importance="outlined" kind="muted">
+<dt-split-button importance="outlined" kind="muted" omega-tooltip-text="More calling options" alpha-tooltip-text="Place call">
   <template #alphaIcon="{ size }">
     <dt-icon name="phone" :size="size" />
   </template>
 </dt-split-button>
-<dt-split-button importance="clear" kind="danger">
+<dt-split-button importance="clear" kind="danger" omega-tooltip-text="More calling options" alpha-tooltip-text="Place call">
   <template #alphaIcon="{ size }">
     <dt-icon name="phone" :size="size" />
   </template>
@@ -556,23 +559,23 @@ vueCode='
 showHtmlWarning />
 
 <code-well-header bgclass="d-bgc-contrast">
-  <div class="d-d-flex d-flow8 d-ai-center">
-    <dt-split-button kind="inverted">
+  <dt-stack direction="row" gap="400">
+    <dt-split-button kind="inverted" omega-tooltip-text="More calling options" alpha-tooltip-text="Place call">
       <template #alphaIcon="{ size }">
         <dt-icon name="phone" :size="size" />
       </template>
     </dt-split-button>
-    <dt-split-button importance="outlined" kind="inverted">
+    <dt-split-button importance="outlined" kind="inverted" omega-tooltip-text="More calling options" alpha-tooltip-text="Place call">
       <template #alphaIcon="{ size }">
         <dt-icon name="phone" :size="size" />
       </template>
     </dt-split-button>
-    <dt-split-button importance="clear" kind="inverted">
+    <dt-split-button importance="clear" kind="inverted" omega-tooltip-text="More calling options" alpha-tooltip-text="Place call">
       <template #alphaIcon="{ size }">
         <dt-icon name="phone" :size="size" />
       </template>
     </dt-split-button>
-  </div>
+  </dt-stack>
 </code-well-header>
 
 <code-example-tabs
@@ -609,17 +612,17 @@ htmlCode='
 </span>
 '
 vueCode='
-<dt-split-button kind="inverted">
+<dt-split-button kind="inverted" omega-tooltip-text="More calling options" alpha-tooltip-text="Place call">
   <template #alphaIcon="{ size }">
     <dt-icon name="phone" :size="size" />
   </template>
 </dt-split-button>
-<dt-split-button importance="outlined" kind="inverted">
+<dt-split-button importance="outlined" kind="inverted" omega-tooltip-text="More calling options" alpha-tooltip-text="Place call">
   <template #alphaIcon="{ size }">
     <dt-icon name="phone" :size="size" />
   </template>
 </dt-split-button>
-<dt-split-button importance="clear" kind="inverted">
+<dt-split-button importance="clear" kind="inverted" omega-tooltip-text="More calling options" alpha-tooltip-text="Place call">
   <template #alphaIcon="{ size }">
     <dt-icon name="phone" :size="size" />
   </template>

--- a/apps/dialtone-documentation/docs/components/split-button.md
+++ b/apps/dialtone-documentation/docs/components/split-button.md
@@ -1,1480 +1,636 @@
 ---
 title: Split Button
-description: A Split Button offers a default action paired with a secondary action to reveal alternate, but related actions.
+description: A split button offers a default action paired with a secondary action to reveal alternate, but related actions.
 status: beta
 thumb: true
 image: assets/images/components/split-button.png
 storybook:
 ---
 
-<div class="asdfasdfqwerqwer">
-  <table class="d-table dialtone-doc-table d-bt d-bb d-bbw2 d-bc-default">
-    <thead>
-      <tr>
-        <th class="d-ta-center d-br d-bc-default">
-          &nbsp;
-        </th>
-        <th class="d-ta-center d-br d-bc-default">
-          Clear
-        </th>
-        <th class="d-ta-center d-br d-bc-default">
-          Outlined
-        </th>
-        <th class="d-ta-center d-br d-bc-default">
-          Primary
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th class="d-ta-right d-br d-brw2 d-bc-default" scope="row">
-          <span class="d-headline--eyebrow">Base</span>
-        </th>
-        <td class="d-ta-right d-br d-bc-default">
-          <dt-stack direction="row" gap="500" class="d-jc-center">
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="clear" class="d-split-btn__alpha d-split-btn__alpha--xs">Place call</dt-button>
-                  <dt-button size="xs" importance="clear" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="clear" class="d-split-btn__alpha d-split-btn__alpha--sm">Place call</dt-button>
-                  <dt-button size="sm" importance="clear" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="clear" class="d-split-btn__alpha d-split-btn__alpha--md">Place call</dt-button>
-                  <dt-button size="md" importance="clear" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="clear" class="d-split-btn__alpha d-split-btn__alpha--lg">Place call</dt-button>
-                  <dt-button size="lg" importance="clear" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="clear" class="d-split-btn__alpha d-split-btn__alpha--xl">Place call</dt-button>
-                  <dt-button size="xl" importance="clear" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="clear" class="d-split-btn__alpha d-split-btn__alpha--xs">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xs" importance="clear" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="clear" class="d-split-btn__alpha d-split-btn__alpha--sm">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="sm" importance="clear" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="clear" class="d-split-btn__alpha d-split-btn__alpha--md">
-                    <template #icon>
-                      <dt-icon name="phone" size="300" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="md" importance="clear" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="clear" class="d-split-btn__alpha d-split-btn__alpha--lg">
-                    <template #icon>
-                      <dt-icon name="phone" size="400" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="lg" importance="clear" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="clear" class="d-split-btn__alpha d-split-btn__alpha--xl">
-                    <template #icon>
-                      <dt-icon name="phone" size="500" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xl" importance="clear" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-          </dt-stack>
-        </td>
-        <td class="d-ta-right d-br d-bc-default">
-          <dt-stack direction="row" gap="500" class="d-jc-center">
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="outlined" class="d-split-btn__alpha d-split-btn__alpha--xs">Place call</dt-button>
-                  <dt-button size="xs" importance="outlined" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="outlined" class="d-split-btn__alpha d-split-btn__alpha--sm">Place call</dt-button>
-                  <dt-button size="sm" importance="outlined" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="outlined" class="d-split-btn__alpha d-split-btn__alpha--md">Place call</dt-button>
-                  <dt-button size="md" importance="outlined" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="outlined" class="d-split-btn__alpha d-split-btn__alpha--lg">Place call</dt-button>
-                  <dt-button size="lg" importance="outlined" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="outlined" class="d-split-btn__alpha d-split-btn__alpha--xl">Place call</dt-button>
-                  <dt-button size="xl" importance="outlined" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="outlined" class="d-split-btn__alpha d-split-btn__alpha--xs">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xs" importance="outlined" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="outlined" class="d-split-btn__alpha d-split-btn__alpha--sm">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="sm" importance="outlined" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="outlined" class="d-split-btn__alpha d-split-btn__alpha--md">
-                    <template #icon>
-                      <dt-icon name="phone" size="300" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="md" importance="outlined" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="outlined" class="d-split-btn__alpha d-split-btn__alpha--lg">
-                    <template #icon>
-                      <dt-icon name="phone" size="400" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="lg" importance="outlined" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="outlined" class="d-split-btn__alpha d-split-btn__alpha--xl">
-                    <template #icon>
-                      <dt-icon name="phone" size="500" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xl" importance="outlined" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-          </dt-stack>
-        </td>
-        <td>
-          <dt-stack direction="row" gap="500" class="d-jc-center">
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" class="d-split-btn__alpha d-split-btn__alpha--xs">Place call</dt-button>
-                  <dt-button size="xs" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" class="d-split-btn__alpha d-split-btn__alpha--sm">Place call</dt-button>
-                  <dt-button size="sm" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" class="d-split-btn__alpha d-split-btn__alpha--md">Place call</dt-button>
-                  <dt-button size="md" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" class="d-split-btn__alpha d-split-btn__alpha--lg">Place call</dt-button>
-                  <dt-button size="lg" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" class="d-split-btn__alpha d-split-btn__alpha--xl">Place call</dt-button>
-                  <dt-button size="xl" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" class="d-split-btn__alpha d-split-btn__alpha--xs">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xs" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" class="d-split-btn__alpha d-split-btn__alpha--sm">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="sm" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" class="d-split-btn__alpha d-split-btn__alpha--md">
-                    <template #icon>
-                      <dt-icon name="phone" size="300" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="md" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" class="d-split-btn__alpha d-split-btn__alpha--lg">
-                    <template #icon>
-                      <dt-icon name="phone" size="400" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="lg" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" class="d-split-btn__alpha d-split-btn__alpha--xl">
-                    <template #icon>
-                      <dt-icon name="phone" size="500" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xl" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-          </dt-stack>
-        </td>
-      </tr>
-      <tr>
-        <th class="d-ta-right d-br d-brw2 d-bc-default" scope="row">
-          <span class="d-headline--eyebrow">Danger</span>
-        </th>
-        <td class="d-br d-bc-default">
-          <dt-stack direction="row" gap="500" class="d-jc-center">
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="clear" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--xs">Place call</dt-button>
-                  <dt-button size="xs" importance="clear" kind="danger" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="clear" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--sm">Place call</dt-button>
-                  <dt-button size="sm" importance="clear" kind="danger" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="clear" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--md">Place call</dt-button>
-                  <dt-button size="md" importance="clear" kind="danger" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="clear" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--lg">Place call</dt-button>
-                  <dt-button size="lg" importance="clear" kind="danger" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="clear" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--xl">Place call</dt-button>
-                  <dt-button size="xl" importance="clear" kind="danger" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="clear" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--xs">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xs" importance="clear" kind="danger" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="clear" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--sm">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="sm" importance="clear" kind="danger" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="clear" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--md">
-                    <template #icon>
-                      <dt-icon name="phone" size="300" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="md" importance="clear" kind="danger" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="clear" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--lg">
-                    <template #icon>
-                      <dt-icon name="phone" size="400" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="lg" importance="clear" kind="danger" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="clear" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--xl">
-                    <template #icon>
-                      <dt-icon name="phone" size="500" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xl" importance="clear" kind="danger" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-          </dt-stack>
-        </td>
-        <td class="d-br d-bc-default">
-          <dt-stack direction="row" gap="500" class="d-jc-center">
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="outlined" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--xs">Place call</dt-button>
-                  <dt-button size="xs" importance="outlined" kind="danger" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="outlined" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--sm">Place call</dt-button>
-                  <dt-button size="sm" importance="outlined" kind="danger" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="outlined" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--md">Place call</dt-button>
-                  <dt-button size="md" importance="outlined" kind="danger" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="outlined" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--lg">Place call</dt-button>
-                  <dt-button size="lg" importance="outlined" kind="danger" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="outlined" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--xl">Place call</dt-button>
-                  <dt-button size="xl" importance="outlined" kind="danger" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="outlined" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--xs">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xs" importance="outlined" kind="danger" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="outlined" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--sm">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="sm" importance="outlined" kind="danger" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="outlined" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--md">
-                    <template #icon>
-                      <dt-icon name="phone" size="300" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="md" importance="outlined" kind="danger" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="outlined" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--lg">
-                    <template #icon>
-                      <dt-icon name="phone" size="400" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="lg" importance="outlined" kind="danger" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="outlined" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--xl">
-                    <template #icon>
-                      <dt-icon name="phone" size="500" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xl" importance="outlined" kind="danger" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-          </dt-stack>
-        </td>
-        <td>
-          <dt-stack direction="row" gap="500" class="d-jc-center">
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--xs">Place call</dt-button>
-                  <dt-button size="xs" kind="danger" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--sm">Place call</dt-button>
-                  <dt-button size="sm" kind="danger" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--md">Place call</dt-button>
-                  <dt-button size="md" kind="danger" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--lg">Place call</dt-button>
-                  <dt-button size="lg" kind="danger" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--xl">Place call</dt-button>
-                  <dt-button size="xl" kind="danger" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--xs">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xs" kind="danger" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--sm">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="sm" kind="danger" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--md">
-                    <template #icon>
-                      <dt-icon name="phone" size="300" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="md" kind="danger" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--lg">
-                    <template #icon>
-                      <dt-icon name="phone" size="400" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="lg" kind="danger" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" kind="danger" class="d-split-btn__alpha d-split-btn__alpha--xl">
-                    <template #icon>
-                      <dt-icon name="phone" size="500" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xl" kind="danger" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-          </dt-stack>
-        </td>
-      </tr>
-      <tr class="d-bgc-contrast">
-        <th class="d-ta-right d-br d-brw2 d-bc-default-inverted" scope="row">
-          <span class="d-headline--eyebrow d-fc-primary-inverted">Inverted</span>
-        </th>
-        <td class="d-br d-bc-default-inverted">
-          <dt-stack direction="row" gap="500" class="d-jc-center">
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="clear" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--xs">Place call</dt-button>
-                  <dt-button size="xs" importance="clear" kind="inverted" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="clear" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--sm">Place call</dt-button>
-                  <dt-button size="sm" importance="clear" kind="inverted" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="clear" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--md">Place call</dt-button>
-                  <dt-button size="md" importance="clear" kind="inverted" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="clear" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--lg">Place call</dt-button>
-                  <dt-button size="lg" importance="clear" kind="inverted" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="clear" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--xl">Place call</dt-button>
-                  <dt-button size="xl" importance="clear" kind="inverted" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="clear" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--xs">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xs" importance="clear" kind="inverted" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="clear" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--sm">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="sm" importance="clear" kind="inverted" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="clear" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--md">
-                    <template #icon>
-                      <dt-icon name="phone" size="300" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="md" importance="clear" kind="inverted" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="clear" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--lg">
-                    <template #icon>
-                      <dt-icon name="phone" size="400" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="lg" importance="clear" kind="inverted" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="clear" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--xl">
-                    <template #icon>
-                      <dt-icon name="phone" size="500" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xl" importance="clear" kind="inverted" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-          </dt-stack>
-        </td>
-        <td class="d-br d-bc-default-inverted">
-          <dt-stack direction="row" gap="500" class="d-jc-center">
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="outlined" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--xs">Place call</dt-button>
-                  <dt-button size="xs" importance="outlined" kind="inverted" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="outlined" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--sm">Place call</dt-button>
-                  <dt-button size="sm" importance="outlined" kind="inverted" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="outlined" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--md">Place call</dt-button>
-                  <dt-button size="md" importance="outlined" kind="inverted" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="outlined" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--lg">Place call</dt-button>
-                  <dt-button size="lg" importance="outlined" kind="inverted" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="outlined" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--xl">Place call</dt-button>
-                  <dt-button size="xl" importance="outlined" kind="inverted" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="outlined" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--xs">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xs" importance="outlined" kind="inverted" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="outlined" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--sm">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="sm" importance="outlined" kind="inverted" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="outlined" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--md">
-                    <template #icon>
-                      <dt-icon name="phone" size="300" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="md" importance="outlined" kind="inverted" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="outlined" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--lg">
-                    <template #icon>
-                      <dt-icon name="phone" size="400" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="lg" importance="outlined" kind="inverted" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="outlined" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--xl">
-                    <template #icon>
-                      <dt-icon name="phone" size="500" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xl" importance="outlined" kind="inverted" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-          </dt-stack>
-        </td>
-        <td>
-          <dt-stack direction="row" gap="500" class="d-jc-center">
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--xs">Place call</dt-button>
-                  <dt-button size="xs" kind="inverted" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--sm">Place call</dt-button>
-                  <dt-button size="sm" kind="inverted" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--md">Place call</dt-button>
-                  <dt-button size="md" kind="inverted" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--lg">Place call</dt-button>
-                  <dt-button size="lg" kind="inverted" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--xl">Place call</dt-button>
-                  <dt-button size="xl" kind="inverted" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--xs">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xs" kind="inverted" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--sm">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="sm" kind="inverted" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--md">
-                    <template #icon>
-                      <dt-icon name="phone" size="300" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="md" kind="inverted" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--lg">
-                    <template #icon>
-                      <dt-icon name="phone" size="400" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="lg" kind="inverted" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" kind="inverted" class="d-split-btn__alpha d-split-btn__alpha--xl">
-                    <template #icon>
-                      <dt-icon name="phone" size="500" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xl" kind="inverted" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-          </dt-stack>
-        </td>
-      </tr>
-      <tr>
-        <th class="d-ta-right d-br d-brw2 d-bc-default" scope="row">
-          <span class="d-headline--eyebrow">Muted</span>
-        </th>
-        <td class="d-br d-bc-default">
-          <dt-stack direction="row" gap="500" class="d-jc-center">
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="clear" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--xs">Place call</dt-button>
-                  <dt-button size="xs" importance="clear" kind="muted" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="clear" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--sm">Place call</dt-button>
-                  <dt-button size="sm" importance="clear" kind="muted" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="clear" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--md">Place call</dt-button>
-                  <dt-button size="md" importance="clear" kind="muted" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="clear" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--lg">Place call</dt-button>
-                  <dt-button size="lg" importance="clear" kind="muted" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="clear" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--xl">Place call</dt-button>
-                  <dt-button size="xl" importance="clear" kind="muted" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="clear" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--xs">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xs" importance="clear" kind="muted" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="clear" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--sm">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="sm" importance="clear" kind="muted" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="clear" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--md">
-                    <template #icon>
-                      <dt-icon name="phone" size="300" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="md" importance="clear" kind="muted" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="clear" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--lg">
-                    <template #icon>
-                      <dt-icon name="phone" size="400" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="lg" importance="clear" kind="muted" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="clear" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--xl">
-                    <template #icon>
-                      <dt-icon name="phone" size="500" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xl" importance="clear" kind="muted" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-          </dt-stack>
-        </td>
-        <td class="d-br d-bc-default">
-          <dt-stack direction="row" gap="500" class="d-jc-center">
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="outlined" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--xs">Place call</dt-button>
-                  <dt-button size="xs" importance="outlined" kind="muted" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="outlined" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--sm">Place call</dt-button>
-                  <dt-button size="sm" importance="outlined" kind="muted" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="outlined" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--md">Place call</dt-button>
-                  <dt-button size="md" importance="outlined" kind="muted" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="outlined" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--lg">Place call</dt-button>
-                  <dt-button size="lg" importance="outlined" kind="muted" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="outlined" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--xl">Place call</dt-button>
-                  <dt-button size="xl" importance="outlined" kind="muted" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-            <dt-stack gap="400">
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xs" importance="outlined" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--xs">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xs" importance="outlined" kind="muted" class="d-split-btn__omega d-split-btn__omega--xs" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="sm" importance="outlined" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--sm">
-                    <template #icon>
-                      <dt-icon name="phone" size="200" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="sm" importance="outlined" kind="muted" class="d-split-btn__omega d-split-btn__omega--sm" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="100" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="md" importance="outlined" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--md">
-                    <template #icon>
-                      <dt-icon name="phone" size="300" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="md" importance="outlined" kind="muted" class="d-split-btn__omega d-split-btn__omega--md" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="lg" importance="outlined" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--lg">
-                    <template #icon>
-                      <dt-icon name="phone" size="400" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="lg" importance="outlined" kind="muted" class="d-split-btn__omega d-split-btn__omega--lg" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="200" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-              <div class="d-ta-center">
-                <span class="d-split-btn">
-                  <dt-button size="xl" importance="outlined" kind="muted" class="d-split-btn__alpha d-split-btn__alpha--xl">
-                    <template #icon>
-                      <dt-icon name="phone" size="500" />
-                    </template>
-                  </dt-button>
-                  <dt-button size="xl" importance="outlined" kind="muted" class="d-split-btn__omega d-split-btn__omega--xl" aria-label="More options">
-                    <template #icon>
-                      <dt-icon name="chevron-down" size="300" />
-                    </template>
-                  </dt-button>
-                </span>
-              </div>
-            </dt-stack>
-          </dt-stack>
-        </td>
-        <td class="d-ta-center">
-          <abbr class="d-fc-muted d-td-none d-fs-100" title="Not applicable">N/A</abbr>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <div class="d-p16">
-    <dt-stack direction="row" gap="600" class="d-jc-center">
-      <dt-toggle size="sm" onclick="const splitButtons = document.querySelectorAll('.d-split-btn'); splitButtons.forEach(splitButton => { const buttons = splitButton.querySelectorAll('.d-btn'); buttons.forEach(button => { if (button.hasAttribute('disabled')) { button.removeAttribute('disabled'); } else { button.setAttribute('disabled', 'true'); } }); });">
-        <div class="d-mr6">
-          Disable all split buttons
-        </div>
-      </dt-toggle>
-      <dt-button importance="outlined" icon-position="left" onclick="var element=document.querySelector('.asdfasdfqwerqwer');if(element){element.closest('.asdfasdfqwerqwer').setAttribute('hidden','');}">
-        Hide grid
-        <template #icon>
-          <dt-icon
-            name="eye"
-            size="300"
-          />
-        </template>
-      </dt-button>
-    </dt-stack>
+<code-well-header>
+  <dt-split-button>
+    Place call
+  </dt-split-button>
+</code-well-header>
+
+## Usage
+
+## Variants
+
+### Base
+
+<code-well-header>
+  <div class="d-d-flex d-flow8">
+      <dt-split-button> Place Call </dt-split-button>
+      <dt-split-button importance="outlined"> Place Call </dt-split-button>
+      <dt-split-button importance="clear"> Place Call </dt-split-button>
   </div>
-</div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--outlined d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+'
+vueCode='
+<dt-split-button> Place Call </dt-button>
+<dt-split-button importance="outlined"> Place Call </dt-button>
+<dt-split-button importance="clear"> Place Call </dt-button>
+'
+showHtmlWarning />
+
+### Danger
+
+<code-well-header>
+  <div class="d-d-flex d-flow8">
+      <dt-split-button kind="danger"> Place Call </dt-split-button>
+      <dt-split-button importance="outlined" kind="danger"> Place Call </dt-split-button>
+      <dt-split-button importance="clear" kind="danger"> Place Call </dt-split-button>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-btn--danger d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--danger d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--outlined d-btn--danger d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--danger d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--danger d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--danger d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+'
+vueCode='
+<dt-split-button kind="danger"> Place Call </dt-button>
+<dt-split-button importance="outlined" kind="danger"> Place Call </dt-button>
+<dt-split-button importance="clear" kind="danger"> Place Call </dt-button>
+'
+showHtmlWarning />
+
+### Inverted
+
+<code-well-header bgclass="d-bgc-contrast">
+  <div class="d-d-flex d-flow8">
+      <dt-split-button kind="inverted"> Place Call </dt-split-button>
+      <dt-split-button importance="outlined" kind="inverted"> Place Call </dt-split-button>
+      <dt-split-button importance="clear" kind="inverted"> Place Call </dt-split-button>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-btn--inverted d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--inverted d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--outlined d-btn--inverted d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--inverted d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--inverted d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--inverted d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+'
+vueCode='
+<dt-split-button kind="inverted"> Place Call </dt-split-button>
+<dt-split-button importance="outlined" kind="inverted"> Place Call </dt-split-button>
+<dt-split-button importance="clear" kind="inverted"> Place Call </dt-split-button>
+'
+showHtmlWarning />
+
+### Muted
+
+<code-well-header>
+  <div class="d-d-flex d-flow8">
+      <dt-split-button importance="outlined" kind="muted"> Place Call </dt-split-button>
+      <dt-split-button importance="clear" kind="muted"> Place Call </dt-split-button>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--outlined d-btn--muted d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--muted d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--muted d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--muted d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+'
+vueCode='
+<dt-split-button importance="outlined" kind="muted"> Place Call </dt-split-button>
+<dt-split-button importance="clear" kind="muted"> Place Call </dt-split-button>
+'
+showHtmlWarning />
+
+### Disabled
+
+<code-well-header>
+  <div class="d-d-flex d-flow8">
+      <dt-split-button disabled> Place Call (disable attribute)</dt-split-button>
+      <span class="d-c-not-allowed">
+        <dt-split-button class="d-btn--disabled"> Place Call (disabled class) </dt-split-button>
+      </span>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-split-btn__alpha d-split-btn__alpha--md" type="button" disabled>
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button" disabled>
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-split-btn__alpha d-split-btn__alpha--md d-btn--disabled" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--icon-only d-split-btn__omega d-split-btn__omega--md d-btn--disabled" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+'
+vueCode='
+<dt-split-button disabled> Place Call (disable attribute)</dt-split-button>
+<span class="d-c-not-allowed">
+  <dt-split-button class="d-btn--disabled"> Place Call (disabled class) </dt-split-button>
+</span>
+'
+showHtmlWarning />
+
+### Active
+
+<code-well-header>
+  <div class="d-d-flex d-flow8">
+    <dt-split-button alpha-active> Alpha active </dt-split-button>
+    <dt-split-button omega-active importance="outlined"> Omega active </dt-split-button>
+    <dt-split-button alpha-active omega-active importance="clear"> Both active </dt-split-button>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-btn--active d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--active d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-btn--active d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--active d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+'
+vueCode='
+<dt-split-button alpha-active> Alpha active </dt-split-button>
+<dt-split-button omega-active importance="outlined"> Omega active </dt-split-button>
+<dt-split-button alpha-active omega-active importance="clear"> Both active </dt-split-button>
+'
+showHtmlWarning />
+
+### Sizes
+
+<code-well-header>
+  <div class="d-d-flex d-flow8 d-ai-center">
+    <dt-split-button size="xs"> xs </dt-split-button>
+    <dt-split-button size="sm"> sm </dt-split-button>
+    <dt-split-button size="md"> md </dt-split-button>
+    <dt-split-button size="lg"> lg </dt-split-button>
+    <dt-split-button size="xl"> xl </dt-split-button>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-btn--xs d-split-btn__alpha d-split-btn__alpha--xs" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--xs d-btn--icon-only d-split-btn__omega d-split-btn__omega--xs" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-btn--sm d-split-btn__alpha d-split-btn__alpha--sm" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--sm d-btn--icon-only d-split-btn__omega d-split-btn__omega--sm" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-btn--lg d-split-btn__alpha d-split-btn__alpha--lg" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--lg d-btn--icon-only d-split-btn__omega d-split-btn__omega--lg" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-btn--xl d-split-btn__alpha d-split-btn__alpha--xl" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--xl d-btn--icon-only d-split-btn__omega d-split-btn__omega--xl" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+'
+vueCode='
+<dt-split-button size="xs"> xs </dt-split-button>
+<dt-split-button size="sm"> sm </dt-split-button>
+<dt-split-button size="md"> md </dt-split-button>
+<dt-split-button size="lg"> lg </dt-split-button>
+<dt-split-button size="xl"> xl </dt-split-button>
+'
+showHtmlWarning />
+
+### Loading
+
+<code-well-header>
+  <div class="d-d-flex d-flow8 d-ai-center">
+    <dt-split-button alpha-loading> Place call </dt-split-button>
+    <dt-split-button alpha-loading importance="outlined"> Place call </dt-split-button>
+    <dt-split-button alpha-loading importance="clear"> Place call </dt-split-button>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-btn--loading d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--outlined d-btn--loading d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--loading d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+'
+vueCode='
+<dt-split-button alpha-loading> Place call </dt-split-button>
+<dt-split-button alpha-loading importance="outlined"> Place call </dt-split-button>
+<dt-split-button alpha-loading importance="clear"> Place call </dt-split-button>
+'
+showHtmlWarning />
+
+### Icon support
+
+#### Icon and label
+
+<code-well-header>
+  <div class="d-d-flex d-flow8 d-ai-center">
+    <dt-split-button importance="outlined">
+      <template #alphaIcon="{ size }">
+        <dt-icon name="phone" :size="size" />
+      </template>
+      Place call
+    </dt-split-button>
+    <dt-split-button importance="outlined" alpha-icon-position="top">
+      <template #alphaIcon="{ size }">
+        <dt-icon name="phone" :size="size" />
+      </template>
+      Place call
+    </dt-split-button>
+    <dt-split-button importance="outlined" alpha-icon-position="right">
+      <template #alphaIcon="{ size }">
+        <dt-icon name="phone" :size="size" />
+      </template>
+      Place call
+    </dt-split-button>
+    <dt-split-button importance="outlined" alpha-icon-position="bottom">
+      <template #alphaIcon="{ size }">
+        <dt-icon name="phone" :size="size" />
+      </template>
+      Place call
+    </dt-split-button>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--outlined d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">
+      <svg class="d-icon--size-300 d-icon">...</svg>
+    </span>
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--outlined d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--top">
+      <svg class="d-icon--size-300 d-icon">...</svg>
+    </span>
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--outlined d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--right">
+      <svg class="d-icon--size-300 d-icon">...</svg>
+    </span>
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--outlined d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--bottom">
+      <svg class="d-icon--size-300 d-icon">...</svg>
+    </span>
+    <span class="d-btn__label base-button__label"> Place Call </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+'
+vueCode='
+<dt-split-button importance="outlined">
+  <template #alphaIcon="{ size }">
+    <dt-icon name="phone" :size="size" />
+  </template>
+  Place call
+</dt-split-button>
+<dt-split-button importance="outlined" alpha-icon-position="top">
+  <template #alphaIcon="{ size }">
+    <dt-icon name="phone" :size="size" />
+  </template>
+  Place call
+</dt-split-button>
+<dt-split-button importance="outlined" alpha-icon-position="right">
+  <template #alphaIcon="{ size }">
+    <dt-icon name="phone" :size="size" />
+  </template>
+  Place call
+</dt-split-button>
+<dt-split-button importance="outlined" alpha-icon-position="bottom">
+  <template #alphaIcon="{ size }">
+    <dt-icon name="phone" :size="size" />
+  </template>
+  Place call
+</dt-split-button>
+'
+showHtmlWarning />
+
+#### Icon only
+
+<code-well-header>
+  <div class="d-d-flex d-flow8 d-ai-center">
+    <dt-split-button>
+      <template #alphaIcon="{ size }">
+        <dt-icon name="phone" :size="size" />
+      </template>
+    </dt-split-button>
+    <dt-split-button importance="outlined" kind="muted">
+      <template #alphaIcon="{ size }">
+        <dt-icon name="phone" :size="size" />
+      </template>
+    </dt-split-button>
+    <dt-split-button importance="clear" kind="danger">
+      <template #alphaIcon="{ size }">
+        <dt-icon name="phone" :size="size" />
+      </template>
+    </dt-split-button>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">
+      <svg class="d-icon--size-300 d-icon">...</svg>
+    </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--outlined d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">
+      <svg class="d-icon--size-300 d-icon">...</svg>
+    </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--danger d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">
+      <svg class="d-icon--size-300 d-icon">...</svg>
+    </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+'
+vueCode='
+<dt-split-button>
+  <template #alphaIcon="{ size }">
+    <dt-icon name="phone" :size="size" />
+  </template>
+</dt-split-button>
+<dt-split-button importance="outlined" kind="muted">
+  <template #alphaIcon="{ size }">
+    <dt-icon name="phone" :size="size" />
+  </template>
+</dt-split-button>
+<dt-split-button importance="clear" kind="danger">
+  <template #alphaIcon="{ size }">
+    <dt-icon name="phone" :size="size" />
+  </template>
+</dt-split-button>
+'
+showHtmlWarning />
+
+<code-well-header bgclass="d-bgc-contrast">
+  <div class="d-d-flex d-flow8 d-ai-center">
+    <dt-split-button kind="inverted">
+      <template #alphaIcon="{ size }">
+        <dt-icon name="phone" :size="size" />
+      </template>
+    </dt-split-button>
+    <dt-split-button importance="outlined" kind="inverted">
+      <template #alphaIcon="{ size }">
+        <dt-icon name="phone" :size="size" />
+      </template>
+    </dt-split-button>
+    <dt-split-button importance="clear" kind="inverted">
+      <template #alphaIcon="{ size }">
+        <dt-icon name="phone" :size="size" />
+      </template>
+    </dt-split-button>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-btn--inverted d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">
+      <svg class="d-icon--size-300 d-icon">...</svg>
+    </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--inverted d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--outlined d-btn--inverted d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">
+      <svg class="d-icon--size-300 d-icon">...</svg>
+    </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--outlined d-btn--inverted d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--inverted d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">
+      <svg class="d-icon--size-300 d-icon">...</svg>
+    </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--inverted d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+'
+vueCode='
+<dt-split-button kind="inverted">
+  <template #alphaIcon="{ size }">
+    <dt-icon name="phone" :size="size" />
+  </template>
+</dt-split-button>
+<dt-split-button importance="outlined" kind="inverted">
+  <template #alphaIcon="{ size }">
+    <dt-icon name="phone" :size="size" />
+  </template>
+</dt-split-button>
+<dt-split-button importance="clear" kind="inverted">
+  <template #alphaIcon="{ size }">
+    <dt-icon name="phone" :size="size" />
+  </template>
+</dt-split-button>
+'
+showHtmlWarning />
+
+## Vue API
+
+<component-vue-api component-name="splitButton" />
+
+## Classes
+
+<component-class-table component-name="split-button" />

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -728,14 +728,6 @@
 //  $   BUTTON GROUP
 //  ----------------------------------------------------------------------------
 
-.asdfasdfqwerqwer {
-  position: fixed;
-  z-index: var(--zi-notification);
-  inset: var(--dt-size-700) var(--dt-size-0) var(--dt-size-0);
-  overflow: auto;
-  background-color: var(--dt-color-surface-primary);
-}
-
 .d-btn-group {
   display: flex;
 

--- a/packages/dialtone-vue2/components/button/button.vue
+++ b/packages/dialtone-vue2/components/button/button.vue
@@ -126,13 +126,7 @@ export default {
 
     /**
      * HTML button disabled attribute
-     * <a
-     *   class="d-link"
-     *   href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled"
-     *   target="_blank"
-     * >
-     *   (Reference)
-     * </a>
+     * <a class="d-link" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled" target="_blank"> (Reference) </a>
      * @values true, false
      */
     disabled: {

--- a/packages/dialtone-vue2/components/split_button/split_button-alpha.vue
+++ b/packages/dialtone-vue2/components/split_button/split_button-alpha.vue
@@ -14,9 +14,7 @@
     :loading="loading"
     :size="size"
   >
-    <template
-      #icon
-    >
+    <template #icon>
       <slot
         name="icon"
         :size="BUTTON_ICON_SIZES[size]"

--- a/packages/dialtone-vue2/components/split_button/split_button-omega.vue
+++ b/packages/dialtone-vue2/components/split_button/split_button-omega.vue
@@ -37,60 +37,7 @@ export default {
 
   props: {
     /**
-     * Element ID, useful in case you need to reference the button
-     * as an external anchor for popover
-     */
-    id: {
-      type: String,
-      default: getUniqueString(),
-    },
-
-    /**
-     * Text shown in tooltip when you hover the button
-     */
-    tooltipText: {
-      type: String,
-      default: '',
-    },
-
-    /**
-     * HTML button disabled attribute
-     * <a
-     *   class="d-link"
-     *   href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled"
-     *   target="_blank"
-     * >
-     *   (Reference)
-     * </a>
-     * @values true, false
-     */
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
-
-    /**
-     * The fill and outline of the button associated with its visual importance.
-     * @values clear, outlined, primary
-     */
-    importance: {
-      type: String,
-      default: 'primary',
-    },
-
-    /**
-     * The color of the button.
-     * @values default, muted, danger, inverted
-     */
-    kind: {
-      type: String,
-      default: 'default',
-    },
-
-    /**
      * Determines whether the button should have active styling
-     * default is false.
-     * @values true, false
      */
     active: {
       type: Boolean,
@@ -106,12 +53,52 @@ export default {
     },
 
     /**
+     * HTML button disabled attribute
+     */
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Element ID, useful in case you need to reference the button
+     * as an external anchor for popover
+     */
+    id: {
+      type: String,
+      default: getUniqueString(),
+    },
+
+    /**
+     * The fill and outline of the button associated with its visual importance.
+     */
+    importance: {
+      type: String,
+      default: 'primary',
+    },
+
+    /**
+     * The color of the button.
+     */
+    kind: {
+      type: String,
+      default: 'default',
+    },
+
+    /**
      * The size of the button.
-     * @values xs, sm, md, lg, xl
      */
     size: {
       type: String,
       default: 'md',
+    },
+
+    /**
+     * Text shown in tooltip when you hover the button
+     */
+    tooltipText: {
+      type: String,
+      default: '',
     },
   },
 

--- a/packages/dialtone-vue2/components/split_button/split_button.vue
+++ b/packages/dialtone-vue2/components/split_button/split_button.vue
@@ -155,12 +155,8 @@ export default {
 
     /**
      * HTML button disabled attribute
-     * <a
-     *   class="d-link"
-     *   href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled"
-     *   target="_blank"
-     * >
-     *   (Reference)
+     * <a class="d-link" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled" target="_blank">
+     *  (Reference)
      * </a>
      * @values true, false
      */

--- a/packages/dialtone-vue2/components/split_button/split_button.vue
+++ b/packages/dialtone-vue2/components/split_button/split_button.vue
@@ -7,7 +7,7 @@
     <split-button-alpha
       v-bind="alphaButtonProps"
       ref="alphaButton"
-      @click.native="(e) => $emit('alpha-clicked', e)"
+      @click.native="$emit('alpha-clicked')"
     >
       <template #icon="{ size: iconSize }">
         <!-- @slot Alpha (left) button icon slot -->
@@ -19,7 +19,7 @@
       <!-- @slot Default content slot -->
       <slot name="default" />
     </split-button-alpha>
-    <!-- @slot Omega (right) content slot -->
+    <!-- @slot Omega (right) content slot, overrides omega button styling and functionality completely -->
     <slot name="omega">
       <dt-dropdown
         v-if="$slots.dropdownList"
@@ -31,7 +31,7 @@
           <split-button-omega
             v-bind="{ ...attrs, ...omegaButtonProps }"
             :active="isDropdownOpen"
-            @click.native="(e) => $emit('omega-clicked', e)"
+            @click.native="$emit('omega-clicked')"
           >
             <template #icon="{ size: iconSize }">
               <!-- @slot Omega (right) button icon slot -->
@@ -43,7 +43,7 @@
           </split-button-omega>
         </template>
         <template #list="{ close }">
-          <!-- @slot Built-in dropdown contents -->
+          <!-- @slot Built-in dropdown content slot, use of dt-list-item is highly recommended here. -->
           <slot
             name="dropdownList"
             :close="close"
@@ -54,7 +54,7 @@
       <split-button-omega
         v-else
         v-bind="omegaButtonProps"
-        @click.native="(e) => $emit('omega-clicked', e)"
+        @click.native="$emit('omega-clicked')"
       >
         <template #icon="{ size: iconSize }">
           <!-- @slot Omega (right) button icon slot -->
@@ -88,10 +88,11 @@ export default {
     SplitButtonAlpha,
   },
 
+  inheritAttrs: false,
+
   props: {
     /**
      * Determines whether the alpha button should have active styling
-     * default is false.
      * @values true, false
      */
     alphaActive: {
@@ -135,7 +136,8 @@ export default {
     },
 
     /**
-     * Text shown in tooltip when you hover the alpha button
+     * Text shown in tooltip when you hover the alpha button,
+     * required if no content is passed to default slot
      */
     alphaTooltipText: {
       type: String,
@@ -145,7 +147,7 @@ export default {
     /**
      * Determines whether a screenreader reads live updates of
      * the button content to the user while the button
-     * is in focus. default is to not.
+     * is in focus.
      * @values true, false
      */
     assertiveOnFocus: {
@@ -196,7 +198,6 @@ export default {
 
     /**
      * Determines whether the omega button should have active styling
-     * default is false.
      * @values true, false
      */
     omegaActive: {
@@ -222,7 +223,8 @@ export default {
     },
 
     /**
-     * Text shown in tooltip when you hover the omega button
+     * Text shown in tooltip when you hover the omega button,
+     * required as it is an icon only button
      */
     omegaTooltipText: {
       type: String,
@@ -290,6 +292,7 @@ export default {
         kind: this.kind,
         size: this.size,
         tooltipText: this.alphaTooltipText,
+        class: this.$attrs.class,
       };
     },
 
@@ -303,6 +306,7 @@ export default {
         kind: this.kind,
         size: this.size,
         tooltipText: this.omegaTooltipText,
+        class: this.$attrs.class,
       };
     },
 
@@ -310,9 +314,9 @@ export default {
       return this.$scopedSlots.default && this.$scopedSlots.default() && this.$scopedSlots.default()[0]?.text?.trim();
     },
 
-    omegaSlotIsSet() {
+    omegaSlotIsSet () {
       return this.$scopedSlots.omega && this.$scopedSlots.omega();
-    }
+    },
   },
 
   created () {
@@ -324,10 +328,6 @@ export default {
   },
 
   methods: {
-    handleClick (side, event) {
-      this.$emit(`${side}-clicked`, event);
-    },
-
     validateProps () {
       this.validateAlphaButtonProps();
       this.validateOmegaButtonProps();

--- a/packages/dialtone-vue2/components/split_button/split_button_default.story.vue
+++ b/packages/dialtone-vue2/components/split_button/split_button_default.story.vue
@@ -44,12 +44,16 @@
         :size="size"
       />
     </template>
-    <template #dropdownList>
-      <ul>
-        <dt-list-item navigation-type="tab">
-          Some text
-        </dt-list-item>
-      </ul>
+    <template #dropdownList="{ close }">
+      <dt-list-item
+        v-for="option in options"
+        :key="option"
+        role="menuitem"
+        navigation-type="arrow-keys"
+        @click="close"
+      >
+        {{ option }}
+      </dt-list-item>
     </template>
     <template
       v-if="$attrs.omega"
@@ -68,5 +72,10 @@ import { DtListItem } from '@/components/list_item';
 export default {
   name: 'DtSplitButtonDefault',
   components: { DtSplitButton, DtIcon, DtListItem },
+  data () {
+    return {
+      options: ['Option 1', 'Option 2', 'Option 3'],
+    };
+  },
 };
 </script>

--- a/packages/dialtone-vue2/components/split_button/split_button_variants.story.vue
+++ b/packages/dialtone-vue2/components/split_button/split_button_variants.story.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable max-lines -->
 <template>
   <dt-stack
     gap="500"

--- a/packages/dialtone-vue3/.eslintrc.cjs
+++ b/packages/dialtone-vue3/.eslintrc.cjs
@@ -1,5 +1,5 @@
 const componentsList = require('../../common/components_list.cjs');
-componentsList.push('btn', 'select', 'validation-message', 'label', 'description');
+componentsList.push('btn', 'select', 'validation-message', 'label', 'description', 'split-btn');
 const componentsNames = componentsList.map(name => name.replace('_', '-').replace('.vue', ''));
 
 module.exports = {

--- a/packages/dialtone-vue3/components/button/button.vue
+++ b/packages/dialtone-vue3/components/button/button.vue
@@ -130,13 +130,7 @@ export default {
 
     /**
      * HTML button disabled attribute
-     * <a
-     *   class="d-link"
-     *   href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled"
-     *   target="_blank"
-     * >
-     *   (Reference)
-     * </a>
+     * <a class="d-link" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled" target="_blank"> (Reference) </a>
      * @values true, false
      */
     disabled: {

--- a/packages/dialtone-vue3/components/button/button.vue
+++ b/packages/dialtone-vue3/components/button/button.vue
@@ -335,11 +335,11 @@ export default {
     },
 
     shouldRenderIcon () {
-      return this.$slots.icon && !this.link;
+      return hasSlotContent(this.$slots.icon) && !this.link;
     },
 
     isIconOnly () {
-      return this.shouldRenderIcon() && !this.$slots.default;
+      return this.shouldRenderIcon() && !hasSlotContent(this.$slots.default);
     },
 
     isVerticalIconLayout () {

--- a/packages/dialtone-vue3/components/split_button/index.js
+++ b/packages/dialtone-vue3/components/split_button/index.js
@@ -1,0 +1,2 @@
+export { default as DtSplitButton } from './split_button.vue';
+export { SPLIT_BUTTON_ICON_SIZES } from './split_button_constants';

--- a/packages/dialtone-vue3/components/split_button/split_button-alpha.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button-alpha.vue
@@ -1,0 +1,134 @@
+<template>
+  <dt-button
+    v-dt-tooltip="tooltipText"
+    data-qa="dt-split-button-alpha"
+    :active="active"
+    :aria-label="ariaLabel"
+    :assertive-on-focus="assertiveOnFocus"
+    :class="`d-split-btn__alpha d-split-btn__alpha--${size}`"
+    :disabled="disabled"
+    :icon-position="iconPosition"
+    :importance="importance"
+    :kind="kind"
+    :label-class="labelClass"
+    :loading="loading"
+    :size="size"
+  >
+    <template #icon>
+      <slot
+        name="icon"
+        :size="BUTTON_ICON_SIZES[size]"
+      />
+    </template>
+    <slot name="default" />
+  </dt-button>
+</template>
+
+<script>
+import { BUTTON_ICON_SIZES, DtButton } from '@/components/button';
+
+export default {
+  name: 'SplitButtonAlpha',
+
+  components: {
+    DtButton,
+  },
+
+  props: {
+    /**
+     * Determines whether the button should have active styling
+     */
+    active: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Descriptive label for the button
+     */
+    ariaLabel: {
+      type: String,
+      default: null,
+    },
+
+    /**
+     * The position of the icon slot within the button.
+     */
+    iconPosition: {
+      type: String,
+      default: 'left',
+    },
+
+    /**
+     * Used to customize the label container
+     */
+    labelClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
+    /**
+     * Whether the button should display a loading animation or not.
+     */
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Text shown in tooltip when you hover the button
+     */
+    tooltipText: {
+      type: String,
+      default: '',
+    },
+
+    /**
+     * Determines whether a screenreader reads live updates of
+     * the button content to the user while the button is in focus.
+     */
+    assertiveOnFocus: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * HTML button disabled attribute
+     */
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * The fill and outline of the button associated with its visual importance.
+     */
+    importance: {
+      type: String,
+      default: 'primary',
+    },
+
+    /**
+     * The color of the button.
+     */
+    kind: {
+      type: String,
+      default: 'default',
+    },
+
+    /**
+     * The size of the button.
+     */
+    size: {
+      type: String,
+      default: 'md',
+    },
+  },
+
+  data () {
+    return {
+      BUTTON_ICON_SIZES,
+    };
+  },
+};
+</script>

--- a/packages/dialtone-vue3/components/split_button/split_button-omega.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button-omega.vue
@@ -1,0 +1,111 @@
+<template>
+  <dt-button
+    :id="id"
+    v-dt-tooltip="tooltipText"
+    data-qa="dt-split-button-omega"
+    :active="active"
+    :aria-label="ariaLabel"
+    :class="`d-split-btn__omega d-split-btn__omega--${size}`"
+    :disabled="disabled"
+    :importance="importance"
+    :kind="kind"
+    :size="size"
+  >
+    <template #icon>
+      <slot
+        name="icon"
+        :size="SPLIT_BUTTON_ICON_SIZES[size]"
+      >
+        <dt-icon-chevron-down :size="SPLIT_BUTTON_ICON_SIZES[size]" />
+      </slot>
+    </template>
+  </dt-button>
+</template>
+
+<script>
+import { SPLIT_BUTTON_ICON_SIZES } from './split_button_constants';
+import { DtButton } from '@/components/button';
+import { DtIconChevronDown } from '@dialpad/dialtone-icons/vue3';
+import { getUniqueString } from '@/common/utils';
+
+export default {
+  name: 'SplitButtonOmega',
+  components: {
+    DtButton,
+    DtIconChevronDown,
+  },
+
+  props: {
+    /**
+     * Determines whether the button should have active styling
+     */
+    active: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Descriptive label for the button
+     */
+    ariaLabel: {
+      type: String,
+      default: null,
+    },
+
+    /**
+     * HTML button disabled attribute
+     */
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Element ID, useful in case you need to reference the button
+     * as an external anchor for popover
+     */
+    id: {
+      type: String,
+      default: getUniqueString(),
+    },
+
+    /**
+     * The fill and outline of the button associated with its visual importance.
+     */
+    importance: {
+      type: String,
+      default: 'primary',
+    },
+
+    /**
+     * The color of the button.
+     */
+    kind: {
+      type: String,
+      default: 'default',
+    },
+
+    /**
+     * The size of the button.
+     */
+    size: {
+      type: String,
+      default: 'md',
+    },
+
+    /**
+     * Text shown in tooltip when you hover the button
+     */
+    tooltipText: {
+      type: String,
+      default: '',
+    },
+  },
+
+  data () {
+    return {
+      SPLIT_BUTTON_ICON_SIZES,
+    };
+  },
+};
+</script>

--- a/packages/dialtone-vue3/components/split_button/split_button.mdx
+++ b/packages/dialtone-vue3/components/split_button/split_button.mdx
@@ -1,0 +1,9 @@
+import { Meta } from '@storybook/blocks';
+import * as DtSplitButtonStories from './split_button.stories.js';
+import RedirectToDocs from "@/common/snippets/redirect-to-docs.mdx"
+
+<Meta of={DtSplitButtonStories} />
+
+# Split Button
+
+<RedirectToDocs name="split-button" />

--- a/packages/dialtone-vue3/components/split_button/split_button.stories.js
+++ b/packages/dialtone-vue3/components/split_button/split_button.stories.js
@@ -1,0 +1,177 @@
+import { action } from '@storybook/addon-actions';
+import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import DtSplitButton from './split_button.vue';
+import DtSplitButtonDefaultTemplate from './split_button_default.story.vue';
+import DtSplitButtonVariantsTemplate from './split_button_variants.story.vue';
+import {
+  BUTTON_SIZE_MODIFIERS,
+  BUTTON_KIND_MODIFIERS,
+  BUTTON_IMPORTANCE_MODIFIERS,
+  ICON_POSITION_MODIFIERS,
+} from '@/components/button';
+import { POPOVER_DIRECTIONS } from '../popover/popover_constants';
+
+const iconsList = getIconNames();
+
+// Set default values at the story level here.
+export const argsData = {
+  onAlphaClicked: action('alpha-clicked'),
+  onOmegaClicked: action('omega-clicked'),
+  omegaAriaLabel: 'Open dropdown',
+  default: 'Place call',
+  dropdownPlacement: 'bottom-end',
+  omegaTooltipText: 'More calling options',
+  alphaIcon: undefined,
+  omegaIcon: undefined,
+};
+
+export const argTypesData = {
+  // Slots
+  alphaIcon: {
+    options: iconsList,
+    table: {
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'select',
+      labels: {
+        undefined: '(empty)',
+      },
+    },
+  },
+
+  dropdownList: {
+    table: {
+      type: { summary: 'VNode' },
+    },
+  },
+
+  omega: {
+    table: {
+      type: { summary: 'VNode' },
+    },
+  },
+
+  omegaIcon: {
+    options: iconsList,
+    table: {
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'select',
+      labels: {
+        undefined: '(empty)',
+      },
+    },
+  },
+
+  default: {
+    table: {
+      type: { summary: 'VNode' },
+    },
+  },
+
+  // Props
+  assertiveOnFocus: {
+    control: 'boolean',
+  },
+
+  disabled: {
+    control: 'boolean',
+  },
+
+  importance: {
+    control: 'select',
+    options: Object.keys(BUTTON_IMPORTANCE_MODIFIERS),
+  },
+
+  kind: {
+    control: 'select',
+    options: Object.keys(BUTTON_KIND_MODIFIERS),
+  },
+
+  size: {
+    control: 'select',
+    options: Object.keys(BUTTON_SIZE_MODIFIERS),
+  },
+
+  alphaActive: {
+    control: 'boolean',
+  },
+
+  alphaIconPosition: {
+    control: 'select',
+    options: Object.keys(ICON_POSITION_MODIFIERS),
+  },
+
+  alphaLoading: {
+    control: 'boolean',
+  },
+
+  omegaActive: {
+    control: 'boolean',
+  },
+
+  dropdownPlacement: {
+    options: POPOVER_DIRECTIONS,
+    control: {
+      type: 'select',
+    },
+    table: {
+      defaultValue: {
+        summary: 'bottom',
+      },
+    },
+  },
+
+  // Action Event Handlers
+  onAlphaClicked: {
+    table: {
+      disable: true,
+    },
+  },
+
+  onOmegaClicked: {
+    table: {
+      disable: true,
+    },
+  },
+};
+
+// Story Collection
+export default {
+  title: 'Components/Split Button',
+  component: DtSplitButton,
+  args: argsData,
+  argTypes: argTypesData,
+  excludeStories: /.*Data$/,
+};
+
+// Templates
+const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  DtSplitButtonDefaultTemplate,
+);
+
+const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  DtSplitButtonVariantsTemplate,
+);
+
+export const Default = {
+  render: DefaultTemplate,
+
+  decorators: [
+    () => ({
+      template: `<div class="d-d-flex d-jc-center d-ai-center d-h164"><story /></div>`,
+    }),
+  ],
+};
+
+export const Variants = {
+  render: VariantsTemplate,
+
+  parameters: { options: { showPanel: false }, controls: { disable: true } },
+};

--- a/packages/dialtone-vue3/components/split_button/split_button.test.js
+++ b/packages/dialtone-vue3/components/split_button/split_button.test.js
@@ -1,0 +1,260 @@
+import { mount } from '@vue/test-utils';
+import DtSplitButton from './split_button.vue';
+import SplitButtonAlpha from './split_button-alpha.vue';
+import SplitButtonOmega from './split_button-omega.vue';
+import { DtIconSend } from '@dialpad/dialtone-icons/vue3';
+import { DtTooltipDirective } from '@/directives/tooltip';
+
+const MOCK_ALPHA_BUTTON_STUB = vi.fn();
+const MOCK_OMEGA_BUTTON_STUB = vi.fn();
+const MOCK_ALPHA_TOOLTIP_TEXT = 'Alpha tooltip text';
+const MOCK_OMEGA_TOOLTIP_TEXT = 'Omega tooltip text';
+
+const baseProps = {
+  omegaTooltipText: MOCK_OMEGA_TOOLTIP_TEXT,
+};
+const baseSlots = {
+  default: () => 'Button text',
+};
+const baseAttrs = {};
+
+let mockProps = {};
+let mockSlots = {};
+let mockAttrs = {};
+
+describe('DtSplitButton Tests', function () {
+  let wrapper;
+  let alphaButton;
+  let omegaButton;
+  let alphaIconSlot;
+  let omegaIconSlot;
+
+  const updateWrapper = () => {
+    wrapper = mount(DtSplitButton, {
+      props: { ...baseProps, ...mockProps },
+      slots: { ...baseSlots, ...mockSlots },
+      global: {
+        stubs: {
+          transition: false,
+        },
+        plugins: [DtTooltipDirective],
+        components: {
+          SplitButtonAlpha,
+          SplitButtonOmega,
+          DtIconSend,
+        },
+      },
+      attrs: { ...baseAttrs, ...mockAttrs },
+      attachTo: document.body,
+    });
+
+    alphaButton = wrapper.find('[data-qa="dt-split-button-alpha"]');
+    alphaIconSlot = alphaButton.find('[data-qa="dt-button-icon"]');
+    omegaButton = wrapper.find('[data-qa="dt-split-button-omega"]');
+    omegaIconSlot = omegaButton.find('[data-qa="dt-button-icon"]');
+  };
+
+  beforeAll(() => {
+    // RequestAnimationFrame and cancelAnimationFrame are undefined in the scope
+    // Need to mock them to avoid error
+    global.requestAnimationFrame = vi.fn();
+    global.cancelAnimationFrame = vi.fn();
+  });
+
+  beforeEach(() => {
+    updateWrapper();
+  });
+
+  afterAll(() => {
+    // Restore RequestAnimationFrame and cancelAnimationFrame
+    global.requestAnimationFrame = undefined;
+    global.cancelAnimationFrame = undefined;
+  });
+
+  afterEach(() => {
+    mockProps = {};
+    mockSlots = {};
+    mockAttrs = {};
+    wrapper.unmount();
+  });
+
+  describe('Presentation Tests', () => {
+    describe('When rendered with default props', () => {
+      it('Should render the component', () => {
+        expect(wrapper.exists()).toBe(true);
+        expect(alphaButton.exists()).toBe(true);
+        expect(omegaButton.exists()).toBe(true);
+        expect(omegaIconSlot.exists()).toBe(true);
+      });
+
+      it('Should render primary by default', async () => {
+        // Default (no props) button should be d-btn--primary
+        expect(alphaButton.classes().includes('d-btn--primary')).toBe(true);
+        expect(omegaButton.classes().includes('d-btn--primary')).toBe(true);
+      });
+    });
+
+    describe('When kind is set to danger', () => {
+      it('Should have danger class', async () => {
+        mockProps = { kind: 'danger' };
+
+        updateWrapper();
+
+        expect(alphaButton.classes().includes('d-btn--danger')).toBe(true);
+        expect(omegaButton.classes().includes('d-btn--danger')).toBe(true);
+      });
+    });
+
+    describe('When importance is set to outlined', () => {
+      it('Should have outlined class', async () => {
+        mockProps = { importance: 'outlined' };
+
+        updateWrapper();
+
+        expect(alphaButton.classes().includes('d-btn--outlined')).toBe(true);
+        expect(omegaButton.classes().includes('d-btn--outlined')).toBe(true);
+      });
+    });
+
+    describe('When loading is set to true', () => {
+      it('Should have loading class', async () => {
+        mockProps = { alphaLoading: true };
+
+        updateWrapper();
+
+        expect(alphaButton.classes().includes('d-btn--loading')).toBe(true);
+      });
+    });
+
+    describe('When alpha-active is set to true', () => {
+      it('Should have active class', async () => {
+        mockProps = { alphaActive: true };
+
+        updateWrapper();
+
+        expect(alphaButton.classes().includes('d-btn--active')).toBe(true);
+      });
+    });
+
+    describe('When omega-active is set to true', () => {
+      it('Should have active class', async () => {
+        mockProps = { omegaActive: true };
+
+        updateWrapper();
+
+        expect(omegaButton.classes().includes('d-btn--active')).toBe(true);
+      });
+    });
+
+    describe('When size is set to xl', () => {
+      it('Class is set to the correct size', async () => {
+        mockProps = { size: 'xl' };
+
+        updateWrapper();
+
+        expect(alphaButton.classes().includes('d-btn--xl')).toBe(true);
+        expect(omegaButton.classes().includes('d-btn--xl')).toBe(true);
+      });
+    });
+
+    describe('When alphaIcon slot is set', () => {
+      beforeEach(() => {
+        mockSlots = { alphaIcon: '<dt-icon-send />' };
+
+        updateWrapper();
+      });
+
+      it('Should render the custom icon', () => {
+        expect(alphaIconSlot.findComponent(DtIconSend).classes().includes('d-icon--send')).toBe(true);
+      });
+
+      it('Should render left by default', () => {
+        expect(alphaIconSlot.classes().includes('d-btn__icon--left')).toBe(true);
+      });
+
+      describe('When alpha-icon-position is set to right', () => {
+        it('Should have correct class', () => {
+          mockProps = { alphaIconPosition: 'right' };
+
+          updateWrapper();
+
+          expect(alphaIconSlot.classes().includes('d-btn__icon--right')).toBe(true);
+        });
+      });
+    });
+
+    describe('When omegaIcon slot is set', () => {
+      beforeEach(() => {
+        mockSlots = { omegaIcon: '<dt-icon-send />' };
+
+        updateWrapper();
+      });
+
+      it('should render the custom icon', () => {
+        expect(omegaIconSlot.findComponent(DtIconSend).classes().includes('d-icon--send')).toBe(true);
+      });
+    });
+
+    describe('When alpha-tooltip-text is set', () => {
+      it('Should render the tooltip with correct text', async () => {
+        mockProps = { alphaTooltipText: MOCK_ALPHA_TOOLTIP_TEXT };
+        await updateWrapper();
+        await alphaButton.trigger('mouseenter');
+
+        const tooltip = document.body.querySelector('[data-qa="dt-tooltip"]');
+
+        expect(tooltip.textContent.trim()).toBe(MOCK_ALPHA_TOOLTIP_TEXT);
+      });
+    });
+
+    describe('When omega-tooltip-text is set', () => {
+      it('Should render the tooltip with correct text', async () => {
+        mockProps = { omegaTooltipText: MOCK_OMEGA_TOOLTIP_TEXT };
+        await updateWrapper();
+        await omegaButton.trigger('mouseenter');
+
+        const tooltip = document.body.querySelector('[data-qa="dt-tooltip"]');
+
+        expect(tooltip.textContent.trim()).toBe(MOCK_OMEGA_TOOLTIP_TEXT);
+      });
+    });
+  });
+
+  describe('Interactivity Tests', () => {
+    describe('When alpha button is clicked', () => {
+      beforeEach(async () => {
+        mockAttrs = { onAlphaClicked: MOCK_ALPHA_BUTTON_STUB };
+
+        updateWrapper();
+
+        await alphaButton.trigger('click');
+      });
+
+      it('Should call listener', async () => {
+        expect(MOCK_ALPHA_BUTTON_STUB).toHaveBeenCalledTimes(1);
+      });
+
+      it('Should emit alpha-clicked event', () => {
+        expect(wrapper.emitted()).toHaveProperty('alpha-clicked');
+      });
+    });
+
+    describe('When omega button is clicked', () => {
+      beforeEach(async () => {
+        mockAttrs = { onOmegaClicked: MOCK_OMEGA_BUTTON_STUB };
+
+        updateWrapper();
+
+        await omegaButton.trigger('click');
+      });
+
+      it('Should call listener', async () => {
+        expect(MOCK_OMEGA_BUTTON_STUB).toHaveBeenCalledTimes(1);
+      });
+
+      it('Should emit omega-clicked event', () => {
+        expect(wrapper.emitted()).toHaveProperty('omega-clicked');
+      });
+    });
+  });
+});

--- a/packages/dialtone-vue3/components/split_button/split_button.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button.vue
@@ -1,0 +1,350 @@
+<template>
+  <span
+    data-qa="dt-split-button"
+    class="d-split-btn"
+    :style="{ width }"
+  >
+    <split-button-alpha
+      v-bind="alphaButtonProps"
+      ref="alphaButton"
+      @click="$emit('alpha-clicked')"
+    >
+      <template #icon="{ size: iconSize }">
+        <!-- @slot Alpha (left) button icon slot -->
+        <slot
+          name="alphaIcon"
+          :size="iconSize"
+        />
+      </template>
+      <!-- @slot Default content slot -->
+      <slot name="default" />
+    </split-button-alpha>
+    <!-- @slot Omega (right) content slot -->
+    <slot name="omega">
+      <dt-dropdown
+        v-if="$slots.dropdownList"
+        :placement="dropdownPlacement"
+        @click="isDropdownOpen = true"
+        @opened="open => isDropdownOpen = open"
+      >
+        <template #anchor="attrs">
+          <split-button-omega
+            v-bind="{ ...attrs, ...omegaButtonProps }"
+            :active="isDropdownOpen"
+            @click="$emit('omega-clicked')"
+          >
+            <template #icon="{ size: iconSize }">
+              <!-- @slot Omega (right) button icon slot -->
+              <slot
+                name="omegaIcon"
+                :size="iconSize"
+              />
+            </template>
+          </split-button-omega>
+        </template>
+        <template #list="{ close }">
+          <!-- @slot Built-in dropdown contents -->
+          <slot
+            name="dropdownList"
+            :close="close"
+          />
+        </template>
+      </dt-dropdown>
+
+      <split-button-omega
+        v-else
+        v-bind="omegaButtonProps"
+        @click="$emit('omega-clicked')"
+      >
+        <template #icon="{ size: iconSize }">
+          <!-- @slot Omega (right) button icon slot -->
+          <slot
+            name="omegaIcon"
+            :size="iconSize"
+          />
+        </template>
+      </split-button-omega>
+    </slot>
+  </span>
+</template>
+
+<script>
+import {
+  BUTTON_IMPORTANCE_MODIFIERS,
+  BUTTON_KIND_MODIFIERS,
+  BUTTON_SIZE_MODIFIERS,
+  ICON_POSITION_MODIFIERS,
+} from '@/components/button';
+import SplitButtonAlpha from './split_button-alpha.vue';
+import SplitButtonOmega from './split_button-omega.vue';
+import { DtDropdown } from '@/components/dropdown';
+import { hasSlotContent } from '@/common/utils';
+
+export default {
+  name: 'DtSplitButton',
+
+  components: {
+    SplitButtonOmega,
+    DtDropdown,
+    SplitButtonAlpha,
+  },
+
+  props: {
+    /**
+     * Determines whether the alpha button should have active styling
+     * default is false.
+     * @values true, false
+     */
+    alphaActive: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Descriptive label for the alpha button
+     */
+    alphaAriaLabel: {
+      type: String,
+      default: null,
+    },
+
+    /**
+     * The position of the icon slot within the alpha button.
+     * @values left, right, top, bottom
+     */
+    alphaIconPosition: {
+      type: String,
+      default: 'left',
+      validator: (position) => Object.keys(ICON_POSITION_MODIFIERS).includes(position),
+    },
+
+    /**
+     * Used to customize the alpha label container
+     */
+    alphaLabelClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
+    /**
+     * Whether the alpha button should display a loading animation or not.
+     * @values true, false
+     */
+    alphaLoading: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Text shown in tooltip when you hover the alpha button
+     */
+    alphaTooltipText: {
+      type: String,
+      default: undefined,
+    },
+
+    /**
+     * Determines whether a screenreader reads live updates of
+     * the button content to the user while the button
+     * is in focus. default is to not.
+     * @values true, false
+     */
+    assertiveOnFocus: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * HTML button disabled attribute
+     * <a
+     *   class="d-link"
+     *   href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled"
+     *   target="_blank"
+     * >
+     *   (Reference)
+     * </a>
+     * @values true, false
+     */
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * The direction the dropdown displays relative to the anchor.
+     * @values top, top-start, top-end, right, right-start, right-end, left, left-start, left-end, bottom, bottom-start, bottom-end, auto, auto-start, auto-end
+     */
+    dropdownPlacement: {
+      type: String,
+      default: 'bottom-end',
+    },
+
+    /**
+     * The fill and outline of the button associated with its visual importance.
+     * @values clear, outlined, primary
+     */
+    importance: {
+      type: String,
+      default: 'primary',
+      validator: (i) => Object.keys(BUTTON_IMPORTANCE_MODIFIERS).includes(i),
+    },
+
+    /**
+     * The color of the button.
+     * @values default, muted, danger, inverted
+     */
+    kind: {
+      type: String,
+      default: 'default',
+      validator: (k) => Object.keys(BUTTON_KIND_MODIFIERS).includes(k),
+    },
+
+    /**
+     * Determines whether the omega button should have active styling
+     * default is false.
+     * @values true, false
+     */
+    omegaActive: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Descriptive label for the omega button
+     */
+    omegaAriaLabel: {
+      type: String,
+      default: null,
+    },
+
+    /**
+     * Element ID, useful in case you need to reference the button
+     * as an external anchor for popover
+     */
+    omegaId: {
+      type: String,
+      default: undefined,
+    },
+
+    /**
+     * Text shown in tooltip when you hover the omega button
+     */
+    omegaTooltipText: {
+      type: String,
+      default: undefined,
+    },
+
+    /**
+     * The size of the button.
+     * @values xs, sm, md, lg, xl
+     */
+    size: {
+      type: String,
+      default: 'md',
+      validator: (s) => Object.keys(BUTTON_SIZE_MODIFIERS).includes(s),
+    },
+
+    /**
+     * Button width, accepts
+     * <a class="d-link" href="https://developer.mozilla.org/en-US/docs/Web/CSS/width" target="_blank">
+     *   CSS width attribute
+     * </a>
+     * values
+     */
+    width: {
+      type: String,
+      default: null,
+    },
+  },
+
+  emits: [
+    /**
+     * Native alpha button click event
+     *
+     * @event click
+     * @type {PointerEvent | KeyboardEvent}
+     */
+    'alpha-clicked',
+
+    /**
+     * Native omega button click event
+     *
+     * @event click
+     * @type {PointerEvent | KeyboardEvent}
+     */
+    'omega-clicked',
+  ],
+
+  data () {
+    return {
+      isDropdownOpen: false,
+    };
+  },
+
+  computed: {
+    alphaButtonProps () {
+      return {
+        active: this.alphaActive,
+        ariaLabel: this.alphaAriaLabel,
+        assertiveOnFocus: this.assertiveOnFocus,
+        disabled: this.disabled,
+        iconPosition: this.alphaIconPosition,
+        labelClass: this.alphaLabelClass,
+        loading: this.alphaLoading,
+        importance: this.importance,
+        kind: this.kind,
+        size: this.size,
+        tooltipText: this.alphaTooltipText,
+      };
+    },
+
+    omegaButtonProps () {
+      return {
+        id: this.omegaId,
+        active: this.omegaActive,
+        ariaLabel: this.omegaAriaLabel,
+        disabled: this.disabled,
+        importance: this.importance,
+        kind: this.kind,
+        size: this.size,
+        tooltipText: this.omegaTooltipText,
+      };
+    },
+  },
+
+  created () {
+    this.validateProps();
+  },
+
+  updated () {
+    this.validateProps();
+  },
+
+  methods: {
+    handleClick (side, event) {
+      this.$emit(`${side}-clicked`, event);
+    },
+
+    validateProps () {
+      this.validateAlphaButtonProps();
+      this.validateOmegaButtonProps();
+    },
+
+    validateAlphaButtonProps () {
+      if (hasSlotContent(this.$slots.default)) return;
+
+      if (hasSlotContent(this.$slots.alphaIcon) && !this.alphaTooltipText) {
+        console.warn('alpha-tooltip-text prop must be set if alpha button has an icon only');
+      }
+    },
+
+    validateOmegaButtonProps () {
+      if (hasSlotContent(this.$slots.omega)) return;
+
+      if (!this.omegaTooltipText) {
+        console.warn('omega-tooltip-text prop is required as it is an icon-only button');
+      }
+    },
+  },
+};
+</script>

--- a/packages/dialtone-vue3/components/split_button/split_button.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button.vue
@@ -19,7 +19,7 @@
       <!-- @slot Default content slot -->
       <slot name="default" />
     </split-button-alpha>
-    <!-- @slot Omega (right) content slot -->
+    <!-- @slot Omega (right) content slot, overrides omega button styling and functionality completely -->
     <slot name="omega">
       <dt-dropdown
         v-if="$slots.dropdownList"
@@ -43,7 +43,7 @@
           </split-button-omega>
         </template>
         <template #list="{ close }">
-          <!-- @slot Built-in dropdown contents -->
+          <!-- @slot Built-in dropdown content slot, use of dt-list-item is highly recommended here. -->
           <slot
             name="dropdownList"
             :close="close"
@@ -89,10 +89,11 @@ export default {
     SplitButtonAlpha,
   },
 
+  inheritAttrs: false,
+
   props: {
     /**
      * Determines whether the alpha button should have active styling
-     * default is false.
      * @values true, false
      */
     alphaActive: {
@@ -136,7 +137,8 @@ export default {
     },
 
     /**
-     * Text shown in tooltip when you hover the alpha button
+     * Text shown in tooltip when you hover the alpha button,
+     * required if no content is passed to default slot
      */
     alphaTooltipText: {
       type: String,
@@ -146,7 +148,7 @@ export default {
     /**
      * Determines whether a screenreader reads live updates of
      * the button content to the user while the button
-     * is in focus. default is to not.
+     * is in focus.
      * @values true, false
      */
     assertiveOnFocus: {
@@ -197,7 +199,6 @@ export default {
 
     /**
      * Determines whether the omega button should have active styling
-     * default is false.
      * @values true, false
      */
     omegaActive: {
@@ -215,7 +216,7 @@ export default {
 
     /**
      * Element ID, useful in case you need to reference the button
-     * as an external anchor for popover
+     * as an external anchor for popover.
      */
     omegaId: {
       type: String,
@@ -223,7 +224,8 @@ export default {
     },
 
     /**
-     * Text shown in tooltip when you hover the omega button
+     * Text shown in tooltip when you hover the omega button,
+     * required as it is an icon only button
      */
     omegaTooltipText: {
       type: String,
@@ -291,6 +293,7 @@ export default {
         kind: this.kind,
         size: this.size,
         tooltipText: this.alphaTooltipText,
+        class: this.$attrs.class,
       };
     },
 
@@ -304,6 +307,7 @@ export default {
         kind: this.kind,
         size: this.size,
         tooltipText: this.omegaTooltipText,
+        class: this.$attrs.class,
       };
     },
   },
@@ -317,10 +321,6 @@ export default {
   },
 
   methods: {
-    handleClick (side, event) {
-      this.$emit(`${side}-clicked`, event);
-    },
-
     validateProps () {
       this.validateAlphaButtonProps();
       this.validateOmegaButtonProps();

--- a/packages/dialtone-vue3/components/split_button/split_button.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button.vue
@@ -156,12 +156,8 @@ export default {
 
     /**
      * HTML button disabled attribute
-     * <a
-     *   class="d-link"
-     *   href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled"
-     *   target="_blank"
-     * >
-     *   (Reference)
+     * <a class="d-link" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled" target="_blank">
+     *  (Reference)
      * </a>
      * @values true, false
      */

--- a/packages/dialtone-vue3/components/split_button/split_button_constants.js
+++ b/packages/dialtone-vue3/components/split_button/split_button_constants.js
@@ -1,0 +1,11 @@
+export const SPLIT_BUTTON_ICON_SIZES = {
+  xs: '100',
+  sm: '100',
+  md: '200',
+  lg: '200',
+  xl: '300',
+};
+
+export default {
+  SPLIT_BUTTON_ICON_SIZES,
+};

--- a/packages/dialtone-vue3/components/split_button/split_button_default.story.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button_default.story.vue
@@ -1,0 +1,81 @@
+<template>
+  <dt-split-button
+    :alpha-active="$attrs.alphaActive"
+    :alpha-aria-label="$attrs.alphaAriaLabel"
+    :alpha-icon-position="$attrs.alphaIconPosition"
+    :alpha-label-class="$attrs.alphaLabelClass"
+    :alpha-loading="$attrs.alphaLoading"
+    :alpha-tooltip-text="$attrs.alphaTooltipText"
+    :dropdown-placement="$attrs.dropdownPlacement"
+    :assertive-on-focus="$attrs.assertiveOnFocus"
+    :disabled="$attrs.disabled"
+    :importance="$attrs.importance"
+    :kind="$attrs.kind"
+    :omega-active="$attrs.omegaActive"
+    :omega-aria-label="$attrs.omegaAriaLabel"
+    :omega-id="$attrs.omegaId"
+    :omega-tooltip-text="$attrs.omegaTooltipText"
+    :size="$attrs.size"
+    :width="$attrs.width"
+    @alpha-clicked="$attrs.onAlphaClicked"
+    @omega-clicked="$attrs.onOmegaClicked"
+  >
+    <template
+      v-if="defaultSlot"
+      #default
+    >
+      {{ defaultSlot }}
+    </template>
+    <template
+      v-if="$attrs.alphaIcon"
+      #alphaIcon="{ size }"
+    >
+      <dt-icon
+        :name="$attrs.alphaIcon"
+        :size="size"
+      />
+    </template>
+    <template
+      v-if="$attrs.omegaIcon"
+      #omegaIcon="{ size }"
+    >
+      <dt-icon
+        :name="$attrs.omegaIcon"
+        :size="size"
+      />
+    </template>
+    <template #dropdownList="{ close }">
+      <dt-list-item
+        v-for="option in options"
+        :key="option"
+        role="menuitem"
+        navigation-type="arrow-keys"
+        @click="close"
+      >
+        {{ option }}
+      </dt-list-item>
+    </template>
+    <template
+      v-if="$attrs.omega"
+      #omega
+    >
+      <span v-html="$attrs.omega" />
+    </template>
+  </dt-split-button>
+</template>
+
+<script>
+import DtSplitButton from './split_button.vue';
+import { DtIcon } from '@/components/icon';
+import { DtListItem } from '@/components/list_item';
+
+export default {
+  name: 'DtSplitButtonDefault',
+  components: { DtSplitButton, DtIcon, DtListItem },
+  data () {
+    return {
+      options: ['Option 1', 'Option 2', 'Option 3'],
+    };
+  },
+};
+</script>

--- a/packages/dialtone-vue3/components/split_button/split_button_variants.story.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button_variants.story.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable max-lines -->
 <template>
   <dt-stack
     gap="500"

--- a/packages/dialtone-vue3/components/split_button/split_button_variants.story.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button_variants.story.vue
@@ -1,0 +1,352 @@
+<!-- eslint-disable max-lines -->
+<template>
+  <dt-stack
+    gap="500"
+    class="d-px8"
+  >
+    <h2>Variants</h2>
+    <table class="d-table d-bt d-bb d-bbw2 d-bc-default">
+      <thead>
+        <tr>
+          <td class="d-ba d-bc-default">
+            &nbsp;
+          </td>
+          <th
+            v-for="importance in importances"
+            :key="importance"
+            class="d-ta-center d-br d-bc-default"
+          >
+            {{ importance }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="kind in kinds"
+          :key="kind"
+          :class="{ 'd-bgc-contrast': kind === 'inverted' }"
+        >
+          <th
+            class="d-ta-right d-ba d-brw2 d-bc-default"
+            scope="row"
+            :class="{ 'd-bc-default-inverted d-fc-primary-inverted': kind === 'inverted' }"
+          >
+            <span
+              class="d-headline--eyebrow"
+              v-text="kind"
+            />
+          </th>
+          <td
+            v-for="importance in importances"
+            :key="`${kind}-${importance}`"
+            class="d-ta-center d-br"
+            :class="[kind === 'inverted' ? 'd-bc-default-inverted' : 'd-bc-default']"
+          >
+            <abbr
+              v-if="isInvalidCombination({ kind, importance })"
+              class="d-td-none d-fs-100"
+              title="Not applicable"
+            >N/A</abbr>
+            <dt-stack
+              v-else
+              gap="500"
+              class="d-jc-center"
+            >
+              <div>
+                <dt-split-button
+                  size="xs"
+                  :kind="kind"
+                  :importance="importance"
+                  :omega-tooltip-text="omegaTooltipText"
+                  :omega-aria-label="omegaAriaLabel"
+                >
+                  Place call
+                  <template #dropdownList>
+                    <dt-list-item
+                      v-for="item in listItems"
+                      :key="item.id"
+                      role="menuitem"
+                      navigation-type="arrow-keys"
+                    >
+                      {{ item.text }}
+                    </dt-list-item>
+                  </template>
+                </dt-split-button>
+              </div>
+            </dt-stack>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <dt-stack
+      direction="row"
+      gap="500"
+      class="d-ai-stretch d-jc-flex-start d-fw-wrap"
+    >
+      <!-- Sizes  -->
+      <dt-stack
+        gap="500"
+        class="d-br d-bc-default d-pr16"
+      >
+        <h2>Sizes</h2>
+        <dt-stack gap="500">
+          <div
+            v-for="size in Object.keys(sizes)"
+            :key="size"
+            class="d-ta-center"
+          >
+            <dt-split-button
+              :size="size"
+              :omega-tooltip-text="omegaTooltipText"
+              :omega-aria-label="omegaAriaLabel"
+            >
+              <span
+                class="d-tt-capitalize"
+                v-text="sizes[size]"
+              />
+            </dt-split-button>
+          </div>
+        </dt-stack>
+      </dt-stack>
+      <!-- With alpha icon  -->
+      <dt-stack
+        gap="500"
+        class="d-br d-bc-default d-pr16"
+      >
+        <h2>With alpha icon</h2>
+        <dt-stack gap="500">
+          <div
+            v-for="position in iconPositions"
+            :key="position"
+            class="d-ta-center"
+          >
+            <dt-split-button
+              size="xs"
+              :alpha-icon-position="position"
+              :omega-tooltip-text="omegaTooltipText"
+              :omega-aria-label="omegaAriaLabel"
+            >
+              <span
+                class="d-tt-capitalize"
+                v-text="position"
+              />
+              <template #alphaIcon>
+                <dt-icon
+                  name="accessibility"
+                  size="300"
+                />
+              </template>
+            </dt-split-button>
+          </div>
+        </dt-stack>
+      </dt-stack>
+      <!-- With custom omega icon  -->
+      <dt-stack
+        gap="500"
+        class="d-br d-bc-default d-pr16"
+      >
+        <h2>With custom omega icon</h2>
+        <dt-stack gap="500">
+          <div
+            v-for="size in Object.keys(sizes)"
+            :key="size"
+            class="d-ta-center"
+          >
+            <dt-split-button
+              :size="size"
+              omega-tooltip-text="Close"
+              :omega-aria-label="omegaAriaLabel"
+            >
+              Place call
+              <template #omegaIcon="{ size: iconSize }">
+                <dt-icon
+                  name="close"
+                  :size="iconSize"
+                />
+              </template>
+            </dt-split-button>
+          </div>
+        </dt-stack>
+      </dt-stack>
+      <!-- Status  -->
+      <dt-stack
+        gap="500"
+        class="d-br d-bc-default d-pr16"
+      >
+        <h2>Status</h2>
+        <dt-stack gap="500">
+          <dt-split-button
+            size="xs"
+            :alpha-active="true"
+            :omega-tooltip-text="omegaTooltipText"
+            :omega-aria-label="omegaAriaLabel"
+          >
+            Alpha active
+          </dt-split-button>
+          <dt-split-button
+            size="xs"
+            :omega-active="true"
+            :omega-tooltip-text="omegaTooltipText"
+            :omega-aria-label="omegaAriaLabel"
+          >
+            Omega active
+          </dt-split-button>
+          <dt-split-button
+            size="xs"
+            :alpha-active="true"
+            :omega-active="true"
+            :omega-tooltip-text="omegaTooltipText"
+            :omega-aria-label="omegaAriaLabel"
+          >
+            Both active
+          </dt-split-button>
+          <dt-split-button
+            size="xs"
+            :alpha-loading="true"
+            alpha-aria-label="loading"
+            :omega-tooltip-text="omegaTooltipText"
+            :omega-aria-label="omegaAriaLabel"
+          />
+        </dt-stack>
+      </dt-stack>
+      <!-- With tooltip -->
+      <dt-stack
+        gap="500"
+        class="d-br d-bc-default d-pr16"
+      >
+        <h2>With tooltip</h2>
+        <dt-stack gap="500">
+          <dt-split-button
+            size="xs"
+            alpha-tooltip-text="Hover text"
+            :omega-tooltip-text="omegaTooltipText"
+            :omega-aria-label="omegaAriaLabel"
+          >
+            Hover me
+          </dt-split-button>
+          <dt-split-button
+            size="xs"
+            :omega-tooltip-text="omegaTooltipText"
+            :omega-aria-label="omegaAriaLabel"
+          >
+            Hover omega
+          </dt-split-button>
+          <dt-split-button
+            size="xs"
+            alpha-tooltip-text="Alpha tooltip"
+            :omega-tooltip-text="omegaTooltipText"
+            :omega-aria-label="omegaAriaLabel"
+          >
+            Hover both
+          </dt-split-button>
+        </dt-stack>
+      </dt-stack>
+      <!-- Icon-only  -->
+      <dt-stack
+        gap="500"
+        class="d-br d-bc-default d-pr16"
+      >
+        <h2>Icon only</h2>
+        <dt-stack gap="500">
+          <div
+            v-for="size in Object.keys(sizes)"
+            :key="`icon-only-${size}`"
+            class="d-ta-center"
+          >
+            <dt-split-button
+              alpha-tooltip-text="Call"
+              alpha-aria-label="Call"
+              :omega-tooltip-text="omegaTooltipText"
+              :size="size"
+              :omega-aria-label="omegaAriaLabel"
+            >
+              <template #alphaIcon="{ size: iconSize }">
+                <dt-icon
+                  name="phone"
+                  :size="iconSize"
+                />
+              </template>
+            </dt-split-button>
+          </div>
+        </dt-stack>
+      </dt-stack>
+      <!-- External anchor -->
+      <dt-stack>
+        <h2>External anchor</h2>
+        <div>
+          <dt-split-button
+            omega-id="external-anchor-example"
+            omega-tooltip-text="Open popover"
+            :omega-aria-label="omegaAriaLabel"
+            @omega-clicked="isPopoverShown = true"
+          >
+            External anchor example
+          </dt-split-button>
+        </div>
+
+        <dt-popover
+          external-anchor="external-anchor-example"
+          :open.sync="isPopoverShown"
+        >
+          <template #content>
+            <ul>
+              <li>Custom popover Content</li>
+            </ul>
+          </template>
+        </dt-popover>
+      </dt-stack>
+    </dt-stack>
+  </dt-stack>
+</template>
+
+<script>
+/* eslint-disable max-lines */
+import { DtSplitButton } from './';
+import { DtStack } from '@/components/stack';
+import { DtIcon } from '@/components/icon';
+import { DtListItem } from '@/components/list_item';
+import { DtPopover } from '@/components/popover';
+
+export default {
+  name: 'DtSplitButtonVariants',
+  components: {
+    DtSplitButton,
+    DtStack,
+    DtIcon,
+    DtListItem,
+    DtPopover,
+  },
+
+  data () {
+    return {
+      sizes: { xs: 'extra small', sm: 'small', md: 'medium', lg: 'large', xl: 'extra large' },
+      kinds: ['default', 'danger', 'inverted', 'muted'],
+      importances: ['clear', 'outlined', 'primary'],
+      iconPositions: ['left', 'right', 'top', 'bottom'],
+      listItems: [
+        { id: 1, text: 'First item' },
+        { id: 2, text: 'Second item' },
+        { id: 3, text: 'Third item' },
+      ],
+
+      isPopoverShown: false,
+      omegaTooltipText: 'More calling options',
+      omegaAriaLabel: 'More calling options',
+    };
+  },
+
+  beforeMount () {
+    this.invalidCombinations = [
+      { kind: 'muted', importance: 'primary' },
+    ];
+  },
+
+  methods: {
+    isInvalidCombination (item) {
+      return this.invalidCombinations.some(combination =>
+        combination.kind === item.kind && combination.importance === item.importance,
+      );
+    },
+  },
+};
+</script>

--- a/packages/dialtone-vue3/index.js
+++ b/packages/dialtone-vue3/index.js
@@ -60,6 +60,7 @@ export * from './components/root_layout';
 export * from './components/scroller';
 export * from './components/select_menu';
 export * from './components/skeleton';
+export * from './components/split_button';
 export * from './components/stack';
 export * from './components/tabs';
 export * from './components/toast';


### PR DESCRIPTION
# Split button - Vue 3

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZXA3dTZsdGR6dHhjdXhodGd3ZDBkc2VneTFnbWFjZ3ZvejdkOXE3NSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l4JyJHAF8blvfplf2/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1819

## :book: Description

- Vue 3 version of #420
- Added examples to documentation

## :bulb: Context

Documentation of this component was waiting for the vue 3 version to be ready to be able to create examples.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

- Add missing content @francisrupert, @fede-dp can you help me with that please? Added the examples but don't know what to add related to more complete component descriptions and information.

## :camera: Screenshots / GIFs

<img width="2168" alt="Screenshot 2024-08-09 at 1 31 39 p m" src="https://github.com/user-attachments/assets/87e6bd4b-a993-4963-b767-3ce632931fed">


https://dialtone.dialpad.com/deploy-previews/pr-438/components/split-button.html
https://dialtone.dialpad.com/vue3/deploy-previews/pr-438/?path=/story/components-split-button--default
https://dialtone.dialpad.com/vue3/deploy-previews/pr-438/?path=/story/components-split-button--variants