### PR TITLE
fix(rich-text-editor): DLT-2120 toggle editable prop removes input class styles

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.test.js
@@ -142,6 +142,13 @@ describe('DtRichTextEditor tests', () => {
         await wrapper.setProps({ editable: false });
 
         expect(editor.attributes('aria-readonly')).toBe('true');
+        expect(editor.attributes('class')).toContain('qa-editor');
+      });
+
+      it('should preserve input classes', async () => {
+        await wrapper.setProps({ editable: false });
+
+        expect(editor.attributes('class')).toContain('qa-editor');
       });
     });
   });

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -644,7 +644,15 @@ export default {
     },
 
     updateEditorAttributes (attributes) {
-      this.editor.setOptions({ editorProps: { attributes } });
+      this.editor.setOptions({
+        editorProps: {
+          attributes: {
+            ...this.inputAttrs,
+            class: this.inputClass,
+            ...attributes,
+          },
+        },
+      });
     },
 
     focusEditor () {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.test.js
@@ -156,6 +156,10 @@ describe('DtRichTextEditor tests', () => {
       it('should have aria-readonly attribute', function () {
         expect(editor.attributes('aria-readonly')).toBe('true');
       });
+
+      it('should preserve input classes', function () {
+        expect(editor.attributes('class')).toContain('qa-editor');
+      });
     });
   });
 

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -643,7 +643,15 @@ export default {
     },
 
     updateEditorAttributes (attributes) {
-      this.editor.setOptions({ editorProps: { attributes } });
+      this.editor.setOptions({
+        editorProps: {
+          attributes: {
+            ...this.inputAttrs,
+            class: this.inputClass,
+            ...attributes,
+          },
+        },
+      });
     },
 
     focusEditor () {


### PR DESCRIPTION
# fix(rich-text-editor): DLT-2120 toggle editable prop removes input class styles

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/Z5xk7fGO5FjjTElnpT/giphy.gif?cid=82a1493b0ab84vkajdl7292omb1r4bbvwtij4pufltjpuah6&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

[DLT-2120](https://dialpad.atlassian.net/browse/DLT-2120)

## :book: Description

Modified updateEditorAttributes method in rich text editor to preserve input class when updated on [editable prop toggled](https://github.com/dialpad/dialtone/blob/e6b5105b0ddf7d58f254daa62c146db3dbbf6693/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue#L478).

## :bulb: Context

This fix was needed because it was causing the font to shrink and certain styles to be removed when changing the value of the editable prop (while email was being sent) which looks strange. Linking a video here where I [reproduce this issue](https://drive.google.com/file/d/1w3F46K4EPbm_Q_vyTX8-7YHh8S4waXT4/view?usp=sharing) in the Dialtone docs.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

Recording of issue fixed with [changes applied locally](https://drive.google.com/file/d/1w3F46K4EPbm_Q_vyTX8-7YHh8S4waXT4/view?usp=sharing).



[DLT-2120]: https://dialpad.atlassian.net/browse/DLT-2120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ