### PR TITLE
fix(rich-text-editor): DLT-2107 message input recipe updates

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -35,7 +35,10 @@
               @click="button.onClick()"
             >
               <template #icon>
-                <component :is="button.icon" size="200" />
+                <component
+                  :is="button.icon"
+                  size="200"
+                />
               </template>
               <span v-if="button.label">{{ button.label }}</span>
             </dt-button>
@@ -43,7 +46,11 @@
         </dt-tooltip>
         <div class="dt-editor--button-group-divider" />
       </dt-stack>
-      <dt-stack v-if="linkButton.showBtn" direction="row" gap="300">
+      <dt-stack
+        v-if="linkButton.showBtn"
+        direction="row"
+        gap="300"
+      >
         <dt-popover
           :open.sync="showLinkInput"
           placement="bottom-start"
@@ -67,9 +74,7 @@
                   importance="clear"
                   kind="muted"
                   class="d-ol-none"
-                  :active="
-                    $refs.richTextEditor?.editor?.isActive(linkButton.selector)
-                  "
+                  :active="$refs.richTextEditor?.editor?.isActive(linkButton.selector)"
                   size="xs"
                   :aria-label="linkButton.tooltipMessage"
                   @click="linkButton.onClick()"
@@ -87,7 +92,9 @@
           </template>
 
           <template #content>
-            <span v-if="showAddLink.setLinkTitle.length > 0">
+            <span
+              v-if="showAddLink.setLinkTitle.length > 0"
+            >
               {{ showAddLink.setLinkTitle }}
             </span>
             <dt-input
@@ -173,16 +180,16 @@ import {
   DtRichTextEditor,
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
   RICH_TEXT_EDITOR_AUTOFOCUS_TYPES,
-} from "@/components/rich_text_editor";
+} from '@/components/rich_text_editor';
 import {
   EDITOR_SUPPORTED_LINK_PROTOCOLS,
   EDITOR_DEFAULT_LINK_PREFIX,
-} from "./editor_constants.js";
-import { DtButton } from "@/components/button";
-import { DtPopover } from "@/components/popover";
-import { DtStack } from "@/components/stack";
-import { DtInput } from "@/components/input";
-import { DtTooltip } from "@/components/tooltip";
+} from './editor_constants.js';
+import { DtButton } from '@/components/button';
+import { DtPopover } from '@/components/popover';
+import { DtStack } from '@/components/stack';
+import { DtInput } from '@/components/input';
+import { DtTooltip } from '@/components/tooltip';
 import {
   DtIconAlignCenter,
   DtIconAlignJustify,
@@ -198,10 +205,14 @@ import {
   DtIconQuote,
   DtIconStrikethrough,
   DtIconUnderline,
-} from "@dialpad/dialtone-icons/vue2";
+<<<<<<< ours
+} from '@dialpad/dialtone-icons/vue2';
+=======
+} from '@dialpad/dialtone-icons/vue3';
+>>>>>>> theirs
 
 export default {
-  name: "DtRecipeEditor",
+  name: 'DtRecipeEditor',
 
   components: {
     DtRichTextEditor,
@@ -235,7 +246,7 @@ export default {
      */
     value: {
       type: [Object, String],
-      default: "",
+      default: '',
     },
 
     /**
@@ -252,7 +263,7 @@ export default {
     inputAriaLabel: {
       type: String,
       required: true,
-      default: "",
+      default: '',
     },
 
     /**
@@ -262,7 +273,7 @@ export default {
      */
     inputClass: {
       type: String,
-      default: "",
+      default: '',
     },
 
     /**
@@ -279,8 +290,8 @@ export default {
     autoFocus: {
       type: [Boolean, String, Number],
       default: false,
-      validator(autoFocus) {
-        if (typeof autoFocus === "string") {
+      validator (autoFocus) {
+        if (typeof autoFocus === 'string') {
           return RICH_TEXT_EDITOR_AUTOFOCUS_TYPES.includes(autoFocus);
         }
         return true;
@@ -292,7 +303,7 @@ export default {
      */
     placeholder: {
       type: String,
-      default: "",
+      default: '',
     },
 
     /**
@@ -301,7 +312,7 @@ export default {
      */
     maxHeight: {
       type: String,
-      default: "unset",
+      default: 'unset',
     },
 
     /**
@@ -309,7 +320,7 @@ export default {
      */
     confirmSetLinkButton: {
       type: Object,
-      default: () => ({ label: "Confirm", ariaLabel: "Confirm set link" }),
+      default: () => ({ label: 'Confirm', ariaLabel: 'Confirm set link' }),
     },
 
     /**
@@ -317,7 +328,7 @@ export default {
      */
     removeLinkButton: {
       type: Object,
-      default: () => ({ label: "Remove", ariaLabel: "Remove link" }),
+      default: () => ({ label: 'Remove', ariaLabel: 'Remove link' }),
     },
 
     /**
@@ -325,7 +336,7 @@ export default {
      */
     cancelSetLinkButton: {
       type: Object,
-      default: () => ({ label: "Cancel", ariaLabel: "Cancel set link" }),
+      default: () => ({ label: 'Cancel', ariaLabel: 'Cancel set link' }),
     },
 
     /**
@@ -333,7 +344,7 @@ export default {
      */
     setLinkPlaceholder: {
       type: String,
-      default: "",
+      default: '',
     },
 
     /**
@@ -447,8 +458,8 @@ export default {
       type: Object,
       default: () => ({
         showAddLinkButton: true,
-        setLinkTitle: "Add a link",
-        setLinkInputAriaLabel: "Input field to add link",
+        setLinkTitle: 'Add a link',
+        setLinkInputAriaLabel: 'Input field to add link',
       }),
     },
   },
@@ -459,54 +470,66 @@ export default {
      * @event input
      * @type {String|JSON}
      */
-    "focus",
+    'focus',
 
     /**
      * Native blur event
      * @event input
      * @type {String|JSON}
      */
-    "blur",
+    'blur',
 
     /**
      * Native input event
      * @event input
      * @type {String|JSON}
      */
-    "input",
+    'input',
 
     /**
      * Quick replies button
      * pressed event
      * @event quick-replies-click
+<<<<<<< ours
+    */
+=======
      */
-    "quick-replies-click",
+>>>>>>> theirs
+    'quick-replies-click',
   ],
 
-  data() {
+  data () {
     return {
       internalInputValue: this.value, // internal input content
       hasFocus: false,
 
       linkOptions: {
-        class: "d-link d-c-text d-d-inline-block",
+        class: 'd-link d-c-text d-d-inline-block',
       },
 
       showLinkInput: false,
-      linkInput: "",
+      linkInput: '',
     };
   },
 
   computed: {
-    inputLength() {
+    inputLength () {
       return this.internalInputValue.length;
     },
 
-    htmlOutputFormat() {
+    htmlOutputFormat () {
       return RICH_TEXT_EDITOR_OUTPUT_FORMATS[2];
     },
 
-    showingTextFormatButtons() {
+    showingTextFormatButtons () {
+<<<<<<< ours
+      return this.showBoldButton || this.showItalicsButton || this.showStrikeButton || this.showUnderlineButton;
+    },
+
+    showingAlignmentButtons () {
+      return this.showAlignLeftButton || this.showAlignCenterButton ||
+          this.showAlignRightButton || this.showAlignJustifyButton;
+=======
       return (
         this.showBoldButton ||
         this.showItalicsButton ||
@@ -515,194 +538,239 @@ export default {
       );
     },
 
-    showingAlignmentButtons() {
+    showingAlignmentButtons () {
       return (
         this.showAlignLeftButton ||
         this.showAlignCenterButton ||
         this.showAlignRightButton ||
         this.showAlignJustifyButton
       );
+>>>>>>> theirs
     },
 
-    showingListButtons() {
+    showingListButtons () {
       return this.showListItemsButton || this.showOrderedListButton;
     },
 
-    buttonGroups() {
+    buttonGroups () {
+<<<<<<< ours
+      const individualButtonStacks = this.individualButtons.map(buttonData => ({
+        key: buttonData.selector,
+        buttonGroup: [buttonData],
+      }));
+=======
       const individualButtonStacks = this.individualButtons.map(
         (buttonData) => ({
           key: buttonData.selector,
           buttonGroup: [buttonData],
         }),
       );
+>>>>>>> theirs
       return [
-        { key: "new", buttonGroup: this.newButtons },
-        { key: "format", buttonGroup: this.textFormatButtons },
-        { key: "alignment", buttonGroup: this.alignmentButtons },
-        { key: "list", buttonGroup: this.listButtons },
+        { key: 'new', buttonGroup: this.newButtons },
+        { key: 'format', buttonGroup: this.textFormatButtons },
+        { key: 'alignment', buttonGroup: this.alignmentButtons },
+        { key: 'list', buttonGroup: this.listButtons },
         ...individualButtonStacks,
-      ].filter((buttonGroupData) => buttonGroupData.buttonGroup.length > 0);
+      ].filter(buttonGroupData => buttonGroupData.buttonGroup.length > 0);
     },
 
-    newButtons() {
+    newButtons () {
       return [
+<<<<<<< ours
+        { showBtn: this.showQuickRepliesButton, label: 'Quick reply', selector: 'quickReplies', icon: DtIconLightningBolt, dataQA: 'dt-editor-quick-replies-btn', tooltipMessage: 'Quick Reply', onClick: this.onQuickRepliesClick },
+      ].filter(button => button.showBtn);
+=======
         {
           showBtn: this.showQuickRepliesButton,
-          label: "Quick reply",
-          selector: "quickReplies",
+          label: 'Quick reply',
+          selector: 'quickReplies',
           icon: DtIconLightningBolt,
-          dataQA: "dt-editor-quick-replies-btn",
-          tooltipMessage: "Quick Reply",
+          dataQA: 'dt-editor-quick-replies-btn',
+          tooltipMessage: 'Quick Reply',
           onClick: this.onQuickRepliesClick,
         },
       ].filter((button) => button.showBtn);
+>>>>>>> theirs
     },
 
-    textFormatButtons() {
+    textFormatButtons () {
       return [
+<<<<<<< ours
+        { showBtn: this.showBoldButton, selector: 'bold', icon: DtIconBold, dataQA: 'dt-editor-bold-btn', tooltipMessage: 'Bold', onClick: this.onBoldTextToggle },
+        { showBtn: this.showItalicsButton, selector: 'italic', icon: DtIconItalic, dataQA: 'dt-editor-italics-btn', tooltipMessage: 'Italics', onClick: this.onItalicTextToggle },
+        { showBtn: this.showUnderlineButton, selector: 'underline', icon: DtIconUnderline, dataQA: 'dt-editor-underline-btn', tooltipMessage: 'Underline', onClick: this.onUnderlineTextToggle },
+        { showBtn: this.showStrikeButton, selector: 'strike', icon: DtIconStrikethrough, dataQA: 'dt-editor-strike-btn', tooltipMessage: 'Strike', onClick: this.onStrikethroughTextToggle },
+      ].filter(button => button.showBtn);
+=======
         {
           showBtn: this.showBoldButton,
-          selector: "bold",
+          selector: 'bold',
           icon: DtIconBold,
-          dataQA: "dt-editor-bold-btn",
-          tooltipMessage: "Bold",
+          dataQA: 'dt-editor-bold-btn',
+          tooltipMessage: 'Bold',
           onClick: this.onBoldTextToggle,
         },
         {
           showBtn: this.showItalicsButton,
-          selector: "italic",
+          selector: 'italic',
           icon: DtIconItalic,
-          dataQA: "dt-editor-italics-btn",
-          tooltipMessage: "Italics",
+          dataQA: 'dt-editor-italics-btn',
+          tooltipMessage: 'Italics',
           onClick: this.onItalicTextToggle,
         },
         {
           showBtn: this.showUnderlineButton,
-          selector: "underline",
+          selector: 'underline',
           icon: DtIconUnderline,
-          dataQA: "dt-editor-underline-btn",
-          tooltipMessage: "Underline",
+          dataQA: 'dt-editor-underline-btn',
+          tooltipMessage: 'Underline',
           onClick: this.onUnderlineTextToggle,
         },
         {
           showBtn: this.showStrikeButton,
-          selector: "strike",
+          selector: 'strike',
           icon: DtIconStrikethrough,
-          dataQA: "dt-editor-strike-btn",
-          tooltipMessage: "Strike",
+          dataQA: 'dt-editor-strike-btn',
+          tooltipMessage: 'Strike',
           onClick: this.onStrikethroughTextToggle,
         },
       ].filter((button) => button.showBtn);
+>>>>>>> theirs
     },
 
-    alignmentButtons() {
+    alignmentButtons () {
       return [
+<<<<<<< ours
+        { showBtn: this.showAlignLeftButton, selector: { textAlign: 'left' }, icon: DtIconAlignLeft, dataQA: 'dt-editor-align-left-btn', tooltipMessage: 'Align Left', onClick: () => this.onTextAlign('left') },
+        { showBtn: this.showAlignCenterButton, selector: { textAlign: 'center' }, icon: DtIconAlignCenter, dataQA: 'dt-editor-align-center-btn', tooltipMessage: 'Align Center', onClick: () => this.onTextAlign('center') },
+        { showBtn: this.showAlignRightButton, selector: { textAlign: 'right' }, icon: DtIconAlignRight, dataQA: 'dt-editor-align-right-btn', tooltipMessage: 'Align Right', onClick: () => this.onTextAlign('right') },
+        { showBtn: this.showAlignJustifyButton, selector: { textAlign: 'justify' }, icon: DtIconAlignJustify, dataQA: 'dt-editor-align-justify-btn', tooltipMessage: 'Align Justify', onClick: () => this.onTextAlign('justify') },
+      ].filter(button => button.showBtn);
+=======
         {
           showBtn: this.showAlignLeftButton,
-          selector: { textAlign: "left" },
+          selector: { textAlign: 'left' },
           icon: DtIconAlignLeft,
-          dataQA: "dt-editor-align-left-btn",
-          tooltipMessage: "Align Left",
-          onClick: () => this.onTextAlign("left"),
+          dataQA: 'dt-editor-align-left-btn',
+          tooltipMessage: 'Align Left',
+          onClick: () => this.onTextAlign('left'),
         },
         {
           showBtn: this.showAlignCenterButton,
-          selector: { textAlign: "center" },
+          selector: { textAlign: 'center' },
           icon: DtIconAlignCenter,
-          dataQA: "dt-editor-align-center-btn",
-          tooltipMessage: "Align Center",
-          onClick: () => this.onTextAlign("center"),
+          dataQA: 'dt-editor-align-center-btn',
+          tooltipMessage: 'Align Center',
+          onClick: () => this.onTextAlign('center'),
         },
         {
           showBtn: this.showAlignRightButton,
-          selector: { textAlign: "right" },
+          selector: { textAlign: 'right' },
           icon: DtIconAlignRight,
-          dataQA: "dt-editor-align-right-btn",
-          tooltipMessage: "Align Right",
-          onClick: () => this.onTextAlign("right"),
+          dataQA: 'dt-editor-align-right-btn',
+          tooltipMessage: 'Align Right',
+          onClick: () => this.onTextAlign('right'),
         },
         {
           showBtn: this.showAlignJustifyButton,
-          selector: { textAlign: "justify" },
+          selector: { textAlign: 'justify' },
           icon: DtIconAlignJustify,
-          dataQA: "dt-editor-align-justify-btn",
-          tooltipMessage: "Align Justify",
-          onClick: () => this.onTextAlign("justify"),
+          dataQA: 'dt-editor-align-justify-btn',
+          tooltipMessage: 'Align Justify',
+          onClick: () => this.onTextAlign('justify'),
         },
       ].filter((button) => button.showBtn);
+>>>>>>> theirs
     },
 
-    listButtons() {
+    listButtons () {
       return [
+<<<<<<< ours
+        { showBtn: this.showListItemsButton, selector: 'bulletList', icon: DtIconListBullet, dataQA: 'dt-editor-list-items-btn', tooltipMessage: 'Bullet List', onClick: this.onBulletListToggle },
+        { showBtn: this.showOrderedListButton, selector: 'orderedList', icon: DtIconListOrdered, dataQA: 'dt-editor-ordered-list-items-btn', tooltipMessage: 'Ordered List', onClick: this.onOrderedListToggle },
+      ].filter(button => button.showBtn);
+=======
         {
           showBtn: this.showListItemsButton,
-          selector: "bulletList",
+          selector: 'bulletList',
           icon: DtIconListBullet,
-          dataQA: "dt-editor-list-items-btn",
-          tooltipMessage: "Bullet List",
+          dataQA: 'dt-editor-list-items-btn',
+          tooltipMessage: 'Bullet List',
           onClick: this.onBulletListToggle,
         },
         {
           showBtn: this.showOrderedListButton,
-          selector: "orderedList",
+          selector: 'orderedList',
           icon: DtIconListOrdered,
-          dataQA: "dt-editor-ordered-list-items-btn",
-          tooltipMessage: "Ordered List",
+          dataQA: 'dt-editor-ordered-list-items-btn',
+          tooltipMessage: 'Ordered List',
           onClick: this.onOrderedListToggle,
         },
       ].filter((button) => button.showBtn);
+>>>>>>> theirs
     },
 
-    individualButtons() {
+    individualButtons () {
       return [
+<<<<<<< ours
+        { showBtn: this.showQuoteButton, selector: 'blockquote', icon: DtIconQuote, dataQA: 'dt-editor-blockquote-btn', tooltipMessage: 'Quote', onClick: this.onBlockquoteToggle },
+        { showBtn: this.showCodeBlockButton, selector: 'codeBlock', icon: DtIconCodeBlock, dataQA: 'dt-editor-code-block-btn', tooltipMessage: 'Code', onClick: this.onCodeBlockToggle },
+      ].filter(button => button.showBtn);
+    },
+
+    linkButton () {
+      return { showBtn: this.showAddLink.showAddLinkButton, selector: 'link', icon: DtIconLink2, dataQA: 'dt-editor-add-link-btn', tooltipMessage: 'Link', onClick: this.openLinkInput };
+=======
         {
           showBtn: this.showQuoteButton,
-          selector: "blockquote",
+          selector: 'blockquote',
           icon: DtIconQuote,
-          dataQA: "dt-editor-blockquote-btn",
-          tooltipMessage: "Quote",
+          dataQA: 'dt-editor-blockquote-btn',
+          tooltipMessage: 'Quote',
           onClick: this.onBlockquoteToggle,
         },
         {
           showBtn: this.showCodeBlockButton,
-          selector: "codeBlock",
+          selector: 'codeBlock',
           icon: DtIconCodeBlock,
-          dataQA: "dt-editor-code-block-btn",
-          tooltipMessage: "Code",
+          dataQA: 'dt-editor-code-block-btn',
+          tooltipMessage: 'Code',
           onClick: this.onCodeBlockToggle,
         },
       ].filter((button) => button.showBtn);
     },
 
-    linkButton() {
+    linkButton () {
       return {
         showBtn: this.showAddLink.showAddLinkButton,
-        selector: "link",
+        selector: 'link',
         icon: DtIconLink2,
-        dataQA: "dt-editor-add-link-btn",
-        tooltipMessage: "Link",
+        dataQA: 'dt-editor-add-link-btn',
+        tooltipMessage: 'Link',
         onClick: this.openLinkInput,
       };
+>>>>>>> theirs
     },
   },
 
   watch: {
-    value(newValue) {
+    value (newValue) {
       this.internalInputValue = newValue;
     },
   },
 
   methods: {
-    onInputFocus(event) {
+    onInputFocus (event) {
       event?.stopPropagation();
     },
 
-    removeLink() {
+    removeLink () {
       this.$refs.richTextEditor?.editor?.chain()?.focus()?.unsetLink()?.run();
       this.closeLinkInput();
     },
 
-    setLink(event) {
+    setLink (event) {
       const editor = this.$refs.richTextEditor?.editor;
       event?.preventDefault();
       event?.stopPropagation();
@@ -715,9 +783,7 @@ export default {
       }
 
       // Check if input matches any of the supported link formats
-      const prefix = EDITOR_SUPPORTED_LINK_PROTOCOLS.find((prefixRegex) =>
-        prefixRegex.test(this.linkInput),
-      );
+      const prefix = EDITOR_SUPPORTED_LINK_PROTOCOLS.find(prefixRegex => prefixRegex.test(this.linkInput));
 
       if (!prefix) {
         // If no matching pattern is found, prepend default prefix
@@ -743,7 +809,7 @@ export default {
         editor
           .chain()
           .focus()
-          .extendMarkRange("link")
+          .extendMarkRange('link')
           .setLink({ href: this.linkInput, class: this.linkOptions.class })
           .run();
       }
@@ -751,59 +817,66 @@ export default {
       this.closeLinkInput();
     },
 
-    openLinkInput() {
+    openLinkInput () {
       this.showLinkInput = true;
     },
 
-    updateInput(openedInput) {
+    updateInput (openedInput) {
       if (!openedInput) {
         return this.closeLinkInput();
       }
+<<<<<<< ours
+      this.linkInput = this.$refs.richTextEditor?.editor?.getAttributes('link')?.href;
+=======
       this.linkInput =
-        this.$refs.richTextEditor?.editor?.getAttributes("link")?.href;
+        this.$refs.richTextEditor?.editor?.getAttributes('link')?.href;
+>>>>>>> theirs
     },
 
-    closeLinkInput() {
+    closeLinkInput () {
       this.showLinkInput = false;
-      this.linkInput = "";
+      this.linkInput = '';
       this.$refs.richTextEditor.editor?.chain().focus();
     },
 
-    onBoldTextToggle() {
+    onBoldTextToggle () {
       this.$refs.richTextEditor?.editor?.chain().focus().toggleBold().run();
     },
 
-    onItalicTextToggle() {
+    onItalicTextToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleItalic().run();
     },
 
-    onUnderlineTextToggle() {
+    onUnderlineTextToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleUnderline().run();
     },
 
-    onStrikethroughTextToggle() {
+    onStrikethroughTextToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleStrike().run();
     },
 
-    onTextAlign(alignment) {
+    onTextAlign (alignment) {
+<<<<<<< ours
+      if (this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })) {
+=======
       if (
         this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })
       ) {
+>>>>>>> theirs
         // If this alignment type is already set here, unset it
-        return this.$refs.richTextEditor?.editor
-          .chain()
-          .focus()
-          .unsetTextAlign()
-          .run();
+        return this.$refs.richTextEditor?.editor.chain().focus().unsetTextAlign().run();
       }
-      this.$refs.richTextEditor?.editor
-        .chain()
-        .focus()
-        .setTextAlign(alignment)
-        .run();
+      this.$refs.richTextEditor?.editor.chain().focus().setTextAlign(alignment).run();
     },
 
-    onBulletListToggle() {
+    onBulletListToggle () {
+<<<<<<< ours
+      this.$refs.richTextEditor?.editor.chain().focus().toggleBulletList().run();
+    },
+
+    onOrderedListToggle () {
+      this.$refs.richTextEditor?.editor.chain().focus().toggleOrderedList().run();
+=======
       this.$refs.richTextEditor?.editor
         .chain()
         .focus()
@@ -811,43 +884,49 @@ export default {
         .run();
     },
 
-    onOrderedListToggle() {
+    onOrderedListToggle () {
       this.$refs.richTextEditor?.editor
         .chain()
         .focus()
         .toggleOrderedList()
         .run();
+>>>>>>> theirs
     },
 
-    onCodeBlockToggle() {
+    onCodeBlockToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleCodeBlock().run();
     },
 
-    onQuickRepliesClick() {
-      this.$emit("quick-replies-click");
+    onQuickRepliesClick () {
+      this.$emit('quick-replies-click');
     },
 
-    onBlockquoteToggle() {
+    onBlockquoteToggle () {
+<<<<<<< ours
+      this.$refs.richTextEditor?.editor.chain().focus().toggleBlockquote().run();
+=======
       this.$refs.richTextEditor?.editor
         .chain()
         .focus()
         .toggleBlockquote()
         .run();
+>>>>>>> theirs
     },
 
-    onFocus(event) {
+    onFocus (event) {
       this.hasFocus = true;
-      this.$emit("focus", event);
+      this.$emit('focus', event);
     },
 
-    onBlur(event) {
+    onBlur (event) {
       this.hasFocus = false;
-      this.$emit("blur", event);
+      this.$emit('blur', event);
     },
 
-    onInput(event) {
-      this.$emit("input", event);
+    onInput (event) {
+      this.$emit('input', event);
     },
+
   },
 };
 </script>

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -35,10 +35,7 @@
               @click="button.onClick()"
             >
               <template #icon>
-                <component
-                  :is="button.icon"
-                  size="200"
-                />
+                <component :is="button.icon" size="200" />
               </template>
               <span v-if="button.label">{{ button.label }}</span>
             </dt-button>
@@ -46,11 +43,7 @@
         </dt-tooltip>
         <div class="dt-editor--button-group-divider" />
       </dt-stack>
-      <dt-stack
-        v-if="linkButton.showBtn"
-        direction="row"
-        gap="300"
-      >
+      <dt-stack v-if="linkButton.showBtn" direction="row" gap="300">
         <dt-popover
           :open.sync="showLinkInput"
           placement="bottom-start"
@@ -74,7 +67,9 @@
                   importance="clear"
                   kind="muted"
                   class="d-ol-none"
-                  :active="$refs.richTextEditor?.editor?.isActive(linkButton.selector)"
+                  :active="
+                    $refs.richTextEditor?.editor?.isActive(linkButton.selector)
+                  "
                   size="xs"
                   :aria-label="linkButton.tooltipMessage"
                   @click="linkButton.onClick()"
@@ -92,9 +87,7 @@
           </template>
 
           <template #content>
-            <span
-              v-if="showAddLink.setLinkTitle.length > 0"
-            >
+            <span v-if="showAddLink.setLinkTitle.length > 0">
               {{ showAddLink.setLinkTitle }}
             </span>
             <dt-input
@@ -180,16 +173,16 @@ import {
   DtRichTextEditor,
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
   RICH_TEXT_EDITOR_AUTOFOCUS_TYPES,
-} from '@/components/rich_text_editor';
+} from "@/components/rich_text_editor";
 import {
   EDITOR_SUPPORTED_LINK_PROTOCOLS,
   EDITOR_DEFAULT_LINK_PREFIX,
-} from './editor_constants.js';
-import { DtButton } from '@/components/button';
-import { DtPopover } from '@/components/popover';
-import { DtStack } from '@/components/stack';
-import { DtInput } from '@/components/input';
-import { DtTooltip } from '@/components/tooltip';
+} from "./editor_constants.js";
+import { DtButton } from "@/components/button";
+import { DtPopover } from "@/components/popover";
+import { DtStack } from "@/components/stack";
+import { DtInput } from "@/components/input";
+import { DtTooltip } from "@/components/tooltip";
 import {
   DtIconAlignCenter,
   DtIconAlignJustify,
@@ -205,14 +198,10 @@ import {
   DtIconQuote,
   DtIconStrikethrough,
   DtIconUnderline,
-<<<<<<< ours
-} from '@dialpad/dialtone-icons/vue2';
-=======
-} from '@dialpad/dialtone-icons/vue3';
->>>>>>> theirs
+} from "@dialpad/dialtone-icons/vue2";
 
 export default {
-  name: 'DtRecipeEditor',
+  name: "DtRecipeEditor",
 
   components: {
     DtRichTextEditor,
@@ -246,7 +235,7 @@ export default {
      */
     value: {
       type: [Object, String],
-      default: '',
+      default: "",
     },
 
     /**
@@ -263,7 +252,7 @@ export default {
     inputAriaLabel: {
       type: String,
       required: true,
-      default: '',
+      default: "",
     },
 
     /**
@@ -273,7 +262,7 @@ export default {
      */
     inputClass: {
       type: String,
-      default: '',
+      default: "",
     },
 
     /**
@@ -290,8 +279,8 @@ export default {
     autoFocus: {
       type: [Boolean, String, Number],
       default: false,
-      validator (autoFocus) {
-        if (typeof autoFocus === 'string') {
+      validator(autoFocus) {
+        if (typeof autoFocus === "string") {
           return RICH_TEXT_EDITOR_AUTOFOCUS_TYPES.includes(autoFocus);
         }
         return true;
@@ -303,7 +292,7 @@ export default {
      */
     placeholder: {
       type: String,
-      default: '',
+      default: "",
     },
 
     /**
@@ -312,7 +301,7 @@ export default {
      */
     maxHeight: {
       type: String,
-      default: 'unset',
+      default: "unset",
     },
 
     /**
@@ -320,7 +309,7 @@ export default {
      */
     confirmSetLinkButton: {
       type: Object,
-      default: () => ({ label: 'Confirm', ariaLabel: 'Confirm set link' }),
+      default: () => ({ label: "Confirm", ariaLabel: "Confirm set link" }),
     },
 
     /**
@@ -328,7 +317,7 @@ export default {
      */
     removeLinkButton: {
       type: Object,
-      default: () => ({ label: 'Remove', ariaLabel: 'Remove link' }),
+      default: () => ({ label: "Remove", ariaLabel: "Remove link" }),
     },
 
     /**
@@ -336,7 +325,7 @@ export default {
      */
     cancelSetLinkButton: {
       type: Object,
-      default: () => ({ label: 'Cancel', ariaLabel: 'Cancel set link' }),
+      default: () => ({ label: "Cancel", ariaLabel: "Cancel set link" }),
     },
 
     /**
@@ -344,7 +333,7 @@ export default {
      */
     setLinkPlaceholder: {
       type: String,
-      default: '',
+      default: "",
     },
 
     /**
@@ -458,8 +447,8 @@ export default {
       type: Object,
       default: () => ({
         showAddLinkButton: true,
-        setLinkTitle: 'Add a link',
-        setLinkInputAriaLabel: 'Input field to add link',
+        setLinkTitle: "Add a link",
+        setLinkInputAriaLabel: "Input field to add link",
       }),
     },
   },
@@ -470,66 +459,54 @@ export default {
      * @event input
      * @type {String|JSON}
      */
-    'focus',
+    "focus",
 
     /**
      * Native blur event
      * @event input
      * @type {String|JSON}
      */
-    'blur',
+    "blur",
 
     /**
      * Native input event
      * @event input
      * @type {String|JSON}
      */
-    'input',
+    "input",
 
     /**
      * Quick replies button
      * pressed event
      * @event quick-replies-click
-<<<<<<< ours
-    */
-=======
      */
->>>>>>> theirs
-    'quick-replies-click',
+    "quick-replies-click",
   ],
 
-  data () {
+  data() {
     return {
       internalInputValue: this.value, // internal input content
       hasFocus: false,
 
       linkOptions: {
-        class: 'd-link d-c-text d-d-inline-block',
+        class: "d-link d-c-text d-d-inline-block",
       },
 
       showLinkInput: false,
-      linkInput: '',
+      linkInput: "",
     };
   },
 
   computed: {
-    inputLength () {
+    inputLength() {
       return this.internalInputValue.length;
     },
 
-    htmlOutputFormat () {
+    htmlOutputFormat() {
       return RICH_TEXT_EDITOR_OUTPUT_FORMATS[2];
     },
 
-    showingTextFormatButtons () {
-<<<<<<< ours
-      return this.showBoldButton || this.showItalicsButton || this.showStrikeButton || this.showUnderlineButton;
-    },
-
-    showingAlignmentButtons () {
-      return this.showAlignLeftButton || this.showAlignCenterButton ||
-          this.showAlignRightButton || this.showAlignJustifyButton;
-=======
+    showingTextFormatButtons() {
       return (
         this.showBoldButton ||
         this.showItalicsButton ||
@@ -538,239 +515,194 @@ export default {
       );
     },
 
-    showingAlignmentButtons () {
+    showingAlignmentButtons() {
       return (
         this.showAlignLeftButton ||
         this.showAlignCenterButton ||
         this.showAlignRightButton ||
         this.showAlignJustifyButton
       );
->>>>>>> theirs
     },
 
-    showingListButtons () {
+    showingListButtons() {
       return this.showListItemsButton || this.showOrderedListButton;
     },
 
-    buttonGroups () {
-<<<<<<< ours
-      const individualButtonStacks = this.individualButtons.map(buttonData => ({
-        key: buttonData.selector,
-        buttonGroup: [buttonData],
-      }));
-=======
+    buttonGroups() {
       const individualButtonStacks = this.individualButtons.map(
         (buttonData) => ({
           key: buttonData.selector,
           buttonGroup: [buttonData],
         }),
       );
->>>>>>> theirs
       return [
-        { key: 'new', buttonGroup: this.newButtons },
-        { key: 'format', buttonGroup: this.textFormatButtons },
-        { key: 'alignment', buttonGroup: this.alignmentButtons },
-        { key: 'list', buttonGroup: this.listButtons },
+        { key: "new", buttonGroup: this.newButtons },
+        { key: "format", buttonGroup: this.textFormatButtons },
+        { key: "alignment", buttonGroup: this.alignmentButtons },
+        { key: "list", buttonGroup: this.listButtons },
         ...individualButtonStacks,
-      ].filter(buttonGroupData => buttonGroupData.buttonGroup.length > 0);
+      ].filter((buttonGroupData) => buttonGroupData.buttonGroup.length > 0);
     },
 
-    newButtons () {
+    newButtons() {
       return [
-<<<<<<< ours
-        { showBtn: this.showQuickRepliesButton, label: 'Quick reply', selector: 'quickReplies', icon: DtIconLightningBolt, dataQA: 'dt-editor-quick-replies-btn', tooltipMessage: 'Quick Reply', onClick: this.onQuickRepliesClick },
-      ].filter(button => button.showBtn);
-=======
         {
           showBtn: this.showQuickRepliesButton,
-          label: 'Quick reply',
-          selector: 'quickReplies',
+          label: "Quick reply",
+          selector: "quickReplies",
           icon: DtIconLightningBolt,
-          dataQA: 'dt-editor-quick-replies-btn',
-          tooltipMessage: 'Quick Reply',
+          dataQA: "dt-editor-quick-replies-btn",
+          tooltipMessage: "Quick Reply",
           onClick: this.onQuickRepliesClick,
         },
       ].filter((button) => button.showBtn);
->>>>>>> theirs
     },
 
-    textFormatButtons () {
+    textFormatButtons() {
       return [
-<<<<<<< ours
-        { showBtn: this.showBoldButton, selector: 'bold', icon: DtIconBold, dataQA: 'dt-editor-bold-btn', tooltipMessage: 'Bold', onClick: this.onBoldTextToggle },
-        { showBtn: this.showItalicsButton, selector: 'italic', icon: DtIconItalic, dataQA: 'dt-editor-italics-btn', tooltipMessage: 'Italics', onClick: this.onItalicTextToggle },
-        { showBtn: this.showUnderlineButton, selector: 'underline', icon: DtIconUnderline, dataQA: 'dt-editor-underline-btn', tooltipMessage: 'Underline', onClick: this.onUnderlineTextToggle },
-        { showBtn: this.showStrikeButton, selector: 'strike', icon: DtIconStrikethrough, dataQA: 'dt-editor-strike-btn', tooltipMessage: 'Strike', onClick: this.onStrikethroughTextToggle },
-      ].filter(button => button.showBtn);
-=======
         {
           showBtn: this.showBoldButton,
-          selector: 'bold',
+          selector: "bold",
           icon: DtIconBold,
-          dataQA: 'dt-editor-bold-btn',
-          tooltipMessage: 'Bold',
+          dataQA: "dt-editor-bold-btn",
+          tooltipMessage: "Bold",
           onClick: this.onBoldTextToggle,
         },
         {
           showBtn: this.showItalicsButton,
-          selector: 'italic',
+          selector: "italic",
           icon: DtIconItalic,
-          dataQA: 'dt-editor-italics-btn',
-          tooltipMessage: 'Italics',
+          dataQA: "dt-editor-italics-btn",
+          tooltipMessage: "Italics",
           onClick: this.onItalicTextToggle,
         },
         {
           showBtn: this.showUnderlineButton,
-          selector: 'underline',
+          selector: "underline",
           icon: DtIconUnderline,
-          dataQA: 'dt-editor-underline-btn',
-          tooltipMessage: 'Underline',
+          dataQA: "dt-editor-underline-btn",
+          tooltipMessage: "Underline",
           onClick: this.onUnderlineTextToggle,
         },
         {
           showBtn: this.showStrikeButton,
-          selector: 'strike',
+          selector: "strike",
           icon: DtIconStrikethrough,
-          dataQA: 'dt-editor-strike-btn',
-          tooltipMessage: 'Strike',
+          dataQA: "dt-editor-strike-btn",
+          tooltipMessage: "Strike",
           onClick: this.onStrikethroughTextToggle,
         },
       ].filter((button) => button.showBtn);
->>>>>>> theirs
     },
 
-    alignmentButtons () {
+    alignmentButtons() {
       return [
-<<<<<<< ours
-        { showBtn: this.showAlignLeftButton, selector: { textAlign: 'left' }, icon: DtIconAlignLeft, dataQA: 'dt-editor-align-left-btn', tooltipMessage: 'Align Left', onClick: () => this.onTextAlign('left') },
-        { showBtn: this.showAlignCenterButton, selector: { textAlign: 'center' }, icon: DtIconAlignCenter, dataQA: 'dt-editor-align-center-btn', tooltipMessage: 'Align Center', onClick: () => this.onTextAlign('center') },
-        { showBtn: this.showAlignRightButton, selector: { textAlign: 'right' }, icon: DtIconAlignRight, dataQA: 'dt-editor-align-right-btn', tooltipMessage: 'Align Right', onClick: () => this.onTextAlign('right') },
-        { showBtn: this.showAlignJustifyButton, selector: { textAlign: 'justify' }, icon: DtIconAlignJustify, dataQA: 'dt-editor-align-justify-btn', tooltipMessage: 'Align Justify', onClick: () => this.onTextAlign('justify') },
-      ].filter(button => button.showBtn);
-=======
         {
           showBtn: this.showAlignLeftButton,
-          selector: { textAlign: 'left' },
+          selector: { textAlign: "left" },
           icon: DtIconAlignLeft,
-          dataQA: 'dt-editor-align-left-btn',
-          tooltipMessage: 'Align Left',
-          onClick: () => this.onTextAlign('left'),
+          dataQA: "dt-editor-align-left-btn",
+          tooltipMessage: "Align Left",
+          onClick: () => this.onTextAlign("left"),
         },
         {
           showBtn: this.showAlignCenterButton,
-          selector: { textAlign: 'center' },
+          selector: { textAlign: "center" },
           icon: DtIconAlignCenter,
-          dataQA: 'dt-editor-align-center-btn',
-          tooltipMessage: 'Align Center',
-          onClick: () => this.onTextAlign('center'),
+          dataQA: "dt-editor-align-center-btn",
+          tooltipMessage: "Align Center",
+          onClick: () => this.onTextAlign("center"),
         },
         {
           showBtn: this.showAlignRightButton,
-          selector: { textAlign: 'right' },
+          selector: { textAlign: "right" },
           icon: DtIconAlignRight,
-          dataQA: 'dt-editor-align-right-btn',
-          tooltipMessage: 'Align Right',
-          onClick: () => this.onTextAlign('right'),
+          dataQA: "dt-editor-align-right-btn",
+          tooltipMessage: "Align Right",
+          onClick: () => this.onTextAlign("right"),
         },
         {
           showBtn: this.showAlignJustifyButton,
-          selector: { textAlign: 'justify' },
+          selector: { textAlign: "justify" },
           icon: DtIconAlignJustify,
-          dataQA: 'dt-editor-align-justify-btn',
-          tooltipMessage: 'Align Justify',
-          onClick: () => this.onTextAlign('justify'),
+          dataQA: "dt-editor-align-justify-btn",
+          tooltipMessage: "Align Justify",
+          onClick: () => this.onTextAlign("justify"),
         },
       ].filter((button) => button.showBtn);
->>>>>>> theirs
     },
 
-    listButtons () {
+    listButtons() {
       return [
-<<<<<<< ours
-        { showBtn: this.showListItemsButton, selector: 'bulletList', icon: DtIconListBullet, dataQA: 'dt-editor-list-items-btn', tooltipMessage: 'Bullet List', onClick: this.onBulletListToggle },
-        { showBtn: this.showOrderedListButton, selector: 'orderedList', icon: DtIconListOrdered, dataQA: 'dt-editor-ordered-list-items-btn', tooltipMessage: 'Ordered List', onClick: this.onOrderedListToggle },
-      ].filter(button => button.showBtn);
-=======
         {
           showBtn: this.showListItemsButton,
-          selector: 'bulletList',
+          selector: "bulletList",
           icon: DtIconListBullet,
-          dataQA: 'dt-editor-list-items-btn',
-          tooltipMessage: 'Bullet List',
+          dataQA: "dt-editor-list-items-btn",
+          tooltipMessage: "Bullet List",
           onClick: this.onBulletListToggle,
         },
         {
           showBtn: this.showOrderedListButton,
-          selector: 'orderedList',
+          selector: "orderedList",
           icon: DtIconListOrdered,
-          dataQA: 'dt-editor-ordered-list-items-btn',
-          tooltipMessage: 'Ordered List',
+          dataQA: "dt-editor-ordered-list-items-btn",
+          tooltipMessage: "Ordered List",
           onClick: this.onOrderedListToggle,
         },
       ].filter((button) => button.showBtn);
->>>>>>> theirs
     },
 
-    individualButtons () {
+    individualButtons() {
       return [
-<<<<<<< ours
-        { showBtn: this.showQuoteButton, selector: 'blockquote', icon: DtIconQuote, dataQA: 'dt-editor-blockquote-btn', tooltipMessage: 'Quote', onClick: this.onBlockquoteToggle },
-        { showBtn: this.showCodeBlockButton, selector: 'codeBlock', icon: DtIconCodeBlock, dataQA: 'dt-editor-code-block-btn', tooltipMessage: 'Code', onClick: this.onCodeBlockToggle },
-      ].filter(button => button.showBtn);
-    },
-
-    linkButton () {
-      return { showBtn: this.showAddLink.showAddLinkButton, selector: 'link', icon: DtIconLink2, dataQA: 'dt-editor-add-link-btn', tooltipMessage: 'Link', onClick: this.openLinkInput };
-=======
         {
           showBtn: this.showQuoteButton,
-          selector: 'blockquote',
+          selector: "blockquote",
           icon: DtIconQuote,
-          dataQA: 'dt-editor-blockquote-btn',
-          tooltipMessage: 'Quote',
+          dataQA: "dt-editor-blockquote-btn",
+          tooltipMessage: "Quote",
           onClick: this.onBlockquoteToggle,
         },
         {
           showBtn: this.showCodeBlockButton,
-          selector: 'codeBlock',
+          selector: "codeBlock",
           icon: DtIconCodeBlock,
-          dataQA: 'dt-editor-code-block-btn',
-          tooltipMessage: 'Code',
+          dataQA: "dt-editor-code-block-btn",
+          tooltipMessage: "Code",
           onClick: this.onCodeBlockToggle,
         },
       ].filter((button) => button.showBtn);
     },
 
-    linkButton () {
+    linkButton() {
       return {
         showBtn: this.showAddLink.showAddLinkButton,
-        selector: 'link',
+        selector: "link",
         icon: DtIconLink2,
-        dataQA: 'dt-editor-add-link-btn',
-        tooltipMessage: 'Link',
+        dataQA: "dt-editor-add-link-btn",
+        tooltipMessage: "Link",
         onClick: this.openLinkInput,
       };
->>>>>>> theirs
     },
   },
 
   watch: {
-    value (newValue) {
+    value(newValue) {
       this.internalInputValue = newValue;
     },
   },
 
   methods: {
-    onInputFocus (event) {
+    onInputFocus(event) {
       event?.stopPropagation();
     },
 
-    removeLink () {
+    removeLink() {
       this.$refs.richTextEditor?.editor?.chain()?.focus()?.unsetLink()?.run();
       this.closeLinkInput();
     },
 
-    setLink (event) {
+    setLink(event) {
       const editor = this.$refs.richTextEditor?.editor;
       event?.preventDefault();
       event?.stopPropagation();
@@ -783,7 +715,9 @@ export default {
       }
 
       // Check if input matches any of the supported link formats
-      const prefix = EDITOR_SUPPORTED_LINK_PROTOCOLS.find(prefixRegex => prefixRegex.test(this.linkInput));
+      const prefix = EDITOR_SUPPORTED_LINK_PROTOCOLS.find((prefixRegex) =>
+        prefixRegex.test(this.linkInput),
+      );
 
       if (!prefix) {
         // If no matching pattern is found, prepend default prefix
@@ -809,7 +743,7 @@ export default {
         editor
           .chain()
           .focus()
-          .extendMarkRange('link')
+          .extendMarkRange("link")
           .setLink({ href: this.linkInput, class: this.linkOptions.class })
           .run();
       }
@@ -817,66 +751,59 @@ export default {
       this.closeLinkInput();
     },
 
-    openLinkInput () {
+    openLinkInput() {
       this.showLinkInput = true;
     },
 
-    updateInput (openedInput) {
+    updateInput(openedInput) {
       if (!openedInput) {
         return this.closeLinkInput();
       }
-<<<<<<< ours
-      this.linkInput = this.$refs.richTextEditor?.editor?.getAttributes('link')?.href;
-=======
       this.linkInput =
-        this.$refs.richTextEditor?.editor?.getAttributes('link')?.href;
->>>>>>> theirs
+        this.$refs.richTextEditor?.editor?.getAttributes("link")?.href;
     },
 
-    closeLinkInput () {
+    closeLinkInput() {
       this.showLinkInput = false;
-      this.linkInput = '';
+      this.linkInput = "";
       this.$refs.richTextEditor.editor?.chain().focus();
     },
 
-    onBoldTextToggle () {
+    onBoldTextToggle() {
       this.$refs.richTextEditor?.editor?.chain().focus().toggleBold().run();
     },
 
-    onItalicTextToggle () {
+    onItalicTextToggle() {
       this.$refs.richTextEditor?.editor.chain().focus().toggleItalic().run();
     },
 
-    onUnderlineTextToggle () {
+    onUnderlineTextToggle() {
       this.$refs.richTextEditor?.editor.chain().focus().toggleUnderline().run();
     },
 
-    onStrikethroughTextToggle () {
+    onStrikethroughTextToggle() {
       this.$refs.richTextEditor?.editor.chain().focus().toggleStrike().run();
     },
 
-    onTextAlign (alignment) {
-<<<<<<< ours
-      if (this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })) {
-=======
+    onTextAlign(alignment) {
       if (
         this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })
       ) {
->>>>>>> theirs
         // If this alignment type is already set here, unset it
-        return this.$refs.richTextEditor?.editor.chain().focus().unsetTextAlign().run();
+        return this.$refs.richTextEditor?.editor
+          .chain()
+          .focus()
+          .unsetTextAlign()
+          .run();
       }
-      this.$refs.richTextEditor?.editor.chain().focus().setTextAlign(alignment).run();
+      this.$refs.richTextEditor?.editor
+        .chain()
+        .focus()
+        .setTextAlign(alignment)
+        .run();
     },
 
-    onBulletListToggle () {
-<<<<<<< ours
-      this.$refs.richTextEditor?.editor.chain().focus().toggleBulletList().run();
-    },
-
-    onOrderedListToggle () {
-      this.$refs.richTextEditor?.editor.chain().focus().toggleOrderedList().run();
-=======
+    onBulletListToggle() {
       this.$refs.richTextEditor?.editor
         .chain()
         .focus()
@@ -884,49 +811,43 @@ export default {
         .run();
     },
 
-    onOrderedListToggle () {
+    onOrderedListToggle() {
       this.$refs.richTextEditor?.editor
         .chain()
         .focus()
         .toggleOrderedList()
         .run();
->>>>>>> theirs
     },
 
-    onCodeBlockToggle () {
+    onCodeBlockToggle() {
       this.$refs.richTextEditor?.editor.chain().focus().toggleCodeBlock().run();
     },
 
-    onQuickRepliesClick () {
-      this.$emit('quick-replies-click');
+    onQuickRepliesClick() {
+      this.$emit("quick-replies-click");
     },
 
-    onBlockquoteToggle () {
-<<<<<<< ours
-      this.$refs.richTextEditor?.editor.chain().focus().toggleBlockquote().run();
-=======
+    onBlockquoteToggle() {
       this.$refs.richTextEditor?.editor
         .chain()
         .focus()
         .toggleBlockquote()
         .run();
->>>>>>> theirs
     },
 
-    onFocus (event) {
+    onFocus(event) {
       this.hasFocus = true;
-      this.$emit('focus', event);
+      this.$emit("focus", event);
     },
 
-    onBlur (event) {
+    onBlur(event) {
       this.hasFocus = false;
-      this.$emit('blur', event);
+      this.$emit("blur", event);
     },
 
-    onInput (event) {
-      this.$emit('input', event);
+    onInput(event) {
+      this.$emit("input", event);
     },
-
   },
 };
 </script>

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -205,11 +205,7 @@ import {
   DtIconQuote,
   DtIconStrikethrough,
   DtIconUnderline,
-<<<<<<< ours
 } from '@dialpad/dialtone-icons/vue2';
-=======
-} from '@dialpad/dialtone-icons/vue3';
->>>>>>> theirs
 
 export default {
   name: 'DtRecipeEditor',
@@ -490,11 +486,7 @@ export default {
      * Quick replies button
      * pressed event
      * @event quick-replies-click
-<<<<<<< ours
     */
-=======
-     */
->>>>>>> theirs
     'quick-replies-click',
   ],
 
@@ -522,30 +514,12 @@ export default {
     },
 
     showingTextFormatButtons () {
-<<<<<<< ours
       return this.showBoldButton || this.showItalicsButton || this.showStrikeButton || this.showUnderlineButton;
     },
 
     showingAlignmentButtons () {
       return this.showAlignLeftButton || this.showAlignCenterButton ||
           this.showAlignRightButton || this.showAlignJustifyButton;
-=======
-      return (
-        this.showBoldButton ||
-        this.showItalicsButton ||
-        this.showStrikeButton ||
-        this.showUnderlineButton
-      );
-    },
-
-    showingAlignmentButtons () {
-      return (
-        this.showAlignLeftButton ||
-        this.showAlignCenterButton ||
-        this.showAlignRightButton ||
-        this.showAlignJustifyButton
-      );
->>>>>>> theirs
     },
 
     showingListButtons () {
@@ -553,19 +527,10 @@ export default {
     },
 
     buttonGroups () {
-<<<<<<< ours
       const individualButtonStacks = this.individualButtons.map(buttonData => ({
         key: buttonData.selector,
         buttonGroup: [buttonData],
       }));
-=======
-      const individualButtonStacks = this.individualButtons.map(
-        (buttonData) => ({
-          key: buttonData.selector,
-          buttonGroup: [buttonData],
-        }),
-      );
->>>>>>> theirs
       return [
         { key: 'new', buttonGroup: this.newButtons },
         { key: 'format', buttonGroup: this.textFormatButtons },
@@ -577,143 +542,37 @@ export default {
 
     newButtons () {
       return [
-<<<<<<< ours
         { showBtn: this.showQuickRepliesButton, label: 'Quick reply', selector: 'quickReplies', icon: DtIconLightningBolt, dataQA: 'dt-editor-quick-replies-btn', tooltipMessage: 'Quick Reply', onClick: this.onQuickRepliesClick },
       ].filter(button => button.showBtn);
-=======
-        {
-          showBtn: this.showQuickRepliesButton,
-          label: 'Quick reply',
-          selector: 'quickReplies',
-          icon: DtIconLightningBolt,
-          dataQA: 'dt-editor-quick-replies-btn',
-          tooltipMessage: 'Quick Reply',
-          onClick: this.onQuickRepliesClick,
-        },
-      ].filter((button) => button.showBtn);
->>>>>>> theirs
     },
 
     textFormatButtons () {
       return [
-<<<<<<< ours
         { showBtn: this.showBoldButton, selector: 'bold', icon: DtIconBold, dataQA: 'dt-editor-bold-btn', tooltipMessage: 'Bold', onClick: this.onBoldTextToggle },
         { showBtn: this.showItalicsButton, selector: 'italic', icon: DtIconItalic, dataQA: 'dt-editor-italics-btn', tooltipMessage: 'Italics', onClick: this.onItalicTextToggle },
         { showBtn: this.showUnderlineButton, selector: 'underline', icon: DtIconUnderline, dataQA: 'dt-editor-underline-btn', tooltipMessage: 'Underline', onClick: this.onUnderlineTextToggle },
         { showBtn: this.showStrikeButton, selector: 'strike', icon: DtIconStrikethrough, dataQA: 'dt-editor-strike-btn', tooltipMessage: 'Strike', onClick: this.onStrikethroughTextToggle },
       ].filter(button => button.showBtn);
-=======
-        {
-          showBtn: this.showBoldButton,
-          selector: 'bold',
-          icon: DtIconBold,
-          dataQA: 'dt-editor-bold-btn',
-          tooltipMessage: 'Bold',
-          onClick: this.onBoldTextToggle,
-        },
-        {
-          showBtn: this.showItalicsButton,
-          selector: 'italic',
-          icon: DtIconItalic,
-          dataQA: 'dt-editor-italics-btn',
-          tooltipMessage: 'Italics',
-          onClick: this.onItalicTextToggle,
-        },
-        {
-          showBtn: this.showUnderlineButton,
-          selector: 'underline',
-          icon: DtIconUnderline,
-          dataQA: 'dt-editor-underline-btn',
-          tooltipMessage: 'Underline',
-          onClick: this.onUnderlineTextToggle,
-        },
-        {
-          showBtn: this.showStrikeButton,
-          selector: 'strike',
-          icon: DtIconStrikethrough,
-          dataQA: 'dt-editor-strike-btn',
-          tooltipMessage: 'Strike',
-          onClick: this.onStrikethroughTextToggle,
-        },
-      ].filter((button) => button.showBtn);
->>>>>>> theirs
     },
 
     alignmentButtons () {
       return [
-<<<<<<< ours
         { showBtn: this.showAlignLeftButton, selector: { textAlign: 'left' }, icon: DtIconAlignLeft, dataQA: 'dt-editor-align-left-btn', tooltipMessage: 'Align Left', onClick: () => this.onTextAlign('left') },
         { showBtn: this.showAlignCenterButton, selector: { textAlign: 'center' }, icon: DtIconAlignCenter, dataQA: 'dt-editor-align-center-btn', tooltipMessage: 'Align Center', onClick: () => this.onTextAlign('center') },
         { showBtn: this.showAlignRightButton, selector: { textAlign: 'right' }, icon: DtIconAlignRight, dataQA: 'dt-editor-align-right-btn', tooltipMessage: 'Align Right', onClick: () => this.onTextAlign('right') },
         { showBtn: this.showAlignJustifyButton, selector: { textAlign: 'justify' }, icon: DtIconAlignJustify, dataQA: 'dt-editor-align-justify-btn', tooltipMessage: 'Align Justify', onClick: () => this.onTextAlign('justify') },
       ].filter(button => button.showBtn);
-=======
-        {
-          showBtn: this.showAlignLeftButton,
-          selector: { textAlign: 'left' },
-          icon: DtIconAlignLeft,
-          dataQA: 'dt-editor-align-left-btn',
-          tooltipMessage: 'Align Left',
-          onClick: () => this.onTextAlign('left'),
-        },
-        {
-          showBtn: this.showAlignCenterButton,
-          selector: { textAlign: 'center' },
-          icon: DtIconAlignCenter,
-          dataQA: 'dt-editor-align-center-btn',
-          tooltipMessage: 'Align Center',
-          onClick: () => this.onTextAlign('center'),
-        },
-        {
-          showBtn: this.showAlignRightButton,
-          selector: { textAlign: 'right' },
-          icon: DtIconAlignRight,
-          dataQA: 'dt-editor-align-right-btn',
-          tooltipMessage: 'Align Right',
-          onClick: () => this.onTextAlign('right'),
-        },
-        {
-          showBtn: this.showAlignJustifyButton,
-          selector: { textAlign: 'justify' },
-          icon: DtIconAlignJustify,
-          dataQA: 'dt-editor-align-justify-btn',
-          tooltipMessage: 'Align Justify',
-          onClick: () => this.onTextAlign('justify'),
-        },
-      ].filter((button) => button.showBtn);
->>>>>>> theirs
     },
 
     listButtons () {
       return [
-<<<<<<< ours
         { showBtn: this.showListItemsButton, selector: 'bulletList', icon: DtIconListBullet, dataQA: 'dt-editor-list-items-btn', tooltipMessage: 'Bullet List', onClick: this.onBulletListToggle },
         { showBtn: this.showOrderedListButton, selector: 'orderedList', icon: DtIconListOrdered, dataQA: 'dt-editor-ordered-list-items-btn', tooltipMessage: 'Ordered List', onClick: this.onOrderedListToggle },
       ].filter(button => button.showBtn);
-=======
-        {
-          showBtn: this.showListItemsButton,
-          selector: 'bulletList',
-          icon: DtIconListBullet,
-          dataQA: 'dt-editor-list-items-btn',
-          tooltipMessage: 'Bullet List',
-          onClick: this.onBulletListToggle,
-        },
-        {
-          showBtn: this.showOrderedListButton,
-          selector: 'orderedList',
-          icon: DtIconListOrdered,
-          dataQA: 'dt-editor-ordered-list-items-btn',
-          tooltipMessage: 'Ordered List',
-          onClick: this.onOrderedListToggle,
-        },
-      ].filter((button) => button.showBtn);
->>>>>>> theirs
     },
 
     individualButtons () {
       return [
-<<<<<<< ours
         { showBtn: this.showQuoteButton, selector: 'blockquote', icon: DtIconQuote, dataQA: 'dt-editor-blockquote-btn', tooltipMessage: 'Quote', onClick: this.onBlockquoteToggle },
         { showBtn: this.showCodeBlockButton, selector: 'codeBlock', icon: DtIconCodeBlock, dataQA: 'dt-editor-code-block-btn', tooltipMessage: 'Code', onClick: this.onCodeBlockToggle },
       ].filter(button => button.showBtn);
@@ -721,36 +580,6 @@ export default {
 
     linkButton () {
       return { showBtn: this.showAddLink.showAddLinkButton, selector: 'link', icon: DtIconLink2, dataQA: 'dt-editor-add-link-btn', tooltipMessage: 'Link', onClick: this.openLinkInput };
-=======
-        {
-          showBtn: this.showQuoteButton,
-          selector: 'blockquote',
-          icon: DtIconQuote,
-          dataQA: 'dt-editor-blockquote-btn',
-          tooltipMessage: 'Quote',
-          onClick: this.onBlockquoteToggle,
-        },
-        {
-          showBtn: this.showCodeBlockButton,
-          selector: 'codeBlock',
-          icon: DtIconCodeBlock,
-          dataQA: 'dt-editor-code-block-btn',
-          tooltipMessage: 'Code',
-          onClick: this.onCodeBlockToggle,
-        },
-      ].filter((button) => button.showBtn);
-    },
-
-    linkButton () {
-      return {
-        showBtn: this.showAddLink.showAddLinkButton,
-        selector: 'link',
-        icon: DtIconLink2,
-        dataQA: 'dt-editor-add-link-btn',
-        tooltipMessage: 'Link',
-        onClick: this.openLinkInput,
-      };
->>>>>>> theirs
     },
   },
 
@@ -825,12 +654,7 @@ export default {
       if (!openedInput) {
         return this.closeLinkInput();
       }
-<<<<<<< ours
       this.linkInput = this.$refs.richTextEditor?.editor?.getAttributes('link')?.href;
-=======
-      this.linkInput =
-        this.$refs.richTextEditor?.editor?.getAttributes('link')?.href;
->>>>>>> theirs
     },
 
     closeLinkInput () {
@@ -856,13 +680,7 @@ export default {
     },
 
     onTextAlign (alignment) {
-<<<<<<< ours
       if (this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })) {
-=======
-      if (
-        this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })
-      ) {
->>>>>>> theirs
         // If this alignment type is already set here, unset it
         return this.$refs.richTextEditor?.editor.chain().focus().unsetTextAlign().run();
       }
@@ -870,27 +688,11 @@ export default {
     },
 
     onBulletListToggle () {
-<<<<<<< ours
       this.$refs.richTextEditor?.editor.chain().focus().toggleBulletList().run();
     },
 
     onOrderedListToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleOrderedList().run();
-=======
-      this.$refs.richTextEditor?.editor
-        .chain()
-        .focus()
-        .toggleBulletList()
-        .run();
-    },
-
-    onOrderedListToggle () {
-      this.$refs.richTextEditor?.editor
-        .chain()
-        .focus()
-        .toggleOrderedList()
-        .run();
->>>>>>> theirs
     },
 
     onCodeBlockToggle () {
@@ -902,15 +704,7 @@ export default {
     },
 
     onBlockquoteToggle () {
-<<<<<<< ours
       this.$refs.richTextEditor?.editor.chain().focus().toggleBlockquote().run();
-=======
-      this.$refs.richTextEditor?.editor
-        .chain()
-        .focus()
-        .toggleBlockquote()
-        .run();
->>>>>>> theirs
     },
 
     onFocus (event) {

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -205,7 +205,11 @@ import {
   DtIconQuote,
   DtIconStrikethrough,
   DtIconUnderline,
+<<<<<<< ours
 } from '@dialpad/dialtone-icons/vue2';
+=======
+} from '@dialpad/dialtone-icons/vue3';
+>>>>>>> theirs
 
 export default {
   name: 'DtRecipeEditor',
@@ -486,7 +490,11 @@ export default {
      * Quick replies button
      * pressed event
      * @event quick-replies-click
+<<<<<<< ours
     */
+=======
+     */
+>>>>>>> theirs
     'quick-replies-click',
   ],
 
@@ -514,12 +522,30 @@ export default {
     },
 
     showingTextFormatButtons () {
+<<<<<<< ours
       return this.showBoldButton || this.showItalicsButton || this.showStrikeButton || this.showUnderlineButton;
     },
 
     showingAlignmentButtons () {
       return this.showAlignLeftButton || this.showAlignCenterButton ||
           this.showAlignRightButton || this.showAlignJustifyButton;
+=======
+      return (
+        this.showBoldButton ||
+        this.showItalicsButton ||
+        this.showStrikeButton ||
+        this.showUnderlineButton
+      );
+    },
+
+    showingAlignmentButtons () {
+      return (
+        this.showAlignLeftButton ||
+        this.showAlignCenterButton ||
+        this.showAlignRightButton ||
+        this.showAlignJustifyButton
+      );
+>>>>>>> theirs
     },
 
     showingListButtons () {
@@ -527,10 +553,19 @@ export default {
     },
 
     buttonGroups () {
+<<<<<<< ours
       const individualButtonStacks = this.individualButtons.map(buttonData => ({
         key: buttonData.selector,
         buttonGroup: [buttonData],
       }));
+=======
+      const individualButtonStacks = this.individualButtons.map(
+        (buttonData) => ({
+          key: buttonData.selector,
+          buttonGroup: [buttonData],
+        }),
+      );
+>>>>>>> theirs
       return [
         { key: 'new', buttonGroup: this.newButtons },
         { key: 'format', buttonGroup: this.textFormatButtons },
@@ -542,37 +577,143 @@ export default {
 
     newButtons () {
       return [
+<<<<<<< ours
         { showBtn: this.showQuickRepliesButton, label: 'Quick reply', selector: 'quickReplies', icon: DtIconLightningBolt, dataQA: 'dt-editor-quick-replies-btn', tooltipMessage: 'Quick Reply', onClick: this.onQuickRepliesClick },
       ].filter(button => button.showBtn);
+=======
+        {
+          showBtn: this.showQuickRepliesButton,
+          label: 'Quick reply',
+          selector: 'quickReplies',
+          icon: DtIconLightningBolt,
+          dataQA: 'dt-editor-quick-replies-btn',
+          tooltipMessage: 'Quick Reply',
+          onClick: this.onQuickRepliesClick,
+        },
+      ].filter((button) => button.showBtn);
+>>>>>>> theirs
     },
 
     textFormatButtons () {
       return [
+<<<<<<< ours
         { showBtn: this.showBoldButton, selector: 'bold', icon: DtIconBold, dataQA: 'dt-editor-bold-btn', tooltipMessage: 'Bold', onClick: this.onBoldTextToggle },
         { showBtn: this.showItalicsButton, selector: 'italic', icon: DtIconItalic, dataQA: 'dt-editor-italics-btn', tooltipMessage: 'Italics', onClick: this.onItalicTextToggle },
         { showBtn: this.showUnderlineButton, selector: 'underline', icon: DtIconUnderline, dataQA: 'dt-editor-underline-btn', tooltipMessage: 'Underline', onClick: this.onUnderlineTextToggle },
         { showBtn: this.showStrikeButton, selector: 'strike', icon: DtIconStrikethrough, dataQA: 'dt-editor-strike-btn', tooltipMessage: 'Strike', onClick: this.onStrikethroughTextToggle },
       ].filter(button => button.showBtn);
+=======
+        {
+          showBtn: this.showBoldButton,
+          selector: 'bold',
+          icon: DtIconBold,
+          dataQA: 'dt-editor-bold-btn',
+          tooltipMessage: 'Bold',
+          onClick: this.onBoldTextToggle,
+        },
+        {
+          showBtn: this.showItalicsButton,
+          selector: 'italic',
+          icon: DtIconItalic,
+          dataQA: 'dt-editor-italics-btn',
+          tooltipMessage: 'Italics',
+          onClick: this.onItalicTextToggle,
+        },
+        {
+          showBtn: this.showUnderlineButton,
+          selector: 'underline',
+          icon: DtIconUnderline,
+          dataQA: 'dt-editor-underline-btn',
+          tooltipMessage: 'Underline',
+          onClick: this.onUnderlineTextToggle,
+        },
+        {
+          showBtn: this.showStrikeButton,
+          selector: 'strike',
+          icon: DtIconStrikethrough,
+          dataQA: 'dt-editor-strike-btn',
+          tooltipMessage: 'Strike',
+          onClick: this.onStrikethroughTextToggle,
+        },
+      ].filter((button) => button.showBtn);
+>>>>>>> theirs
     },
 
     alignmentButtons () {
       return [
+<<<<<<< ours
         { showBtn: this.showAlignLeftButton, selector: { textAlign: 'left' }, icon: DtIconAlignLeft, dataQA: 'dt-editor-align-left-btn', tooltipMessage: 'Align Left', onClick: () => this.onTextAlign('left') },
         { showBtn: this.showAlignCenterButton, selector: { textAlign: 'center' }, icon: DtIconAlignCenter, dataQA: 'dt-editor-align-center-btn', tooltipMessage: 'Align Center', onClick: () => this.onTextAlign('center') },
         { showBtn: this.showAlignRightButton, selector: { textAlign: 'right' }, icon: DtIconAlignRight, dataQA: 'dt-editor-align-right-btn', tooltipMessage: 'Align Right', onClick: () => this.onTextAlign('right') },
         { showBtn: this.showAlignJustifyButton, selector: { textAlign: 'justify' }, icon: DtIconAlignJustify, dataQA: 'dt-editor-align-justify-btn', tooltipMessage: 'Align Justify', onClick: () => this.onTextAlign('justify') },
       ].filter(button => button.showBtn);
+=======
+        {
+          showBtn: this.showAlignLeftButton,
+          selector: { textAlign: 'left' },
+          icon: DtIconAlignLeft,
+          dataQA: 'dt-editor-align-left-btn',
+          tooltipMessage: 'Align Left',
+          onClick: () => this.onTextAlign('left'),
+        },
+        {
+          showBtn: this.showAlignCenterButton,
+          selector: { textAlign: 'center' },
+          icon: DtIconAlignCenter,
+          dataQA: 'dt-editor-align-center-btn',
+          tooltipMessage: 'Align Center',
+          onClick: () => this.onTextAlign('center'),
+        },
+        {
+          showBtn: this.showAlignRightButton,
+          selector: { textAlign: 'right' },
+          icon: DtIconAlignRight,
+          dataQA: 'dt-editor-align-right-btn',
+          tooltipMessage: 'Align Right',
+          onClick: () => this.onTextAlign('right'),
+        },
+        {
+          showBtn: this.showAlignJustifyButton,
+          selector: { textAlign: 'justify' },
+          icon: DtIconAlignJustify,
+          dataQA: 'dt-editor-align-justify-btn',
+          tooltipMessage: 'Align Justify',
+          onClick: () => this.onTextAlign('justify'),
+        },
+      ].filter((button) => button.showBtn);
+>>>>>>> theirs
     },
 
     listButtons () {
       return [
+<<<<<<< ours
         { showBtn: this.showListItemsButton, selector: 'bulletList', icon: DtIconListBullet, dataQA: 'dt-editor-list-items-btn', tooltipMessage: 'Bullet List', onClick: this.onBulletListToggle },
         { showBtn: this.showOrderedListButton, selector: 'orderedList', icon: DtIconListOrdered, dataQA: 'dt-editor-ordered-list-items-btn', tooltipMessage: 'Ordered List', onClick: this.onOrderedListToggle },
       ].filter(button => button.showBtn);
+=======
+        {
+          showBtn: this.showListItemsButton,
+          selector: 'bulletList',
+          icon: DtIconListBullet,
+          dataQA: 'dt-editor-list-items-btn',
+          tooltipMessage: 'Bullet List',
+          onClick: this.onBulletListToggle,
+        },
+        {
+          showBtn: this.showOrderedListButton,
+          selector: 'orderedList',
+          icon: DtIconListOrdered,
+          dataQA: 'dt-editor-ordered-list-items-btn',
+          tooltipMessage: 'Ordered List',
+          onClick: this.onOrderedListToggle,
+        },
+      ].filter((button) => button.showBtn);
+>>>>>>> theirs
     },
 
     individualButtons () {
       return [
+<<<<<<< ours
         { showBtn: this.showQuoteButton, selector: 'blockquote', icon: DtIconQuote, dataQA: 'dt-editor-blockquote-btn', tooltipMessage: 'Quote', onClick: this.onBlockquoteToggle },
         { showBtn: this.showCodeBlockButton, selector: 'codeBlock', icon: DtIconCodeBlock, dataQA: 'dt-editor-code-block-btn', tooltipMessage: 'Code', onClick: this.onCodeBlockToggle },
       ].filter(button => button.showBtn);
@@ -580,6 +721,36 @@ export default {
 
     linkButton () {
       return { showBtn: this.showAddLink.showAddLinkButton, selector: 'link', icon: DtIconLink2, dataQA: 'dt-editor-add-link-btn', tooltipMessage: 'Link', onClick: this.openLinkInput };
+=======
+        {
+          showBtn: this.showQuoteButton,
+          selector: 'blockquote',
+          icon: DtIconQuote,
+          dataQA: 'dt-editor-blockquote-btn',
+          tooltipMessage: 'Quote',
+          onClick: this.onBlockquoteToggle,
+        },
+        {
+          showBtn: this.showCodeBlockButton,
+          selector: 'codeBlock',
+          icon: DtIconCodeBlock,
+          dataQA: 'dt-editor-code-block-btn',
+          tooltipMessage: 'Code',
+          onClick: this.onCodeBlockToggle,
+        },
+      ].filter((button) => button.showBtn);
+    },
+
+    linkButton () {
+      return {
+        showBtn: this.showAddLink.showAddLinkButton,
+        selector: 'link',
+        icon: DtIconLink2,
+        dataQA: 'dt-editor-add-link-btn',
+        tooltipMessage: 'Link',
+        onClick: this.openLinkInput,
+      };
+>>>>>>> theirs
     },
   },
 
@@ -654,7 +825,12 @@ export default {
       if (!openedInput) {
         return this.closeLinkInput();
       }
+<<<<<<< ours
       this.linkInput = this.$refs.richTextEditor?.editor?.getAttributes('link')?.href;
+=======
+      this.linkInput =
+        this.$refs.richTextEditor?.editor?.getAttributes('link')?.href;
+>>>>>>> theirs
     },
 
     closeLinkInput () {
@@ -680,7 +856,13 @@ export default {
     },
 
     onTextAlign (alignment) {
+<<<<<<< ours
       if (this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })) {
+=======
+      if (
+        this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })
+      ) {
+>>>>>>> theirs
         // If this alignment type is already set here, unset it
         return this.$refs.richTextEditor?.editor.chain().focus().unsetTextAlign().run();
       }
@@ -688,11 +870,27 @@ export default {
     },
 
     onBulletListToggle () {
+<<<<<<< ours
       this.$refs.richTextEditor?.editor.chain().focus().toggleBulletList().run();
     },
 
     onOrderedListToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleOrderedList().run();
+=======
+      this.$refs.richTextEditor?.editor
+        .chain()
+        .focus()
+        .toggleBulletList()
+        .run();
+    },
+
+    onOrderedListToggle () {
+      this.$refs.richTextEditor?.editor
+        .chain()
+        .focus()
+        .toggleOrderedList()
+        .run();
+>>>>>>> theirs
     },
 
     onCodeBlockToggle () {
@@ -704,7 +902,15 @@ export default {
     },
 
     onBlockquoteToggle () {
+<<<<<<< ours
       this.$refs.richTextEditor?.editor.chain().focus().toggleBlockquote().run();
+=======
+      this.$refs.richTextEditor?.editor
+        .chain()
+        .focus()
+        .toggleBlockquote()
+        .run();
+>>>>>>> theirs
     },
 
     onFocus (event) {

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -102,7 +102,7 @@
               :input-aria-label="showAddLink.setLinkInputAriaLabel"
               data-qa="dt-editor-link-input"
               :placeholder="setLinkPlaceholder"
-              input-wrapper-class="d-bgc-black-100 d-mt6 d-bar5 d-ba d-baw1 d-bc-black-300 d-py2 d-ol-none"
+              input-wrapper-class="d-bgc-secondary d-mt6 d-bar5 d-ba d-baw1 d-bc-default d-py2 d-ol-none"
               @click="onInputFocus"
               @click.native.stop="onInputFocus"
               @focus="onInputFocus"

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -775,6 +775,11 @@ export default {
   border-radius: var(--dt-size-radius-400);
   border: var(--dt-size-border-100) solid;
   border-color: var(--dt-color-border-default);
+<<<<<<< ours
+=======
+  box-shadow: 0 0 0 0 rgba(0, 0, 0, 0%);
+  line-height: var(--dt-font-line-height-400);
+>>>>>>> theirs
   cursor: text;
 
   &:focus-within {
@@ -783,7 +788,7 @@ export default {
   }
 
   &__editor-wrapper {
-    padding: var(--dt-space-400) var(--dt-space-500) var(--dt-space-300);
+    padding: var(--dt-space-450) var(--dt-space-500) var(--dt-space-300);
   }
 
   &__remaining-char-tooltip {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -801,10 +801,6 @@ export default {
     box-shadow: 0 0 var(--dt-size-300) 0 var(--dt-color-surface-moderate-opaque);
   }
 
-  &:not(:hover):not(:focus-within) .dt-message-input__button {
-    opacity: 0.75;
-  }
-
   &__editor-wrapper {
     padding: var(--dt-space-450) var(--dt-space-500) var(--dt-space-300);
   }

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -51,7 +51,6 @@
     <section class="dt-message-input__bottom-section">
       <!-- Left content -->
       <div class="dt-message-input__bottom-section-left">
-<<<<<<< ours
         <dt-button
           v-if="showImagePicker"
           v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
@@ -130,94 +129,6 @@
         </dt-popover>
         <!-- @slot Slot for emojiGiphy picker -->
         <slot name="emojiGiphyPicker" />
-=======
-        <dt-stack
-          gap="200"
-          direction="row"
-        >
-          <dt-button
-            v-if="showImagePicker"
-            v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
-            data-qa="dt-message-input-image-btn"
-            size="sm"
-            class="d-bar4"
-            style="width: 2.8rem; height: 2.8rem"
-            :kind="imagePickerFocus ? 'muted' : 'muted'"
-            importance="clear"
-            :aria-label="showImagePicker.ariaLabel"
-            @click="onSelectImage"
-            @mouseenter="imagePickerFocus = true"
-            @mouseleave="imagePickerFocus = false"
-            @focus="imagePickerFocus = true"
-            @blur="imagePickerFocus = false"
-          >
-            <template #icon>
-              <dt-icon-image size="300" />
-            </template>
-          </dt-button>
-          <dt-input
-            ref="messageInputImageUpload"
-            data-qa="dt-message-input-image-input"
-            accept="image/*, video/*"
-            type="file"
-            class="dt-message-input__image-input"
-            multiple
-            hidden
-            @input="onImageUpload"
-          />
-          <dt-popover
-            v-if="showEmojiPicker"
-            v-model:open="emojiPickerOpened"
-            data-qa="dt-message-input-emoji-picker-popover"
-            initial-focus-element="#searchInput"
-            padding="none"
-          >
-            <template #anchor="{ attrs }">
-              <dt-button
-                v-dt-tooltip="emojiTooltipMessage"
-                v-bind="attrs"
-                data-qa="dt-message-input-emoji-picker-btn"
-                size="sm"
-                class="d-bar4"
-                style="width: 2.8rem; height: 2.8rem"
-                :kind="emojiPickerHovered ? 'muted' : 'muted'"
-                importance="clear"
-                :aria-label="emojiButtonAriaLabel"
-                @click="toggleEmojiPicker"
-                @mouseenter="emojiPickerFocus = true"
-                @mouseleave="emojiPickerFocus = false"
-                @focus="emojiPickerFocus = true"
-                @blur="emojiPickerFocus = false"
-              >
-                <template #icon>
-                  <dt-icon-very-satisfied
-                    v-if="emojiPickerHovered"
-                    size="300"
-                  />
-                  <dt-icon-satisfied
-                    v-else
-                    size="300"
-                  />
-                </template>
-              </dt-button>
-            </template>
-            <template #content="{ close }">
-              <dt-emoji-picker
-                v-bind="emojiPickerProps"
-                @skin-tone="onSkinTone"
-                @selected-emoji="
-                  (emoji) => {
-                    close();
-                    onSelectEmoji(emoji);
-                  }
-                "
-              />
-            </template>
-          </dt-popover>
-          <!-- @slot Slot for emojiGiphy picker -->
-          <slot name="emojiGiphyPicker" />
-        </dt-stack>
->>>>>>> theirs
       </div>
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
@@ -290,13 +201,9 @@
                 name="sendIcon"
                 :icon-size="sendIconSize"
               >
-<<<<<<< ours
                 <dt-icon-send
                   :size="sendIconSize"
                 />
-=======
-                <dt-icon-send :size="sendIconSize" />
->>>>>>> theirs
               </slot>
             </template>
             <template
@@ -324,17 +231,7 @@ import { DtEmojiPicker } from '@/components/emoji_picker';
 import { DtPopover } from '@/components/popover';
 import { DtInput } from '@/components/input';
 import { DtTooltip } from '@/components/tooltip';
-<<<<<<< ours
 import { DtIconImage, DtIconVerySatisfied, DtIconSatisfied, DtIconSend } from '@dialpad/dialtone-icons/vue2';
-=======
-import { DtStack } from '@/components/stack';
-import {
-  DtIconImage,
-  DtIconVerySatisfied,
-  DtIconSatisfied,
-  DtIconSend,
-} from '@dialpad/dialtone-icons/vue3';
->>>>>>> theirs
 
 export default {
   name: 'DtRecipeMessageInput',
@@ -489,11 +386,7 @@ export default {
           'searchPlaceholderLabel',
           'skinSelectorButtonTooltipLabel',
           'tabSetLabels',
-<<<<<<< ours
         ].every(prop => emojiPickerProps[prop] != null);
-=======
-        ].every((prop) => emojiPickerProps[prop] != null);
->>>>>>> theirs
       },
     },
 
@@ -524,14 +417,7 @@ export default {
 
     showImagePicker: {
       type: [Boolean, Object],
-<<<<<<< ours
       default: () => ({ tooltipLabel: 'Attach Image', ariaLabel: 'image button' }),
-=======
-      default: () => ({
-        tooltipLabel: 'Attach Image',
-        ariaLabel: 'image button',
-      }),
->>>>>>> theirs
     },
 
     /**
@@ -735,11 +621,7 @@ export default {
      * @event update:value
      * @type {String|JSON}
      */
-<<<<<<< ours
     'update:value',
-=======
-    'update:modelValue',
->>>>>>> theirs
   ],
 
   data () {
@@ -762,7 +644,6 @@ export default {
     },
 
     displayCharacterLimitWarning () {
-<<<<<<< ours
       return Boolean(this.showCharacterLimit) &&
         ((this.showCharacterLimit.count - this.inputLength) <= this.showCharacterLimit.warning);
     },
@@ -774,28 +655,6 @@ export default {
     isSendDisabled () {
       return this.disableSend ||
       (this.showCharacterLimit && this.inputLength > this.showCharacterLimit.count);
-=======
-      return (
-        Boolean(this.showCharacterLimit) &&
-        this.showCharacterLimit.count - this.inputLength <=
-          this.showCharacterLimit.warning
-      );
-    },
-
-    characterLimitTooltipEnabled () {
-      return (
-        this.showCharacterLimit.message &&
-        this.showCharacterLimit.count - this.inputLength < 0
-      );
-    },
-
-    isSendDisabled () {
-      return (
-        this.disableSend ||
-        (this.showCharacterLimit &&
-          this.inputLength > this.showCharacterLimit.count)
-      );
->>>>>>> theirs
     },
 
     computedCloseButtonProps () {
@@ -814,11 +673,7 @@ export default {
   },
 
   watch: {
-<<<<<<< ours
     value (newValue) {
-=======
-    modelValue (newValue) {
->>>>>>> theirs
       this.internalInputValue = newValue;
     },
 
@@ -830,26 +685,15 @@ export default {
   },
 
   created () {
-<<<<<<< ours
     if (this.value && this.outputFormat === 'text') {
       this.internalInputValue = this.value.replace(/\n/g, '<br>');
-=======
-    if (this.modelValue && this.outputFormat === 'text') {
-      this.internalInputValue = this.modelValue.replace(/\n/g, '<br>');
->>>>>>> theirs
     }
   },
 
   methods: {
     // Mousedown instead of click because it fires before the blur event.
     onMousedown (e) {
-<<<<<<< ours
       const isWithinInput = this.$refs.richTextEditor.$el.querySelector('.tiptap').contains(e.target);
-=======
-      const isWithinInput = this.$refs.richTextEditor.$el
-        .querySelector('.tiptap')
-        .contains(e.target);
->>>>>>> theirs
 
       // If the click is not within the tiptap rich text editor input itself, but still within the wrapping div,
       // focus the editor.
@@ -899,14 +743,7 @@ export default {
     },
 
     onImageUpload () {
-<<<<<<< ours
       this.$emit('select-media', this.$refs.messageInputImageUpload.$refs.input.files);
-=======
-      this.$emit(
-        'select-media',
-        this.$refs.messageInputImageUpload.$refs.input.files,
-      );
->>>>>>> theirs
     },
 
     toggleEmojiPicker () {
@@ -925,11 +762,7 @@ export default {
     },
 
     onInput (event) {
-<<<<<<< ours
       this.$emit('update:value', event);
-=======
-      this.$emit('update:modelValue', event);
->>>>>>> theirs
     },
   },
 };

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -61,7 +61,7 @@
             data-qa="dt-message-input-image-btn"
             size="sm"
             class="dt-message-input__button"
-            :kind="imagePickerFocus ? 'muted' : 'muted'"
+            kind="muted"
             importance="clear"
             :aria-label="showImagePicker.ariaLabel"
             @click="onSelectImage"
@@ -98,7 +98,7 @@
                 data-qa="dt-message-input-emoji-picker-btn"
                 size="sm"
                 class="dt-message-input__button"
-                :kind="emojiPickerHovered ? 'muted' : 'muted'"
+                kind="muted"
                 importance="clear"
                 :aria-label="emojiButtonAriaLabel"
                 @click="toggleEmojiPicker"
@@ -189,9 +189,10 @@
             kind="default"
             importance="primary"
             :class="[
+              'dt-message-input__button',
               {
-                'dt-message-input__button dt-message-input__send-button--disabled': isSendDisabled,
-                'dt-message-input__button d-btn--icon-only': showSendIcon,
+                'dt-message-input__send-button--disabled': isSendDisabled,
+                'd-btn--icon-only': showSendIcon,
               },
             ]"
             :aria-label="showSend.ariaLabel"

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -789,20 +789,20 @@ export default {
   border-radius: var(--dt-size-radius-400);
   border: var(--dt-size-border-100) solid;
   border-color: var(--dt-color-border-default);
-  box-shadow: 0 0 0 0 rgba(0, 0, 0, 0%);
   line-height: var(--dt-font-line-height-400);
   cursor: text;
-  transition: all 100ms cubic-bezier(0.22, 1, 0.36, 1);
+  opacity: 1;
+  transition-property: border-color, box-shadow, opacity;
+  transition-duration: var(--td200);
+  transition-timing-function: var(--ttf-in-out);
 
   &:focus-within {
     border-color: var(--dt-color-border-bold);
     box-shadow: 0 0 var(--dt-size-300) 0 var(--dt-color-surface-moderate-opaque);
-    transition: all 250ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   &:not(:hover):not(:focus-within) .dt-message-input__button {
     opacity: 0.75;
-    transition: all 250ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   &__editor-wrapper {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -51,6 +51,7 @@
     <section class="dt-message-input__bottom-section">
       <!-- Left content -->
       <div class="dt-message-input__bottom-section-left">
+<<<<<<< ours
         <dt-button
           v-if="showImagePicker"
           v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
@@ -129,6 +130,94 @@
         </dt-popover>
         <!-- @slot Slot for emojiGiphy picker -->
         <slot name="emojiGiphyPicker" />
+=======
+        <dt-stack
+          gap="200"
+          direction="row"
+        >
+          <dt-button
+            v-if="showImagePicker"
+            v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
+            data-qa="dt-message-input-image-btn"
+            size="sm"
+            class="d-bar4"
+            style="width: 2.8rem; height: 2.8rem"
+            :kind="imagePickerFocus ? 'muted' : 'muted'"
+            importance="clear"
+            :aria-label="showImagePicker.ariaLabel"
+            @click="onSelectImage"
+            @mouseenter="imagePickerFocus = true"
+            @mouseleave="imagePickerFocus = false"
+            @focus="imagePickerFocus = true"
+            @blur="imagePickerFocus = false"
+          >
+            <template #icon>
+              <dt-icon-image size="300" />
+            </template>
+          </dt-button>
+          <dt-input
+            ref="messageInputImageUpload"
+            data-qa="dt-message-input-image-input"
+            accept="image/*, video/*"
+            type="file"
+            class="dt-message-input__image-input"
+            multiple
+            hidden
+            @input="onImageUpload"
+          />
+          <dt-popover
+            v-if="showEmojiPicker"
+            v-model:open="emojiPickerOpened"
+            data-qa="dt-message-input-emoji-picker-popover"
+            initial-focus-element="#searchInput"
+            padding="none"
+          >
+            <template #anchor="{ attrs }">
+              <dt-button
+                v-dt-tooltip="emojiTooltipMessage"
+                v-bind="attrs"
+                data-qa="dt-message-input-emoji-picker-btn"
+                size="sm"
+                class="d-bar4"
+                style="width: 2.8rem; height: 2.8rem"
+                :kind="emojiPickerHovered ? 'muted' : 'muted'"
+                importance="clear"
+                :aria-label="emojiButtonAriaLabel"
+                @click="toggleEmojiPicker"
+                @mouseenter="emojiPickerFocus = true"
+                @mouseleave="emojiPickerFocus = false"
+                @focus="emojiPickerFocus = true"
+                @blur="emojiPickerFocus = false"
+              >
+                <template #icon>
+                  <dt-icon-very-satisfied
+                    v-if="emojiPickerHovered"
+                    size="300"
+                  />
+                  <dt-icon-satisfied
+                    v-else
+                    size="300"
+                  />
+                </template>
+              </dt-button>
+            </template>
+            <template #content="{ close }">
+              <dt-emoji-picker
+                v-bind="emojiPickerProps"
+                @skin-tone="onSkinTone"
+                @selected-emoji="
+                  (emoji) => {
+                    close();
+                    onSelectEmoji(emoji);
+                  }
+                "
+              />
+            </template>
+          </dt-popover>
+          <!-- @slot Slot for emojiGiphy picker -->
+          <slot name="emojiGiphyPicker" />
+        </dt-stack>
+>>>>>>> theirs
       </div>
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
@@ -201,9 +290,13 @@
                 name="sendIcon"
                 :icon-size="sendIconSize"
               >
+<<<<<<< ours
                 <dt-icon-send
                   :size="sendIconSize"
                 />
+=======
+                <dt-icon-send :size="sendIconSize" />
+>>>>>>> theirs
               </slot>
             </template>
             <template
@@ -231,7 +324,17 @@ import { DtEmojiPicker } from '@/components/emoji_picker';
 import { DtPopover } from '@/components/popover';
 import { DtInput } from '@/components/input';
 import { DtTooltip } from '@/components/tooltip';
+<<<<<<< ours
 import { DtIconImage, DtIconVerySatisfied, DtIconSatisfied, DtIconSend } from '@dialpad/dialtone-icons/vue2';
+=======
+import { DtStack } from '@/components/stack';
+import {
+  DtIconImage,
+  DtIconVerySatisfied,
+  DtIconSatisfied,
+  DtIconSend,
+} from '@dialpad/dialtone-icons/vue3';
+>>>>>>> theirs
 
 export default {
   name: 'DtRecipeMessageInput',
@@ -386,7 +489,11 @@ export default {
           'searchPlaceholderLabel',
           'skinSelectorButtonTooltipLabel',
           'tabSetLabels',
+<<<<<<< ours
         ].every(prop => emojiPickerProps[prop] != null);
+=======
+        ].every((prop) => emojiPickerProps[prop] != null);
+>>>>>>> theirs
       },
     },
 
@@ -417,7 +524,14 @@ export default {
 
     showImagePicker: {
       type: [Boolean, Object],
+<<<<<<< ours
       default: () => ({ tooltipLabel: 'Attach Image', ariaLabel: 'image button' }),
+=======
+      default: () => ({
+        tooltipLabel: 'Attach Image',
+        ariaLabel: 'image button',
+      }),
+>>>>>>> theirs
     },
 
     /**
@@ -621,7 +735,11 @@ export default {
      * @event update:value
      * @type {String|JSON}
      */
+<<<<<<< ours
     'update:value',
+=======
+    'update:modelValue',
+>>>>>>> theirs
   ],
 
   data () {
@@ -644,6 +762,7 @@ export default {
     },
 
     displayCharacterLimitWarning () {
+<<<<<<< ours
       return Boolean(this.showCharacterLimit) &&
         ((this.showCharacterLimit.count - this.inputLength) <= this.showCharacterLimit.warning);
     },
@@ -655,6 +774,28 @@ export default {
     isSendDisabled () {
       return this.disableSend ||
       (this.showCharacterLimit && this.inputLength > this.showCharacterLimit.count);
+=======
+      return (
+        Boolean(this.showCharacterLimit) &&
+        this.showCharacterLimit.count - this.inputLength <=
+          this.showCharacterLimit.warning
+      );
+    },
+
+    characterLimitTooltipEnabled () {
+      return (
+        this.showCharacterLimit.message &&
+        this.showCharacterLimit.count - this.inputLength < 0
+      );
+    },
+
+    isSendDisabled () {
+      return (
+        this.disableSend ||
+        (this.showCharacterLimit &&
+          this.inputLength > this.showCharacterLimit.count)
+      );
+>>>>>>> theirs
     },
 
     computedCloseButtonProps () {
@@ -673,7 +814,11 @@ export default {
   },
 
   watch: {
+<<<<<<< ours
     value (newValue) {
+=======
+    modelValue (newValue) {
+>>>>>>> theirs
       this.internalInputValue = newValue;
     },
 
@@ -685,15 +830,26 @@ export default {
   },
 
   created () {
+<<<<<<< ours
     if (this.value && this.outputFormat === 'text') {
       this.internalInputValue = this.value.replace(/\n/g, '<br>');
+=======
+    if (this.modelValue && this.outputFormat === 'text') {
+      this.internalInputValue = this.modelValue.replace(/\n/g, '<br>');
+>>>>>>> theirs
     }
   },
 
   methods: {
     // Mousedown instead of click because it fires before the blur event.
     onMousedown (e) {
+<<<<<<< ours
       const isWithinInput = this.$refs.richTextEditor.$el.querySelector('.tiptap').contains(e.target);
+=======
+      const isWithinInput = this.$refs.richTextEditor.$el
+        .querySelector('.tiptap')
+        .contains(e.target);
+>>>>>>> theirs
 
       // If the click is not within the tiptap rich text editor input itself, but still within the wrapping div,
       // focus the editor.
@@ -743,7 +899,14 @@ export default {
     },
 
     onImageUpload () {
+<<<<<<< ours
       this.$emit('select-media', this.$refs.messageInputImageUpload.$refs.input.files);
+=======
+      this.$emit(
+        'select-media',
+        this.$refs.messageInputImageUpload.$refs.input.files,
+      );
+>>>>>>> theirs
     },
 
     toggleEmojiPicker () {
@@ -762,7 +925,11 @@ export default {
     },
 
     onInput (event) {
+<<<<<<< ours
       this.$emit('update:value', event);
+=======
+      this.$emit('update:modelValue', event);
+>>>>>>> theirs
     },
   },
 };

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -171,7 +171,7 @@
           <dt-button
             v-if="showCancel"
             data-qa="dt-message-input-cancel-button"
-            class="dt-message-input__cancel-button dt-message-input__button d-p8"
+            class="dt-message-input__button dt-message-input__cancel-button"
             size="sm"
             kind="muted"
             importance="clear"
@@ -193,7 +193,7 @@
               kind="default"
               importance="primary"
               :class="[
-                'dt-message-input__button',
+                'dt-message-input__button dt-message-input__send-button',
                 {
                   'dt-message-input__send-button--disabled': isSendDisabled,
                   'd-btn--icon-only': showSendIcon,
@@ -826,9 +826,10 @@ export default {
     border-radius: var(--dt-size-radius-300);
   }
 
-  &__send-button,
+  &__send-button.dt-message-input__button:not(.d-btn--icon-only),
   &__cancel-button {
     max-width: unset;
+    padding: var(--dt-space-350);
   }
 
   &__send-button--disabled {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -791,7 +791,6 @@ export default {
   border-color: var(--dt-color-border-default);
   line-height: var(--dt-font-line-height-400);
   cursor: text;
-  opacity: 1;
   transition-property: border-color, box-shadow, opacity;
   transition-duration: var(--td50);
   transition-timing-function: var(--ttf-in-out);

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -793,7 +793,7 @@ export default {
   cursor: text;
   opacity: 1;
   transition-property: border-color, box-shadow, opacity;
-  transition-duration: var(--td200);
+  transition-duration: var(--td50);
   transition-timing-function: var(--ttf-in-out);
 
   &:focus-within {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -52,8 +52,8 @@
       <!-- Left content -->
       <div class="dt-message-input__bottom-section-left">
         <dt-stack
+          direction="row"
           gap="200"
-          directon="row"
         >
           <dt-button
             v-if="showImagePicker"
@@ -786,10 +786,17 @@ export default {
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 0%);
   line-height: var(--dt-font-line-height-400);
   cursor: text;
+  transition: all 100ms cubic-bezier(0.22, 1, 0.36, 1);
 
   &:focus-within {
     border-color: var(--dt-color-border-bold);
-    box-shadow: var(--dt-shadow-small);
+    box-shadow: 0 0 var(--dt-size-300) 0 var(--dt-color-surface-moderate-opaque);
+    transition: all 250ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  &:not(:hover):not(:focus-within) .dt-message-input__button {
+    opacity: 0.75;
+    transition: all 250ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   &__editor-wrapper {
@@ -827,7 +834,7 @@ export default {
   &__bottom-section {
     display: flex;
     justify-content: space-between;
-    padding: var(--dt-space-300) var(--dt-space-400);
+    padding: var(--dt-space-300) var(--dt-space-400) var(--dt-space-400);
   }
 
   &__bottom-section-left {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -138,88 +138,93 @@
       </div>
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
-        <!-- @slot Slot for sms count -->
-        <div class="d-d-flex d-ai-center">
-          <slot name="smsCount" />
-        </div>
-
-        <!-- Optionally displayed remaining character counter -->
-        <dt-tooltip
-          v-if="Boolean(showCharacterLimit)"
-          class="dt-message-input__remaining-char-tooltip"
-          placement="top-end"
-          :enabled="characterLimitTooltipEnabled"
-          :message="showCharacterLimit.message"
-          :offset="[10, 8]"
+        <dt-stack
+          direction="row"
+          gap="300"
         >
-          <template #anchor>
-            <p
-              v-show="displayCharacterLimitWarning"
-              class="dt-message-input__remaining-char"
-              data-qa="dt-message-input-character-limit"
-            >
-              {{ showCharacterLimit.count - inputLength }}
-            </p>
-          </template>
-        </dt-tooltip>
+          <!-- @slot Slot for sms count -->
+          <div class="d-d-flex d-ai-center">
+            <slot name="smsCount" />
+          </div>
 
-        <!-- Cancel button for edit mode -->
-        <dt-button
-          v-if="showCancel"
-          data-qa="dt-message-input-cancel-button"
-          class="dt-message-input__cancel-button dt-message-input__button d-p8"
-          size="sm"
-          kind="muted"
-          importance="clear"
-          :aria-label="showCancel.ariaLabel"
-          @click="onCancel"
-        >
-          <p>{{ showCancel.text }}</p>
-        </dt-button>
-
-        <!-- @slot Slot for sendButton picker -->
-        <slot name="sendButton">
-          <!-- Send button -->
-          <!-- Right positioned UI - send button -->
-          <dt-button
-            v-if="showSend"
-            v-dt-tooltip:top-end="showSend?.tooltipLabel"
-            data-qa="dt-message-input-send-btn"
-            size="sm"
-            kind="default"
-            importance="primary"
-            :class="[
-              'dt-message-input__button',
-              {
-                'dt-message-input__send-button--disabled': isSendDisabled,
-                'd-btn--icon-only': showSendIcon,
-              },
-            ]"
-            :aria-label="showSend.ariaLabel"
-            :aria-disabled="isSendDisabled"
-            @click="onSend"
+          <!-- Optionally displayed remaining character counter -->
+          <dt-tooltip
+            v-if="Boolean(showCharacterLimit)"
+            class="dt-message-input__remaining-char-tooltip"
+            placement="top-end"
+            :enabled="characterLimitTooltipEnabled"
+            :message="showCharacterLimit.message"
+            :offset="[10, 8]"
           >
-            <template
-              v-if="showSendIcon"
-              #icon
-            >
-              <!-- @slot Slot for send button icon -->
-              <slot
-                name="sendIcon"
-                :icon-size="sendIconSize"
+            <template #anchor>
+              <p
+                v-show="displayCharacterLimitWarning"
+                class="dt-message-input__remaining-char"
+                data-qa="dt-message-input-character-limit"
               >
-                <dt-icon-send
-                  :size="sendIconSize"
-                />
-              </slot>
+                {{ showCharacterLimit.count - inputLength }}
+              </p>
             </template>
-            <template
-              v-if="showSend.text"
-            >
-              <p>{{ showSend.text }}</p>
-            </template>
+          </dt-tooltip>
+
+          <!-- Cancel button for edit mode -->
+          <dt-button
+            v-if="showCancel"
+            data-qa="dt-message-input-cancel-button"
+            class="dt-message-input__cancel-button dt-message-input__button d-p8"
+            size="sm"
+            kind="muted"
+            importance="clear"
+            :aria-label="showCancel.ariaLabel"
+            @click="onCancel"
+          >
+            <p>{{ showCancel.text }}</p>
           </dt-button>
-        </slot>
+
+          <!-- @slot Slot for sendButton picker -->
+          <slot name="sendButton">
+            <!-- Send button -->
+            <!-- Right positioned UI - send button -->
+            <dt-button
+              v-if="showSend"
+              v-dt-tooltip:top-end="showSend?.tooltipLabel"
+              data-qa="dt-message-input-send-btn"
+              size="sm"
+              kind="default"
+              importance="primary"
+              :class="[
+                'dt-message-input__button',
+                {
+                  'dt-message-input__send-button--disabled': isSendDisabled,
+                  'd-btn--icon-only': showSendIcon,
+                },
+              ]"
+              :aria-label="showSend.ariaLabel"
+              :aria-disabled="isSendDisabled"
+              @click="onSend"
+            >
+              <template
+                v-if="showSendIcon"
+                #icon
+              >
+                <!-- @slot Slot for send button icon -->
+                <slot
+                  name="sendIcon"
+                  :icon-size="sendIconSize"
+                >
+                  <dt-icon-send
+                    :size="sendIconSize"
+                  />
+                </slot>
+              </template>
+              <template
+                v-if="showSend.text"
+              >
+                <p>{{ showSend.text }}</p>
+              </template>
+            </dt-button>
+          </slot>
+        </dt-stack>
       </div>
     </section>
   </div>
@@ -812,24 +817,24 @@ export default {
   &__remaining-char {
     color: var(--dt-color-foreground-critical);
     font-size: var(--dt-font-size-100);
-    margin-right: var(--dt-space-500);
+    margin-right: var(--dt-space-300);
   }
 
   &__button {
     max-height: 2.8rem;
     max-width: 2.8rem;
-    border-radius: var(--dt-size-radius-400);
+    border-radius: var(--dt-size-radius-300);
+  }
+
+  &__send-button,
+  &__cancel-button {
+    max-width: unset;
   }
 
   &__send-button--disabled {
     background-color: unset;
     color: var(--dt-color-foreground-muted);
     cursor: default;
-  }
-
-  &__cancel-button {
-    max-width: unset;
-    margin-right: var(--dt-space-300);
   }
 
   &__bottom-section {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -51,84 +51,90 @@
     <section class="dt-message-input__bottom-section">
       <!-- Left content -->
       <div class="dt-message-input__bottom-section-left">
-        <dt-button
-          v-if="showImagePicker"
-          v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
-          data-qa="dt-message-input-image-btn"
-          size="sm"
-          circle
-          :kind="imagePickerFocus ? 'default' : 'muted'"
-          importance="clear"
-          :aria-label="showImagePicker.ariaLabel"
-          @click="onSelectImage"
-          @mouseenter="imagePickerFocus = true"
-          @mouseleave="imagePickerFocus = false"
-          @focus="imagePickerFocus = true"
-          @blur="imagePickerFocus = false"
+        <dt-stack
+          gap="200"
+          directon="row"
         >
-          <template #icon>
-            <dt-icon-image
-              size="300"
-            />
-          </template>
-        </dt-button>
-        <dt-input
-          ref="messageInputImageUpload"
-          data-qa="dt-message-input-image-input"
-          accept="image/*, video/*"
-          type="file"
-          class="dt-message-input__image-input"
-          multiple
-          hidden
-          @input="onImageUpload"
-        />
-        <dt-popover
-          v-if="showEmojiPicker"
-          data-qa="dt-message-input-emoji-picker-popover"
-          :open.sync="emojiPickerOpened"
-          initial-focus-element="#searchInput"
-          padding="none"
-        >
-          <template #anchor="{ attrs }">
-            <dt-button
-              v-dt-tooltip="emojiTooltipMessage"
-              v-bind="attrs"
-              data-qa="dt-message-input-emoji-picker-btn"
-              size="sm"
-              circle
-              :kind="emojiPickerHovered ? 'default' : 'muted'"
-              importance="clear"
-              :aria-label="emojiButtonAriaLabel"
-              @click="toggleEmojiPicker"
-              @mouseenter="emojiPickerFocus = true"
-              @mouseleave="emojiPickerFocus = false"
-              @focus="emojiPickerFocus = true"
-              @blur="emojiPickerFocus = false"
-            >
-              <template #icon>
-                <dt-icon-very-satisfied
-                  v-if="emojiPickerHovered"
-                  size="300"
-                />
-                <dt-icon-satisfied
-                  v-else
-                  size="300"
-                />
-              </template>
-            </dt-button>
-          </template>
-          <template
-            #content="{ close }"
+          <dt-button
+            v-if="showImagePicker"
+            v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
+            data-qa="dt-message-input-image-btn"
+            size="sm"
+            class="dt-message-input__button"
+            :kind="imagePickerFocus ? 'muted' : 'muted'"
+            importance="clear"
+            :aria-label="showImagePicker.ariaLabel"
+            @click="onSelectImage"
+            @mouseenter="imagePickerFocus = true"
+            @mouseleave="imagePickerFocus = false"
+            @focus="imagePickerFocus = true"
+            @blur="imagePickerFocus = false"
           >
-            <dt-emoji-picker
-              v-bind="emojiPickerProps"
-              @skin-tone="onSkinTone"
-              @selected-emoji="(emoji) => { close(); onSelectEmoji(emoji); }"
-            />
-          </template>
-        </dt-popover>
-        <!-- @slot Slot for emojiGiphy picker -->
-        <slot name="emojiGiphyPicker" />
+            <template #icon>
+              <dt-icon-image size="300" />
+            </template>
+          </dt-button>
+          <dt-input
+            ref="messageInputImageUpload"
+            data-qa="dt-message-input-image-input"
+            accept="image/*, video/*"
+            type="file"
+            class="dt-message-input__image-input"
+            multiple
+            hidden
+            @input="onImageUpload"
+          />
+          <dt-popover
+            v-if="showEmojiPicker"
+            v-model:open="emojiPickerOpened"
+            data-qa="dt-message-input-emoji-picker-popover"
+            initial-focus-element="#searchInput"
+            padding="none"
+          >
+            <template #anchor="{ attrs }">
+              <dt-button
+                v-dt-tooltip="emojiTooltipMessage"
+                v-bind="attrs"
+                data-qa="dt-message-input-emoji-picker-btn"
+                size="sm"
+                class="dt-message-input__button"
+                :kind="emojiPickerHovered ? 'muted' : 'muted'"
+                importance="clear"
+                :aria-label="emojiButtonAriaLabel"
+                @click="toggleEmojiPicker"
+                @mouseenter="emojiPickerFocus = true"
+                @mouseleave="emojiPickerFocus = false"
+                @focus="emojiPickerFocus = true"
+                @blur="emojiPickerFocus = false"
+              >
+                <template #icon>
+                  <dt-icon-very-satisfied
+                    v-if="emojiPickerHovered"
+                    size="300"
+                  />
+                  <dt-icon-satisfied
+                    v-else
+                    size="300"
+                  />
+                </template>
+              </dt-button>
+            </template>
+            <template #content="{ close }">
+              <dt-emoji-picker
+                v-bind="emojiPickerProps"
+                @skin-tone="onSkinTone"
+                @selected-emoji="
+                  (emoji) => {
+                    close();
+                    onSelectEmoji(emoji);
+                  }
+                "
+              />
+            </template>
+          </dt-popover>
+          <!-- @slot Slot for emojiGiphy picker -->
+          <slot name="emojiGiphyPicker" />
+        </dt-stack>
       </div>
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
@@ -161,7 +167,7 @@
         <dt-button
           v-if="showCancel"
           data-qa="dt-message-input-cancel-button"
-          class="dt-message-input__cancel-button"
+          class="dt-message-input__cancel-button dt-message-input__button d-p8"
           size="sm"
           kind="muted"
           importance="clear"
@@ -184,8 +190,8 @@
             importance="primary"
             :class="[
               {
-                'dt-message-input__send-button--disabled': isSendDisabled,
-                'd-btn--circle': showSendIcon,
+                'dt-message-input__button dt-message-input__send-button--disabled': isSendDisabled,
+                'dt-message-input__button d-btn--icon-only': showSendIcon,
               },
             ]"
             :aria-label="showSend.ariaLabel"
@@ -231,6 +237,7 @@ import { DtEmojiPicker } from '@/components/emoji_picker';
 import { DtPopover } from '@/components/popover';
 import { DtInput } from '@/components/input';
 import { DtTooltip } from '@/components/tooltip';
+import { DtStack } from '@/components/stack';
 import { DtIconImage, DtIconVerySatisfied, DtIconSatisfied, DtIconSend } from '@dialpad/dialtone-icons/vue2';
 
 export default {
@@ -243,6 +250,7 @@ export default {
     DtPopover,
     DtRichTextEditor,
     DtTooltip,
+    DtStack,
     DtIconImage,
     DtIconVerySatisfied,
     DtIconSatisfied,
@@ -775,11 +783,8 @@ export default {
   border-radius: var(--dt-size-radius-400);
   border: var(--dt-size-border-100) solid;
   border-color: var(--dt-color-border-default);
-<<<<<<< ours
-=======
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 0%);
   line-height: var(--dt-font-line-height-400);
->>>>>>> theirs
   cursor: text;
 
   &:focus-within {
@@ -802,6 +807,12 @@ export default {
     margin-right: var(--dt-space-500);
   }
 
+  &__button {
+    max-height: 2.8rem;
+    max-width: 2.8rem;
+    border-radius: var(--dt-size-radius-400);
+  }
+
   &__send-button--disabled {
     background-color: unset;
     color: var(--dt-color-foreground-muted);
@@ -809,6 +820,7 @@ export default {
   }
 
   &__cancel-button {
+    max-width: unset;
     margin-right: var(--dt-space-300);
   }
 

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -51,7 +51,90 @@
     <section class="dt-message-input__bottom-section">
       <!-- Left content -->
       <div class="dt-message-input__bottom-section-left">
-        <dt-stack gap="200" direction="row">
+<<<<<<< ours
+        <dt-button
+          v-if="showImagePicker"
+          v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
+          data-qa="dt-message-input-image-btn"
+          size="sm"
+          circle
+          :kind="imagePickerFocus ? 'default' : 'muted'"
+          importance="clear"
+          :aria-label="showImagePicker.ariaLabel"
+          @click="onSelectImage"
+          @mouseenter="imagePickerFocus = true"
+          @mouseleave="imagePickerFocus = false"
+          @focus="imagePickerFocus = true"
+          @blur="imagePickerFocus = false"
+        >
+          <template #icon>
+            <dt-icon-image
+              size="300"
+            />
+          </template>
+        </dt-button>
+        <dt-input
+          ref="messageInputImageUpload"
+          data-qa="dt-message-input-image-input"
+          accept="image/*, video/*"
+          type="file"
+          class="dt-message-input__image-input"
+          multiple
+          hidden
+          @input="onImageUpload"
+        />
+        <dt-popover
+          v-if="showEmojiPicker"
+          data-qa="dt-message-input-emoji-picker-popover"
+          :open.sync="emojiPickerOpened"
+          initial-focus-element="#searchInput"
+          padding="none"
+        >
+          <template #anchor="{ attrs }">
+            <dt-button
+              v-dt-tooltip="emojiTooltipMessage"
+              v-bind="attrs"
+              data-qa="dt-message-input-emoji-picker-btn"
+              size="sm"
+              circle
+              :kind="emojiPickerHovered ? 'default' : 'muted'"
+              importance="clear"
+              :aria-label="emojiButtonAriaLabel"
+              @click="toggleEmojiPicker"
+              @mouseenter="emojiPickerFocus = true"
+              @mouseleave="emojiPickerFocus = false"
+              @focus="emojiPickerFocus = true"
+              @blur="emojiPickerFocus = false"
+            >
+              <template #icon>
+                <dt-icon-very-satisfied
+                  v-if="emojiPickerHovered"
+                  size="300"
+                />
+                <dt-icon-satisfied
+                  v-else
+                  size="300"
+                />
+              </template>
+            </dt-button>
+          </template>
+          <template
+            #content="{ close }"
+          >
+            <dt-emoji-picker
+              v-bind="emojiPickerProps"
+              @skin-tone="onSkinTone"
+              @selected-emoji="(emoji) => { close(); onSelectEmoji(emoji); }"
+            />
+          </template>
+        </dt-popover>
+        <!-- @slot Slot for emojiGiphy picker -->
+        <slot name="emojiGiphyPicker" />
+=======
+        <dt-stack
+          gap="200"
+          direction="row"
+        >
           <dt-button
             v-if="showImagePicker"
             v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
@@ -111,7 +194,10 @@
                     v-if="emojiPickerHovered"
                     size="300"
                   />
-                  <dt-icon-satisfied v-else size="300" />
+                  <dt-icon-satisfied
+                    v-else
+                    size="300"
+                  />
                 </template>
               </dt-button>
             </template>
@@ -131,6 +217,7 @@
           <!-- @slot Slot for emojiGiphy picker -->
           <slot name="emojiGiphyPicker" />
         </dt-stack>
+>>>>>>> theirs
       </div>
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
@@ -194,13 +281,27 @@
             :aria-disabled="isSendDisabled"
             @click="onSend"
           >
-            <template v-if="showSendIcon" #icon>
+            <template
+              v-if="showSendIcon"
+              #icon
+            >
               <!-- @slot Slot for send button icon -->
-              <slot name="sendIcon" :icon-size="sendIconSize">
+              <slot
+                name="sendIcon"
+                :icon-size="sendIconSize"
+              >
+<<<<<<< ours
+                <dt-icon-send
+                  :size="sendIconSize"
+                />
+=======
                 <dt-icon-send :size="sendIconSize" />
+>>>>>>> theirs
               </slot>
             </template>
-            <template v-if="showSend.text">
+            <template
+              v-if="showSend.text"
+            >
               <p>{{ showSend.text }}</p>
             </template>
           </dt-button>
@@ -216,23 +317,27 @@ import {
   DtRichTextEditor,
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
   RICH_TEXT_EDITOR_AUTOFOCUS_TYPES,
-} from "@/components/rich_text_editor";
-import meetingPill from "./meeting_pill/meeting_pill";
-import { DtButton } from "@/components/button";
-import { DtEmojiPicker } from "@/components/emoji_picker";
-import { DtPopover } from "@/components/popover";
-import { DtInput } from "@/components/input";
-import { DtTooltip } from "@/components/tooltip";
-import { DtStack } from "@/components/stack";
+} from '@/components/rich_text_editor';
+import meetingPill from './meeting_pill/meeting_pill';
+import { DtButton } from '@/components/button';
+import { DtEmojiPicker } from '@/components/emoji_picker';
+import { DtPopover } from '@/components/popover';
+import { DtInput } from '@/components/input';
+import { DtTooltip } from '@/components/tooltip';
+<<<<<<< ours
+import { DtIconImage, DtIconVerySatisfied, DtIconSatisfied, DtIconSend } from '@dialpad/dialtone-icons/vue2';
+=======
+import { DtStack } from '@/components/stack';
 import {
   DtIconImage,
   DtIconVerySatisfied,
   DtIconSatisfied,
   DtIconSend,
-} from "@dialpad/dialtone-icons/vue2";
+} from '@dialpad/dialtone-icons/vue3';
+>>>>>>> theirs
 
 export default {
-  name: "DtRecipeMessageInput",
+  name: 'DtRecipeMessageInput',
 
   components: {
     DtButton,
@@ -258,7 +363,7 @@ export default {
      */
     value: {
       type: [Object, String],
-      default: "",
+      default: '',
     },
 
     /**
@@ -275,7 +380,7 @@ export default {
     inputAriaLabel: {
       type: String,
       required: true,
-      default: "",
+      default: '',
     },
 
     /**
@@ -293,7 +398,7 @@ export default {
      */
     inputClass: {
       type: String,
-      default: "",
+      default: '',
     },
 
     /**
@@ -310,8 +415,8 @@ export default {
     autoFocus: {
       type: [Boolean, String, Number],
       default: false,
-      validator(autoFocus) {
-        if (typeof autoFocus === "string") {
+      validator (autoFocus) {
+        if (typeof autoFocus === 'string') {
           return RICH_TEXT_EDITOR_AUTOFOCUS_TYPES.includes(autoFocus);
         }
         return true;
@@ -326,8 +431,8 @@ export default {
      */
     outputFormat: {
       type: String,
-      default: "text",
-      validator(outputFormat) {
+      default: 'text',
+      validator (outputFormat) {
         return RICH_TEXT_EDITOR_OUTPUT_FORMATS.includes(outputFormat);
       },
     },
@@ -345,7 +450,7 @@ export default {
      */
     placeholder: {
       type: String,
-      default: "",
+      default: '',
     },
 
     /**
@@ -362,7 +467,7 @@ export default {
      */
     maxHeight: {
       type: String,
-      default: "unset",
+      default: 'unset',
     },
 
     // Emoji picker props
@@ -377,14 +482,18 @@ export default {
     emojiPickerProps: {
       type: Object,
       default: () => ({}),
-      validate(emojiPickerProps) {
+      validate (emojiPickerProps) {
         return [
-          "searchNoResultsLabel",
-          "searchResultsLabel",
-          "searchPlaceholderLabel",
-          "skinSelectorButtonTooltipLabel",
-          "tabSetLabels",
+          'searchNoResultsLabel',
+          'searchResultsLabel',
+          'searchPlaceholderLabel',
+          'skinSelectorButtonTooltipLabel',
+          'tabSetLabels',
+<<<<<<< ours
+        ].every(prop => emojiPickerProps[prop] != null);
+=======
         ].every((prop) => emojiPickerProps[prop] != null);
+>>>>>>> theirs
       },
     },
 
@@ -393,7 +502,7 @@ export default {
      */
     emojiTooltipMessage: {
       type: String,
-      default: "Emoji",
+      default: 'Emoji',
     },
 
     // Aria label for buttons
@@ -402,7 +511,7 @@ export default {
      */
     emojiButtonAriaLabel: {
       type: String,
-      default: "emoji button",
+      default: 'emoji button',
     },
 
     /**
@@ -410,15 +519,19 @@ export default {
      */
     showCharacterLimit: {
       type: [Boolean, Object],
-      default: () => ({ count: 1500, warning: 500, message: "" }),
+      default: () => ({ count: 1500, warning: 500, message: '' }),
     },
 
     showImagePicker: {
       type: [Boolean, Object],
+<<<<<<< ours
+      default: () => ({ tooltipLabel: 'Attach Image', ariaLabel: 'image button' }),
+=======
       default: () => ({
-        tooltipLabel: "Attach Image",
-        ariaLabel: "image button",
+        tooltipLabel: 'Attach Image',
+        ariaLabel: 'image button',
       }),
+>>>>>>> theirs
     },
 
     /**
@@ -434,7 +547,7 @@ export default {
      */
     showCancel: {
       type: [Boolean, Object],
-      default: () => ({ text: "Cancel" }),
+      default: () => ({ text: 'Cancel' }),
     },
 
     /**
@@ -505,7 +618,7 @@ export default {
 
     /**
      * Whether the input allows for bullet list to be introduced in the text.
-     */
+    */
     allowBulletList: {
       type: Boolean,
       default: true,
@@ -551,7 +664,7 @@ export default {
      * @event submit
      * @type {String}
      */
-    "submit",
+    'submit',
 
     /**
      * Fires when media is selected from image button
@@ -559,7 +672,7 @@ export default {
      * @event select-media
      * @type {Array}
      */
-    "select-media",
+    'select-media',
 
     /**
      * Fires when media is dropped into the message input
@@ -567,7 +680,7 @@ export default {
      * @event add-media
      * @type {Array}
      */
-    "add-media",
+    'add-media',
 
     /**
      * Fires when media is pasted into the message input
@@ -575,7 +688,7 @@ export default {
      * @event paste-media
      * @type {Array}
      */
-    "paste-media",
+    'paste-media',
 
     /**
      * Fires when cancel button is pressed (only on edit mode)
@@ -583,7 +696,7 @@ export default {
      * @event cancel
      * @type {Boolean}
      */
-    "cancel",
+    'cancel',
 
     /**
      * Fires when skin tone is selected from the emoji picker
@@ -591,7 +704,7 @@ export default {
      * @event skin-tone
      * @type {String}
      */
-    "skin-tone",
+    'skin-tone',
 
     /**
      * Fires when emoji is selected from the emoji picker
@@ -599,7 +712,7 @@ export default {
      * @event selected-emoji
      * @type {String}
      */
-    "selected-emoji",
+    'selected-emoji',
 
     /**
      * Fires when a slash command is selected
@@ -607,7 +720,7 @@ export default {
      * @event selected-command
      * @type {String}
      */
-    "selected-command",
+    'selected-command',
 
     /**
      * Fires when meeting pill is closed
@@ -615,17 +728,21 @@ export default {
      * @event meeting-pill-close
      * @type {String}
      */
-    "meeting-pill-close",
+    'meeting-pill-close',
 
     /**
      * Event to sync the value with the parent
      * @event update:value
      * @type {String|JSON}
      */
-    "update:modelValue",
+<<<<<<< ours
+    'update:value',
+=======
+    'update:modelValue',
+>>>>>>> theirs
   ],
 
-  data() {
+  data () {
     return {
       additionalExtensions: [meetingPill],
       internalInputValue: this.value, // internal input content
@@ -636,15 +753,28 @@ export default {
   },
 
   computed: {
-    showSendIcon() {
+    showSendIcon () {
       return !this.showSend.text;
     },
 
-    inputLength() {
+    inputLength () {
       return this.internalInputValue.length;
     },
 
-    displayCharacterLimitWarning() {
+    displayCharacterLimitWarning () {
+<<<<<<< ours
+      return Boolean(this.showCharacterLimit) &&
+        ((this.showCharacterLimit.count - this.inputLength) <= this.showCharacterLimit.warning);
+    },
+
+    characterLimitTooltipEnabled () {
+      return this.showCharacterLimit.message && (this.showCharacterLimit.count - this.inputLength < 0);
+    },
+
+    isSendDisabled () {
+      return this.disableSend ||
+      (this.showCharacterLimit && this.inputLength > this.showCharacterLimit.count);
+=======
       return (
         Boolean(this.showCharacterLimit) &&
         this.showCharacterLimit.count - this.inputLength <=
@@ -652,60 +782,74 @@ export default {
       );
     },
 
-    characterLimitTooltipEnabled() {
+    characterLimitTooltipEnabled () {
       return (
         this.showCharacterLimit.message &&
         this.showCharacterLimit.count - this.inputLength < 0
       );
     },
 
-    isSendDisabled() {
+    isSendDisabled () {
       return (
         this.disableSend ||
         (this.showCharacterLimit &&
           this.inputLength > this.showCharacterLimit.count)
       );
+>>>>>>> theirs
     },
 
-    computedCloseButtonProps() {
+    computedCloseButtonProps () {
       return {
-        ariaLabel: "Close",
+        ariaLabel: 'Close',
       };
     },
 
-    emojiPickerHovered() {
+    emojiPickerHovered () {
       return this.emojiPickerFocus || this.emojiPickerOpened;
     },
 
-    sendIconSize() {
-      return "300";
+    sendIconSize () {
+      return '300';
     },
   },
 
   watch: {
-    modelValue(newValue) {
+<<<<<<< ours
+    value (newValue) {
+=======
+    modelValue (newValue) {
+>>>>>>> theirs
       this.internalInputValue = newValue;
     },
 
-    emojiPickerOpened(newValue) {
+    emojiPickerOpened (newValue) {
       if (!newValue) {
         this.$refs.richTextEditor?.focusEditor();
       }
     },
   },
 
-  created() {
-    if (this.modelValue && this.outputFormat === "text") {
-      this.internalInputValue = this.modelValue.replace(/\n/g, "<br>");
+  created () {
+<<<<<<< ours
+    if (this.value && this.outputFormat === 'text') {
+      this.internalInputValue = this.value.replace(/\n/g, '<br>');
+=======
+    if (this.modelValue && this.outputFormat === 'text') {
+      this.internalInputValue = this.modelValue.replace(/\n/g, '<br>');
+>>>>>>> theirs
     }
   },
 
   methods: {
     // Mousedown instead of click because it fires before the blur event.
-    onMousedown(e) {
+    onMousedown (e) {
+<<<<<<< ours
+      const isWithinInput = this.$refs.richTextEditor.$el.querySelector('.tiptap').contains(e.target);
+=======
       const isWithinInput = this.$refs.richTextEditor.$el
-        .querySelector(".tiptap")
+        .querySelector('.tiptap')
         .contains(e.target);
+>>>>>>> theirs
 
       // If the click is not within the tiptap rich text editor input itself, but still within the wrapping div,
       // focus the editor.
@@ -716,68 +860,76 @@ export default {
       }
     },
 
-    onDrop(e) {
+    onDrop (e) {
       const dt = e.dataTransfer;
       const files = Array.from(dt.files);
-      this.$emit("add-media", files);
+      this.$emit('add-media', files);
     },
 
-    onPaste(e) {
+    onPaste (e) {
       if (e.clipboardData.files.length) {
         e.stopPropagation();
         e.preventDefault();
         const files = [...e.clipboardData.files];
-        this.$emit("paste-media", files);
+        this.$emit('paste-media', files);
       }
     },
 
-    onSkinTone(skinTone) {
-      this.$emit("skin-tone", skinTone);
+    onSkinTone (skinTone) {
+      this.$emit('skin-tone', skinTone);
     },
 
-    onSelectEmoji(emoji) {
+    onSelectEmoji (emoji) {
       if (!emoji) {
         return;
       }
 
       // Insert emoji into the editor
       this.$refs.richTextEditor.editor.commands.insertContent({
-        type: "emoji",
+        type: 'emoji',
         attrs: {
           code: emoji.shortname,
         },
       });
-      this.$emit("selected-emoji", emoji);
+      this.$emit('selected-emoji', emoji);
     },
 
-    onSelectImage() {
+    onSelectImage () {
       this.$refs.messageInputImageUpload.$refs.input.click();
     },
 
-    onImageUpload() {
+    onImageUpload () {
+<<<<<<< ours
+      this.$emit('select-media', this.$refs.messageInputImageUpload.$refs.input.files);
+=======
       this.$emit(
-        "select-media",
+        'select-media',
         this.$refs.messageInputImageUpload.$refs.input.files,
       );
+>>>>>>> theirs
     },
 
-    toggleEmojiPicker() {
+    toggleEmojiPicker () {
       this.emojiPickerOpened = !this.emojiPickerOpened;
     },
 
-    onSend() {
+    onSend () {
       if (this.isSendDisabled) {
         return;
       }
-      this.$emit("submit", this.internalInputValue);
+      this.$emit('submit', this.internalInputValue);
     },
 
-    onCancel() {
-      this.$emit("cancel");
+    onCancel () {
+      this.$emit('cancel');
     },
 
-    onInput(event) {
-      this.$emit("update:modelValue", event);
+    onInput (event) {
+<<<<<<< ours
+      this.$emit('update:value', event);
+=======
+      this.$emit('update:modelValue', event);
+>>>>>>> theirs
     },
   },
 };

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -51,90 +51,7 @@
     <section class="dt-message-input__bottom-section">
       <!-- Left content -->
       <div class="dt-message-input__bottom-section-left">
-<<<<<<< ours
-        <dt-button
-          v-if="showImagePicker"
-          v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
-          data-qa="dt-message-input-image-btn"
-          size="sm"
-          circle
-          :kind="imagePickerFocus ? 'default' : 'muted'"
-          importance="clear"
-          :aria-label="showImagePicker.ariaLabel"
-          @click="onSelectImage"
-          @mouseenter="imagePickerFocus = true"
-          @mouseleave="imagePickerFocus = false"
-          @focus="imagePickerFocus = true"
-          @blur="imagePickerFocus = false"
-        >
-          <template #icon>
-            <dt-icon-image
-              size="300"
-            />
-          </template>
-        </dt-button>
-        <dt-input
-          ref="messageInputImageUpload"
-          data-qa="dt-message-input-image-input"
-          accept="image/*, video/*"
-          type="file"
-          class="dt-message-input__image-input"
-          multiple
-          hidden
-          @input="onImageUpload"
-        />
-        <dt-popover
-          v-if="showEmojiPicker"
-          data-qa="dt-message-input-emoji-picker-popover"
-          :open.sync="emojiPickerOpened"
-          initial-focus-element="#searchInput"
-          padding="none"
-        >
-          <template #anchor="{ attrs }">
-            <dt-button
-              v-dt-tooltip="emojiTooltipMessage"
-              v-bind="attrs"
-              data-qa="dt-message-input-emoji-picker-btn"
-              size="sm"
-              circle
-              :kind="emojiPickerHovered ? 'default' : 'muted'"
-              importance="clear"
-              :aria-label="emojiButtonAriaLabel"
-              @click="toggleEmojiPicker"
-              @mouseenter="emojiPickerFocus = true"
-              @mouseleave="emojiPickerFocus = false"
-              @focus="emojiPickerFocus = true"
-              @blur="emojiPickerFocus = false"
-            >
-              <template #icon>
-                <dt-icon-very-satisfied
-                  v-if="emojiPickerHovered"
-                  size="300"
-                />
-                <dt-icon-satisfied
-                  v-else
-                  size="300"
-                />
-              </template>
-            </dt-button>
-          </template>
-          <template
-            #content="{ close }"
-          >
-            <dt-emoji-picker
-              v-bind="emojiPickerProps"
-              @skin-tone="onSkinTone"
-              @selected-emoji="(emoji) => { close(); onSelectEmoji(emoji); }"
-            />
-          </template>
-        </dt-popover>
-        <!-- @slot Slot for emojiGiphy picker -->
-        <slot name="emojiGiphyPicker" />
-=======
-        <dt-stack
-          gap="200"
-          direction="row"
-        >
+        <dt-stack gap="200" direction="row">
           <dt-button
             v-if="showImagePicker"
             v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
@@ -194,10 +111,7 @@
                     v-if="emojiPickerHovered"
                     size="300"
                   />
-                  <dt-icon-satisfied
-                    v-else
-                    size="300"
-                  />
+                  <dt-icon-satisfied v-else size="300" />
                 </template>
               </dt-button>
             </template>
@@ -217,7 +131,6 @@
           <!-- @slot Slot for emojiGiphy picker -->
           <slot name="emojiGiphyPicker" />
         </dt-stack>
->>>>>>> theirs
       </div>
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
@@ -281,27 +194,13 @@
             :aria-disabled="isSendDisabled"
             @click="onSend"
           >
-            <template
-              v-if="showSendIcon"
-              #icon
-            >
+            <template v-if="showSendIcon" #icon>
               <!-- @slot Slot for send button icon -->
-              <slot
-                name="sendIcon"
-                :icon-size="sendIconSize"
-              >
-<<<<<<< ours
-                <dt-icon-send
-                  :size="sendIconSize"
-                />
-=======
+              <slot name="sendIcon" :icon-size="sendIconSize">
                 <dt-icon-send :size="sendIconSize" />
->>>>>>> theirs
               </slot>
             </template>
-            <template
-              v-if="showSend.text"
-            >
+            <template v-if="showSend.text">
               <p>{{ showSend.text }}</p>
             </template>
           </dt-button>
@@ -317,27 +216,23 @@ import {
   DtRichTextEditor,
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
   RICH_TEXT_EDITOR_AUTOFOCUS_TYPES,
-} from '@/components/rich_text_editor';
-import meetingPill from './meeting_pill/meeting_pill';
-import { DtButton } from '@/components/button';
-import { DtEmojiPicker } from '@/components/emoji_picker';
-import { DtPopover } from '@/components/popover';
-import { DtInput } from '@/components/input';
-import { DtTooltip } from '@/components/tooltip';
-<<<<<<< ours
-import { DtIconImage, DtIconVerySatisfied, DtIconSatisfied, DtIconSend } from '@dialpad/dialtone-icons/vue2';
-=======
-import { DtStack } from '@/components/stack';
+} from "@/components/rich_text_editor";
+import meetingPill from "./meeting_pill/meeting_pill";
+import { DtButton } from "@/components/button";
+import { DtEmojiPicker } from "@/components/emoji_picker";
+import { DtPopover } from "@/components/popover";
+import { DtInput } from "@/components/input";
+import { DtTooltip } from "@/components/tooltip";
+import { DtStack } from "@/components/stack";
 import {
   DtIconImage,
   DtIconVerySatisfied,
   DtIconSatisfied,
   DtIconSend,
-} from '@dialpad/dialtone-icons/vue3';
->>>>>>> theirs
+} from "@dialpad/dialtone-icons/vue2";
 
 export default {
-  name: 'DtRecipeMessageInput',
+  name: "DtRecipeMessageInput",
 
   components: {
     DtButton,
@@ -363,7 +258,7 @@ export default {
      */
     value: {
       type: [Object, String],
-      default: '',
+      default: "",
     },
 
     /**
@@ -380,7 +275,7 @@ export default {
     inputAriaLabel: {
       type: String,
       required: true,
-      default: '',
+      default: "",
     },
 
     /**
@@ -398,7 +293,7 @@ export default {
      */
     inputClass: {
       type: String,
-      default: '',
+      default: "",
     },
 
     /**
@@ -415,8 +310,8 @@ export default {
     autoFocus: {
       type: [Boolean, String, Number],
       default: false,
-      validator (autoFocus) {
-        if (typeof autoFocus === 'string') {
+      validator(autoFocus) {
+        if (typeof autoFocus === "string") {
           return RICH_TEXT_EDITOR_AUTOFOCUS_TYPES.includes(autoFocus);
         }
         return true;
@@ -431,8 +326,8 @@ export default {
      */
     outputFormat: {
       type: String,
-      default: 'text',
-      validator (outputFormat) {
+      default: "text",
+      validator(outputFormat) {
         return RICH_TEXT_EDITOR_OUTPUT_FORMATS.includes(outputFormat);
       },
     },
@@ -450,7 +345,7 @@ export default {
      */
     placeholder: {
       type: String,
-      default: '',
+      default: "",
     },
 
     /**
@@ -467,7 +362,7 @@ export default {
      */
     maxHeight: {
       type: String,
-      default: 'unset',
+      default: "unset",
     },
 
     // Emoji picker props
@@ -482,18 +377,14 @@ export default {
     emojiPickerProps: {
       type: Object,
       default: () => ({}),
-      validate (emojiPickerProps) {
+      validate(emojiPickerProps) {
         return [
-          'searchNoResultsLabel',
-          'searchResultsLabel',
-          'searchPlaceholderLabel',
-          'skinSelectorButtonTooltipLabel',
-          'tabSetLabels',
-<<<<<<< ours
-        ].every(prop => emojiPickerProps[prop] != null);
-=======
+          "searchNoResultsLabel",
+          "searchResultsLabel",
+          "searchPlaceholderLabel",
+          "skinSelectorButtonTooltipLabel",
+          "tabSetLabels",
         ].every((prop) => emojiPickerProps[prop] != null);
->>>>>>> theirs
       },
     },
 
@@ -502,7 +393,7 @@ export default {
      */
     emojiTooltipMessage: {
       type: String,
-      default: 'Emoji',
+      default: "Emoji",
     },
 
     // Aria label for buttons
@@ -511,7 +402,7 @@ export default {
      */
     emojiButtonAriaLabel: {
       type: String,
-      default: 'emoji button',
+      default: "emoji button",
     },
 
     /**
@@ -519,19 +410,15 @@ export default {
      */
     showCharacterLimit: {
       type: [Boolean, Object],
-      default: () => ({ count: 1500, warning: 500, message: '' }),
+      default: () => ({ count: 1500, warning: 500, message: "" }),
     },
 
     showImagePicker: {
       type: [Boolean, Object],
-<<<<<<< ours
-      default: () => ({ tooltipLabel: 'Attach Image', ariaLabel: 'image button' }),
-=======
       default: () => ({
-        tooltipLabel: 'Attach Image',
-        ariaLabel: 'image button',
+        tooltipLabel: "Attach Image",
+        ariaLabel: "image button",
       }),
->>>>>>> theirs
     },
 
     /**
@@ -547,7 +434,7 @@ export default {
      */
     showCancel: {
       type: [Boolean, Object],
-      default: () => ({ text: 'Cancel' }),
+      default: () => ({ text: "Cancel" }),
     },
 
     /**
@@ -618,7 +505,7 @@ export default {
 
     /**
      * Whether the input allows for bullet list to be introduced in the text.
-    */
+     */
     allowBulletList: {
       type: Boolean,
       default: true,
@@ -664,7 +551,7 @@ export default {
      * @event submit
      * @type {String}
      */
-    'submit',
+    "submit",
 
     /**
      * Fires when media is selected from image button
@@ -672,7 +559,7 @@ export default {
      * @event select-media
      * @type {Array}
      */
-    'select-media',
+    "select-media",
 
     /**
      * Fires when media is dropped into the message input
@@ -680,7 +567,7 @@ export default {
      * @event add-media
      * @type {Array}
      */
-    'add-media',
+    "add-media",
 
     /**
      * Fires when media is pasted into the message input
@@ -688,7 +575,7 @@ export default {
      * @event paste-media
      * @type {Array}
      */
-    'paste-media',
+    "paste-media",
 
     /**
      * Fires when cancel button is pressed (only on edit mode)
@@ -696,7 +583,7 @@ export default {
      * @event cancel
      * @type {Boolean}
      */
-    'cancel',
+    "cancel",
 
     /**
      * Fires when skin tone is selected from the emoji picker
@@ -704,7 +591,7 @@ export default {
      * @event skin-tone
      * @type {String}
      */
-    'skin-tone',
+    "skin-tone",
 
     /**
      * Fires when emoji is selected from the emoji picker
@@ -712,7 +599,7 @@ export default {
      * @event selected-emoji
      * @type {String}
      */
-    'selected-emoji',
+    "selected-emoji",
 
     /**
      * Fires when a slash command is selected
@@ -720,7 +607,7 @@ export default {
      * @event selected-command
      * @type {String}
      */
-    'selected-command',
+    "selected-command",
 
     /**
      * Fires when meeting pill is closed
@@ -728,21 +615,17 @@ export default {
      * @event meeting-pill-close
      * @type {String}
      */
-    'meeting-pill-close',
+    "meeting-pill-close",
 
     /**
      * Event to sync the value with the parent
      * @event update:value
      * @type {String|JSON}
      */
-<<<<<<< ours
-    'update:value',
-=======
-    'update:modelValue',
->>>>>>> theirs
+    "update:modelValue",
   ],
 
-  data () {
+  data() {
     return {
       additionalExtensions: [meetingPill],
       internalInputValue: this.value, // internal input content
@@ -753,28 +636,15 @@ export default {
   },
 
   computed: {
-    showSendIcon () {
+    showSendIcon() {
       return !this.showSend.text;
     },
 
-    inputLength () {
+    inputLength() {
       return this.internalInputValue.length;
     },
 
-    displayCharacterLimitWarning () {
-<<<<<<< ours
-      return Boolean(this.showCharacterLimit) &&
-        ((this.showCharacterLimit.count - this.inputLength) <= this.showCharacterLimit.warning);
-    },
-
-    characterLimitTooltipEnabled () {
-      return this.showCharacterLimit.message && (this.showCharacterLimit.count - this.inputLength < 0);
-    },
-
-    isSendDisabled () {
-      return this.disableSend ||
-      (this.showCharacterLimit && this.inputLength > this.showCharacterLimit.count);
-=======
+    displayCharacterLimitWarning() {
       return (
         Boolean(this.showCharacterLimit) &&
         this.showCharacterLimit.count - this.inputLength <=
@@ -782,74 +652,60 @@ export default {
       );
     },
 
-    characterLimitTooltipEnabled () {
+    characterLimitTooltipEnabled() {
       return (
         this.showCharacterLimit.message &&
         this.showCharacterLimit.count - this.inputLength < 0
       );
     },
 
-    isSendDisabled () {
+    isSendDisabled() {
       return (
         this.disableSend ||
         (this.showCharacterLimit &&
           this.inputLength > this.showCharacterLimit.count)
       );
->>>>>>> theirs
     },
 
-    computedCloseButtonProps () {
+    computedCloseButtonProps() {
       return {
-        ariaLabel: 'Close',
+        ariaLabel: "Close",
       };
     },
 
-    emojiPickerHovered () {
+    emojiPickerHovered() {
       return this.emojiPickerFocus || this.emojiPickerOpened;
     },
 
-    sendIconSize () {
-      return '300';
+    sendIconSize() {
+      return "300";
     },
   },
 
   watch: {
-<<<<<<< ours
-    value (newValue) {
-=======
-    modelValue (newValue) {
->>>>>>> theirs
+    modelValue(newValue) {
       this.internalInputValue = newValue;
     },
 
-    emojiPickerOpened (newValue) {
+    emojiPickerOpened(newValue) {
       if (!newValue) {
         this.$refs.richTextEditor?.focusEditor();
       }
     },
   },
 
-  created () {
-<<<<<<< ours
-    if (this.value && this.outputFormat === 'text') {
-      this.internalInputValue = this.value.replace(/\n/g, '<br>');
-=======
-    if (this.modelValue && this.outputFormat === 'text') {
-      this.internalInputValue = this.modelValue.replace(/\n/g, '<br>');
->>>>>>> theirs
+  created() {
+    if (this.modelValue && this.outputFormat === "text") {
+      this.internalInputValue = this.modelValue.replace(/\n/g, "<br>");
     }
   },
 
   methods: {
     // Mousedown instead of click because it fires before the blur event.
-    onMousedown (e) {
-<<<<<<< ours
-      const isWithinInput = this.$refs.richTextEditor.$el.querySelector('.tiptap').contains(e.target);
-=======
+    onMousedown(e) {
       const isWithinInput = this.$refs.richTextEditor.$el
-        .querySelector('.tiptap')
+        .querySelector(".tiptap")
         .contains(e.target);
->>>>>>> theirs
 
       // If the click is not within the tiptap rich text editor input itself, but still within the wrapping div,
       // focus the editor.
@@ -860,76 +716,68 @@ export default {
       }
     },
 
-    onDrop (e) {
+    onDrop(e) {
       const dt = e.dataTransfer;
       const files = Array.from(dt.files);
-      this.$emit('add-media', files);
+      this.$emit("add-media", files);
     },
 
-    onPaste (e) {
+    onPaste(e) {
       if (e.clipboardData.files.length) {
         e.stopPropagation();
         e.preventDefault();
         const files = [...e.clipboardData.files];
-        this.$emit('paste-media', files);
+        this.$emit("paste-media", files);
       }
     },
 
-    onSkinTone (skinTone) {
-      this.$emit('skin-tone', skinTone);
+    onSkinTone(skinTone) {
+      this.$emit("skin-tone", skinTone);
     },
 
-    onSelectEmoji (emoji) {
+    onSelectEmoji(emoji) {
       if (!emoji) {
         return;
       }
 
       // Insert emoji into the editor
       this.$refs.richTextEditor.editor.commands.insertContent({
-        type: 'emoji',
+        type: "emoji",
         attrs: {
           code: emoji.shortname,
         },
       });
-      this.$emit('selected-emoji', emoji);
+      this.$emit("selected-emoji", emoji);
     },
 
-    onSelectImage () {
+    onSelectImage() {
       this.$refs.messageInputImageUpload.$refs.input.click();
     },
 
-    onImageUpload () {
-<<<<<<< ours
-      this.$emit('select-media', this.$refs.messageInputImageUpload.$refs.input.files);
-=======
+    onImageUpload() {
       this.$emit(
-        'select-media',
+        "select-media",
         this.$refs.messageInputImageUpload.$refs.input.files,
       );
->>>>>>> theirs
     },
 
-    toggleEmojiPicker () {
+    toggleEmojiPicker() {
       this.emojiPickerOpened = !this.emojiPickerOpened;
     },
 
-    onSend () {
+    onSend() {
       if (this.isSendDisabled) {
         return;
       }
-      this.$emit('submit', this.internalInputValue);
+      this.$emit("submit", this.internalInputValue);
     },
 
-    onCancel () {
-      this.$emit('cancel');
+    onCancel() {
+      this.$emit("cancel");
     },
 
-    onInput (event) {
-<<<<<<< ours
-      this.$emit('update:value', event);
-=======
-      this.$emit('update:modelValue', event);
->>>>>>> theirs
+    onInput(event) {
+      this.$emit("update:modelValue", event);
     },
   },
 };

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -36,10 +36,7 @@
               @click="button.onClick()"
             >
               <template #icon>
-                <component
-                  :is="button.icon"
-                  size="200"
-                />
+                <component :is="button.icon" size="200" />
               </template>
               {{ button?.label }}
             </dt-button>
@@ -47,11 +44,7 @@
         </dt-tooltip>
         <div class="dt-editor--button-group-divider" />
       </dt-stack>
-      <dt-stack
-        v-if="linkButton.showBtn"
-        direction="row"
-        gap="300"
-      >
+      <dt-stack v-if="linkButton.showBtn" direction="row" gap="300">
         <dt-popover
           :open="showLinkInput"
           placement="bottom-start"
@@ -75,7 +68,9 @@
                   importance="clear"
                   kind="muted"
                   class="d-ol-none"
-                  :active="$refs.richTextEditor?.editor?.isActive(linkButton.selector)"
+                  :active="
+                    $refs.richTextEditor?.editor?.isActive(linkButton.selector)
+                  "
                   size="xs"
                   :aria-label="linkButton.tooltipMessage"
                   @click="linkButton.onClick()"
@@ -93,9 +88,7 @@
           </template>
 
           <template #content>
-            <span
-              v-if="showAddLink.setLinkTitle.length > 0"
-            >
+            <span v-if="showAddLink.setLinkTitle.length > 0">
               {{ showAddLink.setLinkTitle }}
             </span>
             <dt-input
@@ -103,7 +96,7 @@
               :input-aria-label="showAddLink.setLinkInputAriaLabel"
               data-qa="dt-editor-link-input"
               :placeholder="setLinkPlaceholder"
-              input-wrapper-class="d-bgc-black-100 d-mt6 d-bar5 d-ba d-baw1 d-bc-black-300 d-py2 d-ol-none"
+              input-wrapper-class="d-bgc-secondary d-mt6 d-bar5 d-ba d-baw1 d-bc-default d-py2 d-ol-none"
               @click="onInputFocus"
               @click.stop="onInputFocus"
               @focus="onInputFocus"
@@ -151,7 +144,7 @@
 
     <!-- Some wrapper to restrict the height and show the scrollbar -->
     <div
-      class="d-of-auto d-mx16 d-mt8 d-mb16 d-c-text"
+      class="d-of-auto d-mx12 d-mt12 d-mb16 d-c-text"
       :style="{ 'max-height': maxHeight }"
     >
       <dt-rich-text-editor
@@ -181,16 +174,16 @@ import {
   DtRichTextEditor,
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
   RICH_TEXT_EDITOR_AUTOFOCUS_TYPES,
-} from '@/components/rich_text_editor';
+} from "@/components/rich_text_editor";
 import {
   EDITOR_SUPPORTED_LINK_PROTOCOLS,
   EDITOR_DEFAULT_LINK_PREFIX,
-} from './editor_constants.js';
-import { DtButton } from '@/components/button';
-import { DtPopover } from '@/components/popover';
-import { DtStack } from '@/components/stack';
-import { DtInput } from '@/components/input';
-import { DtTooltip } from '@/components/tooltip';
+} from "./editor_constants.js";
+import { DtButton } from "@/components/button";
+import { DtPopover } from "@/components/popover";
+import { DtStack } from "@/components/stack";
+import { DtInput } from "@/components/input";
+import { DtTooltip } from "@/components/tooltip";
 import {
   DtIconAlignCenter,
   DtIconAlignJustify,
@@ -206,10 +199,10 @@ import {
   DtIconQuote,
   DtIconStrikethrough,
   DtIconUnderline,
-} from '@dialpad/dialtone-icons/vue3';
+} from "@dialpad/dialtone-icons/vue3";
 
 export default {
-  name: 'DtRecipeEditor',
+  name: "DtRecipeEditor",
 
   components: {
     DtRichTextEditor,
@@ -245,7 +238,7 @@ export default {
      */
     value: {
       type: [Object, String],
-      default: '',
+      default: "",
     },
 
     /**
@@ -262,7 +255,7 @@ export default {
     inputAriaLabel: {
       type: String,
       required: true,
-      default: '',
+      default: "",
     },
 
     /**
@@ -272,7 +265,7 @@ export default {
      */
     inputClass: {
       type: String,
-      default: '',
+      default: "",
     },
 
     /**
@@ -289,8 +282,8 @@ export default {
     autoFocus: {
       type: [Boolean, String, Number],
       default: false,
-      validator (autoFocus) {
-        if (typeof autoFocus === 'string') {
+      validator(autoFocus) {
+        if (typeof autoFocus === "string") {
           return RICH_TEXT_EDITOR_AUTOFOCUS_TYPES.includes(autoFocus);
         }
         return true;
@@ -302,7 +295,7 @@ export default {
      */
     placeholder: {
       type: String,
-      default: '',
+      default: "",
     },
 
     /**
@@ -311,7 +304,7 @@ export default {
      */
     maxHeight: {
       type: String,
-      default: 'unset',
+      default: "unset",
     },
 
     /**
@@ -319,7 +312,7 @@ export default {
      */
     confirmSetLinkButton: {
       type: Object,
-      default: () => ({ label: 'Confirm', ariaLabel: 'Confirm set link' }),
+      default: () => ({ label: "Confirm", ariaLabel: "Confirm set link" }),
     },
 
     /**
@@ -327,7 +320,7 @@ export default {
      */
     removeLinkButton: {
       type: Object,
-      default: () => ({ label: 'Remove', ariaLabel: 'Remove link' }),
+      default: () => ({ label: "Remove", ariaLabel: "Remove link" }),
     },
 
     /**
@@ -335,7 +328,7 @@ export default {
      */
     cancelSetLinkButton: {
       type: Object,
-      default: () => ({ label: 'Cancel', ariaLabel: 'Cancel set link' }),
+      default: () => ({ label: "Cancel", ariaLabel: "Cancel set link" }),
     },
 
     /**
@@ -343,7 +336,7 @@ export default {
      */
     setLinkPlaceholder: {
       type: String,
-      default: '',
+      default: "",
     },
 
     /**
@@ -457,8 +450,8 @@ export default {
       type: Object,
       default: () => ({
         showAddLinkButton: true,
-        setLinkTitle: 'Add a link',
-        setLinkInputAriaLabel: 'Input field to add link',
+        setLinkTitle: "Add a link",
+        setLinkInputAriaLabel: "Input field to add link",
       }),
     },
   },
@@ -469,140 +462,250 @@ export default {
      * @event input
      * @type {String|JSON}
      */
-    'focus',
+    "focus",
 
     /**
      * Native blur event
      * @event input
      * @type {String|JSON}
      */
-    'blur',
+    "blur",
 
     /**
      * Native input event
      * @event input
      * @type {String|JSON}
      */
-    'input',
+    "input",
 
     /**
      * Quick replies button
      * pressed event
      * @event quick-replies-click
-    */
-    'quick-replies-click',
+     */
+    "quick-replies-click",
   ],
 
-  data () {
+  data() {
     return {
       internalInputValue: this.value, // internal input content
       hasFocus: false,
 
       linkOptions: {
-        class: 'd-link d-c-text d-d-inline-block',
+        class: "d-link d-c-text d-d-inline-block",
       },
 
       showLinkInput: false,
-      linkInput: '',
+      linkInput: "",
     };
   },
 
   computed: {
-    inputLength () {
+    inputLength() {
       return this.internalInputValue.length;
     },
 
-    htmlOutputFormat () {
+    htmlOutputFormat() {
       return RICH_TEXT_EDITOR_OUTPUT_FORMATS[2];
     },
 
-    showingTextFormatButtons () {
-      return this.showBoldButton || this.showItalicsButton || this.showStrikeButton || this.showUnderlineButton;
+    showingTextFormatButtons() {
+      return (
+        this.showBoldButton ||
+        this.showItalicsButton ||
+        this.showStrikeButton ||
+        this.showUnderlineButton
+      );
     },
 
-    showingAlignmentButtons () {
-      return this.showAlignLeftButton || this.showAlignCenterButton ||
-          this.showAlignRightButton || this.showAlignJustifyButton;
+    showingAlignmentButtons() {
+      return (
+        this.showAlignLeftButton ||
+        this.showAlignCenterButton ||
+        this.showAlignRightButton ||
+        this.showAlignJustifyButton
+      );
     },
 
-    showingListButtons () {
+    showingListButtons() {
       return this.showListItemsButton || this.showOrderedListButton;
     },
 
-    buttonGroups () {
-      const individualButtonStacks = this.individualButtons.map(buttonData => ({
-        key: buttonData.selector,
-        buttonGroup: [buttonData],
-      }));
+    buttonGroups() {
+      const individualButtonStacks = this.individualButtons.map(
+        (buttonData) => ({
+          key: buttonData.selector,
+          buttonGroup: [buttonData],
+        }),
+      );
       return [
-        { key: 'new', buttonGroup: this.newButtons },
-        { key: 'format', buttonGroup: this.textFormatButtons },
-        { key: 'alignment', buttonGroup: this.alignmentButtons },
-        { key: 'list', buttonGroup: this.listButtons },
+        { key: "new", buttonGroup: this.newButtons },
+        { key: "format", buttonGroup: this.textFormatButtons },
+        { key: "alignment", buttonGroup: this.alignmentButtons },
+        { key: "list", buttonGroup: this.listButtons },
         ...individualButtonStacks,
-      ].filter(buttonGroupData => buttonGroupData.buttonGroup.length > 0);
+      ].filter((buttonGroupData) => buttonGroupData.buttonGroup.length > 0);
     },
 
-    newButtons () {
+    newButtons() {
       return [
-        { showBtn: this.showQuickRepliesButton, label: 'Quick reply', selector: 'quickReplies', icon: DtIconLightningBolt, dataQA: 'dt-editor-quick-replies-btn', tooltipMessage: 'Quick Reply', onClick: this.onQuickRepliesClick },
-      ].filter(button => button.showBtn);
+        {
+          showBtn: this.showQuickRepliesButton,
+          label: "Quick reply",
+          selector: "quickReplies",
+          icon: DtIconLightningBolt,
+          dataQA: "dt-editor-quick-replies-btn",
+          tooltipMessage: "Quick Reply",
+          onClick: this.onQuickRepliesClick,
+        },
+      ].filter((button) => button.showBtn);
     },
 
-    textFormatButtons () {
+    textFormatButtons() {
       return [
-        { showBtn: this.showBoldButton, selector: 'bold', icon: DtIconBold, dataQA: 'dt-editor-bold-btn', tooltipMessage: 'Bold', onClick: this.onBoldTextToggle },
-        { showBtn: this.showItalicsButton, selector: 'italic', icon: DtIconItalic, dataQA: 'dt-editor-italics-btn', tooltipMessage: 'Italics', onClick: this.onItalicTextToggle },
-        { showBtn: this.showUnderlineButton, selector: 'underline', icon: DtIconUnderline, dataQA: 'dt-editor-underline-btn', tooltipMessage: 'Underline', onClick: this.onUnderlineTextToggle },
-        { showBtn: this.showStrikeButton, selector: 'strike', icon: DtIconStrikethrough, dataQA: 'dt-editor-strike-btn', tooltipMessage: 'Strike', onClick: this.onStrikethroughTextToggle },
-      ].filter(button => button.showBtn);
+        {
+          showBtn: this.showBoldButton,
+          selector: "bold",
+          icon: DtIconBold,
+          dataQA: "dt-editor-bold-btn",
+          tooltipMessage: "Bold",
+          onClick: this.onBoldTextToggle,
+        },
+        {
+          showBtn: this.showItalicsButton,
+          selector: "italic",
+          icon: DtIconItalic,
+          dataQA: "dt-editor-italics-btn",
+          tooltipMessage: "Italics",
+          onClick: this.onItalicTextToggle,
+        },
+        {
+          showBtn: this.showUnderlineButton,
+          selector: "underline",
+          icon: DtIconUnderline,
+          dataQA: "dt-editor-underline-btn",
+          tooltipMessage: "Underline",
+          onClick: this.onUnderlineTextToggle,
+        },
+        {
+          showBtn: this.showStrikeButton,
+          selector: "strike",
+          icon: DtIconStrikethrough,
+          dataQA: "dt-editor-strike-btn",
+          tooltipMessage: "Strike",
+          onClick: this.onStrikethroughTextToggle,
+        },
+      ].filter((button) => button.showBtn);
     },
 
-    alignmentButtons () {
+    alignmentButtons() {
       return [
-        { showBtn: this.showAlignLeftButton, selector: { textAlign: 'left' }, icon: DtIconAlignLeft, dataQA: 'dt-editor-align-left-btn', tooltipMessage: 'Align Left', onClick: () => this.onTextAlign('left') },
-        { showBtn: this.showAlignCenterButton, selector: { textAlign: 'center' }, icon: DtIconAlignCenter, dataQA: 'dt-editor-align-center-btn', tooltipMessage: 'Align Center', onClick: () => this.onTextAlign('center') },
-        { showBtn: this.showAlignRightButton, selector: { textAlign: 'right' }, icon: DtIconAlignRight, dataQA: 'dt-editor-align-right-btn', tooltipMessage: 'Align Right', onClick: () => this.onTextAlign('right') },
-        { showBtn: this.showAlignJustifyButton, selector: { textAlign: 'justify' }, icon: DtIconAlignJustify, dataQA: 'dt-editor-align-justify-btn', tooltipMessage: 'Align Justify', onClick: () => this.onTextAlign('justify') },
-      ].filter(button => button.showBtn);
+        {
+          showBtn: this.showAlignLeftButton,
+          selector: { textAlign: "left" },
+          icon: DtIconAlignLeft,
+          dataQA: "dt-editor-align-left-btn",
+          tooltipMessage: "Align Left",
+          onClick: () => this.onTextAlign("left"),
+        },
+        {
+          showBtn: this.showAlignCenterButton,
+          selector: { textAlign: "center" },
+          icon: DtIconAlignCenter,
+          dataQA: "dt-editor-align-center-btn",
+          tooltipMessage: "Align Center",
+          onClick: () => this.onTextAlign("center"),
+        },
+        {
+          showBtn: this.showAlignRightButton,
+          selector: { textAlign: "right" },
+          icon: DtIconAlignRight,
+          dataQA: "dt-editor-align-right-btn",
+          tooltipMessage: "Align Right",
+          onClick: () => this.onTextAlign("right"),
+        },
+        {
+          showBtn: this.showAlignJustifyButton,
+          selector: { textAlign: "justify" },
+          icon: DtIconAlignJustify,
+          dataQA: "dt-editor-align-justify-btn",
+          tooltipMessage: "Align Justify",
+          onClick: () => this.onTextAlign("justify"),
+        },
+      ].filter((button) => button.showBtn);
     },
 
-    listButtons () {
+    listButtons() {
       return [
-        { showBtn: this.showListItemsButton, selector: 'bulletList', icon: DtIconListBullet, dataQA: 'dt-editor-list-items-btn', tooltipMessage: 'Bullet List', onClick: this.onBulletListToggle },
-        { showBtn: this.showOrderedListButton, selector: 'orderedList', icon: DtIconListOrdered, dataQA: 'dt-editor-ordered-list-items-btn', tooltipMessage: 'Ordered List', onClick: this.onOrderedListToggle },
-      ].filter(button => button.showBtn);
+        {
+          showBtn: this.showListItemsButton,
+          selector: "bulletList",
+          icon: DtIconListBullet,
+          dataQA: "dt-editor-list-items-btn",
+          tooltipMessage: "Bullet List",
+          onClick: this.onBulletListToggle,
+        },
+        {
+          showBtn: this.showOrderedListButton,
+          selector: "orderedList",
+          icon: DtIconListOrdered,
+          dataQA: "dt-editor-ordered-list-items-btn",
+          tooltipMessage: "Ordered List",
+          onClick: this.onOrderedListToggle,
+        },
+      ].filter((button) => button.showBtn);
     },
 
-    individualButtons () {
+    individualButtons() {
       return [
-        { showBtn: this.showQuoteButton, selector: 'blockquote', icon: DtIconQuote, dataQA: 'dt-editor-blockquote-btn', tooltipMessage: 'Quote', onClick: this.onBlockquoteToggle },
-        { showBtn: this.showCodeBlockButton, selector: 'codeBlock', icon: DtIconCodeBlock, dataQA: 'dt-editor-code-block-btn', tooltipMessage: 'Code', onClick: this.onCodeBlockToggle },
-      ].filter(button => button.showBtn);
+        {
+          showBtn: this.showQuoteButton,
+          selector: "blockquote",
+          icon: DtIconQuote,
+          dataQA: "dt-editor-blockquote-btn",
+          tooltipMessage: "Quote",
+          onClick: this.onBlockquoteToggle,
+        },
+        {
+          showBtn: this.showCodeBlockButton,
+          selector: "codeBlock",
+          icon: DtIconCodeBlock,
+          dataQA: "dt-editor-code-block-btn",
+          tooltipMessage: "Code",
+          onClick: this.onCodeBlockToggle,
+        },
+      ].filter((button) => button.showBtn);
     },
 
-    linkButton () {
-      return { showBtn: this.showAddLink.showAddLinkButton, selector: 'link', icon: DtIconLink2, dataQA: 'dt-editor-add-link-btn', tooltipMessage: 'Link', onClick: this.openLinkInput };
+    linkButton() {
+      return {
+        showBtn: this.showAddLink.showAddLinkButton,
+        selector: "link",
+        icon: DtIconLink2,
+        dataQA: "dt-editor-add-link-btn",
+        tooltipMessage: "Link",
+        onClick: this.openLinkInput,
+      };
     },
   },
 
   watch: {
-    value (newValue) {
+    value(newValue) {
       this.internalInputValue = newValue;
     },
   },
 
   methods: {
-    onInputFocus (event) {
+    onInputFocus(event) {
       event?.stopPropagation();
     },
 
-    removeLink () {
+    removeLink() {
       this.$refs.richTextEditor?.editor?.chain()?.focus()?.unsetLink()?.run();
       this.closeLinkInput();
     },
 
-    setLink (event) {
+    setLink(event) {
       const editor = this.$refs.richTextEditor?.editor;
       event?.preventDefault();
       event?.stopPropagation();
@@ -615,7 +718,9 @@ export default {
       }
 
       // Check if input matches any of the supported link formats
-      const prefix = EDITOR_SUPPORTED_LINK_PROTOCOLS.find(prefixRegex => prefixRegex.test(this.linkInput));
+      const prefix = EDITOR_SUPPORTED_LINK_PROTOCOLS.find((prefixRegex) =>
+        prefixRegex.test(this.linkInput),
+      );
 
       if (!prefix) {
         // If no matching pattern is found, prepend default prefix
@@ -641,7 +746,7 @@ export default {
         editor
           .chain()
           .focus()
-          .extendMarkRange('link')
+          .extendMarkRange("link")
           .setLink({ href: this.linkInput, class: this.linkOptions.class })
           .run();
       }
@@ -649,81 +754,103 @@ export default {
       this.closeLinkInput();
     },
 
-    openLinkInput () {
+    openLinkInput() {
       this.showLinkInput = true;
     },
 
-    updateInput (openedInput) {
+    updateInput(openedInput) {
       if (!openedInput) {
         return this.closeLinkInput();
       }
-      this.linkInput = this.$refs.richTextEditor?.editor?.getAttributes('link')?.href;
+      this.linkInput =
+        this.$refs.richTextEditor?.editor?.getAttributes("link")?.href;
     },
 
-    closeLinkInput () {
+    closeLinkInput() {
       this.showLinkInput = false;
-      this.linkInput = '';
+      this.linkInput = "";
       this.$refs.richTextEditor.editor?.chain().focus();
     },
 
-    onBoldTextToggle () {
+    onBoldTextToggle() {
       this.$refs.richTextEditor?.editor?.chain().focus().toggleBold().run();
     },
 
-    onItalicTextToggle () {
+    onItalicTextToggle() {
       this.$refs.richTextEditor?.editor.chain().focus().toggleItalic().run();
     },
 
-    onUnderlineTextToggle () {
+    onUnderlineTextToggle() {
       this.$refs.richTextEditor?.editor.chain().focus().toggleUnderline().run();
     },
 
-    onStrikethroughTextToggle () {
+    onStrikethroughTextToggle() {
       this.$refs.richTextEditor?.editor.chain().focus().toggleStrike().run();
     },
 
-    onTextAlign (alignment) {
-      if (this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })) {
+    onTextAlign(alignment) {
+      if (
+        this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })
+      ) {
         // If this alignment type is already set here, unset it
-        return this.$refs.richTextEditor?.editor.chain().focus().unsetTextAlign().run();
+        return this.$refs.richTextEditor?.editor
+          .chain()
+          .focus()
+          .unsetTextAlign()
+          .run();
       }
-      this.$refs.richTextEditor?.editor.chain().focus().setTextAlign(alignment).run();
+      this.$refs.richTextEditor?.editor
+        .chain()
+        .focus()
+        .setTextAlign(alignment)
+        .run();
     },
 
-    onBulletListToggle () {
-      this.$refs.richTextEditor?.editor.chain().focus().toggleBulletList().run();
+    onBulletListToggle() {
+      this.$refs.richTextEditor?.editor
+        .chain()
+        .focus()
+        .toggleBulletList()
+        .run();
     },
 
-    onOrderedListToggle () {
-      this.$refs.richTextEditor?.editor.chain().focus().toggleOrderedList().run();
+    onOrderedListToggle() {
+      this.$refs.richTextEditor?.editor
+        .chain()
+        .focus()
+        .toggleOrderedList()
+        .run();
     },
 
-    onCodeBlockToggle () {
+    onCodeBlockToggle() {
       this.$refs.richTextEditor?.editor.chain().focus().toggleCodeBlock().run();
     },
 
-    onQuickRepliesClick () {
-      this.$emit('quick-replies-click');
+    onQuickRepliesClick() {
+      this.$emit("quick-replies-click");
     },
 
-    onBlockquoteToggle () {
-      this.$refs.richTextEditor?.editor.chain().focus().toggleBlockquote().run();
+    onBlockquoteToggle() {
+      this.$refs.richTextEditor?.editor
+        .chain()
+        .focus()
+        .toggleBlockquote()
+        .run();
     },
 
-    onFocus (event) {
+    onFocus(event) {
       this.hasFocus = true;
-      this.$emit('focus', event);
+      this.$emit("focus", event);
     },
 
-    onBlur (event) {
+    onBlur(event) {
       this.hasFocus = false;
-      this.$emit('blur', event);
+      this.$emit("blur", event);
     },
 
-    onInput (event) {
-      this.$emit('input', event);
+    onInput(event) {
+      this.$emit("input", event);
     },
-
   },
 };
 </script>

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -36,7 +36,10 @@
               @click="button.onClick()"
             >
               <template #icon>
-                <component :is="button.icon" size="200" />
+                <component
+                  :is="button.icon"
+                  size="200"
+                />
               </template>
               {{ button?.label }}
             </dt-button>
@@ -44,7 +47,11 @@
         </dt-tooltip>
         <div class="dt-editor--button-group-divider" />
       </dt-stack>
-      <dt-stack v-if="linkButton.showBtn" direction="row" gap="300">
+      <dt-stack
+        v-if="linkButton.showBtn"
+        direction="row"
+        gap="300"
+      >
         <dt-popover
           :open="showLinkInput"
           placement="bottom-start"
@@ -174,16 +181,16 @@ import {
   DtRichTextEditor,
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
   RICH_TEXT_EDITOR_AUTOFOCUS_TYPES,
-} from "@/components/rich_text_editor";
+} from '@/components/rich_text_editor';
 import {
   EDITOR_SUPPORTED_LINK_PROTOCOLS,
   EDITOR_DEFAULT_LINK_PREFIX,
-} from "./editor_constants.js";
-import { DtButton } from "@/components/button";
-import { DtPopover } from "@/components/popover";
-import { DtStack } from "@/components/stack";
-import { DtInput } from "@/components/input";
-import { DtTooltip } from "@/components/tooltip";
+} from './editor_constants.js';
+import { DtButton } from '@/components/button';
+import { DtPopover } from '@/components/popover';
+import { DtStack } from '@/components/stack';
+import { DtInput } from '@/components/input';
+import { DtTooltip } from '@/components/tooltip';
 import {
   DtIconAlignCenter,
   DtIconAlignJustify,
@@ -199,10 +206,10 @@ import {
   DtIconQuote,
   DtIconStrikethrough,
   DtIconUnderline,
-} from "@dialpad/dialtone-icons/vue3";
+} from '@dialpad/dialtone-icons/vue3';
 
 export default {
-  name: "DtRecipeEditor",
+  name: 'DtRecipeEditor',
 
   components: {
     DtRichTextEditor,
@@ -238,7 +245,7 @@ export default {
      */
     value: {
       type: [Object, String],
-      default: "",
+      default: '',
     },
 
     /**
@@ -255,7 +262,7 @@ export default {
     inputAriaLabel: {
       type: String,
       required: true,
-      default: "",
+      default: '',
     },
 
     /**
@@ -265,7 +272,7 @@ export default {
      */
     inputClass: {
       type: String,
-      default: "",
+      default: '',
     },
 
     /**
@@ -282,8 +289,8 @@ export default {
     autoFocus: {
       type: [Boolean, String, Number],
       default: false,
-      validator(autoFocus) {
-        if (typeof autoFocus === "string") {
+      validator (autoFocus) {
+        if (typeof autoFocus === 'string') {
           return RICH_TEXT_EDITOR_AUTOFOCUS_TYPES.includes(autoFocus);
         }
         return true;
@@ -295,7 +302,7 @@ export default {
      */
     placeholder: {
       type: String,
-      default: "",
+      default: '',
     },
 
     /**
@@ -304,7 +311,7 @@ export default {
      */
     maxHeight: {
       type: String,
-      default: "unset",
+      default: 'unset',
     },
 
     /**
@@ -312,7 +319,7 @@ export default {
      */
     confirmSetLinkButton: {
       type: Object,
-      default: () => ({ label: "Confirm", ariaLabel: "Confirm set link" }),
+      default: () => ({ label: 'Confirm', ariaLabel: 'Confirm set link' }),
     },
 
     /**
@@ -320,7 +327,7 @@ export default {
      */
     removeLinkButton: {
       type: Object,
-      default: () => ({ label: "Remove", ariaLabel: "Remove link" }),
+      default: () => ({ label: 'Remove', ariaLabel: 'Remove link' }),
     },
 
     /**
@@ -328,7 +335,7 @@ export default {
      */
     cancelSetLinkButton: {
       type: Object,
-      default: () => ({ label: "Cancel", ariaLabel: "Cancel set link" }),
+      default: () => ({ label: 'Cancel', ariaLabel: 'Cancel set link' }),
     },
 
     /**
@@ -336,7 +343,7 @@ export default {
      */
     setLinkPlaceholder: {
       type: String,
-      default: "",
+      default: '',
     },
 
     /**
@@ -450,8 +457,8 @@ export default {
       type: Object,
       default: () => ({
         showAddLinkButton: true,
-        setLinkTitle: "Add a link",
-        setLinkInputAriaLabel: "Input field to add link",
+        setLinkTitle: 'Add a link',
+        setLinkInputAriaLabel: 'Input field to add link',
       }),
     },
   },
@@ -462,54 +469,54 @@ export default {
      * @event input
      * @type {String|JSON}
      */
-    "focus",
+    'focus',
 
     /**
      * Native blur event
      * @event input
      * @type {String|JSON}
      */
-    "blur",
+    'blur',
 
     /**
      * Native input event
      * @event input
      * @type {String|JSON}
      */
-    "input",
+    'input',
 
     /**
      * Quick replies button
      * pressed event
      * @event quick-replies-click
      */
-    "quick-replies-click",
+    'quick-replies-click',
   ],
 
-  data() {
+  data () {
     return {
       internalInputValue: this.value, // internal input content
       hasFocus: false,
 
       linkOptions: {
-        class: "d-link d-c-text d-d-inline-block",
+        class: 'd-link d-c-text d-d-inline-block',
       },
 
       showLinkInput: false,
-      linkInput: "",
+      linkInput: '',
     };
   },
 
   computed: {
-    inputLength() {
+    inputLength () {
       return this.internalInputValue.length;
     },
 
-    htmlOutputFormat() {
+    htmlOutputFormat () {
       return RICH_TEXT_EDITOR_OUTPUT_FORMATS[2];
     },
 
-    showingTextFormatButtons() {
+    showingTextFormatButtons () {
       return (
         this.showBoldButton ||
         this.showItalicsButton ||
@@ -518,7 +525,7 @@ export default {
       );
     },
 
-    showingAlignmentButtons() {
+    showingAlignmentButtons () {
       return (
         this.showAlignLeftButton ||
         this.showAlignCenterButton ||
@@ -527,11 +534,11 @@ export default {
       );
     },
 
-    showingListButtons() {
+    showingListButtons () {
       return this.showListItemsButton || this.showOrderedListButton;
     },
 
-    buttonGroups() {
+    buttonGroups () {
       const individualButtonStacks = this.individualButtons.map(
         (buttonData) => ({
           key: buttonData.selector,
@@ -539,173 +546,173 @@ export default {
         }),
       );
       return [
-        { key: "new", buttonGroup: this.newButtons },
-        { key: "format", buttonGroup: this.textFormatButtons },
-        { key: "alignment", buttonGroup: this.alignmentButtons },
-        { key: "list", buttonGroup: this.listButtons },
+        { key: 'new', buttonGroup: this.newButtons },
+        { key: 'format', buttonGroup: this.textFormatButtons },
+        { key: 'alignment', buttonGroup: this.alignmentButtons },
+        { key: 'list', buttonGroup: this.listButtons },
         ...individualButtonStacks,
       ].filter((buttonGroupData) => buttonGroupData.buttonGroup.length > 0);
     },
 
-    newButtons() {
+    newButtons () {
       return [
         {
           showBtn: this.showQuickRepliesButton,
-          label: "Quick reply",
-          selector: "quickReplies",
+          label: 'Quick reply',
+          selector: 'quickReplies',
           icon: DtIconLightningBolt,
-          dataQA: "dt-editor-quick-replies-btn",
-          tooltipMessage: "Quick Reply",
+          dataQA: 'dt-editor-quick-replies-btn',
+          tooltipMessage: 'Quick Reply',
           onClick: this.onQuickRepliesClick,
         },
       ].filter((button) => button.showBtn);
     },
 
-    textFormatButtons() {
+    textFormatButtons () {
       return [
         {
           showBtn: this.showBoldButton,
-          selector: "bold",
+          selector: 'bold',
           icon: DtIconBold,
-          dataQA: "dt-editor-bold-btn",
-          tooltipMessage: "Bold",
+          dataQA: 'dt-editor-bold-btn',
+          tooltipMessage: 'Bold',
           onClick: this.onBoldTextToggle,
         },
         {
           showBtn: this.showItalicsButton,
-          selector: "italic",
+          selector: 'italic',
           icon: DtIconItalic,
-          dataQA: "dt-editor-italics-btn",
-          tooltipMessage: "Italics",
+          dataQA: 'dt-editor-italics-btn',
+          tooltipMessage: 'Italics',
           onClick: this.onItalicTextToggle,
         },
         {
           showBtn: this.showUnderlineButton,
-          selector: "underline",
+          selector: 'underline',
           icon: DtIconUnderline,
-          dataQA: "dt-editor-underline-btn",
-          tooltipMessage: "Underline",
+          dataQA: 'dt-editor-underline-btn',
+          tooltipMessage: 'Underline',
           onClick: this.onUnderlineTextToggle,
         },
         {
           showBtn: this.showStrikeButton,
-          selector: "strike",
+          selector: 'strike',
           icon: DtIconStrikethrough,
-          dataQA: "dt-editor-strike-btn",
-          tooltipMessage: "Strike",
+          dataQA: 'dt-editor-strike-btn',
+          tooltipMessage: 'Strike',
           onClick: this.onStrikethroughTextToggle,
         },
       ].filter((button) => button.showBtn);
     },
 
-    alignmentButtons() {
+    alignmentButtons () {
       return [
         {
           showBtn: this.showAlignLeftButton,
-          selector: { textAlign: "left" },
+          selector: { textAlign: 'left' },
           icon: DtIconAlignLeft,
-          dataQA: "dt-editor-align-left-btn",
-          tooltipMessage: "Align Left",
-          onClick: () => this.onTextAlign("left"),
+          dataQA: 'dt-editor-align-left-btn',
+          tooltipMessage: 'Align Left',
+          onClick: () => this.onTextAlign('left'),
         },
         {
           showBtn: this.showAlignCenterButton,
-          selector: { textAlign: "center" },
+          selector: { textAlign: 'center' },
           icon: DtIconAlignCenter,
-          dataQA: "dt-editor-align-center-btn",
-          tooltipMessage: "Align Center",
-          onClick: () => this.onTextAlign("center"),
+          dataQA: 'dt-editor-align-center-btn',
+          tooltipMessage: 'Align Center',
+          onClick: () => this.onTextAlign('center'),
         },
         {
           showBtn: this.showAlignRightButton,
-          selector: { textAlign: "right" },
+          selector: { textAlign: 'right' },
           icon: DtIconAlignRight,
-          dataQA: "dt-editor-align-right-btn",
-          tooltipMessage: "Align Right",
-          onClick: () => this.onTextAlign("right"),
+          dataQA: 'dt-editor-align-right-btn',
+          tooltipMessage: 'Align Right',
+          onClick: () => this.onTextAlign('right'),
         },
         {
           showBtn: this.showAlignJustifyButton,
-          selector: { textAlign: "justify" },
+          selector: { textAlign: 'justify' },
           icon: DtIconAlignJustify,
-          dataQA: "dt-editor-align-justify-btn",
-          tooltipMessage: "Align Justify",
-          onClick: () => this.onTextAlign("justify"),
+          dataQA: 'dt-editor-align-justify-btn',
+          tooltipMessage: 'Align Justify',
+          onClick: () => this.onTextAlign('justify'),
         },
       ].filter((button) => button.showBtn);
     },
 
-    listButtons() {
+    listButtons () {
       return [
         {
           showBtn: this.showListItemsButton,
-          selector: "bulletList",
+          selector: 'bulletList',
           icon: DtIconListBullet,
-          dataQA: "dt-editor-list-items-btn",
-          tooltipMessage: "Bullet List",
+          dataQA: 'dt-editor-list-items-btn',
+          tooltipMessage: 'Bullet List',
           onClick: this.onBulletListToggle,
         },
         {
           showBtn: this.showOrderedListButton,
-          selector: "orderedList",
+          selector: 'orderedList',
           icon: DtIconListOrdered,
-          dataQA: "dt-editor-ordered-list-items-btn",
-          tooltipMessage: "Ordered List",
+          dataQA: 'dt-editor-ordered-list-items-btn',
+          tooltipMessage: 'Ordered List',
           onClick: this.onOrderedListToggle,
         },
       ].filter((button) => button.showBtn);
     },
 
-    individualButtons() {
+    individualButtons () {
       return [
         {
           showBtn: this.showQuoteButton,
-          selector: "blockquote",
+          selector: 'blockquote',
           icon: DtIconQuote,
-          dataQA: "dt-editor-blockquote-btn",
-          tooltipMessage: "Quote",
+          dataQA: 'dt-editor-blockquote-btn',
+          tooltipMessage: 'Quote',
           onClick: this.onBlockquoteToggle,
         },
         {
           showBtn: this.showCodeBlockButton,
-          selector: "codeBlock",
+          selector: 'codeBlock',
           icon: DtIconCodeBlock,
-          dataQA: "dt-editor-code-block-btn",
-          tooltipMessage: "Code",
+          dataQA: 'dt-editor-code-block-btn',
+          tooltipMessage: 'Code',
           onClick: this.onCodeBlockToggle,
         },
       ].filter((button) => button.showBtn);
     },
 
-    linkButton() {
+    linkButton () {
       return {
         showBtn: this.showAddLink.showAddLinkButton,
-        selector: "link",
+        selector: 'link',
         icon: DtIconLink2,
-        dataQA: "dt-editor-add-link-btn",
-        tooltipMessage: "Link",
+        dataQA: 'dt-editor-add-link-btn',
+        tooltipMessage: 'Link',
         onClick: this.openLinkInput,
       };
     },
   },
 
   watch: {
-    value(newValue) {
+    value (newValue) {
       this.internalInputValue = newValue;
     },
   },
 
   methods: {
-    onInputFocus(event) {
+    onInputFocus (event) {
       event?.stopPropagation();
     },
 
-    removeLink() {
+    removeLink () {
       this.$refs.richTextEditor?.editor?.chain()?.focus()?.unsetLink()?.run();
       this.closeLinkInput();
     },
 
-    setLink(event) {
+    setLink (event) {
       const editor = this.$refs.richTextEditor?.editor;
       event?.preventDefault();
       event?.stopPropagation();
@@ -746,7 +753,7 @@ export default {
         editor
           .chain()
           .focus()
-          .extendMarkRange("link")
+          .extendMarkRange('link')
           .setLink({ href: this.linkInput, class: this.linkOptions.class })
           .run();
       }
@@ -754,41 +761,41 @@ export default {
       this.closeLinkInput();
     },
 
-    openLinkInput() {
+    openLinkInput () {
       this.showLinkInput = true;
     },
 
-    updateInput(openedInput) {
+    updateInput (openedInput) {
       if (!openedInput) {
         return this.closeLinkInput();
       }
       this.linkInput =
-        this.$refs.richTextEditor?.editor?.getAttributes("link")?.href;
+        this.$refs.richTextEditor?.editor?.getAttributes('link')?.href;
     },
 
-    closeLinkInput() {
+    closeLinkInput () {
       this.showLinkInput = false;
-      this.linkInput = "";
+      this.linkInput = '';
       this.$refs.richTextEditor.editor?.chain().focus();
     },
 
-    onBoldTextToggle() {
+    onBoldTextToggle () {
       this.$refs.richTextEditor?.editor?.chain().focus().toggleBold().run();
     },
 
-    onItalicTextToggle() {
+    onItalicTextToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleItalic().run();
     },
 
-    onUnderlineTextToggle() {
+    onUnderlineTextToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleUnderline().run();
     },
 
-    onStrikethroughTextToggle() {
+    onStrikethroughTextToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleStrike().run();
     },
 
-    onTextAlign(alignment) {
+    onTextAlign (alignment) {
       if (
         this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })
       ) {
@@ -806,7 +813,7 @@ export default {
         .run();
     },
 
-    onBulletListToggle() {
+    onBulletListToggle () {
       this.$refs.richTextEditor?.editor
         .chain()
         .focus()
@@ -814,7 +821,7 @@ export default {
         .run();
     },
 
-    onOrderedListToggle() {
+    onOrderedListToggle () {
       this.$refs.richTextEditor?.editor
         .chain()
         .focus()
@@ -822,15 +829,15 @@ export default {
         .run();
     },
 
-    onCodeBlockToggle() {
+    onCodeBlockToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleCodeBlock().run();
     },
 
-    onQuickRepliesClick() {
-      this.$emit("quick-replies-click");
+    onQuickRepliesClick () {
+      this.$emit('quick-replies-click');
     },
 
-    onBlockquoteToggle() {
+    onBlockquoteToggle () {
       this.$refs.richTextEditor?.editor
         .chain()
         .focus()
@@ -838,18 +845,18 @@ export default {
         .run();
     },
 
-    onFocus(event) {
+    onFocus (event) {
       this.hasFocus = true;
-      this.$emit("focus", event);
+      this.$emit('focus', event);
     },
 
-    onBlur(event) {
+    onBlur (event) {
       this.hasFocus = false;
-      this.$emit("blur", event);
+      this.$emit('blur', event);
     },
 
-    onInput(event) {
-      this.$emit("input", event);
+    onInput (event) {
+      this.$emit('input', event);
     },
   },
 };

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -184,13 +184,12 @@
             v-dt-tooltip:top-end="showSend?.tooltipLabel"
             data-qa="dt-message-input-send-btn"
             size="sm"
-            class="dt-message-input__button"
             kind="default"
             importance="primary"
             :class="[
               {
-                'dt-message-input__send-button--disabled': isSendDisabled,
-                'd-btn--icon-only': showSendIcon,
+                'dt-message-input__button dt-message-input__send-button--disabled': isSendDisabled,
+                'dt-message-input__button d-btn--icon-only': showSendIcon,
               },
             ]"
             :aria-label="showSend.ariaLabel"

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -59,7 +59,7 @@
             data-qa="dt-message-input-image-btn"
             size="sm"
             class="dt-message-input__button"
-            :kind="imagePickerFocus ? 'muted' : 'muted'"
+            kind="muted"
             importance="clear"
             :aria-label="showImagePicker.ariaLabel"
             @click="onSelectImage"
@@ -96,7 +96,7 @@
                 data-qa="dt-message-input-emoji-picker-btn"
                 size="sm"
                 class="dt-message-input__button"
-                :kind="emojiPickerHovered ? 'muted' : 'muted'"
+                kind="muted"
                 importance="clear"
                 :aria-label="emojiButtonAriaLabel"
                 @click="toggleEmojiPicker"
@@ -187,9 +187,10 @@
             kind="default"
             importance="primary"
             :class="[
+              'dt-message-input__button',
               {
-                'dt-message-input__button dt-message-input__send-button--disabled': isSendDisabled,
-                'dt-message-input__button d-btn--icon-only': showSendIcon,
+                'dt-message-input__send-button--disabled': isSendDisabled,
+                'd-btn--icon-only': showSendIcon,
               },
             ]"
             :aria-label="showSend.ariaLabel"

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -49,84 +49,86 @@
     <section class="dt-message-input__bottom-section">
       <!-- Left content -->
       <div class="dt-message-input__bottom-section-left">
-        <dt-button
-          v-if="showImagePicker"
-          v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
-          data-qa="dt-message-input-image-btn"
-          size="sm"
-          circle
-          :kind="imagePickerFocus ? 'default' : 'muted'"
-          importance="clear"
-          :aria-label="showImagePicker.ariaLabel"
-          @click="onSelectImage"
-          @mouseenter="imagePickerFocus = true"
-          @mouseleave="imagePickerFocus = false"
-          @focus="imagePickerFocus = true"
-          @blur="imagePickerFocus = false"
-        >
-          <template #icon>
-            <dt-icon-image
-              size="300"
-            />
-          </template>
-        </dt-button>
-        <dt-input
-          ref="messageInputImageUpload"
-          data-qa="dt-message-input-image-input"
-          accept="image/*, video/*"
-          type="file"
-          class="dt-message-input__image-input"
-          multiple
-          hidden
-          @input="onImageUpload"
-        />
-        <dt-popover
-          v-if="showEmojiPicker"
-          v-model:open="emojiPickerOpened"
-          data-qa="dt-message-input-emoji-picker-popover"
-          initial-focus-element="#searchInput"
-          padding="none"
-        >
-          <template #anchor="{ attrs }">
-            <dt-button
-              v-dt-tooltip="emojiTooltipMessage"
-              v-bind="attrs"
-              data-qa="dt-message-input-emoji-picker-btn"
-              size="sm"
-              circle
-              :kind="emojiPickerHovered ? 'default' : 'muted'"
-              importance="clear"
-              :aria-label="emojiButtonAriaLabel"
-              @click="toggleEmojiPicker"
-              @mouseenter="emojiPickerFocus = true"
-              @mouseleave="emojiPickerFocus = false"
-              @focus="emojiPickerFocus = true"
-              @blur="emojiPickerFocus = false"
-            >
-              <template #icon>
-                <dt-icon-very-satisfied
-                  v-if="emojiPickerHovered"
-                  size="300"
-                />
-                <dt-icon-satisfied
-                  v-else
-                  size="300"
-                />
-              </template>
-            </dt-button>
-          </template>
-          <template
-            #content="{ close }"
+        <dt-stack gap="200" direction="row">
+          <dt-button
+            v-if="showImagePicker"
+            v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
+            data-qa="dt-message-input-image-btn"
+            size="sm"
+            class="d-bar4"
+            style="width: 2.8rem; height: 2.8rem"
+            :kind="imagePickerFocus ? 'muted' : 'muted'"
+            importance="clear"
+            :aria-label="showImagePicker.ariaLabel"
+            @click="onSelectImage"
+            @mouseenter="imagePickerFocus = true"
+            @mouseleave="imagePickerFocus = false"
+            @focus="imagePickerFocus = true"
+            @blur="imagePickerFocus = false"
           >
-            <dt-emoji-picker
-              v-bind="emojiPickerProps"
-              @skin-tone="onSkinTone"
-              @selected-emoji="(emoji) => { close(); onSelectEmoji(emoji); }"
-            />
-          </template>
-        </dt-popover>
-        <!-- @slot Slot for emojiGiphy picker -->
-        <slot name="emojiGiphyPicker" />
+            <template #icon>
+              <dt-icon-image size="300" />
+            </template>
+          </dt-button>
+          <dt-input
+            ref="messageInputImageUpload"
+            data-qa="dt-message-input-image-input"
+            accept="image/*, video/*"
+            type="file"
+            class="dt-message-input__image-input"
+            multiple
+            hidden
+            @input="onImageUpload"
+          />
+          <dt-popover
+            v-if="showEmojiPicker"
+            v-model:open="emojiPickerOpened"
+            data-qa="dt-message-input-emoji-picker-popover"
+            initial-focus-element="#searchInput"
+            padding="none"
+          >
+            <template #anchor="{ attrs }">
+              <dt-button
+                v-dt-tooltip="emojiTooltipMessage"
+                v-bind="attrs"
+                data-qa="dt-message-input-emoji-picker-btn"
+                size="sm"
+                class="d-bar4"
+                style="width: 2.8rem; height: 2.8rem"
+                :kind="emojiPickerHovered ? 'muted' : 'muted'"
+                importance="clear"
+                :aria-label="emojiButtonAriaLabel"
+                @click="toggleEmojiPicker"
+                @mouseenter="emojiPickerFocus = true"
+                @mouseleave="emojiPickerFocus = false"
+                @focus="emojiPickerFocus = true"
+                @blur="emojiPickerFocus = false"
+              >
+                <template #icon>
+                  <dt-icon-very-satisfied
+                    v-if="emojiPickerHovered"
+                    size="300"
+                  />
+                  <dt-icon-satisfied v-else size="300" />
+                </template>
+              </dt-button>
+            </template>
+            <template #content="{ close }">
+              <dt-emoji-picker
+                v-bind="emojiPickerProps"
+                @skin-tone="onSkinTone"
+                @selected-emoji="
+                  (emoji) => {
+                    close();
+                    onSelectEmoji(emoji);
+                  }
+                "
+              />
+            </template>
+          </dt-popover>
+          <!-- @slot Slot for emojiGiphy picker -->
+          <slot name="emojiGiphyPicker" />
+        </dt-stack>
       </div>
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
@@ -159,8 +161,9 @@
         <dt-button
           v-if="showCancel"
           data-qa="dt-message-input-cancel-button"
-          class="dt-message-input__cancel-button"
+          class="dt-message-input__cancel-button d-bar4 d-p8"
           size="sm"
+          style="max-height: 2.8rem"
           kind="muted"
           importance="clear"
           :aria-label="showCancel.ariaLabel"
@@ -178,35 +181,27 @@
             v-dt-tooltip:top-end="showSend?.tooltipLabel"
             data-qa="dt-message-input-send-btn"
             size="sm"
+            class="d-bar4"
+            style="width: 2.8rem; height: 2.8rem"
             kind="default"
             importance="primary"
             :class="[
               {
                 'dt-message-input__send-button--disabled': isSendDisabled,
-                'd-btn--circle': showSendIcon,
+                'd-btn--icon-only': showSendIcon,
               },
             ]"
             :aria-label="showSend.ariaLabel"
             :aria-disabled="isSendDisabled"
             @click="onSend"
           >
-            <template
-              v-if="showSendIcon"
-              #icon
-            >
+            <template v-if="showSendIcon" #icon>
               <!-- @slot Slot for send button icon -->
-              <slot
-                name="sendIcon"
-                :icon-size="sendIconSize"
-              >
-                <dt-icon-send
-                  :size="sendIconSize"
-                />
+              <slot name="sendIcon" :icon-size="sendIconSize">
+                <dt-icon-send :size="sendIconSize" />
               </slot>
             </template>
-            <template
-              v-if="showSend.text"
-            >
+            <template v-if="showSend.text">
               <p>{{ showSend.text }}</p>
             </template>
           </dt-button>
@@ -222,17 +217,23 @@ import {
   DtRichTextEditor,
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
   RICH_TEXT_EDITOR_AUTOFOCUS_TYPES,
-} from '@/components/rich_text_editor';
-import meetingPill from './meeting_pill/meeting_pill';
-import { DtButton } from '@/components/button';
-import { DtEmojiPicker } from '@/components/emoji_picker';
-import { DtPopover } from '@/components/popover';
-import { DtInput } from '@/components/input';
-import { DtTooltip } from '@/components/tooltip';
-import { DtIconImage, DtIconVerySatisfied, DtIconSatisfied, DtIconSend } from '@dialpad/dialtone-icons/vue3';
+} from "@/components/rich_text_editor";
+import meetingPill from "./meeting_pill/meeting_pill";
+import { DtButton } from "@/components/button";
+import { DtEmojiPicker } from "@/components/emoji_picker";
+import { DtPopover } from "@/components/popover";
+import { DtInput } from "@/components/input";
+import { DtTooltip } from "@/components/tooltip";
+import { DtStack } from "@/components/stack";
+import {
+  DtIconImage,
+  DtIconVerySatisfied,
+  DtIconSatisfied,
+  DtIconSend,
+} from "@dialpad/dialtone-icons/vue3";
 
 export default {
-  name: 'DtRecipeMessageInput',
+  name: "DtRecipeMessageInput",
 
   components: {
     DtButton,
@@ -241,6 +242,7 @@ export default {
     DtPopover,
     DtRichTextEditor,
     DtTooltip,
+    DtStack,
     DtIconImage,
     DtIconVerySatisfied,
     DtIconSatisfied,
@@ -258,7 +260,7 @@ export default {
      */
     modelValue: {
       type: [Object, String],
-      default: '',
+      default: "",
     },
 
     /**
@@ -275,7 +277,7 @@ export default {
     inputAriaLabel: {
       type: String,
       required: true,
-      default: '',
+      default: "",
     },
 
     /**
@@ -293,7 +295,7 @@ export default {
      */
     inputClass: {
       type: String,
-      default: '',
+      default: "",
     },
 
     /**
@@ -310,8 +312,8 @@ export default {
     autoFocus: {
       type: [Boolean, String, Number],
       default: false,
-      validator (autoFocus) {
-        if (typeof autoFocus === 'string') {
+      validator(autoFocus) {
+        if (typeof autoFocus === "string") {
           return RICH_TEXT_EDITOR_AUTOFOCUS_TYPES.includes(autoFocus);
         }
         return true;
@@ -326,8 +328,8 @@ export default {
      */
     outputFormat: {
       type: String,
-      default: 'text',
-      validator (outputFormat) {
+      default: "text",
+      validator(outputFormat) {
         return RICH_TEXT_EDITOR_OUTPUT_FORMATS.includes(outputFormat);
       },
     },
@@ -345,7 +347,7 @@ export default {
      */
     placeholder: {
       type: String,
-      default: '',
+      default: "",
     },
 
     /**
@@ -362,7 +364,7 @@ export default {
      */
     maxHeight: {
       type: String,
-      default: 'unset',
+      default: "unset",
     },
 
     // Emoji picker props
@@ -377,14 +379,14 @@ export default {
     emojiPickerProps: {
       type: Object,
       default: () => ({}),
-      validate (emojiPickerProps) {
+      validate(emojiPickerProps) {
         return [
-          'searchNoResultsLabel',
-          'searchResultsLabel',
-          'searchPlaceholderLabel',
-          'skinSelectorButtonTooltipLabel',
-          'tabSetLabels',
-        ].every(prop => emojiPickerProps[prop] != null);
+          "searchNoResultsLabel",
+          "searchResultsLabel",
+          "searchPlaceholderLabel",
+          "skinSelectorButtonTooltipLabel",
+          "tabSetLabels",
+        ].every((prop) => emojiPickerProps[prop] != null);
       },
     },
 
@@ -393,7 +395,7 @@ export default {
      */
     emojiTooltipMessage: {
       type: String,
-      default: 'Emoji',
+      default: "Emoji",
     },
 
     // Aria label for buttons
@@ -402,7 +404,7 @@ export default {
      */
     emojiButtonAriaLabel: {
       type: String,
-      default: 'emoji button',
+      default: "emoji button",
     },
 
     /**
@@ -410,12 +412,15 @@ export default {
      */
     showCharacterLimit: {
       type: [Boolean, Object],
-      default: () => ({ count: 1500, warning: 500, message: '' }),
+      default: () => ({ count: 1500, warning: 500, message: "" }),
     },
 
     showImagePicker: {
       type: [Boolean, Object],
-      default: () => ({ tooltipLabel: 'Attach Image', ariaLabel: 'image button' }),
+      default: () => ({
+        tooltipLabel: "Attach Image",
+        ariaLabel: "image button",
+      }),
     },
 
     /**
@@ -431,7 +436,7 @@ export default {
      */
     showCancel: {
       type: [Boolean, Object],
-      default: () => ({ text: 'Cancel' }),
+      default: () => ({ text: "Cancel" }),
     },
 
     /**
@@ -502,7 +507,7 @@ export default {
 
     /**
      * Whether the input allows for bullet list to be introduced in the text.
-    */
+     */
     allowBulletList: {
       type: Boolean,
       default: true,
@@ -548,7 +553,7 @@ export default {
      * @event submit
      * @type {String}
      */
-    'submit',
+    "submit",
 
     /**
      * Fires when media is selected from image button
@@ -556,7 +561,7 @@ export default {
      * @event select-media
      * @type {Array}
      */
-    'select-media',
+    "select-media",
 
     /**
      * Fires when media is dropped into the message input
@@ -564,7 +569,7 @@ export default {
      * @event add-media
      * @type {Array}
      */
-    'add-media',
+    "add-media",
 
     /**
      * Fires when media is pasted into the message input
@@ -572,7 +577,7 @@ export default {
      * @event paste-media
      * @type {Array}
      */
-    'paste-media',
+    "paste-media",
 
     /**
      * Fires when cancel button is pressed (only on edit mode)
@@ -580,7 +585,7 @@ export default {
      * @event cancel
      * @type {Boolean}
      */
-    'cancel',
+    "cancel",
 
     /**
      * Fires when skin tone is selected from the emoji picker
@@ -588,7 +593,7 @@ export default {
      * @event skin-tone
      * @type {String}
      */
-    'skin-tone',
+    "skin-tone",
 
     /**
      * Fires when emoji is selected from the emoji picker
@@ -596,7 +601,7 @@ export default {
      * @event selected-emoji
      * @type {String}
      */
-    'selected-emoji',
+    "selected-emoji",
 
     /**
      * Fires when a slash command is selected
@@ -604,7 +609,7 @@ export default {
      * @event selected-command
      * @type {String}
      */
-    'selected-command',
+    "selected-command",
 
     /**
      * Fires when meeting pill is closed
@@ -612,17 +617,17 @@ export default {
      * @event meeting-pill-close
      * @type {String}
      */
-    'meeting-pill-close',
+    "meeting-pill-close",
 
     /**
      * Event to sync the value with the parent
      * @event update:modelValue
      * @type {String|JSON}
      */
-    'update:modelValue',
+    "update:modelValue",
   ],
 
-  data () {
+  data() {
     return {
       additionalExtensions: [meetingPill],
       internalInputValue: this.modelValue, // internal input content
@@ -633,65 +638,76 @@ export default {
   },
 
   computed: {
-    showSendIcon () {
+    showSendIcon() {
       return !this.showSend.text;
     },
 
-    inputLength () {
+    inputLength() {
       return this.internalInputValue.length;
     },
 
-    displayCharacterLimitWarning () {
-      return Boolean(this.showCharacterLimit) &&
-        ((this.showCharacterLimit.count - this.inputLength) <= this.showCharacterLimit.warning);
+    displayCharacterLimitWarning() {
+      return (
+        Boolean(this.showCharacterLimit) &&
+        this.showCharacterLimit.count - this.inputLength <=
+          this.showCharacterLimit.warning
+      );
     },
 
-    characterLimitTooltipEnabled () {
-      return this.showCharacterLimit.message && (this.showCharacterLimit.count - this.inputLength < 0);
+    characterLimitTooltipEnabled() {
+      return (
+        this.showCharacterLimit.message &&
+        this.showCharacterLimit.count - this.inputLength < 0
+      );
     },
 
-    isSendDisabled () {
-      return this.disableSend ||
-      (this.showCharacterLimit && this.inputLength > this.showCharacterLimit.count);
+    isSendDisabled() {
+      return (
+        this.disableSend ||
+        (this.showCharacterLimit &&
+          this.inputLength > this.showCharacterLimit.count)
+      );
     },
 
-    computedCloseButtonProps () {
+    computedCloseButtonProps() {
       return {
-        ariaLabel: 'Close',
+        ariaLabel: "Close",
       };
     },
 
-    emojiPickerHovered () {
+    emojiPickerHovered() {
       return this.emojiPickerFocus || this.emojiPickerOpened;
     },
 
-    sendIconSize () {
-      return '300';
+    sendIconSize() {
+      return "300";
     },
   },
 
   watch: {
-    modelValue (newValue) {
+    modelValue(newValue) {
       this.internalInputValue = newValue;
     },
 
-    emojiPickerOpened (newValue) {
+    emojiPickerOpened(newValue) {
       if (!newValue) {
         this.$refs.richTextEditor?.focusEditor();
       }
     },
   },
 
-  created () {
-    if (this.modelValue && this.outputFormat === 'text') {
-      this.internalInputValue = this.modelValue.replace(/\n/g, '<br>');
+  created() {
+    if (this.modelValue && this.outputFormat === "text") {
+      this.internalInputValue = this.modelValue.replace(/\n/g, "<br>");
     }
   },
 
   methods: {
     // Mousedown instead of click because it fires before the blur event.
-    onMousedown (e) {
-      const isWithinInput = this.$refs.richTextEditor.$el.querySelector('.tiptap').contains(e.target);
+    onMousedown(e) {
+      const isWithinInput = this.$refs.richTextEditor.$el
+        .querySelector(".tiptap")
+        .contains(e.target);
 
       // If the click is not within the tiptap rich text editor input itself, but still within the wrapping div,
       // focus the editor.
@@ -702,65 +718,68 @@ export default {
       }
     },
 
-    onDrop (e) {
+    onDrop(e) {
       const dt = e.dataTransfer;
       const files = Array.from(dt.files);
-      this.$emit('add-media', files);
+      this.$emit("add-media", files);
     },
 
-    onPaste (e) {
+    onPaste(e) {
       if (e.clipboardData.files.length) {
         e.stopPropagation();
         e.preventDefault();
         const files = [...e.clipboardData.files];
-        this.$emit('paste-media', files);
+        this.$emit("paste-media", files);
       }
     },
 
-    onSkinTone (skinTone) {
-      this.$emit('skin-tone', skinTone);
+    onSkinTone(skinTone) {
+      this.$emit("skin-tone", skinTone);
     },
 
-    onSelectEmoji (emoji) {
+    onSelectEmoji(emoji) {
       if (!emoji) {
         return;
       }
 
       // Insert emoji into the editor
       this.$refs.richTextEditor.editor.commands.insertContent({
-        type: 'emoji',
+        type: "emoji",
         attrs: {
           code: emoji.shortname,
         },
       });
-      this.$emit('selected-emoji', emoji);
+      this.$emit("selected-emoji", emoji);
     },
 
-    onSelectImage () {
+    onSelectImage() {
       this.$refs.messageInputImageUpload.$refs.input.click();
     },
 
-    onImageUpload () {
-      this.$emit('select-media', this.$refs.messageInputImageUpload.$refs.input.files);
+    onImageUpload() {
+      this.$emit(
+        "select-media",
+        this.$refs.messageInputImageUpload.$refs.input.files,
+      );
     },
 
-    toggleEmojiPicker () {
+    toggleEmojiPicker() {
       this.emojiPickerOpened = !this.emojiPickerOpened;
     },
 
-    onSend () {
+    onSend() {
       if (this.isSendDisabled) {
         return;
       }
-      this.$emit('submit', this.internalInputValue);
+      this.$emit("submit", this.internalInputValue);
     },
 
-    onCancel () {
-      this.$emit('cancel');
+    onCancel() {
+      this.$emit("cancel");
     },
 
-    onInput (event) {
-      this.$emit('update:modelValue', event);
+    onInput(event) {
+      this.$emit("update:modelValue", event);
     },
   },
 };
@@ -773,11 +792,17 @@ export default {
   border-radius: var(--dt-size-radius-400);
   border: var(--dt-size-border-100) solid;
   border-color: var(--dt-color-border-default);
+  box-shadow: 0 0 0 0 rgba(0, 0, 0, 0%);
   cursor: text;
+  transition: all 100ms cubic-bezier(0.22, 1, 0.36, 1);
 
   &:focus-within {
     border-color: var(--dt-color-border-bold);
-    box-shadow: var(--dt-shadow-small);
+    box-shadow: 0 0 var(--dt-size-300) 0 var(--dt-color-surface-moderate-opaque);
+    transition: all 250ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  &:not(:focus-within) .d-btn.d-btn--icon-only {
+    opacity: 0.5;
   }
 
   &__editor-wrapper {
@@ -808,7 +833,7 @@ export default {
   &__bottom-section {
     display: flex;
     justify-content: space-between;
-    padding: var(--dt-space-300) var(--dt-space-400);
+    padding: var(--dt-space-300) var(--dt-space-400) var(--dt-space-400);
   }
 
   &__bottom-section-left {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -805,20 +805,20 @@ export default {
   border-radius: var(--dt-size-radius-400);
   border: var(--dt-size-border-100) solid;
   border-color: var(--dt-color-border-default);
-  box-shadow: 0 0 0 0 rgba(0, 0, 0, 0%);
   line-height: var(--dt-font-line-height-400);
   cursor: text;
-  transition: all 100ms cubic-bezier(0.22, 1, 0.36, 1);
+  opacity: 1;
+  transition-property: border-color, box-shadow, opacity;
+  transition-duration: var(--td200);
+  transition-timing-function: var(--ttf-in-out);
 
   &:focus-within {
     border-color: var(--dt-color-border-bold);
     box-shadow: 0 0 var(--dt-size-300) 0 var(--dt-color-surface-moderate-opaque);
-    transition: all 250ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   &:not(:hover):not(:focus-within) .dt-message-input__button {
     opacity: 0.75;
-    transition: all 250ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   &__editor-wrapper {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -49,17 +49,13 @@
     <section class="dt-message-input__bottom-section">
       <!-- Left content -->
       <div class="dt-message-input__bottom-section-left">
-        <dt-stack
-          gap="200"
-          direction="row"
-        >
+        <dt-stack gap="200" direction="row">
           <dt-button
             v-if="showImagePicker"
             v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
             data-qa="dt-message-input-image-btn"
             size="sm"
-            class="d-bar4"
-            style="width: 2.8rem; height: 2.8rem"
+            class="dt-message-input__button"
             :kind="imagePickerFocus ? 'muted' : 'muted'"
             importance="clear"
             :aria-label="showImagePicker.ariaLabel"
@@ -96,8 +92,7 @@
                 v-bind="attrs"
                 data-qa="dt-message-input-emoji-picker-btn"
                 size="sm"
-                class="d-bar4"
-                style="width: 2.8rem; height: 2.8rem"
+                class="dt-message-input__button"
                 :kind="emojiPickerHovered ? 'muted' : 'muted'"
                 importance="clear"
                 :aria-label="emojiButtonAriaLabel"
@@ -112,10 +107,7 @@
                     v-if="emojiPickerHovered"
                     size="300"
                   />
-                  <dt-icon-satisfied
-                    v-else
-                    size="300"
-                  />
+                  <dt-icon-satisfied v-else size="300" />
                 </template>
               </dt-button>
             </template>
@@ -167,9 +159,8 @@
         <dt-button
           v-if="showCancel"
           data-qa="dt-message-input-cancel-button"
-          class="dt-message-input__cancel-button d-bar4 d-p8"
+          class="dt-message-input__cancel-button dt-message-input__button"
           size="sm"
-          style="max-height: 2.8rem"
           kind="muted"
           importance="clear"
           :aria-label="showCancel.ariaLabel"
@@ -187,8 +178,7 @@
             v-dt-tooltip:top-end="showSend?.tooltipLabel"
             data-qa="dt-message-input-send-btn"
             size="sm"
-            class="d-bar4"
-            style="width: 2.8rem; height: 2.8rem"
+            class="dt-message-input__button"
             kind="default"
             importance="primary"
             :class="[
@@ -201,15 +191,9 @@
             :aria-disabled="isSendDisabled"
             @click="onSend"
           >
-            <template
-              v-if="showSendIcon"
-              #icon
-            >
+            <template v-if="showSendIcon" #icon>
               <!-- @slot Slot for send button icon -->
-              <slot
-                name="sendIcon"
-                :icon-size="sendIconSize"
-              >
+              <slot name="sendIcon" :icon-size="sendIconSize">
                 <dt-icon-send :size="sendIconSize" />
               </slot>
             </template>
@@ -229,23 +213,23 @@ import {
   DtRichTextEditor,
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
   RICH_TEXT_EDITOR_AUTOFOCUS_TYPES,
-} from '@/components/rich_text_editor';
-import meetingPill from './meeting_pill/meeting_pill';
-import { DtButton } from '@/components/button';
-import { DtEmojiPicker } from '@/components/emoji_picker';
-import { DtPopover } from '@/components/popover';
-import { DtInput } from '@/components/input';
-import { DtTooltip } from '@/components/tooltip';
-import { DtStack } from '@/components/stack';
+} from "@/components/rich_text_editor";
+import meetingPill from "./meeting_pill/meeting_pill";
+import { DtButton } from "@/components/button";
+import { DtEmojiPicker } from "@/components/emoji_picker";
+import { DtPopover } from "@/components/popover";
+import { DtInput } from "@/components/input";
+import { DtTooltip } from "@/components/tooltip";
+import { DtStack } from "@/components/stack";
 import {
   DtIconImage,
   DtIconVerySatisfied,
   DtIconSatisfied,
   DtIconSend,
-} from '@dialpad/dialtone-icons/vue3';
+} from "@dialpad/dialtone-icons/vue3";
 
 export default {
-  name: 'DtRecipeMessageInput',
+  name: "DtRecipeMessageInput",
 
   components: {
     DtButton,
@@ -272,7 +256,7 @@ export default {
      */
     modelValue: {
       type: [Object, String],
-      default: '',
+      default: "",
     },
 
     /**
@@ -289,7 +273,7 @@ export default {
     inputAriaLabel: {
       type: String,
       required: true,
-      default: '',
+      default: "",
     },
 
     /**
@@ -307,7 +291,7 @@ export default {
      */
     inputClass: {
       type: String,
-      default: '',
+      default: "",
     },
 
     /**
@@ -324,8 +308,8 @@ export default {
     autoFocus: {
       type: [Boolean, String, Number],
       default: false,
-      validator (autoFocus) {
-        if (typeof autoFocus === 'string') {
+      validator(autoFocus) {
+        if (typeof autoFocus === "string") {
           return RICH_TEXT_EDITOR_AUTOFOCUS_TYPES.includes(autoFocus);
         }
         return true;
@@ -340,8 +324,8 @@ export default {
      */
     outputFormat: {
       type: String,
-      default: 'text',
-      validator (outputFormat) {
+      default: "text",
+      validator(outputFormat) {
         return RICH_TEXT_EDITOR_OUTPUT_FORMATS.includes(outputFormat);
       },
     },
@@ -359,7 +343,7 @@ export default {
      */
     placeholder: {
       type: String,
-      default: '',
+      default: "",
     },
 
     /**
@@ -376,7 +360,7 @@ export default {
      */
     maxHeight: {
       type: String,
-      default: 'unset',
+      default: "unset",
     },
 
     // Emoji picker props
@@ -391,13 +375,13 @@ export default {
     emojiPickerProps: {
       type: Object,
       default: () => ({}),
-      validate (emojiPickerProps) {
+      validate(emojiPickerProps) {
         return [
-          'searchNoResultsLabel',
-          'searchResultsLabel',
-          'searchPlaceholderLabel',
-          'skinSelectorButtonTooltipLabel',
-          'tabSetLabels',
+          "searchNoResultsLabel",
+          "searchResultsLabel",
+          "searchPlaceholderLabel",
+          "skinSelectorButtonTooltipLabel",
+          "tabSetLabels",
         ].every((prop) => emojiPickerProps[prop] != null);
       },
     },
@@ -407,7 +391,7 @@ export default {
      */
     emojiTooltipMessage: {
       type: String,
-      default: 'Emoji',
+      default: "Emoji",
     },
 
     // Aria label for buttons
@@ -416,7 +400,7 @@ export default {
      */
     emojiButtonAriaLabel: {
       type: String,
-      default: 'emoji button',
+      default: "emoji button",
     },
 
     /**
@@ -424,14 +408,14 @@ export default {
      */
     showCharacterLimit: {
       type: [Boolean, Object],
-      default: () => ({ count: 1500, warning: 500, message: '' }),
+      default: () => ({ count: 1500, warning: 500, message: "" }),
     },
 
     showImagePicker: {
       type: [Boolean, Object],
       default: () => ({
-        tooltipLabel: 'Attach Image',
-        ariaLabel: 'image button',
+        tooltipLabel: "Attach Image",
+        ariaLabel: "image button",
       }),
     },
 
@@ -448,7 +432,7 @@ export default {
      */
     showCancel: {
       type: [Boolean, Object],
-      default: () => ({ text: 'Cancel' }),
+      default: () => ({ text: "Cancel" }),
     },
 
     /**
@@ -565,7 +549,7 @@ export default {
      * @event submit
      * @type {String}
      */
-    'submit',
+    "submit",
 
     /**
      * Fires when media is selected from image button
@@ -573,7 +557,7 @@ export default {
      * @event select-media
      * @type {Array}
      */
-    'select-media',
+    "select-media",
 
     /**
      * Fires when media is dropped into the message input
@@ -581,7 +565,7 @@ export default {
      * @event add-media
      * @type {Array}
      */
-    'add-media',
+    "add-media",
 
     /**
      * Fires when media is pasted into the message input
@@ -589,7 +573,7 @@ export default {
      * @event paste-media
      * @type {Array}
      */
-    'paste-media',
+    "paste-media",
 
     /**
      * Fires when cancel button is pressed (only on edit mode)
@@ -597,7 +581,7 @@ export default {
      * @event cancel
      * @type {Boolean}
      */
-    'cancel',
+    "cancel",
 
     /**
      * Fires when skin tone is selected from the emoji picker
@@ -605,7 +589,7 @@ export default {
      * @event skin-tone
      * @type {String}
      */
-    'skin-tone',
+    "skin-tone",
 
     /**
      * Fires when emoji is selected from the emoji picker
@@ -613,7 +597,7 @@ export default {
      * @event selected-emoji
      * @type {String}
      */
-    'selected-emoji',
+    "selected-emoji",
 
     /**
      * Fires when a slash command is selected
@@ -621,7 +605,7 @@ export default {
      * @event selected-command
      * @type {String}
      */
-    'selected-command',
+    "selected-command",
 
     /**
      * Fires when meeting pill is closed
@@ -629,17 +613,17 @@ export default {
      * @event meeting-pill-close
      * @type {String}
      */
-    'meeting-pill-close',
+    "meeting-pill-close",
 
     /**
      * Event to sync the value with the parent
      * @event update:modelValue
      * @type {String|JSON}
      */
-    'update:modelValue',
+    "update:modelValue",
   ],
 
-  data () {
+  data() {
     return {
       additionalExtensions: [meetingPill],
       internalInputValue: this.modelValue, // internal input content
@@ -650,15 +634,15 @@ export default {
   },
 
   computed: {
-    showSendIcon () {
+    showSendIcon() {
       return !this.showSend.text;
     },
 
-    inputLength () {
+    inputLength() {
       return this.internalInputValue.length;
     },
 
-    displayCharacterLimitWarning () {
+    displayCharacterLimitWarning() {
       return (
         Boolean(this.showCharacterLimit) &&
         this.showCharacterLimit.count - this.inputLength <=
@@ -666,14 +650,14 @@ export default {
       );
     },
 
-    characterLimitTooltipEnabled () {
+    characterLimitTooltipEnabled() {
       return (
         this.showCharacterLimit.message &&
         this.showCharacterLimit.count - this.inputLength < 0
       );
     },
 
-    isSendDisabled () {
+    isSendDisabled() {
       return (
         this.disableSend ||
         (this.showCharacterLimit &&
@@ -681,44 +665,44 @@ export default {
       );
     },
 
-    computedCloseButtonProps () {
+    computedCloseButtonProps() {
       return {
-        ariaLabel: 'Close',
+        ariaLabel: "Close",
       };
     },
 
-    emojiPickerHovered () {
+    emojiPickerHovered() {
       return this.emojiPickerFocus || this.emojiPickerOpened;
     },
 
-    sendIconSize () {
-      return '300';
+    sendIconSize() {
+      return "300";
     },
   },
 
   watch: {
-    modelValue (newValue) {
+    modelValue(newValue) {
       this.internalInputValue = newValue;
     },
 
-    emojiPickerOpened (newValue) {
+    emojiPickerOpened(newValue) {
       if (!newValue) {
         this.$refs.richTextEditor?.focusEditor();
       }
     },
   },
 
-  created () {
-    if (this.modelValue && this.outputFormat === 'text') {
-      this.internalInputValue = this.modelValue.replace(/\n/g, '<br>');
+  created() {
+    if (this.modelValue && this.outputFormat === "text") {
+      this.internalInputValue = this.modelValue.replace(/\n/g, "<br>");
     }
   },
 
   methods: {
     // Mousedown instead of click because it fires before the blur event.
-    onMousedown (e) {
+    onMousedown(e) {
       const isWithinInput = this.$refs.richTextEditor.$el
-        .querySelector('.tiptap')
+        .querySelector(".tiptap")
         .contains(e.target);
 
       // If the click is not within the tiptap rich text editor input itself, but still within the wrapping div,
@@ -730,68 +714,68 @@ export default {
       }
     },
 
-    onDrop (e) {
+    onDrop(e) {
       const dt = e.dataTransfer;
       const files = Array.from(dt.files);
-      this.$emit('add-media', files);
+      this.$emit("add-media", files);
     },
 
-    onPaste (e) {
+    onPaste(e) {
       if (e.clipboardData.files.length) {
         e.stopPropagation();
         e.preventDefault();
         const files = [...e.clipboardData.files];
-        this.$emit('paste-media', files);
+        this.$emit("paste-media", files);
       }
     },
 
-    onSkinTone (skinTone) {
-      this.$emit('skin-tone', skinTone);
+    onSkinTone(skinTone) {
+      this.$emit("skin-tone", skinTone);
     },
 
-    onSelectEmoji (emoji) {
+    onSelectEmoji(emoji) {
       if (!emoji) {
         return;
       }
 
       // Insert emoji into the editor
       this.$refs.richTextEditor.editor.commands.insertContent({
-        type: 'emoji',
+        type: "emoji",
         attrs: {
           code: emoji.shortname,
         },
       });
-      this.$emit('selected-emoji', emoji);
+      this.$emit("selected-emoji", emoji);
     },
 
-    onSelectImage () {
+    onSelectImage() {
       this.$refs.messageInputImageUpload.$refs.input.click();
     },
 
-    onImageUpload () {
+    onImageUpload() {
       this.$emit(
-        'select-media',
+        "select-media",
         this.$refs.messageInputImageUpload.$refs.input.files,
       );
     },
 
-    toggleEmojiPicker () {
+    toggleEmojiPicker() {
       this.emojiPickerOpened = !this.emojiPickerOpened;
     },
 
-    onSend () {
+    onSend() {
       if (this.isSendDisabled) {
         return;
       }
-      this.$emit('submit', this.internalInputValue);
+      this.$emit("submit", this.internalInputValue);
     },
 
-    onCancel () {
-      this.$emit('cancel');
+    onCancel() {
+      this.$emit("cancel");
     },
 
-    onInput (event) {
-      this.$emit('update:modelValue', event);
+    onInput(event) {
+      this.$emit("update:modelValue", event);
     },
   },
 };
@@ -804,6 +788,7 @@ export default {
   border-radius: var(--dt-size-radius-400);
   border: var(--dt-size-border-100) solid;
   border-color: var(--dt-color-border-default);
+  line-height: var(--dt-font-line-height-400);
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 0%);
   cursor: text;
   transition: all 100ms cubic-bezier(0.22, 1, 0.36, 1);
@@ -818,7 +803,7 @@ export default {
   }
 
   &__editor-wrapper {
-    padding: var(--dt-space-400) var(--dt-space-500) var(--dt-space-300);
+    padding: var(--dt-space-450) var(--dt-space-500) var(--dt-space-300);
   }
 
   &__remaining-char-tooltip {
@@ -829,7 +814,7 @@ export default {
   &__remaining-char {
     color: var(--dt-color-foreground-critical);
     font-size: var(--dt-font-size-100);
-    margin-right: var(--dt-space-500);
+    margin-right: var(--dt-space-400);
   }
 
   &__send-button--disabled {
@@ -838,7 +823,16 @@ export default {
     cursor: default;
   }
 
+  &__button {
+    max-width: 2.8rem;
+    max-height: 2.8rem;
+    border-radius: var(--dt-size-radius-400);
+  }
+
   &__cancel-button {
+    max-width: unset;
+    padding-left: var(--dt-space-400);
+    padding-right: var(--dt-space-400);
     margin-right: var(--dt-space-300);
   }
 

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -169,7 +169,7 @@
           <dt-button
             v-if="showCancel"
             data-qa="dt-message-input-cancel-button"
-            class="dt-message-input__cancel-button dt-message-input__button d-p8"
+            class="dt-message-input__button dt-message-input__cancel-button"
             size="sm"
             kind="muted"
             importance="clear"
@@ -191,7 +191,7 @@
               kind="default"
               importance="primary"
               :class="[
-                'dt-message-input__button',
+                'dt-message-input__button dt-message-input__send-button',
                 {
                   'dt-message-input__send-button--disabled': isSendDisabled,
                   'd-btn--icon-only': showSendIcon,
@@ -842,9 +842,10 @@ export default {
     border-radius: var(--dt-size-radius-300);
   }
 
-  &__send-button,
+  &__send-button.dt-message-input__button:not(.d-btn--icon-only),
   &__cancel-button {
     max-width: unset;
+    padding: var(--dt-space-350);
   }
 
   &__send-button--disabled {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -805,6 +805,7 @@ export default {
   border: var(--dt-size-border-100) solid;
   border-color: var(--dt-color-border-default);
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 0%);
+  line-height: var(--dt-font-line-height-400);
   cursor: text;
   transition: all 100ms cubic-bezier(0.22, 1, 0.36, 1);
 
@@ -818,7 +819,7 @@ export default {
   }
 
   &__editor-wrapper {
-    padding: var(--dt-space-400) var(--dt-space-500) var(--dt-space-300);
+    padding: var(--dt-space-450) var(--dt-space-500) var(--dt-space-300);
   }
 
   &__remaining-char-tooltip {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -809,16 +809,12 @@ export default {
   cursor: text;
   opacity: 1;
   transition-property: border-color, box-shadow, opacity;
-  transition-duration: var(--td200);
+  transition-duration: var(--td50);
   transition-timing-function: var(--ttf-in-out);
 
   &:focus-within {
     border-color: var(--dt-color-border-bold);
     box-shadow: 0 0 var(--dt-size-300) 0 var(--dt-color-surface-moderate-opaque);
-  }
-
-  &:not(:hover):not(:focus-within) .dt-message-input__button {
-    opacity: 0.75;
   }
 
   &__editor-wrapper {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -809,8 +809,10 @@ export default {
     box-shadow: 0 0 var(--dt-size-300) 0 var(--dt-color-surface-moderate-opaque);
     transition: all 250ms cubic-bezier(0.22, 1, 0.36, 1);
   }
-  &:not(:focus-within) .d-btn.d-btn--icon-only {
-    opacity: 0.5;
+
+  &:not(:hover):not(:focus-within) .dt-message-input__button {
+    opacity: 0.75;
+    transition: all 250ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   &__editor-wrapper {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -58,8 +58,7 @@
             v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
             data-qa="dt-message-input-image-btn"
             size="sm"
-            class="d-bar4"
-            style="width: 2.8rem; height: 2.8rem"
+            class="dt-message-input__button"
             :kind="imagePickerFocus ? 'muted' : 'muted'"
             importance="clear"
             :aria-label="showImagePicker.ariaLabel"
@@ -96,8 +95,7 @@
                 v-bind="attrs"
                 data-qa="dt-message-input-emoji-picker-btn"
                 size="sm"
-                class="d-bar4"
-                style="width: 2.8rem; height: 2.8rem"
+                class="dt-message-input__button"
                 :kind="emojiPickerHovered ? 'muted' : 'muted'"
                 importance="clear"
                 :aria-label="emojiButtonAriaLabel"
@@ -167,9 +165,8 @@
         <dt-button
           v-if="showCancel"
           data-qa="dt-message-input-cancel-button"
-          class="dt-message-input__cancel-button d-bar4 d-p8"
+          class="dt-message-input__cancel-button dt-message-input__button d-p8"
           size="sm"
-          style="max-height: 2.8rem"
           kind="muted"
           importance="clear"
           :aria-label="showCancel.ariaLabel"
@@ -187,8 +184,7 @@
             v-dt-tooltip:top-end="showSend?.tooltipLabel"
             data-qa="dt-message-input-send-btn"
             size="sm"
-            class="d-bar4"
-            style="width: 2.8rem; height: 2.8rem"
+            class="dt-message-input__button"
             kind="default"
             importance="primary"
             :class="[
@@ -833,6 +829,12 @@ export default {
     margin-right: var(--dt-space-500);
   }
 
+  &__button {
+    max-height: 2.8rem;
+    max-width: 2.8rem;
+    border-radius: var(--dt-size-radius-400);
+  }
+
   &__send-button--disabled {
     background-color: unset;
     color: var(--dt-color-foreground-muted);
@@ -840,6 +842,7 @@ export default {
   }
 
   &__cancel-button {
+    max-width: unset;
     margin-right: var(--dt-space-300);
   }
 

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -136,84 +136,89 @@
       </div>
       <!-- Right content -->
       <div class="dt-message-input__bottom-section-right">
-        <!-- @slot Slot for sms count -->
-        <div class="d-d-flex d-ai-center">
-          <slot name="smsCount" />
-        </div>
-
-        <!-- Optionally displayed remaining character counter -->
-        <dt-tooltip
-          v-if="Boolean(showCharacterLimit)"
-          class="dt-message-input__remaining-char-tooltip"
-          placement="top-end"
-          :enabled="characterLimitTooltipEnabled"
-          :message="showCharacterLimit.message"
-          :offset="[10, 8]"
+        <dt-stack
+          direction="row"
+          gap="300"
         >
-          <template #anchor>
-            <p
-              v-show="displayCharacterLimitWarning"
-              class="dt-message-input__remaining-char"
-              data-qa="dt-message-input-character-limit"
-            >
-              {{ showCharacterLimit.count - inputLength }}
-            </p>
-          </template>
-        </dt-tooltip>
+          <!-- @slot Slot for sms count -->
+          <div class="d-d-flex d-ai-center">
+            <slot name="smsCount" />
+          </div>
 
-        <!-- Cancel button for edit mode -->
-        <dt-button
-          v-if="showCancel"
-          data-qa="dt-message-input-cancel-button"
-          class="dt-message-input__cancel-button dt-message-input__button d-p8"
-          size="sm"
-          kind="muted"
-          importance="clear"
-          :aria-label="showCancel.ariaLabel"
-          @click="onCancel"
-        >
-          <p>{{ showCancel.text }}</p>
-        </dt-button>
-
-        <!-- @slot Slot for sendButton picker -->
-        <slot name="sendButton">
-          <!-- Send button -->
-          <!-- Right positioned UI - send button -->
-          <dt-button
-            v-if="showSend"
-            v-dt-tooltip:top-end="showSend?.tooltipLabel"
-            data-qa="dt-message-input-send-btn"
-            size="sm"
-            kind="default"
-            importance="primary"
-            :class="[
-              'dt-message-input__button',
-              {
-                'dt-message-input__send-button--disabled': isSendDisabled,
-                'd-btn--icon-only': showSendIcon,
-              },
-            ]"
-            :aria-label="showSend.ariaLabel"
-            :aria-disabled="isSendDisabled"
-            @click="onSend"
+          <!-- Optionally displayed remaining character counter -->
+          <dt-tooltip
+            v-if="Boolean(showCharacterLimit)"
+            class="dt-message-input__remaining-char-tooltip"
+            placement="top-end"
+            :enabled="characterLimitTooltipEnabled"
+            :message="showCharacterLimit.message"
+            :offset="[10, 8]"
           >
-            <template
-              v-if="showSendIcon"
-              #icon
-            >
-              <!-- @slot Slot for send button icon -->
-              <slot
-                name="sendIcon"
-                :icon-size="sendIconSize"
+            <template #anchor>
+              <p
+                v-show="displayCharacterLimitWarning"
+                class="dt-message-input__remaining-char"
+                data-qa="dt-message-input-character-limit"
               >
-                <dt-icon-send :size="sendIconSize" />
-              </slot>
+                {{ showCharacterLimit.count - inputLength }}
+              </p>
             </template>
-            <template v-if="showSend.text">
-              <p>{{ showSend.text }}</p>
-            </template>
+          </dt-tooltip>
+
+          <!-- Cancel button for edit mode -->
+          <dt-button
+            v-if="showCancel"
+            data-qa="dt-message-input-cancel-button"
+            class="dt-message-input__cancel-button dt-message-input__button d-p8"
+            size="sm"
+            kind="muted"
+            importance="clear"
+            :aria-label="showCancel.ariaLabel"
+            @click="onCancel"
+          >
+            <p>{{ showCancel.text }}</p>
           </dt-button>
-        </slot>
+
+          <!-- @slot Slot for sendButton picker -->
+          <slot name="sendButton">
+            <!-- Send button -->
+            <!-- Right positioned UI - send button -->
+            <dt-button
+              v-if="showSend"
+              v-dt-tooltip:top-end="showSend?.tooltipLabel"
+              data-qa="dt-message-input-send-btn"
+              size="sm"
+              kind="default"
+              importance="primary"
+              :class="[
+                'dt-message-input__button',
+                {
+                  'dt-message-input__send-button--disabled': isSendDisabled,
+                  'd-btn--icon-only': showSendIcon,
+                },
+              ]"
+              :aria-label="showSend.ariaLabel"
+              :aria-disabled="isSendDisabled"
+              @click="onSend"
+            >
+              <template
+                v-if="showSendIcon"
+                #icon
+              >
+                <!-- @slot Slot for send button icon -->
+                <slot
+                  name="sendIcon"
+                  :icon-size="sendIconSize"
+                >
+                  <dt-icon-send :size="sendIconSize" />
+                </slot>
+              </template>
+              <template v-if="showSend.text">
+                <p>{{ showSend.text }}</p>
+              </template>
+            </dt-button>
+          </slot>
+        </dt-stack>
       </div>
     </section>
   </div>
@@ -828,24 +833,24 @@ export default {
   &__remaining-char {
     color: var(--dt-color-foreground-critical);
     font-size: var(--dt-font-size-100);
-    margin-right: var(--dt-space-500);
+    margin-right: var(--dt-space-300);
   }
 
   &__button {
     max-height: 2.8rem;
     max-width: 2.8rem;
-    border-radius: var(--dt-size-radius-400);
+    border-radius: var(--dt-size-radius-300);
+  }
+
+  &__send-button,
+  &__cancel-button {
+    max-width: unset;
   }
 
   &__send-button--disabled {
     background-color: unset;
     color: var(--dt-color-foreground-muted);
     cursor: default;
-  }
-
-  &__cancel-button {
-    max-width: unset;
-    margin-right: var(--dt-space-300);
   }
 
   &__bottom-section {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -807,7 +807,6 @@ export default {
   border-color: var(--dt-color-border-default);
   line-height: var(--dt-font-line-height-400);
   cursor: text;
-  opacity: 1;
   transition-property: border-color, box-shadow, opacity;
   transition-duration: var(--td50);
   transition-timing-function: var(--ttf-in-out);

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -49,7 +49,10 @@
     <section class="dt-message-input__bottom-section">
       <!-- Left content -->
       <div class="dt-message-input__bottom-section-left">
-        <dt-stack gap="200" direction="row">
+        <dt-stack
+          gap="200"
+          direction="row"
+        >
           <dt-button
             v-if="showImagePicker"
             v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
@@ -109,7 +112,10 @@
                     v-if="emojiPickerHovered"
                     size="300"
                   />
-                  <dt-icon-satisfied v-else size="300" />
+                  <dt-icon-satisfied
+                    v-else
+                    size="300"
+                  />
                 </template>
               </dt-button>
             </template>
@@ -195,9 +201,15 @@
             :aria-disabled="isSendDisabled"
             @click="onSend"
           >
-            <template v-if="showSendIcon" #icon>
+            <template
+              v-if="showSendIcon"
+              #icon
+            >
               <!-- @slot Slot for send button icon -->
-              <slot name="sendIcon" :icon-size="sendIconSize">
+              <slot
+                name="sendIcon"
+                :icon-size="sendIconSize"
+              >
                 <dt-icon-send :size="sendIconSize" />
               </slot>
             </template>
@@ -217,23 +229,23 @@ import {
   DtRichTextEditor,
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
   RICH_TEXT_EDITOR_AUTOFOCUS_TYPES,
-} from "@/components/rich_text_editor";
-import meetingPill from "./meeting_pill/meeting_pill";
-import { DtButton } from "@/components/button";
-import { DtEmojiPicker } from "@/components/emoji_picker";
-import { DtPopover } from "@/components/popover";
-import { DtInput } from "@/components/input";
-import { DtTooltip } from "@/components/tooltip";
-import { DtStack } from "@/components/stack";
+} from '@/components/rich_text_editor';
+import meetingPill from './meeting_pill/meeting_pill';
+import { DtButton } from '@/components/button';
+import { DtEmojiPicker } from '@/components/emoji_picker';
+import { DtPopover } from '@/components/popover';
+import { DtInput } from '@/components/input';
+import { DtTooltip } from '@/components/tooltip';
+import { DtStack } from '@/components/stack';
 import {
   DtIconImage,
   DtIconVerySatisfied,
   DtIconSatisfied,
   DtIconSend,
-} from "@dialpad/dialtone-icons/vue3";
+} from '@dialpad/dialtone-icons/vue3';
 
 export default {
-  name: "DtRecipeMessageInput",
+  name: 'DtRecipeMessageInput',
 
   components: {
     DtButton,
@@ -260,7 +272,7 @@ export default {
      */
     modelValue: {
       type: [Object, String],
-      default: "",
+      default: '',
     },
 
     /**
@@ -277,7 +289,7 @@ export default {
     inputAriaLabel: {
       type: String,
       required: true,
-      default: "",
+      default: '',
     },
 
     /**
@@ -295,7 +307,7 @@ export default {
      */
     inputClass: {
       type: String,
-      default: "",
+      default: '',
     },
 
     /**
@@ -312,8 +324,8 @@ export default {
     autoFocus: {
       type: [Boolean, String, Number],
       default: false,
-      validator(autoFocus) {
-        if (typeof autoFocus === "string") {
+      validator (autoFocus) {
+        if (typeof autoFocus === 'string') {
           return RICH_TEXT_EDITOR_AUTOFOCUS_TYPES.includes(autoFocus);
         }
         return true;
@@ -328,8 +340,8 @@ export default {
      */
     outputFormat: {
       type: String,
-      default: "text",
-      validator(outputFormat) {
+      default: 'text',
+      validator (outputFormat) {
         return RICH_TEXT_EDITOR_OUTPUT_FORMATS.includes(outputFormat);
       },
     },
@@ -347,7 +359,7 @@ export default {
      */
     placeholder: {
       type: String,
-      default: "",
+      default: '',
     },
 
     /**
@@ -364,7 +376,7 @@ export default {
      */
     maxHeight: {
       type: String,
-      default: "unset",
+      default: 'unset',
     },
 
     // Emoji picker props
@@ -379,13 +391,13 @@ export default {
     emojiPickerProps: {
       type: Object,
       default: () => ({}),
-      validate(emojiPickerProps) {
+      validate (emojiPickerProps) {
         return [
-          "searchNoResultsLabel",
-          "searchResultsLabel",
-          "searchPlaceholderLabel",
-          "skinSelectorButtonTooltipLabel",
-          "tabSetLabels",
+          'searchNoResultsLabel',
+          'searchResultsLabel',
+          'searchPlaceholderLabel',
+          'skinSelectorButtonTooltipLabel',
+          'tabSetLabels',
         ].every((prop) => emojiPickerProps[prop] != null);
       },
     },
@@ -395,7 +407,7 @@ export default {
      */
     emojiTooltipMessage: {
       type: String,
-      default: "Emoji",
+      default: 'Emoji',
     },
 
     // Aria label for buttons
@@ -404,7 +416,7 @@ export default {
      */
     emojiButtonAriaLabel: {
       type: String,
-      default: "emoji button",
+      default: 'emoji button',
     },
 
     /**
@@ -412,14 +424,14 @@ export default {
      */
     showCharacterLimit: {
       type: [Boolean, Object],
-      default: () => ({ count: 1500, warning: 500, message: "" }),
+      default: () => ({ count: 1500, warning: 500, message: '' }),
     },
 
     showImagePicker: {
       type: [Boolean, Object],
       default: () => ({
-        tooltipLabel: "Attach Image",
-        ariaLabel: "image button",
+        tooltipLabel: 'Attach Image',
+        ariaLabel: 'image button',
       }),
     },
 
@@ -436,7 +448,7 @@ export default {
      */
     showCancel: {
       type: [Boolean, Object],
-      default: () => ({ text: "Cancel" }),
+      default: () => ({ text: 'Cancel' }),
     },
 
     /**
@@ -553,7 +565,7 @@ export default {
      * @event submit
      * @type {String}
      */
-    "submit",
+    'submit',
 
     /**
      * Fires when media is selected from image button
@@ -561,7 +573,7 @@ export default {
      * @event select-media
      * @type {Array}
      */
-    "select-media",
+    'select-media',
 
     /**
      * Fires when media is dropped into the message input
@@ -569,7 +581,7 @@ export default {
      * @event add-media
      * @type {Array}
      */
-    "add-media",
+    'add-media',
 
     /**
      * Fires when media is pasted into the message input
@@ -577,7 +589,7 @@ export default {
      * @event paste-media
      * @type {Array}
      */
-    "paste-media",
+    'paste-media',
 
     /**
      * Fires when cancel button is pressed (only on edit mode)
@@ -585,7 +597,7 @@ export default {
      * @event cancel
      * @type {Boolean}
      */
-    "cancel",
+    'cancel',
 
     /**
      * Fires when skin tone is selected from the emoji picker
@@ -593,7 +605,7 @@ export default {
      * @event skin-tone
      * @type {String}
      */
-    "skin-tone",
+    'skin-tone',
 
     /**
      * Fires when emoji is selected from the emoji picker
@@ -601,7 +613,7 @@ export default {
      * @event selected-emoji
      * @type {String}
      */
-    "selected-emoji",
+    'selected-emoji',
 
     /**
      * Fires when a slash command is selected
@@ -609,7 +621,7 @@ export default {
      * @event selected-command
      * @type {String}
      */
-    "selected-command",
+    'selected-command',
 
     /**
      * Fires when meeting pill is closed
@@ -617,17 +629,17 @@ export default {
      * @event meeting-pill-close
      * @type {String}
      */
-    "meeting-pill-close",
+    'meeting-pill-close',
 
     /**
      * Event to sync the value with the parent
      * @event update:modelValue
      * @type {String|JSON}
      */
-    "update:modelValue",
+    'update:modelValue',
   ],
 
-  data() {
+  data () {
     return {
       additionalExtensions: [meetingPill],
       internalInputValue: this.modelValue, // internal input content
@@ -638,15 +650,15 @@ export default {
   },
 
   computed: {
-    showSendIcon() {
+    showSendIcon () {
       return !this.showSend.text;
     },
 
-    inputLength() {
+    inputLength () {
       return this.internalInputValue.length;
     },
 
-    displayCharacterLimitWarning() {
+    displayCharacterLimitWarning () {
       return (
         Boolean(this.showCharacterLimit) &&
         this.showCharacterLimit.count - this.inputLength <=
@@ -654,14 +666,14 @@ export default {
       );
     },
 
-    characterLimitTooltipEnabled() {
+    characterLimitTooltipEnabled () {
       return (
         this.showCharacterLimit.message &&
         this.showCharacterLimit.count - this.inputLength < 0
       );
     },
 
-    isSendDisabled() {
+    isSendDisabled () {
       return (
         this.disableSend ||
         (this.showCharacterLimit &&
@@ -669,44 +681,44 @@ export default {
       );
     },
 
-    computedCloseButtonProps() {
+    computedCloseButtonProps () {
       return {
-        ariaLabel: "Close",
+        ariaLabel: 'Close',
       };
     },
 
-    emojiPickerHovered() {
+    emojiPickerHovered () {
       return this.emojiPickerFocus || this.emojiPickerOpened;
     },
 
-    sendIconSize() {
-      return "300";
+    sendIconSize () {
+      return '300';
     },
   },
 
   watch: {
-    modelValue(newValue) {
+    modelValue (newValue) {
       this.internalInputValue = newValue;
     },
 
-    emojiPickerOpened(newValue) {
+    emojiPickerOpened (newValue) {
       if (!newValue) {
         this.$refs.richTextEditor?.focusEditor();
       }
     },
   },
 
-  created() {
-    if (this.modelValue && this.outputFormat === "text") {
-      this.internalInputValue = this.modelValue.replace(/\n/g, "<br>");
+  created () {
+    if (this.modelValue && this.outputFormat === 'text') {
+      this.internalInputValue = this.modelValue.replace(/\n/g, '<br>');
     }
   },
 
   methods: {
     // Mousedown instead of click because it fires before the blur event.
-    onMousedown(e) {
+    onMousedown (e) {
       const isWithinInput = this.$refs.richTextEditor.$el
-        .querySelector(".tiptap")
+        .querySelector('.tiptap')
         .contains(e.target);
 
       // If the click is not within the tiptap rich text editor input itself, but still within the wrapping div,
@@ -718,68 +730,68 @@ export default {
       }
     },
 
-    onDrop(e) {
+    onDrop (e) {
       const dt = e.dataTransfer;
       const files = Array.from(dt.files);
-      this.$emit("add-media", files);
+      this.$emit('add-media', files);
     },
 
-    onPaste(e) {
+    onPaste (e) {
       if (e.clipboardData.files.length) {
         e.stopPropagation();
         e.preventDefault();
         const files = [...e.clipboardData.files];
-        this.$emit("paste-media", files);
+        this.$emit('paste-media', files);
       }
     },
 
-    onSkinTone(skinTone) {
-      this.$emit("skin-tone", skinTone);
+    onSkinTone (skinTone) {
+      this.$emit('skin-tone', skinTone);
     },
 
-    onSelectEmoji(emoji) {
+    onSelectEmoji (emoji) {
       if (!emoji) {
         return;
       }
 
       // Insert emoji into the editor
       this.$refs.richTextEditor.editor.commands.insertContent({
-        type: "emoji",
+        type: 'emoji',
         attrs: {
           code: emoji.shortname,
         },
       });
-      this.$emit("selected-emoji", emoji);
+      this.$emit('selected-emoji', emoji);
     },
 
-    onSelectImage() {
+    onSelectImage () {
       this.$refs.messageInputImageUpload.$refs.input.click();
     },
 
-    onImageUpload() {
+    onImageUpload () {
       this.$emit(
-        "select-media",
+        'select-media',
         this.$refs.messageInputImageUpload.$refs.input.files,
       );
     },
 
-    toggleEmojiPicker() {
+    toggleEmojiPicker () {
       this.emojiPickerOpened = !this.emojiPickerOpened;
     },
 
-    onSend() {
+    onSend () {
       if (this.isSendDisabled) {
         return;
       }
-      this.$emit("submit", this.internalInputValue);
+      this.$emit('submit', this.internalInputValue);
     },
 
-    onCancel() {
-      this.$emit("cancel");
+    onCancel () {
+      this.$emit('cancel');
     },
 
-    onInput(event) {
-      this.$emit("update:modelValue", event);
+    onInput (event) {
+      this.$emit('update:modelValue', event);
     },
   },
 };

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -49,13 +49,17 @@
     <section class="dt-message-input__bottom-section">
       <!-- Left content -->
       <div class="dt-message-input__bottom-section-left">
-        <dt-stack gap="200" direction="row">
+        <dt-stack
+          gap="200"
+          direction="row"
+        >
           <dt-button
             v-if="showImagePicker"
             v-dt-tooltip:top-start="showImagePicker?.tooltipLabel"
             data-qa="dt-message-input-image-btn"
             size="sm"
-            class="dt-message-input__button"
+            class="d-bar4"
+            style="width: 2.8rem; height: 2.8rem"
             :kind="imagePickerFocus ? 'muted' : 'muted'"
             importance="clear"
             :aria-label="showImagePicker.ariaLabel"
@@ -92,7 +96,8 @@
                 v-bind="attrs"
                 data-qa="dt-message-input-emoji-picker-btn"
                 size="sm"
-                class="dt-message-input__button"
+                class="d-bar4"
+                style="width: 2.8rem; height: 2.8rem"
                 :kind="emojiPickerHovered ? 'muted' : 'muted'"
                 importance="clear"
                 :aria-label="emojiButtonAriaLabel"
@@ -107,7 +112,10 @@
                     v-if="emojiPickerHovered"
                     size="300"
                   />
-                  <dt-icon-satisfied v-else size="300" />
+                  <dt-icon-satisfied
+                    v-else
+                    size="300"
+                  />
                 </template>
               </dt-button>
             </template>
@@ -159,8 +167,9 @@
         <dt-button
           v-if="showCancel"
           data-qa="dt-message-input-cancel-button"
-          class="dt-message-input__cancel-button dt-message-input__button"
+          class="dt-message-input__cancel-button d-bar4 d-p8"
           size="sm"
+          style="max-height: 2.8rem"
           kind="muted"
           importance="clear"
           :aria-label="showCancel.ariaLabel"
@@ -178,7 +187,8 @@
             v-dt-tooltip:top-end="showSend?.tooltipLabel"
             data-qa="dt-message-input-send-btn"
             size="sm"
-            class="dt-message-input__button"
+            class="d-bar4"
+            style="width: 2.8rem; height: 2.8rem"
             kind="default"
             importance="primary"
             :class="[
@@ -191,9 +201,15 @@
             :aria-disabled="isSendDisabled"
             @click="onSend"
           >
-            <template v-if="showSendIcon" #icon>
+            <template
+              v-if="showSendIcon"
+              #icon
+            >
               <!-- @slot Slot for send button icon -->
-              <slot name="sendIcon" :icon-size="sendIconSize">
+              <slot
+                name="sendIcon"
+                :icon-size="sendIconSize"
+              >
                 <dt-icon-send :size="sendIconSize" />
               </slot>
             </template>
@@ -213,23 +229,23 @@ import {
   DtRichTextEditor,
   RICH_TEXT_EDITOR_OUTPUT_FORMATS,
   RICH_TEXT_EDITOR_AUTOFOCUS_TYPES,
-} from "@/components/rich_text_editor";
-import meetingPill from "./meeting_pill/meeting_pill";
-import { DtButton } from "@/components/button";
-import { DtEmojiPicker } from "@/components/emoji_picker";
-import { DtPopover } from "@/components/popover";
-import { DtInput } from "@/components/input";
-import { DtTooltip } from "@/components/tooltip";
-import { DtStack } from "@/components/stack";
+} from '@/components/rich_text_editor';
+import meetingPill from './meeting_pill/meeting_pill';
+import { DtButton } from '@/components/button';
+import { DtEmojiPicker } from '@/components/emoji_picker';
+import { DtPopover } from '@/components/popover';
+import { DtInput } from '@/components/input';
+import { DtTooltip } from '@/components/tooltip';
+import { DtStack } from '@/components/stack';
 import {
   DtIconImage,
   DtIconVerySatisfied,
   DtIconSatisfied,
   DtIconSend,
-} from "@dialpad/dialtone-icons/vue3";
+} from '@dialpad/dialtone-icons/vue3';
 
 export default {
-  name: "DtRecipeMessageInput",
+  name: 'DtRecipeMessageInput',
 
   components: {
     DtButton,
@@ -256,7 +272,7 @@ export default {
      */
     modelValue: {
       type: [Object, String],
-      default: "",
+      default: '',
     },
 
     /**
@@ -273,7 +289,7 @@ export default {
     inputAriaLabel: {
       type: String,
       required: true,
-      default: "",
+      default: '',
     },
 
     /**
@@ -291,7 +307,7 @@ export default {
      */
     inputClass: {
       type: String,
-      default: "",
+      default: '',
     },
 
     /**
@@ -308,8 +324,8 @@ export default {
     autoFocus: {
       type: [Boolean, String, Number],
       default: false,
-      validator(autoFocus) {
-        if (typeof autoFocus === "string") {
+      validator (autoFocus) {
+        if (typeof autoFocus === 'string') {
           return RICH_TEXT_EDITOR_AUTOFOCUS_TYPES.includes(autoFocus);
         }
         return true;
@@ -324,8 +340,8 @@ export default {
      */
     outputFormat: {
       type: String,
-      default: "text",
-      validator(outputFormat) {
+      default: 'text',
+      validator (outputFormat) {
         return RICH_TEXT_EDITOR_OUTPUT_FORMATS.includes(outputFormat);
       },
     },
@@ -343,7 +359,7 @@ export default {
      */
     placeholder: {
       type: String,
-      default: "",
+      default: '',
     },
 
     /**
@@ -360,7 +376,7 @@ export default {
      */
     maxHeight: {
       type: String,
-      default: "unset",
+      default: 'unset',
     },
 
     // Emoji picker props
@@ -375,13 +391,13 @@ export default {
     emojiPickerProps: {
       type: Object,
       default: () => ({}),
-      validate(emojiPickerProps) {
+      validate (emojiPickerProps) {
         return [
-          "searchNoResultsLabel",
-          "searchResultsLabel",
-          "searchPlaceholderLabel",
-          "skinSelectorButtonTooltipLabel",
-          "tabSetLabels",
+          'searchNoResultsLabel',
+          'searchResultsLabel',
+          'searchPlaceholderLabel',
+          'skinSelectorButtonTooltipLabel',
+          'tabSetLabels',
         ].every((prop) => emojiPickerProps[prop] != null);
       },
     },
@@ -391,7 +407,7 @@ export default {
      */
     emojiTooltipMessage: {
       type: String,
-      default: "Emoji",
+      default: 'Emoji',
     },
 
     // Aria label for buttons
@@ -400,7 +416,7 @@ export default {
      */
     emojiButtonAriaLabel: {
       type: String,
-      default: "emoji button",
+      default: 'emoji button',
     },
 
     /**
@@ -408,14 +424,14 @@ export default {
      */
     showCharacterLimit: {
       type: [Boolean, Object],
-      default: () => ({ count: 1500, warning: 500, message: "" }),
+      default: () => ({ count: 1500, warning: 500, message: '' }),
     },
 
     showImagePicker: {
       type: [Boolean, Object],
       default: () => ({
-        tooltipLabel: "Attach Image",
-        ariaLabel: "image button",
+        tooltipLabel: 'Attach Image',
+        ariaLabel: 'image button',
       }),
     },
 
@@ -432,7 +448,7 @@ export default {
      */
     showCancel: {
       type: [Boolean, Object],
-      default: () => ({ text: "Cancel" }),
+      default: () => ({ text: 'Cancel' }),
     },
 
     /**
@@ -549,7 +565,7 @@ export default {
      * @event submit
      * @type {String}
      */
-    "submit",
+    'submit',
 
     /**
      * Fires when media is selected from image button
@@ -557,7 +573,7 @@ export default {
      * @event select-media
      * @type {Array}
      */
-    "select-media",
+    'select-media',
 
     /**
      * Fires when media is dropped into the message input
@@ -565,7 +581,7 @@ export default {
      * @event add-media
      * @type {Array}
      */
-    "add-media",
+    'add-media',
 
     /**
      * Fires when media is pasted into the message input
@@ -573,7 +589,7 @@ export default {
      * @event paste-media
      * @type {Array}
      */
-    "paste-media",
+    'paste-media',
 
     /**
      * Fires when cancel button is pressed (only on edit mode)
@@ -581,7 +597,7 @@ export default {
      * @event cancel
      * @type {Boolean}
      */
-    "cancel",
+    'cancel',
 
     /**
      * Fires when skin tone is selected from the emoji picker
@@ -589,7 +605,7 @@ export default {
      * @event skin-tone
      * @type {String}
      */
-    "skin-tone",
+    'skin-tone',
 
     /**
      * Fires when emoji is selected from the emoji picker
@@ -597,7 +613,7 @@ export default {
      * @event selected-emoji
      * @type {String}
      */
-    "selected-emoji",
+    'selected-emoji',
 
     /**
      * Fires when a slash command is selected
@@ -605,7 +621,7 @@ export default {
      * @event selected-command
      * @type {String}
      */
-    "selected-command",
+    'selected-command',
 
     /**
      * Fires when meeting pill is closed
@@ -613,17 +629,17 @@ export default {
      * @event meeting-pill-close
      * @type {String}
      */
-    "meeting-pill-close",
+    'meeting-pill-close',
 
     /**
      * Event to sync the value with the parent
      * @event update:modelValue
      * @type {String|JSON}
      */
-    "update:modelValue",
+    'update:modelValue',
   ],
 
-  data() {
+  data () {
     return {
       additionalExtensions: [meetingPill],
       internalInputValue: this.modelValue, // internal input content
@@ -634,15 +650,15 @@ export default {
   },
 
   computed: {
-    showSendIcon() {
+    showSendIcon () {
       return !this.showSend.text;
     },
 
-    inputLength() {
+    inputLength () {
       return this.internalInputValue.length;
     },
 
-    displayCharacterLimitWarning() {
+    displayCharacterLimitWarning () {
       return (
         Boolean(this.showCharacterLimit) &&
         this.showCharacterLimit.count - this.inputLength <=
@@ -650,14 +666,14 @@ export default {
       );
     },
 
-    characterLimitTooltipEnabled() {
+    characterLimitTooltipEnabled () {
       return (
         this.showCharacterLimit.message &&
         this.showCharacterLimit.count - this.inputLength < 0
       );
     },
 
-    isSendDisabled() {
+    isSendDisabled () {
       return (
         this.disableSend ||
         (this.showCharacterLimit &&
@@ -665,44 +681,44 @@ export default {
       );
     },
 
-    computedCloseButtonProps() {
+    computedCloseButtonProps () {
       return {
-        ariaLabel: "Close",
+        ariaLabel: 'Close',
       };
     },
 
-    emojiPickerHovered() {
+    emojiPickerHovered () {
       return this.emojiPickerFocus || this.emojiPickerOpened;
     },
 
-    sendIconSize() {
-      return "300";
+    sendIconSize () {
+      return '300';
     },
   },
 
   watch: {
-    modelValue(newValue) {
+    modelValue (newValue) {
       this.internalInputValue = newValue;
     },
 
-    emojiPickerOpened(newValue) {
+    emojiPickerOpened (newValue) {
       if (!newValue) {
         this.$refs.richTextEditor?.focusEditor();
       }
     },
   },
 
-  created() {
-    if (this.modelValue && this.outputFormat === "text") {
-      this.internalInputValue = this.modelValue.replace(/\n/g, "<br>");
+  created () {
+    if (this.modelValue && this.outputFormat === 'text') {
+      this.internalInputValue = this.modelValue.replace(/\n/g, '<br>');
     }
   },
 
   methods: {
     // Mousedown instead of click because it fires before the blur event.
-    onMousedown(e) {
+    onMousedown (e) {
       const isWithinInput = this.$refs.richTextEditor.$el
-        .querySelector(".tiptap")
+        .querySelector('.tiptap')
         .contains(e.target);
 
       // If the click is not within the tiptap rich text editor input itself, but still within the wrapping div,
@@ -714,68 +730,68 @@ export default {
       }
     },
 
-    onDrop(e) {
+    onDrop (e) {
       const dt = e.dataTransfer;
       const files = Array.from(dt.files);
-      this.$emit("add-media", files);
+      this.$emit('add-media', files);
     },
 
-    onPaste(e) {
+    onPaste (e) {
       if (e.clipboardData.files.length) {
         e.stopPropagation();
         e.preventDefault();
         const files = [...e.clipboardData.files];
-        this.$emit("paste-media", files);
+        this.$emit('paste-media', files);
       }
     },
 
-    onSkinTone(skinTone) {
-      this.$emit("skin-tone", skinTone);
+    onSkinTone (skinTone) {
+      this.$emit('skin-tone', skinTone);
     },
 
-    onSelectEmoji(emoji) {
+    onSelectEmoji (emoji) {
       if (!emoji) {
         return;
       }
 
       // Insert emoji into the editor
       this.$refs.richTextEditor.editor.commands.insertContent({
-        type: "emoji",
+        type: 'emoji',
         attrs: {
           code: emoji.shortname,
         },
       });
-      this.$emit("selected-emoji", emoji);
+      this.$emit('selected-emoji', emoji);
     },
 
-    onSelectImage() {
+    onSelectImage () {
       this.$refs.messageInputImageUpload.$refs.input.click();
     },
 
-    onImageUpload() {
+    onImageUpload () {
       this.$emit(
-        "select-media",
+        'select-media',
         this.$refs.messageInputImageUpload.$refs.input.files,
       );
     },
 
-    toggleEmojiPicker() {
+    toggleEmojiPicker () {
       this.emojiPickerOpened = !this.emojiPickerOpened;
     },
 
-    onSend() {
+    onSend () {
       if (this.isSendDisabled) {
         return;
       }
-      this.$emit("submit", this.internalInputValue);
+      this.$emit('submit', this.internalInputValue);
     },
 
-    onCancel() {
-      this.$emit("cancel");
+    onCancel () {
+      this.$emit('cancel');
     },
 
-    onInput(event) {
-      this.$emit("update:modelValue", event);
+    onInput (event) {
+      this.$emit('update:modelValue', event);
     },
   },
 };
@@ -788,7 +804,6 @@ export default {
   border-radius: var(--dt-size-radius-400);
   border: var(--dt-size-border-100) solid;
   border-color: var(--dt-color-border-default);
-  line-height: var(--dt-font-line-height-400);
   box-shadow: 0 0 0 0 rgba(0, 0, 0, 0%);
   cursor: text;
   transition: all 100ms cubic-bezier(0.22, 1, 0.36, 1);
@@ -803,7 +818,7 @@ export default {
   }
 
   &__editor-wrapper {
-    padding: var(--dt-space-450) var(--dt-space-500) var(--dt-space-300);
+    padding: var(--dt-space-400) var(--dt-space-500) var(--dt-space-300);
   }
 
   &__remaining-char-tooltip {
@@ -814,7 +829,7 @@ export default {
   &__remaining-char {
     color: var(--dt-color-foreground-critical);
     font-size: var(--dt-font-size-100);
-    margin-right: var(--dt-space-400);
+    margin-right: var(--dt-space-500);
   }
 
   &__send-button--disabled {
@@ -823,16 +838,7 @@ export default {
     cursor: default;
   }
 
-  &__button {
-    max-width: 2.8rem;
-    max-height: 2.8rem;
-    border-radius: var(--dt-size-radius-400);
-  }
-
   &__cancel-button {
-    max-width: unset;
-    padding-left: var(--dt-space-400);
-    padding-right: var(--dt-space-400);
     margin-right: var(--dt-space-300);
   }
 


### PR DESCRIPTION
# Message Input Recipe Updates

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

![Obligatory GIF](https://media0.giphy.com/media/l22ysLe54hZP0wubek/200.webp?cid=82a1493b9o0rp34og3jkcbg5gnayxnwxmzd906hrl7gcwjp0&ep=v1_gifs_trending&rid=200.webp&ct=gf)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

[DLT-2107](https://dialpad.atlassian.net/browse/DLT-2107)

## :book: Description

Jira ticket outlines all changes in PR.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.


[DLT-2107]: https://dialpad.atlassian.net/browse/DLT-2107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ