### PR TITLE
feat: DP-108555 change prop type in contact centers recipe component

### DIFF
--- a/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_centers_row/contact_centers_row.vue
@@ -129,11 +129,11 @@ export default {
     },
 
     /**
-     * Number of unread messages
+     * Number of unread messages, could be a string to support '99+'
      */
     unreadCount: {
-      type: Number,
-      default: 0,
+      type: String,
+      default: null,
     },
 
     /**
@@ -188,7 +188,7 @@ export default {
     },
 
     showUnreadCount () {
-      return this.unreadCount > 0;
+      return !!this.unreadCount;
     },
   },
 

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.vue
@@ -124,17 +124,17 @@ export default {
     /**
      * Making this true will hide the unread count badge, the chevron button, and the right slot
      */
-     hideActions: {
+    hideActions: {
       type: Boolean,
       default: false,
     },
 
     /**
-     * Number of unread messages
+     * Number of unread messages, could be a string to support '99+'
      */
     unreadCount: {
-      type: Number,
-      default: 0,
+      type: String,
+      default: null,
     },
 
     /**
@@ -193,7 +193,7 @@ export default {
     },
 
     showUnreadCount () {
-      return this.unreadCount > 0;
+      return !!this.unreadCount;
     },
   },
 


### PR DESCRIPTION
# PR Title

## Obligatory GIF (super important!)

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcXZrMDc1c3dwOG9vNm5tZmF6dHc4ZWF0c3A3MDRpMzB3dDB0NzJ2eCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/0XLxdy5fM8RbxnYAht/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [x] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

[DP-108555](https://dialpad.atlassian.net/browse/DP-108555)

## :book: Description

Update the type of the `unreadCount` prop.

## :bulb: Context

Right now we're having an error when we try to set the unread count to `99+`.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

[DP-108555]: https://dialpad.atlassian.net/browse/DP-108555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ