### PR TITLE
fix(message-input): DP-107570 fix long names on mentions

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
@@ -9,7 +9,9 @@
       :image-alt="name"
       size="xs"
     />
-    {{ name }}
+    <span class="mention-suggestion-name">
+      {{ name }}
+    </span>
   </dt-stack>
 </template>
 
@@ -42,3 +44,11 @@ export default {
   },
 };
 </script>
+
+<style lang="less" scoped>
+.mention-suggestion-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/packages/dialtone-vue2/components/rich_text_editor/mention_suggestion.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/mention_suggestion.js
@@ -40,6 +40,16 @@ const CONTACT_LIST = [
     name: 'Nina Repetto',
     avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
   },
+  {
+    id: 'long.name',
+    name: 'LongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongname',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'long.name.with.spaces',
+    name: 'Long Name Long Name Long Name Long NameLong Name Long Name Long Name Long NameLong Name Long Name Long Name Long NameLong Name Long Name Long Name Long NameLong Name Long Name Long Name Long Name ',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
 ];
 
 export default {

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
@@ -9,7 +9,9 @@
       :image-alt="name"
       size="xs"
     />
-    {{ name }}
+    <span class="mention-suggestion-name">
+      {{ name }}
+    </span>
   </dt-stack>
 </template>
 
@@ -42,3 +44,11 @@ export default {
   },
 };
 </script>
+
+<style lang="less" scoped>
+.mention-suggestion-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/packages/dialtone-vue3/components/rich_text_editor/mention_suggestion.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/mention_suggestion.js
@@ -40,6 +40,16 @@ const CONTACT_LIST = [
     name: 'Nina Repetto',
     avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
   },
+  {
+    id: 'long.name',
+    name: 'LongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongname',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
+  {
+    id: 'long.name.with.spaces',
+    name: 'Long Name Long Name Long Name Long NameLong Name Long Name Long Name Long NameLong Name Long Name Long Name Long NameLong Name Long Name Long Name Long NameLong Name Long Name Long Name Long Name ',
+    avatarSrc: 'https://avatars.githubusercontent.com/u/13851061?s=460&u=1f1b5b0b5b2b2b2b2b2b2b2b2b2b2b2b2b2b2b&v=4',
+  },
 ];
 
 export default {


### PR DESCRIPTION
# fix(message-input): DP-107570 fix long names on mentions

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3IyaWFtNm5lOHZjejllaDAyOHltODA4MGM0cGFlc2F5MjcxeGZiaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/gwmaDt1M6x0Zy/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DP-107570
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Added some styles to improve the UI when having long names on mentions

https://github.com/user-attachments/assets/b605053b-4ef7-4bf8-bbfd-f429d8431618

## :bulb: Context
QA reported an UI issue in which the mention dropdown was not looking as expected when users have long names
Old UI:
![image](https://github.com/user-attachments/assets/55e19283-1d42-4c02-a111-7a315c43f6e9)
