### PR TITLE
fix(rich-text-editor): DLT-2029 double line breaks on paste

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -10,6 +10,7 @@
 <script>
 /* eslint-disable max-lines */
 import { Editor, EditorContent } from '@tiptap/vue-2';
+import { Slice, Fragment } from '@tiptap/pm/model';
 import Blockquote from '@tiptap/extension-blockquote';
 import CodeBlock from '@tiptap/extension-code-block';
 import Document from '@tiptap/extension-document';
@@ -527,6 +528,44 @@ export default {
           attributes: {
             ...this.inputAttrs,
             class: this.inputClass,
+          },
+
+          // Absolutely crazy that this is what's needed to paste line breaks properly in prosemirror, but it does seem
+          // to fix our issue of line breaks outputting as paragraphs. Code taken from this thread:
+          // https://discuss.prosemirror.net/t/how-to-preserve-hard-breaks-when-pasting-html-into-a-plain-text-schema/4202/4
+          handlePaste: function (view, event, slice) {
+            const { state } = view;
+            const { tr } = state;
+
+            if (!state.schema.nodes.hardBreak) {
+              return false;
+            }
+
+            const clipboardText = event.clipboardData?.getData('text/plain').trim();
+
+            if (!clipboardText) {
+              return false;
+            }
+
+            const textLines = clipboardText.split(/(?:\r\n|\r|\n)/g);
+
+            const nodes = textLines.reduce((nodes, line, index) => {
+              if (line.length > 0) {
+                nodes.push(state.schema.text(line));
+              }
+
+              if (index < textLines.length - 1) {
+                nodes.push(state.schema.nodes.hardBreak.create());
+              }
+
+              return nodes;
+            }, []);
+
+            view.dispatch(
+              tr.replaceSelection(Slice.maxOpen(Fragment.fromArray(nodes))).scrollIntoView(),
+            );
+
+            return true;
           },
         },
       });

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -530,9 +530,10 @@ export default {
             class: this.inputClass,
           },
 
-          // Absolutely crazy that this is what's needed to paste line breaks properly in prosemirror, but it does seem
-          // to fix our issue of line breaks outputting as paragraphs. Code taken from this thread:
-          // https://discuss.prosemirror.net/t/how-to-preserve-hard-breaks-when-pasting-html-into-a-plain-text-schema/4202/4
+          /* Absolutely crazy that this is what's needed to paste line breaks properly in prosemirror, but it does seem
+            to fix our issue of line breaks outputting as paragraphs. Code taken from this thread:
+            https://discuss.prosemirror.net/t/how-to-preserve-hard-breaks-when-pasting-html-into-a-plain-text-schema/4202/4
+          */
           handlePaste: function (view, event, slice) {
             const { state } = view;
             const { tr } = state;

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -530,9 +530,10 @@ export default {
             class: this.inputClass,
           },
 
-          // Absolutely crazy that this is what's needed to paste line breaks properly in prosemirror, but it does seem
-          // to fix our issue of line breaks outputting as paragraphs. Code taken from this thread:
-          // https://discuss.prosemirror.net/t/how-to-preserve-hard-breaks-when-pasting-html-into-a-plain-text-schema/4202/4
+          /* Absolutely crazy that this is what's needed to paste line breaks properly in prosemirror, but it does seem
+            to fix our issue of line breaks outputting as paragraphs. Code taken from this thread:
+            https://discuss.prosemirror.net/t/how-to-preserve-hard-breaks-when-pasting-html-into-a-plain-text-schema/4202/4
+          */
           handlePaste: function (view, event, slice) {
             const { state } = view;
             const { tr } = state;

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -10,6 +10,7 @@
 <script>
 /* eslint-disable max-lines */
 import { Editor, EditorContent } from '@tiptap/vue-3';
+import { Slice, Fragment } from '@tiptap/pm/model';
 import Blockquote from '@tiptap/extension-blockquote';
 import CodeBlock from '@tiptap/extension-code-block';
 import Document from '@tiptap/extension-document';
@@ -527,6 +528,44 @@ export default {
           attributes: {
             ...this.inputAttrs,
             class: this.inputClass,
+          },
+
+          // Absolutely crazy that this is what's needed to paste line breaks properly in prosemirror, but it does seem
+          // to fix our issue of line breaks outputting as paragraphs. Code taken from this thread:
+          // https://discuss.prosemirror.net/t/how-to-preserve-hard-breaks-when-pasting-html-into-a-plain-text-schema/4202/4
+          handlePaste: function (view, event, slice) {
+            const { state } = view;
+            const { tr } = state;
+
+            if (!state.schema.nodes.hardBreak) {
+              return false;
+            }
+
+            const clipboardText = event.clipboardData?.getData('text/plain').trim();
+
+            if (!clipboardText) {
+              return false;
+            }
+
+            const textLines = clipboardText.split(/(?:\r\n|\r|\n)/g);
+
+            const nodes = textLines.reduce((nodes, line, index) => {
+              if (line.length > 0) {
+                nodes.push(state.schema.text(line));
+              }
+
+              if (index < textLines.length - 1) {
+                nodes.push(state.schema.nodes.hardBreak.create());
+              }
+
+              return nodes;
+            }, []);
+
+            view.dispatch(
+              tr.replaceSelection(Slice.maxOpen(Fragment.fromArray(nodes))).scrollIntoView(),
+            );
+
+            return true;
           },
         },
       });


### PR DESCRIPTION
# fix(rich-text-editor): DLT-2029 double line breaks on paste

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNnJzbXA4MG1ub2IzNTd4YXFyMnZkNGc1NTJ4c2hsczhwMGM1aWdhdSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/kBZRtJgRgYUqaWwoxD/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2029

## :book: Description

Added custom `handlePaste` proseMirror function to paste line breaks as line breaks instead of paragraphs.

## :bulb: Context

When pasting text into the message input it would make it into a paragraph instead of a line break meaning it would make one line break into two line breaks. Completely ridiculous that it would modify the ACTUAL CHARACTERS you pasted to completely different characters. After exploring a bunch of threads where many people were attempting to put in a workaround for this irrational behaviour, and prosemirror saying they're never going to fix it, I found this fairly complex `handlePaste` function that seems to work the best out of all the solutions I found from 

https://discuss.prosemirror.net/t/how-to-preserve-hard-breaks-when-pasting-html-into-a-plain-text-schema/4202/4

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :link: Sources

Other discussions on this issue that I found, mostly with no valid solution:
https://discuss.prosemirror.net/t/an-extra-br-is-added-in-certain-pasted-content/4730/14
https://discuss.prosemirror.net/t/please-change-the-rules-for-pasting-plain-text/3996
