### PR TITLE
fix(rich-text-editor): NO-JIRA fix error when allowBulletList false

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -397,7 +397,7 @@ export default {
               }
               editor.commands.first(({ commands }) => [
                 () => commands.newlineInCode(),
-                () => self.allowBulletList ? commands.splitListItem('listItem') : false,
+                () => self.allowBulletList && commands.splitListItem('listItem'),
                 () => commands.createParagraphNear(),
                 () => commands.liftEmptyBlock(),
                 () => commands.splitBlock(),

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -397,7 +397,7 @@ export default {
               }
               editor.commands.first(({ commands }) => [
                 () => commands.newlineInCode(),
-                () => commands.splitListItem('listItem'),
+                () => self.allowBulletList ? commands.splitListItem('listItem') : false,
                 () => commands.createParagraphNear(),
                 () => commands.liftEmptyBlock(),
                 () => commands.splitBlock(),

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -397,7 +397,7 @@ export default {
               }
               editor.commands.first(({ commands }) => [
                 () => commands.newlineInCode(),
-                () => self.allowBulletList ? commands.splitListItem('listItem') : false,
+                () => self.allowBulletList && commands.splitListItem('listItem'),
                 () => commands.createParagraphNear(),
                 () => commands.liftEmptyBlock(),
                 () => commands.splitBlock(),

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -397,7 +397,7 @@ export default {
               }
               editor.commands.first(({ commands }) => [
                 () => commands.newlineInCode(),
-                () => commands.splitListItem('listItem'),
+                () => self.allowBulletList ? commands.splitListItem('listItem') : false,
                 () => commands.createParagraphNear(),
                 () => commands.liftEmptyBlock(),
                 () => commands.splitBlock(),


### PR DESCRIPTION
# fix(rich-text-editor): fix error when allowBulletList false

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZm5yazdncDh6eHJlOWV0cDdkZ2hvenNxZGE4Y3dkd3R6eXNoOWNxNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/gNke2UrUTopOg/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Don't trigger `splitListItem()` on enter when `allowBulletList` is false

## :bulb: Context

If allowBulletList was false it would not include the list item extension and therefore error out on the splitListItem command. This will prevent calling this function if allowBulletList is false.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

Update product and CP to beta
