### PR TITLE
fix(tokens): DLT-1951 corrected muted outlined border color

### DIFF
--- a/packages/dialtone-tokens/tokens/semantic/dp/default.json
+++ b/packages/dialtone-tokens/tokens/semantic/dp/default.json
@@ -1750,7 +1750,7 @@
         "inverted": {
           "outlined": {
             "default": {
-              "value": "{color.black.100}",
+              "value": "{color.border.moderate-inverted}",
               "type": "color"
             }
           }

--- a/packages/dialtone-tokens/tokens/semantic/dp/default.json
+++ b/packages/dialtone-tokens/tokens/semantic/dp/default.json
@@ -1758,7 +1758,7 @@
         "muted": {
           "outlined": {
             "default": {
-              "value": "{color.black.600}",
+              "value": "{color.border.moderate}",
               "type": "color"
             }
           }


### PR DESCRIPTION
# Corrected muted outlined border color

![robot-face-smash](https://github.com/user-attachments/assets/899e1669-cbc0-41a7-9a92-4fcd093f1f83)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

[<!--- Enter the URL of the Jira ticket associated with this PR -->](https://dialpad.atlassian.net/browse/DLT-1951)

## :book: Description

The Muted Outlined Button border color was incorrect all along since DT7. Was supposed to be a touch softer — using `color.border.moderate` as reference in both light and dark.

I only just realized this when considering the Filter Pill design.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :camera: Screenshots / GIFs

<img width="639" alt="image" src="https://github.com/user-attachments/assets/d8cc3457-661d-45c5-ad11-27554d49818d">
