### PR TITLE
fix(avatar): DP-113524 avatar icon not reactive

### DIFF
--- a/packages/dialtone-vue2/components/avatar/avatar.vue
+++ b/packages/dialtone-vue2/components/avatar/avatar.vue
@@ -23,7 +23,7 @@
         :alt="imageAlt"
       >
       <div
-        v-else-if="isIconType"
+        v-else-if="isIconType()"
         :class="[iconClass, AVATAR_KIND_MODIFIERS.icon]"
         :aria-label="clickable ? iconAriaLabel : ''"
         :data-qa="iconDataQa"
@@ -264,14 +264,6 @@ export default {
       type: String,
       default: undefined,
     },
-
-    /**
-     * Show the icon in the avatar.
-     */
-    showIcon: {
-      type: Boolean,
-      default: false,
-    },
   },
 
   emits: [
@@ -297,10 +289,6 @@ export default {
   },
 
   computed: {
-    isIconType () {
-      return this.showIcon || (this.$scopedSlots.icon && this.$scopedSlots.icon());
-    },
-
     hasOverlayIcon () {
       return !!this.$slots.overlayIcon;
     },
@@ -316,7 +304,7 @@ export default {
         this.avatarClass,
         {
           'd-avatar--group': this.showGroup,
-          [`d-avatar--color-${this.getColor()}`]: !this.isIconType,
+          [`d-avatar--color-${this.getColor()}`]: !this.isIconType(),
           'd-avatar--clickable': this.clickable,
         },
       ];
@@ -385,6 +373,10 @@ export default {
   },
 
   methods: {
+    isIconType () {
+      return this.$scopedSlots.icon && this.$scopedSlots.icon();
+    },
+
     async setImageListeners () {
       await this.$nextTick();
       const el = this.$refs.avatarImage;

--- a/packages/dialtone-vue2/components/avatar/avatar.vue
+++ b/packages/dialtone-vue2/components/avatar/avatar.vue
@@ -264,6 +264,14 @@ export default {
       type: String,
       default: undefined,
     },
+
+    /**
+     * Show the icon in the avatar.
+     */
+    showIcon: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   emits: [
@@ -290,7 +298,7 @@ export default {
 
   computed: {
     isIconType () {
-      return this.$scopedSlots.icon && this.$scopedSlots.icon();
+      return this.showIcon || (this.$scopedSlots.icon && this.$scopedSlots.icon());
     },
 
     hasOverlayIcon () {

--- a/packages/dialtone-vue2/recipes/item_layout/contact_info/contact_info.vue
+++ b/packages/dialtone-vue2/recipes/item_layout/contact_info/contact_info.vue
@@ -28,7 +28,6 @@
             image-alt=""
             :overlay-text="avatar.text"
             :avatar-class="[{ 'd-mln24': index > 0, 'd-bc-brand': !!avatar.halo }]"
-            :show-icon="showAvatarIcon"
           >
             <template
               #icon="{ iconSize }"
@@ -56,7 +55,6 @@
           :seed="avatarSeed"
           :color="avatarColor"
           :presence="presence"
-          :show-icon="showAvatarIcon"
         >
           <template
             #icon="{ iconSize }"
@@ -216,14 +214,6 @@ export default {
     avatarList: {
       type: Array,
       default: null,
-    },
-
-    /**
-     * Show avatar icon
-     */
-    showAvatarIcon: {
-      type: Boolean,
-      default: false,
     },
   },
 

--- a/packages/dialtone-vue2/recipes/item_layout/contact_info/contact_info.vue
+++ b/packages/dialtone-vue2/recipes/item_layout/contact_info/contact_info.vue
@@ -28,13 +28,13 @@
             image-alt=""
             :overlay-text="avatar.text"
             :avatar-class="[{ 'd-mln24': index > 0, 'd-bc-brand': !!avatar.halo }]"
+            :show-icon="showAvatarIcon"
           >
             <template
               #icon="{ iconSize }"
             >
               <!-- @slot Slot for avatar icon in a list -->
               <slot
-                v-if="hasAvatarIcon"
                 name="avatarIcon"
                 :icon-size="iconSize"
               />
@@ -56,13 +56,13 @@
           :seed="avatarSeed"
           :color="avatarColor"
           :presence="presence"
+          :show-icon="showAvatarIcon"
         >
           <template
             #icon="{ iconSize }"
           >
             <!-- @slot Slot for avatar icon in a list -->
             <slot
-              v-if="hasAvatarIcon"
               name="avatarIcon"
               :icon-size="iconSize"
             />
@@ -217,15 +217,17 @@ export default {
       type: Array,
       default: null,
     },
+
+    /**
+     * Show avatar icon
+     */
+    showAvatarIcon: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   emits: ['avatar-click'],
-
-  computed: {
-    hasAvatarIcon () {
-      return this.$scopedSlots.avatarIcon && this.$scopedSlots.avatarIcon();
-    },
-  },
 
   methods: {
     avatarClick () {

--- a/packages/dialtone-vue3/components/avatar/avatar.vue
+++ b/packages/dialtone-vue3/components/avatar/avatar.vue
@@ -23,7 +23,7 @@
         :alt="imageAlt"
       >
       <div
-        v-else-if="isIconType"
+        v-else-if="isIconType()"
         :class="[iconClass, AVATAR_KIND_MODIFIERS.icon]"
         :aria-label="clickable ? iconAriaLabel : ''"
         :data-qa="iconDataQa"
@@ -290,10 +290,6 @@ export default {
   },
 
   computed: {
-    isIconType () {
-      return hasSlotContent(this.$slots.icon);
-    },
-
     hasOverlayIcon () {
       return hasSlotContent(this.$slots.overlayIcon);
     },
@@ -309,7 +305,7 @@ export default {
         this.avatarClass,
         {
           'd-avatar--group': this.showGroup,
-          [`d-avatar--color-${this.getColor()}`]: !this.isIconType,
+          [`d-avatar--color-${this.getColor()}`]: !this.isIconType(),
           'd-avatar--clickable': this.clickable,
         },
       ];
@@ -378,6 +374,10 @@ export default {
   },
 
   methods: {
+    isIconType () {
+      return hasSlotContent(this.$slots.icon);
+    },
+
     async setImageListeners () {
       await this.$nextTick();
       const el = this.$refs.avatarImage;

--- a/packages/dialtone-vue3/recipes/item_layout/contact_info/contact_info.vue
+++ b/packages/dialtone-vue3/recipes/item_layout/contact_info/contact_info.vue
@@ -34,7 +34,6 @@
             >
               <!-- @slot Slot for avatar icon in a list -->
               <slot
-                v-if="hasAvatarIcon"
                 name="avatarIcon"
                 :icon-size="iconSize"
               />
@@ -62,7 +61,6 @@
           >
             <!-- @slot Slot for avatar icon in a list -->
             <slot
-              v-if="hasAvatarIcon"
               name="avatarIcon"
               :icon-size="iconSize"
             />
@@ -221,12 +219,6 @@ export default {
   },
 
   emits: ['avatar-click'],
-
-  computed: {
-    hasAvatarIcon () {
-      return hasSlotContent(this.$slots.avatarIcon);
-    },
-  },
 
   methods: {
     avatarClick () {


### PR DESCRIPTION
# Fix avatar icon not displaying when transferring the call

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DP-113524]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
The problem is that `$slots` (and `$scopedSlots`) is not reactive. That is explained here: https://github.com/vuejs/vue/issues/3517
So in this case, initially the slot was undefined, but then when transferring the call to an external it was defined, but the computed `isIconType` would not reevaluate. 
Changing the computed to a method makes it work as expected.

<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps
- Add changes to vue 3

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

### Before

![call-2](https://github.com/user-attachments/assets/5304da86-ae0f-445c-b6c3-84c5a082640f)


### After

![call](https://github.com/user-attachments/assets/30d305d4-27cc-4439-9a8d-7462256423b1)

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->




[DP-113524]: https://dialpad.atlassian.net/browse/DP-113524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ