### PR TITLE
chore: NO-JIRA remove volar labs from recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -14,7 +14,6 @@
     "stylelint.vscode-stylelint",
     "jock.svg",
     "vitest.explorer",
-    "vue.volar",
-    "johnsoncodehk.volarjs-labs"
+    "vue.volar"
   ]
 }


### PR DESCRIPTION
This extension is not needed anymore.