### PR TITLE
feat(input): DLT-1945 add clear slot prop to rightIcon

### DIFF
--- a/apps/dialtone-documentation/docs/components/input.md
+++ b/apps/dialtone-documentation/docs/components/input.md
@@ -444,7 +444,7 @@ showHtmlWarning />
 
 <dt-notice
   kind="warning"
-  hideClose="true"
+  :hide-close="true"
   class="d-wmx100p d-mb24"
 >
   <template #default>
@@ -452,23 +452,27 @@ showHtmlWarning />
   </template>
 </dt-notice>
 
+In this example we show a search input with a clear button on the right side. The clear button is a button with a close icon that clears the input field when clicked. The clear button is only visible when the input field is not empty.
+
 <code-well-header>
   <div class="d-w100p">
     <dt-input
       aria-label="Search items"
       placeholder="Search Items"
       type="text"
+      v-model="inputValue"
     >
       <template #leftIcon="{ iconSize }">
         <dt-icon name="search" :size="iconSize" />
       </template>
-      <template #rightIcon>
+      <template v-if="inputValue.length !== 0" #rightIcon="{ clear }">
         <dt-button
           kind="muted"
           importance="clear"
           size="xs"
           circle
           aria-label="Clear search"
+          @click="clear"
         >
         <template #icon="{ iconSize }">
             <dt-icon name="close" :size="iconSize" />
@@ -496,17 +500,19 @@ vueCode='
   aria-label="Search items"
   placeholder="Search Items"
   type="text"
+  v-model="inputValue"
 >
   <template #leftIcon="{ iconSize }">
     <dt-icon name="search" :size="iconSize" />
   </template>
-  <template #rightIcon>
+  <template v-if="inputValue.length !== 0" #rightIcon="{ clear }">
     <dt-button
       kind="muted"
       importance="clear"
       size="xs"
       circle
       aria-label="Clear search"
+      @click="clear"
     >
       <template #icon="{ iconSize }">
         <dt-icon name="close" :size="iconSize" />

--- a/packages/dialtone-vue2/components/input/input.stories.js
+++ b/packages/dialtone-vue2/components/input/input.stories.js
@@ -5,6 +5,7 @@ import DtInput from './input.vue';
 import { INPUT_SIZES, INPUT_TYPES } from './input_constants';
 
 import InputDefault from './input_default.story.vue';
+import InputSearchVariant from './input_search_variant.story.vue';
 
 const iconsList = getIconNames();
 
@@ -372,4 +373,8 @@ export const WithLengthValidation = {
       },
     },
   },
+};
+
+export const SearchVariant = {
+  render: (argsData) => createRenderConfig(DtInput, InputSearchVariant, argsData),
 };

--- a/packages/dialtone-vue2/components/input/input.vue
+++ b/packages/dialtone-vue2/components/input/input.vue
@@ -100,6 +100,7 @@
           <slot
             name="rightIcon"
             :icon-size="iconSize"
+            :clear="clearInput"
           />
         </span>
       </div>
@@ -562,9 +563,10 @@ export default {
       }
     },
 
-    clear () {
+    emitClearEvents () {
       this.$emit('input', '');
       this.$emit('clear');
+      this.$emit('update:modelValue', '');
     },
 
     blur () {
@@ -585,6 +587,12 @@ export default {
 
     validateLength (length) {
       this.isInvalid = (length > this.validationProps.length.max);
+    },
+
+    clearInput () {
+      this.$refs.input.value = '';
+      this.$refs.input.focus();
+      this.emitClearEvents();
     },
   },
 };

--- a/packages/dialtone-vue2/components/input/input_search_variant.story.vue
+++ b/packages/dialtone-vue2/components/input/input_search_variant.story.vue
@@ -1,0 +1,131 @@
+<template>
+  <dt-input
+    ref="input"
+    v-model="inputValue"
+    autocomplete="on"
+    :type="$attrs.type"
+    :messages="$attrs.messages"
+    :size="$attrs.size"
+    :label="$attrs.label"
+    :messages-child-props="$attrs.messagesChildProps"
+    :name="$attrs.name"
+    :disabled="$attrs.disabled"
+    :show-messages="$attrs.showMessages"
+    :messages-class="$attrs.messagesClass"
+    :placeholder="$attrs.placeholder"
+    :input-class="$attrs.inputClass"
+    :retain-warning="$attrs.retainWarning"
+    :input-wrapper-class="$attrs.inputWrapperClass"
+    :current-length="$attrs.currentLength"
+    :validate="validationConfig"
+    @blur="$attrs.onBlur"
+    @input="$attrs.onInput"
+    @clear="$attrs.onClear"
+    @focus="$attrs.onFocus"
+    @focusin="$attrs.onFocusIn"
+    @focusout="$attrs.onFocusOut"
+    @update:length="updateLength"
+    @update:invalid="$attrs.onUpdateIsInvalid"
+  >
+    <template
+      v-if="$attrs.labelSlot"
+      #labelSlot
+    >
+      <span v-html="$attrs.labelSlot" />
+    </template>
+    <template
+      v-if="$attrs.description"
+      #description
+    >
+      <span v-html="$attrs.description" />
+    </template>
+    <template #leftIcon="{ iconSize }">
+      <dt-icon
+        name="search"
+        :size="iconSize"
+      />
+    </template>
+    <template
+      v-if="inputValue.length !== 0"
+      #rightIcon="{ clear }"
+    >
+      <dt-button
+        kind="muted"
+        importance="clear"
+        size="xs"
+        circle
+        aria-label="Clear search"
+        @click="clear"
+      >
+        <template #icon="{ iconSize }">
+          <dt-icon
+            name="close"
+            :size="iconSize"
+          />
+        </template>
+      </dt-button>
+    </template>
+  </dt-input>
+</template>
+
+<script>
+import DtInput from './input.vue';
+import { DtButton } from '@/components/button';
+import { DtIcon } from '@/components/icon';
+
+export default {
+  name: 'InputSearchVariant',
+
+  components: { DtInput, DtIcon, DtButton },
+
+  inheritAttrs: false,
+
+  data () {
+    return {
+      inputValue: '',
+      inputLength: 0,
+    };
+  },
+
+  computed: {
+    validationMessage () {
+      const remainingCharacters = this.$attrs.validate?.length?.max - this.inputLength;
+
+      if (remainingCharacters < 0) {
+        return `${Math.abs(remainingCharacters)} characters over limit`;
+      } else {
+        return `${remainingCharacters} characters left`;
+      }
+    },
+
+    validationConfig () {
+      if (!this?.$attrs?.validate?.length) {
+        return null;
+      }
+
+      // Deep clone validate object
+      const validateConfigData = JSON.parse(JSON.stringify(this.$attrs.validate));
+
+      // Adds validation message
+      validateConfigData.length.message = this?.$attrs?.validate?.length?.message
+        ? this.$attrs.validate.length.message
+        : this.validationMessage;
+
+      return validateConfigData;
+    },
+  },
+
+  watch: {
+    modelValue (val) {
+      this.inputValue = val;
+    },
+  },
+
+  methods: {
+    updateLength ($event) {
+      this.inputLength = $event;
+      this.$attrs.onUpdateLength($event);
+    },
+  },
+};
+</script>

--- a/packages/dialtone-vue3/components/input/input.stories.js
+++ b/packages/dialtone-vue3/components/input/input.stories.js
@@ -5,6 +5,7 @@ import DtInput from './input.vue';
 import { INPUT_SIZES, INPUT_TYPES } from './input_constants';
 
 import InputDefault from './input_default.story.vue';
+import InputSearchVariant from './input_search_variant.story.vue';
 
 const iconsList = getIconNames();
 
@@ -364,4 +365,14 @@ export const WithLengthValidation = {
       },
     },
   },
+};
+
+const SearchVariantTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  InputSearchVariant,
+);
+
+export const SearchVariant = {
+  render: SearchVariantTemplate,
 };

--- a/packages/dialtone-vue3/components/input/input.vue
+++ b/packages/dialtone-vue3/components/input/input.vue
@@ -100,6 +100,7 @@
           <slot
             name="rightIcon"
             :icon-size="iconSize"
+            :clear="clearInput"
           />
         </span>
       </div>
@@ -576,9 +577,10 @@ export default {
       }
     },
 
-    clear () {
+    emitClearEvents () {
       this.$emit('input', '');
       this.$emit('clear');
+      this.$emit('update:modelValue', '');
     },
 
     blur () {
@@ -599,6 +601,12 @@ export default {
 
     validateLength (length) {
       this.isInvalid = (length > this.validationProps.length.max);
+    },
+
+    clearInput () {
+      this.$refs.input.value = '';
+      this.$refs.input.focus();
+      this.emitClearEvents();
     },
   },
 };

--- a/packages/dialtone-vue3/components/input/input_search_variant.story.vue
+++ b/packages/dialtone-vue3/components/input/input_search_variant.story.vue
@@ -1,0 +1,131 @@
+<template>
+  <dt-input
+    ref="input"
+    v-model="inputValue"
+    autocomplete="on"
+    :type="$attrs.type"
+    :messages="$attrs.messages"
+    :size="$attrs.size"
+    :label="$attrs.label"
+    :messages-child-props="$attrs.messagesChildProps"
+    :name="$attrs.name"
+    :disabled="$attrs.disabled"
+    :show-messages="$attrs.showMessages"
+    :messages-class="$attrs.messagesClass"
+    :placeholder="$attrs.placeholder"
+    :input-class="$attrs.inputClass"
+    :retain-warning="$attrs.retainWarning"
+    :input-wrapper-class="$attrs.inputWrapperClass"
+    :current-length="$attrs.currentLength"
+    :validate="validationConfig"
+    @blur="$attrs.onBlur"
+    @input="$attrs.onInput"
+    @clear="$attrs.onClear"
+    @focus="$attrs.onFocus"
+    @focusin="$attrs.onFocusIn"
+    @focusout="$attrs.onFocusOut"
+    @update:length="updateLength"
+    @update:invalid="$attrs.onUpdateIsInvalid"
+  >
+    <template
+      v-if="$attrs.labelSlot"
+      #labelSlot
+    >
+      <span v-html="$attrs.labelSlot" />
+    </template>
+    <template
+      v-if="$attrs.description"
+      #description
+    >
+      <span v-html="$attrs.description" />
+    </template>
+    <template #leftIcon="{ iconSize }">
+      <dt-icon
+        name="search"
+        :size="iconSize"
+      />
+    </template>
+    <template
+      v-if="inputValue.length !== 0"
+      #rightIcon="{ clear }"
+    >
+      <dt-button
+        kind="muted"
+        importance="clear"
+        size="xs"
+        circle
+        aria-label="Clear search"
+        @click="clear"
+      >
+        <template #icon="{ iconSize }">
+          <dt-icon
+            name="close"
+            :size="iconSize"
+          />
+        </template>
+      </dt-button>
+    </template>
+  </dt-input>
+</template>
+
+<script>
+import DtInput from './input.vue';
+import { DtButton } from '@/components/button';
+import { DtIcon } from '@/components/icon';
+
+export default {
+  name: 'InputSearchVariant',
+
+  components: { DtInput, DtIcon, DtButton },
+
+  inheritAttrs: false,
+
+  data () {
+    return {
+      inputValue: '',
+      inputLength: 0,
+    };
+  },
+
+  computed: {
+    validationMessage () {
+      const remainingCharacters = this.$attrs.validate?.length?.max - this.inputLength;
+
+      if (remainingCharacters < 0) {
+        return `${Math.abs(remainingCharacters)} characters over limit`;
+      } else {
+        return `${remainingCharacters} characters left`;
+      }
+    },
+
+    validationConfig () {
+      if (!this?.$attrs?.validate?.length) {
+        return null;
+      }
+
+      // Deep clone validate object
+      const validateConfigData = JSON.parse(JSON.stringify(this.$attrs.validate));
+
+      // Adds validation message
+      validateConfigData.length.message = this?.$attrs?.validate?.length?.message
+        ? this.$attrs.validate.length.message
+        : this.validationMessage;
+
+      return validateConfigData;
+    },
+  },
+
+  watch: {
+    modelValue (val) {
+      this.inputValue = val;
+    },
+  },
+
+  methods: {
+    updateLength ($event) {
+      this.inputLength = $event;
+      this.$attrs.onUpdateLength($event);
+    },
+  },
+};
+</script>


### PR DESCRIPTION
# feat(input): DLT-1945 add clear slot prop to rightIcon

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/wboRTWZFjszCQArSyg/giphy.gif?cid=790b7611othpnymbn3npuofac6vk8huxik2b0zwuisjuujab&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
[DLT-1945]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adds the "clear" slot prop to the `rightIcon` slot, so when this prop is passed and used in the click handler, the input is cleared and focused.
<!--- Describe specifically what the changes are -->

## :bulb: Context
We need this to more easily replace the native inputs with type "search" for DtInput in the product.
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :crystal_ball: Next Steps
Add changes to Vue 2
<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

![clear-input](https://github.com/user-attachments/assets/ab8d37a7-55cb-464d-90a9-79e9563c25a3)



<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->


[DLT-1945]: https://dialpad.atlassian.net/browse/DLT-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ