### PR TITLE
ci: DLT-2048 combinator release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
         options:
           - all
           - dialtone
+          - combinator
           - css
           - emojis
           - icons
@@ -98,6 +99,10 @@ jobs:
       - name: Release Dialtone ${{ env.RELEASE_TAG }}
         if: ${{ github.event_name == 'schedule' || github.event.inputs.package == 'all' || github.event.inputs.package == 'dialtone' }}
         run: pnpm nx run dialtone:release
+
+      - name: Release Dialtone Combinator ${{ env.RELEASE_TAG }}
+        if: ${{ github.event_name == 'schedule' || github.event.inputs.package == 'all' || github.event.inputs.package == 'combinator' }}
+        run: pnpm nx run dialtone-combinator:release
 
       - name: Release Dialtone CSS ${{ env.RELEASE_TAG }}
         if: ${{ github.event_name == 'schedule' || github.event.inputs.package == 'all' || github.event.inputs.package == 'css' }}

--- a/packages/combinator/package.json
+++ b/packages/combinator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dialpad/dialtone-combinator",
   "version": "0.3.1",
-  "description": "Dialtone vue component combinator playground",
+  "description": "Dialtone vue component combinator",
   "scripts": {
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
     "test": "vue-cli-service test:unit --timeout 100000 --colors --recursive --glob *.test.js src"
@@ -42,9 +42,8 @@
   "keywords": [
     "Dialpad",
     "Dialtone",
-    "Dialtone Vue",
-    "Vue Components",
-    "Component Combinator",
+    "Components",
+    "Combinator",
     "Vue"
   ],
   "license": "MIT",

--- a/packages/combinator/project.json
+++ b/packages/combinator/project.json
@@ -37,6 +37,13 @@
           }
         ]
       }
+    },
+    "release": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm semantic-release-plus --extends ./packages/combinator/release-ci.config.cjs && sleep 3",
+        "parallel": false
+      }
     }
   }
 }

--- a/packages/combinator/release-ci.config.cjs
+++ b/packages/combinator/release-ci.config.cjs
@@ -1,0 +1,54 @@
+/* eslint-disable no-template-curly-in-string */
+const name = 'combinator';
+const srcRoot = `packages/${name}`;
+
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
+module.exports = {
+  pkgRoot: srcRoot,
+  tagFormat: name + '/v${version}',
+  commitPaths: [`${srcRoot}/*`],
+  plugins: [
+    ['@semantic-release/commit-analyzer', {
+      preset: 'angular',
+      releaseRules: [
+        { type: 'refactor', release: 'patch' },
+      ],
+    }],
+    ['@semantic-release/release-notes-generator', {
+      config: '@dialpad/conventional-changelog-angular',
+    }],
+    ['@dialpad/semantic-release-changelog-json', {
+      changelogFile: `${srcRoot}/CHANGELOG.md`,
+      changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
+    }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
+    ['@semantic-release/npm', { npmPublish: false }],
+    ['@semantic-release/git', {
+      assets: [
+        `${srcRoot}/CHANGELOG.md`,
+        `${srcRoot}/CHANGELOG.json`,
+        `${srcRoot}/package.json`,
+      ],
+      message: `chore(release): NO-JIRA ${name}` +
+        '/v${nextRelease.version}\n\n${nextRelease.notes}',
+    }],
+    ['@semantic-release/github', {
+      successComment: false,
+      failTitle: false,
+    }],
+  ],
+  branches: [
+    'staging',
+    'next',
+    {
+      name: 'beta',
+      prerelease: true,
+    },
+    {
+      name: 'alpha',
+      prerelease: true,
+    },
+  ],
+};


### PR DESCRIPTION
# Dialtone Combinator release process

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/gjgWQA5QBuBmUZahOP/giphy.gif?cid=790b7611uujvrxv3pe4e39n7lqgfvmmhvfuuvz5hhqska7r3&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] CI

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2048

## :book: Description

- Added combinator to release process to enable semantic versioning, this package is not going to be released as it's intended to be used internally only.

## :bulb: Context

- We were lacking of a proper combinator release process.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.