### PR TITLE
chore: DLT-1692 vue examples blog post

### DIFF
--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-8-13.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-8-13.md
@@ -14,9 +14,9 @@ We have a pretty short announcement, but packed with great news! 🥳
 
 We are currently on an effort to unify our two documentation sites [Dialtone vue - Storybook](https://dialtone.dialpad.com/vue) and [Dialtone](https://dialtone.dialpad.com) into [Dialtone](https://dialtone.dialpad.com) only.
 
-Today, We are happy to announce the availability of **Vue component examples** on the documentation site. That way is easier for you to understand the usage of it, slots, props, events, see some examples and copy the code directly so you can start using our components right away!
+Today, we are happy to announce the availability of **Vue component examples** on the documentation site. This makes it easier for you to understand the usage, slots, props, events, see some examples and copy the code directly so you can start using our components right away!
 
-We are continuosly working on making Dialtone better, so your days working with Dialtone are more enjoyable and hassle free.
+We are continuously working on making Dialtone better, so your days working with Dialtone are more enjoyable and hassle free.
 
 If you have any doubt, comment or suggestion, don't hesitate to get in contact with us through our multiple communication channels.
 

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-8-13.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-8-13.md
@@ -1,0 +1,31 @@
+---
+heading: Vue and HTML examples on Documentation site
+author: Julio Ortega
+posted: '2024-8-13'
+---
+
+<BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">
+
+Hi everyone. We have a pretty short announcement, but packed with great news!
+
+We are currently on an effort to unify our two documentation sites [Dialtone vue - Storybook](https://dialtone.dialpad.com/vue) and [Dialtone](https://dialtone.dialpad.com) into [Dialtone](https://dialtone.dialpad.com) only.
+
+Today, We are happy to announce the availability of **Vue component examples** on the documentation site. That way is easier for you to understand the usage of it, slots, props, events, see some examples and copy the code directly so you can start using our components right away!
+
+We are continuosly working on making Dialtone better, so your days working with Dialtone are more enjoyable and hassle free.
+
+If you have any doubt, comment or suggestion, don't hesitate to get in contact with us through our multiple communication channels.
+
+- #dialtone channel on Dialpad.
+- Replying to this email.
+- [Making a request](https://dialpad.atlassian.net/secure/CreateIssue.jspa?issuetype=10975&pid=12508) directly on our Jira project.
+
+Thanks everyone and have a great day!
+Dialtone Team 💜
+
+</BlogPost>
+
+<script setup>
+import BlogPost from '@baseComponents/BlogPost.vue';
+import { parse } from 'date-fns';
+</script>

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-8-13.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-8-13.md
@@ -6,7 +6,11 @@ posted: '2024-8-13'
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">
 
-Hi everyone. We have a pretty short announcement, but packed with great news!
+# Hi Dialers 💜
+
+We have a pretty short announcement, but packed with great news! 🥳
+
+## Dialtone documentation
 
 We are currently on an effort to unify our two documentation sites [Dialtone vue - Storybook](https://dialtone.dialpad.com/vue) and [Dialtone](https://dialtone.dialpad.com) into [Dialtone](https://dialtone.dialpad.com) only.
 


### PR DESCRIPTION
# Vue examples blog post

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/PHkIfAw1FUUms/giphy.gif?cid=ecf05e47rnnrwtswggy0fyzzfz84n1skvcdtd8alussf9rnf&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1692

## :book: Description

Added blog post to announce we now have Vue examples on https://dialtone.dialpad.com

## :bulb: Context

We finished most of the tasks on https://dialpad.atlassian.net/browse/DLT-221 epic long ago, but we haven't announced it properly yet.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

## :crystal_ball: Next Steps

- Should I include the announcement of the prototype on https://dialtone.dialpad.com/vue/index.html?path=/story/prototypes-dialpad--default ?