### PR TITLE
fix(scrollbar-directive): NO-JIRA overlayscrollbars missing styles

### DIFF
--- a/apps/dialtone-documentation/docs/components/scrollbar.md
+++ b/apps/dialtone-documentation/docs/components/scrollbar.md
@@ -58,16 +58,27 @@ vueCode='
 
 ## Usage
 
-Import the directive from dialtone-vue
+Import the directive and styling from dialtone
 
 ```javascript
-import { DtScrollbarDirective } from "@dialpad/dialtone-vue";
+// For Vue 2
+import { DtScrollbarDirective } from "@dialpad/dialtone/vue2";
+
+// For Vue 3+
+import { DtScrollbarDirective } from "@dialpad/dialtone/vue3";
+
+// Import styling
+import 'overlayscrollbars/overlayscrollbars.css';
 ```
 
 Install the directive into vue instance
 
 ```javascript
+// For Vue 2
 Vue.use(DtScrollbarDirective);
+
+// For Vue 3+
+app.use(DtScrollbarDirective);
 ```
 
 To add a custom overlay scrollbar to a scrollable region, apply the `v-dt-scrollbar` directive to the parent element of the desired region.

--- a/packages/dialtone-vue2/.storybook/preview.jsx
+++ b/packages/dialtone-vue2/.storybook/preview.jsx
@@ -1,5 +1,5 @@
 import '../css/dialtone-globals.less';
-import '@dialpad/dialtone-css/lib/dist/dialtone.css';
+import '@dialpad/dialtone-css';
 import 'overlayscrollbars/overlayscrollbars.css';
 import { addons } from '@storybook/preview-api';
 import { setTheme } from '@dialpad/dialtone-tokens/themes/config';

--- a/packages/dialtone-vue2/.storybook/preview.jsx
+++ b/packages/dialtone-vue2/.storybook/preview.jsx
@@ -1,5 +1,6 @@
 import '../css/dialtone-globals.less';
 import '@dialpad/dialtone-css/lib/dist/dialtone.css';
+import 'overlayscrollbars/overlayscrollbars.css';
 import { addons } from '@storybook/preview-api';
 import { setTheme } from '@dialpad/dialtone-tokens/themes/config';
 import DpLight from '@dialpad/dialtone-tokens/themes/dp-light.js';

--- a/packages/dialtone-vue2/directives/scrollbar/scrollbar.js
+++ b/packages/dialtone-vue2/directives/scrollbar/scrollbar.js
@@ -1,5 +1,4 @@
 import { OverlayScrollbars, ClickScrollPlugin } from 'overlayscrollbars';
-import 'overlayscrollbars/overlayscrollbars.css';
 
 export const DtScrollbarDirective = {
   name: 'dt-scrollbar-directive',

--- a/packages/dialtone-vue3/.storybook/preview.jsx
+++ b/packages/dialtone-vue3/.storybook/preview.jsx
@@ -1,5 +1,5 @@
 import '../css/dialtone-globals.less';
-import '@dialpad/dialtone-css/lib/dist/dialtone.css';
+import '@dialpad/dialtone-css';
 import 'overlayscrollbars/overlayscrollbars.css';
 import { addons } from '@storybook/preview-api';
 import { setTheme } from '@dialpad/dialtone-tokens/themes/config';

--- a/packages/dialtone-vue3/.storybook/preview.jsx
+++ b/packages/dialtone-vue3/.storybook/preview.jsx
@@ -1,5 +1,6 @@
 import '../css/dialtone-globals.less';
 import '@dialpad/dialtone-css/lib/dist/dialtone.css';
+import 'overlayscrollbars/overlayscrollbars.css';
 import { addons } from '@storybook/preview-api';
 import { setTheme } from '@dialpad/dialtone-tokens/themes/config';
 import DpLight from '@dialpad/dialtone-tokens/themes/dp-light.js';

--- a/packages/dialtone-vue3/directives/scrollbar/scrollbar.js
+++ b/packages/dialtone-vue3/directives/scrollbar/scrollbar.js
@@ -1,5 +1,4 @@
 import { OverlayScrollbars, ClickScrollPlugin } from 'overlayscrollbars';
-import 'overlayscrollbars/overlayscrollbars.css';
 
 export const DtScrollbarDirective = {
   name: 'dt-scrollbar-directive',


### PR DESCRIPTION
# Fix scrollbar directive missing styling

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/JhSL4vfyXR1HVgYm3s/giphy.gif?cid=82a1493b4e0ktdksv6k6jylh8aoysjipffle61m8vjfxxosh&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Description

- Removed style import from scrollbar directive as it was too obscure and not easily discoverable.
- Updated documentation to mention that you need to import `overlayscrollbars.css` in your project.

## :bulb: Context

@bianca-artola-dialpad found issues with message input after a [dialtone update](https://github.com/dialpad/firespotter/pull/46896).

Investigated and found that overlayscrollbars styling was missing after [fixing tree-shaking](https://github.com/dialpad/dialtone/commit/f24eb29397918238cf12f5882e12f30745947a3c) as it was added as an external dependency (intended). 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.
