### PR TITLE
fix(message-input): DLT-1996 fix line breaks when initializing input value

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -216,6 +216,13 @@ export const Default = {
   render: (argsData) => createRenderConfig(DtRecipeMessageInput, DtRecipeMessageInputDefaultTemplate, argsData),
 };
 
+export const InitializeWithLineBreaks = {
+  render: (argsData) => createRenderConfig(DtRecipeMessageInput, DtRecipeMessageInputDefaultTemplate, argsData),
+  args: {
+    value: 'Always the Padawan,\n never the Jedi.',
+  },
+};
+
 export const WithoutExtensions = {
   render: (argsData) => createRenderConfig(DtRecipeMessageInput, DtRecipeMessageInputDefaultTemplate, argsData),
   args: {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -665,6 +665,12 @@ export default {
     },
   },
 
+  created () {
+    if (this.value && this.outputFormat === 'text') {
+      this.internalInputValue = this.value.replace(/\n/g, '<br>');
+    }
+  },
+
   methods: {
     // Mousedown instead of click because it fires before the blur event.
     onMousedown (e) {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -224,6 +224,13 @@ export const Default = {
   args: {},
 };
 
+export const InitializeWithLineBreaks = {
+  render: DefaultTemplate,
+  args: {
+    modelValue: 'Always the Padawan,\n never the Jedi.',
+  },
+};
+
 export const WithoutExtensions = {
   render: DefaultTemplate,
   args: {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -664,8 +664,8 @@ export default {
   },
 
   created () {
-    if (this.value && this.outputFormat === 'text') {
-      this.internalInputValue = this.value.replace(/\n/g, '<br>');
+    if (this.modelValue && this.outputFormat === 'text') {
+      this.internalInputValue = this.modelValue.replace(/\n/g, '<br>');
     }
   },
 

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -663,6 +663,12 @@ export default {
     },
   },
 
+  created () {
+    if (this.value && this.outputFormat === 'text') {
+      this.internalInputValue = this.value.replace(/\n/g, '<br>');
+    }
+  },
+
   methods: {
     // Mousedown instead of click because it fires before the blur event.
     onMousedown (e) {


### PR DESCRIPTION
# fix(message-input): DLT-1996 fix line breaks when initializing input value

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExb2picmNpa3FkbTJ0MG81MDI5MGd4b3N0aDFidGVkbDd0OWdnenlhMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/vVzH2XY3Y0Ar6/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-1996
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
We need a solution to ensure line breaks function correctly across both the product and Dialtone. The primary issue is that when the message input component is initialized with a value, we must use `<br>` tags instead of \n to represent line breaks. This is problematic because, on the product side, we rely on \n as `<br>` tags are not supported by the back-end.

After discussing various approaches with @braddialpad, I believe the best solution is to handle this on the Dialtone side. This approach minimizes the number of replacements required in Firespotter. Initially, I considered managing this on the Firespotter side, but I think that solution can bring some issues on the future (like when having SMS count projects to correctly bill our clients, it would be better if we can just display on the input what we will send) and also would be better to don't modify/update the text we send. In case you wanna check, these would be the changes needed on firespotter if we don't go with this one: https://github.com/dialpad/firespotter/pull/45975

## Context
We encounter two scenarios where the input needs to be initialized with text:

- When editing a message
- When working with drafts

Currently, if the text contains line breaks, it doesn’t function well, as the product side uses \n for line breaks, which isn’t compatible with Dialtone.