### PR TITLE
chore: DLT-2051 add blog post to communicate breaking changes for 9.77.0

### DIFF
--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-10-1.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-10-1.md
@@ -1,0 +1,65 @@
+---
+heading: Dialtone Vue is now fully tree-shakeable (BREAKING CHANGE)
+author: Nina Repetto
+posted: '2024-10-1'
+---
+
+<BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">
+
+Hello there! We're excited to share that we've enhanced the tree-shaking capabilities of Dialtone components. This allows you to import just the components you require, rather than the entire library. This change will help decrease your bundle size and enhance performance.
+
+You can read more about how to take advantage of this feature in [this blog post](/about/whats-new/posts/2024-4-15.html).
+
+There are some breaking changes to be aware of in Dialtone version 9.77.0. Please update your projects as mentioned below.
+
+## Breaking changes
+
+Some components that previously received an icon name as a prop now require an icon component to be passed as a slot.
+These components are Avatar, Badge and Empty State. Here's an example of how to update your code:
+
+Previously, you would have passed an icon name as a prop like this:
+
+```vue
+<dt-avatar icon="user" />
+```
+
+Now, you will need to use the icon slot like this:
+
+```vue
+<dt-avatar>
+  <template #icon="{ iconSize }">
+    <dt-icon-user :size="iconSize" />
+  </template>
+</dt-avatar>
+```
+
+Notice in this case there's also a slot prop "iconSize" that you can use to pass the size of the icon to the icon component. Using the slot prop as in the example will set the size of the icon to the size of the avatar.
+
+Similarly, for the Badge component, now instead of passing the `icon-left` and `icon-right` props, now the slots `leftIcon` and `rightIcon` should be used. Here's an example:
+
+```vue
+<dt-badge type="default" text="Label" kind="label">
+  <template #leftIcon="{ iconSize }">
+    <dt-icon-lightning-bolt :size="iconSize" />
+  </template>
+</dt-badge>
+```
+
+For more examples, check the updated documentation for the [Avatar](/components/avatar.html) and [Badge](/components/badge.html) components.
+
+Also, some recipes where updated following the same pattern:
+
+* Contact info: introduced a new slot `avatarIcon` to pass the icon instead of the previous prop.
+* Message input: added the slot `sendIcon` to pass the icon instead of the previous prop.
+* Feed item pill: you should now use the slot `leftIcon` instead of the prop `iconName`.
+
+Thanks for your patience and understanding, and as always, we're here to help! Reach out to us in the `#dialtone` channel for any assistance you need.
+
+Dialtone Team 💜
+
+</BlogPost>
+
+<script setup>
+import BlogPost from '@baseComponents/BlogPost.vue';
+import { parse } from 'date-fns';
+</script>

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-10-1.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-10-1.md
@@ -10,7 +10,7 @@ Hello there! We're excited to share that we've enhanced the tree-shaking capabil
 
 You can read more about how to take advantage of this feature in [this blog post](/about/whats-new/posts/2024-4-15.html).
 
-There are some breaking changes to be aware of in Dialtone version 9.77.0. Please update your projects as mentioned below.
+There are some breaking changes to be aware of in Dialtone version 9.77.0. Please update your projects as mentioned below. Dialpad and Dialpad Meetings were already updated, so the following instructions are for other projects using Dialtone.
 
 ## Breaking changes
 
@@ -47,7 +47,7 @@ Similarly, for the Badge component, now instead of passing the `icon-left` and `
 
 For more examples, check the updated documentation for the [Avatar](/components/avatar.html) and [Badge](/components/badge.html) components.
 
-Also, some recipes where updated following the same pattern:
+Also, some recipes were updated following the same pattern:
 
 * Contact info: introduced a new slot `avatarIcon` to pass the icon instead of the previous prop.
 * Message input: added the slot `sendIcon` to pass the icon instead of the previous prop.

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-10-3.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-10-3.md
@@ -33,6 +33,18 @@ Now, you will need to use the icon slot like this:
 </dt-avatar>
 ```
 
+Another option is to use the `dt-icon` component inside the `dt-avatar` component:
+
+```vue
+<dt-avatar>
+  <template #icon="{ iconSize }">
+    <dt-icon name="user" :size="iconSize" />
+  </template>
+</dt-avatar>
+```
+
+But this will import all the icons instead of just the one you need, so it's not recommended.
+
 Notice in this case there's also a slot prop "iconSize" that you can use to pass the size of the icon to the icon component. Using the slot prop as in the example will set the size of the icon to the size of the avatar.
 
 Similarly, for the Badge component, now instead of passing the `icon-left` and `icon-right` props, now the slots `leftIcon` and `rightIcon` should be used. Here's an example:

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-10-3.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-10-3.md
@@ -1,7 +1,7 @@
 ---
 heading: Dialtone Vue is now fully tree-shakeable (BREAKING CHANGE)
 author: Nina Repetto
-posted: '2024-10-1'
+posted: '2024-10-3'
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">


### PR DESCRIPTION
# chore: DLT-2051 add blog post to communicate breaking changes for 9.77.0

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/sr8jYZVVsCmxddga8w/giphy.gif?cid=790b76119ly6nxs0ofaytljfekiepadvejvbp7ncx7afssa5&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [x] Other (chore)

## :book: Jira Ticket
[DLT-2051]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adds blog post to communicate the breaking changes introduced in Dialtone 9.77.0 after removing dt-icon from components.
Explains how to migrate, main examples are Avatar and Badge which are the most used components that where affected.
<!--- Describe specifically what the changes are -->


[DLT-2051]: https://dialpad.atlassian.net/browse/DLT-2051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ