### PR TITLE
fix(emoji-text-wrapper): DLT-2176 invalid regular expression error

### DIFF
--- a/packages/dialtone-vue2/common/emoji/index.js
+++ b/packages/dialtone-vue2/common/emoji/index.js
@@ -196,12 +196,3 @@ export function filterValidShortCodes (shortcodes) {
   const filtered = shortcodes ? shortcodes.filter(code => shortcodeToEmojiData(code)) : [];
   return new Set(filtered);
 }
-
-// Finds every emoji in slot text
-// removes duplicates
-// @returns {string[]}
-export function findEmojis (textContent) {
-  const matches = [...textContent.matchAll(emojiRegex)];
-  const emojis = matches.length ? matches.map(match => match[0]) : [];
-  return new Set(emojis);
-}

--- a/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.stories.js
+++ b/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.stories.js
@@ -56,7 +56,7 @@ export const Default = {
 
   args: {
     default:
-      'Some text with :invalid-emoji: :smile: :cry: and 😄, and custom emojis :octocat: :shipit:',
+      'Some text with :invalid-emoji: :smile: :cry: *️⃣ and 😄, and custom emojis :octocat: :shipit:',
   },
 };
 

--- a/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -58,6 +58,9 @@ export default {
       return items
         .filter(item => item.trim() !== '')
         .map((item) => {
+          // Reset the regexp index to 0 to start from the beginning
+          // Otherwise, it will start from the last index
+          regexp.lastIndex = 0;
           if (replaceList.includes(item) || regexp.test(item)) {
             return this.$createElement(DtEmoji, {
               props: { code: item, size: this.size },

--- a/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -1,7 +1,8 @@
 <script>
 import { DtEmoji } from '../emoji';
-import { findEmojis, findShortCodes } from '@/common/emoji';
+import { findShortCodes } from '@/common/emoji';
 import { ICON_SIZE_MODIFIERS } from '@/components/icon/icon_constants';
+import { emojiPattern } from 'regex-combined-emojis';
 
 /**
  * Wrapper to find and replace shortcodes like :smile: or unicode chars such as 😄 with our custom Emojis implementation.
@@ -57,7 +58,7 @@ export default {
       return items
         .filter(item => item.trim() !== '')
         .map((item) => {
-          if (replaceList.includes(item)) {
+          if (replaceList.includes(item) || regexp.test(item)) {
             return this.$createElement(DtEmoji, {
               props: { code: item, size: this.size },
             });
@@ -93,9 +94,7 @@ export default {
      */
     searchCodes (textContent) {
       const shortcodes = findShortCodes(textContent);
-      const emojis = findEmojis(textContent);
-
-      const replaceList = [...shortcodes, ...emojis];
+      const replaceList = [...shortcodes, emojiPattern];
       return this.replaceDtEmojis(replaceList, textContent);
     },
   },

--- a/packages/dialtone-vue3/common/emoji/index.js
+++ b/packages/dialtone-vue3/common/emoji/index.js
@@ -196,12 +196,3 @@ export function filterValidShortCodes (shortcodes) {
   const filtered = shortcodes ? shortcodes.filter(code => shortcodeToEmojiData(code)) : [];
   return new Set(filtered);
 }
-
-// Finds every emoji in slot text
-// removes duplicates
-// @returns {string[]}
-export function findEmojis (textContent) {
-  const matches = [...textContent.matchAll(emojiRegex)];
-  const emojis = matches.length ? matches.map(match => match[0]) : [];
-  return new Set(emojis);
-}

--- a/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.stories.js
+++ b/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.stories.js
@@ -68,7 +68,7 @@ export const Default = {
 
   args: {
     default:
-      'Some text with :invalid-emoji: :smile: :cry: and 😄, and custom emojis :octocat: :shipit:',
+      'Some text with :invalid-emoji: :smile: :cry: *️⃣ and 😄, and custom emojis :octocat: :shipit:',
   },
 };
 

--- a/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -1,8 +1,9 @@
 <script>
 import { DtEmoji } from '../emoji';
-import { findEmojis, findShortCodes } from '@/common/emoji';
+import { findShortCodes } from '@/common/emoji';
 import { h } from 'vue';
 import { ICON_SIZE_MODIFIERS } from '@/components/icon/icon_constants';
+import { emojiPattern } from 'regex-combined-emojis';
 
 /**
  * Wrapper to find and replace shortcodes like :smile: or unicode chars such as 😄 with our custom Emojis implementation.
@@ -58,7 +59,7 @@ export default {
       return items
         .filter(item => item.trim() !== '')
         .map((item) => {
-          if (replaceList.includes(item)) {
+          if (replaceList.includes(item) || regexp.test(item)) {
             return h(DtEmoji, { code: item, size: this.size });
           }
           return h('span', { class: 'd-emoji-text-wrapper__text' }, item);
@@ -91,9 +92,8 @@ export default {
      */
     searchCodes (textContent) {
       const shortcodes = findShortCodes(textContent);
-      const emojis = findEmojis(textContent);
 
-      const replaceList = [...shortcodes, ...emojis];
+      const replaceList = [...shortcodes, emojiPattern];
       if (replaceList.length === 0) return textContent;
       return this.replaceDtEmojis(replaceList, textContent);
     },

--- a/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -59,6 +59,9 @@ export default {
       return items
         .filter(item => item.trim() !== '')
         .map((item) => {
+          // Reset the regexp index to 0 to start from the beginning
+          // Otherwise, it will start from the last index
+          regexp.lastIndex = 0;
           if (replaceList.includes(item) || regexp.test(item)) {
             return h(DtEmoji, { code: item, size: this.size });
           }


### PR DESCRIPTION
# fix(emoji-text-wrapper): DLT-2176 invalid regular expression error

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DLT-2176]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Fixes the error `Error: SyntaxError: Invalid regular expression: /(X)/g: Nothing to repeat` when entering *️⃣ emoji on a message.
I fixed it by using directly the `emojiPattern` regex instead of the `findEmojis` function.
<!--- Describe specifically what the changes are -->

## :bulb: Context
The error appeared in prod: https://dialpad.atlassian.net/browse/DP-115263
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

### Previous
<img width="1908" alt="image-20241025-192541" src="https://github.com/user-attachments/assets/fc04b8f1-edf3-436e-b642-d7c7e689c0c6">

### Now
<img width="704" alt="image" src="https://github.com/user-attachments/assets/7d558662-5d53-4725-aca8-5e029c67ac18">


<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->



[DLT-2176]: https://dialpad.atlassian.net/browse/DLT-2176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ