### PR TITLE
fix(docs): DLT-1994 use dialtone scrollbar in docsite

### DIFF
--- a/apps/dialtone-documentation/package.json
+++ b/apps/dialtone-documentation/package.json
@@ -50,7 +50,8 @@
   "dependencies": {
     "@dialpad/dialtone": "workspace:*",
     "@dialpad/dialtone-css": "workspace:*",
-    "@dialpad/dialtone-icons": "workspace:*"
+    "@dialpad/dialtone-icons": "workspace:*",
+    "overlayscrollbars": "2.9.1"
   },
   "devDependencies": {
     "@dialpad/dialtone-combinator": "^0.3.1",

--- a/apps/dialtone-documentation/package.json
+++ b/apps/dialtone-documentation/package.json
@@ -50,8 +50,7 @@
   "dependencies": {
     "@dialpad/dialtone": "workspace:*",
     "@dialpad/dialtone-css": "workspace:*",
-    "@dialpad/dialtone-icons": "workspace:*",
-    "overlayscrollbars": "2.9.1"
+    "@dialpad/dialtone-icons": "workspace:*"
   },
   "devDependencies": {
     "@dialpad/dialtone-combinator": "^0.3.1",

--- a/common/utils.js
+++ b/common/utils.js
@@ -15,7 +15,15 @@ export function kebabCaseToPascalCase (string) {
     .join('');
 }
 
+const scheduler = typeof setImmediate === 'function' ? setImmediate : setTimeout;
+export function flushPromises () {
+  return new Promise((resolve) => {
+    scheduler(resolve);
+  });
+}
+
 export default {
   getUniqueString,
   kebabCaseToPascalCase,
+  flushPromises,
 };

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "docopt": "0.6.2",
     "emoji-regex": "10.3.0",
     "emoji-toolkit": "8.0.0",
-    "overlayscrollbars": "2.2.0",
+    "overlayscrollbars": "2.10.0",
     "requireindex": "1.2.0",
     "stylelint": "15.11.0",
     "tippy.js": "6.3.7"

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "docopt": "0.6.2",
     "emoji-regex": "10.3.0",
     "emoji-toolkit": "8.0.0",
+    "overlayscrollbars": "2.2.0",
     "requireindex": "1.2.0",
     "stylelint": "15.11.0",
     "tippy.js": "6.3.7"

--- a/packages/dialtone-vue2/package.json
+++ b/packages/dialtone-vue2/package.json
@@ -55,7 +55,6 @@
     "@tiptap/vue-2": "2.3.0",
     "date-fns": "2.30.0",
     "emoji-toolkit": "8.0.0",
-    "overlayscrollbars": "2.9.1",
     "regex-combined-emojis": "1.6.0",
     "tippy.js": "6.3.7"
   },

--- a/packages/dialtone-vue3/package.json
+++ b/packages/dialtone-vue3/package.json
@@ -54,7 +54,6 @@
     "@tiptap/vue-3": "2.3.0",
     "date-fns": "2.30.0",
     "emoji-toolkit": "8.0.0",
-    "overlayscrollbars": "2.9.1",
     "regex-combined-emojis": "1.6.0",
     "tippy.js": "6.3.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       '@dialpad/dialtone-icons':
         specifier: workspace:*
         version: link:../../packages/dialtone-icons
+      overlayscrollbars:
+        specifier: 2.9.1
+        version: 2.9.1
     devDependencies:
       '@dialpad/dialtone-combinator':
         specifier: ^0.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       emoji-toolkit:
         specifier: 8.0.0
         version: 8.0.0
+      overlayscrollbars:
+        specifier: 2.2.0
+        version: 2.2.0
       requireindex:
         specifier: 1.2.0
         version: 1.2.0
@@ -251,9 +254,6 @@ importers:
       '@dialpad/dialtone-icons':
         specifier: workspace:*
         version: link:../../packages/dialtone-icons
-      overlayscrollbars:
-        specifier: 2.9.1
-        version: 2.9.1
     devDependencies:
       '@dialpad/dialtone-combinator':
         specifier: ^0.3.1
@@ -657,9 +657,6 @@ importers:
       emoji-toolkit:
         specifier: 8.0.0
         version: 8.0.0
-      overlayscrollbars:
-        specifier: 2.9.1
-        version: 2.9.1
       regex-combined-emojis:
         specifier: 1.6.0
         version: 1.6.0
@@ -892,9 +889,6 @@ importers:
       emoji-toolkit:
         specifier: 8.0.0
         version: 8.0.0
-      overlayscrollbars:
-        specifier: 2.9.1
-        version: 2.9.1
       regex-combined-emojis:
         specifier: 1.6.0
         version: 1.6.0
@@ -11685,8 +11679,8 @@ packages:
     resolution: {integrity: sha512-eqaVuDxnxDO55+pncqTTphbeq6O5XHMyrSfWQoL48mG2rUjr2ZBzvkFkcxIiG3l7IaIY6/L1oX1AJIDdZyzuPQ==}
     engines: {node: '>= 10.0'}
 
-  overlayscrollbars@2.9.1:
-    resolution: {integrity: sha512-BY3hfQcQVZvi25e3YcYe06HPy9yn0lE3akBnUE02fGu3S8OyJmGFx/LDC9rjFJg6Im+YdweXLYEFJTuEhVLMvA==}
+  overlayscrollbars@2.2.0:
+    resolution: {integrity: sha512-Sx7gI2TEx+TFvFXJq4BUYM5R4bfWQR2ertdxyzAQ589ouPKKifMBU0/opdCb1bUC7x6sMiSNI1u9ngC0RbMnBg==}
 
   p-any@2.1.0:
     resolution: {integrity: sha512-JAERcaMBLYKMq+voYw36+x5Dgh47+/o7yuv2oQYuSSUml4YeqJEFznBrY2UeEkoSHqBua6hz518n/PsowTYLLg==}
@@ -29422,7 +29416,7 @@ snapshots:
       domino: 2.1.6
       validator: 13.11.0
 
-  overlayscrollbars@2.9.1: {}
+  overlayscrollbars@2.2.0: {}
 
   p-any@2.1.0:
     dependencies:
@@ -31602,7 +31596,7 @@ snapshots:
     dependencies:
       chokidar: 3.5.3
       immutable: 4.3.4
-      source-map-js: 1.0.2
+      source-map-js: 1.2.0
 
   sax@1.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ importers:
         specifier: 8.0.0
         version: 8.0.0
       overlayscrollbars:
-        specifier: 2.2.0
-        version: 2.2.0
+        specifier: 2.10.0
+        version: 2.10.0
       requireindex:
         specifier: 1.2.0
         version: 1.2.0
@@ -11679,8 +11679,8 @@ packages:
     resolution: {integrity: sha512-eqaVuDxnxDO55+pncqTTphbeq6O5XHMyrSfWQoL48mG2rUjr2ZBzvkFkcxIiG3l7IaIY6/L1oX1AJIDdZyzuPQ==}
     engines: {node: '>= 10.0'}
 
-  overlayscrollbars@2.2.0:
-    resolution: {integrity: sha512-Sx7gI2TEx+TFvFXJq4BUYM5R4bfWQR2ertdxyzAQ589ouPKKifMBU0/opdCb1bUC7x6sMiSNI1u9ngC0RbMnBg==}
+  overlayscrollbars@2.10.0:
+    resolution: {integrity: sha512-diNMeEafWTE0A4GJfwRpdBp2rE/BEvrhptBdBcDu8/UeytWcdCy9Td8tZWnztJeJ26f8/uHCWfPnPUC/dtgJdw==}
 
   p-any@2.1.0:
     resolution: {integrity: sha512-JAERcaMBLYKMq+voYw36+x5Dgh47+/o7yuv2oQYuSSUml4YeqJEFznBrY2UeEkoSHqBua6hz518n/PsowTYLLg==}
@@ -29416,7 +29416,7 @@ snapshots:
       domino: 2.1.6
       validator: 13.11.0
 
-  overlayscrollbars@2.2.0: {}
+  overlayscrollbars@2.10.0: {}
 
   p-any@2.1.0:
     dependencies:
@@ -30096,11 +30096,11 @@ snapshots:
     dependencies:
       postcss: 7.0.39
 
-  postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39):
+  postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39):
     dependencies:
       htmlparser2: 3.10.1
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
 
   postcss-image-set-function@3.0.1:
     dependencies:
@@ -30111,11 +30111,11 @@ snapshots:
     dependencies:
       postcss: 7.0.39
 
-  postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39):
+  postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39):
     dependencies:
       '@babel/core': 7.23.2
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
     transitivePeerDependencies:
       - supports-color
 
@@ -30168,10 +30168,10 @@ snapshots:
     dependencies:
       postcss: 7.0.39
 
-  postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39):
+  postcss-markdown@0.36.0(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39):
     dependencies:
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
       remark: 10.0.1
       unist-util-find-all-after: 1.0.5
 
@@ -30564,14 +30564,14 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 3.0.2
 
-  postcss-syntax@0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39):
+  postcss-syntax@0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39):
     dependencies:
       postcss: 7.0.39
     optionalDependencies:
-      postcss-html: 0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39)
-      postcss-jsx: 0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39)
+      postcss-html: 0.36.0(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39)
+      postcss-jsx: 0.36.4(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39)
       postcss-less: 3.1.4
-      postcss-markdown: 0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39)
+      postcss-markdown: 0.36.0(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39)
       postcss-scss: 2.1.1
 
   postcss-unique-selectors@5.1.1(postcss@8.4.33):
@@ -32625,10 +32625,10 @@ snapshots:
       normalize-selector: 0.2.0
       pify: 4.0.1
       postcss: 7.0.39
-      postcss-html: 0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39)
-      postcss-jsx: 0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39)
+      postcss-html: 0.36.0(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39)
+      postcss-jsx: 0.36.4(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39)
       postcss-less: 3.1.4
-      postcss-markdown: 0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39)
+      postcss-markdown: 0.36.0(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39)
       postcss-media-query-parser: 0.2.3
       postcss-reporter: 6.0.1
       postcss-resolve-nested-selector: 0.1.1
@@ -32636,7 +32636,7 @@ snapshots:
       postcss-sass: 0.3.5
       postcss-scss: 2.1.1
       postcss-selector-parser: 3.1.2
-      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@8.4.33))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
+      postcss-syntax: 0.36.2(postcss-html@0.36.0(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39))(postcss-jsx@0.36.4(postcss-syntax@0.36.2(postcss@7.0.39))(postcss@7.0.39))(postcss-less@3.1.4)(postcss-markdown@0.36.0)(postcss-scss@2.1.1)(postcss@7.0.39)
       postcss-value-parser: 3.3.1
       resolve-from: 4.0.0
       signal-exit: 3.0.7


### PR DESCRIPTION
# fix(docs): DLT-1994 use dialtone scrollbar in docsite

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExODB5YnV4MWtjenEzOWhvdWl6M2JmcWJoeXA0NDlxbTJzOHJtc2tvcyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/o3I14sI7tYFJSobEe9/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1994

## :book: Description

Update the main scrollbar of the docsite to use the new dialtone scrollbar. Could not use the directive because the vuepress scrollbar actually exists outside of the vue instance on the body, so just used overlayscrollbars directly.

Can probably update the leftbar as well, but I have one technical concern I want to discuss outside the scope of this PR.

## :bulb: Context

Mostly because this "jumping" problem annoys me.

![2024-08-15 16 53 01](https://github.com/user-attachments/assets/4959759d-e976-4c29-9058-3b8b16f8d62e)

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change..

## :link: Sources

https://github.com/KingSora/OverlayScrollbars
