### PR TITLE
feat(design-tokens): DLT-2004 typography and radius design tokens for button, input, select, tabs

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeWellHeader.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeWellHeader.vue
@@ -1,6 +1,6 @@
 <template>
-  <aside class="d-bar8">
-    <header :class="classes">
+  <aside>
+    <header class="d-bar8" :class="classes">
       <slot />
     </header>
   </aside>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/IconPopover.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/IconPopover.vue
@@ -12,7 +12,8 @@
   >
     <template #anchor>
       <dt-button
-        class="dialtone-icon-grid__item"
+        class="dialtone-icon-grid__item d-gg8"
+        label-class="d-fl-grow-unset"
         icon-position="top"
         importance="clear"
         kind="muted"
@@ -22,7 +23,6 @@
           <dt-icon
             :name="iconName"
             size="600"
-            class="d-mb8"
           />
         </template>
         <span

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/AllTokens.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/AllTokens.vue
@@ -6,14 +6,9 @@
     v-model:brand="brand"
     @filter="filterTokens"
   />
-  <div
-    v-if="noSearchResults"
-    class="d-d-flex d-fl-center d-p16 d-gg4 d-fc-tertiary d-fs-300"
-  >
-    <span>No results found for</span>
-    <strong class="d-fw-semibold">
-      &OpenCurlyDoubleQuote;{{ searchCriteria }}&CloseCurlyDoubleQuote;
-    </strong>
+  <div v-if="noSearchResults" class="d-body d-fc-tertiary d-p16 d-ta-center">
+    No results found for
+    <strong class="d-fw-semibold"> &OpenCurlyDoubleQuote;{{ searchCriteria }}&CloseCurlyDoubleQuote;</strong>
   </div>
   <token-tree v-else :node="filteredTokens" :category="null" :level="2" :theme="theme" />
 </template>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokensBar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokensBar.vue
@@ -1,12 +1,12 @@
 <!-- eslint-disable vuejs-accessibility/no-autofocus -->
 <template>
-  <dt-stack gap="500">
+  <dt-stack gap="500" class="d-p16 d-bgc-secondary d-bar8">
     <dt-input
       id="search-input"
       v-model="searchCriteria"
+      label="Search Tokens / Value / Keyword"
       autofocus
       aria-label="Search tokens"
-      placeholder="Search Tokens / Value / Keyword"
       type="text"
       autocomplete="off"
       @keyup="searchToken"
@@ -60,10 +60,11 @@
         v-dt-tooltip:top-end="shareLinkTooltip"
         importance="clear"
         kind="muted"
-        icon-position="right"
+        icon-position="left"
+        class="d-ml-auto"
         @click="copyURLToClipboard"
       >
-        Share filter
+        Share Search Filter
         <template #icon="{ iconSize }">
           <dt-icon
             name="link-2"

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleHovercard.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleHovercard.vue
@@ -1,8 +1,8 @@
 <template>
   <dt-hovercard placement="bottom-start" content-class="d-wmn332 ">
     <template #anchor>
-      <dt-button kind="muted" importance="outlined">
-        Hover for Example
+      <dt-button>
+        Hover for example
       </dt-button>
     </template>
     <template #content>

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-d-flex d-ai-flex-end d-jc-space-between d-w100p">
+  <div class="d-d-flex d-ai-flex-end d-jc-space-between">
     <div v-if="bannerTitle" class="d-w100p d-mr8">
       <dt-select-menu
         label="Kind of Banner"

--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -388,13 +388,12 @@ a.header-anchor {
 //      Styles our icon pages
 //  ----------------------------------------------------------------------------
 .d-gl-docsite-icons {
-  --icon-card-width: 12rem;
+  --icon-card-width: minmax(var(--dt-size-775), 1fr);
   --icon-grid-columns: auto-fit;
 
   display: grid;
-  grid-auto-rows: 12rem;
-  grid-gap: var(--dt-space-500);
   grid-template-columns: repeat(var(--icon-grid-columns), [col] var(--icon-card-width));
+  gap: var(--dt-space-400);
 
   &--large {
     grid-auto-rows: 18rem;
@@ -520,9 +519,7 @@ a.header-anchor {
   width: 100%;
   margin-bottom: 0;
   overflow: hidden;
-  font-size: var(--dt-font-size-100);
-  line-height: var(--lh-none);
-  white-space: nowrap;
+  font: var(--dt-typography-label-sm-plain);
   text-align: center;
   text-overflow: ellipsis;
 }

--- a/apps/dialtone-documentation/docs/.vuepress/views/IconCatalog.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/views/IconCatalog.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vuejs-accessibility/no-autofocus -->
 <template>
-  <div class="d-d-grid d-gg16 d-g-cols6 d-mt32 d-mb16">
+  <div class="d-d-grid d-gg16 d-g-cols6 d-mt32 d-mb16 d-p16 d-bgc-secondary d-bar8">
     <div class="d-gc4">
       <dt-input
         id="search-input"
@@ -8,7 +8,7 @@
         v-model="search"
         autofocus
         aria-label="Search icon"
-        placeholder="Search for an icon"
+        label="Find an icon"
         class="d-input d-input-icon--left d-input-icon--right"
         type="text"
         autocomplete="off"
@@ -35,32 +35,31 @@
         </template>
       </dt-input>
     </div>
-    <div class="d-gc2 d-select">
-      <label
-        class="d-vi-visible-sr"
-        for="Dialtone--SelectCategory"
-      >
-        Categories
-      </label>
-      <select
-        id="Dialtone--SelectCategory"
-        v-model="selectedCategory"
-        class="d-select__input d-tt-capitalize"
-      >
-        <option
-          value=""
-          selected
+    <div class="d-gc2">
+      <div class="d-label">
+        <label for="Dialtone--SelectCategory"> Category</label>
+      </div>
+      <div class="d-select">
+        <select
+          id="Dialtone--SelectCategory"
+          v-model="selectedCategory"
+          class="d-select__input d-tt-capitalize"
         >
-          All categories
-        </option>
-        <option
-          v-for="(_, category) in categories"
-          :key="category"
-          :value="category"
-        >
-          {{ category }}
-        </option>
-      </select>
+          <option
+            value=""
+            selected
+          >
+            All
+          </option>
+          <option
+            v-for="(_, category) in categories"
+            :key="category"
+            :value="category"
+          >
+            {{ category }}
+          </option>
+        </select>
+      </div>
     </div>
   </div>
   <div
@@ -68,8 +67,8 @@
     :key="category"
     class="d-mb16"
   >
-    <span
-      class="d-headline--md d-tt-capitalize"
+    <div
+      class="d-headline--lg d-tt-capitalize d-mb4"
       v-text="category"
     />
     <div class="d-gl-docsite-icons">
@@ -85,10 +84,7 @@
       />
     </div>
   </div>
-  <div
-    v-if="!hasSearchResults"
-    class="d-d-flex d-fl-center d-p16 d-gg4 d-fc-tertiary d-fs-300"
-  >
+  <div v-if="!hasSearchResults" class="d-body d-fc-tertiary d-p16 d-pt0 d-ta-center">
     <span>No results found for</span>
     <strong class="d-fw-semibold">
       &OpenCurlyDoubleQuote;{{ search }}&CloseCurlyDoubleQuote;

--- a/apps/dialtone-documentation/docs/components/badge.md
+++ b/apps/dialtone-documentation/docs/components/badge.md
@@ -8,7 +8,7 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-badge--defau
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8914%3A21227&viewport=656%2C314%2C0.55&t=xHutRjwo1o5zMTgT-11
 ---
 
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <dt-stack direction="row" gap="400" class="d-ai-center">
     <dt-badge text="Label" />
     <dt-badge kind="count" text="1" />

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -9,9 +9,7 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 ---
 
 <code-well-header>
-  <button class="d-btn d-btn--primary" type="button">
-    <span class="d-btn__label">Place Call</span>
-  </button>
+  <dt-button> Place Call </dt-button>
 </code-well-header>
 
 <!-- <component-combinator component-name="DtButton" /> -->

--- a/apps/dialtone-documentation/docs/components/hovercard.md
+++ b/apps/dialtone-documentation/docs/components/hovercard.md
@@ -10,7 +10,7 @@ figma_url: https://www.figma.com/design/2adf7JhZOncRyjYiy2joil/DT9-Component-Lib
 
 The hovercard will appear upon the mouse entering the anchor, with a delay of 300 milliseconds. It will remain open as long as the mouse cursor is over either the open card or the anchor.
 
-<code-well-header bgclass="d-bgc-primary" class="d-h264 d-jc-flex-start">
+<code-well-header>
   <example-hovercard />
 </code-well-header>
 

--- a/apps/dialtone-documentation/docs/components/input.md
+++ b/apps/dialtone-documentation/docs/components/input.md
@@ -9,10 +9,10 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 ---
 
 <code-well-header>
-  <dt-stack gap="500" class="d-w100p">
+  <div class="d-d-grid d-gg16 d-g-cols2 d-w100p">
     <dt-input label="Label" placeholder="Placeholder" />
     <dt-input label="Label" type="textarea" placeholder="Placeholder" />
-  </dt-stack>
+  </div>
 </code-well-header>
 
 <!-- <component-combinator component-name="DtInput" /> -->

--- a/apps/dialtone-documentation/docs/components/input.md
+++ b/apps/dialtone-documentation/docs/components/input.md
@@ -347,99 +347,6 @@ const validate = () => {
 };
 ```
 
-### With icons
-
-<code-well-header>
-  <div class="d-stack16 d-w100p">
-    <dt-input label="Left icon" type="text" placeholder="Placeholder">
-      <template #leftIcon="{ iconSize }">
-        <dt-icon name="send" :size="iconSize" />
-      </template>
-    </dt-input>
-    <dt-input label="Right icon" type="text" placeholder="Placeholder">
-      <template #rightIcon="{ iconSize }">
-        <dt-icon name="lock" :size="iconSize" />
-      </template>
-    </dt-input>
-  </div>
-</code-well-header>
-
-<code-example-tabs
-htmlCode='
-<div>
-  <label class="d-label" for="Dialtone--InputExample--IconLeft">Label</label>
-  <div class="d-input__wrapper">
-    <span class="d-input-icon d-input-icon--left">
-      <svg class="d-icon d-icon--size-200">...</svg>
-    </span>
-    <input class="d-input" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
-  </div>
-</div>
-<div>
-  <label class="d-label" for="Dialtone--InputExample--IconRight">Label</label>
-  <div class="d-input__wrapper">
-    <input class="d-input" id="Dialtone--InputExample--IconRight" type="text" placeholder="Placeholder" />
-    <span class="d-input-icon d-input-icon--right">
-      <svg class="d-icon d-icon--size-200">...</svg>
-    </span>
-  </div>
-</div>
-'
-vueCode='
-<dt-input label="Left icon" type="text" placeholder="Placeholder">
-  <template #leftIcon="{ iconSize }">
-    <dt-icon name="send" :size="iconSize" />
-  </template>
-</dt-input>
-<dt-input label="Right icon" type="text" placeholder="Placeholder">
-  <template #rightIcon="{ iconSize }">
-    <dt-icon name="lock" :size="iconSize" />
-  </template>
-</dt-input>
-'
-showHtmlWarning />
-
-<code-well-header>
-  <div class="d-stack16 d-w100p">
-    <dt-input label="Left icon" type="textarea" placeholder="Placeholder">
-      <template #leftIcon="{ iconSize }">
-        <dt-icon name="send" :size="iconSize" />
-      </template>
-    </dt-input>
-    <dt-input label="Right icon" type="textarea" placeholder="Placeholder">
-      <template #rightIcon="{ iconSize }">
-        <dt-icon name="lock" :size="iconSize" />
-      </template>
-    </dt-input>
-  </div>
-</code-well-header>
-
-<code-example-tabs
-htmlCode='
-<div>
-  <label class="d-label" for="Dialtone--InputExample--IconLeft">...</label>
-  <div class="d-input__wrapper">
-    <span class="d-input-icon d-input-icon--left">
-      <svg class="d-icon d-icon--size-200">...</svg>
-    </span>
-    <textarea class="d-textarea" id="Dialtone--InputExample--IconLeft" type="text" placeholder="..."></textarea>
-  </div>
-</div>
-'
-vueCode='
-<dt-input label="Left icon" type="textarea" placeholder="Placeholder">
-  <template #leftIcon="{ iconSize }">
-    <dt-icon name="send" :size="iconSize" />
-  </template>
-</dt-input>
-<dt-input label="Right icon" type="textarea" placeholder="Placeholder">
-  <template #rightIcon="{ iconSize }">
-    <dt-icon name="lock" :size="iconSize" />
-  </template>
-</dt-input>
-'
-showHtmlWarning />
-
 ### Search input
 
 <dt-notice
@@ -523,7 +430,7 @@ vueCode='
 '
 showHtmlWarning />
 
-### Input sizes
+## Sizes
 
 We offer different sizes for instances in which the interface requires a smaller or larger input. In general, though, use the base (medium) size input as much as possible, especially in forms.
 
@@ -648,6 +555,99 @@ vueCode='
 <dt-input label="Medium" type="textarea" placeholder="Placeholder" size="md" />
 <dt-input label="Large" type="textarea" placeholder="Placeholder" size="lg" />
 <dt-input label="Extra large" type="textarea" placeholder="Placeholder" size="xl" />
+'
+showHtmlWarning />
+
+## Icon support
+
+<code-well-header>
+  <div class="d-stack16 d-w100p">
+    <dt-input label="Left icon" type="text" placeholder="Placeholder">
+      <template #leftIcon="{ iconSize }">
+        <dt-icon name="send" :size="iconSize" />
+      </template>
+    </dt-input>
+    <dt-input label="Right icon" type="text" placeholder="Placeholder">
+      <template #rightIcon="{ iconSize }">
+        <dt-icon name="lock" :size="iconSize" />
+      </template>
+    </dt-input>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<div>
+  <label class="d-label" for="Dialtone--InputExample--IconLeft">Label</label>
+  <div class="d-input__wrapper">
+    <span class="d-input-icon d-input-icon--left">
+      <svg class="d-icon d-icon--size-200">...</svg>
+    </span>
+    <input class="d-input" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+  </div>
+</div>
+<div>
+  <label class="d-label" for="Dialtone--InputExample--IconRight">Label</label>
+  <div class="d-input__wrapper">
+    <input class="d-input" id="Dialtone--InputExample--IconRight" type="text" placeholder="Placeholder" />
+    <span class="d-input-icon d-input-icon--right">
+      <svg class="d-icon d-icon--size-200">...</svg>
+    </span>
+  </div>
+</div>
+'
+vueCode='
+<dt-input label="Left icon" type="text" placeholder="Placeholder">
+  <template #leftIcon="{ iconSize }">
+    <dt-icon name="send" :size="iconSize" />
+  </template>
+</dt-input>
+<dt-input label="Right icon" type="text" placeholder="Placeholder">
+  <template #rightIcon="{ iconSize }">
+    <dt-icon name="lock" :size="iconSize" />
+  </template>
+</dt-input>
+'
+showHtmlWarning />
+
+<code-well-header>
+  <div class="d-stack16 d-w100p">
+    <dt-input label="Left icon" type="textarea" placeholder="Placeholder">
+      <template #leftIcon="{ iconSize }">
+        <dt-icon name="send" :size="iconSize" />
+      </template>
+    </dt-input>
+    <dt-input label="Right icon" type="textarea" placeholder="Placeholder">
+      <template #rightIcon="{ iconSize }">
+        <dt-icon name="lock" :size="iconSize" />
+      </template>
+    </dt-input>
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<div>
+  <label class="d-label" for="Dialtone--InputExample--IconLeft">...</label>
+  <div class="d-input__wrapper">
+    <span class="d-input-icon d-input-icon--left">
+      <svg class="d-icon d-icon--size-200">...</svg>
+    </span>
+    <textarea class="d-textarea" id="Dialtone--InputExample--IconLeft" type="text" placeholder="..."></textarea>
+  </div>
+</div>
+'
+vueCode='
+<dt-input label="Left icon" type="textarea" placeholder="Placeholder">
+  <template #leftIcon="{ iconSize }">
+    <dt-icon name="send" :size="iconSize" />
+  </template>
+</dt-input>
+<dt-input label="Right icon" type="textarea" placeholder="Placeholder">
+  <template #rightIcon="{ iconSize }">
+    <dt-icon name="lock" :size="iconSize" />
+  </template>
+</dt-input>
 '
 showHtmlWarning />
 

--- a/apps/dialtone-documentation/docs/components/input.md
+++ b/apps/dialtone-documentation/docs/components/input.md
@@ -9,9 +9,10 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 ---
 
 <code-well-header>
-  <div class="d-w100p">
+  <dt-stack gap="500" class="d-w100p">
     <dt-input label="Label" placeholder="Placeholder" />
-  </div>
+    <dt-input label="Label" type="textarea" placeholder="Placeholder" />
+  </dt-stack>
 </code-well-header>
 
 <!-- <component-combinator component-name="DtInput" /> -->
@@ -42,7 +43,123 @@ This component combines both the `input` and `textarea` elements as options with
 - Do not use placeholder text (i.e. `placeholder` attribute) in place of an accessible `label`.
 - Consider the type of content a user may enter to aid mobile device entry; mobile devices typically surface a keyboard UI attuned to the type. For example, type="tel" will surface a [phone keyboard](http://html5doctor.com/html5-forms-input-types/#input-tel).
 
-## Variants and examples
+## Sizes
+
+We offer different sizes for instances in which the interface requires a smaller or larger input. In general, though, use the base (medium) size input as much as possible, especially in forms.
+
+<code-well-header>
+  <div class="d-d-grid d-gg16 d-g-cols2 d-w100p">
+    <dt-input label="Extra Small" type="text" placeholder="Placeholder" size="xs" />
+    <dt-input label="Extra Small" type="textarea" placeholder="Placeholder" size="xs" />
+    <dt-input label="Small" type="text" placeholder="Placeholder" size="sm" />
+    <dt-input label="Small" type="textarea" placeholder="Placeholder" size="sm" />
+    <dt-input label="Medium" type="text" placeholder="Placeholder" size="md" />
+    <dt-input label="Medium" type="textarea" placeholder="Placeholder" size="md" />
+    <dt-input label="Large" type="text" placeholder="Placeholder" size="lg" />
+    <dt-input label="Large" type="textarea" placeholder="Placeholder" size="lg" />
+    <dt-input label="Extra large" type="text" placeholder="Placeholder" size="xl" />
+    <dt-input label="Extra large" type="textarea" placeholder="Placeholder" size="xl" />
+  </div>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<div>
+  <label>
+    <div class="d-label d-label--xs">Extra small</div>
+    <div class="d-input__wrapper">
+      <input type="text" class="d-input d-input--xs" placeholder="Placeholder">
+    </div>
+  </label>
+</div>
+<div>
+  <label>
+    <div class="d-label d-label--sm">Small</div>
+    <div class="d-input__wrapper">
+      <input type="text" class="d-input d-input--sm" placeholder="Placeholder">
+    </div>
+  </label>
+</div>
+<div>
+  <label>
+    <div class="d-label d-label--md">Medium</div>
+    <div class="d-input__wrapper">
+      <input type="text" class="d-input" placeholder="Placeholder">
+    </div>
+  </label>
+</div>
+<div>
+  <label>
+    <div class="d-label d-label--lg">Large</div>
+    <div class="d-input__wrapper">
+      <input type="text" class="d-input d-input--lg" placeholder="Placeholder">
+    </div>
+  </label>
+</div>
+<div>
+  <label>
+    <div class="d-label d-label--xl">Extra large</div>
+    <div class="d-input__wrapper">
+      <input type="text" class="d-input d-input--xl" placeholder="Placeholder">
+    </div>
+  </label>
+</div>
+<div>
+  <label>
+    <div class="d-label d-label--xs">Extra small</div>
+    <div class="d-input__wrapper">
+      <textarea class="d-textarea d-textarea--xs" placeholder="Placeholder" />
+    </div>
+  </label>
+</div>
+<div>
+  <label>
+    <div class="d-label d-label--sm">Small</div>
+    <div class="d-input__wrapper">
+      <textarea class="d-textarea d-textarea--sm" placeholder="Placeholder" />
+    </div>
+  </label>
+</div>
+<div>
+  <label>
+    <div class="d-label d-label--md">Medium</div>
+    <div class="d-input__wrapper">
+      <textarea class="d-textarea" placeholder="Placeholder" />
+    </div>
+  </label>
+</div>
+<div>
+  <label>
+    <div class="d-label d-label--lg">Large</div>
+    <div class="d-input__wrapper">
+      <textarea class="d-textarea d-textarea--lg" placeholder="Placeholder" />
+    </div>
+  </label>
+</div>
+<div>
+  <label>
+    <div class="d-label d-label--xl">Extra large</div>
+    <div class="d-input__wrapper">
+      <textarea class="d-textarea d-textarea--xl" placeholder="Placeholder" />
+    </div>
+  </label>
+</div>
+'
+vueCode='
+<dt-input label="Extra Small" type="text" placeholder="Placeholder" size="xs" />
+<dt-input label="Extra Small" type="textarea" placeholder="Placeholder" size="xs" />
+<dt-input label="Small" type="text" placeholder="Placeholder" size="sm" />
+<dt-input label="Small" type="textarea" placeholder="Placeholder" size="sm" />
+<dt-input label="Medium" type="text" placeholder="Placeholder" size="md" />
+<dt-input label="Medium" type="textarea" placeholder="Placeholder" size="md" />
+<dt-input label="Large" type="text" placeholder="Placeholder" size="lg" />
+<dt-input label="Large" type="textarea" placeholder="Placeholder" size="lg" />
+<dt-input label="Extra large" type="text" placeholder="Placeholder" size="xl" />
+<dt-input label="Extra large" type="textarea" placeholder="Placeholder" size="xl" />
+'
+showHtmlWarning />
+
+## Examples
 
 ### Base Styles
 
@@ -347,19 +464,19 @@ const validate = () => {
 };
 ```
 
-### Search input
+### Search
 
 <dt-notice
   kind="warning"
   :hide-close="true"
-  class="d-wmx100p d-mb24"
+  class="d-wmx100p d-my16"
 >
   <template #default>
-  Note: The usage of <code>type="search"</code> is not recommended for this component as it may cause unintended styling issues in Chrome. Instead, refer to the provided example code if you need to implement a search input.
+    The use of <code>type="search"</code> is not recommended as it may cause a style collision with a browser's native Shadow DOM, e.g. its clearing functionality. Instead, refer to the below example code if you need to implement a search input with clearing functionality.
   </template>
 </dt-notice>
 
-In this example we show a search input with a clear button on the right side. The clear button is a button with a close icon that clears the input field when clicked. The clear button is only visible when the input field is not empty.
+Use `type="text"` with a clear button in the `icon` slot. When the input is not empty, the clear button will render and will clears the input field when triggered.
 
 <code-well-header>
   <div class="d-w100p">
@@ -427,134 +544,6 @@ vueCode='
     </dt-button>
   </template>
 </dt-input>
-'
-showHtmlWarning />
-
-## Sizes
-
-We offer different sizes for instances in which the interface requires a smaller or larger input. In general, though, use the base (medium) size input as much as possible, especially in forms.
-
-<code-well-header>
-  <div class="d-stack16 d-w100p">
-    <dt-input label="Extra Small" type="text" placeholder="Placeholder" size="xs" />
-    <dt-input label="Small" type="text" placeholder="Placeholder" size="sm" />
-    <dt-input label="Medium" type="text" placeholder="Placeholder" size="md" />
-    <dt-input label="Large" type="text" placeholder="Placeholder" size="lg" />
-    <dt-input label="Extra large" type="text" placeholder="Placeholder" size="xl" />
-  </div>
-</code-well-header>
-
-<code-example-tabs
-htmlCode='
-<div>
-  <label>
-    <div class="d-label d-label--xs">Extra small</div>
-    <div class="d-input__wrapper">
-      <input type="text" class="d-input d-input--xs" placeholder="Placeholder">
-    </div>
-  </label>
-</div>
-<div>
-  <label>
-    <div class="d-label d-label--sm">Small</div>
-    <div class="d-input__wrapper">
-      <input type="text" class="d-input d-input--sm" placeholder="Placeholder">
-    </div>
-  </label>
-</div>
-<div>
-  <label>
-    <div class="d-label d-label--md">Medium</div>
-    <div class="d-input__wrapper">
-      <input type="text" class="d-input" placeholder="Placeholder">
-    </div>
-  </label>
-</div>
-<div>
-  <label>
-    <div class="d-label d-label--lg">Large</div>
-    <div class="d-input__wrapper">
-      <input type="text" class="d-input d-input--lg" placeholder="Placeholder">
-    </div>
-  </label>
-</div>
-<div>
-  <label>
-    <div class="d-label d-label--xl">Extra large</div>
-    <div class="d-input__wrapper">
-      <input type="text" class="d-input d-input--xl" placeholder="Placeholder">
-    </div>
-  </label>
-</div>
-'
-vueCode='
-<dt-input label="Extra Small" type="text" placeholder="Placeholder" size="xs" />
-<dt-input label="Small" type="text" placeholder="Placeholder" size="sm" />
-<dt-input label="Medium" type="text" placeholder="Placeholder" size="md" />
-<dt-input label="Large" type="text" placeholder="Placeholder" size="lg" />
-<dt-input label="Extra large" type="text" placeholder="Placeholder" size="xl" />
-'
-showHtmlWarning />
-
-<code-well-header>
-  <div class="d-stack16 d-w100p">
-    <dt-input label="Extra Small" type="textarea" placeholder="Placeholder" size="xs" />
-    <dt-input label="Small" type="textarea" placeholder="Placeholder" size="sm" />
-    <dt-input label="Medium" type="textarea" placeholder="Placeholder" size="md" />
-    <dt-input label="Large" type="textarea" placeholder="Placeholder" size="lg" />
-    <dt-input label="Extra large" type="textarea" placeholder="Placeholder" size="xl" />
-  </div>
-</code-well-header>
-
-<code-example-tabs
-htmlCode='
-<div>
-  <label>
-    <div class="d-label d-label--xs">Extra small</div>
-    <div class="d-input__wrapper">
-      <textarea class="d-textarea d-textarea--xs" placeholder="Placeholder" />
-    </div>
-  </label>
-</div>
-<div>
-  <label>
-    <div class="d-label d-label--sm">Small</div>
-    <div class="d-input__wrapper">
-      <textarea class="d-textarea d-textarea--sm" placeholder="Placeholder" />
-    </div>
-  </label>
-</div>
-<div>
-  <label>
-    <div class="d-label d-label--md">Medium</div>
-    <div class="d-input__wrapper">
-      <textarea class="d-textarea" placeholder="Placeholder" />
-    </div>
-  </label>
-</div>
-<div>
-  <label>
-    <div class="d-label d-label--lg">Large</div>
-    <div class="d-input__wrapper">
-      <textarea class="d-textarea d-textarea--lg" placeholder="Placeholder" />
-    </div>
-  </label>
-</div>
-<div>
-  <label>
-    <div class="d-label d-label--xl">Extra large</div>
-    <div class="d-input__wrapper">
-      <textarea class="d-textarea d-textarea--xl" placeholder="Placeholder" />
-    </div>
-  </label>
-</div>
-'
-vueCode='
-<dt-input label="Extra Small" type="textarea" placeholder="Placeholder" size="xs" />
-<dt-input label="Small" type="textarea" placeholder="Placeholder" size="sm" />
-<dt-input label="Medium" type="textarea" placeholder="Placeholder" size="md" />
-<dt-input label="Large" type="textarea" placeholder="Placeholder" size="lg" />
-<dt-input label="Extra large" type="textarea" placeholder="Placeholder" size="xl" />
 '
 showHtmlWarning />
 
@@ -653,7 +642,7 @@ showHtmlWarning />
 
 ### Icon Sizes
 
-You may use different icon sizes in different sized inputs
+Each Text Input size has a default icon size, keeping it proportional. While rare, customizing the icon size is possible.
 
 <code-well-header>
   <div class="d-stack16 d-w100p">

--- a/apps/dialtone-documentation/docs/components/popover.md
+++ b/apps/dialtone-documentation/docs/components/popover.md
@@ -7,7 +7,7 @@ image: assets/images/components/popover.png
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-popover--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8921%3A22411&viewport=831%2C-269%2C0.43&t=xHutRjwo1o5zMTgT-11
 ---
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-popover modal />
 </code-well-header>
 
@@ -58,7 +58,7 @@ Your popover should be non-modal when:
 
 ### Popover - Modal
 
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-popover modal />
 </code-well-header>
 
@@ -113,7 +113,7 @@ showHtmlWarning />
 
 ### Popover - Non Modal
 
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-popover />
 </code-well-header>
 
@@ -169,7 +169,7 @@ showHtmlWarning />
 
 ### With Header - Modal
 
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-popover modal header>
     <template #content>
       <div class="d-mb8">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae.<br></div>
@@ -249,7 +249,7 @@ showHtmlWarning />
 
 ### With Footer - Modal
 
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-popover modal footer>
     <template #content>
       <div class="d-mb8">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae.<br></div>

--- a/apps/dialtone-documentation/docs/components/presence.md
+++ b/apps/dialtone-documentation/docs/components/presence.md
@@ -7,7 +7,7 @@ image: assets/images/components/presence.png
 storybook: https://dialtone.dialpad.com/vue/?path=/docs/components-presence--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=9628%3A59018&viewport=-1353%2C1919%2C1.91&t=xHutRjwo1o5zMTgT-11
 ---
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-presence presence="active"/>
 </code-well-header>
 
@@ -20,7 +20,7 @@ Located at the bottom right of an avatar, the `presence` indicator displays a us
 ### Active
 
 When a user is available.
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-presence presence="active"/>
 </code-well-header>
 
@@ -40,7 +40,7 @@ showHtmlWarning />
 ### Busy
 
 When a user is unavailable, either due to being **'On a call'**, **'In a meeting'**, or set to **'DND (Do Not Disturb)'**. Additionally, a text label indicating their specific status will appear under the user's name.
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-presence presence="busy"/>
 </code-well-header>
 
@@ -60,7 +60,7 @@ showHtmlWarning />
 ### Away
 
 When a user has a scheduled meeting on their synced calendar (Google G Suite or Microsoft Office 365) and is not actively participating in it through the app. Additionally, **'In a meeting'** will appear under the user's name.
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-presence presence="away"/>
 </code-well-header>
 
@@ -80,7 +80,7 @@ showHtmlWarning />
 ### Offline
 
 When a user has not logged in for their first time.
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-presence presence="offline"/>
 </code-well-header>
 

--- a/apps/dialtone-documentation/docs/components/select-menu.md
+++ b/apps/dialtone-documentation/docs/components/select-menu.md
@@ -8,7 +8,7 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-select-menu-
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21569&viewport=-1857%2C206%2C0.37&t=xHutRjwo1o5zMTgT-11
 ---
 
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <div class="d-w100p">
     <div class="d-label">
       <label for="Dialtone--SelectExample1">Label</label>
@@ -121,7 +121,7 @@ vueCode='
         { value: ``, label: `Please select one` },
         { value: `1`, label: `Option 1` },
         { value: `2`, label: `Option 2` },
-        { value: `3`, label: `Option 3` },  
+        { value: `3`, label: `Option 3` },
       ]"
   label="Default"
   :value="value"
@@ -133,7 +133,7 @@ vueCode='
         { value: ``, label: `Please select one` },
         { value: `1`, label: `Option 1` },
         { value: `2`, label: `Option 2` },
-        { value: `3`, label: `Option 3` },  
+        { value: `3`, label: `Option 3` },
       ]"
   label="Disabled"
   disabled
@@ -188,7 +188,7 @@ vueCode='
         { value: ``, label: `Please select one` },
         { value: `1`, label: `Option 1` },
         { value: `2`, label: `Option 2` },
-        { value: `3`, label: `Option 3` },  
+        { value: `3`, label: `Option 3` },
       ]"
   label="Label"
   description="Optional description text"

--- a/apps/dialtone-documentation/docs/components/stack.md
+++ b/apps/dialtone-documentation/docs/components/stack.md
@@ -8,38 +8,38 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-stack--defau
 ---
 
 <code-well-header>
-    <div class="d-stack d-stack--gap-500">
-      <div class="d-bgc-magenta-100">
-        Stack item 1
-      </div>
-      <div class="d-bgc-magenta-100">
-        Stack item 2
-      </div>
-      <div class="d-bgc-magenta-100">
-        Stack item 3
-      </div>
+  <div class="d-stack d-stack--gap-500 d-bgc-magenta-100">
+    <div class="d-bgc-secondary">
+      Stack item 1
     </div>
+    <div class="d-bgc-secondary">
+      Stack item 2
+    </div>
+    <div class="d-bgc-secondary">
+      Stack item 3
+    </div>
+  </div>
 </code-well-header>
 
 <code-example-tabs
 htmlCode='
 <div class="d-stack d-stack--gap-500">
-  <div class="d-bgc-magenta-100">Stack item 1</div>
-  <div class="d-bgc-magenta-100">Stack item 2</div>
-  <div class="d-bgc-magenta-100">Stack item 3</div>
+  <div>Stack item 1</div>
+  <div>Stack item 2</div>
+  <div>Stack item 3</div>
 </div>
 '
 vueCode='
 <dt-stack
   gap="500"
 >
-  <div class="d-bgc-magenta-100">
+  <div>
     Stack item 1
   </div>
-  <div class="d-bgc-magenta-100">
+  <div>
     Stack item 2
   </div>
-  <div class="d-bgc-magenta-100">
+  <div>
     Stack item 3
   </div>
 </dt-stack>
@@ -53,22 +53,22 @@ showHtmlWarning />
 Row: flow horizontally
 
 <code-well-header>
-    <div class="d-stack d-stack--row d-stack--gap-400">
-      <span class="d-badge">Co-host</span>
-      <span class="d-badge">Customer</span>
-      <span class="d-badge">
-        <span class="d-badge__icon-left">
-          <dt-icon name="lock" size="200" />
-        </span>
-        <span class="d-badge__label">Locked</span>
+  <div class="d-stack d-stack--row d-stack--gap-400">
+    <span class="d-badge">Co-host</span>
+    <span class="d-badge">Customer</span>
+    <span class="d-badge">
+      <span class="d-badge__icon-left">
+        <dt-icon name="lock" size="200" />
       </span>
-      <span class="d-badge">
-        <span class="d-badge__icon-left">
-          <dt-icon name="message" size="200" />
-        </span>
-        <span class="d-badge__label">Chat log</span>
+      <span class="d-badge__label">Locked</span>
+    </span>
+    <span class="d-badge">
+      <span class="d-badge__icon-left">
+        <dt-icon name="message" size="200" />
       </span>
-    </div>
+      <span class="d-badge__label">Chat log</span>
+    </span>
+  </div>
 </code-well-header>
 
 <code-example-tabs
@@ -118,14 +118,14 @@ showHtmlWarning />
 Stacks column at small screen size and column reverse at large screen
 
 <code-well-header>
-    <div class="d-stack d-stack--row d-stack--sm-column d-stack--lg-column-reverse d-stack--gap-100">
-      <div class="d-bgc-magenta-100">
+    <div class="d-stack d-stack--row d-stack--sm-column d-stack--lg-column-reverse d-stack--gap-500 d-bgc-magenta-100">
+      <div class="d-bgc-secondary">
         Stack item 1
       </div>
-      <div class="d-bgc-magenta-100">
+      <div class="d-bgc-secondary">
         Stack item 2
       </div>
-      <div class="d-bgc-magenta-100">
+      <div class="d-bgc-secondary">
         Stack item 3
       </div>
     </div>
@@ -134,22 +134,22 @@ Stacks column at small screen size and column reverse at large screen
 <code-example-tabs
 htmlCode='
 <div class="d-stack d-stack--row d-stack--sm-column d-stack--lg-column-reverse d-stack--gap-0">
-  <div class="d-bgc-magenta-100">Stack item 1</div>
-  <div class="d-bgc-magenta-100">Stack item 2</div>
-  <div class="d-bgc-magenta-100">Stack item 3</div>
+  <div>Stack item 1</div>
+  <div>Stack item 2</div>
+  <div>Stack item 3</div>
 </div>
 '
 vueCode='
 <dt-stack
   :direction="{ `default`: `row`, `sm`: `column`, `lg`: `column-reverse` }"
 >
-  <div class="d-bgc-magenta-100">
+  <div>
     Stack item 1
   </div>
-  <div class="d-bgc-magenta-100">
+  <div>
     Stack item 2
   </div>
-  <div class="d-bgc-magenta-100">
+  <div>
     Stack item 3
   </div>
 </dt-stack>
@@ -159,14 +159,14 @@ showHtmlWarning />
 Set 300 as the default gap, 600 at <= XL, 500 at <= L, 400 at <= M, and 300 at <= SM. Check how our breakpoints work [here](/utilities/responsive/breakpoints.html).
 
 <code-well-header>
-  <dt-stack :gap="{ default: '300', xl: '600', lg: '500', md: '400', sm: '300' }">
-    <div class="d-bgc-magenta-100">
+  <dt-stack :gap="{ default: '300', xl: '600', lg: '500', md: '400', sm: '300' }" class="d-bgc-magenta-100">
+    <div class="d-bgc-secondary">
       Stack item 1
     </div>
-    <div class="d-bgc-magenta-100">
+    <div class="d-bgc-secondary">
       Stack item 2
     </div>
-    <div class="d-bgc-magenta-100">
+    <div class="d-bgc-secondary">
       Stack item 3
     </div>
   </dt-stack>
@@ -195,22 +195,22 @@ vueCode='
 '
 />
 
-Stacks row with gap 300 and stacks in row reverse the second element with gap 600
+Stacks row with gap 300 and stacks in row reverse the nested stack with gap 600.
 
 <code-well-header>
-    <section class="d-stack d-stack--row d-stack--gap-300">
-      <div class="d-bgc-magenta-100">
+    <section class="d-stack d-stack--row d-stack--gap-300 d-bgc-magenta-100 d-ai-stretch">
+      <div class="d-bgc-secondary d-ba d-bc-default">
         Stack item 1
       </div>
       <div>
-        <div class="d-bgc-magenta-100">
+        <div class="d-bgc-secondary d-ba d-bc-default">
           Stack item 2
         </div>
-        <div class="d-stack d-stack--row-reverse d-stack--gap-600">
-          <div class="d-bgc-magenta-200">
+        <div class="d-stack d-stack--row-reverse d-stack--gap-600 d-bgc-magenta-100">
+          <div class="d-bgc-secondary d-ba d-bc-default">
             Stack item 3
           </div>
-          <div class="d-bgc-magenta-200">
+          <div class="d-bgc-secondary d-ba d-bc-default">
             Stack item 4
           </div>
         </div>

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -6,6 +6,7 @@ description: Tabs allow users to navigation between grouped content in different
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-tabs--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21321&viewport=306%2C-547%2C1.01&t=xHutRjwo1o5zMTgT-11
 ---
+
 <code-well-header>
   <example-tabs />
 </code-well-header>

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -10,12 +10,9 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   <example-tabs />
 </code-well-header>
 
-[//]: # (## Usage)
-[//]: # (Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi massa ante, tempus vitae lacus id, luctus tristique lorem. Mauris feugiat massa ex, id aliquet mi tempor non. Curabitur non tristique lectus. Fusce ut nisl non diam dignissim viverra. In posuere dui arcu, sed eleifend massa faucibus sed. Phasellus quis leo vitae erat pellentesque venenatis id vitae lectus. Suspendisse convallis, metus a congue tincidunt, velit sem tincidunt dui, eget auctor ipsum ipsum in ex. Nullam lobortis, mauris vel vestibulum rutrum, lorem elit vehicula est, nec viverra ante erat nec dolor. Proin at placerat tortor. Nam ullamcorper metus et eros porta, at lacinia leo scelerisque. Curabitur finibus sollicitudin odio tempor finibus. Donec lobortis metus vitae mollis gravida.)
+## Variants
 
-## Variants and examples
-
-### Base Styles
+### Default
 
 <code-well-header>
   <example-tabs />
@@ -23,23 +20,10 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 
 <code-example-tabs
 htmlCode='
-<div>
-  <div role="tablist" class="d-tablist">
-    <button type="button" class="base-button__button d-btn d-btn--primary d-tab d-tab--selected" id="dt-tab-1" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">
-      <span class="d-btn__label base-button__label"> First </span>
-    </button>
-    <button type="button" class="base-button__button d-btn d-btn--primary d-tab" id="dt-tab-3" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">
-      <span class="d-btn__label base-button__label"> Second </span>
-    </button>
-    <button type="button" class="base-button__button d-btn d-btn--primary d-tab" id="dt-tab-5`" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">
-      <span class="d-btn__label base-button__label"> Third </span>
-    </button>
-  </div>
-  <div>
-    <div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false" style=""><p>First Panel</p></div>
-    <div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;"><p>Second Panel</p></div>
-    <div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;"><p>Third Panel</p></div>
-  </div>
+<div class="d-tablist" role="tablist" aria-label="Label Example Group" tabindex="0">
+  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
+  <button id="base-tab-1" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
+  <button id="base-tab-2" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
 </div>
 '
 vueCode='
@@ -55,63 +39,6 @@ vueCode='
       Third
     </dt-tab>
   </template>
-
-  <div>
-    <dt-tab-panel id="2" tab-id="1">
-      <p>First Panel</p>
-    </dt-tab-panel>
-    <dt-tab-panel id="4" tab-id="3">
-      <p>Second Panel</p>
-    </dt-tab-panel>
-    <dt-tab-panel id="6" tab-id="5">
-      <p>Third Panel</p>
-    </dt-tab-panel>
-  </div>
-</dt-tab-group>
-'
-showHtmlWarning />
-
-### Sizes
-
-<code-well-header>
-  <example-tabs hide-content size="small" />
-</code-well-header>
-
-<code-example-tabs
-htmlCode='
-<div>
-  <div role="tablist" class="d-tablist d-tablist--sm">
-    <button type="button" class="base-button__button d-btn d-btn--primary d-tab d-tab--selected" id="dt-tab-1" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">
-      <span class="d-btn__label base-button__label"> First </span>
-    </button>
-    <button type="button" class="base-button__button d-btn d-btn--primary d-tab" id="dt-tab-3" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">
-      <span class="d-btn__label base-button__label"> Second </span>
-    </button>
-    <button type="button" class="base-button__button d-btn d-btn--primary d-tab" id="dt-tab-5`" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">
-      <span class="d-btn__label base-button__label"> Third </span>
-    </button>
-  </div>
-  <div>
-    <div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false" style=""><p>First Panel</p></div>
-    <div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;"><p>Second Panel</p></div>
-    <div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;"><p>Third Panel</p></div>
-  </div>
-</div>
-'
-vueCode='
-<dt-tab-group size="sm">
-  <template #tabs>
-    <dt-tab id="1" panel-id="2" selected>
-      First
-    </dt-tab>
-    <dt-tab id="3" panel-id="4">
-      Second
-    </dt-tab>
-    <dt-tab id="5`" panel-id="6">
-      Third
-    </dt-tab>
-  </template>
-
   <div>
     <dt-tab-panel id="2" tab-id="1">
       <p>First Panel</p>
@@ -137,23 +64,10 @@ Add a `d-tablist--no-border` to remove the bottom border of any tablist. Handy f
 
 <code-example-tabs
 htmlCode='
-<div>
-  <div role="tablist" class="d-tablist d-tablist--no-border">
-    <button type="button" class="base-button__button d-btn d-btn--primary d-tab d-tab--selected" id="dt-tab-1" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">
-      <span class="d-btn__label base-button__label"> First </span>
-    </button>
-    <button type="button" class="base-button__button d-btn d-btn--primary d-tab" id="dt-tab-3" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">
-      <span class="d-btn__label base-button__label"> Second </span>
-    </button>
-    <button type="button" class="base-button__button d-btn d-btn--primary d-tab" id="dt-tab-5`" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">
-      <span class="d-btn__label base-button__label"> Third </span>
-    </button>
-  </div>
-  <div>
-    <div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false" style=""><p>First Panel</p></div>
-    <div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;"><p>Second Panel</p></div>
-    <div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;"><p>Third Panel</p></div>
-  </div>
+<div class="d-tablist d-tablist--no-border" role="tablist" aria-label="Label Example Group" tabindex="0">
+  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
+  <button id="base-tab-1" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
+  <button id="base-tab-2" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
 </div>
 '
 vueCode='
@@ -195,27 +109,100 @@ Add `d-tablist--inverted` when you want to display tabs on inverted background.
 
 <code-example-tabs
 htmlCode='
-<div>
-  <div role="tablist" class="d-tablist d-tablist--inverted">
-    <button type="button" class="base-button__button d-btn d-btn--primary d-tab d-tab--selected" id="dt-tab-1" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">
-      <span class="d-btn__label base-button__label"> First </span>
-    </button>
-    <button type="button" class="base-button__button d-btn d-btn--primary d-tab" id="dt-tab-3" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">
-      <span class="d-btn__label base-button__label"> Second </span>
-    </button>
-    <button type="button" class="base-button__button d-btn d-btn--primary d-tab" id="dt-tab-5`" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">
-      <span class="d-btn__label base-button__label"> Third </span>
-    </button>
-  </div>
-  <div>
-    <div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false" style=""><p>First Panel</p></div>
-    <div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;"><p>Second Panel</p></div>
-    <div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;"><p>Third Panel</p></div>
-  </div>
+<div class="d-tablist d-tablist--inverted" role="tablist" aria-label="Label Example Group" tabindex="0">
+  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
+  <button id="base-tab-1" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
+  <button id="base-tab-2" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
 </div>
 '
 vueCode='
 <dt-tab-group :inverted="true">
+  <template #tabs>
+    <dt-tab id="1" panel-id="2" selected>
+      First
+    </dt-tab>
+    <dt-tab id="3" panel-id="4">
+      Second
+    </dt-tab>
+    <dt-tab id="5`" panel-id="6">
+      Third
+    </dt-tab>
+  </template>
+
+  <div>
+    <dt-tab-panel id="2" tab-id="1">
+      <p>First Panel</p>
+    </dt-tab-panel>
+    <dt-tab-panel id="4" tab-id="3">
+      <p>Second Panel</p>
+    </dt-tab-panel>
+    <dt-tab-panel id="6" tab-id="5">
+      <p>Third Panel</p>
+    </dt-tab-panel>
+  </div>
+</dt-tab-group>
+'
+showHtmlWarning />
+
+## Sizes
+
+### Default
+
+<code-well-header>
+  <example-tabs />
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<div class="d-tablist" role="tablist" aria-label="Label Example Group" tabindex="0">
+  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
+  <button id="base-tab-1" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
+  <button id="base-tab-2" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
+</div>
+'
+vueCode='
+<dt-tab-group>
+  <template #tabs>
+    <dt-tab id="1" panel-id="2" selected>
+      First
+    </dt-tab>
+    <dt-tab id="3" panel-id="4">
+      Second
+    </dt-tab>
+    <dt-tab id="5`" panel-id="6">
+      Third
+    </dt-tab>
+  </template>
+  <div>
+    <dt-tab-panel id="2" tab-id="1">
+      <p>First Panel</p>
+    </dt-tab-panel>
+    <dt-tab-panel id="4" tab-id="3">
+      <p>Second Panel</p>
+    </dt-tab-panel>
+    <dt-tab-panel id="6" tab-id="5">
+      <p>Third Panel</p>
+    </dt-tab-panel>
+  </div>
+</dt-tab-group>
+'
+showHtmlWarning />
+
+### Small
+
+<code-well-header>
+  <example-tabs hide-content size="small" />
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<div class="d-tablist d-tablist--sm" role="tablist" aria-label="Label Example Group" tabindex="0">
+  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
+  <button id="base-tab-1" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
+  <button id="base-tab-2" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
+</div>'
+vueCode='
+<dt-tab-group size="sm">
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>
       First

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -6,7 +6,7 @@ description: Tabs allow users to navigation between grouped content in different
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-tabs--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21321&viewport=306%2C-547%2C1.01&t=xHutRjwo1o5zMTgT-11
 ---
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-tabs />
 </code-well-header>
 
@@ -17,7 +17,7 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 
 ### Base Styles
 
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-tabs />
 </code-well-header>
 
@@ -73,7 +73,7 @@ showHtmlWarning />
 
 ### Sizes
 
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-tabs hide-content size="small" />
 </code-well-header>
 
@@ -131,7 +131,7 @@ showHtmlWarning />
 
 Add a `d-tablist--no-border` to remove the bottom border of any tablist. Handy for small tablists and tablists serving as subtabs to a larger menu.
 
-<code-well-header bgclass="d-bgc-primary">
+<code-well-header>
   <example-tabs hide-content borderless />
 </code-well-header>
 

--- a/apps/dialtone-documentation/docs/components/tooltip.md
+++ b/apps/dialtone-documentation/docs/components/tooltip.md
@@ -7,13 +7,9 @@ description: A tooltip is a floating label that briefly explains an action, func
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-tooltip--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21626&viewport=-614%2C359%2C0.86&t=xHutRjwo1o5zMTgT-11
 ---
-<code-well-header class='d-hmn164'>
-  <button class="d-btn d-btn--outlined d-tooltip--hover" type="button">
-    <div class="d-tooltip d-tooltip__arrow--bottom-center d-ps-absolute">
-      <span>Simple tooltip</span>
-    </div>
-    <span>Hover for Tooltip Example</span>
-  </button>
+
+<code-well-header>
+  <dt-button v-dt-tooltip="`Simple tooltip`">Hover me</dt-button>
 </code-well-header>
 
 ## Tooltip as a directive

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -87,7 +87,6 @@
   border-style: solid;
   border-width: var(--button-border-width);
   border-radius: var(--button-border-radius);
-  box-shadow: var(--button--bs);
   cursor: pointer;
   transition-timing-function: var(--ttf-out-quint);
   transition-duration: var(--td200);

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -26,9 +26,7 @@
   --button-gap: calc(var(--button-padding-x) / 2);
   --button-border-radius: var(--dt-size-400);
   --button-border-width: var(--dt-size-100);
-  --button-font-size: var(--dt-font-size-200);
-  --button-font-weight: var(--dt-font-weight-medium);
-  --button-line-height: var(--dt-font-line-height-200);
+  --button-font-style: var(--dt-typography-button-md);
   --button-padding-y-xs: calc(
     calc(var(--dt-space-400) - var(--dt-space-100)) - var(--button-border-width)
   ); // ((8 - 1) - border-width)
@@ -80,10 +78,7 @@
   box-sizing: border-box;
   padding: var(--button-padding-y) var(--button-padding-x);
   color: var(--button-color-text);
-  font-weight: var(--button-font-weight);
-  font-size: var(--button-font-size);
-  font-family: inherit;
-  line-height: var(--button-line-height);
+  font: var(--button-font-style);
   text-transform: inherit;
   text-decoration: none;
   vertical-align: middle;
@@ -139,18 +134,18 @@
 //  $$  EXTRA SMALL
 //  ----------------------------------------------------------------------------
 .d-btn--xs {
+  --button-font-style: var(--dt-typography-button-xs);
   --button-padding-y: var(--button-padding-y-xs);
   --button-padding-x: var(--button-padding-x-xs);
-  --button-font-size: var(--dt-font-size-100);
   --button-border-radius: var(--dt-size-300);
 }
 
 //  $$ SMALL
 //  ----------------------------------------------------------------------------
 .d-btn--sm {
+  --button-font-style: var(--dt-typography-button-sm);
   --button-padding-y: var(--button-padding-y-sm);
   --button-padding-x: var(--button-padding-x-sm);
-  --button-font-size: var(--dt-font-size-100);
 }
 
 //  $$  MEDIUM
@@ -162,19 +157,18 @@
 //  $$  LARGE
 //  ----------------------------------------------------------------------------
 .d-btn--lg {
+  --button-font-style: var(--dt-typography-button-lg);
   --button-padding-y: var(--button-padding-y-lg);
   --button-padding-x: var(--button-padding-x-lg);
-  --button-font-size: var(--dt-font-size-300);
   --button-border-radius: var(--dt-size-450);
 }
 
 //  $$  EXTRA LARGE
 //  ----------------------------------------------------------------------------
 .d-btn--xl {
+  --button-font-style: var(--dt-typography-button-xl);
   --button-padding-y: var(--button-padding-y-xl);
   --button-padding-x: var(--button-padding-x-xl);
-  --button-font-size: var(--dt-font-size-400);
-  --button-font-weight: var(--dt-font-weight-normal);
   --button-border-radius: var(--dt-size-500);
 }
 

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -26,7 +26,7 @@
   --button-gap: calc(var(--button-padding-x) / 2);
   --button-border-radius: var(--dt-button-size-radius-md);
   --button-border-width: var(--dt-size-border-100);
-  --button-font-style: var(--dt-typography-button-md);
+  --button-typography: var(--dt-typography-button-md);
   --button-padding-y-xs: calc(
     calc(var(--dt-space-400) - var(--dt-space-100)) - var(--button-border-width)
   ); // ((8 - 1) - border-width)
@@ -78,7 +78,7 @@
   box-sizing: border-box;
   padding: var(--button-padding-y) var(--button-padding-x);
   color: var(--button-color-text);
-  font: var(--button-font-style);
+  font: var(--button-typography);
   text-transform: inherit;
   text-decoration: none;
   vertical-align: middle;
@@ -133,7 +133,7 @@
 //  $$  EXTRA SMALL
 //  ----------------------------------------------------------------------------
 .d-btn--xs {
-  --button-font-style: var(--dt-typography-button-xs);
+  --button-typography: var(--dt-typography-button-xs);
   --button-padding-y: var(--button-padding-y-xs);
   --button-padding-x: var(--button-padding-x-xs);
   --button-border-radius: var(--dt-button-size-radius-xs);
@@ -142,7 +142,7 @@
 //  $$ SMALL
 //  ----------------------------------------------------------------------------
 .d-btn--sm {
-  --button-font-style: var(--dt-typography-button-sm);
+  --button-typography: var(--dt-typography-button-sm);
   --button-padding-y: var(--button-padding-y-sm);
   --button-padding-x: var(--button-padding-x-sm);
   --button-border-radius: var(--dt-button-size-radius-sm);
@@ -157,7 +157,7 @@
 //  $$  LARGE
 //  ----------------------------------------------------------------------------
 .d-btn--lg {
-  --button-font-style: var(--dt-typography-button-lg);
+  --button-typography: var(--dt-typography-button-lg);
   --button-padding-y: var(--button-padding-y-lg);
   --button-padding-x: var(--button-padding-x-lg);
   --button-border-radius: var(--dt-button-size-radius-lg);
@@ -166,7 +166,7 @@
 //  $$  EXTRA LARGE
 //  ----------------------------------------------------------------------------
 .d-btn--xl {
-  --button-font-style: var(--dt-typography-button-xl);
+  --button-typography: var(--dt-typography-button-xl);
   --button-padding-y: var(--button-padding-y-xl);
   --button-padding-x: var(--button-padding-x-xl);
   --button-border-radius: var(--dt-button-size-radius-xl);

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -25,7 +25,7 @@
   --button-color-border: transparent;
   --button-gap: calc(var(--button-padding-x) / 2);
   --button-border-radius: var(--dt-button-size-radius-md);
-  --button-border-width: var(--dt-size-100);
+  --button-border-width: var(--dt-size-border-100);
   --button-font-style: var(--dt-typography-button-md);
   --button-padding-y-xs: calc(
     calc(var(--dt-space-400) - var(--dt-space-100)) - var(--button-border-width)

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -24,7 +24,7 @@
   --button-color-background: var(--dt-action-color-background-base-default);
   --button-color-border: transparent;
   --button-gap: calc(var(--button-padding-x) / 2);
-  --button-border-radius: var(--dt-size-400);
+  --button-border-radius: var(--dt-button-size-radius-md);
   --button-border-width: var(--dt-size-100);
   --button-font-style: var(--dt-typography-button-md);
   --button-padding-y-xs: calc(
@@ -137,7 +137,7 @@
   --button-font-style: var(--dt-typography-button-xs);
   --button-padding-y: var(--button-padding-y-xs);
   --button-padding-x: var(--button-padding-x-xs);
-  --button-border-radius: var(--dt-size-300);
+  --button-border-radius: var(--dt-button-size-radius-xs);
 }
 
 //  $$ SMALL
@@ -146,6 +146,7 @@
   --button-font-style: var(--dt-typography-button-sm);
   --button-padding-y: var(--button-padding-y-sm);
   --button-padding-x: var(--button-padding-x-sm);
+  --button-border-radius: var(--dt-button-size-radius-sm);
 }
 
 //  $$  MEDIUM
@@ -160,7 +161,7 @@
   --button-font-style: var(--dt-typography-button-lg);
   --button-padding-y: var(--button-padding-y-lg);
   --button-padding-x: var(--button-padding-x-lg);
-  --button-border-radius: var(--dt-size-450);
+  --button-border-radius: var(--dt-button-size-radius-lg);
 }
 
 //  $$  EXTRA LARGE
@@ -169,7 +170,7 @@
   --button-font-style: var(--dt-typography-button-xl);
   --button-padding-y: var(--button-padding-y-xl);
   --button-padding-x: var(--button-padding-x-xl);
-  --button-border-radius: var(--dt-size-500);
+  --button-border-radius: var(--dt-button-size-radius-xl);
 }
 
 //  ============================================================================

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -89,7 +89,7 @@
   border-radius: var(--button-border-radius);
   cursor: pointer;
   transition-timing-function: var(--ttf-out-quint);
-  transition-duration: var(--td200);
+  transition-duration: var(--td100);
   transition-property: background-color, border, box-shadow;
   user-select: none;
   fill: currentColor;

--- a/packages/dialtone-css/lib/build/less/components/emoji-picker.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji-picker.less
@@ -17,18 +17,18 @@
   width: calc(var(--dt-size-925) + var(--dt-size-600) + var(--dt-size-400));
   height: 100%;
   background-color: var(--dt-color-surface-primary);
-  border-radius: var(--dt-size-300);
+  border-radius: var(--dt-size-radius-300);
 
   &--header {
     position: relative;
-    padding: var(--dt-space-300) var(--dt-space-300) 0 var(--dt-space-400);
+    padding: var(--dt-space-300) var(--dt-space-300) 0;
 
     &::after {
       position: absolute;
       right: 0;
       bottom: 0;
       left: 0;
-      height: var(--dt-size-100);
+      height: var(--dt-size-border-200);
       background-color: var(--dt-color-surface-moderate) !important;
       content: '';
     }
@@ -50,22 +50,26 @@
     height: calc(var(--dt-size-650) + var(--dt-size-400) + var(--dt-size-200));
     padding: 0 var(--dt-space-500);
     background: var(--dt-color-surface-secondary);
-    border-top: var(--dt-size-100) solid var(--dt-color-border-subtle);
+    border-top: var(--dt-size-border-100) solid var(--dt-color-border-subtle);
   }
 
   &__tabset-list {
-      gap: var(--dt-space-300);
+      gap: var(--dt-space-0);
+      justify-content: space-between;
 
       &::after {
         background-color: var(--dt-color-surface-moderate) !important;
       }
 
-      button {
-        padding: var(--dt-space-400);
+      .d-tab {
+        --tab-padding-y: var(--dt-space-400);
+        --tab-padding-x: var(--dt-space-300);
+
+        flex-grow: 1;
 
         &.d-tab--selected {
           &::after {
-            height: var(--dt-size-200);
+            height: var(--dt-size-border-200);
           }
         }
     }
@@ -77,8 +81,8 @@
     gap: var(--dt-space-300);
     align-items: flex-start;
     padding: var(--dt-space-300);
-    background: rgba(0, 0, 0, 0.05);
-    border-radius: calc(var(--dt-size-600) + var(--dt-size-400));
+    background: var(--dt-color-surface-moderate-opaque);
+    border-radius: var(--dt-size-radius-pill);
 
     button {
       width: var(--dt-size-600);
@@ -86,19 +90,18 @@
       margin: 0;
       padding: 0;
       background: none;
-      border: none;
+      border: var(--dt-size-border-100) solid transparent;
       border-radius: calc(var(--dt-size-550) + var(--dt-size-300));
       outline: none;
       cursor: pointer;
 
       &:hover {
-        background: rgba(0, 0, 0, 0.1);
-        border-radius: calc(var(--dt-size-550) + var(--dt-size-300));
+        background: var(--dt-color-surface-moderate-opaque);
       }
 
+      &:active,
       &.selected {
-        border: var(--dt-size-100) solid rgba(0, 0, 0, 0.25);
-        border-radius: calc(var(--dt-size-550) + var(--dt-size-300));
+        border-color: var(--dt-color-border-bold);
       }
     }
   }
@@ -110,9 +113,9 @@
       height: var(--dt-size-625);
       margin: 0;
       padding: calc(var(--dt-space-350) + var(--dt-space-100));
-      background: rgba(0, 0, 0, 0.1);
+      background: var(--dt-color-surface-moderate-opaque);
       border: none;
-      border-radius: calc(var(--dt-size-550) + var(--dt-size-300));
+      border-radius: var(--dt-size-radius-circle);
       outline: none;
       cursor: pointer;
 
@@ -126,10 +129,10 @@
     min-height: calc(var(--dt-size-905) + var(--dt-size-600) + var(--dt-size-100));
 
     p {
-      margin-bottom: var(--dt-space-300);
-      font-weight: 700;
-      font-size: var(--dt-size-450);
-      letter-spacing: -0.01em;
+      padding-bottom: var(--dt-space-300);
+      color: var(--dt-color-foreground-secondary);
+      font: var(--dt-typography-headline-eyebrow);
+      text-transform: var(--dt-typography-headline-eyebrow-text-case);
     }
   }
 
@@ -138,7 +141,7 @@
     top: 0;
     width: 100%;
     margin: 0;
-    padding: var(--dt-space-525) var(--dt-space-500) 0 var(--dt-space-500);
+    padding: var(--dt-space-500) var(--dt-space-500) 0 var(--dt-space-500);
     background: var(--dt-color-surface-primary);
   }
 
@@ -151,13 +154,13 @@
 
     div:not(:first-child) {
       p {
-        margin-top: calc(var(--dt-space-525) + var(--dt-space-200));
+        margin-top: var(--dt-space-500);
       }
     }
   }
 
   &__search-label {
-    margin-top: calc(var(--dt-space-525));
+    padding-top: var(--dt-space-500);
   }
 
   &__tab {
@@ -168,6 +171,7 @@
     max-width: calc(var(--dt-size-925) + var(--dt-size-400));
     // We use this margin left to align the emoji list with the tabset label
     margin-left: var(--dt-space-350-negative);
+    padding-top: var(--dt-space-300);
 
     button {
       display: flex;
@@ -179,17 +183,17 @@
       padding: 0;
       background: none;
       border: none;
-      border-radius: 50%;
+      border-radius: var(--dt-size-radius-circle);
       outline: none;
       cursor: pointer;
 
       &:hover,
       &:active {
-        background: rgba(0, 0, 0, 0.1);
+        background: var(--dt-color-surface-moderate-opaque);
       }
 
       &.hover-emoji {
-        background: rgba(0, 0, 0, 0.1);
+        background: var(--dt-color-surface-moderate-opaque);
       }
 
       &:focus {
@@ -201,8 +205,7 @@
   &__search {
     position: relative;
     z-index: 1;
-    margin: var(--dt-space-500) var(--dt-space-550) 0 var(--dt-space-500);
-    background-color: var(--dt-color-surface-primary);
+    padding: var(--dt-space-500) 0 0 0;
   }
 
   &__search-button {
@@ -221,5 +224,7 @@
     align-items: center;
     width: 100%;
     max-width: calc(var(--dt-size-905) + var(--dt-size-550) + var(--dt-size-200));
+    color: var(--dt-color-foreground-tertiary);
+    font: var(--dt-typography-body-md);
   }
 }

--- a/packages/dialtone-css/lib/build/less/components/forms.less
+++ b/packages/dialtone-css/lib/build/less/components/forms.less
@@ -29,7 +29,8 @@ fieldset {
 //  ============================================================================
 //  $  LABELS
 //  ----------------------------------------------------------------------------
-.d-label {
+.d-label,
+.d-label--md {
   display: flex;
   flex: 1 0%;
   align-items: baseline;
@@ -37,10 +38,7 @@ fieldset {
   box-sizing: border-box;
   margin-bottom: var(--dt-space-300);
   color: var(--dt-color-foreground-secondary);
-  font-weight: var(--dt-font-weight-semi-bold);
-  font-size: var(--dt-font-size-200);
-  font-family: inherit;
-  line-height: var(--dt-font-line-height-300);
+  font: var(--dt-typography-label-md);
   word-break: break-word;
   overflow-wrap: break-word;
 

--- a/packages/dialtone-css/lib/build/less/components/input.less
+++ b/packages/dialtone-css/lib/build/less/components/input.less
@@ -30,12 +30,11 @@
     --input-color-background: var(--dt-inputs-color-background-default);
     --input-color-background-disabled: var(--dt-inputs-color-background-disabled);
     --input-color-text: var(--dt-inputs-color-foreground-default);
-    --input-border-width: calc(var(--dt-size-100) + var(--dt-size-50)); // 1.5
-    --input-border-radius: var(--dt-size-400);
+    --input-border-width: var(--dt-size-border-150);
+    --input-border-radius: var(--dt-inputs-size-radius-md);
     --input-padding-y: calc(var(--dt-space-400) - var(--input-border-width));
     --input-padding-x: calc((var(--dt-space-500) - var(--dt-space-300)) - var(--input-border-width));
-    --input-font-size: var(--dt-font-size-200);
-    --input-line-height: var(--dt-font-line-height-200);
+    --input-typography: var(--dt-typography-inputs-md);
 
     position: relative;
     display: inline-flex;
@@ -45,20 +44,44 @@
     min-width: 0;
     padding: var(--input-padding-y) var(--input-padding-x);
     color: var(--input-color-text);
-    font-weight: inherit;
-    font-size: var(--input-font-size);
-    font-family: inherit;
-    line-height: var(--input-line-height);
+    font: var(--input-typography);
     background-color: var(--input-color-background);
     border: var(--input-border-width) solid var(--input-color-border);
     border-radius: var(--input-border-radius);
     outline: none;
     box-shadow: none;
-    transition-timing-function: var(--ttf-in-out);
-    transition-duration: var(--td100);
-    transition-property: box-shadow, background-color;
     appearance: none;
-    caret-color: var(--input-color-text);
+    caret-color: fieldtext;
+
+    &:has(.d-textarea) {
+        border-end-end-radius: var(--dt-inputs-size-radius-xs);
+    }
+
+    &:has(.d-input--xs),
+    &:has(.d-textarea--xs) {
+        --input-border-radius: var(--dt-inputs-size-radius-xs);
+    }
+
+    &:has(.d-input--sm),
+    &:has(.d-textarea--sm) {
+        --input-border-radius: var(--dt-inputs-size-radius-sm);
+    }
+
+    &:has(.d-input--md),
+    &:has(.d-textarea--md) {
+        --input-border-radius: var(--dt-inputs-size-radius-md);
+    }
+
+    &:has(.d-input--lg),
+    &:has(.d-textarea--lg) {
+        --input-border-radius: var(--dt-inputs-size-radius-lg);
+    }
+
+    &:has(.d-input--xl),
+    &:has(.d-textarea--xl) {
+        --input-border-radius: var(--dt-inputs-size-radius-xl);
+    }
+
 
     //  --  Placeholder copy
     &::placeholder {
@@ -74,7 +97,7 @@
         --input-color-background: var(--dt-inputs-color-background-focus);
         --input-color-border: var(--dt-inputs-color-border-focus) !important;
 
-        box-shadow: 0 0 0 var(--dt-size-100) var(--dt-inputs-color-border-focus) inset;
+        box-shadow: 0 0 0 var(--dt-size-border-100) var(--dt-inputs-color-border-focus) inset;
     }
     //  --  DISABLED / READ-ONLY
     &[disabled],
@@ -203,14 +226,12 @@
     #d-internal__input-and-select-xl();
 }
 
-
 //  ============================================================================
 //  $  TEXTAREAS
 //  ----------------------------------------------------------------------------
 .d-textarea {
     min-height: calc(var(--dt-size-300) * 20); // 80
     vertical-align: top;
-    border-bottom-right-radius: var(--dt-size-300);
     resize: vertical;
     scroll-padding-block: var(--input-padding-y);
 }

--- a/packages/dialtone-css/lib/build/less/components/radio-checkbox.less
+++ b/packages/dialtone-css/lib/build/less/components/radio-checkbox.less
@@ -30,7 +30,7 @@
     --check-radio-color-background: var(--dt-inputs-color-background-default);
     --check-radio-color-background-checked: var(--dt-checkbox-color-background-checked);
     --check-radio-color-background-disabled: var(--dt-inputs-color-background-disabled);
-    --check-radio-border-width: calc(var(--dt-size-100) + var(--dt-size-50)); // 1.5
+    --check-radio-border-width: var(--dt-size-border-150);
 
     //  [1] Check to see if we can use custom styles, if so reset the defaults
     //  ------------------------------------------------------------------------
@@ -155,9 +155,7 @@
     flex-direction: column;
     align-items: flex-start;
     color: var(--dt-color-foreground-primary);
-    font-weight: var(--dt-font-weight-normal);
-    font-size: var(--dt-font-size-200);
-    line-height: var(--dt-font-line-height-400);
+    font: var(--dt-typography-label-md-plain);
     cursor: pointer;
 }
 
@@ -179,7 +177,7 @@
         background-repeat: no-repeat;
         background-position: center center;
         background-size: contain;
-        border-radius: var(--dt-size-300);
+        border-radius: var(--dt-size-radius-circle);
 
         &:focus-visible,
         &:checked:focus-visible {

--- a/packages/dialtone-css/lib/build/less/components/radio-checkbox.less
+++ b/packages/dialtone-css/lib/build/less/components/radio-checkbox.less
@@ -177,7 +177,7 @@
         background-repeat: no-repeat;
         background-position: center center;
         background-size: contain;
-        border-radius: var(--dt-size-radius-circle);
+        border-radius: var(--dt-size-radius-300);
 
         &:focus-visible,
         &:checked:focus-visible {

--- a/packages/dialtone-css/lib/build/less/components/tabs.less
+++ b/packages/dialtone-css/lib/build/less/components/tabs.less
@@ -14,6 +14,17 @@
 //  $   WRAPPERS
 //  ----------------------------------------------------------------------------
 .d-tablist {
+    //  --  COMPONENT CSS VARS
+    //  ------------------------------------------------------------------------
+    --tab-color-background: var(--dt-action-color-background-base-default);
+    --tab-color-text: var(--dt-action-color-foreground-muted-default);
+    --tab-line-height: var(--dt-font-line-height-200);
+    --tab-font-weight: var(--dt-font-weight-medium);
+    --tab-border-radius-top: var(--dt-size-radius-400);
+    --tab-padding-x: var(--dt-space-450);
+    --tab-padding-y: var(--dt-space-400);
+    --tab-padding-bottom: calc(var(--tab-padding-y) + var(--dt-space-100));
+
     position: relative;
     display: flex;
     flex-wrap: wrap;
@@ -37,23 +48,6 @@
         content: '';
     }
 
-    //  ============================================================================
-    //  $   SIZES
-    //  ----------------------------------------------------------------------------
-    &--sm {
-        font-size: var(--dt-font-size-100);
-
-        .d-tab {
-            --tab-padding-x: var(--dt-space-400);
-            --tab-padding-y: var(--dt-space-400);
-            --tab-padding-bottom: calc(var(--tab-padding-y) + var(--dt-space-100));
-            --tab-border-radius-top: var(--dt-size-radius-300);
-
-            .d-tablist--no-border &:not(.d-tab--selected) {
-                border-radius: var(--tab-border-radius-top);
-            }
-        }
-    }
 }
 
 
@@ -61,17 +55,6 @@
 //  $   BASE STYLE
 //  ----------------------------------------------------------------------------
 .d-tab {
-    //  --  COMPONENT CSS VARS
-    //  ------------------------------------------------------------------------
-    --tab-color-background: var(--dt-action-color-background-base-default);
-    --tab-color-text: var(--dt-action-color-foreground-muted-default);
-    --tab-line-height: var(--dt-font-line-height-200);
-    --tab-font-weight: var(--dt-font-weight-medium);
-    --tab-border-radius-top: var(--dt-size-radius-400);
-    --tab-padding-x: var(--dt-space-450);
-    --tab-padding-y: var(--dt-space-400);
-    --tab-padding-bottom: calc(var(--tab-padding-y) + var(--dt-space-100));
-
     position: relative;
     display: inline-flex;
     gap: var(--dt-space-400);
@@ -144,6 +127,22 @@
     @media (prefers-reduced-motion) {
         transition: none;
     }
+
+    //  ============================================================================
+    //  $   SIZES
+    //  ----------------------------------------------------------------------------
+    .d-tablist--sm & {
+        --tab-padding-x: var(--dt-space-400);
+        --tab-padding-y: var(--dt-space-400);
+        --tab-padding-bottom: calc(var(--tab-padding-y) + var(--dt-space-100));
+        --tab-border-radius-top: var(--dt-size-radius-300);
+
+        font-size: var(--dt-font-size-100);
+
+        .d-tablist--no-border &:not(.d-tab--selected) {
+            border-radius: var(--tab-border-radius-top);
+        }
+    }
 }
 
 //  ============================================================================
@@ -173,7 +172,6 @@
         }
     }
 }
-
 
 //  ============================================================================
 //  $   INVERTED STYLE

--- a/packages/dialtone-css/lib/build/less/components/tabs.less
+++ b/packages/dialtone-css/lib/build/less/components/tabs.less
@@ -18,19 +18,16 @@
     //  ------------------------------------------------------------------------
     --tab-color-background: var(--dt-action-color-background-base-default);
     --tab-color-text: var(--dt-action-color-foreground-muted-default);
-    --tab-line-height: var(--dt-font-line-height-200);
-    --tab-font-weight: var(--dt-font-weight-medium);
-    --tab-border-radius-top: var(--dt-size-radius-400);
-    --tab-padding-x: var(--dt-space-450);
-    --tab-padding-y: var(--dt-space-400);
-    --tab-padding-bottom: calc(var(--tab-padding-y) + var(--dt-space-100));
+    --tab-font-style: var(--dt-typography-button-md);
+    --tab-border-radius: var(--dt-button-size-radius-md);
+    --tab-padding-x: calc(var(--dt-space-450) - var(--dt-size-border-100));
+    --tab-padding-y: calc(var(--dt-space-400) - var(--dt-size-border-100));
 
     position: relative;
     display: flex;
     flex-wrap: wrap;
     gap: var(--dt-space-300);
-    color: var(--dt-color-foreground-muted-default);
-    font-size: var(--dt-font-size-200);
+    align-items: baseline;
 
     &:focus {
         outline: 0;
@@ -39,17 +36,14 @@
     // Add a bottom border unless no border is requested
     &:not(.d-tablist--no-border)::after {
         position: absolute;
-        right: 0;
-        bottom: 0;
-        left: 0;
+        inset-inline: 0;
+        inset-block-end: 0;
         z-index: var(--zi-base1);
-        height: var(--dt-size-100);
+        block-size: var(--dt-size-border-100);
         background-color: var(--dt-color-border-default);
         content: '';
     }
-
 }
-
 
 //  ============================================================================
 //  $   BASE STYLE
@@ -62,40 +56,36 @@
     justify-content: center;
     box-sizing: border-box;
     padding: var(--tab-padding-y) var(--tab-padding-x);
-    padding-bottom: var(--tab-padding-bottom);
     color: var(--tab-color-text);
-    font: inherit;
-    font-weight: var(--tab-font-weight);
-    line-height: var(--tab-line-height);
+    font: var(--tab-font-style);
     background-color: var(--tab-color-background);
-    border: 0;
-    border-radius: var(--tab-border-radius-top) var(--tab-border-radius-top) 0 0;
+    border: var(--dt-size-border-100) solid transparent;
+    border-radius: var(--tab-border-radius) var(--tab-border-radius) 0 0;
     cursor: pointer;
     transition-timing-function: var(--ttf-out-quint);
-    transition-duration: var(--td200);
+    transition-duration: var(--td100);
     transition-property: background-color, border, color, box-shadow;
     fill: currentColor;
 
     .d-tablist--no-border &:not(.d-tab--selected) {
-        border-radius: var(--tab-border-radius-top);
+        border-radius: var(--tab-border-radius);
     }
 
     &:first-of-type {
-        margin-left: 0;
+        margin-inline-start: 0;
     }
 
     &:last-of-type {
-        margin-right: 0;
+        margin-inline-end: 0;
     }
 
     &::after {
         position: absolute;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        height: var(--dt-size-200);
+        block-size: var(--dt-size-border-200);
         background-color: var(--tab-color-background);
         content: '';
+        inset-inline: var(--dt-size-100-negative) var(--dt-size-100-negative);
+        inset-block-end: var(--dt-size-100-negative);
 
         .d-tablist--no-border & {
             background-color: transparent;
@@ -132,15 +122,12 @@
     //  $   SIZES
     //  ----------------------------------------------------------------------------
     .d-tablist--sm & {
-        --tab-padding-x: var(--dt-space-400);
-        --tab-padding-y: var(--dt-space-400);
-        --tab-padding-bottom: calc(var(--tab-padding-y) + var(--dt-space-100));
-        --tab-border-radius-top: var(--dt-size-radius-300);
-
-        font-size: var(--dt-font-size-100);
+        --tab-padding-x: calc(var(--dt-space-400) - var(--dt-size-border-100));
+        --tab-border-radius: var(--dt-button-size-radius-xs);
+        --tab-font-style: var(--dt-typography-button-xs);
 
         .d-tablist--no-border &:not(.d-tab--selected) {
-            border-radius: var(--tab-border-radius-top);
+            border-radius: var(--tab-border-radius);
         }
     }
 }

--- a/packages/dialtone-css/lib/build/less/dialtone.less
+++ b/packages/dialtone-css/lib/build/less/dialtone.less
@@ -24,9 +24,6 @@
 @import 'components/collapsible';
 @import 'components/combobox';
 @import 'components/datepicker';
-@import 'components/emoji';
-@import 'components/emoji-text-wrapper';
-@import 'components/emoji-picker';
 @import 'components/empty-state';
 @import 'components/forms';
 @import 'components/image-viewer';
@@ -52,6 +49,9 @@
 @import 'components/presence';
 @import 'components/icon';
 @import 'components/scrollbar';
+@import 'components/emoji';
+@import 'components/emoji-text-wrapper';
+@import 'components/emoji-picker';
 
 //  --  UTILITIES
 @import 'utilities/backgrounds';

--- a/packages/dialtone-css/lib/build/less/variables/sizes.less
+++ b/packages/dialtone-css/lib/build/less/variables/sizes.less
@@ -13,12 +13,12 @@
 #d-internal__input-and-select-xs() {
     --input-padding-y: calc(calc(var(--dt-space-400) - var(--dt-space-100)) - var(--input-border-width));
     --input-padding-x: calc(var(--dt-space-400) - var(--input-border-width));
-    --input-font-size: var(--dt-font-size-100);
-    --input-border-radius: var(--dt-size-300);
+    --input-border-radius: var(--dt-inputs-size-radius-xs);
+    --input-typography: var(--dt-typography-inputs-xs);
 
     .d-btn__icon {
-        width: calc(var(--dt-size-500) - var(--dt-size-200));
-        height: calc(var(--dt-size-500) - var(--dt-size-200));
+        width: var(--dt-icon-size-100);
+        height: var(--dt-icon-size-100);
     }
 }
 
@@ -27,11 +27,12 @@
 #d-internal__input-and-select-sm() {
     --input-padding-y: calc(var(--dt-space-400) - var(--input-border-width));
     --input-padding-x: calc((var(--dt-space-500) - var(--dt-space-300)) - var(--input-border-width));
-    --input-font-size: var(--dt-font-size-100);
+    --input-typography: var(--dt-typography-inputs-sm);
+    --input-border-radius: var(--dt-inputs-size-radius-sm);
 
     .d-btn__icon {
-        width: var(--dt-size-500);
-        height: var(--dt-size-500);
+        width: var(--dt-icon-size-200);
+        height: var(--dt-icon-size-200);
     }
 }
 
@@ -40,12 +41,12 @@
 #d-internal__input-and-select-lg() {
     --input-padding-y: calc((var(--dt-space-400) + var(--dt-space-200)) - var(--input-border-width));
     --input-padding-x: calc(var(--dt-space-500) - var(--input-border-width));
-    --input-font-size: var(--dt-font-size-300);
-    --input-border-radius: var(--dt-size-450);
+    --input-border-radius: var(--dt-inputs-size-radius-lg);
+    --input-typography: var(--dt-typography-inputs-lg);
 
     .d-btn__icon {
-        width: calc(var(--dt-size-300) * 5);
-        height: calc(var(--dt-size-300) * 5);
+        width: var(--dt-icon-size-400);
+        height: var(--dt-icon-size-400);
     }
 }
 
@@ -54,11 +55,11 @@
 #d-internal__input-and-select-xl() {
     --input-padding-y: calc((var(--dt-space-500) - var(--dt-space-300)) - var(--input-border-width));
     --input-padding-x: calc(var(--dt-space-500) - var(--input-border-width));
-    --input-font-size: var(--dt-font-size-400);
-    --input-border-radius: var(--dt-size-500);
+    --input-border-radius: var(--dt-inputs-size-radius-xl);
+    --input-typography: var(--dt-typography-inputs-xl);
 
     .d-btn__icon {
-        width: var(--dt-size-550);
-        height: var(--dt-size-550);
+        width: var(--dt-icon-size-500);
+        height: var(--dt-icon-size-500);
     }
 }

--- a/packages/dialtone-tokens/postcss/constants.cjs
+++ b/packages/dialtone-tokens/postcss/constants.cjs
@@ -38,8 +38,11 @@ module.exports = {
       'label',
       'helper',
       'code',
+      'button',
+      'inputs',
     ].join('|'),
     TYPOGRAPHY_SIZES: [
+      'xs',
       'sm',
       'md',
       'lg',

--- a/packages/dialtone-tokens/tokens/$metadata.json
+++ b/packages/dialtone-tokens/tokens/$metadata.json
@@ -14,6 +14,7 @@
     "components/avatar/default",
     "components/badge/default",
     "components/badge/dark",
+    "components/button/default",
     "components/checkbox/default",
     "components/checkbox/dark",
     "components/icon/default",

--- a/packages/dialtone-tokens/tokens/$themes.json
+++ b/packages/dialtone-tokens/tokens/$themes.json
@@ -350,7 +350,12 @@
       "badge.color.border.bulletin-subtle": "S:c390f0a63586ca48aac6566934330ee1847e2ca3,",
       "color.brand.gold": "S:a93609c07d43bca028d6298b018416a767db8e0f,",
       "theme.mention.color.foreground-strong": "S:f140617ad26ac60a0bdd5a7e2a6b45b3ef4458f3,",
-      "theme.mention.color.background-strong": "S:9167dd3c2301abc86096e84b28e94ec351332053,"
+      "theme.mention.color.background-strong": "S:9167dd3c2301abc86096e84b28e94ec351332053,",
+      "typography.button.xs": "S:5847d6b641a16663c9d550808418e2af0f5b7d61,",
+      "typography.button.sm": "S:53a2af33a04175e6aec85458ea41ae62dff904f9,",
+      "typography.button.md": "S:d10235a1b57019ddc60259fb4439114510afe4bb,",
+      "typography.button.lg": "S:b173098ab5c803206a353e1c28fd76bd2fb816f2,",
+      "typography.button.xl": "S:fe8c46d1218f4ae0b48ded87bd4c4efb66867640,"
     },
     "selectedTokenSets": {
       "base/default": "source",

--- a/packages/dialtone-tokens/tokens/$themes.json
+++ b/packages/dialtone-tokens/tokens/$themes.json
@@ -355,7 +355,12 @@
       "typography.button.sm": "S:53a2af33a04175e6aec85458ea41ae62dff904f9,",
       "typography.button.md": "S:d10235a1b57019ddc60259fb4439114510afe4bb,",
       "typography.button.lg": "S:b173098ab5c803206a353e1c28fd76bd2fb816f2,",
-      "typography.button.xl": "S:fe8c46d1218f4ae0b48ded87bd4c4efb66867640,"
+      "typography.button.xl": "S:fe8c46d1218f4ae0b48ded87bd4c4efb66867640,",
+      "typography.inputs.xs": "S:1457a4c4bac05d58dd308dfc0fadf818bb24d56c,",
+      "typography.inputs.sm": "S:1d24092f05dcd62ba0c90e6790e78e8b6207032a,",
+      "typography.inputs.md": "S:36c3ab10c677829159e0fb2907b28939f4d5be3f,",
+      "typography.inputs.lg": "S:3b97cecb39dbc717065cde0b1e77636752743590,",
+      "typography.inputs.xl": "S:e1be518c006a03f9e2c04dc33bc2bccfedc2106f,"
     },
     "selectedTokenSets": {
       "base/default": "source",

--- a/packages/dialtone-tokens/tokens/$themes.json
+++ b/packages/dialtone-tokens/tokens/$themes.json
@@ -360,7 +360,8 @@
       "components/checkbox/default": "enabled",
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
-      "root": "source"
+      "root": "source",
+      "components/button/default": "enabled"
     },
     "$figmaCollectionId": "VariableCollectionId:406:18994",
     "$figmaModeId": "406:0",
@@ -1274,7 +1275,8 @@
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
       "root": "source",
-      "components/badge/dark": "enabled"
+      "components/badge/dark": "enabled",
+      "components/button/default": "disabled"
     },
     "$figmaCollectionId": "VariableCollectionId:406:18994",
     "$figmaModeId": "406:1",
@@ -2177,7 +2179,8 @@
       "components/checkbox/default": "enabled",
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
-      "root": "source"
+      "root": "source",
+      "components/button/default": "disabled"
     },
     "$figmaCollectionId": "VariableCollectionId:406:19535",
     "$figmaModeId": "406:2",
@@ -2743,7 +2746,8 @@
       "components/checkbox/default": "enabled",
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
-      "root": "source"
+      "root": "source",
+      "components/button/default": "disabled"
     },
     "$figmaCollectionId": "VariableCollectionId:406:19535",
     "$figmaModeId": "406:3",
@@ -3651,7 +3655,8 @@
       "components/checkbox/default": "enabled",
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
-      "semantic/dp/default": "enabled"
+      "semantic/dp/default": "enabled",
+      "components/button/default": "disabled"
     },
     "group": "expressive"
   },
@@ -3672,7 +3677,8 @@
       "components/checkbox/dark": "enabled",
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
-      "components/radio/dark": "enabled"
+      "components/radio/dark": "enabled",
+      "components/button/default": "disabled"
     },
     "group": "expressive"
   },
@@ -3690,7 +3696,8 @@
       "components/checkbox/default": "enabled",
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
-      "semantic/expressive/default": "enabled"
+      "semantic/expressive/default": "enabled",
+      "components/button/default": "disabled"
     },
     "group": "expressive-sm"
   },
@@ -3712,7 +3719,8 @@
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
       "components/radio/dark": "enabled",
-      "semantic/expressive/default": "enabled"
+      "semantic/expressive/default": "enabled",
+      "components/button/default": "disabled"
     },
     "group": "expressive-sm"
   },
@@ -3782,7 +3790,8 @@
     },
     "selectedTokenSets": {
       "root": "source",
-      "base/default": "enabled"
+      "base/default": "enabled",
+      "components/button/default": "disabled"
     },
     "group": "base"
   },
@@ -3853,7 +3862,8 @@
     "selectedTokenSets": {
       "root": "source",
       "base/default": "enabled",
-      "base/dark": "enabled"
+      "base/dark": "enabled",
+      "components/button/default": "disabled"
     },
     "group": "base"
   }

--- a/packages/dialtone-tokens/tokens/$themes.json
+++ b/packages/dialtone-tokens/tokens/$themes.json
@@ -1276,7 +1276,7 @@
       "components/radio/default": "enabled",
       "root": "source",
       "components/badge/dark": "enabled",
-      "components/button/default": "disabled"
+      "components/button/default": "enabled"
     },
     "$figmaCollectionId": "VariableCollectionId:406:18994",
     "$figmaModeId": "406:1",
@@ -2179,8 +2179,7 @@
       "components/checkbox/default": "enabled",
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
-      "root": "source",
-      "components/button/default": "disabled"
+      "root": "source"
     },
     "$figmaCollectionId": "VariableCollectionId:406:19535",
     "$figmaModeId": "406:2",
@@ -2746,8 +2745,7 @@
       "components/checkbox/default": "enabled",
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
-      "root": "source",
-      "components/button/default": "disabled"
+      "root": "source"
     },
     "$figmaCollectionId": "VariableCollectionId:406:19535",
     "$figmaModeId": "406:3",
@@ -3655,8 +3653,7 @@
       "components/checkbox/default": "enabled",
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
-      "semantic/dp/default": "enabled",
-      "components/button/default": "disabled"
+      "semantic/dp/default": "enabled"
     },
     "group": "expressive"
   },
@@ -3677,8 +3674,7 @@
       "components/checkbox/dark": "enabled",
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
-      "components/radio/dark": "enabled",
-      "components/button/default": "disabled"
+      "components/radio/dark": "enabled"
     },
     "group": "expressive"
   },
@@ -3696,8 +3692,7 @@
       "components/checkbox/default": "enabled",
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
-      "semantic/expressive/default": "enabled",
-      "components/button/default": "disabled"
+      "semantic/expressive/default": "enabled"
     },
     "group": "expressive-sm"
   },
@@ -3719,8 +3714,7 @@
       "components/icon/default": "enabled",
       "components/radio/default": "enabled",
       "components/radio/dark": "enabled",
-      "semantic/expressive/default": "enabled",
-      "components/button/default": "disabled"
+      "semantic/expressive/default": "enabled"
     },
     "group": "expressive-sm"
   },
@@ -3790,8 +3784,7 @@
     },
     "selectedTokenSets": {
       "root": "source",
-      "base/default": "enabled",
-      "components/button/default": "disabled"
+      "base/default": "enabled"
     },
     "group": "base"
   },
@@ -3862,8 +3855,7 @@
     "selectedTokenSets": {
       "root": "source",
       "base/default": "enabled",
-      "base/dark": "enabled",
-      "components/button/default": "disabled"
+      "base/dark": "enabled"
     },
     "group": "base"
   }

--- a/packages/dialtone-tokens/tokens/base/default.json
+++ b/packages/dialtone-tokens/tokens/base/default.json
@@ -1372,6 +1372,10 @@
         "value": "8px",
         "type": "borderRadius"
       },
+      "450": {
+        "value": "12px",
+        "type": "borderRadius"
+      },
       "500": {
         "value": "16px",
         "type": "borderRadius"

--- a/packages/dialtone-tokens/tokens/components/button/default.json
+++ b/packages/dialtone-tokens/tokens/components/button/default.json
@@ -82,6 +82,35 @@
         "type": "lineHeights",
         "description": "Line-height for XL button"
       }
+    },
+    "size": {
+      "radius": {
+        "xs": {
+          "value": "{size.radius.300}",
+          "type": "borderRadius",
+          "description": "Border radius for extra small button"
+        },
+        "sm": {
+          "value": "{size.radius.400}",
+          "type": "borderRadius",
+          "description": "Border radius for small button"
+        },
+        "md": {
+          "value": "{size.radius.400}",
+          "type": "borderRadius",
+          "description": "Border radius for medium button."
+        },
+        "lg": {
+          "value": "{size.radius.450}",
+          "type": "borderRadius",
+          "description": "Border radius for large button."
+        },
+        "xl": {
+          "value": "{size.radius.500}",
+          "type": "borderRadius",
+          "description": "Border radius for extra large button."
+        }
+      }
     }
   },
   "typography": {

--- a/packages/dialtone-tokens/tokens/components/button/default.json
+++ b/packages/dialtone-tokens/tokens/components/button/default.json
@@ -1,0 +1,33 @@
+{
+  "button": {
+    "font": {
+      "size": {
+        "xs": {
+          "value": "{font.size.100}",
+          "type": "fontSizes",
+          "description": "Extra small Button text size"
+        },
+        "sm": {
+          "value": "{font.size.100}",
+          "type": "fontSizes",
+          "description": "Small Button text size"
+        },
+        "md": {
+          "value": "{font.size.200}",
+          "type": "fontSizes",
+          "description": "Medium Button text size"
+        },
+        "lg": {
+          "value": "{font.size.300}",
+          "type": "fontSizes",
+          "description": "Large Button text size"
+        },
+        "xl": {
+          "value": "{font.size.400}",
+          "type": "fontSizes",
+          "description": "Extra large Button text size"
+        }
+      }
+    }
+  }
+}

--- a/packages/dialtone-tokens/tokens/components/button/default.json
+++ b/packages/dialtone-tokens/tokens/components/button/default.json
@@ -27,6 +27,114 @@
           "type": "fontSizes",
           "description": "Extra large Button text size"
         }
+      },
+      "weight": {
+        "xs": {
+          "value": "{font.weight.medium}",
+          "type": "fontWeights",
+          "description": "Font weight for XS button"
+        },
+        "sm": {
+          "value": "{font.weight.medium}",
+          "type": "fontWeights",
+          "description": "Font weight for SM button"
+        },
+        "md": {
+          "value": "{font.weight.medium}",
+          "type": "fontWeights",
+          "description": "Font weight for MD button"
+        },
+        "lg": {
+          "value": "{font.weight.medium}",
+          "type": "fontWeights",
+          "description": "Font weight for LG button"
+        },
+        "xl": {
+          "value": "{font.weight.normal}",
+          "type": "fontWeights",
+          "description": "Font weight for XL button"
+        }
+      }
+    },
+    "lineHeight": {
+      "xs": {
+        "value": "{font.lineHeight.200}",
+        "type": "lineHeights",
+        "description": "Line-height for XS button"
+      },
+      "sm": {
+        "value": "{font.lineHeight.200}",
+        "type": "lineHeights",
+        "description": "Line-height for SM button"
+      },
+      "md": {
+        "value": "{font.lineHeight.200}",
+        "type": "lineHeights",
+        "description": "Line-height for MD button"
+      },
+      "lg": {
+        "value": "{font.lineHeight.200}",
+        "type": "lineHeights",
+        "description": "Line-height for LG button"
+      },
+      "xl": {
+        "value": "{font.lineHeight.200}",
+        "type": "lineHeights",
+        "description": "Line-height for XL button"
+      }
+    }
+  },
+  "typography": {
+    "button": {
+      "xs": {
+        "value": {
+          "fontFamily": "{font.family.body}",
+          "fontWeight": "{button.font.weight.xs}",
+          "fontSize": "{button.font.size.xs}",
+          "lineHeight": "{button.lineHeight.xs}"
+        },
+        "type": "typography",
+        "description": "Text style for XS button"
+      },
+      "sm": {
+        "value": {
+          "fontFamily": "{font.family.body}",
+          "fontWeight": "{button.font.weight.sm}",
+          "fontSize": "{button.font.size.sm}",
+          "lineHeight": "{button.lineHeight.sm}"
+        },
+        "type": "typography",
+        "description": "Text style for SM button"
+      },
+      "md": {
+        "value": {
+          "fontFamily": "{font.family.body}",
+          "fontWeight": "{button.font.weight.md}",
+          "fontSize": "{button.font.size.md}",
+          "lineHeight": "{button.lineHeight.md}"
+        },
+        "type": "typography",
+        "description": "Text style for MD button"
+      },
+      "lg": {
+        "value": {
+          "fontFamily": "{font.family.body}",
+          "fontWeight": "{button.font.weight.lg}",
+          "fontSize": "{button.font.size.lg}",
+          "lineHeight": "{button.lineHeight.lg}"
+        },
+        "type": "typography",
+        "description": "Text style for LG button"
+      },
+      "xl": {
+        "value": {
+          "fontFamily": "{font.family.body}",
+          "fontWeight": "{button.font.weight.xl}",
+          "fontSize": "{button.font.size.xl}",
+          "lineHeight": "{button.lineHeight.xl}"
+        },
+        "type": "typography",
+        "description": "Text style for XL button"
       }
     }
   }

--- a/packages/dialtone-tokens/tokens/components/button/default.json
+++ b/packages/dialtone-tokens/tokens/components/button/default.json
@@ -94,7 +94,7 @@
           "lineHeight": "{button.lineHeight.xs}"
         },
         "type": "typography",
-        "description": "Text style for XS button"
+        "description": "Text style for extra small button"
       },
       "sm": {
         "value": {
@@ -104,7 +104,7 @@
           "lineHeight": "{button.lineHeight.sm}"
         },
         "type": "typography",
-        "description": "Text style for SM button"
+        "description": "Text style for small button"
       },
       "md": {
         "value": {
@@ -114,7 +114,7 @@
           "lineHeight": "{button.lineHeight.md}"
         },
         "type": "typography",
-        "description": "Text style for MD button"
+        "description": "Text style for medium button"
       },
       "lg": {
         "value": {
@@ -124,7 +124,7 @@
           "lineHeight": "{button.lineHeight.lg}"
         },
         "type": "typography",
-        "description": "Text style for LG button"
+        "description": "Text style for large button"
       },
       "xl": {
         "value": {
@@ -134,7 +134,7 @@
           "lineHeight": "{button.lineHeight.xl}"
         },
         "type": "typography",
-        "description": "Text style for XL button"
+        "description": "Text style for extra large button"
       }
     }
   }

--- a/packages/dialtone-tokens/tokens/semantic/dp/default.json
+++ b/packages/dialtone-tokens/tokens/semantic/dp/default.json
@@ -1145,6 +1145,58 @@
         "type": "typography",
         "description": "Smaller text size for monospace code, suitable for inline references or less prominent code examples."
       }
+    },
+    "inputs": {
+      "xs": {
+        "value": {
+          "fontFamily": "{font.family.body}",
+          "fontWeight": "{inputs.font.weight.xs}",
+          "fontSize": "{inputs.font.size.xs}",
+          "lineHeight": "{inputs.lineHeight.xs}"
+        },
+        "type": "typography",
+        "description": "Text style for extra small inputs (e.g. input and textarea)"
+      },
+      "sm": {
+        "value": {
+          "fontFamily": "{font.family.body}",
+          "fontWeight": "{inputs.font.weight.sm}",
+          "fontSize": "{inputs.font.size.sm}",
+          "lineHeight": "{inputs.lineHeight.sm}"
+        },
+        "type": "typography",
+        "description": "Text style for small inputs (e.g. input and textarea)"
+      },
+      "md": {
+        "value": {
+          "fontFamily": "{font.family.body}",
+          "fontWeight": "{inputs.font.weight.md}",
+          "fontSize": "{inputs.font.size.md}",
+          "lineHeight": "{inputs.lineHeight.md}"
+        },
+        "type": "typography",
+        "description": "Text style for medium inputs (e.g. input and textarea)"
+      },
+      "lg": {
+        "value": {
+          "fontFamily": "{font.family.body}",
+          "fontWeight": "{inputs.font.weight.lg}",
+          "fontSize": "{inputs.font.size.lg}",
+          "lineHeight": "{inputs.lineHeight.lg}"
+        },
+        "type": "typography",
+        "description": "Text style for large inputs (e.g. input and textarea)"
+      },
+      "xl": {
+        "value": {
+          "fontFamily": "{font.family.body}",
+          "fontWeight": "{inputs.font.weight.xl}",
+          "fontSize": "{inputs.font.size.xl}",
+          "lineHeight": "{inputs.lineHeight.xl}"
+        },
+        "type": "typography",
+        "description": "Text style for extra large inputs (e.g. input and textarea)"
+      }
     }
   },
   "size": {

--- a/packages/dialtone-tokens/tokens/semantic/dp/default.json
+++ b/packages/dialtone-tokens/tokens/semantic/dp/default.json
@@ -1191,32 +1191,85 @@
       }
     },
     "lineHeight": {
-      "default": {
+      "xs": {
         "value": "{font.lineHeight.200}",
-        "type": "lineHeights"
+        "type": "lineHeights",
+        "description": "Line height for extra small inputs (e.g. input and textarea)"
+      },
+      "sm": {
+        "value": "{font.lineHeight.200}",
+        "type": "lineHeights",
+        "description": "Line height for small inputs (e.g. input and textarea)"
+      },
+      "md": {
+        "value": "{font.lineHeight.200}",
+        "type": "lineHeights",
+        "description": "Line height for medium inputs (e.g. input and textarea)"
+      },
+      "lg": {
+        "value": "{font.lineHeight.200}",
+        "type": "lineHeights",
+        "description": "Line height for large inputs (e.g. input and textarea)"
+      },
+      "xl": {
+        "value": "{font.lineHeight.200}",
+        "type": "lineHeights",
+        "description": "Line height for extra large inputs (e.g. input and textarea)"
       }
     },
     "font": {
       "size": {
         "xs": {
           "value": "{font.size.100}",
-          "type": "fontSizes"
+          "type": "fontSizes",
+          "description": "Font size for extra small inputs (e.g. input and textarea)"
         },
         "sm": {
           "value": "{font.size.100}",
-          "type": "fontSizes"
+          "type": "fontSizes",
+          "description": "Font size for small inputs (e.g. input and textarea)"
         },
         "md": {
           "value": "{font.size.200}",
-          "type": "fontSizes"
+          "type": "fontSizes",
+          "description": "Font size for medium inputs (e.g. input and textarea)"
         },
         "lg": {
           "value": "{font.size.300}",
-          "type": "fontSizes"
+          "type": "fontSizes",
+          "description": "Font size for large inputs (e.g. input and textarea)"
         },
         "xl": {
           "value": "{font.size.400}",
-          "type": "fontSizes"
+          "type": "fontSizes",
+          "description": "Font size for extra large inputs (e.g. input and textarea)"
+        }
+      },
+      "weight": {
+        "xs": {
+          "value": "{font.weight.normal}",
+          "type": "fontWeights",
+          "description": "Font weight for extra small inputs (e.g. input and textarea)"
+        },
+        "sm": {
+          "value": "{font.weight.normal}",
+          "type": "fontWeights",
+          "description": "Font weight for small inputs (e.g. input and textarea)"
+        },
+        "md": {
+          "value": "{font.weight.normal}",
+          "type": "fontWeights",
+          "description": "Font weight for medium inputs (e.g. input and textarea)"
+        },
+        "lg": {
+          "value": "{font.weight.normal}",
+          "type": "fontWeights",
+          "description": "Font weight for large inputs (e.g. input and textarea)"
+        },
+        "xl": {
+          "value": "{font.weight.normal}",
+          "type": "fontWeights",
+          "description": "Font weight for extra large inputs (e.g. input and textarea)"
         }
       }
     },

--- a/packages/dialtone-tokens/tokens/semantic/dp/default.json
+++ b/packages/dialtone-tokens/tokens/semantic/dp/default.json
@@ -1233,7 +1233,7 @@
           "type": "borderRadius"
         },
         "lg": {
-          "value": "{size.radius.300} * 3",
+          "value": "{size.radius.450}",
           "type": "borderRadius"
         },
         "xl": {

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_search.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_search.vue
@@ -22,12 +22,15 @@
       >
         <dt-button
           importance="clear"
+          size="xs"
+          class="d-mrn4"
+          circle
           kind="muted"
           @click="clearSearch"
         >
           <template #icon>
             <dt-icon
-              name="x-circle"
+              name="close"
               size="200"
             />
           </template>

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="d-emoji-picker__tabset">
     <dt-tab-group
+      size="sm"
       tab-list-class="d-emoji-picker__tabset-list"
       :selected="selectedTab"
     >

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_search.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_search.vue
@@ -22,12 +22,15 @@
       >
         <dt-button
           importance="clear"
+          size="xs"
+          class="d-mrn4"
+          circle
           kind="muted"
           @click="clearSearch"
         >
           <template #icon>
             <dt-icon
-              name="x-circle"
+              name="close"
               size="200"
             />
           </template>

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="d-emoji-picker__tabset">
     <dt-tab-group
+      size="sm"
       tab-list-class="d-emoji-picker__tabset-list"
       :selected="selectedTab"
     >


### PR DESCRIPTION
# Component Design Tokens for button- and input-like components

![high-five-knailed-it](https://github.com/user-attachments/assets/77a745d9-c6db-4b35-b23a-b073ed843e5e)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2004

## :book: Description

* Created Design Tokens for Buttons and form elements. We're not (yet) creating design tokens for every component, though some definitely need them to further support Expressive Theming in both Vue and Figma components. 
* Applied them to CSS.
  * Button
  * Split Button
  * Input (`text` and `textarea` types)
  * Tabs
* Emoji Picker impacted by a few pixels (thanks Percy). Adjusted those and corrected some style usage within — most especially color tokens.
* Also did a little reordering and tweaking of markdown docs

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.