### PR TITLE
feat(badge): DLT-1907 remove ai logomark for type ai

### DIFF
--- a/apps/dialtone-documentation/docs/components/badge.md
+++ b/apps/dialtone-documentation/docs/components/badge.md
@@ -147,7 +147,7 @@ showHtmlWarning />
     <tr>
       <th class="d-ta-left">Ai</th>
       <td>
-        <dt-badge type="ai" text="Label" kind="label" icon-left="dialpad-ai"/>
+        <dt-badge type="ai" text="Label" kind="label" />
       </td>
       <td><abbr class="d-fc-black-400 d-td-none d-fs-100" title="Not applicable">N/A</abbr></td>
       <td>To call out Dialpad Ai features.</td>
@@ -183,7 +183,7 @@ vueCode='
 <dt-badge type="warning" kind="label" text="Label" />
 <dt-badge type="critical" kind="label" text="Label" />
 <dt-badge type="bulletin" kind="label" text="Label" />
-<dt-badge type="ai" text="Label" kind="label" icon-left="dialpad-ai" />
+<dt-badge type="ai" text="Label" kind="label" />
 <dt-badge type="default" text="1" kind="count" />
 <dt-badge type="info" text="2" kind="count" />
 <dt-badge type="success" text="3" kind="count" />
@@ -451,34 +451,10 @@ showHtmlWarning />
       <span class="d-badge d-badge--bulletin"><span class="d-badge__label">Presenter</span></span>
     </dt-stack>
     <dt-stack direction="row" gap="400">
-      <span class="d-badge d-badge--ai">
-        <span class="d-badge__icon-left">
-          <dt-icon name="dialpad-ai" size="200" />
-        </span>
-        <span class="d-vi-visible-sr">Ai</span>
-        <span class="d-badge__label">Notes</span>
-      </span>
-      <span class="d-badge d-badge--ai">
-        <span class="d-badge__icon-left">
-          <dt-icon name="dialpad-ai" size="200" />
-        </span>
-        <span class="d-vi-visible-sr">Ai</span>
-        <span class="d-badge__label">Suggestion</span>
-      </span>
-      <span class="d-badge d-badge--ai">
-        <span class="d-badge__icon-left">
-          <dt-icon name="dialpad-ai" size="200" />
-        </span>
-        <span class="d-vi-visible-sr">Ai</span>
-        <span class="d-badge__label">enabled</span>
-      </span>
-      <span class="d-badge d-badge--ai">
-        <span class="d-badge__icon-left">
-          <dt-icon name="dialpad-ai" size="200" />
-        </span>
-        <span class="d-vi-visible-sr">Ai</span>
-        <span class="d-badge__label">Transcript</span>
-      </span>
+      <dt-badge type="ai" text="Ai Notes" />
+      <dt-badge type="ai" text="Ai Suggestion" />
+      <dt-badge type="ai" text="Ai enabled" />
+      <dt-badge type="ai" text="Ai Transcript" />
     </dt-stack>
   </dt-stack>
 </code-well-header>

--- a/packages/dialtone-vue2/components/badge/badge.test.js
+++ b/packages/dialtone-vue2/components/badge/badge.test.js
@@ -15,8 +15,6 @@ const testContext = {};
 describe('DtBadge Tests', () => {
   let wrapper;
   let badge;
-  let iconLeftWrapper;
-  let iconLeft;
 
   const updateWrapper = () => {
     wrapper = mount(DtBadge, {
@@ -26,7 +24,6 @@ describe('DtBadge Tests', () => {
     });
 
     badge = wrapper.find('[data-qa="dt-badge"]');
-    iconLeftWrapper = wrapper.find('.d-badge__icon-left');
   };
 
   beforeAll(() => {
@@ -126,12 +123,6 @@ describe('DtBadge Tests', () => {
           await wrapper.setProps({ type: 'ai' });
 
           expect(badge.classes(BADGE_TYPE_MODIFIERS.ai)).toBe(true);
-        });
-
-        it('renders ai icon in iconLeft slot by default', () => {
-          iconLeft = iconLeftWrapper.find('[data-qa="dt-icon"]');
-
-          expect(iconLeft.attributes('data-name') === 'Dialpad Ai').toBe(true);
         });
       });
     });

--- a/packages/dialtone-vue2/components/badge/badge.vue
+++ b/packages/dialtone-vue2/components/badge/badge.vue
@@ -15,11 +15,11 @@
       class="d-badge__decorative"
     />
     <span
-      v-if="iconLeft || type === 'ai'"
+      v-if="iconLeft"
       class="d-badge__icon-left"
     >
       <dt-icon
-        :name="iconLeft || 'dialpad-ai'"
+        :name="iconLeft"
         size="200"
       />
     </span>

--- a/packages/dialtone-vue2/components/badge/badge_examples.story.vue
+++ b/packages/dialtone-vue2/components/badge/badge_examples.story.vue
@@ -92,19 +92,19 @@
       class="d-d-flex d-gg8 d-ai-center"
     >
       <dt-badge
-        text="Notes"
+        text="Ai Notes"
         type="ai"
       />
       <dt-badge
-        text="Suggestion"
+        text="Ai Suggestion"
         type="ai"
       />
       <dt-badge
-        text="on"
+        text="Ai on"
         type="ai"
       />
       <dt-badge
-        text="Transcript"
+        text="Ai Transcript"
         type="ai"
       />
     </div>

--- a/packages/dialtone-vue3/components/badge/badge.test.js
+++ b/packages/dialtone-vue3/components/badge/badge.test.js
@@ -14,8 +14,6 @@ let mockSlots = {};
 describe('DtBadge Tests', () => {
   let wrapper;
   let badge;
-  let iconLeftWrapper;
-  let iconLeft;
 
   const updateWrapper = () => {
     wrapper = mount(DtBadge, {
@@ -24,7 +22,6 @@ describe('DtBadge Tests', () => {
     });
 
     badge = wrapper.find('[data-qa="dt-badge"]');
-    iconLeftWrapper = wrapper.find('.d-badge__icon-left');
   };
 
   beforeEach(() => {
@@ -118,12 +115,6 @@ describe('DtBadge Tests', () => {
 
         it('should have correct type', async () => {
           expect(badge.classes(BADGE_TYPE_MODIFIERS.ai)).toBe(true);
-        });
-
-        it('renders ai icon in iconLeft slot by default', () => {
-          iconLeft = iconLeftWrapper.find('[data-qa="dt-icon"]');
-
-          expect(iconLeft.attributes('data-name') === 'Dialpad Ai').toBe(true);
         });
       });
     });

--- a/packages/dialtone-vue3/components/badge/badge.vue
+++ b/packages/dialtone-vue3/components/badge/badge.vue
@@ -15,11 +15,11 @@
       class="d-badge__decorative"
     />
     <span
-      v-if="iconLeft || type === 'ai'"
+      v-if="iconLeft"
       class="d-badge__icon-left"
     >
       <dt-icon
-        :name="iconLeft || 'dialpad-ai'"
+        :name="iconLeft"
         size="200"
       />
     </span>

--- a/packages/dialtone-vue3/components/badge/badge_examples.story.vue
+++ b/packages/dialtone-vue3/components/badge/badge_examples.story.vue
@@ -92,19 +92,19 @@
       class="d-d-flex d-gg8 d-ai-center"
     >
       <dt-badge
-        text="Notes"
+        text="Ai Notes"
         type="ai"
       />
       <dt-badge
-        text="Suggestion"
+        text="Ai Suggestion"
         type="ai"
       />
       <dt-badge
-        text="on"
+        text="Ai on"
         type="ai"
       />
       <dt-badge
-        text="Transcript"
+        text="Ai Transcript"
         type="ai"
       />
     </div>


### PR DESCRIPTION
# feat(badge): DLT-1907 remove ai logomark for type ai

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMngxNGZoZnp3aHBwMG90OXE4aDlvdmtmaHUyeTY1eTlybG5ncnMyNCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/5JmRkeGYnxVwWBQFL9/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DLT-1907]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Updates badge do that it doesn't add the `dialpad-ai` icon by default when the type is `ai`. We are looking to stop using this icon for Ai.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :crystal_ball: Next Steps
Let QA know about this breaking change.
Relabel the badges that use type `ai` in the Dialpad app.
<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

### Before
<img width="389" alt="image" src="https://github.com/user-attachments/assets/575bea38-69c3-4b70-933c-ad231a701a77">

### After
<img width="395" alt="image" src="https://github.com/user-attachments/assets/0a5eeb6c-caa0-4dde-9290-bd6b465382fb">

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->


[DLT-1907]: https://dialpad.atlassian.net/browse/DLT-1907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ