### PR TITLE
fix(callbar-button-with-popover): DLT-2129 text overlapping anchor

### DIFF
--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
@@ -212,23 +212,25 @@ export default {
   excludeStories: /.*Data$/,
 };
 
+const defaultArgs = {
+  default: 'Button',
+  tooltip: 'Tooltip Text',
+  ariaLabel: 'Button',
+  arrowButtonLabel: 'Open popover',
+  content: 'Popover body content',
+  contentClass: ['d-h464', 'd-w512'],
+  headerContent: 'Header content',
+  showCloseButton: true,
+  forceShowArrow: false,
+  openPopover: false,
+  icon: 'dialpad-ai',
+};
+
 export const Default = {
   render: (argsData) =>
     createRenderConfig(DtRecipeCallbarButtonWithPopover, DtRecipeCallbarButtonWithPopoverDefaultTemplate, argsData),
 
-  args: {
-    default: 'Button',
-    tooltip: 'Tooltip Text',
-    ariaLabel: 'Button',
-    arrowButtonLabel: 'Open popover',
-    content: 'Popover body content',
-    contentClass: ['d-h464', 'd-w512'],
-    headerContent: 'Header content',
-    showCloseButton: true,
-    forceShowArrow: false,
-    openPopover: false,
-    icon: 'dialpad-ai',
-  },
+  args: defaultArgs,
 };
 
 export const Variants = {
@@ -243,5 +245,15 @@ export const Variants = {
         openPopover: true,
       },
     },
+  },
+};
+
+export const WithLongText = {
+  render: (argsData) =>
+    createRenderConfig(DtRecipeCallbarButtonWithPopover, DtRecipeCallbarButtonWithPopoverDefaultTemplate, argsData),
+
+  args: {
+    ...defaultArgs,
+    default: 'Button with long text',
   },
 };

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -344,7 +344,7 @@ export default {
 
 <style lang="less">
 .dt-recipe--callbar-button-with-popover--arrow {
-  margin-top: var(--dt-space-350-negative);
+  margin-top: var(--dt-space-450);
   margin-left: calc(var(--dt-space-300-negative) * 5);
   width: var(--dt-size-500);
   height: var(--dt-size-500);
@@ -392,6 +392,6 @@ export default {
 
 .dt-recipe--callbar-button-with-popover {
   display: flex;
-  align-items: center;
+  align-items: start;
 }
 </style>

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.stories.js
@@ -213,6 +213,20 @@ export default {
 };
 
 // Templates
+const defaultArgs = {
+  default: 'Button',
+  tooltip: 'Tooltip Text',
+  ariaLabel: 'Button',
+  arrowButtonLabel: 'Open popover',
+  content: 'Popover body content',
+  contentClass: ['d-h464', 'd-w512'],
+  headerContent: 'Header content',
+  showCloseButton: true,
+  forceShowArrow: false,
+  openPopover: false,
+  icon: 'dialpad-ai',
+};
+
 const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
   args,
   argTypes,
@@ -226,20 +240,7 @@ const VariantsTemplate = (args, { argTypes }) => createTemplateFromVueFile(
 
 export const Default = {
   render: DefaultTemplate,
-
-  args: {
-    default: 'Button',
-    tooltip: 'Tooltip Text',
-    ariaLabel: 'Button',
-    arrowButtonLabel: 'Open popover',
-    content: 'Popover body content',
-    contentClass: ['d-h464', 'd-w512'],
-    headerContent: 'Header content',
-    showCloseButton: true,
-    forceShowArrow: false,
-    openPopover: false,
-    icon: 'dialpad-ai',
-  },
+  args: defaultArgs,
 };
 
 export const Variants = {
@@ -253,5 +254,13 @@ export const Variants = {
         openPopover: true,
       },
     },
+  },
+};
+
+export const WithLongText = {
+  render: DefaultTemplate,
+  args: {
+    ...defaultArgs,
+    default: 'Button with long text',
   },
 };

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -353,7 +353,7 @@ export default {
 
 <style lang="less">
 .dt-recipe--callbar-button-with-popover--arrow {
-  margin-top: var(--dt-space-350-negative);
+  margin-top: var(--dt-space-450);
   margin-left: calc(var(--dt-space-300-negative) * 5);
   width: var(--dt-size-500);
   height: var(--dt-size-500);
@@ -401,6 +401,6 @@ export default {
 
 .dt-recipe--callbar-button-with-popover {
   display: flex;
-  align-items: center;
+  align-items: start;
 }
 </style>


### PR DESCRIPTION
# fix callbar button with popover - text overlapping anchor

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DLT-2129]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Previously, the chevron icon was aligned to the center so it would overlap the text if the text was long. Now I am aligning it to the icon.
This changes the design so I'm going to ask for design approval.

| Previous | Now |
|------|------|
| <img width="86" alt="image" src="https://github.com/user-attachments/assets/c85017a4-f2f0-44b8-a1d1-6094d5e81115"> | <img width="99" alt="image" src="https://github.com/user-attachments/assets/4e64787f-9016-4985-897c-e82de6512983"> |
| <img width="82" alt="image" src="https://github.com/user-attachments/assets/62411564-bd13-4ab7-acca-f90d3f47d12c"> | <img width="88" alt="image" src="https://github.com/user-attachments/assets/a993e1ca-305f-42f1-8932-56f103c7014e"> |
| <img width="291" alt="image" src="https://github.com/user-attachments/assets/59a06461-27bc-4553-bccc-9308ec6f1c69"> | <img width="295" alt="image" src="https://github.com/user-attachments/assets/886d825d-cc39-42c6-b4d2-0eed9fa9a6ac"> |





<!--- Describe specifically what the changes are -->

## :bulb: Context
This is causing a visual bug on the product for the Italian language.
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps
- Add changes to vue 3
<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->



[DLT-2129]: https://dialpad.atlassian.net/browse/DLT-2129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ