### PR TITLE
fix(emoji): DLT-1913 alignment issue

### DIFF
--- a/apps/dialtone-documentation/docs/components/emoji.md
+++ b/apps/dialtone-documentation/docs/components/emoji.md
@@ -77,7 +77,7 @@ vueCode='
 ### Sizes
 
 <code-well-header>
-  <div class="d-d-inline-flex d-ai-center d-flow8 sizesExample" ref="exampleSizes">
+  <div class="d-d-inline-flex d-ai-center d-flow8" ref="exampleSizes">
     <dt-emoji v-for="size in sizes" :size="size" code=":smile:" />
   </div>
 </code-well-header>
@@ -230,15 +230,3 @@ By default the emoji will be rendered with an aria-label attribute describing th
 const sizes = ['100', '200', '300', '400', '500', '600', '700', '800'];
 
 </script>
-
-<style scoped lang="less">
-.sizesExample .d-emoji {
-  position: relative;
-  &:deep(.d-icon) {
-    position: absolute;
-    top: calc(50% - 1px);
-    transform: translateY(-50%);
-  }
-}
-
-</style>

--- a/packages/dialtone-css/lib/build/less/components/emoji-text-wrapper.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji-text-wrapper.less
@@ -1,14 +1,9 @@
 .d-emoji-text-wrapper {
   .d-emoji {
-    position: relative;
     height: 1em;
-    vertical-align: middle;
 
     .d-icon {
-      position: absolute;
       top: calc(50% - 1px);
-      display: block;
-      transform: translateY(-50%);
     }
   }
 }

--- a/packages/dialtone-css/lib/build/less/components/emoji.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji.less
@@ -1,4 +1,12 @@
 .d-emoji {
+  position: relative;
   display: inline-block;
   vertical-align: middle;
+
+  .d-icon {
+    position: absolute;
+    top: 50%;
+    display: block;
+    transform: translateY(-50%);
+  }
 }


### PR DESCRIPTION
# Fix DtEmoji alignment issue

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/RLEdq1A9PT0BZo27s3/giphy.gif?cid=82a1493bc8sufp4chmwf1hcu0fbysk661sda202gmrxm8aeh&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1913

## :book: Description

- Moved styles from `emoji-text-wrapper.less` to `emoji.less`
- Removed temp fix from the docsite

## :bulb: Context

- DtEmojiTextWrapper alignment was fixed on #407 but issues with emoji were found after that.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

https://dialtone.dialpad.com/deploy-previews/pr-453/components/emoji.html
https://dialtone.dialpad.com/vue/deploy-previews/pr-453/index.html?path=/story/components-emoji--variants