### PR TITLE
fix(rich-text-editor): DLT-2237 configure image extension to inline content so they will show up inside paragraph tags

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -465,7 +465,7 @@ export default {
       }
 
       if (this.allowInlineImages) {
-        extensions.push(Image);
+        extensions.push(Image.configure({ inline: true }));
       }
 
       if (this.additionalExtensions.length) {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -465,7 +465,7 @@ export default {
       }
 
       if (this.allowInlineImages) {
-        extensions.push(Image);
+        extensions.push(Image.configure({ inline: true }));
       }
 
       if (this.additionalExtensions.length) {


### PR DESCRIPTION
# fix(rich-text-editor): DLT-2237 configure image extension

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

![Obligatory GIF (me, again)](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExaXlwazJzYTdqZ29uYnB6bm45ZDExbjZsaWp2bHFmY2h3ZHJob2dtbyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ka55CqnDNjQ7iIKtRa/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

I'm reusing the JIRA ticket I used last week to add the extension, but I can create a new one if needed.

[DLT-2237](https://dialpad.atlassian.net/browse/DLT-2237)

## :book: Description

After testing the editor with the image extension using an actual email signature on beta, I realized something was not quite working. I detected that the issue was when image tags were being placed inside a paragraph tag. I looked it up and I found that there was a tip tap issue reported [here](https://github.com/ueberdosis/tiptap/issues/1206), where they recommend configuring the extension as inline so it will be rendered inside paragraph tags as well.

## :bulb: Context

I added the image extension to the rich text editor last week in order to be able to use it in the editor for email. 
The reason why we needed to add this extension in the first place was so that we could add previous email quotes as editable content in the email editor when agent hits 'reply' or 'forward' button.
When testing with an actual signature I spotted the issue described above.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

Adding a screenshot of test with the signature I used to test in beta:

<img width="1483" alt="Screenshot 2024-12-16 at 8 53 58 PM" src="https://github.com/user-attachments/assets/239addba-f37b-4bed-8ef6-1a01537952f1" />

Simple tags still work although they're displayed inline now, if not wrapped inside a paragraph tag

<img width="1493" alt="Screenshot 2024-12-16 at 9 27 32 PM" src="https://github.com/user-attachments/assets/1034996a-0860-46e1-a429-2a1ca866cf1a" />


## :link: Sources

See reported issue in tip tap editor for more details on why this issue was happening in the first place, [here](https://github.com/ueberdosis/tiptap/issues/1206)

[DLT-2237]: https://dialpad.atlassian.net/browse/DLT-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ