### PR TITLE
feat(message-input): DLT-2128 avoid closing the emoji picker when shift is pressed

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -123,12 +123,7 @@
               <dt-emoji-picker
                 v-bind="emojiPickerProps"
                 @skin-tone="onSkinTone"
-                @selected-emoji="
-                  (emoji) => {
-                    close();
-                    onSelectEmoji(emoji);
-                  }
-                "
+                @selected-emoji="(emoji) => onSelectEmoji(emoji, close)"
               />
             </template>
           </dt-popover>
@@ -737,9 +732,13 @@ export default {
       this.$emit('skin-tone', skinTone);
     },
 
-    onSelectEmoji (emoji) {
+    onSelectEmoji (emoji, close) {
       if (!emoji) {
         return;
+      }
+
+      if (!emoji.shift_key) {
+        close();
       }
 
       // Insert emoji into the editor

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -121,12 +121,7 @@
               <dt-emoji-picker
                 v-bind="emojiPickerProps"
                 @skin-tone="onSkinTone"
-                @selected-emoji="
-                  (emoji) => {
-                    close();
-                    onSelectEmoji(emoji);
-                  }
-                "
+                @selected-emoji="(emoji) => onSelectEmoji(emoji, close)"
               />
             </template>
           </dt-popover>
@@ -750,9 +745,13 @@ export default {
       this.$emit('skin-tone', skinTone);
     },
 
-    onSelectEmoji (emoji) {
+    onSelectEmoji (emoji, close) {
       if (!emoji) {
         return;
+      }
+
+      if (!emoji.shift_key) {
+        close();
       }
 
       // Insert emoji into the editor


### PR DESCRIPTION
 # feat(message-input): DLT-2128 avoid closing the emoji picker when shift is pressed

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
[DLT-2128]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

On the message input, when doing shift + click on the emoji picker the component won't close.
<!--- Describe specifically what the changes are -->

## :bulb: Context
That was the behavior in the product for the previous message input.
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

![emoji-picker](https://github.com/user-attachments/assets/a04c2c3a-92f1-466c-9a9b-60ca3430267a)


<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->


[DLT-2128]: https://dialpad.atlassian.net/browse/DLT-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ