### PR TITLE
fix(dialtone-icons): NO-JIRA add data-qa to individual icon and illustration

### DIFF
--- a/packages/dialtone-icons/src/IconTemplate.vue
+++ b/packages/dialtone-icons/src/IconTemplate.vue
@@ -43,6 +43,10 @@ export default {
     ariaHidden () {
       return !this.ariaLabel ? 'true' : 'false';
     },
+
+    dataQA () {
+      return this.$attrs['data-qa'] ?? 'dt-icon';
+    },
   },
 
   created () {

--- a/packages/dialtone-icons/src/IllustrationTemplate.vue
+++ b/packages/dialtone-icons/src/IllustrationTemplate.vue
@@ -28,6 +28,10 @@ export default {
     ariaHidden () {
       return !this.ariaLabel ? 'true' : 'false';
     },
+
+    dataQA () {
+      return this.$attrs['data-qa'] ?? 'dt-illustration';
+    },
   },
 
   created () {

--- a/packages/dialtone-icons/transformSVGtoVue.cjs
+++ b/packages/dialtone-icons/transformSVGtoVue.cjs
@@ -1,5 +1,5 @@
+/* eslint-disable no-template-curly-in-string */
 const fs = require('node:fs');
-const _ = require('lodash');
 
 (function () {
   /**
@@ -15,34 +15,33 @@ const _ = require('lodash');
     }
 
     fileNames.forEach(function (fileName) {
-        const svgContent = fs.readFileSync(`./dist/svg/icons/${fileName}`, 'utf8');
-        const template = fs.readFileSync('./src/IconTemplate.vue', 'utf8');
-        const iconName = `dt-icon-${fileName.replace('.svg', '')}`.toLowerCase()
+      const svgContent = fs.readFileSync(`./dist/svg/icons/${fileName}`, 'utf8');
+      const template = fs.readFileSync('./src/IconTemplate.vue', 'utf8');
+      const iconName = `dt-icon-${fileName.replace('.svg', '')}`.toLowerCase()
         .split('-')
         .map(word => word.charAt(0).toUpperCase() + word.slice(1))
         .join('');
 
-        let result = template.replace('__SVG_CONTENT__', svgContent);
-        result = result.replaceAll('__ICON_NAME__', iconName);
+      let result = template.replace('__SVG_CONTENT__', svgContent);
+      result = result.replaceAll('__ICON_NAME__', iconName);
 
-        // result = result.replace('<svg', '<svg :aria-label="ariaLabel" :class="[iconSizeClass]"')
-        result = result.replace('<svg', '<svg :aria-label="ariaLabel" :class="iconSizeClass"')
+      result = result.replace('<svg', '<svg :aria-label="ariaLabel" :class="iconSizeClass" :data-qa="dataQA"');
 
-        result = result.replace('aria-hidden="true"', ':aria-hidden="ariaHidden"')
+      result = result.replace('aria-hidden="true"', ':aria-hidden="ariaHidden"');
 
-        // Create unique IDs
-        result = result.replace(/(clip-path|fill)="url\(#([^)]+)\)"/g, ':$1="`url(#${uniqueID}$2)`"')
-        result = result.replace(/(clipPath|linearGradient|radialGradient) id="([^"]+)"/g, '$1 :id="`${uniqueID}$2`"')
+      // Create unique IDs
+      result = result.replace(/(clip-path|fill)="url\(#([^)]+)\)"/g, ':$1="`url(#${uniqueID}$2)`"');
+      result = result.replace(/(clipPath|linearGradient|radialGradient) id="([^"]+)"/g, '$1 :id="`${uniqueID}$2`"');
 
-        if (!/\${uniqueID}/g.test(result)) {
-          // Remove created function if not needed
-          result = result.replace(/\n\s+this.uniqueID.*;/, '');
-          result = result.replace(/import \{ getUniqueString \} from '\.\.\/utils';\n+/, '');
-        }
+      if (!/\${uniqueID}/g.test(result)) {
+        // Remove created function if not needed
+        result = result.replace(/\n\s+this.uniqueID.*;/, '');
+        result = result.replace(/import \{ getUniqueString } from '@\/src\/utils';\n+/, '');
+      }
 
-        fs.writeFileSync(`./src/icons/${fileName.replace('.svg', '.vue')}`, result, 'utf8');
-    })
-  })
+      fs.writeFileSync(`./src/icons/${fileName.replace('.svg', '.vue')}`, result, 'utf8');
+    });
+  });
 
   /**
    * ILLUSTRATIONS BUILD
@@ -57,33 +56,31 @@ const _ = require('lodash');
     }
 
     fileNames.forEach(function (fileName) {
-        const svgContent = fs.readFileSync(`./dist/svg/illustrations/${fileName}`, 'utf8');
-        const template = fs.readFileSync('./src/IllustrationTemplate.vue', 'utf8');
-        const illustrationName = `dt-illustration-${fileName.replace('.svg', '')}`.toLowerCase()
+      const svgContent = fs.readFileSync(`./dist/svg/illustrations/${fileName}`, 'utf8');
+      const template = fs.readFileSync('./src/IllustrationTemplate.vue', 'utf8');
+      const illustrationName = `dt-illustration-${fileName.replace('.svg', '')}`.toLowerCase()
         .split('-')
         .map(word => word.charAt(0).toUpperCase() + word.slice(1))
         .join('');
 
-        let result = template.replace('__SVG_CONTENT__', svgContent);
-        result = result.replaceAll('__ILLUSTRATION_NAME__', illustrationName);
+      let result = template.replace('__SVG_CONTENT__', svgContent);
+      result = result.replaceAll('__ILLUSTRATION_NAME__', illustrationName);
 
-        result = result.replace('<svg', '<svg :aria-label="ariaLabel"')
+      result = result.replace('<svg', '<svg :aria-label="ariaLabel" :data-qa="dataQA"');
 
-        result = result.replace('aria-hidden="true"', ':aria-hidden="ariaHidden"')
+      result = result.replace('aria-hidden="true"', ':aria-hidden="ariaHidden"');
 
-        // Create unique IDs
-        result = result.replace(/(clip-path|fill)="url\(#([^)]+)\)"/g, ':$1="`url(#${uniqueID}$2)`"')
-        result = result.replace(/(clipPath|linearGradient|radialGradient) id="([^"]+)"/g, '$1 :id="`${uniqueID}$2`"')
+      // Create unique IDs
+      result = result.replace(/(clip-path|fill)="url\(#([^)]+)\)"/g, ':$1="`url(#${uniqueID}$2)`"');
+      result = result.replace(/(clipPath|linearGradient|radialGradient) id="([^"]+)"/g, '$1 :id="`${uniqueID}$2`"');
 
-        if (!/\${uniqueID}/g.test(result)) {
-          // Remove created function if not needed
-          result = result.replace(/\n\s+this.uniqueID.*;/, '');
-          result = result.replace(/import \{ getUniqueString \} from '\.\.\/utils';\n+/, '');
-        }
+      if (!/\${uniqueID}/g.test(result)) {
+        // Remove created function if not needed
+        result = result.replace(/\n\s+this.uniqueID.*;/, '');
+        result = result.replace(/import \{ getUniqueString } from '@\/src\/utils';\n+/, '');
+      }
 
-        fs.writeFileSync(`./src/illustrations/${fileName.replace('.svg', '.vue')}`, result, 'utf8');
-    })
-  })
-
+      fs.writeFileSync(`./src/illustrations/${fileName.replace('.svg', '.vue')}`, result, 'utf8');
+    });
+  });
 })();
-


### PR DESCRIPTION
# Add `data-qa` to individual icon and illustration

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/2WGDUTmsB4DzFuvZ2t/giphy.gif?cid=82a1493b4ic3f6qntjq5fuvnzxvs9apkdyweypha4fykehzg&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Description

- Added default `data-qa` value of `dt-icon` and `dt-illustration` to corresponding components.

## :bulb: Context

When changing usages of DtIcon to individual icons, tests were failing due to the individual icons didn't included the `data-qa='dt-icon'` that the actual DtIcon component has. (Thanks to @ninamarina for finding it). 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

## :crystal_ball: Next Steps

- Merge to remove/dt-icon branch 