### PR TITLE
fix: NO-JIRA es6 errors with json imports

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,19 +1,3 @@
-# dependencies
-node_modules
-
-# storybook
-storybook-static
-
-# tests
-tests/.cache
-tests/compiled
-
-# ejs files
-**/*.ejs
-
-# builds
-dist
-
 # TEMPORARY can be removed once we upgrade to eslint 9
 **/common/emoji/index.js
 **/common/storybook_utils.js

--- a/packages/dialtone-vue2/common/emoji/index.js
+++ b/packages/dialtone-vue2/common/emoji/index.js
@@ -1,5 +1,5 @@
 import { emojiPattern } from 'regex-combined-emojis';
-import emojiJsonLocal from 'emoji-toolkit/emoji_strategy.json';
+import emojiJsonLocal from 'emoji-toolkit/emoji_strategy.json' with { type: 'json' };
 
 export const emojiRegex = new RegExp(emojiPattern, 'g');
 export const emojiVersion = '8.0';

--- a/packages/dialtone-vue2/common/storybook_utils.js
+++ b/packages/dialtone-vue2/common/storybook_utils.js
@@ -1,5 +1,5 @@
-import iconNames from '@dialpad/dialtone-icons/icons.json';
-import illustrationNames from '@dialpad/dialtone-icons/illustrations.json';
+import iconNames from '@dialpad/dialtone-icons/icons.json' with { type: 'json' };
+import illustrationNames from '@dialpad/dialtone-icons/illustrations.json' with { type: 'json' };
 
 /**
  * Will use a Vue SFC to render the template rather than a template string.

--- a/packages/dialtone-vue2/components/emoji/emoji.test.js
+++ b/packages/dialtone-vue2/components/emoji/emoji.test.js
@@ -1,7 +1,7 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import DtEmoji from './emoji.vue';
 import { setEmojiAssetUrlSmall, setEmojiAssetUrlLarge, setCustomEmojiUrl, setCustomEmojiJson } from '@/common/emoji';
-import customEmojiJson from '@/common/custom-emoji.json';
+import customEmojiJson from '@/common/custom-emoji.json' with { type: 'json' };
 
 setEmojiAssetUrlSmall('https://mockstorage.com/emojis/', '.png');
 setEmojiAssetUrlLarge('https://mockstorage.com/emojis/', '.svg');

--- a/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.test.js
+++ b/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.test.js
@@ -1,7 +1,7 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import DtEmojiTextWrapper from './emoji_text_wrapper.vue';
 import { setCustomEmojiJson, setCustomEmojiUrl, setEmojiAssetUrlLarge } from '@/common/emoji';
-import customEmojiJson from '@/common/custom-emoji.json';
+import customEmojiJson from '@/common/custom-emoji.json' with { type: 'json' };
 
 setEmojiAssetUrlLarge('https://mockstorage.com/emojis/', '.svg');
 setCustomEmojiUrl('https://mockstorage.com/emojis/');

--- a/packages/dialtone-vue2/components/icon/icon_constants.js
+++ b/packages/dialtone-vue2/components/icon/icon_constants.js
@@ -1,4 +1,4 @@
-import iconNames from '@dialpad/dialtone-icons/icons.json';
+import iconNames from '@dialpad/dialtone-icons/icons.json' with { type: 'json' };
 export const ICON_SIZE_MODIFIERS = {
   100: 'd-icon--size-100',
   200: 'd-icon--size-200',

--- a/packages/dialtone-vue2/components/illustration/illustration_constants.js
+++ b/packages/dialtone-vue2/components/illustration/illustration_constants.js
@@ -1,4 +1,4 @@
-import illustrationNames from '@dialpad/dialtone-icons/illustrations.json';
+import illustrationNames from '@dialpad/dialtone-icons/illustrations.json' with { type: 'json' };
 
 export const ILLUSTRATION_NAMES = illustrationNames;
 

--- a/packages/dialtone-vue3/.eslintignore
+++ b/packages/dialtone-vue3/.eslintignore
@@ -13,3 +13,12 @@ tests/compiled
 
 # builds
 dist
+
+
+# TEMPORARY can be removed once we upgrade to eslint 9
+**/common/emoji/index.js
+**/common/storybook_utils.js
+**/components/emoji/emoji.test.js
+**/components/emoji_text_wrapper/emoji_text_wrapper.test.js
+**/components/icon/icon_constants.js
+**/components/illustration/illustration_constants.js

--- a/packages/dialtone-vue3/common/storybook_utils.js
+++ b/packages/dialtone-vue3/common/storybook_utils.js
@@ -1,5 +1,5 @@
-import iconNames from '@dialpad/dialtone-icons/icons.json';
-import illustrationNames from '@dialpad/dialtone-icons/illustrations.json';
+import iconNames from '@dialpad/dialtone-icons/icons.json' with { type: 'json' };
+import illustrationNames from '@dialpad/dialtone-icons/illustrations.json' with { type: 'json' };
 
 /**
  * Will use a Vue SFC to render the template rather than a template string.

--- a/packages/dialtone-vue3/components/emoji/emoji.test.js
+++ b/packages/dialtone-vue3/components/emoji/emoji.test.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import DtEmoji from './emoji.vue';
 import { setEmojiAssetUrlSmall, setEmojiAssetUrlLarge, setCustomEmojiUrl, setCustomEmojiJson } from '@/common/emoji';
-import customEmojiJson from '@/common/custom-emoji.json';
+import customEmojiJson from '@/common/custom-emoji.json' with { type: 'json' };
 
 setEmojiAssetUrlSmall('https://mockstorage.com/emojis/', '.png');
 setEmojiAssetUrlLarge('https://mockstorage.com/emojis/', '.svg');

--- a/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.test.js
+++ b/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.test.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import DtEmojiTextWrapper from './emoji_text_wrapper.vue';
 import { setCustomEmojiJson, setCustomEmojiUrl, setEmojiAssetUrlLarge } from '@/common/emoji';
-import customEmojiJson from '@/common/custom-emoji.json';
+import customEmojiJson from '@/common/custom-emoji.json' with { type: 'json' };
 
 setEmojiAssetUrlLarge('https://mockstorage.com/emojis/', '.svg');
 setCustomEmojiUrl('https://mockstorage.com/emojis/');

--- a/packages/dialtone-vue3/components/icon/icon_constants.js
+++ b/packages/dialtone-vue3/components/icon/icon_constants.js
@@ -1,4 +1,4 @@
-import iconNames from '@dialpad/dialtone-icons/icons.json';
+import iconNames from '@dialpad/dialtone-icons/icons.json' with { type: 'json' };
 export const ICON_SIZE_MODIFIERS = {
   100: 'd-icon--size-100',
   200: 'd-icon--size-200',

--- a/packages/dialtone-vue3/components/illustration/illustration_constants.js
+++ b/packages/dialtone-vue3/components/illustration/illustration_constants.js
@@ -1,4 +1,4 @@
-import illustrationNames from '@dialpad/dialtone-icons/illustrations.json';
+import illustrationNames from '@dialpad/dialtone-icons/illustrations.json' with { type: 'json' };
 
 export const ILLUSTRATION_NAMES = illustrationNames;
 


### PR DESCRIPTION
# fix: es6 errors with json imports

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbjRycWxrMDZmNG80dDU2NHAxZHhkaXU1dnVmNm5wc28yNnM0bWk0YiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/UO5elnTqo4vSg/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Trying to get this one out quickly to unblock the team that is having this problem. 

["import attribute"](https://github.com/tc39/proposal-import-attributes?tab=readme-ov-file) syntax is required on json imports as of newer versions of node due to some sort of security issue. I think this may only be happening in the dx-console project because they have their tsconfig set to "esnext". Going forward this will be the correct way to import json though so we should change it.

I'm putting in this quick fix in because the version of eslint we're on doesn't support this syntax at all and completely errors out, you cant even ignore the error in the file using a comment. 

The real fix should be updating to ESLint 9 which supports this, but that's a huge breaking change to configuration files and will be alot of work to migrate.

I confirmed that the tests do run correctly using pnpm link.

Also it says that firefox doesn't support this on caniuse: https://caniuse.com/?search=import%20attributes

However I tested in firefox and everything seemed fine. Maybe vite/rollup is doing some kind of magic?

## :link: Sources

https://github.com/tc39/proposal-import-attributes
https://caniuse.com/?search=import%20attributes
