### PR TITLE
docs(hovercard, empty-state): DLT-1934 update docs

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleHovercard.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleHovercard.vue
@@ -2,11 +2,11 @@
   <dt-hovercard placement="bottom-start" content-class="d-wmn332 ">
     <template #anchor>
       <dt-button>
-        Hover for example
+        {{ label }}
       </dt-button>
     </template>
     <template #content>
-      <div>Content</div>
+      <div>{{ content }}</div>
     </template>
     <template #headerContent>
       <div>Header</div>
@@ -17,6 +17,9 @@
   </dt-hovercard>
 </template>
 
-<script>
-
+<script setup>
+defineProps({
+  label: { type: String, default: 'Hover for example' },
+  content: { type: String, default: 'Content' },
+});
 </script>

--- a/apps/dialtone-documentation/docs/components/empty-state.md
+++ b/apps/dialtone-documentation/docs/components/empty-state.md
@@ -566,29 +566,27 @@ showHtmlWarning />
 
 #### Title
 
-* Should be scannable and informative.
-* Short and concise.
+- Should be scannable and informative.
+- Short and concise.
 
 #### Description
 
-* Short and to the point.
-* Avoid repeating the title's message, favoring complementary and useful information.
-* Inline text links (i.e. `<a class="d-link">...</a>`) may be appropriate given its use case, though first consider if it should be an action button.
+- Short and to the point.
+- Avoid repeating the title's message, favoring complementary and useful information.
+- Inline text links (i.e. `<a class="d-link">...</a>`) may be appropriate given its use case, though first consider if it should be an action button.
 
 #### Actions
 
-* Follow existing writing guidelines for Dialtone's Button commponent.
-* Connect its labels to the paired Title and Description.
-
+- Follow existing writing guidelines for Dialtone's Button commponent.
+- Connect its labels to the paired Title and Description.
 
 ### Scenarios
-
 
 #### Zero state
 
 Encourage and guide the user through product engagement.
 
-```
+```text
 Title: No Ai recaps yet
 Description: Enable Ai for calls and meetings and check back here!
 Action: [Show me how]
@@ -598,7 +596,7 @@ Action: [Show me how]
 
 Consider the user’s intent and provide guidance to resolve in a useful result.
 
-```
+```text
 Title: No matching results
 Description: Try adjusting your search criteria or filters.
 ```
@@ -607,7 +605,7 @@ Description: Try adjusting your search criteria or filters.
 
 Call out interesting new features or services, and entice the user to explore them.
 
-```
+```text
 Title: Discover Ai recaps
 Description: Enable Ai for calls and meetings to view and share a recap.
 Action: [Tell me more]
@@ -617,7 +615,7 @@ Action: [Tell me more]
 
 Be direct in communicating the unavailability of a feature or service, and provide quick actions.
 
-```
+```text
 Title: Restricted access
 Description: Permission required. You can request access from the owner.
 Action: [Cancel] [Request access]
@@ -625,7 +623,7 @@ Action: [Cancel] [Request access]
 
 ## Vue API
 
-<component-vue-api component-name="empty-state" />
+<component-vue-api component-name="empty_state" />
 
 ## Classes
 

--- a/apps/dialtone-documentation/docs/components/hovercard.md
+++ b/apps/dialtone-documentation/docs/components/hovercard.md
@@ -65,10 +65,37 @@ vueCode='
 '
 showHtmlWarning />
 
+## Variants
+
+### Many hovercards
+
+Initially, there is a 300ms delay when numerous hovercards are present. However, when transitioning from one anchor to another, the delay is determined by the mouse movement time. This implies that the closer the anchors are, the faster the hovercard appears. To achieve this, the component uses a global timer. Move the mouse over the avatars to reveal the hovercards in the example.
+
+<code-well-header>
+  <dt-stack direction="row" gap="500">
+    <example-hovercard v-for="data in exampleData" :label="data.label" :content="data.content" />
+  </dt-stack>
+</code-well-header>
+
 ## Vue API
 
 <component-vue-api component-name="hovercard" />
 
 <script setup>
   import ExampleHovercard from '@exampleComponents/ExampleHovercard.vue';
+
+  const exampleData = [
+    {
+      label: 'Example 1',
+      content: 'Content 1',
+    },
+    {
+      label: 'Example 2',
+      content: 'Content 2',
+    },
+    {
+      label: 'Example 3',
+      content: 'Content 3',
+    },
+  ];
 </script>

--- a/common/components_list.js
+++ b/common/components_list.js
@@ -18,6 +18,7 @@ module.exports = [
   'emoji.vue',
   'emoji_picker.vue',
   'emoji_text_wrapper.vue',
+  'empty_state.vue',
   'hovercard.vue',
   'icon.vue',
   'image_viewer.vue',

--- a/packages/dialtone-vue2/components/empty_state/empty_state.mdx
+++ b/packages/dialtone-vue2/components/empty_state/empty_state.mdx
@@ -1,65 +1,10 @@
-import { Canvas, Story, Subtitle, Controls, Meta } from '@storybook/blocks';
+import { Meta } from '@storybook/blocks';
 
 import * as EmptyStateStories from './empty_state.stories';
+import RedirectToDocs from "@/common/snippets/redirect-to-docs.mdx"
 
 <Meta of={EmptyStateStories}/>
 
 # Empty state
 
-<Subtitle>
-  When there's no data to display in a list, table, or other information container, we use an ‘Empty State’ component to guide users, clarifying the expected information and suggesting ways to populate it.
-</Subtitle>
-
-## Uses & Best practices
-We identify 4 types of empty states:
-
-<b>Zero state:</b> nothing has been added yet, we recommend to use this space to teach the user how to fill this container, or give a useful tip like a shortcut for something relatable or tell them what needs to happen if no action can be taken.
-
-<b>No results:</b> the user performed an action and there are no results, in this scenario the best usage of the empty state will be to recommend how to recover. If the user is filtering a table, recommend another filter that has results or, like the zero state case, how to create a new entry with the properties the user is filtering.
-
-<b>New feature:</b> A new section or screen the user doesn’t know and we want to introduce to them, if this action would include a change in their plan we should inform it in the component, also try to indulge/seduce the user to use this feature or to look interesting to them.
-
-<b>Not enabled:</b> the section isn’t available to the user at the moment.
-
-
-## Writing and tone
-We think this component is one of the most important regarding the writing guidelines (along with the error messages) so we take some time to write about how to communicate with our empty states. First of all, let’s talk about the different atoms that can have a writing variable
-
-<b>Titles:</b> Needs to be scannable and informative, keep it short and concise. <br/>
-<b>Body:</b> Avoid repeating the content of the title. Also, same as the title, keep it short and to the point. If you need to provide a link to the user, you can use it here (e.g learn more) but please consider using the CTA section to be more concise to the user and more consistent to Dialtone.<br/>
-<b>CTA:</b> We recommend the usage of imperative verbs (Create, Delete) instead of using more open words such as (OK, No, Yes). Also, try to connect the Title wording to the CTA, to keep the action clear to the user, we recommend avoiding using more than two words.<br/>
-
-And regarding the difference of the types of variables of the component:
-
-<b>Zero state:</b> Like we said in the uses and best practices, we recommend combining the title and the CTA (if usable and possible) to teach the user how to populate this area. E.g Title: You don’t have any AI recaps yet Description: Use it to analyze your calls and get more insights about it! CTA: [Activate]<br/>
-<b>No results:</b> In this scenario, we need to contemplate the variables of the user to understand how to react, this could be a expected scenario (searching for something you know you won’t find) or the surprised scenario (‘I was expecting to find something here, but there’s nothing’) Title: No results found Description: Try adjusting the your search or filters to find what you are looking for CTA: [create] [clear filters]<br/>
-<b>New feature:</b> We want to communicate this variable to be as easy to understand as possible. Usually when we communicate with this variable, we are offering a new service (paid or not) that the user can take advantage of, so work on selling it in a more marketable way. Title: Now you can analyze your metrics in live calls! Description: Don’t need to end a call to have the best insights. CTA: [Activate]<br/>
-<b>Not available:</b> The user doesn’t have permission to see the information for X or Y. Try to use this space to make it easier to request permission to access. Be clear and concise to communicate that they don’t have access, and don’t spend too much time telling them why, focus on asking for permission. Title: You don’t have access to this information Description: Ask your administrators permission CTA: Request permission<br/>
-
-## Base Style
-
-<Canvas>
-  <Story of={EmptyStateStories.Default} />
-</Canvas>
-
-## Slots, Props & Events
-
-<Controls />
-
-## Usage
-
-### Import
-
-```js
-import { DtEmptyState } from '@dialpad/dialtone-vue'; // vite
-```
-
-### Default
-
-```html
-<dt-empty-state
-  illustration-name="mind"
-  header-text="Nothing to see here"
-  body-text="Lorem ipsum dolor sit amet consectetur. Diam in aliquam arcu elit pulvinar morbi lorem ac neque."
-/>
-```
+<RedirectToDocs name="empty-state" />

--- a/packages/dialtone-vue2/components/hovercard/hovercard.mdx
+++ b/packages/dialtone-vue2/components/hovercard/hovercard.mdx
@@ -1,47 +1,10 @@
-import { Canvas, Story, Subtitle, Controls, Meta } from '@storybook/blocks';
+import { Meta } from '@storybook/blocks';
 
 import * as HovercardStories from './hovercard.stories';
+import RedirectToDocs from "@/common/snippets/redirect-to-docs.mdx"
 
 <Meta of={HovercardStories}/>
 
 # Hovercard
 
-<Subtitle>
-  The Hovercard component provides a popover-like experience for displaying additional information.
-</Subtitle>
-
-## Base Style
-
-The hovercard will appear upon the mouse entering the anchor, with a delay of 300 milliseconds.
-It will remain open as long as the mouse cursor is over either the open card or the anchor.
-
-<Canvas>
-  <Story of={HovercardStories.Default} />
-</Canvas>
-
-## When there are many hovercards
-
-Initially, there is a 300ms delay when numerous hovercards are present.
-However, when transitioning from one anchor to another, the delay is determined by the mouse movement time.
-This implies that the closer the anchors are, the faster the hovercard appears.
-To achive this, the component uses a global timer.
-Move the mouse over the avatars to reveal the hovercards in the example.
-
-<Canvas>
-  <Story of={HovercardStories.Many} />
-</Canvas>
-
-## Slots, Props & Events
-
-<Controls />
-
-### Import
-
-```js
-import { DtHovercard } from '@dialpad/dialtone-vue';
-```
-
-### Default
-
-```html
-```
+<RedirectToDocs name="hovercard" />

--- a/packages/dialtone-vue3/components/empty_state/empty_state.mdx
+++ b/packages/dialtone-vue3/components/empty_state/empty_state.mdx
@@ -1,65 +1,10 @@
-import { Canvas, Story, Subtitle, Controls, Meta } from '@storybook/blocks';
+import { Meta } from '@storybook/blocks';
 
 import * as EmptyStateStories from './empty_state.stories';
+import RedirectToDocs from "@/common/snippets/redirect-to-docs.mdx"
 
 <Meta of={EmptyStateStories}/>
 
 # Empty state
 
-<Subtitle>
-  When there's no data to display in a list, table, or other information container, we use an ‘Empty State’ component to guide users, clarifying the expected information and suggesting ways to populate it.
-</Subtitle>
-
-## Uses & Best practices
-We identify 4 types of empty states:
-
-<b>Zero state:</b> nothing has been added yet, we recommend to use this space to teach the user how to fill this container, or give a useful tip like a shortcut for something relatable or tell them what needs to happen if no action can be taken.
-
-<b>No results:</b> the user performed an action and there are no results, in this scenario the best usage of the empty state will be to recommend how to recover. If the user is filtering a table, recommend another filter that has results or, like the zero state case, how to create a new entry with the properties the user is filtering.
-
-<b>New feature:</b> A new section or screen the user doesn’t know and we want to introduce to them, if this action would include a change in their plan we should inform it in the component, also try to indulge/seduce the user to use this feature or to look interesting to them.
-
-<b>Not enabled:</b> the section isn’t available to the user at the moment.
-
-
-## Writing and tone
-We think this component is one of the most important regarding the writing guidelines (along with the error messages) so we take some time to write about how to communicate with our empty states. First of all, let’s talk about the different atoms that can have a writing variable
-
-<b>Titles:</b> Needs to be scannable and informative, keep it short and concise. <br/>
-<b>Body:</b> Avoid repeating the content of the title. Also, same as the title, keep it short and to the point. If you need to provide a link to the user, you can use it here (e.g learn more) but please consider using the CTA section to be more concise to the user and more consistent to Dialtone.<br/>
-<b>CTA:</b> We recommend the usage of imperative verbs (Create, Delete) instead of using more open words such as (OK, No, Yes). Also, try to connect the Title wording to the CTA, to keep the action clear to the user, we recommend avoiding using more than two words.<br/>
-
-And regarding the difference of the types of variables of the component:
-
-<b>Zero state:</b> Like we said in the uses and best practices, we recommend combining the title and the CTA (if usable and possible) to teach the user how to populate this area. E.g Title: You don’t have any AI recaps yet Description: Use it to analyze your calls and get more insights about it! CTA: [Activate]<br/>
-<b>No results:</b> In this scenario, we need to contemplate the variables of the user to understand how to react, this could be a expected scenario (searching for something you know you won’t find) or the surprised scenario (‘I was expecting to find something here, but there’s nothing’) Title: No results found Description: Try adjusting the your search or filters to find what you are looking for CTA: [create] [clear filters]<br/>
-<b>New feature:</b> We want to communicate this variable to be as easy to understand as possible. Usually when we communicate with this variable, we are offering a new service (paid or not) that the user can take advantage of, so work on selling it in a more marketable way. Title: Now you can analyze your metrics in live calls! Description: Don’t need to end a call to have the best insights. CTA: [Activate]<br/>
-<b>Not available:</b> The user doesn’t have permission to see the information for X or Y. Try to use this space to make it easier to request permission to access. Be clear and concise to communicate that they don’t have access, and don’t spend too much time telling them why, focus on asking for permission. Title: You don’t have access to this information Description: Ask your administrators permission CTA: Request permission<br/>
-
-## Base Style
-
-<Canvas>
-  <Story of={EmptyStateStories.Default} />
-</Canvas>
-
-## Slots, Props & Events
-
-<Controls />
-
-## Usage
-
-### Import
-
-```js
-import { DtEmptyState } from '@dialpad/dialtone-vue'; // vite
-```
-
-### Default
-
-```html
-<dt-empty-state
-  illustration-name="mind"
-  header-text="Nothing to see here"
-  body-text="Lorem ipsum dolor sit amet consectetur. Diam in aliquam arcu elit pulvinar morbi lorem ac neque."
-/>
-```
+<RedirectToDocs name="empty-state" />

--- a/packages/dialtone-vue3/components/hovercard/hovercard.mdx
+++ b/packages/dialtone-vue3/components/hovercard/hovercard.mdx
@@ -1,47 +1,10 @@
-import { Canvas, Story, Subtitle, Controls, Meta } from '@storybook/blocks';
+import { Meta } from '@storybook/blocks';
 
 import * as HovercardStories from './hovercard.stories';
+import RedirectToDocs from "@/common/snippets/redirect-to-docs.mdx"
 
 <Meta of={HovercardStories}/>
 
 # Hovercard
 
-<Subtitle>
-  The Hovercard component provides a popover-like experience for displaying additional information.
-</Subtitle>
-
-## Base Style
-
-The hovercard will appear upon the mouse entering the anchor, with a delay of 300 milliseconds.
-It will remain open as long as the mouse cursor is over either the open card or the anchor.
-
-<Canvas>
-  <Story of={HovercardStories.Default} />
-</Canvas>
-
-## When there are many hovercards
-
-Initially, there is a 300ms delay when numerous hovercards are present.
-However, when transitioning from one anchor to another, the delay is determined by the mouse movement time.
-This implies that the closer the anchors are, the faster the hovercard appears.
-To achive this, the component uses a global timer.
-Move the mouse over the avatars to reveal the hovercards in the example.
-
-<Canvas>
-  <Story of={HovercardStories.Many} />
-</Canvas>
-
-## Slots, Props & Events
-
-<Controls />
-
-### Import
-
-```js
-import { DtHovercard } from '@dialpad/dialtone-vue';
-```
-
-### Default
-
-```html
-```
+<RedirectToDocs name="hovercard" />


### PR DESCRIPTION
# docs(hovercard, empty-state): DLT-1934 update docs

Updates the docs for Hovercard and Empty State component. 
Not many changes, only adds for the Hovercard the many example and for the Empty State the Vue api.
<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/l0IybQ6l8nfKjxQv6/giphy.gif?cid=82a1493bkrhkrxs18d6cdr9djg3ivfbh5uy3iqmgrn36bkgs&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
[DLT-1934]
<!--- Enter the URL of the Jira ticket associated with this PR -->




[DLT-1934]: https://dialpad.atlassian.net/browse/DLT-1934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ