### PR TITLE
fix(combobox-multiselect): DLT-2015  add reservedRightSpace prop

### DIFF
--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -315,6 +315,16 @@ export default {
       type: String,
       default: '',
     },
+
+    /**
+    * Amount of reserved space (in px) on the right side of the input
+    * before the chips and the input caret jump to the next line.
+    * default is 64
+    */
+    reservedRightSpace: {
+      type: Number,
+      default: 64,
+    },
   },
 
   emits: [
@@ -613,18 +623,25 @@ export default {
       // Get the position of the last chip
       // The input cursor should be the same "top" as that chip and next besides it
       const left = lastChip.offsetLeft + this.getFullWidth(lastChip);
-      input.style.paddingLeft = left + 'px';
+      const spaceLeft = input.getBoundingClientRect().width - left;
+      // input.style.paddingLeft = left + 'px';
 
-      // Get the chip size minus the 4px padding
-      const chipsSize = chipsWrapper.getBoundingClientRect().height - 4;
+      if (spaceLeft > this.reservedRightSpace) {
+        input.style.paddingLeft = left + 'px';
+      } else {
+        input.style.paddingLeft = '4px';
+      }
+
+      // Get the chip wrapper height minus the 4px padding
+      const chipsWrapperHeight = chipsWrapper.getBoundingClientRect().height - 4;
+      const lastChipHeight = lastChip.getBoundingClientRect().height - 4;
 
       // Get lastChip offsetTop plus 2px of the input padding.
-      const top = lastChip.offsetTop + 2;
+      const top = spaceLeft > this.reservedRightSpace
+        ? lastChip.offsetTop + 2
+        : (chipsWrapperHeight + lastChipHeight - 9);
 
-      // Add padding to Top only if the chips need more space
-      if (chipsSize > this.initialInputHeight) {
-        input.style.paddingTop = `${top}px`;
-      }
+      input.style.paddingTop = `${top}px`;
     },
 
     revertInputPadding (input) {

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
@@ -22,6 +22,7 @@
     :visually-hidden-close-label="$attrs.visuallyHiddenCloseLabel"
     :append-to="$attrs.appendTo"
     :transition="$attrs.transition"
+    :reserved-right-space="$attrs.reservedRightSpace"
     @input="onComboboxInput"
     @select="onComboboxSelect"
     @remove="onComboboxRemove"
@@ -99,6 +100,9 @@ export default {
         // Clear input box and unfilter list
         this.$refs.comboboxMultiSelect.$data.value = '';
         this.items = ITEMS_LIST_DATA;
+      } else {
+        const item = this.$refs.comboboxMultiSelect.$refs.input.value;
+        item && this.$attrs.selectedItems.push(item);
       }
     },
 

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -315,6 +315,16 @@ export default {
       type: String,
       default: '',
     },
+
+    /**
+    * Amount of reserved space (in px) on the right side of the input
+    * before the chips and the input caret jump to the next line.
+    * default is 64
+    */
+    reservedRightSpace: {
+      type: Number,
+      default: 64,
+    },
   },
 
   emits: [
@@ -606,18 +616,25 @@ export default {
       // Get the position of the last chip
       // The input cursor should be the same "top" as that chip and next besides it
       const left = lastChip.offsetLeft + this.getFullWidth(lastChip);
-      input.style.paddingLeft = left + 'px';
+      const spaceLeft = input.getBoundingClientRect().width - left;
+      // input.style.paddingLeft = left + 'px';
 
-      // Get the chip size minus the 4px padding
-      const chipsSize = chipsWrapper.getBoundingClientRect().height - 4;
+      if (spaceLeft > this.reservedRightSpace) {
+        input.style.paddingLeft = left + 'px';
+      } else {
+        input.style.paddingLeft = '4px';
+      }
+
+      // Get the chip wrapper height minus the 4px padding
+      const chipsWrapperHeight = chipsWrapper.getBoundingClientRect().height - 4;
+      const lastChipHeight = lastChip.getBoundingClientRect().height - 4;
 
       // Get lastChip offsetTop plus 2px of the input padding.
-      const top = lastChip.offsetTop + 2;
+      const top = spaceLeft > this.reservedRightSpace
+        ? lastChip.offsetTop + 2
+        : (chipsWrapperHeight + lastChipHeight - 9);
 
-      // Add padding to Top only if the chips need more space
-      if (chipsSize > this.initialInputHeight) {
-        input.style.paddingTop = `${top}px`;
-      }
+      input.style.paddingTop = `${top}px`;
     },
 
     revertInputPadding (input) {

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
@@ -22,6 +22,7 @@
     :visually-hidden-close-label="$attrs.visuallyHiddenCloseLabel"
     :append-to="$attrs.appendTo"
     :transition="$attrs.transition"
+    :reserved-right-space="$attrs.reservedRightSpace"
     @input="onComboboxInput"
     @select="onComboboxSelect"
     @remove="onComboboxRemove"
@@ -99,6 +100,9 @@ export default {
         // Clear input box and unfilter list
         this.$refs.comboboxMultiSelect.$data.value = '';
         this.items = ITEMS_LIST_DATA;
+      } else {
+        const item = this.$refs.comboboxMultiSelect.$refs.input.value;
+        item && this.$attrs.selectedItems.push(item);
       }
     },
 


### PR DESCRIPTION
# Combobox Multiselect - add ReservedRightSpace prop

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/chVcxKO8wAZZFSoVlL/giphy.gif?cid=790b7611a6exs6ye2nscb3nsx0ye7cab5htqjunbh239pcx5&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2015

## :book: Description

- Added `reserved-right-space` prop to be able to reserve some space at the right side, didn't make it a fixed value as it might be too much for smaller devices or too low for larger depending on the use-case.

- Added the ability to add any text chip to default story as some clients we're using it that way so it's good that we have that option to so we can play with it.

## :bulb: Context

Issues reported with the component not having enough space to keep typing while many chips entered. 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.


## :camera: Screenshots / GIFs

![2024-09-12 14 05 27](https://github.com/user-attachments/assets/a6a5b5ca-9586-4f72-b58d-c55f7afc2a7f)

https://dialtone.dialpad.com/vue/deploy-previews/pr-496/?path=/story/recipes-comboboxes-combobox-multi-select--default

https://dialtone.dialpad.com/vue3/deploy-previews/pr-496/?path=/story/recipes-comboboxes-combobox-multi-select--default