### PR TITLE
fix(lint): NO-JIRA fix linter rule for text styles

### DIFF
--- a/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
@@ -38,7 +38,6 @@ module.exports = {
             'd-fw-medium',
             'd-fw-semibold',
             'd-fw-bold',
-            'd-fw-unset',
             'd-lh',
             'd-ff-custom',
             'd-ff-sans',

--- a/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
@@ -32,7 +32,20 @@ module.exports = {
       VAttribute(node) {
         if (node.key.name === 'class') {
           const classes = node.value.value.split(' ');
-          const typographyClasses = ['d-fs', 'd-fw', 'd-lh', 'd-ff'];
+          const typographyClasses = [
+            'd-fs',
+            'd-fw-normal',
+            'd-fw-medium',
+            'd-fw-semibold',
+            'd-fw-bold',
+            'd-fw-unset',
+            'd-lh',
+            'd-ff-custom',
+            'd-ff-sans',
+            'd-ff-mono',
+            'd-ff-marketing',
+            'd-ff-unset',
+          ];
           const typographyClassesFound = classes.filter((className) =>
             typographyClasses.some((typographyClass) => className.includes(typographyClass))
           );


### PR DESCRIPTION
# Fix recommend-typography-style rule false positives

In this rule we were checking for `d-fw` and `d-ff` prefixes, which are also used for flex-wrap and flex-flow properties.
I improved the rule to target the specific properties to avoid getting a warning in those cases.

<img width="1023" alt="image" src="https://github.com/user-attachments/assets/034d7b72-9d98-4608-9351-8735a5112796">

