### PR TITLE
fix(tooltip): DLT-2039 flush promises when external anchor

### DIFF
--- a/packages/dialtone-vue2/components/split_button/split_button.test.js
+++ b/packages/dialtone-vue2/components/split_button/split_button.test.js
@@ -1,4 +1,5 @@
 import { createLocalVue, mount } from '@vue/test-utils';
+import { flushPromises } from '@/common/utils';
 import DtSplitButton from './split_button.vue';
 import { DtIconSend } from '@dialpad/dialtone-icons/vue2';
 import { DtTooltipDirective } from '@/directives/tooltip';
@@ -201,6 +202,7 @@ describe('DtSplitButton Tests', function () {
       it('Should render the tooltip with correct text', async () => {
         mockProps = { alphaTooltipText: MOCK_ALPHA_TOOLTIP_TEXT };
         await updateWrapper();
+        await flushPromises();
         await alphaButton.trigger('mouseenter');
 
         const tooltip = document.body.querySelector('[data-qa="dt-tooltip"]');
@@ -213,6 +215,7 @@ describe('DtSplitButton Tests', function () {
       it('Should render the tooltip with correct text', async () => {
         mockProps = { omegaTooltipText: MOCK_OMEGA_TOOLTIP_TEXT };
         await updateWrapper();
+        await flushPromises();
         await omegaButton.trigger('mouseenter');
 
         const tooltip = document.body.querySelector('[data-qa="dt-tooltip"]');

--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -51,7 +51,7 @@ import {
 import {
   POPOVER_APPEND_TO_VALUES,
 } from '../popover/popover_constants';
-import { getUniqueString } from '@/common/utils';
+import { flushPromises, getUniqueString } from '@/common/utils';
 import {
   createTippy,
   getAnchor,
@@ -351,12 +351,16 @@ export default {
     },
   },
 
-  mounted () {
+  async mounted () {
     if (!this.enabled && this.show != null) {
       console.warn('Tooltip: You cannot use both the enabled and show props at the same time.');
       console.warn('The show prop will be ignored.');
     }
-    this.externalAnchor && this.addExternalAnchorEventListeners();
+
+    if (this.externalAnchor) {
+      await flushPromises();
+      this.addExternalAnchorEventListeners();
+    }
     this.tip = createTippy(this.anchor, this.initOptions());
   },
 

--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -357,11 +357,11 @@ export default {
       console.warn('The show prop will be ignored.');
     }
 
+    this.tip = createTippy(this.anchor, this.initOptions());
     if (this.externalAnchor) {
       await flushPromises();
       this.addExternalAnchorEventListeners();
     }
-    this.tip = createTippy(this.anchor, this.initOptions());
   },
 
   beforeDestroy () {

--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -502,19 +502,19 @@ export default {
 
     addExternalAnchorEventListeners () {
       ['focusin', 'mouseenter'].forEach(listener => {
-        this.anchor.addEventListener(listener, (event) => this.onEnterAnchor(event));
+        this.anchor?.addEventListener(listener, (event) => this.onEnterAnchor(event));
       });
       ['focusout', 'mouseleave', 'keydown'].forEach(listener => {
-        this.anchor.addEventListener(listener, (event) => this.onLeaveAnchor(event));
+        this.anchor?.addEventListener(listener, (event) => this.onLeaveAnchor(event));
       });
     },
 
     removeExternalAnchorEventListeners () {
       ['focusin', 'mouseenter'].forEach(listener => {
-        this.anchor.removeEventListener(listener, (event) => this.onEnterAnchor(event));
+        this.anchor?.removeEventListener(listener, (event) => this.onEnterAnchor(event));
       });
       ['focusout', 'mouseleave', 'keydown'].forEach(listener => {
-        this.anchor.removeEventListener(listener, (event) => this.onLeaveAnchor(event));
+        this.anchor?.removeEventListener(listener, (event) => this.onLeaveAnchor(event));
       });
     },
   },

--- a/packages/dialtone-vue2/directives/tooltip/tooltip.test.js
+++ b/packages/dialtone-vue2/directives/tooltip/tooltip.test.js
@@ -1,6 +1,6 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import { DtTooltipDirective } from './tooltip.js';
-import { getUniqueString } from '@/common/utils';
+import { getUniqueString, flushPromises } from '@/common/utils';
 
 const MOCK_TOOLTIP_TEXT = 'Tooltip text content';
 const MOCK_ANCHOR_TEXT = 'Button placeholder';
@@ -71,6 +71,7 @@ describe('DtTooltipDirective Tests', () => {
     describe('when tooltip is open', () => {
       beforeEach(async () => {
         await updateWrapper();
+        await flushPromises();
         await anchor.trigger('mouseenter');
       });
 

--- a/packages/dialtone-vue3/components/split_button/split_button.test.js
+++ b/packages/dialtone-vue3/components/split_button/split_button.test.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import DtSplitButton from './split_button.vue';
 import SplitButtonAlpha from './split_button-alpha.vue';
 import SplitButtonOmega from './split_button-omega.vue';
@@ -199,6 +199,7 @@ describe('DtSplitButton Tests', function () {
       it('Should render the tooltip with correct text', async () => {
         mockProps = { alphaTooltipText: MOCK_ALPHA_TOOLTIP_TEXT };
         await updateWrapper();
+        await flushPromises();
         await alphaButton.trigger('mouseenter');
 
         const tooltip = document.body.querySelector('[data-qa="dt-tooltip"]');
@@ -211,6 +212,7 @@ describe('DtSplitButton Tests', function () {
       it('Should render the tooltip with correct text', async () => {
         mockProps = { omegaTooltipText: MOCK_OMEGA_TOOLTIP_TEXT };
         await updateWrapper();
+        await flushPromises();
         await omegaButton.trigger('mouseenter');
 
         const tooltip = document.body.querySelector('[data-qa="dt-tooltip"]');

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -357,11 +357,11 @@ export default {
       console.warn('The show prop will be ignored.');
     }
 
+    this.tip = createTippy(this.anchor, this.initOptions());
     if (this.externalAnchor) {
       await flushPromises();
       this.addExternalAnchorEventListeners();
     }
-    this.tip = createTippy(this.anchor, this.initOptions());
   },
 
   beforeUnmount () {

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -50,7 +50,7 @@ import {
 import {
   POPOVER_APPEND_TO_VALUES,
 } from '../popover/popover_constants';
-import { getUniqueString, hasSlotContent } from '@/common/utils';
+import { flushPromises, getUniqueString, hasSlotContent } from '@/common/utils';
 import {
   createTippy,
   getAnchor,
@@ -351,13 +351,16 @@ export default {
     },
   },
 
-  mounted () {
+  async mounted () {
     if (!this.enabled && this.show != null) {
       console.warn('Tooltip: You cannot use both the enabled and show props at the same time.');
       console.warn('The show prop will be ignored.');
     }
 
-    this.externalAnchor && this.addExternalAnchorEventListeners();
+    if (this.externalAnchor) {
+      await flushPromises();
+      this.addExternalAnchorEventListeners();
+    }
     this.tip = createTippy(this.anchor, this.initOptions());
   },
 

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -502,19 +502,19 @@ export default {
 
     addExternalAnchorEventListeners () {
       ['focusin', 'mouseenter'].forEach(listener => {
-        this.anchor.addEventListener(listener, (event) => this.onEnterAnchor(event));
+        this.anchor?.addEventListener(listener, (event) => this.onEnterAnchor(event));
       });
       ['focusout', 'mouseleave', 'keydown'].forEach(listener => {
-        this.anchor.addEventListener(listener, (event) => this.onLeaveAnchor(event));
+        this.anchor?.addEventListener(listener, (event) => this.onLeaveAnchor(event));
       });
     },
 
     removeExternalAnchorEventListeners () {
       ['focusin', 'mouseenter'].forEach(listener => {
-        this.anchor.removeEventListener(listener, (event) => this.onEnterAnchor(event));
+        this.anchor?.removeEventListener(listener, (event) => this.onEnterAnchor(event));
       });
       ['focusout', 'mouseleave', 'keydown'].forEach(listener => {
-        this.anchor.removeEventListener(listener, (event) => this.onLeaveAnchor(event));
+        this.anchor?.removeEventListener(listener, (event) => this.onLeaveAnchor(event));
       });
     },
   },

--- a/packages/dialtone-vue3/directives/tooltip/tooltip.test.js
+++ b/packages/dialtone-vue3/directives/tooltip/tooltip.test.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { DtTooltipDirective } from './tooltip.js';
 import { getUniqueString } from '@/common/utils';
 
@@ -72,6 +72,7 @@ describe('DtTooltipDirective Tests', () => {
     describe('when tooltip is open', () => {
       beforeEach(async () => {
         await updateWrapper();
+        await flushPromises();
         await anchor.trigger('mouseenter');
       });
 


### PR DESCRIPTION
# fix(tooltip): flush promises when external anchor

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExczgwYWU0ZmM5ZzRiNDF3aXVoOGwycDFjMjdrdHBxeTc2dnZlaGIzcyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/uUP7F5A1rQR9uKls9P/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2039

## :book: Description

Added a flush promises when using an external anchor so we can guarantee the dom is updated when setting events on the anchors

## :bulb: Context

Problem in https://dialpad.atlassian.net/browse/DP-110869, This may fix it.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

Get integrations to test the fix