### PR TITLE
feat: NO-JIRA introduce appendTo prop to image viewer

### DIFF
--- a/packages/dialtone-vue2/components/image_viewer/image_viewer.vue
+++ b/packages/dialtone-vue2/components/image_viewer/image_viewer.vue
@@ -86,8 +86,10 @@ export default {
 
   props: {
     /**
-     * By default the portal appends to the body. We can modify
-     * this behaviour by passing an appendTo prop that points to an id.
+     * By default the portal appends to the body of the root parent. We can modify
+     * this behaviour by passing an appendTo prop that points to an id or an html tag from the root of the parent.
+     * The appendTo prop expects a CSS selector string or an actual DOM node.
+     * type: string | HTMLElement, default: 'body'
     */
     appendTo: {
       type: String,

--- a/packages/dialtone-vue2/components/image_viewer/image_viewer.vue
+++ b/packages/dialtone-vue2/components/image_viewer/image_viewer.vue
@@ -13,7 +13,10 @@
         :alt="imageAlt"
       >
     </dt-button>
-    <portal v-if="isOpen">
+    <portal
+     v-if="isOpen"
+     :selector="appendTo"
+    >
       <div
         :aria-hidden="!isOpen ? 'true' : 'false'"
         class="d-modal"
@@ -82,6 +85,15 @@ export default {
   mixins: [Modal],
 
   props: {
+    /**
+     * By default the portal appends to the body. We can modify
+     * this behaviour by passing an appendTo prop that points to an id.
+    */
+    appendTo: {
+      type: String,
+      default: 'body',
+    },
+
     /**
      * Controls whether the image modal is shown. Leaving this null will have the image modal
      * trigger on click by default.

--- a/packages/dialtone-vue2/components/image_viewer/image_viewer_default.story.vue
+++ b/packages/dialtone-vue2/components/image_viewer/image_viewer_default.story.vue
@@ -1,5 +1,6 @@
 <template>
   <dt-image-viewer
+    :append-to="$attrs.appendTo"
     :image-src="$attrs.imageSrc"
     :image-alt="$attrs.imageAlt"
     :close-aria-label="$attrs.closeAriaLabel"

--- a/packages/dialtone-vue3/components/image_viewer/image_viewer.vue
+++ b/packages/dialtone-vue3/components/image_viewer/image_viewer.vue
@@ -15,7 +15,7 @@
     </dt-button>
     <Teleport
       v-if="isOpen"
-      to="body"
+      :to="appendTo"
     >
       <div
         :aria-hidden="!isOpen ? 'true' : 'false'"
@@ -83,6 +83,14 @@ export default {
   mixins: [Modal],
 
   props: {
+    /**
+     * By default the teleport appends to the body. We can modify
+     * this behaviour by passing an appendTo prop that points to an id.
+    */
+    appendTo: {
+      type: String,
+      default: 'body',
+    },
     /**
      * Controls whether the image modal is shown. Leaving this null will have the image modal
      * trigger on click by default.

--- a/packages/dialtone-vue3/components/image_viewer/image_viewer.vue
+++ b/packages/dialtone-vue3/components/image_viewer/image_viewer.vue
@@ -84,8 +84,10 @@ export default {
 
   props: {
     /**
-     * By default the teleport appends to the body. We can modify
-     * this behaviour by passing an appendTo prop that points to an id.
+     * By default the portal appends to the body of the root parent. We can modify
+     * this behaviour by passing an appendTo prop that points to an id or an html tag from the root of the parent.
+     * The appendTo prop expects a CSS selector string or an actual DOM node.
+     * type: string | HTMLElement, default: 'body'
     */
     appendTo: {
       type: String,

--- a/packages/dialtone-vue3/components/image_viewer/image_viewer_default.story.vue
+++ b/packages/dialtone-vue3/components/image_viewer/image_viewer_default.story.vue
@@ -1,6 +1,7 @@
 <template>
   <dt-image-viewer
     v-model:open="isOpen"
+    :append-to="$attrs.appendTo"
     :image-src="$attrs.imageSrc"
     :image-alt="$attrs.imageAlt"
     :close-aria-label="$attrs.closeAriaLabel"


### PR DESCRIPTION
# feat: introduce appendTo prop to image viewer


## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![ricketyrick](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcmlhbWd6cDV2dmd4cXg3czF4ajYybHAweDB6Ynl5eW42dmJod2tpYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/J27g804oxGiBHpzMJ4/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

Currently when consuming image viewer on chat client, the preview is opening up in the body of the root html while the chat client is inside a shadowDOM. Probably a short fix for now to pass in a selector to append the preview to.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

If new component:

<!--- There are lots of things to remember when adding a new component to the system! This is so you don't forget any of them. -->

- I am exporting any new components or constants:
  - [ ] from the index.js in the component directory.
  - [ ] from the index.js in the root (either `packages/dialtone-vue2` or `packages/dialtone-vue3`).
- [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
- [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
- [ ] I have added the new component to `common/components_list.cjs`
- [ ] I have created a component story in storybook
- [ ] I have created story / stories for any relevant component variants in storybook
- [ ] I have created a docs page for the component in storybook.
- [ ] I have checked that changing all props/slots via the UI in storybook works as expected.

