### PR TITLE
feat: DP-107407 add new prop to hide the actions in leftbar contact centers recipe

### DIFF
--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row.vue
@@ -37,7 +37,10 @@
           </dt-emoji-text-wrapper>
         </div>
       </a>
-      <div class="dt-leftbar-row__omega">
+      <div
+        v-show="!hideActions"
+        class="dt-leftbar-row__omega"
+      >
         <slot name="right" />
         <div class="dt-leftbar-row__action-container">
           <dt-badge
@@ -72,15 +75,15 @@
 </template>
 
 <script>
+import { safeConcatStrings } from '@/common/utils';
 import { DtBadge } from '@/components/badge';
 import { DtButton } from '@/components/button';
-import DtIconHeadphones from '@dialpad/dialtone-icons/vue2/headphones';
-import DtIconChevronDown from '@dialpad/dialtone-icons/vue2/chevron-down';
 import DtEmojiTextWrapper from '@/components/emoji_text_wrapper/emoji_text_wrapper.vue';
-import { safeConcatStrings } from '@/common/utils';
+import DtIconChevronDown from '@dialpad/dialtone-icons/vue2/chevron-down';
+import DtIconHeadphones from '@dialpad/dialtone-icons/vue2/headphones';
 
 export default {
-  name: 'DtRecipeGeneralRow',
+  name: 'DtRecipeContactCentersRow',
 
   components: {
     DtButton,
@@ -113,6 +116,14 @@ export default {
      * Determines if the row is selected
      */
     selected: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Making this true will hide the unread count badge, the chevron button, and the right slot
+     */
+    hideActions: {
       type: Boolean,
       default: false,
     },
@@ -184,7 +195,8 @@ export default {
   watch: {
     $props: {
       deep: true,
-      handler () {
+      async handler () {
+        await this.$nextTick();
         this.adjustLabelWidth();
       },
     },

--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row_default.story.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row_default.story.vue
@@ -5,6 +5,7 @@
     :aria-label="$attrs.ariaLabel"
     :menu-button-aria-label="$attrs.menuButtonAriaLabel"
     :selected="$attrs.selected"
+    :hide-actions="$attrs.hideActions"
     @click="$attrs.click"
     @click-menu="$attrs.clickMenu"
   >
@@ -37,8 +38,8 @@
 
 <script>
 import { DtButton } from '@/components/button';
-import DtRecipeContactCentersRow from './contact_centers_row.vue';
 import DtIconBellRing from '@dialpad/dialtone-icons/vue2/bell-ring';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
 
 export default {
   name: 'DtRecipeContactCentersRowDefault',

--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row_off_duty.story.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row_off_duty.story.vue
@@ -5,6 +5,7 @@
     :aria-label="$attrs.ariaLabel"
     :menu-button-aria-label="$attrs.menuButtonAriaLabel"
     :selected="$attrs.selected"
+    :hide-actions="$attrs.hideActions"
     @click="$attrs.click"
     @click-menu="$attrs.clickMenu"
   >
@@ -51,8 +52,8 @@
 
 <script>
 import { DtButton } from '@/components/button';
-import DtRecipeContactCentersRow from './contact_centers_row.vue';
 import DtIconBellRing from '@dialpad/dialtone-icons/vue2/bell-ring';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
 
 export default {
   name: 'DtRecipeContactCentersRowDefault',

--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row_variants.story.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row_variants.story.vue
@@ -137,14 +137,48 @@
         </template>
       </dt-recipe-contact-centers-row>
     </div>
+    <div>
+      <h3 class="d-mb8">
+        Ai Contact Centers leftbar with hidden actions
+      </h3>
+      <dt-recipe-contact-centers-row
+        description="Ai Contact Centers"
+        menu-button-aria-label="Menu button"
+        :hide-actions="true"
+      >
+        <template #right>
+          <dt-button
+            importance="clear"
+            kind="muted"
+            :class="[
+              'leftbar-call-centers-duty-status__button',
+              'd-bar-pill',
+              'd-py4',
+              'd-fc-success',
+            ]"
+            class="d-to-ellipsis"
+            size="sm"
+            data-qa="leftbar-call-centers-duty-value"
+            aria-label="Available"
+          >
+            <template #icon>
+              <dt-icon-bell-ring size="100" />
+            </template>
+            <span class="d-truncate d-wmx128">
+              Available
+            </span>
+          </dt-button>
+        </template>
+      </dt-recipe-contact-centers-row>
+    </div>
   </dt-stack>
 </template>
 
 <script>
-import DtRecipeContactCentersRow from './contact_centers_row.vue';
-import { DtStack } from '@/components/stack';
 import { DtButton } from '@/components/button';
+import { DtStack } from '@/components/stack';
 import DtIconBellRing from '@dialpad/dialtone-icons/vue2/bell-ring';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
 
 export default {
   name: 'DtRecipeContactCentersRowVariants',

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.vue
@@ -38,7 +38,10 @@
           </dt-emoji-text-wrapper>
         </div>
       </a>
-      <div class="dt-leftbar-row__omega">
+      <div
+        v-if="!hideActions"
+        class="dt-leftbar-row__omega"
+      >
         <slot name="right" />
         <div class="dt-leftbar-row__action-container">
           <dt-badge
@@ -73,15 +76,15 @@
 </template>
 
 <script>
+import { extractVueListeners, safeConcatStrings } from '@/common/utils';
 import { DtBadge } from '@/components/badge';
 import { DtButton } from '@/components/button';
-import DtIconHeadphones from '@dialpad/dialtone-icons/vue3/headphones';
-import DtIconChevronDown from '@dialpad/dialtone-icons/vue3/chevron-down';
 import DtEmojiTextWrapper from '@/components/emoji_text_wrapper/emoji_text_wrapper.vue';
-import { safeConcatStrings, extractVueListeners } from '@/common/utils';
+import DtIconChevronDown from '@dialpad/dialtone-icons/vue3/chevron-down';
+import DtIconHeadphones from '@dialpad/dialtone-icons/vue3/headphones';
 
 export default {
-  name: 'DtRecipeGeneralRow',
+  name: 'DtRecipeContactCentersRow',
 
   components: {
     DtButton,
@@ -114,6 +117,14 @@ export default {
      * Determines if the row is selected
      */
     selected: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Making this true will hide the unread count badge, the chevron button, and the right slot
+     */
+     hideActions: {
       type: Boolean,
       default: false,
     },
@@ -189,7 +200,8 @@ export default {
   watch: {
     $props: {
       deep: true,
-      handler () {
+      async handler () {
+        await this.$nextTick();
         this.adjustLabelWidth();
       },
     },

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row_default.story.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row_default.story.vue
@@ -5,6 +5,7 @@
     :aria-label="$attrs.ariaLabel"
     :menu-button-aria-label="$attrs.menuButtonAriaLabel"
     :selected="$attrs.selected"
+    :hide-actions="$attrs.hideActions"
     @click="$attrs.click"
     @click-menu="$attrs.clickMenu"
   >
@@ -37,8 +38,8 @@
 
 <script>
 import { DtButton } from '@/components/button';
-import DtRecipeContactCentersRow from './contact_centers_row.vue';
 import DtIconBellRing from '@dialpad/dialtone-icons/vue3/bell-ring';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
 
 export default {
   name: 'DtRecipeContactCentersRowDefault',

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row_off_duty.story.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row_off_duty.story.vue
@@ -5,6 +5,7 @@
     :aria-label="$attrs.ariaLabel"
     :menu-button-aria-label="$attrs.menuButtonAriaLabel"
     :selected="$attrs.selected"
+    :hide-actions="$attrs.hideActions"
     @click="$attrs.click"
     @click-menu="$attrs.clickMenu"
   >
@@ -51,8 +52,8 @@
 
 <script>
 import { DtButton } from '@/components/button';
-import DtRecipeContactCentersRow from './contact_centers_row.vue';
 import DtIconBellRing from '@dialpad/dialtone-icons/vue3/bell-ring';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
 
 export default {
   name: 'DtRecipeContactCentersRowDefault',

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row_variants.story.vue
@@ -137,14 +137,48 @@
         </template>
       </dt-recipe-contact-centers-row>
     </div>
+    <div>
+      <h3 class="d-mb8">
+        Ai Contact Centers leftbar with hidden actions
+      </h3>
+      <dt-recipe-contact-centers-row
+        description="Ai Contact Centers"
+        menu-button-aria-label="Menu button"
+        :hide-actions="true"
+      >
+        <template #right>
+          <dt-button
+            importance="clear"
+            kind="muted"
+            :class="[
+              'leftbar-call-centers-duty-status__button',
+              'd-bar-pill',
+              'd-py4',
+              'd-fc-success',
+            ]"
+            class="d-to-ellipsis"
+            size="sm"
+            data-qa="leftbar-call-centers-duty-value"
+            aria-label="Available"
+          >
+            <template #icon>
+              <dt-icon-bell-ring size="100" />
+            </template>
+            <span class="d-truncate d-wmx128">
+              Available
+            </span>
+          </dt-button>
+        </template>
+      </dt-recipe-contact-centers-row>
+    </div>
   </dt-stack>
 </template>
 
 <script>
-import DtRecipeContactCentersRow from './contact_centers_row.vue';
-import { DtStack } from '@/components/stack';
 import { DtButton } from '@/components/button';
+import { DtStack } from '@/components/stack';
 import DtIconBellRing from '@dialpad/dialtone-icons/vue3/bell-ring';
+import DtRecipeContactCentersRow from './contact_centers_row.vue';
 
 export default {
   name: 'DtRecipeContactCentersRowVariants',


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExc2JrOWg0ejc1ZnUzb2g5Yjk2dXFxYjNtamg5azhxbWdkcnRobjNoNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/pHYaWbspekVsTKRFQT/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [x] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

[DP-107407](https://dialpad.atlassian.net/browse/DP-107407)

## :book: Description

Adding a new prop called `hide-actions` to the Contact Centers recipe component.

## :bulb: Context

We need to be able to hide the menu button and the right slot for certain scenarios. Specifically, when an Office Admin user was not assigned to any Contact Center but still should be able to access to monitor all existing CCs.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

![image](https://github.com/user-attachments/assets/b9937281-c7f6-497a-b776-5eb4483250c2)

[DP-107407]: https://dialpad.atlassian.net/browse/DP-107407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ