### PR TITLE
feat(emoji-row): DLT-2248 display larger emoji and inline shortcode in emoji row tooltip

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -5,17 +5,41 @@
       :key="reaction.unicodeOutput"
       :reaction="reaction"
     >
+      <!--
+        CONSIDERATION: on product side, content-class="d-wmx###"
+        can be adjusted to wider if more than X people.
+        Or even narrower if fewer.
+      -->
       <dt-tooltip
         class="d-recipe-emoji-row__tooltip"
-        content-class="d-wmx464"
+        content-class="d-wmx216"
         sticky="popper"
+        :fallback-placements="['top', 'bottom']"
         @shown="(shown) => emojiHovered(reaction, shown)"
       >
-        <span aria-hidden="true">
-          <dt-emoji-text-wrapper size="200">
-            {{ reaction.tooltip }}
-          </dt-emoji-text-wrapper>
-        </span>
+        <!-- TODO: move CSS utilitites to emoji_row.less -->
+        <div
+          aria-hidden="true"
+          class="d-bar4 d-bgc-neutral-white d-p4 d-d-inline-block d-mt4 d-mb6"
+        >
+          <!-- TODO: will ultimately need to work for Custom Emojis, including animated. Presumably same size -->
+          <dt-emoji
+            :code="reaction.emojiUnicodeOrShortname"
+            size="800"
+          />
+        </div>
+        <div>
+          Brad Paugh,
+          Julio Ortega,
+          Ignacio Ropolo,
+          Nina Repetto,
+          Francis Rupert,
+          and
+          you
+          <span class="d-fc-tertiary-inverted d-fw-normal">
+            reacted with :sparkling_heart:
+          </span>
+        </div>
         <template #anchor="{ attrs }">
           <dt-button
             importance="clear"
@@ -52,12 +76,11 @@ import { REACTIONS_ATTRIBUTES } from './emoji_row_constants.js';
 import { DtButton } from '../../../components/button';
 import { DtTooltip } from '../../../components/tooltip';
 import { DtEmoji } from '../../../components/emoji';
-import { DtEmojiTextWrapper } from '../../../components/emoji_text_wrapper';
 
 export default {
   name: 'DtRecipeEmojiRow',
 
-  components: { DtTooltip, DtButton, DtEmoji, DtEmojiTextWrapper },
+  components: { DtTooltip, DtButton, DtEmoji },
 
   mixins: [],
 


### PR DESCRIPTION
# Display larger emoji and inline shortcode in emoji row tooltip

Why am I doing this on a Friday night before Christmas break? Sat on couch with the wife and teenage daughters, did this instead while they watched some schmaltzy Hallmark Christmas movie.

![image](https://github.com/user-attachments/assets/415c3e7d-d535-437b-a4a8-72b26e8f7b9e)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2248

## :book: Description

* Display larger emoji
* Display shortcode inline
* BONUS: will make Custom Emojis more useful

This is effectively a simple prototype, so someone will need to take it over from me and update it correctly.

<img width="449" alt="image" src="https://github.com/user-attachments/assets/758aac24-97a6-4192-8e40-91c9e042be15" />

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [ ] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.