### PR TITLE
fix(emoji): NO-JIRA revert back to emoji-toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@tiptap/suggestion": "^2.6.6",
     "date-fns": "2.30.0",
     "docopt": "0.6.2",
-    "emoji-toolkit": "8",
+    "emoji-toolkit": "8.0.0",
     "overlayscrollbars": "2.10.0",
     "regex-combined-emojis": "1.6.0",
     "tippy.js": "6.3.7"

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@tiptap/suggestion": "^2.6.6",
     "date-fns": "2.30.0",
     "docopt": "0.6.2",
+    "emoji-toolkit": "8",
     "overlayscrollbars": "2.10.0",
     "regex-combined-emojis": "1.6.0",
     "tippy.js": "6.3.7"

--- a/packages/dialtone-vue2/common/emoji/index.js
+++ b/packages/dialtone-vue2/common/emoji/index.js
@@ -175,7 +175,6 @@ export function codeToEmojiData (code) {
     return shortcodeToEmojiData(code);
   } else {
     const unicodeString = unicodeToString(code);
-    console.log(unicodeString);
     const result = emojiJson[unicodeString];
     if (result) result.key = unicodeString;
     return result;

--- a/packages/dialtone-vue2/common/emoji/index.js
+++ b/packages/dialtone-vue2/common/emoji/index.js
@@ -1,5 +1,5 @@
 import { emojiPattern } from 'regex-combined-emojis';
-import { emojisIndexed } from '@dialpad/dialtone-emojis';
+import emojiJsonLocal from 'emoji-toolkit/emoji_strategy.json' with { type: 'json' };
 
 export const emojiRegex = new RegExp(emojiPattern, 'g');
 export const emojiVersion = '8.0';
@@ -14,7 +14,7 @@ export let emojiFileExtensionSmall = '.png';
 export let emojiImageUrlLarge = defaultEmojiAssetUrl;
 export let emojiFileExtensionLarge = '.png';
 
-export const emojiJson = emojisIndexed;
+export const emojiJson = emojiJsonLocal;
 
 export const emojiShortCodeRegex = /(^| |(?<=:))(:\w+:)/g;
 
@@ -175,6 +175,7 @@ export function codeToEmojiData (code) {
     return shortcodeToEmojiData(code);
   } else {
     const unicodeString = unicodeToString(code);
+    console.log(unicodeString);
     const result = emojiJson[unicodeString];
     if (result) result.key = unicodeString;
     return result;

--- a/packages/dialtone-vue3/common/emoji/index.js
+++ b/packages/dialtone-vue3/common/emoji/index.js
@@ -1,5 +1,5 @@
 import { emojiPattern } from 'regex-combined-emojis';
-import { emojisIndexed } from '@dialpad/dialtone-emojis';
+import emojiJsonLocal from 'emoji-toolkit/emoji_strategy.json' with { type: 'json' };
 
 export const emojiRegex = new RegExp(emojiPattern, 'g');
 export const emojiVersion = '8.0';
@@ -14,7 +14,7 @@ export let emojiFileExtensionSmall = '.png';
 export let emojiImageUrlLarge = defaultEmojiAssetUrl;
 export let emojiFileExtensionLarge = '.png';
 
-export const emojiJson = emojisIndexed;
+export const emojiJson = emojiJsonLocal;
 
 export const emojiShortCodeRegex = /(^| |(?<=:))(:\w+:)/g;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       docopt:
         specifier: 0.6.2
         version: 0.6.2
+      emoji-toolkit:
+        specifier: '8'
+        version: 8.0.0
       overlayscrollbars:
         specifier: 2.10.0
         version: 2.10.0
@@ -169,10 +172,10 @@ importers:
         version: 7.6.20(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@vitejs/plugin-vue':
         specifier: ^5.0.3
-        version: 5.1.4(vite@5.4.2(@types/node@20.16.5)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1))(vue@3.4.15(typescript@5.4.2))
+        version: 5.1.4(vite@5.4.2(@types/node@20.16.5)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1))
       '@vitejs/plugin-vue2':
         specifier: ^2.3.1
-        version: 2.3.1(vite@5.4.2(@types/node@20.16.5)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1))(vue@3.4.15(typescript@5.4.2))
+        version: 2.3.1(vite@5.4.2(@types/node@20.16.5)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1))
       '@vue/tsconfig':
         specifier: ^0.4.0
         version: 0.4.0
@@ -355,10 +358,10 @@ importers:
         version: 1.0.4(@types/node@20.16.5)(jsdom@24.0.0)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1)
       vue-docgen-api:
         specifier: ^4.75.0
-        version: 4.75.0(vue@3.4.15(typescript@5.4.2))
+        version: 4.75.0(vue@3.4.15(typescript@5.6.3))
       vue-template-compiler:
         specifier: ^2.7.16
-        version: 2.7.16(vue@3.4.15(typescript@5.4.2))
+        version: 2.7.16(vue@2.7.16)
       wait-on:
         specifier: ^7.2.0
         version: 7.2.0
@@ -7380,6 +7383,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  emoji-toolkit@8.0.0:
+    resolution: {integrity: sha512-Vz8YIqQJsQ+QZ4yuKMMzliXceayqfWbNjb6bST+vm77QAhU2is3I+/PRxrNknW+q1bvHHMgjLCQXxzINWLVapg==}
 
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -15320,8 +15326,8 @@ packages:
   vue-component-type-helpers@1.8.24:
     resolution: {integrity: sha512-lqWs/7fdRXoSBAlbouHBX+LNuaY6gI9xWW34m/ZIz9zVPYHEyw0b2/zaCBwlKx0NtKTeF/6pOpvrxVkh7nhIYg==}
 
-  vue-component-type-helpers@2.1.8:
-    resolution: {integrity: sha512-ii36gDzrYAfOQIkOlo44yceDdT5269gKmNGxf07Qx6seH2U50+tQ2ol02XLhYPmxrh6YabAsOdte8WDrpaO6Tw==}
+  vue-component-type-helpers@2.1.10:
+    resolution: {integrity: sha512-lfgdSLQKrUmADiSV6PbBvYgQ33KF3Ztv6gP85MfGaGaSGMTXORVaHT1EHfsqCgzRNBstPKYDmvAV9Do5CmJ07A==}
 
   vue-demi@0.14.7:
     resolution: {integrity: sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==}
@@ -20127,7 +20133,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.15(typescript@5.6.3)
-      vue-component-type-helpers: 2.1.8
+      vue-component-type-helpers: 2.1.10
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -20703,7 +20709,7 @@ snapshots:
   '@types/vinyl@2.0.12':
     dependencies:
       '@types/expect': 1.20.4
-      '@types/node': 20.16.5
+      '@types/node': 22.8.4
 
   '@types/wait-on@5.3.4':
     dependencies:
@@ -20985,10 +20991,9 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-vue2@2.3.1(vite@5.4.2(@types/node@20.16.5)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1))(vue@3.4.15(typescript@5.4.2))':
+  '@vitejs/plugin-vue2@2.3.1(vite@5.4.2(@types/node@20.16.5)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1))':
     dependencies:
       vite: 5.4.2(@types/node@20.16.5)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1)
-      vue: 3.4.15(typescript@5.4.2)
 
   '@vitejs/plugin-vue@4.6.2(vite@4.0.5(@types/node@22.8.4)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1))(vue@3.4.15(typescript@5.6.3))':
     dependencies:
@@ -21000,10 +21005,9 @@ snapshots:
       vite: 5.4.2(@types/node@22.8.4)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1)
       vue: 3.4.15(typescript@5.6.3)
 
-  '@vitejs/plugin-vue@5.1.4(vite@5.4.2(@types/node@20.16.5)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1))(vue@3.4.15(typescript@5.4.2))':
+  '@vitejs/plugin-vue@5.1.4(vite@5.4.2(@types/node@20.16.5)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1))':
     dependencies:
       vite: 5.4.2(@types/node@20.16.5)(less@4.2.0)(sass@1.69.5)(sugarss@2.0.0)(terser@5.34.1)
-      vue: 3.4.15(typescript@5.4.2)
 
   '@vitest/expect@1.0.4':
     dependencies:
@@ -24168,6 +24172,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  emoji-toolkit@8.0.0: {}
 
   emojis-list@3.0.0: {}
 
@@ -33763,7 +33769,7 @@ snapshots:
 
   vue-component-type-helpers@1.8.24: {}
 
-  vue-component-type-helpers@2.1.8: {}
+  vue-component-type-helpers@2.1.10: {}
 
   vue-demi@0.14.7(vue@3.4.15(typescript@5.6.3)):
     dependencies:
@@ -33783,21 +33789,6 @@ snapshots:
       ts-map: 1.0.3
       vue: 2.7.16
       vue-inbrowser-compiler-independent-utils: 4.71.1(vue@2.7.16)
-
-  vue-docgen-api@4.75.0(vue@3.4.15(typescript@5.4.2)):
-    dependencies:
-      '@babel/parser': 7.23.9
-      '@babel/types': 7.23.0
-      '@vue/compiler-dom': 3.4.15
-      '@vue/compiler-sfc': 3.4.15
-      ast-types: 0.16.1
-      hash-sum: 2.0.0
-      lru-cache: 8.0.5
-      pug: 3.0.2
-      recast: 0.23.4
-      ts-map: 1.0.3
-      vue: 3.4.15(typescript@5.4.2)
-      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.4.15(typescript@5.4.2))
 
   vue-docgen-api@4.75.0(vue@3.4.15(typescript@5.6.3)):
     dependencies:
@@ -33832,10 +33823,6 @@ snapshots:
   vue-inbrowser-compiler-independent-utils@4.71.1(vue@2.7.16):
     dependencies:
       vue: 2.7.16
-
-  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.4.15(typescript@5.4.2)):
-    dependencies:
-      vue: 3.4.15(typescript@5.4.2)
 
   vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.4.15(typescript@5.6.3)):
     dependencies:
@@ -33933,12 +33920,6 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
       vue: 2.7.16
-
-  vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.4.2)):
-    dependencies:
-      de-indent: 1.0.2
-      he: 1.2.0
-      vue: 3.4.15(typescript@5.4.2)
 
   vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
         specifier: 0.6.2
         version: 0.6.2
       emoji-toolkit:
-        specifier: '8'
+        specifier: 8.0.0
         version: 8.0.0
       overlayscrollbars:
         specifier: 2.10.0


### PR DESCRIPTION
# fix(emoji): NO-JIRA revert back to emoji-toolkit

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3kyajJ6emVnbTNlOXV2djkxdnZhdnhoa3didDUwa3YwcmUwOTh3eCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/TpsuCxwsNH8gatbpR5/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Updated our emoji data to reference emoji-toolkit again rather than dialtone-emojis

## :bulb: Context

This is a temporary fix due to dialtone-emoijs missing a number of emojis in our current emoji set. Created ticket https://dialpad.atlassian.net/browse/DLT-2193 for the real fix.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

CP to beta since this bug is already in there

## :camera: Screenshots / GIFs

<img width="605" alt="Screenshot 2024-10-30 at 2 45 15 PM" src="https://github.com/user-attachments/assets/b35ef504-21f4-4ca3-b56b-04a3c229706b">
