### PR TITLE
fix(tokens): NO-JIRA incorrect hsl for reference tokens

### DIFF
--- a/packages/dialtone-tokens/postcss/constants.cjs
+++ b/packages/dialtone-tokens/postcss/constants.cjs
@@ -9,6 +9,7 @@
  */
 
 module.exports = {
+  HSLA_EXCLUDED_COLORS: ['--dt-color-gradient-magenta-purple', '--dt-badge-color-background-ai', '--dt-color-border-ai'],
   IS_COLOR_REGEX: /--dt.*-color/,
   IS_THEME_COLOR_REGEX: /(--dt-theme-).*-(color).*/,
   IS_SHADOW_REGEX: /--dt.*-shadow/,


### PR DESCRIPTION
# fix(tokens): NO-JIRA incorrect hsl for reference tokens

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbDAzMW5rcDQyN2FjYmtmanVuMXNiZXRqM3BqdGN5anYwdWx4bDc3eSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/hVinjWdIDiigU/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Fixing a problem Julio noticed where referenced tokens were not correctly generating HSL colors because a string like `var(--dt-color-foreground-critical-strong-inverted);` obviously doesn't contain any color information. Instead made the hsl reference its token instead of trying to generate new color data where it cannot.

Not generating HSL for gradient because it's very abnormal and I don't even think possible

Haven't really tested this much yet, will do more testing tomorrow.
