### PR TITLE
fix(multi-select): DP-116677 avoid deleting input content when loading

### DIFF
--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -547,6 +547,7 @@ export default {
     },
 
     onComboboxSelect (i) {
+      if (this.loading) return;
       this.value = '';
       this.$emit('select', i);
     },

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -540,6 +540,7 @@ export default {
     },
 
     onComboboxSelect (i) {
+      if (this.loading) return;
       this.value = '';
       this.$emit('select', i);
     },


### PR DESCRIPTION
# fix(multi-select): DP-116677 avoid deleting input content when loading

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMXV6NGgwN3owOGF6azl2b2l2eW1zbG95dHgzd3NicDh0emR0aXM2bSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l0FF56cexcW2JAXCJj/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DP-116677
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
When using the multi-select component on the product side, we have a use case where if the list is still loading and the user clicks enter, the content of the input is cleared. Somehow this is not reproducible on the dialtone side 🤔 
After some investigation I realised that the problem is that the 'select' event is fired even when the list is still loading and we are clearing the input when this event is fired. Reference: https://github.com/dialpad/dialtone/blob/8bc31e209104fb73c9039c3bfb366e8c83419eac/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue#L549-L552

Video:
https://github.com/user-attachments/assets/9f7bcd44-c295-4894-946e-fdd9f075907a

So to fix this, I added a condition so we don't clear the input value if the list is loading.
If you want to check, this is how we use the combobox-multi-select on the product page: https://github.com/dialpad/firespotter/blob/7931c73df55b6e636dceb097e098a0d48f364b66/ubervoice/static/js/single/components/bulk_sms/bulk_sms_manual_recipients_menu.vue#L4

## :bulb: Context
In Bulk SMS, if a user tries to search for a number/name in the multi-select component and clicks Enter before the list is loaded, the search input value is cleared. We want to improve this behaviour; we shouldn't clear the input if the user doesn't select anything.