### PR TITLE
fix(emoji-picker): NO-JIRA multiple fixs

### DIFF
--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
@@ -9,7 +9,6 @@
         :show-recently-used-tab="showRecentlyUsedTab"
         :scroll-into-tab="scrollIntoTab"
         :tab-set-labels="tabSetLabels"
-        :is-scrolling="isScrolling"
         @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
         @focus-search-input="showSearch ? $refs.searchInputRef.focusSearchInput() : $refs.emojiSelectorRef.focusEmojiSelector()"
         @selected-tabset="scrollToSelectedTabset"
@@ -38,7 +37,6 @@
         :recently-used-emojis="recentlyUsedEmojis"
         :selected-tabset="selectedTabset"
         @scroll-into-tab="updateScrollIntoTab"
-        @is-scrolling="updateIsScrolling"
         @highlighted-emoji="updateHighlightedEmoji"
         @selected-emoji="$emit('selected-emoji', $event)"
         @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
@@ -200,7 +198,6 @@ export default {
       highlightedEmoji: null,
       selectedTabset: {},
       scrollIntoTab: 0,
-      isScrolling: false,
     };
   },
 
@@ -224,10 +221,6 @@ export default {
 
     updateScrollIntoTab (value) {
       this.scrollIntoTab = value;
-    },
-
-    updateIsScrolling (value) {
-      this.isScrolling = value;
     },
 
     updateHighlightedEmoji (emoji) {

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -334,26 +334,7 @@ export default {
 
       vm.$nextTick(function () {
         const container = vm.$refs.listRef;
-        const offsetTop = tabIndex === '1' ? 0 : tabElement.offsetTop - 20;
-
-        let isScrolling = true;
-        let prevScrollTop = container.scrollTop;
-        vm.$emit('is-scrolling', true);
-
-        /* eslint-disable-next-line complexity */
-        container.addEventListener('scroll', function () {
-          if (isScrolling) {
-            const scrollTop = container.scrollTop;
-            if (
-              (prevScrollTop < scrollTop && scrollTop >= offsetTop) ||
-            (prevScrollTop > scrollTop && scrollTop <= offsetTop)
-            ) {
-              isScrolling = false;
-              vm.$emit('is-scrolling', false);
-            }
-            prevScrollTop = scrollTop;
-          }
-        });
+        const offsetTop = tabIndex === 1 ? 0 : tabElement.offsetTop - 15;
 
         container.scrollTop = offsetTop;
 
@@ -471,7 +452,7 @@ export default {
         this.handleHorizontalNavigation('right', indexTab, indexEmoji);
       }
 
-      if (event.key === 'Tab') {
+      if (event.key === 'Tab' && !event.shiftKey) {
         if (this.focusEmoji(indexTab + 1, 0)) {
           this.scrollToTab((indexTab + 1) + 1, false);
         } else {
@@ -591,7 +572,6 @@ export default {
 
     setTabLabelObserver () {
       this.tabLabelObserver = new IntersectionObserver(entries => {
-        this.$emit('is-scrolling', false);
         /* eslint-disable-next-line complexity */
         entries.forEach(entry => {
           const { target } = entry;
@@ -619,7 +599,7 @@ export default {
     },
 
     focusLastEmoji () {
-      this.focusEmoji(this.tabs.length - 1, 0);
+      this.scrollToTab(this.tabs.length, true);
     },
 
   },

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
@@ -54,11 +54,6 @@ export default {
       required: true,
     },
 
-    isScrolling: {
-      type: Boolean,
-      default: false,
-    },
-
     emojiFilter: {
       type: String,
       default: '',
@@ -94,6 +89,7 @@ export default {
       return tabsData.map((tab, index) => ({
         ...tab,
         label: this.tabSetLabels[index],
+        // IDs on dt-tab component need to be on string
         id: (index + 1).toString(),
         panelId: (index + 1).toString(),
       }));
@@ -106,7 +102,7 @@ export default {
 
   watch: {
     scrollIntoTab: function (newVal) {
-      if (!this.isScrolling && !this.isSearching) {
+      if (!this.isSearching) {
         this.selectedTab = (newVal + 1).toString();
       }
     },
@@ -126,10 +122,11 @@ export default {
 
   methods: {
     selectTabset (id) {
-      if (!this.isScrolling) {
-        this.selectedTab = id;
-      }
-      this.$emit('selected-tabset', id);
+      // IDs on scrollToTab need to be on number
+      const parseId = parseInt(id);
+      // IDs on dt-tab component need to be on string
+      this.selectedTab = id;
+      this.$emit('selected-tabset', parseId);
     },
 
     setTabsetRef () {

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
@@ -9,7 +9,6 @@
         :show-recently-used-tab="showRecentlyUsedTab"
         :scroll-into-tab="scrollIntoTab"
         :tabset-labels="tabSetLabels"
-        :is-scrolling="isScrolling"
         @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
         @focus-search-input="showSearch ? $refs.searchInputRef.focusSearchInput() : $refs.emojiSelectorRef.focusEmojiSelector()"
         @selected-tabset="scrollToSelectedTabset"
@@ -37,7 +36,6 @@
         :recently-used-emojis="recentlyUsedEmojis"
         :selected-tabset="selectedTabset"
         @scroll-into-tab="updateScrollIntoTab"
-        @is-scrolling="updateIsScrolling"
         @highlighted-emoji="updateHighlightedEmoji"
         @selected-emoji="emits('selected-emoji', $event)"
         @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
@@ -213,7 +211,6 @@ const highlightedEmoji = ref(null);
 const selectedTabset = ref({});
 
 const scrollIntoTab = ref(0);
-const isScrolling = ref(false);
 
 const showRecentlyUsedTab = computed(() => props.recentlyUsedEmojis.length > 0);
 
@@ -243,9 +240,6 @@ function updateScrollIntoTab (value) {
   scrollIntoTab.value = value;
 }
 
-function updateIsScrolling (value) {
-  isScrolling.value = value;
-}
 function updateHighlightedEmoji (emoji) {
   highlightedEmoji.value = emoji;
 }

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
@@ -192,13 +192,6 @@ const emits = defineEmits([
   'scroll-into-tab',
 
   /**
-   * Emitted when the scrollTo function starts scrolling and stops scrolling
-   * @event is-scrolling
-   * @param {Boolean} is-scrolling - Whether the user is scrolling with the scroll-to
-    */
-  'is-scrolling',
-
-  /**
    * Emitted when the user reach the end of the emoji list
    * @event focus-skin-selector
     */
@@ -407,39 +400,7 @@ function scrollToTab (tabIndex, focusFirstEmoji = true) {
 
   nextTick(() => {
     const container = listRef.value;
-    const offsetTop = tabIndex === '1' ? 0 : tabElement.offsetTop - 20;
-
-    /**
-     * This variable is used to check if the user is scrolling inside the emoji picker
-     * This is used to check if the user is scrolling using the scrollTo function
-     * This is useful because this flag will prevent to update the fixed label when the user is scrolling
-     * using the scrollTo function
-     */
-    let isScrolling = true;
-
-    let prevScrollTop = container.scrollTop;
-    emits('is-scrolling', true);
-
-    /**
-     * This event listener checks whether the user is scrolling up or down by comparing the current scrollTop
-     * to prevScrollTop. If the scrollToTab function is scrolling from bottom to top and has reached the desired
-     * position (scrollTop <= offsetTop),or if the scrollToTab function is scrolling from top to bottom and has
-     * passed the desired position(scrollTop >= offsetTop), then isScrolling is set to false.
-     */
-    /* eslint-disable-next-line complexity */
-    container.addEventListener('scroll', () => {
-      if (isScrolling) {
-        const scrollTop = container.scrollTop;
-        if (
-          (prevScrollTop < scrollTop && scrollTop >= offsetTop) ||
-          (prevScrollTop > scrollTop && scrollTop <= offsetTop)
-        ) {
-          isScrolling = false;
-          emits('is-scrolling', false);
-        }
-        prevScrollTop = scrollTop;
-      }
-    });
+    const offsetTop = tabIndex === 1 ? 0 : tabElement.offsetTop - 15;
 
     container.scrollTop = offsetTop;
 
@@ -466,7 +427,6 @@ function setTabLabelObserver () {
    * and checks whether the target intersects with the root and is positioned above or below it.
    */
   tabLabelObserver.value = new IntersectionObserver(async (entries) => {
-    emits('is-scrolling', false);
     // eslint-disable-next-line complexity
     entries.forEach(entry => {
       const { target } = entry;
@@ -580,7 +540,7 @@ function focusEmojiSelector () {
 }
 
 function focusLastEmoji () {
-  focusEmoji(tabs.value.length - 1, 0);
+  scrollToTab(tabs.value.length, true);
 }
 
 onMounted(() => {

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
@@ -50,11 +50,6 @@ const props = defineProps({
     required: true,
   },
 
-  isScrolling: {
-    type: Boolean,
-    default: false,
-  },
-
   emojiFilter: {
     type: String,
     default: '',
@@ -101,6 +96,7 @@ const tabs = computed(() => {
   return tabsData.map((tab, index) => ({
     ...tab,
     label: props.tabsetLabels[index],
+    // IDs on dt-tab component need to be on string
     id: (index + 1).toString(),
     panelId: (index + 1).toString(),
   }));
@@ -110,13 +106,11 @@ const isSearching = computed(() => props.emojiFilter.length > 0);
 
 const selectedTab = ref('1');
 
-const { isScrolling } = toRefs(props);
-
 const tabsetRef = ref([]);
 
 watch(() => props.scrollIntoTab,
   () => {
-    if (!isScrolling.value && !isSearching.value) {
+    if (!isSearching.value) {
       selectedTab.value = (props.scrollIntoTab + 1).toString();
     }
   });
@@ -134,10 +128,11 @@ watch(isSearching,
  * dt-tab component
  */
 function selectTabset (id) {
-  if (!isScrolling.value) {
-    selectedTab.value = id;
-  }
-  emits('selected-tabset', id);
+  // IDs on scrollToTab need to be on number
+  const parseId = parseInt(id);
+  // IDs on dt-tab component need to be on string
+  selectedTab.value = id;
+  emits('selected-tabset', parseId);
 }
 
 function setTabsetRef (ref) {


### PR DESCRIPTION
# fix(emoji-picker): no-jira multiple fixs


- Removed all related to `is-scrolling` function, if I remember correctly that was introduced because previously we had a scroll animation when the user navigate with the Tab section. Later the animation was removed so I think this is no longer necessary.
- There was an issue were we pass a `string` to our `scrollToTab` from the `emoji_tabset.vue` component. This function need a `number` type to work properly.
- The offset was adjust from `20` to `15` hopefully this will fit better.
- Now the `focusLastEmoji` method works more precisely.

Reported issues to solve:
https://dialpad.atlassian.net/browse/DP-111895
https://dialpad.atlassian.net/browse/DLT-2063
