### PR TITLE
feat(emoji-picker): DP-113112 add shift key info on selected-emoji event

### DIFF
--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -44,7 +44,7 @@
             :ref="`emojiRef-${indexTab}`"
             type="button"
             :aria-label="emoji.name"
-            @click="$emit('selected-emoji', emoji)"
+            @click="event => handleEmojiSelection(emoji, event)"
             @focusin="$emit('highlighted-emoji', emoji)"
             @focusout="$emit('highlighted-emoji', null)"
             @mouseover="$emit('highlighted-emoji', emoji)"
@@ -79,7 +79,7 @@
             :class="{
               'hover-emoji': (index === 0 && hoverFirstEmoji),
             }"
-            @click="$emit('selected-emoji', emoji)"
+            @click="event => handleEmojiSelection(emoji, event)"
             @focusin="$emit('highlighted-emoji', emoji)"
             @focusout="$emit('highlighted-emoji', null)"
             @mouseover="hoverEmoji(emoji)"
@@ -471,7 +471,7 @@ export default {
       }
 
       if (event.key === 'Enter') {
-        this.$emit('selected-emoji', { ...emoji, shift_key: event.shiftKey });
+        this.handleEmojiSelection(emoji, event);
       }
     },
 
@@ -522,6 +522,10 @@ export default {
       }
     },
 
+    handleEmojiSelection (emoji, event) {
+      this.$emit('selected-emoji', { ...emoji, shift_key: event.shiftKey });
+    },
+
     /* eslint-disable-next-line complexity */
     handleKeyDownFilteredEmojis (event, indexEmoji, emoji) {
       event.preventDefault();
@@ -566,7 +570,7 @@ export default {
       }
 
       if (event.key === 'Enter') {
-        this.$emit('selected-emoji', { ...emoji, shift_key: event.shiftKey });
+        this.handleEmojiSelection(emoji, event);
       }
     },
 

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -471,7 +471,7 @@ export default {
       }
 
       if (event.key === 'Enter') {
-        this.$emit('selected-emoji', emoji);
+        this.$emit('selected-emoji', { ...emoji, shift_key: event.shiftKey });
       }
     },
 
@@ -566,7 +566,7 @@ export default {
       }
 
       if (event.key === 'Enter') {
-        this.$emit('selected-emoji', emoji);
+        this.$emit('selected-emoji', { ...emoji, shift_key: event.shiftKey });
       }
     },
 

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
@@ -483,7 +483,7 @@ const handleKeyDownFilteredEmojis = (event, indexEmoji, emoji) => {
       emits('focus-skin-selector');
       break;
     case 'Enter':
-      selectEmoji(emoji);
+      selectEmoji({ ...emoji, shift_key: event.shiftKey });
       break;
     default:
       break;
@@ -519,7 +519,7 @@ const handleKeyDown = (event, indexTab, indexEmoji, emoji) => {
       break;
 
     case 'Enter':
-      selectEmoji(emoji);
+      selectEmoji({ ...emoji, shift_key: event.shiftKey });
       break;
 
     default:

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
@@ -44,7 +44,7 @@
             :ref="el => { if (el) setEmojiRef(el, indexTab, indexEmoji) }"
             type="button"
             :aria-label="emoji.name"
-            @click="selectEmoji(emoji)"
+            @click="event => selectEmoji(emoji, event)"
             @focusin="highlightEmoji(emoji)"
             @focusout="highlightEmoji(null)"
             @mouseover="highlightEmoji(emoji)"
@@ -79,7 +79,7 @@
             :class="{
               'hover-emoji': (index === 0 && hoverFirstEmoji),
             }"
-            @click="selectEmoji(emoji)"
+            @click="event => selectEmoji(emoji, event)"
             @focusin="highlightEmoji(emoji)"
             @focusout="highlightEmoji(null)"
             @mouseover="hoverEmoji(emoji)"
@@ -483,7 +483,7 @@ const handleKeyDownFilteredEmojis = (event, indexEmoji, emoji) => {
       emits('focus-skin-selector');
       break;
     case 'Enter':
-      selectEmoji({ ...emoji, shift_key: event.shiftKey });
+      selectEmoji(emoji, event);
       break;
     default:
       break;
@@ -519,7 +519,7 @@ const handleKeyDown = (event, indexTab, indexEmoji, emoji) => {
       break;
 
     case 'Enter':
-      selectEmoji({ ...emoji, shift_key: event.shiftKey });
+      selectEmoji(emoji, event);
       break;
 
     default:
@@ -527,8 +527,8 @@ const handleKeyDown = (event, indexTab, indexEmoji, emoji) => {
   }
 };
 
-function selectEmoji (emoji) {
-  emits('selected-emoji', emoji);
+function selectEmoji (emoji, event) {
+  emits('selected-emoji', { ...emoji, shift_key: event.shiftKey });
 }
 
 function highlightEmoji (emoji) {


### PR DESCRIPTION
# add(emoji-picker): DP-113112 add shift key info on selected-emoji event

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNHhmbDh6Z2RzMGc5d3V6YjUyczV0eDh5NzFnd2NnNDNuOW85a3Y3NCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/f4HpCDvF84oh2/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DP-113112
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
This pull request enhances the selected-emoji event by including information about key events. With this update, we can now identify whether an emoji was selected using the Shift + Enter keys.

## :bulb: Context
For going into GA with the new message input component, we need to allow users to add an emoji to the input field with Shift + Enter without closing the emoji picker. To enable this functionality on the product side, it's essential to detect when an emoji is selected using the Shift + Enter key combination.