### PR TITLE
feat(rich-text-editor): DLT-2237 add image extension to editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@tiptap/extension-code-block": "^2.6.6",
     "@tiptap/extension-document": "^2.6.6",
     "@tiptap/extension-hard-break": "^2.6.6",
+    "@tiptap/extension-image": "^2.6.6",
     "@tiptap/extension-history": "^2.6.6",
     "@tiptap/extension-italic": "^2.6.6",
     "@tiptap/extension-link": "^2.6.6",

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -288,7 +288,7 @@ export default {
      */
     allowInlineImages: {
       type: Boolean,
-      default: true,
+      default: false,
     },
 
     /**

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -19,6 +19,7 @@ import Paragraph from '@tiptap/extension-paragraph';
 import Placeholder from '@tiptap/extension-placeholder';
 import Bold from '@tiptap/extension-bold';
 import BulletList from '@tiptap/extension-bullet-list';
+import Image from '@tiptap/extension-image';
 import Italic from '@tiptap/extension-italic';
 import TipTapLink from '@tiptap/extension-link';
 import ListItem from '@tiptap/extension-list-item';
@@ -283,6 +284,14 @@ export default {
     },
 
     /**
+     * Whether the input allows inline images to be rendered.
+     */
+    allowInlineImages: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
      * Additional TipTap extensions to be added to the editor.
      */
     additionalExtensions: {
@@ -445,6 +454,10 @@ export default {
             class: 'd-rich-text-editor__code-block',
           },
         }));
+      }
+
+      if (this.allowInlineImages) {
+        extensions.push(Image);
       }
 
       if (this.additionalExtensions.length) {

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -164,6 +164,7 @@
         :auto-focus="autoFocus"
         :placeholder="placeholder"
         :allow-line-breaks="true"
+        :allow-inline-images="true"
         :link="true"
         v-bind="$attrs"
         @focus="onFocus"

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -288,7 +288,7 @@ export default {
      */
     allowInlineImages: {
       type: Boolean,
-      default: true,
+      default: false,
     },
 
     /**

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -15,6 +15,7 @@ import Blockquote from '@tiptap/extension-blockquote';
 import CodeBlock from '@tiptap/extension-code-block';
 import Document from '@tiptap/extension-document';
 import HardBreak from '@tiptap/extension-hard-break';
+import Image from '@tiptap/extension-image';
 import Paragraph from '@tiptap/extension-paragraph';
 import Placeholder from '@tiptap/extension-placeholder';
 import Bold from '@tiptap/extension-bold';
@@ -283,6 +284,14 @@ export default {
     },
 
     /**
+     * Whether the input allows inline images to be rendered.
+     */
+    allowInlineImages: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
      * Additional TipTap extensions to be added to the editor.
      */
     additionalExtensions: {
@@ -445,6 +454,10 @@ export default {
             class: 'd-rich-text-editor__code-block',
           },
         }));
+      }
+
+      if (this.allowInlineImages) {
+        extensions.push(Image);
       }
 
       if (this.additionalExtensions.length) {

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -165,6 +165,7 @@
         :auto-focus="autoFocus"
         :placeholder="placeholder"
         :allow-line-breaks="true"
+        :allow-inline-images="true"
         :link="true"
         v-bind="$attrs"
         @focus="onFocus"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@tiptap/extension-history':
         specifier: ^2.6.6
         version: 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(@tiptap/pm@2.6.6)
+      '@tiptap/extension-image':
+        specifier: ^2.6.6
+        version: 2.10.3(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
       '@tiptap/extension-italic':
         specifier: ^2.6.6
         version: 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
@@ -286,7 +289,7 @@ importers:
         version: 4.1.5
       null-loader:
         specifier: ^4.0.1
-        version: 4.0.1(webpack@5.95.0(@swc/core@1.3.96)(esbuild@0.18.20))
+        version: 4.0.1(webpack@5.95.0(@swc/core@1.3.96))
       nx:
         specifier: 19.8.0
         version: 19.8.0(@swc/core@1.3.96)
@@ -503,7 +506,7 @@ importers:
     devDependencies:
       '@vue/cli-plugin-unit-mocha':
         specifier: ^5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))(encoding@0.1.13)(webpack@5.95.0(@swc/core@1.3.96)(esbuild@0.18.20))
+        version: 5.0.8(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))(encoding@0.1.13)(webpack@5.95.0(@swc/core@1.3.96))
       chai:
         specifier: ^4.3.6
         version: 4.3.10
@@ -537,10 +540,10 @@ importers:
         version: link:../postcss-responsive-variations
       '@vue/cli-plugin-eslint':
         specifier: ~5.0.8
-        version: 5.0.8(@swc/core@1.3.96)(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))(encoding@0.1.13)(esbuild@0.18.20)(eslint@8.57.1)
+        version: 5.0.8(@swc/core@1.3.96)(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@8.57.1)
       '@vue/cli-service':
         specifier: ~5.0.8
-        version: 5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3)
+        version: 5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3)
       autoprefixer:
         specifier: ^10.4.14
         version: 10.4.16(postcss@8.4.39)
@@ -4482,6 +4485,11 @@ packages:
       '@tiptap/core': ^2.6.6
       '@tiptap/pm': ^2.6.6
 
+  '@tiptap/extension-image@2.10.3':
+    resolution: {integrity: sha512-YIjAF5CwDkMe28OQ5pvnmdRgbJ9JcGMIHY1kyqNunSf2iwphK+6SWz9UEIkDFiT7AsRZySqxFSq93iK1XyTifw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
   '@tiptap/extension-italic@2.6.6':
     resolution: {integrity: sha512-t7ZPsXqa8nJZZ/6D0rQyZ/KsvzLaSihC6hBTjUQ77CeDGV9PhDWjIcBW4OrvwraJDBd12ETBeQ2CkULJOgH+lQ==}
     peerDependencies:
@@ -5487,7 +5495,7 @@ packages:
     peerDependencies:
       '@types/inquirer': ^9.0.3
       inquirer: '*'
-      mem-fs: ^3.0.0
+      mem-fs: ^3.0.0 || ^4.0.0
       mem-fs-editor: ^10.0.2
     peerDependenciesMeta:
       inquirer:
@@ -8787,7 +8795,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -20213,13 +20221,13 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.0
 
-  '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))':
+  '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.89.0(@swc/core@1.3.96))':
     dependencies:
       chalk: 3.0.0
       error-stack-parser: 2.1.4
       string-width: 4.2.3
       strip-ansi: 6.0.1
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
 
   '@soda/get-current-script@1.0.2': {}
 
@@ -21075,6 +21083,10 @@ snapshots:
       '@tiptap/core': 2.6.6(@tiptap/pm@2.6.6)
       '@tiptap/pm': 2.6.6
 
+  '@tiptap/extension-image@2.10.3(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))':
+    dependencies:
+      '@tiptap/core': 2.6.6(@tiptap/pm@2.6.6)
+
   '@tiptap/extension-italic@2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))':
     dependencies:
       '@tiptap/core': 2.6.6(@tiptap/pm@2.6.6)
@@ -21898,14 +21910,14 @@ snapshots:
 
   '@vue/cli-overlay@5.0.8': {}
 
-  '@vue/cli-plugin-eslint@5.0.8(@swc/core@1.3.96)(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))(encoding@0.1.13)(esbuild@0.18.20)(eslint@8.57.1)':
+  '@vue/cli-plugin-eslint@5.0.8(@swc/core@1.3.96)(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@8.57.1)':
     dependencies:
-      '@vue/cli-service': 5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       eslint: 8.57.1
-      eslint-webpack-plugin: 3.2.0(eslint@8.57.1)(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      eslint-webpack-plugin: 3.2.0(eslint@8.57.1)(webpack@5.89.0(@swc/core@1.3.96))
       globby: 11.1.0
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
       yorkie: 2.0.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -21914,21 +21926,21 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))(encoding@0.1.13)':
+  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))(encoding@0.1.13)':
     dependencies:
-      '@vue/cli-service': 5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
-  '@vue/cli-plugin-unit-mocha@5.0.8(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))(encoding@0.1.13)(webpack@5.95.0(@swc/core@1.3.96)(esbuild@0.18.20))':
+  '@vue/cli-plugin-unit-mocha@5.0.8(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))(encoding@0.1.13)(webpack@5.95.0(@swc/core@1.3.96))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       jsdom: 18.1.1
       jsdom-global: 3.0.2(jsdom@18.1.1)
       mocha: 8.4.0
-      mochapack: 2.1.4(mocha@8.4.0)(webpack@5.95.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      mochapack: 2.1.4(mocha@8.4.0)(webpack@5.95.0(@swc/core@1.3.96))
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -21937,22 +21949,22 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))':
+  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3)
 
-  '@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3)':
+  '@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3)':
     dependencies:
       '@babel/helper-compilation-targets': 7.22.15
-      '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.89.0(@swc/core@1.3.96))
       '@soda/get-current-script': 1.0.2
       '@types/minimist': 1.2.5
       '@vue/cli-overlay': 5.0.8
-      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))(encoding@0.1.13)
-      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))
+      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))(encoding@0.1.13)
+      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@swc/core@1.3.96)(@vue/compiler-sfc@3.4.15)(ejs@3.1.9)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))(webpack-sources@3.2.3))
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       '@vue/component-compiler-utils': 3.3.0(ejs@3.1.9)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)
-      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.4.15)(css-loader@6.8.1(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)))(ejs@3.1.9)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.4.15)(css-loader@6.8.1(webpack@5.89.0(@swc/core@1.3.96)))(ejs@3.1.9)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(webpack@5.89.0(@swc/core@1.3.96))
       '@vue/web-component-wrapper': 1.3.0
       acorn: 8.11.2
       acorn-walk: 8.3.0
@@ -21963,9 +21975,9 @@ snapshots:
       cli-highlight: 2.1.11
       clipboardy: 2.3.0
       cliui: 7.0.4
-      copy-webpack-plugin: 9.1.0(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
-      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
-      css-minimizer-webpack-plugin: 3.4.1(esbuild@0.18.20)(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      copy-webpack-plugin: 9.1.0(webpack@5.89.0(@swc/core@1.3.96))
+      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.3.96))
+      css-minimizer-webpack-plugin: 3.4.1(webpack@5.89.0(@swc/core@1.3.96))
       cssnano: 5.1.15(postcss@8.4.39)
       debug: 4.3.6
       default-gateway: 6.0.3
@@ -21974,27 +21986,27 @@ snapshots:
       fs-extra: 9.1.0
       globby: 11.1.0
       hash-sum: 2.0.0
-      html-webpack-plugin: 5.5.3(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      html-webpack-plugin: 5.5.3(webpack@5.89.0(@swc/core@1.3.96))
       is-file-esm: 1.0.0
       launch-editor-middleware: 2.6.1
       lodash.defaultsdeep: 4.6.1
       lodash.mapvalues: 4.6.0
-      mini-css-extract-plugin: 2.7.6(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      mini-css-extract-plugin: 2.7.6(webpack@5.89.0(@swc/core@1.3.96))
       minimist: 1.2.8
       module-alias: 2.2.3
       portfinder: 1.0.32
       postcss: 8.4.39
-      postcss-loader: 6.2.1(postcss@8.4.39)(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
-      progress-webpack-plugin: 1.0.16(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      postcss-loader: 6.2.1(postcss@8.4.39)(webpack@5.89.0(@swc/core@1.3.96))
+      progress-webpack-plugin: 1.0.16(webpack@5.89.0(@swc/core@1.3.96))
       ssri: 8.0.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.96)(esbuild@0.18.20)(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
-      thread-loader: 3.0.4(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
-      vue-loader: 17.3.1(@vue/compiler-sfc@3.4.15)(vue@3.4.15(typescript@5.6.3))(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.96)(webpack@5.89.0(@swc/core@1.3.96))
+      thread-loader: 3.0.4(webpack@5.89.0(@swc/core@1.3.96))
+      vue-loader: 17.3.1(@vue/compiler-sfc@3.4.15)(vue@3.4.15(typescript@5.6.3))(webpack@5.89.0(@swc/core@1.3.96))
       vue-style-loader: 4.1.3
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
       webpack-bundle-analyzer: 4.10.1
       webpack-chain: 6.5.1
-      webpack-dev-server: 4.15.1(debug@4.3.6)(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      webpack-dev-server: 4.15.1(debug@4.3.6)(webpack@5.89.0(@swc/core@1.3.96))
       webpack-merge: 5.10.0
       webpack-virtual-modules: 0.4.6
       whatwg-fetch: 3.6.19
@@ -24406,7 +24418,7 @@ snapshots:
       each-props: 1.3.2
       is-plain-object: 5.0.0
 
-  copy-webpack-plugin@9.1.0(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  copy-webpack-plugin@9.1.0(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -24414,7 +24426,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
 
   core-js-compat@3.33.2:
     dependencies:
@@ -24530,7 +24542,7 @@ snapshots:
       postcss: 7.0.39
       postcss-selector-parser: 5.0.0
 
-  css-loader@6.8.1(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  css-loader@6.8.1(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.39)
       postcss: 8.4.39
@@ -24540,7 +24552,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.4.39)
       postcss-value-parser: 4.2.0
       semver: 7.6.3
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
 
   css-loader@6.8.1(webpack@5.95.0(@swc/core@1.3.96)(esbuild@0.18.20)):
     dependencies:
@@ -24554,7 +24566,7 @@ snapshots:
       semver: 7.6.3
       webpack: 5.95.0(@swc/core@1.3.96)(esbuild@0.18.20)
 
-  css-minimizer-webpack-plugin@3.4.1(esbuild@0.18.20)(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  css-minimizer-webpack-plugin@3.4.1(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       cssnano: 5.1.15(postcss@8.4.39)
       jest-worker: 27.5.1
@@ -24562,9 +24574,7 @@ snapshots:
       schema-utils: 4.2.0
       serialize-javascript: 6.0.1
       source-map: 0.6.1
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
-    optionalDependencies:
-      esbuild: 0.18.20
+      webpack: 5.89.0(@swc/core@1.3.96)
 
   css-prefers-color-scheme@3.1.1:
     dependencies:
@@ -25794,7 +25804,7 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint-webpack-plugin@3.2.0(eslint@8.57.1)(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  eslint-webpack-plugin@3.2.0(eslint@8.57.1)(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       '@types/eslint': 8.44.7
       eslint: 8.57.1
@@ -25802,7 +25812,7 @@ snapshots:
       micromatch: 4.0.5
       normalize-path: 3.0.0
       schema-utils: 4.2.0
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
 
   eslint@8.56.0:
     dependencies:
@@ -27249,14 +27259,14 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.5.3(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  html-webpack-plugin@5.5.3(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
 
   htmlparser2@3.10.1:
     dependencies:
@@ -29746,10 +29756,10 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.7.6(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  mini-css-extract-plugin@2.7.6(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       schema-utils: 4.2.0
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
 
   minimalistic-assert@1.0.1: {}
 
@@ -29930,7 +29940,7 @@ snapshots:
       yargs-parser: 20.2.4
       yargs-unparser: 2.0.0
 
-  mochapack@2.1.4(mocha@8.4.0)(webpack@5.95.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  mochapack@2.1.4(mocha@8.4.0)(webpack@5.95.0(@swc/core@1.3.96)):
     dependencies:
       '@babel/runtime-corejs2': 7.26.0
       chalk: 2.4.2
@@ -29949,7 +29959,7 @@ snapshots:
       progress: 2.0.3
       source-map-support: 0.5.21
       toposort: 2.0.2
-      webpack: 5.95.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.95.0(@swc/core@1.3.96)
       yargs: 14.0.0
 
   modify-values@1.0.1: {}
@@ -30320,11 +30330,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.95.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  null-loader@4.0.1(webpack@5.95.0(@swc/core@1.3.96)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.95.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.95.0(@swc/core@1.3.96)
 
   num2fraction@1.2.2: {}
 
@@ -31365,13 +31375,13 @@ snapshots:
       postcss: 8.4.39
       tsx: 4.19.0
 
-  postcss-loader@6.2.1(postcss@8.4.39)(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  postcss-loader@6.2.1(postcss@8.4.39)(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
       postcss: 8.4.39
       semver: 7.6.3
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
 
   postcss-logical@3.0.0:
     dependencies:
@@ -31911,12 +31921,12 @@ snapshots:
 
   process@0.11.10: {}
 
-  progress-webpack-plugin@1.0.16(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  progress-webpack-plugin@1.0.16(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       chalk: 2.4.2
       figures: 2.0.0
       log-update: 2.3.0
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
 
   progress@2.0.3: {}
 
@@ -34159,17 +34169,27 @@ snapshots:
       '@swc/core': 1.3.96
       esbuild: 0.18.20
 
-  terser-webpack-plugin@5.3.9(@swc/core@1.3.96)(esbuild@0.18.20)(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.3.96)(webpack@5.95.0(@swc/core@1.3.96)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.20
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.34.1
+      webpack: 5.95.0(@swc/core@1.3.96)
+    optionalDependencies:
+      '@swc/core': 1.3.96
+
+  terser-webpack-plugin@5.3.9(@swc/core@1.3.96)(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.20
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.24.0
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
     optionalDependencies:
       '@swc/core': 1.3.96
-      esbuild: 0.18.20
 
   terser@5.24.0:
     dependencies:
@@ -34215,14 +34235,14 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  thread-loader@3.0.4(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  thread-loader@3.0.4(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.0
       loader-utils: 2.0.4
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
 
   through2-filter@3.0.0:
     dependencies:
@@ -35266,15 +35286,15 @@ snapshots:
     dependencies:
       vue: 3.4.15(typescript@5.6.3)
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.4.15)(css-loader@6.8.1(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)))(ejs@3.1.9)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.4.15)(css-loader@6.8.1(webpack@5.89.0(@swc/core@1.3.96)))(ejs@3.1.9)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.6.3)))(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(ejs@3.1.9)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.5.3))(pug@3.0.2)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)
-      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.3.96))
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4
       vue-style-loader: 4.1.3
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
     optionalDependencies:
       '@vue/compiler-sfc': 3.4.15
       vue-template-compiler: 2.7.16(vue@3.4.15(typescript@5.6.3))
@@ -35333,12 +35353,12 @@ snapshots:
       - walrus
       - whiskers
 
-  vue-loader@17.3.1(@vue/compiler-sfc@3.4.15)(vue@3.4.15(typescript@5.6.3))(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  vue-loader@17.3.1(@vue/compiler-sfc@3.4.15)(vue@3.4.15(typescript@5.6.3))(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.0
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
     optionalDependencies:
       '@vue/compiler-sfc': 3.4.15
       vue: 3.4.15(typescript@5.6.3)
@@ -35575,16 +35595,16 @@ snapshots:
       deepmerge: 1.5.2
       javascript-stringify: 2.1.0
 
-  webpack-dev-middleware@5.3.3(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  webpack-dev-middleware@5.3.3(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
 
-  webpack-dev-server@4.15.1(debug@4.3.6)(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)):
+  webpack-dev-server@4.15.1(debug@4.3.6)(webpack@5.89.0(@swc/core@1.3.96)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.3
@@ -35614,10 +35634,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.3(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      webpack-dev-middleware: 5.3.3(webpack@5.89.0(@swc/core@1.3.96))
       ws: 8.18.0
     optionalDependencies:
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)
+      webpack: 5.89.0(@swc/core@1.3.96)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -35636,7 +35656,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.0: {}
 
-  webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20):
+  webpack@5.89.0(@swc/core@1.3.96):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -35659,8 +35679,38 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.96)(esbuild@0.18.20)(webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20))
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.96)(webpack@5.89.0(@swc/core@1.3.96))
       watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.95.0(@swc/core@1.3.96):
+    dependencies:
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.11.2
+      acorn-import-attributes: 1.9.5(acorn@8.11.2)
+      browserslist: 4.22.1
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.3.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.96)(webpack@5.95.0(@swc/core@1.3.96))
+      watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'


### PR DESCRIPTION
# feat(rich-text-editor): DLT-2237 add image extension to editor

## Obligatory GIF (super important!)

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMHd0Nnl6OWtla2J6OWxxamNoZG92bWdqanZ3MXJ2bjZ5OHJxaHFpMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/HeArjdf9JB6uc5DEJS/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

[DLT-2237](https://dialpad.atlassian.net/browse/DLT-2237)

## :book: Description

Added image extension to editor in order to be able to render images inside the editor. 

For us to be able to support this we need to add the [tiptap image extension](https://tiptap.dev/docs/editor/extensions/nodes/image) to the editor.

## :bulb: Context

We need this because as part of our implementation of the ‘forward’ feature for email, we want to add quotes to previous emails in the editor, and allow the user to edit the forwarded emails as desired.

However, the emails can contain inline images in the email body or as part of the email signatures, which would be included in the quotes.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

<img width="1498" alt="Screenshot 2024-12-10 at 6 57 39 PM" src="https://github.com/user-attachments/assets/6f644c2f-22da-487c-8c56-d9b15ae3eb5b">

## :link: Sources

<!--- Add any links to external reference material -->

[tiptap image extension](https://tiptap.dev/docs/editor/extensions/nodes/image)

[DLT-2237]: https://dialpad.atlassian.net/browse/DLT-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ