### PR TITLE
fix(multi-select): DLT-2001 avoid overlap between input text and pills

### DIFF
--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -46,7 +46,7 @@
           ref="input"
           v-model="value"
           class="combobox__input"
-          :class="{ 'combobox__input--hide_text': hideInputText }"
+          :input-class="{ 'd-fc-transparent': hideInputText }"
           :aria-label="label"
           :label="labelVisible ? label : ''"
           :description="description"
@@ -682,9 +682,10 @@ export default {
         const input = this.getInput();
         if (!input) return;
         // Hide the input text when is not on first line
-        if (input.style.paddingBottom !== '') {
-          this.hideInputText = true;
+        if (!input.style.paddingTop) {
+          return;
         }
+        this.hideInputText = true;
         this.revertInputPadding(input);
       }
     },
@@ -729,10 +730,6 @@ export default {
 
 .combobox__input {
   flex-grow: 1;
-}
-
-.combobox__input--hide_text {
-  color: transparent;
 }
 
 .combobox__list--loading {

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -46,6 +46,7 @@
           ref="input"
           v-model="value"
           class="combobox__input"
+          :class="{ 'combobox__input--hide_text': hideInputText }"
           :aria-label="label"
           :label="labelVisible ? label : ''"
           :description="description"
@@ -375,6 +376,7 @@ export default {
       initialInputHeight: null,
       CHIP_SIZES,
       inputFocused: false,
+      hideInputText: false,
     };
   },
 
@@ -670,6 +672,7 @@ export default {
       if (this.collapseOnFocusOut) {
         await this.$nextTick();
         this.setInputPadding();
+        this.hideInputText = false;
       }
     },
 
@@ -678,6 +681,10 @@ export default {
       if (this.collapseOnFocusOut) {
         const input = this.getInput();
         if (!input) return;
+        // Hide the input text when is not on first line
+        if (input.style.paddingBottom !== '') {
+          this.hideInputText = true;
+        }
         this.revertInputPadding(input);
       }
     },
@@ -722,6 +729,10 @@ export default {
 
 .combobox__input {
   flex-grow: 1;
+}
+
+.combobox__input--hide_text {
+  color: transparent;
 }
 
 .combobox__list--loading {

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -46,6 +46,7 @@
           ref="input"
           v-model="value"
           class="combobox__input"
+          :class="{ 'combobox__input--hide_text': hideInputText }"
           :aria-label="label"
           :label="labelVisible ? label : ''"
           :description="description"
@@ -376,6 +377,7 @@ export default {
       CHIP_SIZES,
       hasSlotContent,
       inputFocused: false,
+      hideInputText: false,
     };
   },
 
@@ -663,6 +665,7 @@ export default {
       if (this.collapseOnFocusOut) {
         await this.$nextTick();
         this.setInputPadding();
+        this.hideInputText = false;
       }
     },
 
@@ -671,6 +674,10 @@ export default {
       if (this.collapseOnFocusOut) {
         const input = this.getInput();
         if (!input) return;
+        // Hide the input text when is not on first line
+        if (input.style.paddingBottom !== '') {
+          this.hideInputText = true;
+        }
         this.revertInputPadding(input);
       }
     },
@@ -715,6 +722,10 @@ export default {
 
 .combobox__input {
   flex-grow: 1;
+}
+
+.combobox__input--hide_text {
+  color: transparent;
 }
 
 .combobox__list--loading {

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -46,7 +46,7 @@
           ref="input"
           v-model="value"
           class="combobox__input"
-          :class="{ 'combobox__input--hide_text': hideInputText }"
+          :input-class="{ 'd-fc-transparent': hideInputText }"
           :aria-label="label"
           :label="labelVisible ? label : ''"
           :description="description"
@@ -675,9 +675,10 @@ export default {
         const input = this.getInput();
         if (!input) return;
         // Hide the input text when is not on first line
-        if (input.style.paddingBottom !== '') {
-          this.hideInputText = true;
+        if (!input.style.paddingTop) {
+          return;
         }
+        this.hideInputText = true;
         this.revertInputPadding(input);
       }
     },
@@ -722,10 +723,6 @@ export default {
 
 .combobox__input {
   flex-grow: 1;
-}
-
-.combobox__input--hide_text {
-  color: transparent;
 }
 
 .combobox__list--loading {


### PR DESCRIPTION
# fix(multi-select): DLT-2001 avoid overlap between input text and pills

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExd3IwNWYyenR6ZjUwNGVjZ2U3MTRxcWJmaWU3OW43eXpzc2ZwdXNiZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3NtY188QaxDdC/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-2001
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
As part of this pull request, we avoid text overlap between input text and multi-select pills when using the `collapseOnFocusOut` prop. I have made some updates to make the component work like this:

- If the multi-select needs to collapse (that is, there are pills to hide), the input text will not be present when the focus is lost. As soon as the user regains focus, the text will appear.

https://github.com/user-attachments/assets/db015ff4-c804-4492-bdcb-cadf801235a5

- If the multi-select does not need to be collapsed (only one line of items), the input text will still be there, as it was odd to hide it when the focus was lost.

https://github.com/user-attachments/assets/60caa66a-ca39-4530-bb17-70027546abfb


## :bulb: Context
This problem was only reproducible when the `collapseOnFocusOut` prop was true on the multi-select component. This change should not affect the behaviour when `collapseOnFocusOut` is false.
https://github.com/user-attachments/assets/9d77a3b8-f938-460c-be50-6c82bbf08c69