### PR TITLE
Revert "fix(rich-text-editor): DLT-1822 fix hard break default configuration for rich text editor"

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -411,15 +411,7 @@ export default {
           }),
         );
       } else {
-        extensions.push(HardBreak.extend({
-          addKeyboardShortcuts () {
-            return {
-              Enter: () => {
-                this.editor.commands.setHardBreak();
-              },
-            };
-          },
-        }));
+        extensions.push(HardBreak);
       }
 
       if (this.mentionSuggestion) {

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.test.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.test.js
@@ -580,18 +580,6 @@ describe('DtRecipeEditor tests', () => {
       });
     });
 
-    describe('When enter key is pressed', () => {
-      it('editor should add br tag html content', async () => {
-        let editorHtmlOutput = editor.html();
-        expect(editorHtmlOutput).not.toContain('<br>');
-        await editor.trigger('keydown.enter');
-        await wrapper.vm.$nextTick();
-
-        editorHtmlOutput = editor.html();
-        expect(editorHtmlOutput).toContain('<br>');
-      });
-    });
-
     describe('When quick replies button is clicked', () => {
       it('quick replies clicked event should be fired', async () => {
         await quickRepliesBtn.trigger('click');

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -411,15 +411,7 @@ export default {
           }),
         );
       } else {
-        extensions.push(HardBreak.extend({
-          addKeyboardShortcuts () {
-            return {
-              Enter: () => {
-                this.editor.commands.setHardBreak();
-              },
-            };
-          },
-        }));
+        extensions.push(HardBreak);
       }
 
       if (this.mentionSuggestion) {

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.test.js
@@ -546,20 +546,5 @@ describe('DtRecipeEditor tests', () => {
         expect('quick-replies-click' in wrapper.emitted()).toBeTruthy();
       });
     });
-
-    describe('When enter key is pressed', () => {
-      beforeEach(async () => {
-        wrapper.vm.$refs.richTextEditor?.editor.commands.focus('end');
-      });
-
-      it('editor should add br tag html content', async () => {
-        let editorHtmlOutput = editor.html();
-        expect(editorHtmlOutput).not.toContain('<br>');
-        await wrapper.vm.$refs.richTextEditor?.editor.commands.enter();
-        await wrapper.vm.$nextTick();
-        editorHtmlOutput = editor.html();
-        expect(editorHtmlOutput).toContain('<br>');
-      });
-    });
   });
 });


### PR DESCRIPTION
This fix doesn't work as I expected and is not fixing the issue. Sending a revert for now, will try to handle this from ubervoice.
Reverts dialpad/dialtone#436