### PR TITLE
fix(tokens): NO-JIRA resolveMath for android

### DIFF
--- a/packages/dialtone-tokens/build-sd-transforms.js
+++ b/packages/dialtone-tokens/build-sd-transforms.js
@@ -166,6 +166,7 @@ export async function run () {
             'dt/android/compose/opacity/percentToFloat',
             'dt/android/compose/size/pxToDp',
             'dt/android/compose/size/pxToSp',
+            'dt/android/compose/size/resolveMath',
             'dt/android/compose/color',
             'dt/stringify',
             'attribute/cti',

--- a/packages/dialtone-tokens/dialtone-transforms.js
+++ b/packages/dialtone-tokens/dialtone-transforms.js
@@ -169,7 +169,7 @@ export function registerDialtoneTransforms (styleDictionary) {
       return [...SPACING_IDENTIFIERS, ...SIZE_IDENTIFIERS, ...FONT_SIZE_IDENTIFIERS].includes(token.type);
     },
     transform: (token) => {
-      // replace dp or sp with empty string
+      // replace unmathable characters with empty string
       let unit;
       if (token.value.includes('.dp')) unit = 'dp';
       if (token.value.includes('.sp')) unit = 'sp';
@@ -177,7 +177,6 @@ export function registerDialtoneTransforms (styleDictionary) {
       const mathString = token.value.replace(/\.dp|\.sp|\.em/g, '');
       // eslint-disable-next-line no-eval
       const result = eval(mathString);
-
       return `${result}.${unit}`;
     },
   });

--- a/packages/dialtone-tokens/dialtone-transforms.js
+++ b/packages/dialtone-tokens/dialtone-transforms.js
@@ -162,6 +162,27 @@ export function registerDialtoneTransforms (styleDictionary) {
   });
 
   styleDictionary.registerTransform({
+    name: 'dt/android/compose/size/resolveMath',
+    type: 'value',
+    transitive: true,
+    filter: function (token) {
+      return [...SPACING_IDENTIFIERS, ...SIZE_IDENTIFIERS, ...FONT_SIZE_IDENTIFIERS].includes(token.type);
+    },
+    transform: (token) => {
+      // replace dp or sp with empty string
+      let unit;
+      if (token.value.includes('.dp')) unit = 'dp';
+      if (token.value.includes('.sp')) unit = 'sp';
+      if (token.value.includes('.em')) unit = 'em';
+      const mathString = token.value.replace(/\.dp|\.sp|\.em/g, '');
+      // eslint-disable-next-line no-eval
+      const result = eval(mathString);
+
+      return `${result}.${unit}`;
+    },
+  });
+
+  styleDictionary.registerTransform({
     name: 'dt/android/compose/lineHeight/percentToDecimal',
     type: 'value',
     filter: function (token) {


### PR DESCRIPTION
# fix(tokens): resolveMath for android

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHdweXdvcnFnamVqNnZzcmFwa3o5bWxzeG9seGEydWM4NHZtOWV4dCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/llarwdtFqG63IlqUR1/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Created a new transformer to resolve math for android kotlin to fix errors.

## :bulb: Context

Since some of the changes in style dictionary 4 with the new transitive transformers some calculated android sizing were not resolving and causing some syntax errors in the file. This is maybe a bit of a brute force method using eval but it should work well enough for what we currently need.

Before you would see calculations in the android kotlin size tokens for example `10.dp * 0.8 * 1.5`. Now it should all be resolved like so `12.dp`.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

Check with android team that it's working, make sure build releases correctly.
