### PR TITLE
fix: NO-JIRA size and space pages in doc site

### DIFF
--- a/apps/dialtone-documentation/docs/design/size/index.md
+++ b/apps/dialtone-documentation/docs/design/size/index.md
@@ -119,12 +119,12 @@ To ensure clickable and interactive areas are easily accessible, we recommend a 
 
 Here are some frequently used tokens. For a complete list, visit the [Size Tokens](/tokens/size/) section.
 
-<token-table category="size" :tokenList="true" :tokens="tokens" />
+<token-table category="size" :tokenList="true" :tokens="tokens" theme="light" />
 
 <dt-notice
   kind="info"
   title="Figma Variables"
-  hideClose="true"
+  :hideClose="true"
 >
   <template #default>
     By April 2024, we aim to integrate sizing units into Figma Variables. This will simplify the process of setting these tokens on width, min-width, height, min-height in your Figma files, making it easier for engineers to obtain the correct variable for each case.
@@ -141,7 +141,7 @@ import { ref } from 'vue';
 import tokensJson from '@dialpad/dialtone-tokens/dist/doc.json';
 
 const sizes = ["size/300", "size/450", "size/400", "size/500", "size/550", "size/600"];
-const theme = "light";
+const theme = "base-light";
 const tokens = Object.keys(tokensJson[theme]).reduce((acc, curr) => {
   if (sizes.includes(curr)) {
     const { name, value, description } = tokensJson[theme][curr]["css/variables"];

--- a/apps/dialtone-documentation/docs/design/size/index.md
+++ b/apps/dialtone-documentation/docs/design/size/index.md
@@ -142,7 +142,7 @@ import tokensJson from '@dialpad/dialtone-tokens/dist/doc.json';
 
 const sizes = ["size/300", "size/450", "size/400", "size/500", "size/550", "size/600"];
 const theme = "base-light";
-const tokens = Object.keys(tokensJson[theme]).reduce((acc, curr) => {
+const tokens = Object.keys(tokensJson[theme] ?? {}).reduce((acc, curr) => {
   if (sizes.includes(curr)) {
     const { name, value, description } = tokensJson[theme][curr]["css/variables"];
     acc.push({

--- a/apps/dialtone-documentation/docs/design/space/index.md
+++ b/apps/dialtone-documentation/docs/design/space/index.md
@@ -195,7 +195,7 @@ const spaces = {
   "space/650": {}
 };
 const theme = "base-light";
-const tokens = Object.keys(tokensJson[theme]).reduce((acc, curr) => {
+const tokens = Object.keys(tokensJson[theme] ?? {}).reduce((acc, curr) => {
   if (Object.keys(spaces).includes(curr)) {
     const { name, value, description } = tokensJson[theme][curr]["css/variables"];
     acc.push({

--- a/apps/dialtone-documentation/docs/design/space/index.md
+++ b/apps/dialtone-documentation/docs/design/space/index.md
@@ -157,12 +157,12 @@ Avoid using `margin`, which adds space outside the element and can affect the la
 
 Here are some frequently used tokens, don't use values outside the recommended range for specific types of spacing. For a complete list, visit the [Spacing Tokens](/tokens/space) section.
 
-<token-table category="space" :tokenList="true" :tokens="tokens" />
+<token-table category="space" :tokenList="true" :tokens="tokens" theme="light" />
 
 <dt-notice
   kind="info"
   title="Figma Variables"
-  hideClose="true"
+  :hideClose="true"
 >
   <template #default>
     By April 2024, we aim to integrate sizing units into Figma Variables. This will simplify the process of setting these tokens on width, min-width, height, min-height in your Figma files, making it easier for engineers to obtain the correct variable for each case.
@@ -194,7 +194,7 @@ const spaces = {
   "space/600": {},
   "space/650": {}
 };
-const theme = "light";
+const theme = "base-light";
 const tokens = Object.keys(tokensJson[theme]).reduce((acc, curr) => {
   if (Object.keys(spaces).includes(curr)) {
     const { name, value, description } = tokensJson[theme][curr]["css/variables"];


### PR DESCRIPTION
# fix size and space pages in doc site

Fixes the error `TypeError: Cannot convert undefined or null to object` for `design/size` and `design/space` pages in the doc site.

To test check out these pages:
https://dialtone.dialpad.com/deploy-previews/pr-447/design/size/
https://dialtone.dialpad.com/deploy-previews/pr-447/design/space/

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/uLgd9dOYWpnu5WkShY/giphy.gif?cid=6c09b9521rj0h6iahw6kuk3iuf4ulyvnb25szi3z7uyowvbu&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
NO-JIRA
<!--- Enter the URL of the Jira ticket associated with this PR -->

