### PR TITLE
feat(avatar): DLT-1916 remove dt-icon

### DIFF
--- a/packages/dialtone-vue3/components/avatar/avatar.test.js
+++ b/packages/dialtone-vue3/components/avatar/avatar.test.js
@@ -9,6 +9,7 @@ const MOCK_INITIALS = 'JN';
 const MOCK_SIZE = 'lg';
 const MOCK_GROUP = 25;
 const MOCK_CUSTOM_CLASS = 'my-custom-class';
+const MOCK_ICON_SLOT = '<template #icon=>Icon</template>';
 let MOCK_ELEMENT = null;
 
 const baseProps = {
@@ -19,6 +20,7 @@ const baseAttrs = {};
 
 let mockProps = {};
 let mockAttrs = {};
+let mockSlots = {};
 
 describe('DtAvatar Tests', () => {
   let wrapper;
@@ -30,6 +32,7 @@ describe('DtAvatar Tests', () => {
     wrapper = mount(DtAvatar, {
       props: { ...baseProps, ...mockProps },
       attrs: { ...baseAttrs, ...mockAttrs },
+      slots: { ...mockSlots },
     });
 
     image = wrapper.find('[data-qa="dt-avatar-image"]');
@@ -43,6 +46,7 @@ describe('DtAvatar Tests', () => {
 
   afterEach(() => {
     mockProps = {};
+    mockSlots = {};
   });
 
   describe('Presentation Tests', () => {
@@ -76,19 +80,19 @@ describe('DtAvatar Tests', () => {
       });
     });
 
-    describe('When the iconName is provided', () => {
+    describe('When the icon slot is provided', () => {
       beforeEach(() => {
-        mockProps = { iconName: 'accessibility' };
+        mockSlots = { icon: MOCK_ICON_SLOT };
 
         updateWrapper();
       });
 
       it('icon should exist', () => {
-        expect(wrapper.find('svg').exists()).toBeTruthy();
+        expect(wrapper.find('[data-qa="dt-avatar-icon"]').exists()).toBeTruthy();
       });
 
       it('should have correct class', () => {
-        expect(wrapper.find('svg').classes(AVATAR_KIND_MODIFIERS.icon)).toBe(true);
+        expect(wrapper.find('[data-qa="dt-avatar-icon"]').classes(AVATAR_KIND_MODIFIERS.icon)).toBe(true);
       });
     });
 

--- a/packages/dialtone-vue3/components/avatar/avatar.vue
+++ b/packages/dialtone-vue3/components/avatar/avatar.vue
@@ -22,15 +22,19 @@
         :src="imageSrc"
         :alt="imageAlt"
       >
-      <!-- @slot Slot for avatar icon. It will display if no imageSrc is provided -->
-      <slot
-        v-else-if="hasSlotContent($slots.icon)"
-        name="icon"
-        :aria-label="iconAriaLabel"
-        :icon-size="iconSize || AVATAR_ICON_SIZES[size]"
-        :icon-class="[iconClass, AVATAR_KIND_MODIFIERS.icon]"
+      <div
+        v-else-if="isIconType"
+        :class="[iconClass, AVATAR_KIND_MODIFIERS.icon]"
+        :aria-label="clickable ? iconAriaLabel : ''"
         :data-qa="iconDataQa"
-      />
+        :role="clickable ? 'button' : ''"
+      >
+        <!-- @slot Slot for avatar icon. It will display if no imageSrc is provided -->
+        <slot
+          name="icon"
+          :icon-size="iconSize || AVATAR_ICON_SIZES[size]"
+        />
+      </div>
       <span
         v-else
         :class="[AVATAR_KIND_MODIFIERS.initials]"

--- a/packages/dialtone-vue3/components/avatar/avatar_variants.story.vue
+++ b/packages/dialtone-vue3/components/avatar/avatar_variants.story.vue
@@ -36,13 +36,8 @@
           :size="size"
           full-name="Avatar Icon"
         >
-          <template #icon="{ iconSize, iconClass, dataQa, ariaLabel }">
-            <dt-icon-user
-              :size="iconSize"
-              :class="iconClass"
-              :data-qa="dataQa"
-              :aria-label="ariaLabel"
-            />
+          <template #icon="{ iconSize }">
+            <dt-icon-user :size="iconSize" />
           </template>
         </dt-avatar>
       </div>
@@ -100,13 +95,8 @@
           icon-aria-label="user icon"
           clickable
         >
-          <template #icon="{ iconSize, iconClass, dataQa, ariaLabel }">
-            <dt-icon-user
-              :size="iconSize"
-              :class="iconClass"
-              :data-qa="dataQa"
-              :aria-label="ariaLabel"
-            />
+          <template #icon="{ iconSize }">
+            <dt-icon-user :size="iconSize" />
           </template>
         </dt-avatar>
         <dt-avatar
@@ -130,13 +120,8 @@
           :seed="$attrs.seed"
           :group="10"
         >
-          <template #icon="{ iconSize, iconClass, dataQa, ariaLabel }">
-            <dt-icon-user
-              :size="iconSize"
-              :class="iconClass"
-              :data-qa="dataQa"
-              :aria-label="ariaLabel"
-            />
+          <template #icon="{ iconSize }">
+            <dt-icon-user :size="iconSize" />
           </template>
         </dt-avatar>
         <dt-avatar

--- a/packages/dialtone-vue3/components/avatar/avatar_variants.story.vue
+++ b/packages/dialtone-vue3/components/avatar/avatar_variants.story.vue
@@ -35,8 +35,16 @@
           :seed="$attrs.seed"
           :size="size"
           full-name="Avatar Icon"
-          icon-name="user"
-        />
+        >
+          <template #icon="{ iconSize, iconClass, dataQa, ariaLabel }">
+            <dt-icon-user
+              :size="iconSize"
+              :class="iconClass"
+              :data-qa="dataQa"
+              :aria-label="ariaLabel"
+            />
+          </template>
+        </dt-avatar>
       </div>
     </div>
     <div>
@@ -64,7 +72,11 @@
           :image-src="$attrs.imageSrc"
           :image-alt="$attrs.imageAlt"
           overlay-icon="hear"
-        />
+        >
+          <template #overlayIcon>
+            <dt-icon-hear />
+          </template>
+        </dt-avatar>
         <dt-avatar
           :seed="$attrs.seed"
           size="xl"
@@ -85,10 +97,18 @@
         />
         <dt-avatar
           :seed="$attrs.seed"
-          icon-name="user"
           icon-aria-label="user icon"
           clickable
-        />
+        >
+          <template #icon="{ iconSize, iconClass, dataQa, ariaLabel }">
+            <dt-icon-user
+              :size="iconSize"
+              :class="iconClass"
+              :data-qa="dataQa"
+              :aria-label="ariaLabel"
+            />
+          </template>
+        </dt-avatar>
         <dt-avatar
           :seed="$attrs.seed"
           full-name="Person avatar"
@@ -108,9 +128,17 @@
         />
         <dt-avatar
           :seed="$attrs.seed"
-          icon-name="user"
           :group="10"
-        />
+        >
+          <template #icon="{ iconSize, iconClass, dataQa, ariaLabel }">
+            <dt-icon-user
+              :size="iconSize"
+              :class="iconClass"
+              :data-qa="dataQa"
+              :aria-label="ariaLabel"
+            />
+          </template>
+        </dt-avatar>
         <dt-avatar
           :seed="$attrs.seed"
           full-name="Person avatar"
@@ -124,12 +152,13 @@
 </template>
 
 <script>
+import { DtIconUser, DtIconHear } from '@dialpad/dialtone-icons/vue3';
 import DtAvatar from './avatar.vue';
 import { AVATAR_PRESENCE_STATES, AVATAR_SIZE_MODIFIERS } from './avatar_constants.js';
 
 export default {
   name: 'DtAvatarVariants',
-  components: { DtAvatar },
+  components: { DtAvatar, DtIconUser, DtIconHear },
   data () {
     return {
       avatarSizes: Object.keys(AVATAR_SIZE_MODIFIERS),

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -21,9 +21,17 @@
             :full-name="displayName"
             :image-src="avatarImageUrl"
             image-alt=""
-            :icon-name="iconName"
             :seed="avatarSeed"
-          />
+          >
+            <template
+              v-if="noInitials"
+              #icon="{ iconSize }"
+            >
+              <dt-icon-user
+                :size="iconSize"
+              />
+            </template>
+          </dt-avatar>
         </slot>
       </div>
       <!-- show time instead of avatar when headers not present -->
@@ -118,6 +126,7 @@ import { DtLazyShow } from '@/components/lazy_show';
 import { DtListItem } from '@/components/list_item';
 import { DtBadge } from '@/components/badge';
 import Modal from '@/common/mixins/modal';
+import { DtIconUser } from '@dialpad/dialtone-icons/vue3';
 
 export default {
   name: 'DtRecipeFeedItemRow',
@@ -127,6 +136,7 @@ export default {
     DtLazyShow,
     DtListItem,
     DtBadge,
+    DtIconUser,
   },
 
   mixins: [Modal],
@@ -268,10 +278,6 @@ export default {
           this.$emit('keydown', event);
         },
       };
-    },
-
-    iconName () {
-      return this.noInitials ? 'user' : null;
     },
 
     listItemClasses () {

--- a/packages/dialtone-vue3/recipes/item_layout/contact_info/contact_info.stories.js
+++ b/packages/dialtone-vue3/recipes/item_layout/contact_info/contact_info.stories.js
@@ -1,15 +1,15 @@
 /* eslint-disable max-lines */
 import { action } from '@storybook/addon-actions';
-import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import DtRecipeContactInfo from './contact_info.vue';
 
 import DtRecipeContactInfoDefaultTemplate from './contact_info_default.story.vue';
 import DtRecipeContactInfoVariantsTemplate from './contact_info_variants.story.vue';
 import { AVATAR_SIZE_MODIFIERS, AVATAR_COLORS } from '@/components/avatar';
 import { PRESENCE_STATES_LIST } from '@/components/presence';
+import { DtIconUser } from '@dialpad/dialtone-icons/vue3';
 
 import avatarImage from '@/common/assets/avatar1.png';
-const iconsList = getIconNames();
 
 // Default Prop Values
 export const argsData = {
@@ -39,13 +39,7 @@ export const argTypesData = {
   },
 
   avatarIcon: {
-    options: iconsList,
-    control: {
-      type: 'select',
-      labels: {
-        undefined: '(empty)',
-      },
-    },
+    control: 'object',
   },
 
   avatarColor: {
@@ -158,6 +152,7 @@ export const Default = {
   render: DefaultTemplate,
 
   args: {
+    avatarIcon: DtIconUser,
     avatarSrc: avatarImage,
     avatarSeed: 'JL',
     avatarFullName: 'Joseph Lumaban',

--- a/packages/dialtone-vue3/recipes/item_layout/contact_info/contact_info.vue
+++ b/packages/dialtone-vue3/recipes/item_layout/contact_info/contact_info.vue
@@ -26,11 +26,25 @@
             :full-name="avatar.fullName"
             :image-src="avatar.src"
             image-alt=""
-            :icon-name="avatarIcon"
-            :overlay-icon="avatar.icon"
             :overlay-text="avatar.text"
             :avatar-class="[{ 'd-mln24': index > 0, 'd-bc-brand': !!avatar.halo }]"
-          />
+          >
+            <template
+              v-if="avatarIcon"
+              #icon="{ iconSize }"
+            >
+              <component
+                :is="avatarIcon"
+                :size="iconSize"
+              />
+            </template>
+            <template
+              v-if="avatar.icon"
+              #overlayIcon
+            >
+              <component :is="avatar.icon" />
+            </template>
+          </dt-avatar>
         </span>
         <dt-avatar
           v-else
@@ -38,11 +52,20 @@
           :full-name="avatarFullName"
           :image-src="avatarSrc"
           image-alt=""
-          :icon-name="avatarIcon"
           :seed="avatarSeed"
           :color="avatarColor"
           :presence="presence"
-        />
+        >
+          <template
+            v-if="avatarIcon"
+            #icon="{ iconSize }"
+          >
+            <component
+              :is="avatarIcon"
+              :size="iconSize"
+            />
+          </template>
+        </dt-avatar>
       </button>
     </template>
     <template #default>
@@ -145,7 +168,7 @@ export default {
      * Avatar icon to display if `avatarSrc` is empty.
      */
     avatarIcon: {
-      type: String,
+      type: Object,
       default: null,
     },
 

--- a/packages/dialtone-vue3/recipes/item_layout/contact_info/contact_info_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/item_layout/contact_info/contact_info_variants.story.vue
@@ -6,7 +6,7 @@
       </p>
       <dt-recipe-contact-info
         avatar-labelled-by="contact-number1"
-        avatar-icon="user"
+        :avatar-icon="avatarIcon"
       >
         <template #header>
           <div class="d-d-flex d-ai-center d-mb2">
@@ -33,7 +33,7 @@
       </p>
       <dt-recipe-contact-info
         avatar-labelled-by="contact-number2"
-        avatar-icon="user"
+        :avatar-icon="avatarIcon"
       >
         <template #header>
           <div class="d-d-flex d-ai-center d-mb2">
@@ -68,7 +68,7 @@
       >
         <dt-recipe-contact-info
           avatar-labelled-by="contact-name1"
-          avatar-icon="user"
+          :avatar-icon="avatarIcon"
         >
           <template #header>
             <div class="d-d-flex d-ai-center d-mb2">
@@ -111,7 +111,7 @@
       </p>
       <dt-recipe-contact-info
         avatar-labelled-by="contact-name2"
-        avatar-icon="user"
+        :avatar-icon="avatarIcon"
       >
         <template #header>
           <div class="d-d-flex d-ai-center d-mb2">
@@ -290,6 +290,7 @@
 </template>
 
 <script>
+/* eslint-disable max-lines */
 import DtRecipeContactInfo from './contact_info.vue';
 import { DtButton } from '@/components/button';
 import { DtIcon } from '@/components/icon';
@@ -297,15 +298,17 @@ import { DtLink } from '@/components/link';
 
 import avatar1 from '@/common/assets/avatar1.png';
 import avatar2 from '@/common/assets/avatar2.png';
+import { DtIconHear, DtIconUser } from '@dialpad/dialtone-icons/vue3';
 
 export default {
   name: 'DtRecipeContactInfoVariants',
   components: { DtButton, DtRecipeContactInfo, DtIcon, DtLink },
+
   data () {
     return {
       adminListenInAvatars: [
         { src: avatar1, fullName: 'Jaqueline Nackos', seed: 'JN' },
-        { src: avatar2, fullName: 'Joseph Lumaban', icon: 'hear', seed: 'JL' },
+        { src: avatar2, fullName: 'Joseph Lumaban', icon: DtIconHear, seed: 'JL' },
       ],
 
       groupCallAvatars: [
@@ -313,6 +316,8 @@ export default {
         { src: avatar1, fullName: 'Jaqueline Nackos', seed: 'JN' },
         { src: avatar2, fullName: 'Natalie Woods', text: '+3', seed: 'NW' },
       ],
+
+      avatarIcon: DtIconUser,
     };
   },
 };

--- a/packages/dialtone-vue3/recipes/leftbar/callbox/callbox.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/callbox/callbox.vue
@@ -26,10 +26,16 @@
           :full-name="avatarFullName"
           :seed="avatarSeed"
           :clickable="clickable"
-          :overlay-icon="isOnHold ? 'pause' : null"
           size="sm"
           @click="handleClick"
-        />
+        >
+          <template
+            v-if="isOnHold"
+            #overlayIcon
+          >
+            <dt-icon-pause />
+          </template>
+        </dt-avatar>
         <div class="dt-recipe-callbox--content">
           <component
             :is="clickable ? 'button' : 'span'"
@@ -85,11 +91,12 @@
 import { CALLBOX_BADGE_COLORS, CALLBOX_BORDER_COLORS } from './callbox_constants';
 import DtAvatar from '@/components/avatar/avatar.vue';
 import DtBadge from '@/components/badge/badge.vue';
+import { DtIconPause } from '@dialpad/dialtone-icons/vue3';
 
 export default {
   name: 'DtRecipeCallbox',
 
-  components: { DtBadge, DtAvatar },
+  components: { DtBadge, DtAvatar, DtIconPause },
 
   inheritAttrs: false,
 

--- a/packages/dialtone-vue3/recipes/leftbar/contact_row/contact_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_row/contact_row.vue
@@ -18,12 +18,19 @@
         :full-name="name"
         :image-src="avatarSrc"
         image-alt=""
-        :icon-name="iconName"
-        icon-size="200"
         size="sm"
         :seed="avatarSeed"
         :presence="avatarPresence"
-      />
+      >
+        <template
+          v-if="noInitials"
+          #icon
+        >
+          <dt-icon-user
+            :size="200"
+          />
+        </template>
+      </dt-avatar>
     </template>
     <template #label>
       <dt-emoji-text-wrapper
@@ -60,6 +67,7 @@ import { DtRecipeGeneralRow } from '@/recipes/leftbar/general_row';
 import DtEmojiTextWrapper from '@/components/emoji_text_wrapper/emoji_text_wrapper.vue';
 import DtAvatar from '@/components/avatar/avatar.vue';
 import { extractVueListeners, safeConcatStrings } from '@/common/utils';
+import { DtIconUser } from '@dialpad/dialtone-icons/vue3';
 
 export default {
   name: 'DtRecipeContactRow',
@@ -68,6 +76,7 @@ export default {
     DtAvatar,
     DtRecipeGeneralRow,
     DtEmojiTextWrapper,
+    DtIconUser,
   },
 
   inheritAttrs: false,
@@ -230,10 +239,6 @@ export default {
 
     contactDescription () {
       return safeConcatStrings([this.name, this.presenceText, this.userStatus]);
-    },
-
-    iconName () {
-      return this.noInitials ? 'user' : null;
     },
   },
 };

--- a/packages/dialtone-vue3/recipes/leftbar/contact_row/contact_row_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_row/contact_row_variants.story.vue
@@ -88,6 +88,19 @@
     </div>
     <div>
       <h3>
+        With icon
+      </h3>
+      <dt-recipe-contact-row
+        name="Jaqueline Nackos"
+        avatar-presence="active"
+        avatar-seed="JN"
+        avatar-alt="Avatar person"
+        call-button-tooltip="Call"
+        :no-initials="true"
+      />
+    </div>
+    <div>
+      <h3>
         With emojis in the name
       </h3>
       <dt-recipe-contact-row


### PR DESCRIPTION
# feat(avatar): DLT-1916 remove dt-icon

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DLT-1916]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Removes the use of `dt-icon` from the Avatar component. Adds instead a slot for the avatar icon and for the overlay icon.
As a consequence of these changes, these recipes need to be updated:
- [x] Feed item row
- [x] Contact Info 
- [x] Callbox 
- [x] Contact Row

<!--- Describe specifically what the changes are -->

## :bulb: Context
The want to remove all the uses of `dt-icon` from Dialtone so that consumers can make use of the tree shakable feature of Dialtone icons.
Instead, all icons should be directly imported in this format: `import { DtIconDownload } from '@dialpad/dialtone-icons/vue2';`

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps
- [ ] Do a beta release with just the Avatar component and test that in the chat bot app everything works as expected and that dialtone-icons is effectively tree shaken
- [ ] Update doc site for all updated components
- [ ] Update vue 2
- [ ] Update product

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

### Avatar
<img width="280" alt="image" src="https://github.com/user-attachments/assets/a1dbdbd5-f5ee-4c0a-8c12-964f152fac3a">

### Contact Info
<img width="434" alt="image" src="https://github.com/user-attachments/assets/ca39783b-1f6c-43be-b027-1cac89132038">

### Callbox
<img width="283" alt="image" src="https://github.com/user-attachments/assets/e6eabdf9-3771-4780-9930-6773a14f6f1b">

### Contact Row
<img width="263" alt="image" src="https://github.com/user-attachments/assets/8046b126-6705-4b15-9fd9-202745e63f30">


<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->


[DLT-1916]: https://dialpad.atlassian.net/browse/DLT-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ