### PR TITLE
fix(tooltip): NO-JIRA inline css for tippy arrow

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/tooltip.less
+++ b/packages/dialtone-css/lib/build/less/components/tooltip.less
@@ -28,7 +28,7 @@
 //  $   BASE STYLE
 //  ----------------------------------------------------------------------------
 
-@import 'tippy.js/dist/svg-arrow.css';
+@import (inline) 'tippy.js/dist/svg-arrow.css';
 
 .d-tooltip-container {
   position: relative;


### PR DESCRIPTION
# fix(tooltip): inline css for tippy arrow

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

missed inlining the tippy arrow css, causes a build error otherwise