### PR TITLE
fix(tokens): DLT-1961 output font related tokens as rem instead of px

### DIFF
--- a/packages/dialtone-tokens/postcss/dialtone-tokens.cjs
+++ b/packages/dialtone-tokens/postcss/dialtone-tokens.cjs
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const Color = require('colorjs.io').default;
 const {
   PLATFORM_FONT_SIZES,
@@ -86,6 +87,10 @@ function boxShadows (shadowDeclarations, Declaration) {
  */
 function wrapInCalc (declaration) {
   if ([' * ', ' + '].some(str => declaration.value.includes(str)) && !declaration.value.startsWith('calc')) {
+    if (declaration.value.includes('var(--dt-font-size-root)')) {
+      // replace referenced root font size with 1 rem so they output as rem instead of px.
+      declaration.value = declaration.value.replace('var(--dt-font-size-root)', '1rem');
+    }
     declaration.value = `calc(${declaration.value})`;
   }
 }
@@ -211,7 +216,7 @@ function getThemeFromFilename (filename) {
 /**
  * @type {import('postcss').PluginCreator}
  */
-module.exports = (opts = {}) => {
+module.exports = () => {
   return {
     postcssPlugin: 'dialtone-tokens',
     async Once (root, { Declaration }) {


### PR DESCRIPTION
# fix(tokens): DLT-1961 output font related tokens as rem instead of px

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExamZpejF2a2xuNW9vczMxNXZqMXl2NXltZDN0bDM4ZWY0NmY3ejB4MSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/75P7GlQ7djBDy/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-1961

## :book: Description

add a new line to postcss to convert px to rem

## :bulb: Context

Our base font size is set in px (10px) so when we switched to using reference tokens and added calc() all values referencing base font size would remain in px instead of rem. This caused the issue mentioned in the jira ticket. Just added some postcss to convert the root font size to use 1rem instead of 10px when referencing base font size.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

Get UC team to confirm it is fixed.

## :camera: Screenshots / GIFs

![Screenshot 2024-11-29 at 3 55 12 PM](https://github.com/user-attachments/assets/bfd468fa-bdc7-4b66-b5a0-a0463fa4da3e)