### PR TITLE
fix(tokens): DLT-2058 fix uncalced focus ring token

### DIFF
--- a/packages/dialtone-tokens/postcss/dialtone-tokens.cjs
+++ b/packages/dialtone-tokens/postcss/dialtone-tokens.cjs
@@ -73,17 +73,18 @@ function boxShadows (shadowDeclarations, Declaration) {
           return `var(${shadowVar}${shadowNumber}-offset-x) var(${shadowVar}${shadowNumber}-offset-y) var(${shadowVar}${shadowNumber}-blur) var(${shadowVar}${shadowNumber}-spread) var(${shadowVar}${shadowNumber}-color)${isInset ? ' inset' : ''}`;
         }).join(', ');
 
-      shadowDeclarations.at(-1).after(new Declaration({ prop: shadowVar, value }));
+      shadowDeclarations.at(0).after(new Declaration({ prop: shadowVar, value }));
       newDocEntries[shadowVar] = formatCompositionTokenForDocs(shadowVar, value);
     });
 }
 
 /**
  * Wrap the value in a calc function if it is not already wrapped.
+ * Checks for multiplication and addition operators within the value.
  * @param { Declaration } declaration
  */
 function wrapInCalc (declaration) {
-  if (declaration.value.includes(' * ') && !declaration.value.startsWith('calc')) {
+  if ([' * ', ' + '].some(str => declaration.value.includes(str)) && !declaration.value.startsWith('calc')) {
     declaration.value = `calc(${declaration.value})`;
   }
 }


### PR DESCRIPTION
# fix(tokens): DLT-2058 fix uncalced focus ring token

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2I0NWJsaGRlengzenl6NndtcDJpanlsdGh3aGxsZW01OTYwdmI5diZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/CLQNFY6YIHanjWSEhW/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2058

## :book: Description

Updated the postcss to wrap addition calculations in calc.

## :bulb: Context

A whole ton of issues with missing focus rings started popping up on beta today. There was one portion of the focus ring token with a calculation in it that wasn't wrapped in calc causing invalid css.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

CP to beta
