### PR TITLE
fix: NO-JIRA eslint documentation links

### DIFF
--- a/packages/eslint-plugin-dialtone/lib/rules/custom-implementation.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/custom-implementation.js
@@ -15,7 +15,7 @@ module.exports = {
     docs: {
       description: "Detects custom dialtone icons implementations",
       recommended: false,
-      url: 'https://github.com/dialpad/eslint-plugin-dialtone/blob/main/docs/rules/custom-implementation.md', // URL to the documentation page for this rule
+      url: 'https://github.com/dialpad/dialtone/blob/staging/packages/eslint-plugin-dialtone/docs/rules/custom-implementation.md', // URL to the documentation page for this rule
     },
     fixable: null, // Or `code` or `whitespace`
     schema: [], // Add a schema if the rule has options

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-component.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-component.js
@@ -17,7 +17,7 @@ module.exports = {
     docs: {
       description: "Detects usages of deprecated components that should be replaced by Dialtone Vue components",
       recommended: false,
-      url: 'https://github.com/dialpad/eslint-plugin-dialtone/blob/main/docs/rules/deprecated-component.md', // URL to the documentation page for this rule
+      url: 'https://github.com/dialpad/dialtone/blob/staging/packages/eslint-plugin-dialtone/docs/rules/deprecated-component.md', // URL to the documentation page for this rule
     },
     fixable: null, // Or `code` or `whitespace`
     schema: [], // Add a schema if the rule has options

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-directive.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-directive.js
@@ -15,7 +15,7 @@ module.exports = {
       description:
         'Detects usages of deprecated vue directives that should be replaced by Dialtone Vue directives',
       recommended: false,
-      url: 'https://github.com/dialpad/eslint-plugin-dialtone/blob/main/docs/rules/deprecated-directive.md', // URL to the documentation page for this rule
+      url: 'https://github.com/dialpad/dialtone/blob/staging/packages/eslint-plugin-dialtone/docs/rules/deprecated-directive.md', // URL to the documentation page for this rule
     },
     fixable: null, // Or `code` or `whitespace`
     schema: [], // Add a schema if the rule has options

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-icons.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-icons.js
@@ -15,7 +15,7 @@ module.exports = {
         docs: {
             description: 'Finds deprecated svg and vue icon imports from dialtone',
             recommended: false,
-            url: 'https://github.com/dialpad/eslint-plugin-dialtone/blob/main/docs/rules/deprecated-icons.md', // URL to the documentation page for this rule
+            url: 'https://github.com/dialpad/dialtone/blob/staging/packages/eslint-plugin-dialtone/docs/rules/deprecated-icons.md', // URL to the documentation page for this rule
         },
         fixable: null, // Or `code` or `whitespace`
         schema: [], // Add a schema if the rule has options

--- a/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
@@ -14,7 +14,7 @@ module.exports = {
     docs: {
       description: "Utilities to set Font family, Font weight, Font size, and Line height separately are discouraged in favor of composed typography utilities",
       recommended: false,
-      url: 'https://github.com/dialpad/eslint-plugin-dialtone/blob/main/docs/rules/recommend-typography-style.md', // URL to the documentation page for this rule
+      url: 'https://github.com/dialpad/dialtone/blob/staging/packages/eslint-plugin-dialtone/docs/rules/recommend-typography-style.md', // URL to the documentation page for this rule
     },
     fixable: null, // Or `code` or `whitespace`
     schema: [], // Add a schema if the rule has options


### PR DESCRIPTION
# Fix eslint plugin doc links

<!--- Feel free to remove any unused sections -->
Update the links to point to the correct URL. They were probably like this since the migration to the monorepo.

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/BcJbdfFSsJPwK4O66J/giphy.gif?cid=790b76115lo38cf0yuzqr3vrr0t8vs1n1akwo1bgsq7ylrxx&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

