### PR TITLE
chore: DLT-2000 add warning when component doesn't mount properly

### DIFF
--- a/packages/dialtone-vue2/common/utils/index.js
+++ b/packages/dialtone-vue2/common/utils/index.js
@@ -372,6 +372,18 @@ export function capitalizeFirstLetter (str, locale = 'en-US') {
   return str.replace(/^\p{CWU}/u, char => char.toLocaleUpperCase(locale));
 }
 
+/**
+ * Warns if the component is not mounted properly. Useful for tests.
+ * @param {HTMLElement} componentRef - the component reference
+ * @param {string} componentName - the component name
+ */
+export function warnIfUnmounted (componentRef, componentName) {
+  if (!componentRef || !(componentRef instanceof HTMLElement) || !document?.body) return;
+  if (!document.body.contains(componentRef)) {
+    console.warn(`The ${componentName} component is not attached to the document body. This may cause issues.`);
+  }
+}
+
 export default {
   getUniqueString,
   getRandomElement,

--- a/packages/dialtone-vue2/components/card/card.test.js
+++ b/packages/dialtone-vue2/components/card/card.test.js
@@ -21,7 +21,6 @@ describe('DtCard Tests', () => {
   const updateWrapper = () => {
     wrapper = mount(DtCard, {
       slots: { ...baseSlots, ...mockSlots },
-      attachTo: document.body,
     });
 
     contentElement = wrapper.find('[data-qa="content-element"]');

--- a/packages/dialtone-vue2/components/collapsible/collapsible.test.js
+++ b/packages/dialtone-vue2/components/collapsible/collapsible.test.js
@@ -24,7 +24,6 @@ describe('DtCollapsible Tests', () => {
     wrapper = mount(DtCollapsible, {
       propsData: { ...baseProps, ...mockProps },
       slots: { ...baseSlots, ...mockSlots },
-      attachTo: document.body,
     });
 
     anchorElement = wrapper.find('[data-qa="dt-button"]');

--- a/packages/dialtone-vue2/components/datepicker/datepicker.vue
+++ b/packages/dialtone-vue2/components/datepicker/datepicker.vue
@@ -40,6 +40,7 @@
 import MonthYearPicker from './modules/month-year-picker.vue';
 import Calendar from './modules/calendar.vue';
 import DtStack from '@/components/stack/stack.vue';
+import { warnIfUnmounted } from '@/common/utils';
 
 export default {
   name: 'DtDatepicker',
@@ -155,6 +156,10 @@ export default {
     return {
       calendarDays: [],
     };
+  },
+
+  mounted () {
+    warnIfUnmounted(this.$el, this.$options.name);
   },
 
   methods: {

--- a/packages/dialtone-vue2/components/dropdown/dropdown.test.js
+++ b/packages/dialtone-vue2/components/dropdown/dropdown.test.js
@@ -79,6 +79,7 @@ describe('DtDropdown Tests', () => {
     mockSlots = {};
     mockScopedSlots = {};
     mockListeners = {};
+    wrapper.destroy();
   });
 
   describe('Presentation Tests', () => {

--- a/packages/dialtone-vue2/components/hovercard/hovercard.test.js
+++ b/packages/dialtone-vue2/components/hovercard/hovercard.test.js
@@ -59,7 +59,6 @@ describe('DtHovercard Tests', () => {
     vi.useRealTimers();
     vi.clearAllTimers();
     wrapper.destroy();
-    document.body.innerHTML = '';
   });
 
   describe('Presentation Tests', () => {

--- a/packages/dialtone-vue2/components/popover/popover.test.js
+++ b/packages/dialtone-vue2/components/popover/popover.test.js
@@ -83,6 +83,7 @@ describe('DtPopover Tests', () => {
     mockSlots = {};
     mockScopedSlots = {};
     mockStubs = {};
+    wrapper.destroy();
   });
 
   afterAll(() => {

--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -130,7 +130,7 @@ import {
   POPOVER_ROLES,
   POPOVER_STICKY_VALUES,
 } from './popover_constants';
-import { getUniqueString, isOutOfViewPort } from '@/common/utils';
+import { getUniqueString, isOutOfViewPort, warnIfUnmounted } from '@/common/utils';
 import { DtLazyShow } from '@/components/lazy_show';
 import { Portal } from '@linusborg/vue-simple-portal';
 import ModalMixin from '@/common/mixins/modal';
@@ -676,6 +676,8 @@ export default {
   },
 
   mounted () {
+    warnIfUnmounted(this.$el, this.$options.name);
+
     const externalAnchorEl = this.externalAnchor
       ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
       : null;

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/custom_link/custom_link.test.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/custom_link/custom_link.test.js
@@ -104,6 +104,7 @@ describe('DtRichTextEditor Link Extension tests', () => {
   afterEach(() => {
     propsData = baseProps;
     slots = {};
+    wrapper.destroy();
   });
 
   describe('Functionality Tests', () => {

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.test.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.test.js
@@ -75,6 +75,7 @@ describe('DtRichTextEditor Emoji Extension tests', () => {
   // Test Teardown
   afterEach(() => {
     propsData = baseProps;
+    wrapper.destroy();
   });
 
   describe('Functionality Tests', () => {

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.test.js
@@ -52,6 +52,7 @@ describe('DtRichTextEditor tests', () => {
   afterEach(() => {
     mockProps = {};
     mockListeners = {};
+    wrapper.destroy();
   });
 
   describe('Presentation Tests', () => {

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -41,6 +41,7 @@ import {
 import mentionSuggestion from './extensions/mentions/suggestion';
 import channelSuggestion from './extensions/channels/suggestion';
 import slashCommandSuggestion from './extensions/slash_command/suggestion';
+import { warnIfUnmounted } from '@/common/utils';
 
 export default {
   name: 'DtRichTextEditor',
@@ -512,6 +513,10 @@ export default {
 
   beforeUnmount () {
     this.destroyEditor();
+  },
+
+  mounted () {
+    warnIfUnmounted(this.$el, this.$options.name);
   },
 
   methods: {

--- a/packages/dialtone-vue2/components/split_button/split_button.vue
+++ b/packages/dialtone-vue2/components/split_button/split_button.vue
@@ -78,6 +78,7 @@ import {
 import SplitButtonAlpha from './split_button-alpha.vue';
 import SplitButtonOmega from './split_button-omega.vue';
 import { DtDropdown } from '@/components/dropdown';
+import { warnIfUnmounted } from '@/common/utils';
 
 export default {
   name: 'DtSplitButton',
@@ -325,6 +326,10 @@ export default {
 
   updated () {
     this.validateProps();
+  },
+
+  mounted () {
+    warnIfUnmounted(this.$el, this.$options.name);
   },
 
   methods: {

--- a/packages/dialtone-vue2/directives/scrollbar/scrollbar.test.js
+++ b/packages/dialtone-vue2/directives/scrollbar/scrollbar.test.js
@@ -18,7 +18,6 @@ describe('DtScrollbarDirective Tests', () => {
   const updateWrapper = () => {
     wrapper = mount(WrapperComponent, {
       localVue: testContext.localVue,
-      attachTo: document.body,
     });
 
     viewportElement = wrapper.find('#viewport').element;

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button/callbar_button.test.js
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button/callbar_button.test.js
@@ -37,7 +37,6 @@ describe('DtRecipeCallbarButton Tests', () => {
       slots,
       provide,
       listeners,
-      attachTo: document.body,
       localVue: testContext.localVue,
     });
     _setChildWrappers();

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -82,7 +82,7 @@ import { DtButton } from '@/components/button';
 import { DtPopover } from '@/components/popover';
 import { DtIcon } from '@/components/icon';
 import { DtRecipeCallbarButton, CALLBAR_BUTTON_VALID_WIDTH_SIZE } from '../callbar_button';
-import utils from '@/common/utils';
+import utils, { warnIfUnmounted } from '@/common/utils';
 
 export default {
   name: 'DtRecipeCallbarButtonWithPopover',
@@ -304,6 +304,10 @@ export default {
 
       return this.toggleOpen();
     },
+  },
+
+  mounted () {
+    warnIfUnmounted(this.$el, this.$options.name);
   },
 
   methods: {

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.test.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.test.js
@@ -92,6 +92,7 @@ describe('DtRecipeEditor tests', () => {
   // Test Teardown
   afterEach(function () {
     propsData = baseProps;
+    wrapper.destroy();
   });
 
   describe('Presentation Tests', function () {

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.test.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.test.js
@@ -58,7 +58,6 @@ describe('DtRecipeEmojiRow Tests', function () {
       slots,
       provide,
       localVue: testContext.localVue,
-      attachTo: document.body,
     });
     _setChildWrappers();
   };

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.test.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.test.js
@@ -54,7 +54,6 @@ const _mountWrapper = () => {
     listeners,
     slots,
     localVue: testContext.localVue,
-    attachTo: document.body,
   });
 };
 

--- a/packages/dialtone-vue3/common/utils/index.js
+++ b/packages/dialtone-vue3/common/utils/index.js
@@ -393,6 +393,18 @@ export function capitalizeFirstLetter (str, locale = 'en-US') {
   return str.replace(/^\p{CWU}/u, char => char.toLocaleUpperCase(locale));
 }
 
+/**
+ * Warns if the component is not mounted properly. Useful for tests.
+ * @param {HTMLElement} componentRef - the component reference
+ * @param {string} componentName - the component name
+ */
+export function warnIfUnmounted (componentRef, componentName) {
+  if (!componentRef || !(componentRef instanceof HTMLElement) || !document?.body) return;
+  if (!document.body.contains(componentRef)) {
+    console.warn(`The ${componentName} component is not attached to the document body. This may cause issues.`);
+  }
+}
+
 export default {
   getUniqueString,
   getRandomElement,

--- a/packages/dialtone-vue3/components/card/card.test.js
+++ b/packages/dialtone-vue3/components/card/card.test.js
@@ -21,7 +21,6 @@ describe('DtCard Tests', () => {
   const updateWrapper = () => {
     wrapper = mount(DtCard, {
       slots: { ...baseSlots, ...mockSlots },
-      attachTo: document.body,
     });
 
     contentElement = wrapper.find('[data-qa="content-element"]');

--- a/packages/dialtone-vue3/components/collapsible/collapsible.test.js
+++ b/packages/dialtone-vue3/components/collapsible/collapsible.test.js
@@ -23,7 +23,6 @@ describe('DtCollapsible Tests', () => {
     wrapper = mount(DtCollapsible, {
       props: { ...baseProps, ...mockProps },
       slots: { ...baseSlots, ...mockSlots },
-      attachTo: document.body,
     });
 
     anchorElement = wrapper.find('[data-qa="dt-button"]');

--- a/packages/dialtone-vue3/components/datepicker/datepicker.vue
+++ b/packages/dialtone-vue3/components/datepicker/datepicker.vue
@@ -41,7 +41,8 @@ import MonthYearPicker from './modules/month-year-picker.vue';
 import Calendar from './modules/calendar.vue';
 import { DtStack } from '@/components/stack';
 
-import { ref } from 'vue';
+import { onMounted, ref, getCurrentInstance } from 'vue';
+import { warnIfUnmounted } from '@/common/utils';
 
 defineProps({
   /**
@@ -153,4 +154,9 @@ const calendarDays = ref([]);
 function updateCalendarDays (days) {
   calendarDays.value = days;
 }
+
+onMounted(() => {
+  const instance = getCurrentInstance();
+  warnIfUnmounted(instance.proxy.$el, 'datepicker');
+});
 </script>

--- a/packages/dialtone-vue3/components/dropdown/dropdown.test.js
+++ b/packages/dialtone-vue3/components/dropdown/dropdown.test.js
@@ -74,6 +74,7 @@ describe('DtDropdown Tests', () => {
     mockSlots = {};
     mockAttrs = {};
     vi.restoreAllMocks();
+    wrapper.unmount();
   });
 
   describe('Presentation Tests', () => {

--- a/packages/dialtone-vue3/components/hovercard/hovercard.test.js
+++ b/packages/dialtone-vue3/components/hovercard/hovercard.test.js
@@ -55,7 +55,6 @@ describe('DtHovercard Tests', () => {
     vi.useRealTimers();
     vi.clearAllTimers();
     wrapper.unmount();
-    document.body.innerHTML = '';
   });
 
   describe('Presentation Tests', () => {

--- a/packages/dialtone-vue3/components/image_viewer/image_viewer.test.js
+++ b/packages/dialtone-vue3/components/image_viewer/image_viewer.test.js
@@ -28,7 +28,6 @@ describe('DtImageViewer Tests', () => {
           teleport: true,
         },
       },
-      attachTo: document.body,
     });
 
     imageViewerPreview = wrapper.find('[data-qa="dt-image-viewer-preview"]');

--- a/packages/dialtone-vue3/components/popover/popover.test.js
+++ b/packages/dialtone-vue3/components/popover/popover.test.js
@@ -70,6 +70,7 @@ describe('DtPopover Tests', () => {
   afterEach(() => {
     mockProps = {};
     mockSlots = {};
+    wrapper.unmount();
   });
 
   afterAll(() => {

--- a/packages/dialtone-vue3/components/popover/popover.vue
+++ b/packages/dialtone-vue3/components/popover/popover.vue
@@ -135,7 +135,7 @@ import {
   POPOVER_ROLES,
   POPOVER_STICKY_VALUES,
 } from './popover_constants';
-import { getUniqueString, hasSlotContent, isOutOfViewPort } from '@/common/utils';
+import { getUniqueString, hasSlotContent, isOutOfViewPort, warnIfUnmounted } from '@/common/utils';
 import { DtLazyShow } from '@/components/lazy_show';
 import ModalMixin from '@/common/mixins/modal';
 import { createTippyPopover, getPopperOptions } from './tippy_utils';
@@ -703,6 +703,8 @@ export default {
   },
 
   mounted () {
+    warnIfUnmounted(this.$el, this.$options.name);
+
     const externalAnchorEl = this.externalAnchor
       ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
       : null;

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/custom_link/custom_link.test.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/custom_link/custom_link.test.js
@@ -102,6 +102,7 @@ describe('DtRichTextEditor Link Extension tests', () => {
   afterEach(() => {
     props = baseProps;
     slots = {};
+    wrapper.unmount();
   });
 
   describe('Functionality Tests', () => {

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/emoji.test.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/emoji.test.js
@@ -75,6 +75,7 @@ describe('DtRichTextEditor Emoji Extension tests', () => {
   // Test Teardown
   afterEach(() => {
     propsData = baseProps;
+    wrapper.unmount();
   });
 
   describe('Functionality Tests', () => {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.test.js
@@ -69,6 +69,7 @@ describe('DtRichTextEditor tests', () => {
   afterEach(function () {
     props = baseProps;
     slots = {};
+    wrapper.unmount();
   });
 
   describe('Presentation Tests', function () {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -41,6 +41,7 @@ import {
 import mentionSuggestion from './extensions/mentions/suggestion';
 import channelSuggestion from './extensions/channels/suggestion';
 import slashCommandSuggestion from './extensions/slash_command/suggestion';
+import { warnIfUnmounted } from '@/common/utils';
 
 export default {
   name: 'DtRichTextEditor',
@@ -512,6 +513,10 @@ export default {
 
   beforeUnmount () {
     this.destroyEditor();
+  },
+
+  mounted () {
+    warnIfUnmounted(this.$el, this.$options.name);
   },
 
   methods: {

--- a/packages/dialtone-vue3/components/split_button/split_button.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button.vue
@@ -78,7 +78,7 @@ import {
 import SplitButtonAlpha from './split_button-alpha.vue';
 import SplitButtonOmega from './split_button-omega.vue';
 import { DtDropdown } from '@/components/dropdown';
-import { hasSlotContent } from '@/common/utils';
+import { hasSlotContent, warnIfUnmounted } from '@/common/utils';
 
 export default {
   name: 'DtSplitButton',
@@ -318,6 +318,10 @@ export default {
 
   updated () {
     this.validateProps();
+  },
+
+  mounted () {
+    warnIfUnmounted(this.$el, this.$options.name);
   },
 
   methods: {

--- a/packages/dialtone-vue3/components/tabs/tab_group.test.js
+++ b/packages/dialtone-vue3/components/tabs/tab_group.test.js
@@ -86,6 +86,14 @@ describe('DtTabGroup Tests', () => {
     _setWrappers();
   };
 
+  beforeEach(() => {
+    _mountWrapper();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
   describe('Presentation Tests', () => {
     // Setup
     beforeAll(async () => {

--- a/packages/dialtone-vue3/components/tabs/tab_group.vue
+++ b/packages/dialtone-vue3/components/tabs/tab_group.vue
@@ -33,7 +33,6 @@
 </template>
 
 <script>
-import { warnIfUnmounted } from '@/common/utils';
 import {
   TAB_LIST_SIZES,
   TAB_LIST_KIND_MODIFIERS,
@@ -172,7 +171,6 @@ export default {
 
   mounted () {
     this.updateSelected();
-    warnIfUnmounted(this.$el, this.$options.name);
   },
 
   beforeUpdate () {

--- a/packages/dialtone-vue3/components/tabs/tab_group.vue
+++ b/packages/dialtone-vue3/components/tabs/tab_group.vue
@@ -33,6 +33,7 @@
 </template>
 
 <script>
+import { warnIfUnmounted } from '@/common/utils';
 import {
   TAB_LIST_SIZES,
   TAB_LIST_KIND_MODIFIERS,
@@ -171,6 +172,7 @@ export default {
 
   mounted () {
     this.updateSelected();
+    warnIfUnmounted(this.$el, this.$options.name);
   },
 
   beforeUpdate () {

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -50,7 +50,7 @@ import {
 import {
   POPOVER_APPEND_TO_VALUES,
 } from '../popover/popover_constants';
-import { flushPromises, getUniqueString, hasSlotContent } from '@/common/utils';
+import { flushPromises, getUniqueString, hasSlotContent, warnIfUnmounted } from '@/common/utils';
 import {
   createTippy,
   getAnchor,
@@ -362,6 +362,7 @@ export default {
       await flushPromises();
       this.addExternalAnchorEventListeners();
     }
+    warnIfUnmounted(this.$el, this.$options.name);
   },
 
   beforeUnmount () {

--- a/packages/dialtone-vue3/directives/scrollbar/scrollbar.test.js
+++ b/packages/dialtone-vue3/directives/scrollbar/scrollbar.test.js
@@ -18,7 +18,6 @@ describe('DtScrollbarDirective Tests', () => {
       global: {
         plugins: [DtScrollbarDirective],
       },
-      attachTo: document.body,
     });
 
     viewportElement = wrapper.find('#viewport').element;

--- a/packages/dialtone-vue3/directives/tooltip/tooltip.test.js
+++ b/packages/dialtone-vue3/directives/tooltip/tooltip.test.js
@@ -44,6 +44,7 @@ describe('DtTooltipDirective Tests', () => {
         },
         plugins: [DtTooltipDirective],
       },
+      attachTo: document.body,
     });
 
     anchor = wrapper.find('button');

--- a/packages/dialtone-vue3/directives/tooltip/tooltip.test.js
+++ b/packages/dialtone-vue3/directives/tooltip/tooltip.test.js
@@ -44,7 +44,6 @@ describe('DtTooltipDirective Tests', () => {
         },
         plugins: [DtTooltipDirective],
       },
-      attachTo: document.body,
     });
 
     anchor = wrapper.find('button');

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button/callbar_button.test.js
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button/callbar_button.test.js
@@ -29,7 +29,6 @@ describe('DtRecipeCallbarButton Tests', () => {
       attrs,
       slots,
       provide,
-      attachTo: document.body,
     });
     _setChildWrappers();
   };

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -77,7 +77,7 @@ import { DtButton } from '@/components/button';
 import { DtPopover } from '@/components/popover';
 import { DtIcon } from '@/components/icon';
 import { DtRecipeCallbarButton, CALLBAR_BUTTON_VALID_WIDTH_SIZE } from '../callbar_button';
-import utils from '@/common/utils';
+import utils, { warnIfUnmounted } from '@/common/utils';
 
 export default {
   name: 'DtRecipeCallbarButtonWithPopover',
@@ -313,6 +313,10 @@ export default {
 
       return this.toggleOpen();
     },
+  },
+
+  mounted () {
+    warnIfUnmounted(this.$el, this.$options.name);
   },
 
   methods: {

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_with_popover/combobox_with_popover.test.js
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_with_popover/combobox_with_popover.test.js
@@ -83,7 +83,6 @@ describe('DtRecipeComboboxWithPopover Tests', () => {
     props = baseProps;
     slots = {};
     wrapper.unmount();
-    document.body.innerHTML = '';
   });
 
   afterAll(() => {

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.test.js
@@ -87,6 +87,7 @@ describe('DtRecipeEditor tests', () => {
   // Test Teardown
   afterEach(function () {
     propsData = baseProps;
+    wrapper.unmount();
   });
 
   describe('Presentation Tests', function () {

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.test.js
@@ -55,7 +55,6 @@ describe('DtRecipeEmojiRow Tests', function () {
       attrs,
       slots,
       provide,
-      attachTo: document.body,
     });
     _setChildWrappers();
   };

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.test.js
@@ -54,7 +54,6 @@ const _mountWrapper = () => {
     listeners,
     attrs,
     slots,
-    attachTo: document.body,
   });
 };
 


### PR DESCRIPTION
# Add warning when component doesn't mount properly

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/Y5wlazC8lSVuU/giphy.gif?cid=790b7611shtqjguqwtct3dfc4dwfz0o0flwotlx3acfhbf38&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [x] Other (chore)

## :book: Jira Ticket
[DLT-2000]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adds a warning for the components that need `attachTo: document.body` when testing. This will help developers understand why their tests are failing some times.

First commit: general clean up for tests. Detected some components that don't need `attachTo: document.body` so I removed it. For the ones that need it, added `wrapper.unmount()` to correctly remove it from the DOM after every test case, as the documentation says https://test-utils.vuejs.org/api/#attachTo

Second commit: adds function to output a warning if the component is not mounted in the `document.body` and adds it to the components that need it.

 <!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

Add changes to Vue 2.
<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

[DLT-2000]: https://dialpad.atlassian.net/browse/DLT-2000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ