### PR TITLE
fix(input): DLT-2083 fix clear button margin

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/input.less
+++ b/packages/dialtone-css/lib/build/less/components/input.less
@@ -290,7 +290,7 @@
     &--right:not(:empty) {
         margin-right: var(--dt-space-400);
 
-        button {
+        .d-btn {
             margin-right: var(--dt-space-350-negative);
         }
     }

--- a/packages/dialtone-css/lib/build/less/components/input.less
+++ b/packages/dialtone-css/lib/build/less/components/input.less
@@ -289,6 +289,10 @@
 
     &--right:not(:empty) {
         margin-right: var(--dt-space-400);
+
+        button {
+            margin-right: var(--dt-space-350-negative);
+        }
     }
 
     &--left:not(:empty) {

--- a/packages/dialtone-vue2/components/input/input_default.story.vue
+++ b/packages/dialtone-vue2/components/input/input_default.story.vue
@@ -39,13 +39,19 @@
     >
       <span v-html="$attrs.description" />
     </template>
-    <template #leftIcon="{ iconSize }">
+    <template
+      v-if="$attrs.leftIcon"
+      #leftIcon="{ iconSize }"
+    >
       <dt-icon
         :name="$attrs.leftIcon"
         :size="iconSize"
       />
     </template>
-    <template #rightIcon="{ iconSize }">
+    <template
+      v-if="$attrs.rightIcon"
+      #rightIcon="{ iconSize }"
+    >
       <dt-icon
         :name="$attrs.rightIcon"
         :size="iconSize"

--- a/packages/dialtone-vue3/components/input/input_default.story.vue
+++ b/packages/dialtone-vue3/components/input/input_default.story.vue
@@ -39,13 +39,19 @@
     >
       <span v-html="$attrs.description" />
     </template>
-    <template #leftIcon="{ iconSize }">
+    <template
+      v-if="$attrs.leftIcon"
+      #leftIcon="{ iconSize }"
+    >
       <dt-icon
         :name="$attrs.leftIcon"
         :size="iconSize"
       />
     </template>
-    <template #rightIcon="{ iconSize }">
+    <template
+      v-if="$attrs.rightIcon"
+      #rightIcon="{ iconSize }"
+    >
       <dt-icon
         :name="$attrs.rightIcon"
         :size="iconSize"


### PR DESCRIPTION
# fix(input): DLT-2083 fix clear button margin

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/Nv1roC7mg5Kec/giphy.gif?cid=82a1493biepgn35b970737s68ikmc7xh8rd9u2scuh2se95e&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DLT-2083]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adds negative margin for the right button to compensate the default margin for the icon and make it .2rem

<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :camera: Screenshots / GIFs

### Previous
<img width="520" alt="image" src="https://github.com/user-attachments/assets/8c3bc157-20a8-4171-8581-f6102eb96eeb"> 

### Now
<img width="523" alt="image" src="https://github.com/user-attachments/assets/a16e22f2-d704-4102-8de6-804940eb572a"> 



<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->



[DLT-2083]: https://dialpad.atlassian.net/browse/DLT-2083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ