### PR TITLE
feat(tokens): DLT-2014 add postcss plugin to transform rem to px

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,10 @@
     "./css-default-theme": "./dist/css/dialtone-default-theme.min.css",
     "./tokens/*.css": "./dist/tokens/css/*.css",
     "./tokens/*.less": "./dist/tokens/less/*.less",
+    "./tokens/postcss/rem-to-px": {
+      "import": "./dist/tokens/postcss/rem-to-px.js",
+      "require": "./dist/tokens/postcss/rem-to-px.cjs"
+    },
     "./vue2": {
       "types": "./dist/vue2/types/index.d.ts",
       "import": "./dist/vue2/dialtone-vue.js",

--- a/packages/dialtone-tokens/README.md
+++ b/packages/dialtone-tokens/README.md
@@ -25,6 +25,15 @@ npm install @dialpad/dialtone-tokens
 @import "@dialpad/dialtone-tokens/dist/tokens-base-dark.css";  // Dark variables
 ```
 
+dialtone-tokens provides a postcss plugin that you can use to convert all tokens using rem to px. This could be useful if you are using dialtone in an embedded situation where you don't have control over the root font size.
+
+You can reference this script from:
+
+- @dialpad/dialtone-tokens package: `@dialpad/dialtone-tokens/dist/postcss/rem-to-px.js`
+- @dialpad/dialtone package: `@dialpad/dialtone/tokens/postcss/rem-to-px.js`
+
+To use this script you will have to run it as part of your build process on the tokens files you are importing. There are various ways to run postcss as part of your build process, please see the documentation here: <https://github.com/postcss/postcss?tab=readme-ov-file#usage>
+
 #### Use CSS Token
 
 ```css

--- a/packages/dialtone-tokens/postcss/rem-to-px.cjs
+++ b/packages/dialtone-tokens/postcss/rem-to-px.cjs
@@ -1,0 +1,15 @@
+/**
+ * @type {import('postcss').PluginCreator}
+ */
+module.exports = () => {
+  return {
+    postcssPlugin: 'postcss-dialtone-rem-to-px',
+    Declaration (decl) {
+      if (decl.value.includes('rem')) {
+        decl.assign({ value: decl.value.replace('rem', 'px') });
+      }
+    },
+  };
+};
+
+module.exports.postcss = true;

--- a/packages/dialtone-tokens/postcss/rem-to-px.cjs
+++ b/packages/dialtone-tokens/postcss/rem-to-px.cjs
@@ -6,7 +6,9 @@ module.exports = () => {
     postcssPlugin: 'postcss-dialtone-rem-to-px',
     Declaration (decl) {
       if (decl.value.includes('rem')) {
-        decl.assign({ value: decl.value.replace('rem', 'px') });
+        const numericValue = parseFloat(decl.value);
+        const newValue = numericValue * 10;
+        decl.assign({ value: `${newValue}px` });
       }
     },
   };

--- a/packages/dialtone-tokens/vite.config.js
+++ b/packages/dialtone-tokens/vite.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
     emptyOutDir: false,
     lib: {
       entry: {
+        'postcss/rem-to-px': resolve(__dirname, './postcss/rem-to-px.cjs'),
         'themes/config': resolve(__dirname, './themes/config.js'),
         'themes/dp-light': resolve(__dirname, './themes/dp-light.js'),
         'themes/dp-dark': resolve(__dirname, './themes/dp-dark.js'),


### PR DESCRIPTION
# feat(tokens): DLT-2014 add postcss plugin to transform rem to px

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNGFmamw1dzNucDBpOXpxdnNnbGgzZzRta3djZHhhMGdkOWdlazMxNyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5mYdQz29sWo7NWg7O2/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2014

## :book: Description

Publishing a PostCSS plugin along with dialtone tokens that will convert rem values to px.

## :bulb: Context

When embedding a module using dialtone into an existing page it will always use the rem of the root of the page, even though the module has no control over it. In this case it is ideal to use px over rem.

See thread: https://dialpad.com/app/messages/agxzfnViZXItdm9pY2VyGAsSC1RleHRNZXNzYWdlGICA1b-viJwIDA

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

## :crystal_ball: Next Steps

Test with Dhruba

## :link: Sources

https://postcss.org/docs/writing-a-postcss-plugin
