### PR TITLE
fix: DLT-2117 copy/paste on message input

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -10,7 +10,6 @@
 <script>
 /* eslint-disable max-lines */
 import { Editor, EditorContent } from '@tiptap/vue-2';
-import { Slice, Fragment } from '@tiptap/pm/model';
 import Blockquote from '@tiptap/extension-blockquote';
 import CodeBlock from '@tiptap/extension-code-block';
 import Document from '@tiptap/extension-document';
@@ -289,14 +288,6 @@ export default {
       type: Array,
       default: () => [],
     },
-
-    /**
-     * Use default paste handler.
-     */
-    useDefaultPasteHandler: {
-      type: Boolean,
-      default: false,
-    },
   },
 
   emits: [
@@ -533,50 +524,9 @@ export default {
             ...this.inputAttrs,
             class: this.inputClass,
           },
-
-          /* Absolutely crazy that this is what's needed to paste line breaks properly in prosemirror, but it does seem
-            to fix our issue of line breaks outputting as paragraphs. Code taken from this thread:
-            https://discuss.prosemirror.net/t/how-to-preserve-hard-breaks-when-pasting-html-into-a-plain-text-schema/4202/4
-          */
-          ...(!this.useDefaultPasteHandler && { handlePaste: this.handlerPreserveBreaksOnPaste }),
         },
       });
       this.addEditorListeners();
-    },
-
-    handlerPreserveBreaksOnPaste (view, event, slice) {
-      const { state } = view;
-      const { tr } = state;
-
-      if (!state.schema.nodes.hardBreak) {
-        return false;
-      }
-
-      const clipboardText = event.clipboardData?.getData('text/plain').trim();
-
-      if (!clipboardText) {
-        return false;
-      }
-
-      const textLines = clipboardText.split(/(?:\r\n|\r|\n)/g);
-
-      const nodes = textLines.reduce((nodes, line, index) => {
-        if (line.length > 0) {
-          nodes.push(state.schema.text(line));
-        }
-
-        if (index < textLines.length - 1) {
-          nodes.push(state.schema.nodes.hardBreak.create());
-        }
-
-        return nodes;
-      }, []);
-
-      view.dispatch(
-        tr.replaceSelection(Slice.maxOpen(Fragment.fromArray(nodes))).scrollIntoView(),
-      );
-
-      return true;
     },
 
     processValue (newValue, returnIfEqual = true) {
@@ -642,7 +592,7 @@ export default {
           return this.editor.getHTML();
         case 'text':
         default:
-          return this.editor.getText();
+          return this.editor.getText({ blockSeparator: '\n' });
       }
     },
 

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -1,8 +1,8 @@
 <template>
   <editor-content
     :editor="editor"
-    data-qa="dt-rich-text-editor"
     class="dt-rich-text-editor"
+    data-qa="dt-rich-text-editor"
     v-on="editorListeners"
   />
 </template>
@@ -243,7 +243,7 @@ export default {
 
     /**
      * Whether the input allows for bullet list to be introduced in the text.
-    */
+     */
     allowBulletList: {
       type: Boolean,
       default: true,
@@ -467,10 +467,10 @@ export default {
   },
 
   /**
-    * Because the Editor instance is initialized when mounted it does not get
-    * updated props automatically, so the ones that can change after mount have
-    * to be hooked up to the Editor's own API.
-    */
+   * Because the Editor instance is initialized when mounted it does not get
+   * updated props automatically, so the ones that can change after mount have
+   * to be hooked up to the Editor's own API.
+   */
   watch: {
     editable (isEditable) {
       this.editor.setEditable(isEditable);
@@ -523,6 +523,12 @@ export default {
           attributes: {
             ...this.inputAttrs,
             class: this.inputClass,
+          },
+
+          // Moves the <br /> tags inside the previous closing tag to avoid
+          // Prosemirror wrapping them within another </p> tag.
+          transformPastedHTML (html) {
+            return html.replace(/(<\/\w+>)((<br \/>)+)/g, '$2$3$1');
           },
         },
       });
@@ -623,40 +629,40 @@ export default {
 </script>
 
 <style lang="less">
-  .dt-rich-text-editor {
-    &--code-block {
-      background: var(--dt-color-surface-secondary);
-      padding: var(--dt-space-400);
+.dt-rich-text-editor {
+  &--code-block {
+    background: var(--dt-color-surface-secondary);
+    padding: var(--dt-space-400);
+  }
+
+  > .ProseMirror {
+    box-shadow: none;
+
+    p.is-editor-empty:first-child::before {
+      content: attr(data-placeholder);
+      float: left;
+      color: var(--dt-color-foreground-placeholder);
+      pointer-events: none;
+      height: 0;
     }
 
-    > .ProseMirror {
-      box-shadow: none;
+    ul, ol {
+      padding-left: var(--dt-space-525);
+    }
 
-      p.is-editor-empty:first-child::before {
-        content: attr(data-placeholder);
-        float: left;
-        color: var(--dt-color-foreground-placeholder);
-        pointer-events: none;
-        height: 0;
-      }
+    ul > li {
+      list-style-type: disc;
+    }
 
-      ul, ol {
-        padding-left: var(--dt-space-525);
-      }
+    ol > li {
+      list-style-type: decimal;
+    }
 
-      ul > li {
-        list-style-type: disc;
-      }
-
-      ol > li {
-        list-style-type: decimal;
-      }
-
-      blockquote {
-        padding-left: var(--dt-space-400);
-        border-left: var(--dt-size-border-300) solid var(--dt-color-foreground-muted-inverted);
-        margin-left: 0;
-      }
+    blockquote {
+      padding-left: var(--dt-space-400);
+      border-left: var(--dt-size-border-300) solid var(--dt-color-foreground-muted-inverted);
+      margin-left: 0;
     }
   }
+}
 </style>

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -163,7 +163,6 @@
         :output-format="htmlOutputFormat"
         :auto-focus="autoFocus"
         :placeholder="placeholder"
-        :use-default-paste-handler="useDefaultPasteHandler"
         :allow-line-breaks="true"
         :link="true"
         v-bind="$attrs"
@@ -458,14 +457,6 @@ export default {
         setLinkTitle: 'Add a link',
         setLinkInputAriaLabel: 'Input field to add link',
       }),
-    },
-
-    /**
-     * Use default paste handler.
-     */
-    useDefaultPasteHandler: {
-      type: Boolean,
-      default: false,
     },
   },
 

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor_default.story.vue
@@ -28,7 +28,6 @@
       :show-quote-button="$attrs.showQuoteButton"
       :show-quick-replies-button="$attrs.showQuickRepliesButton"
       :show-code-block-button="$attrs.showCodeBlockButton"
-      :use-default-paste-handler="$attrs.useDefaultPasteHandler"
       @focus="$attrs.onFocus"
       @blur="$attrs.onBlur"
       @input="$attrs.onInput"

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -10,7 +10,6 @@
 <script>
 /* eslint-disable max-lines */
 import { Editor, EditorContent } from '@tiptap/vue-3';
-import { Slice, Fragment } from '@tiptap/pm/model';
 import Blockquote from '@tiptap/extension-blockquote';
 import CodeBlock from '@tiptap/extension-code-block';
 import Document from '@tiptap/extension-document';
@@ -289,14 +288,6 @@ export default {
       type: Array,
       default: () => [],
     },
-
-    /**
-     * Use default paste handler.
-     */
-    useDefaultPasteHandler: {
-      type: Boolean,
-      default: false,
-    },
   },
 
   emits: [
@@ -533,50 +524,9 @@ export default {
             ...this.inputAttrs,
             class: this.inputClass,
           },
-
-          /* Absolutely crazy that this is what's needed to paste line breaks properly in prosemirror, but it does seem
-            to fix our issue of line breaks outputting as paragraphs. Code taken from this thread:
-            https://discuss.prosemirror.net/t/how-to-preserve-hard-breaks-when-pasting-html-into-a-plain-text-schema/4202/4
-          */
-          ...(!this.useDefaultPasteHandler && { handlePaste: this.handlerPreserveBreaksOnPaste }),
         },
       });
       this.addEditorListeners();
-    },
-
-    handlerPreserveBreaksOnPaste (view, event, slice) {
-      const { state } = view;
-      const { tr } = state;
-
-      if (!state.schema.nodes.hardBreak) {
-        return false;
-      }
-
-      const clipboardText = event.clipboardData?.getData('text/plain').trim();
-
-      if (!clipboardText) {
-        return false;
-      }
-
-      const textLines = clipboardText.split(/(?:\r\n|\r|\n)/g);
-
-      const nodes = textLines.reduce((nodes, line, index) => {
-        if (line.length > 0) {
-          nodes.push(state.schema.text(line));
-        }
-
-        if (index < textLines.length - 1) {
-          nodes.push(state.schema.nodes.hardBreak.create());
-        }
-
-        return nodes;
-      }, []);
-
-      view.dispatch(
-        tr.replaceSelection(Slice.maxOpen(Fragment.fromArray(nodes))).scrollIntoView(),
-      );
-
-      return true;
     },
 
     processValue (newValue, returnIfEqual = true) {
@@ -585,6 +535,7 @@ export default {
         newValue = JSON.stringify(newValue);
         currentValue = JSON.stringify(currentValue);
       }
+
       if (returnIfEqual && newValue === currentValue) {
         // The new value came from this component and was passed back down
         // through the parent, so don't do anything here.
@@ -641,7 +592,7 @@ export default {
           return this.editor.getHTML();
         case 'text':
         default:
-          return this.editor.getText();
+          return this.editor.getText({ blockSeparator: '\n' });
       }
     },
 

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -1,8 +1,8 @@
 <template>
   <editor-content
     :editor="editor"
-    data-qa="dt-rich-text-editor"
     class="dt-rich-text-editor"
+    data-qa="dt-rich-text-editor"
     v-bind="attrs"
   />
 </template>
@@ -243,7 +243,7 @@ export default {
 
     /**
      * Whether the input allows for bullet list to be introduced in the text.
-    */
+     */
     allowBulletList: {
       type: Boolean,
       default: true,
@@ -467,10 +467,10 @@ export default {
   },
 
   /**
-    * Because the Editor instance is initialized when mounted it does not get
-    * updated props automatically, so the ones that can change after mount have
-    * to be hooked up to the Editor's own API.
-    */
+   * Because the Editor instance is initialized when mounted it does not get
+   * updated props automatically, so the ones that can change after mount have
+   * to be hooked up to the Editor's own API.
+   */
   watch: {
     editable (isEditable) {
       this.editor.setEditable(isEditable);
@@ -523,6 +523,12 @@ export default {
           attributes: {
             ...this.inputAttrs,
             class: this.inputClass,
+          },
+
+          // Moves the <br /> tags inside the previous closing tag to avoid
+          // Prosemirror wrapping them within another </p> tag.
+          transformPastedHTML (html) {
+            return html.replace(/(<\/\w+>)((<br \/>)+)/g, '$2$3$1');
           },
         },
       });
@@ -623,40 +629,40 @@ export default {
 </script>
 
 <style lang="less">
-  .dt-rich-text-editor {
-    &--code-block {
-      background: var(--dt-color-surface-secondary);
-      padding: var(--dt-space-400);
+.dt-rich-text-editor {
+  &--code-block {
+    background: var(--dt-color-surface-secondary);
+    padding: var(--dt-space-400);
+  }
+
+  > .ProseMirror {
+    box-shadow: none;
+
+    p.is-editor-empty:first-child::before {
+      content: attr(data-placeholder);
+      float: left;
+      color: var(--dt-color-foreground-placeholder);
+      pointer-events: none;
+      height: 0;
     }
 
-    > .ProseMirror {
-      box-shadow: none;
+    ul, ol {
+      padding-left: var(--dt-space-525);
+    }
 
-      p.is-editor-empty:first-child::before {
-        content: attr(data-placeholder);
-        float: left;
-        color: var(--dt-color-foreground-placeholder);
-        pointer-events: none;
-        height: 0;
-      }
+    ul > li {
+      list-style-type: disc;
+    }
 
-      ul, ol {
-        padding-left: var(--dt-space-525);
-      }
+    ol > li {
+      list-style-type: decimal;
+    }
 
-      ul > li {
-        list-style-type: disc;
-      }
-
-      ol > li {
-        list-style-type: decimal;
-      }
-
-      blockquote {
-        padding-left: var(--dt-space-400);
-        border-left: var(--dt-size-border-300) solid var(--dt-color-foreground-muted-inverted);
-        margin-left: 0;
-      }
+    blockquote {
+      padding-left: var(--dt-space-400);
+      border-left: var(--dt-size-border-300) solid var(--dt-color-foreground-muted-inverted);
+      margin-left: 0;
     }
   }
+}
 </style>

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -164,7 +164,6 @@
         :output-format="htmlOutputFormat"
         :auto-focus="autoFocus"
         :placeholder="placeholder"
-        :use-default-paste-handler="useDefaultPasteHandler"
         :allow-line-breaks="true"
         :link="true"
         v-bind="$attrs"
@@ -461,14 +460,6 @@ export default {
         setLinkTitle: 'Add a link',
         setLinkInputAriaLabel: 'Input field to add link',
       }),
-    },
-
-    /**
-     * Use default paste handler.
-     */
-    useDefaultPasteHandler: {
-      type: Boolean,
-      default: false,
     },
   },
 

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
@@ -28,7 +28,6 @@
       :show-quote-button="$attrs.showQuoteButton"
       :show-quick-replies-button="$attrs.showQuickRepliesButton"
       :show-code-block-button="$attrs.showCodeBlockButton"
-      :use-default-paste-handler="$attrs.useDefaultPasteHandler"
       @focus="$attrs.onFocus"
       @blur="$attrs.onBlur"
       @input="$attrs.onInput"


### PR DESCRIPTION
# Fix copy/paste behavior on message input

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbzZiazY2d3U2dnFvMWduazR6aXpwbWY4bzd5cGVvazBsdzQ3N2ZxNSZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/o75ajIFH0QnQC3nCeD/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2117

## :book: Description

Removed custom pasteHandler added on: https://github.com/dialpad/dialtone/pull/511 and subsequent prop added on: https://github.com/dialpad/dialtone/pull/543.

This custom pasteHandler was removing custom nodes while pasting (emojis, links, mentions, etc). We detected only emojis, but none of the mentioned nodes would work as we were obtaining the `text/plain` content of the clipboard.

## :bulb: Context

The custom behavior introduced was not needed as the issue was only on getting the input text, which can be configured to output `\n` character to solve the issue.

If we want to improve even more this behavior in the future, we could also find a way to just replace the hard breaks with soft breaks, but for now I think this fix will do.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

Test if this helps at all with https://dialpad.atlassian.net/browse/DP-116205

## :camera: Screenshots / GIFs

- Html output

![html output](https://github.com/user-attachments/assets/769f3f3e-c569-4d3b-a749-81ee8f3b9185)

- Text output

![text output](https://github.com/user-attachments/assets/73c38f81-297c-4ad1-a4f7-a7c4061d89ea)


## :link: Sources

https://tiptap.dev/docs/editor/api/editor#gettext
