### PR TITLE
fix(tokens): DLT-1961 make typography tokens rem instead of px

### DIFF
--- a/packages/dialtone-tokens/dialtone-transforms.js
+++ b/packages/dialtone-tokens/dialtone-transforms.js
@@ -49,7 +49,7 @@ export function registerDialtoneTransforms (styleDictionary) {
     name: 'dt/size/pxToRem',
     type: 'value',
     filter: function (token) {
-      return SIZE_IDENTIFIERS.includes(token.type);
+      return [...FONT_SIZE_IDENTIFIERS, ...SIZE_IDENTIFIERS].includes(token.type);
     },
     transform: pxToRemTransformer,
   });


### PR DESCRIPTION
# fix(tokens): make typography tokens rem instead of px

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcjhjMHZiOWpucGp0czltemF2d29mZnc2bjdxdTg2aGwwejg5YzFpciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ZqtmJPeQ7hJRmjgrf7/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1961

## :book: Description

Seems at some point in the theming migration typography tokens got changed from rem to px. This change makes all the typography tokens rem instead of px.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
