### PR TITLE
fix(rich-text-editor, editor): DLT-2175 editor loses text formatting while pasting

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -163,6 +163,7 @@
         :output-format="htmlOutputFormat"
         :auto-focus="autoFocus"
         :placeholder="placeholder"
+        :use-default-paste-handler="useDefaultPasteHandler"
         :allow-line-breaks="true"
         :link="true"
         v-bind="$attrs"
@@ -457,6 +458,14 @@ export default {
         setLinkTitle: 'Add a link',
         setLinkInputAriaLabel: 'Input field to add link',
       }),
+    },
+
+    /**
+     * Use default paste handler.
+     */
+    useDefaultPasteHandler: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor_default.story.vue
@@ -28,6 +28,7 @@
       :show-quote-button="$attrs.showQuoteButton"
       :show-quick-replies-button="$attrs.showQuickRepliesButton"
       :show-code-block-button="$attrs.showCodeBlockButton"
+      :use-default-paste-handler="$attrs.useDefaultPasteHandler"
       @focus="$attrs.onFocus"
       @blur="$attrs.onBlur"
       @input="$attrs.onInput"

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -164,6 +164,7 @@
         :output-format="htmlOutputFormat"
         :auto-focus="autoFocus"
         :placeholder="placeholder"
+        :use-default-paste-handler="useDefaultPasteHandler"
         :allow-line-breaks="true"
         :link="true"
         v-bind="$attrs"
@@ -460,6 +461,14 @@ export default {
         setLinkTitle: 'Add a link',
         setLinkInputAriaLabel: 'Input field to add link',
       }),
+    },
+
+    /**
+     * Use default paste handler.
+     */
+    useDefaultPasteHandler: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
@@ -28,6 +28,7 @@
       :show-quote-button="$attrs.showQuoteButton"
       :show-quick-replies-button="$attrs.showQuickRepliesButton"
       :show-code-block-button="$attrs.showCodeBlockButton"
+      :use-default-paste-handler="$attrs.useDefaultPasteHandler"
       @focus="$attrs.onFocus"
       @blur="$attrs.onBlur"
       @input="$attrs.onInput"


### PR DESCRIPTION
# fix(rich-text-editor, editor): DLT-2175 editor loses text formatting while pasting

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExeGNzZ3BxcTVhajR2cW5panA5ZWxsd2NxNjQ0Y2t6NXNrY3R3OTlqYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fUQ4rhUZJYiQsas6WD/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

[https://dialpad.atlassian.net/browse/DLT-2175](https://dialpad.atlassian.net/browse/DLT-2175)
[https://dialpad.atlassian.net/browse/DP-115096](https://dialpad.atlassian.net/browse/DP-115096)


## :book: Description

The email composer does not retain formatting while pasting a text.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

Urgent fix required: the email composer does not retain formatting while pasting a text.
For now we're just passing a prop to override custom handler to fix this urgently and allow formatting to be preserved.
Property is set to default false to avoid breaking backwards compatibility.
We need to come up with a fix that tackles the break issue but also preserves formatting on paste for future release.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.


## :crystal_ball: Next Steps

We need to remove this parameter in the future and analyze how to both:

- preserve formatting on paste
- preserve breaks/double breaks when pasting

## :camera: Screenshots / GIFs

Video evidence of fix [here](https://drive.google.com/file/d/18H7hwHkggSAF6gmlz3BVOHVADvDMXLVc/view?usp=sharing)

