### PR TITLE
fix(emoji-picker): NO-JIRA fix ref reactivity in vue2

### DIFF
--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -184,8 +184,8 @@ export default {
 
     tabLabels () {
       return this.recentlyUsedEmojis.length
-        ? this.tabSetLabels.map((label, index) => ({ label, ref: this.$refs[`tabLabelRef-${index}`] }))
-        : this.tabSetLabels.slice(1).map((label, index) => ({ label, ref: this.$refs[`tabLabelRef-${index}`] }));
+        ? this.tabSetLabels.map((label) => ({ label }))
+        : this.tabSetLabels.slice(1).map((label) => ({ label }));
     },
 
     tabs () {
@@ -254,10 +254,10 @@ export default {
 
   methods: {
     setupTabLabelRefs () {
-      this.tabSetLabels?.forEach((label, index) => {
+      this.tabSetLabels?.forEach((_, index) => {
         const refKey = `tabLabelRef-${index}`;
         if (this.$refs[refKey]) {
-          this.$set(this.tabLabels, index, { label, ref: this.$refs[refKey] });
+          this.$set(this.tabLabels, index, { ...this.tabLabels[index], ref: this.$refs[refKey] });
         }
       });
     },


### PR DESCRIPTION
# fix(emoji-picker): no-jira fix ref reactivity in vue2

There were a bug on ref reactivity in vue2 version.

We already did a method to bypass this using `setupTabLabelRefs` method in the `mounted` section.

Previously `tabLabels` computed was working with the refs, and this refs were not updated accordingly.

Now we just leave the refs calculation to the `setupTabLabelRefs` method since this is being call inside the `this.$nextTick` and it just use the labels of `tabLabels`.


To test this improvement, you can go to 
`packages/dialtone-vue2/components/emoji_picker/emoji_picker.stories.js`
and remove the `recentlyUsedEmojis` from `argsData`.

You will see now works properly with `SMILEYS AND PEOPLE` tab label

<img width="375" alt="image" src="https://github.com/user-attachments/assets/8af26d3f-2c06-4b21-84fa-da210d033a0c">


Previously it shows `MOST RECENTLY USED` tab label

<img width="375" alt="image" src="https://github.com/user-attachments/assets/76f7eb88-3750-40ee-8020-9a847d423d16">



