### PR TITLE
fix(popover): NO-JIRA set -webkit-app-region: no-drag

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/modal.less
+++ b/packages/dialtone-css/lib/build/less/components/modal.less
@@ -33,6 +33,8 @@
     --modal-header-color-text: var(--dt-color-foreground-primary);
     --modal-dialog-shadow: var(--dt-shadow-large);
 
+    // If we don't set this the native app header region will override all click events on the modal overlay
+    -webkit-app-region: no-drag;
     position: fixed;
     inset: 0;
     z-index: var(--zi-hide);
@@ -50,6 +52,9 @@
 
 .d-modal--transparent {
   --modal-backdrop-color-background: var(--d-bgc-transparent);
+
+  // If we don't set this the native app header region will override all click events on the modal overlay
+  -webkit-app-region: no-drag;
 
   &[aria-hidden='false'] {
     position: fixed;

--- a/packages/dialtone-css/lib/build/less/components/popover.less
+++ b/packages/dialtone-css/lib/build/less/components/popover.less
@@ -30,6 +30,9 @@
     --popover-color-border: var(--dt-color-border-subtle);
     --popover-shadow: var(--dt-shadow-card);
 
+    // If we don't set this the native app header region will override all click events within the popover
+    -webkit-app-region: no-drag;
+
     &,
     *,
     *::before,


### PR DESCRIPTION
# fix(popover): NO-JIRA set -webkit-app-region: no-drag

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExem55OW80OXMwNGIwYW00Mnh3a3NhYTRnb3g1Zm1jMWplMDRwZ3pwMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/VdnYIoeVQvQDVPEoKn/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Add `-webkit-app-region: no-drag` to popover and modal overlays.

## :bulb: Context

The header region in the native app header is very aggressive and by default overrides all mouse events. So this means if you have a popover that's over the header, it won't highlight items and won't trigger click events if you click on the portion that is over top of the app header. It also will not close the popover if you click outside of the popover on the header, which is not expected behaviour. Setting `-webkit-app-region: no-drag` allows click events to pass through.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

test that it's fixed in the native app

## :camera: Screenshots / GIFs

![2024-10-16 14 11 19](https://github.com/user-attachments/assets/937d089f-3bd9-40e8-9fca-60ea3d1ec76a)

## :link: Sources

https://github.com/electron/electron/issues/1354
