### PR TITLE
refactor: DLT-2123 remove utility classes from recipes

### DIFF
--- a/packages/dialtone-css/lib/build/less/recipes/callbar_button.less
+++ b/packages/dialtone-css/lib/build/less/recipes/callbar_button.less
@@ -11,13 +11,25 @@
 //  $   BASE STYLE
 //  ----------------------------------------------------------------------------
 .d-recipe-callbar-button {
+  padding-right: var(--dt-space-0);
+  padding-left: var(--dt-space-0);
+  color: var(--dt-color-foreground-primary);
+
   &:not(.d-recipe-callbar-button--circle) {
     line-height: var(--dt-font-line-height-300);
   }
 
-  &.d-btn[disabled] {
+  &.d-btn--disabled {
     background-color: unset;
-    opacity: .5;
+    opacity: var(--dt-opacity-700);
+  }
+}
+
+.d-recipe-callbar-button__text {
+  font-size: var(--dt-font-size-100);
+
+  @media (max-width: 980px) {
+    display: none;
   }
 }
 

--- a/packages/dialtone-css/lib/build/less/recipes/callbar_button_with_popover.less
+++ b/packages/dialtone-css/lib/build/less/recipes/callbar_button_with_popover.less
@@ -26,16 +26,20 @@
 
 .d-recipe-callbar-button-with-popover__popover {
   .d-popover__header {
-    display: flex;
-    align-items: center;
-    padding-left: var(--dt-space-450);
     color: var(--dt-color-foreground-primary-inverted);
-    font-weight: normal;
     background: var(--dt-color-surface-contrast);
 
     .d-btn {
       color: var(--dt-color-foreground-primary-inverted);
     }
+  }
+
+  .d-popover__header__content {
+    display: flex;
+    align-items: center;
+    padding-right: var(--dt-space-450);
+    padding-left: var(--dt-space-450);
+    font-weight: normal;
   }
 }
 

--- a/packages/dialtone-css/lib/build/less/recipes/callbar_button_with_popover.less
+++ b/packages/dialtone-css/lib/build/less/recipes/callbar_button_with_popover.less
@@ -26,7 +26,11 @@
 
 .d-recipe-callbar-button-with-popover__popover {
   .d-popover__header {
+    display: flex;
+    align-items: center;
+    padding-left: var(--dt-space-450);
     color: var(--dt-color-foreground-primary-inverted);
+    font-weight: normal;
     background: var(--dt-color-surface-contrast);
 
     .d-btn {

--- a/packages/dialtone-css/lib/build/less/recipes/combobox_multi_select.less
+++ b/packages/dialtone-css/lib/build/less/recipes/combobox_multi_select.less
@@ -36,6 +36,10 @@
   flex-grow: 1;
 }
 
+.d-recipe-combobox-multi-select__input--hidden {
+  color: transparent;
+}
+
 .d-recipe-combobox-multi-select__input-wrapper {
   position: relative;
   display: block;

--- a/packages/dialtone-css/lib/build/less/recipes/contact_info.less
+++ b/packages/dialtone-css/lib/build/less/recipes/contact_info.less
@@ -51,5 +51,13 @@
     box-sizing: unset;
     border: var(--dt-size-300) solid var(--contact-info-avatar-border-color);
     border-radius: var(--dt-size-radius-pill);
+
+    &.d-recipe-contact-info__avatar-stacked {
+      margin-left: var(--dt-space-550-negative);
+    }
+
+    &.d-recipe-contact-info__avatar-halo {
+      border-color: var(--dt-color-border-brand);
+    }
   }
 }

--- a/packages/dialtone-css/lib/build/less/recipes/editor.less
+++ b/packages/dialtone-css/lib/build/less/recipes/editor.less
@@ -1,4 +1,10 @@
-.d-recipe-editor__top-bar-background {
+.d-recipe-editor {
+  display: flex;
+  flex-direction: column;
+}
+
+.d-recipe-editor__top-bar {
+  padding: var(--dt-space-400);
   background-color: var(--dt-color-surface-secondary);
 }
 
@@ -7,4 +13,40 @@
   height: calc(var(--dt-size-550) + var(--dt-size-300));
   margin-left: var(--dt-space-400);
   background: var(--dt-color-border-subtle);
+}
+
+.d-recipe-editor-link__input-wrapper {
+  margin-top: var(--dt-space-350);
+  padding-top: var(--dt-space-200);
+  padding-bottom: var(--dt-space-200);
+  background-color: var(--dt-color-surface-secondary);
+  border: var(--dt-size-border-100) solid var(--dt-color-border-default);
+  outline: none;
+  box-shadow: none !important; // This doesn't work if !important is removed
+}
+
+.d-recipe-editor__popover-content {
+  padding: var(--dt-space-500);
+}
+
+.d-recipe-editor__popover-footer {
+  padding-right: var(--dt-space-450);
+  padding-left: var(--dt-space-550);
+}
+
+.d-recipe-editor__content {
+  margin: var(--dt-space-400) var(--dt-space-500) var(--dt-space-500);
+  overflow: auto;
+  cursor: text;
+}
+
+.d-recipe-editor__content-input {
+  margin-top: var(--dt-space-350);
+  margin-bottom: var(--dt-space-350);
+  margin-left: var(--dt-space-500);
+}
+
+.d-recipe-editor__link {
+  display: inline-block;
+  cursor: text;
 }

--- a/packages/dialtone-css/lib/build/less/recipes/emoji_row.less
+++ b/packages/dialtone-css/lib/build/less/recipes/emoji_row.less
@@ -8,6 +8,10 @@
   display: inline-block;
 }
 
+.d-recipe-emoji-row__tooltip-content {
+   max-width: var(--dt-size-975);
+}
+
 .d-recipe-emoji-row__reaction {
   --emoji-item-color-inset-shadow: transparent;
   --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-default);

--- a/packages/dialtone-css/lib/build/less/recipes/feed_item_pill.less
+++ b/packages/dialtone-css/lib/build/less/recipes/feed_item_pill.less
@@ -1,3 +1,7 @@
+.d-recipe-feed-item-pill--toggleable {
+  cursor: pointer;
+}
+
 .d-recipe-feed-item-pill__wrapper {
   padding: var(--dt-space-400);
   background-color: var(--dt-color-surface-secondary);

--- a/packages/dialtone-css/lib/build/less/recipes/grouped_chip.less
+++ b/packages/dialtone-css/lib/build/less/recipes/grouped_chip.less
@@ -3,6 +3,10 @@
   white-space: nowrap;
   background-color: unset;
   background-image: unset;
+
+  .d-chip__text {
+    font-size: var(--dt-font-size-100);
+  }
 }
 
 .d-recipe-grouped-chip__content {

--- a/packages/dialtone-css/lib/build/less/recipes/ivr_node.less
+++ b/packages/dialtone-css/lib/build/less/recipes/ivr_node.less
@@ -1,29 +1,87 @@
+//  ============================================================================
+//  $   BASE STYLE
+//  ----------------------------------------------------------------------------
 .d-recipe-ivr-node {
   display: flex;
   flex-direction: column;
   align-items: center;
   width: 280px; /* stylelint-disable-line meowtec/no-px */
   cursor: pointer;
+
+  .d-card {
+    width: var(--dt-size-100-percent);
+  }
+
+  .d-card__header {
+    margin-top: var(--dt-size-100-negative);
+    padding: var(--dt-space-0);
+    border-top-left-radius: var(--dt-size-border-300);
+    border-top-right-radius: var(--dt-size-border-300);
+  }
+
+  .d-card__content {
+    padding: var(--dt-space-400) var(--dt-space-450) var(--dt-space-450);
+    border-top: var(--dt-size-border-100) solid var(--dt-color-black-300);
+  }
 }
 
-.d-recipe-ivr-node__header-left {
-  display: flex;
-  align-items: center;
+//  ============================================================================
+//  $   NODE TYPES
+//  ----------------------------------------------------------------------------
+.d-recipe-ivr-node-prompt {
+  .d-card__header {
+    border-top: var(--dt-size-border-300) solid var(--dt-color-blue-200);
+  }
 }
 
-.d-recipe-ivr-node__label {
-  font-weight: var(--dt-font-weight-bold);
-  font-size: var(--dt-font-size-200);
+.d-recipe-ivr-node-prompt--selected {
+  .d-card {
+    border: var(--dt-size-border-300) solid var(--dt-color-blue-300);
+    border-radius: var(--dt-size-radius-400);
+  }
+
+  .d-card__header {
+    border-top: var(--dt-size-border-300) solid var(--dt-color-blue-300);
+  }
 }
 
-.d-recipe-ivr-node__dropdown-list {
-  width: var(--dt-size-825);
+.d-recipe-ivr-node-logic {
+  .d-card__header {
+    border-top: var(--dt-size-border-300) solid var(--dt-color-purple-200);
+  }
 }
 
-.d-recipe-ivr-node__goto-icon {
-  transform: rotate(90deg);
+.d-recipe-ivr-node-logic--selected {
+  .d-card {
+    border: var(--dt-size-border-300) solid var(--dt-color-purple-400);
+    border-radius: var(--dt-size-radius-400);
+  }
+
+  .d-card__header {
+    border-top: var(--dt-size-border-300) solid var(--dt-color-purple-400);
+  }
 }
 
+.d-recipe-ivr-node-terminal {
+  .d-card__header {
+    border-top: var(--dt-size-border-300) solid var(--dt-color-red-100);
+  }
+}
+
+.d-recipe-ivr-node-terminal--selected {
+  .d-card {
+    border: var(--dt-size-border-300) solid var(--dt-color-red-200);
+    border-radius: var(--dt-size-radius-400);
+  }
+
+  .d-card__header {
+    border-top: var(--dt-size-border-300) solid var(--dt-color-red-200);
+  }
+}
+
+//  ============================================================================
+//  $   NODE CONNECTOR
+//  ----------------------------------------------------------------------------
 .d-recipe-ivr-node__connector {
   z-index: var(--zi-base);
   display: flex;
@@ -51,4 +109,26 @@
   .d-recipe-ivr-node__connector--selected {
     margin-bottom: var(--dt-space-500-negative);
   }
+}
+
+//  ============================================================================
+//  $   MISC
+//  ----------------------------------------------------------------------------
+
+.d-recipe-ivr-node__header-left {
+  display: flex;
+  align-items: center;
+}
+
+.d-recipe-ivr-node__label {
+  font-weight: var(--dt-font-weight-bold);
+  font-size: var(--dt-font-size-200);
+}
+
+.d-recipe-ivr-node__dropdown-list {
+  width: var(--dt-size-825);
+}
+
+.d-recipe-ivr-node__goto-icon {
+  transform: rotate(90deg);
 }

--- a/packages/dialtone-css/lib/build/less/recipes/leftbar_row.less
+++ b/packages/dialtone-css/lib/build/less/recipes/leftbar_row.less
@@ -108,10 +108,10 @@
   }
 
   &--has-unread {
-  --leftbar-row-description-font-weight: var(--dt-font-weight-bold);
-  --leftbar-row-description-color-foreground: var(--dt-theme-sidebar-color-foreground-unread);
-  --leftbar-row-alpha-color-foreground: var(--dt-theme-sidebar-color-foreground-unread);
-}
+    --leftbar-row-description-font-weight: var(--dt-font-weight-bold);
+    --leftbar-row-description-color-foreground: var(--dt-theme-sidebar-color-foreground-unread);
+    --leftbar-row-alpha-color-foreground: var(--dt-theme-sidebar-color-foreground-unread);
+  }
 
   &--muted {
     --leftbar-row-opacity: 60%;
@@ -364,4 +364,19 @@
     transform: translate(0, -0.5rem);
     opacity: 0.9;
   }
+}
+
+//  ============================================================================
+//  $   Contact Row
+//  ----------------------------------------------------------------------------
+.d-recipe-contact-row--active {
+  color: var(--dt-color-foreground-success);
+}
+
+.d-recipe-contact-row--busy {
+  color: var(--dt-color-foreground-critical);
+}
+
+.d-recipe-contact-row--away {
+  color: var(--dt-color-foreground-warning);
 }

--- a/packages/dialtone-css/lib/build/less/recipes/leftbar_row.less
+++ b/packages/dialtone-css/lib/build/less/recipes/leftbar_row.less
@@ -380,3 +380,62 @@
 .d-recipe-contact-row--away {
   color: var(--dt-color-foreground-warning);
 }
+
+//  ============================================================================
+//  $   CSS General Row
+//  ----------------------------------------------------------------------------
+.d-recipe-leftbar-general-row {
+  &__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__contact-center {
+    &--magenta-100 {
+      background-color: var(--dt-color-magenta-100);
+    }
+
+    &--magenta-200 {
+      background-color: var(--dt-color-magenta-200);
+    }
+
+    &--magenta-300 {
+      background-color: var(--dt-color-magenta-300);
+    }
+
+    &--magenta-400 {
+      background-color: var(--dt-color-magenta-400);
+    }
+
+    &--green-200 {
+      background-color: var(--dt-color-green-200);
+    }
+
+    &--green-500 {
+      background-color: var(--dt-color-green-500);
+    }
+
+    &--gold-300 {
+      background-color: var(--dt-color-gold-300);
+    }
+
+    &--purple-100 {
+      background-color: var(--dt-color-purple-100);
+    }
+
+    &--purple-300 {
+      background-color: var(--dt-color-purple-300);
+    }
+
+    &--purple-600 {
+      background-color: var(--dt-color-purple-600);
+    }
+
+    &--black-300 {
+      background-color: var(--dt-color-black-300);
+    }
+  }
+}
+
+

--- a/packages/dialtone-css/lib/build/less/recipes/message_input.less
+++ b/packages/dialtone-css/lib/build/less/recipes/message_input.less
@@ -90,3 +90,8 @@
   display: flex;
   justify-content: flex-end;
 }
+
+.d-recipe-message-input__sms-count {
+  display: flex;
+  align-items: center;
+}

--- a/packages/dialtone-css/lib/build/less/recipes/top_banner_info.less
+++ b/packages/dialtone-css/lib/build/less/recipes/top_banner_info.less
@@ -28,3 +28,23 @@
   margin: var(--dt-space-300) var(--dt-space-500) var(--dt-space-300) 0;
   text-align: right;
 }
+
+.d-recipe-top-banner-info--success {
+  background-color: var(--dt-color-surface-success);
+}
+
+.d-recipe-top-banner-info--critical {
+  background-color: var(--dt-color-surface-critical);
+}
+
+.d-recipe-top-banner-info--warning {
+  background-color: var(--dt-color-surface-warning);
+}
+
+.d-recipe-top-banner-info--info {
+  background-color: var(--dt-color-surface-info);
+}
+
+.d-recipe-top-banner-info--primary {
+  background-color: var(--dt-color-surface-primary);
+}

--- a/packages/dialtone-vue2/.eslintrc.cjs
+++ b/packages/dialtone-vue2/.eslintrc.cjs
@@ -1,5 +1,5 @@
 const componentsList = require('../../common/components_list.js');
-componentsList.push('btn', 'select', 'validation-message', 'label', 'description', 'split-btn');
+componentsList.push('btn', 'select', 'validation-message', 'label', 'description', 'split-btn', 'mention-suggestion', 'suggestion-list');
 const componentsNames = componentsList.map(name => name.replace('_', '-').replace('.vue', ''));
 
 module.exports = {

--- a/packages/dialtone-vue2/package.json
+++ b/packages/dialtone-vue2/package.json
@@ -49,9 +49,13 @@
   "devDependencies": {
     "@dialpad/dialtone-css": "workspace:*",
     "@dialpad/generator-dialtone": "workspace:*",
+    "@storybook/addon-a11y": "7.6.20",
+    "@storybook/addon-essentials": "7.6.20",
+    "@storybook/addon-links": "7.6.20",
     "@storybook/vue": "7.6.20",
     "@storybook/vue-vite": "7.6.20",
     "@vue/test-utils": "1.3",
+    "storybook-dark-mode": "^3.0.3",
     "vue": "^2.7.15"
   },
   "peerDependencies": {

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button/callbar_button.test.js
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button/callbar_button.test.js
@@ -101,7 +101,6 @@ describe('DtRecipeCallbarButton Tests', () => {
       it('Should display a disabled button when "disabled"', async () => {
         await wrapper.setProps({ disabled: true });
         expect(button.classes().includes('d-btn--disabled')).toBe(true);
-        expect(button.classes().includes('d-bgc-transparent')).toBe(true);
       });
 
       it(

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button/callbar_button.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button/callbar_button.vue
@@ -189,19 +189,17 @@ export default {
       return [
         this.buttonClass,
         'd-recipe-callbar-button',
-        'd-px0',
         {
           'd-recipe-callbar-button--circle': this.circle,
           'd-recipe-callbar-button--active': this.active,
           'd-recipe-callbar-button--danger': this.danger,
-          'd-btn--disabled d-bgc-transparent': this.disabled,
-          'd-fc-primary': !this.disabled,
+          'd-btn--disabled': this.disabled,
         }];
     },
 
     callbarButtonTextClass () {
       return [
-        'd-fs-100 lg:d-d-none md:d-d-none sm:d-d-none',
+        'd-recipe-callbar-button__text',
         this.textClass,
       ];
     },

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -38,7 +38,6 @@
       padding="none"
       class="d-recipe-callbar-button-with-popover__popover-wrapper"
       :dialog-class="['d-recipe-callbar-button-with-popover__popover', contentClass]"
-      header-class="d-d-flex d-ai-center d-fw-normal d-px12"
       v-bind="$attrs"
       :open-popover="showPopover"
       @opened="onModalIsOpened"

--- a/packages/dialtone-vue2/recipes/cards/ivr_node/ivr_node.test.js
+++ b/packages/dialtone-vue2/recipes/cards/ivr_node/ivr_node.test.js
@@ -1,7 +1,7 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import DtRecipeIvrNode from './ivr_node.vue';
 import {
-  IVR_NODE_COLOR_MAPPING, IVR_NODE_HANGUP, IVR_NODE_LABELS,
+  IVR_NODE_CLASS_MAPPING, IVR_NODE_HANGUP, IVR_NODE_LABELS,
 } from '@/recipes/cards/ivr_node/ivr_node_constants';
 
 const basePropsData = {
@@ -119,12 +119,7 @@ describe('DtRecipeIvrNode Tests', () => {
         await _setWrappers();
       });
       it('should include selected class', () => {
-        const card = wrapper.find('[data-qa="dt-card"]');
-        const header = wrapper.find('.d-card__header');
-        expect(card.classes().includes(IVR_NODE_COLOR_MAPPING[IVR_NODE_HANGUP].selected)).toBe(true);
-        expect(
-          header.classes().includes(IVR_NODE_COLOR_MAPPING[IVR_NODE_HANGUP].selected),
-        ).toBe(true);
+        expect(wrapper.classes().includes(IVR_NODE_CLASS_MAPPING[IVR_NODE_HANGUP].selected)).toBe(true);
       });
     });
   });

--- a/packages/dialtone-vue2/recipes/cards/ivr_node/ivr_node.vue
+++ b/packages/dialtone-vue2/recipes/cards/ivr_node/ivr_node.vue
@@ -1,6 +1,9 @@
 <template>
   <div
-    class="d-recipe-ivr-node"
+    :class="[
+      'd-recipe-ivr-node',
+      nodeClass,
+    ]"
     v-on="$listeners"
   >
     <div
@@ -21,22 +24,7 @@
       class="d-recipe-ivr-node__connector"
       :class="{ 'd-recipe-ivr-node__connector--selected': isSelected }"
     />
-    <dt-card
-      content-class="d-bt d-bc-black-300 d-px12 d-pt8 d-pb12"
-      :container-class="[
-        'd-w100p',
-        { 'd-ba d-bar8 d-baw4': isSelected },
-        headerColor,
-      ]"
-      :header-class="[
-        'd-mtn1',
-        'd-bt',
-        'd-btw4',
-        'd-p0',
-        headerColor,
-        { 'd-btr4': !isSelected },
-      ]"
-    >
+    <dt-card>
       <template #header>
         <!-- node label and icon section on left of the header -->
         <div class="d-recipe-ivr-node__header-left">
@@ -112,7 +100,7 @@ import {
   DtIconMoreVertical,
 } from '@dialpad/dialtone-icons/vue2';
 import {
-  IVR_NODE_COLOR_MAPPING,
+  IVR_NODE_CLASS_MAPPING,
   IVR_NODE_PROMPT_MENU,
   IVR_NODE_PROMPT_COLLECT,
   IVR_NODE_PROMPT_PLAY,
@@ -220,8 +208,8 @@ export default {
       return typeToIcon.get(this.nodeType);
     },
 
-    headerColor () {
-      const { normal, selected } = IVR_NODE_COLOR_MAPPING[this.nodeType];
+    nodeClass () {
+      const { normal, selected } = IVR_NODE_CLASS_MAPPING[this.nodeType];
       return this.isSelected ? selected : normal;
     },
 

--- a/packages/dialtone-vue2/recipes/cards/ivr_node/ivr_node_constants.js
+++ b/packages/dialtone-vue2/recipes/cards/ivr_node/ivr_node_constants.js
@@ -32,29 +32,29 @@ export const IVR_NODE_LABELS = {
   [IVR_NODE_ASSIGN]: 'Assign',
 };
 
-const IVR_NODE_COLORS = {
+const IVR_NODE_CLASSES = {
   PROMPT: {
-    normal: 'd-bc-blue-200',
-    selected: 'd-bc-blue-300',
+    normal: 'd-recipe-ivr-node-prompt',
+    selected: 'd-recipe-ivr-node-prompt--selected',
   },
   LOGIC: {
-    normal: 'd-bc-purple-200',
-    selected: 'd-bc-purple-400',
+    normal: 'd-recipe-ivr-node-logic',
+    selected: 'd-recipe-ivr-node-logic--selected',
   },
   TERMINAL: {
-    normal: 'd-bc-red-100',
-    selected: 'd-bc-red-200',
+    normal: 'd-recipe-ivr-node-terminal',
+    selected: 'd-recipe-ivr-node-terminal--selected',
   },
 };
 
-export const IVR_NODE_COLOR_MAPPING = {
-  [IVR_NODE_PROMPT_MENU]: IVR_NODE_COLORS.PROMPT,
-  [IVR_NODE_PROMPT_COLLECT]: IVR_NODE_COLORS.PROMPT,
-  [IVR_NODE_PROMPT_PLAY]: IVR_NODE_COLORS.PROMPT,
-  [IVR_NODE_EXPERT]: IVR_NODE_COLORS.LOGIC,
-  [IVR_NODE_BRANCH]: IVR_NODE_COLORS.LOGIC,
-  [IVR_NODE_GO_TO]: IVR_NODE_COLORS.LOGIC,
-  [IVR_NODE_ASSIGN]: IVR_NODE_COLORS.LOGIC,
-  [IVR_NODE_TRANSFER]: IVR_NODE_COLORS.TERMINAL,
-  [IVR_NODE_HANGUP]: IVR_NODE_COLORS.TERMINAL,
+export const IVR_NODE_CLASS_MAPPING = {
+  [IVR_NODE_PROMPT_MENU]: IVR_NODE_CLASSES.PROMPT,
+  [IVR_NODE_PROMPT_COLLECT]: IVR_NODE_CLASSES.PROMPT,
+  [IVR_NODE_PROMPT_PLAY]: IVR_NODE_CLASSES.PROMPT,
+  [IVR_NODE_EXPERT]: IVR_NODE_CLASSES.LOGIC,
+  [IVR_NODE_BRANCH]: IVR_NODE_CLASSES.LOGIC,
+  [IVR_NODE_GO_TO]: IVR_NODE_CLASSES.LOGIC,
+  [IVR_NODE_ASSIGN]: IVR_NODE_CLASSES.LOGIC,
+  [IVR_NODE_TRANSFER]: IVR_NODE_CLASSES.TERMINAL,
+  [IVR_NODE_HANGUP]: IVR_NODE_CLASSES.TERMINAL,
 };

--- a/packages/dialtone-vue2/recipes/chips/grouped_chip/grouped_chip.test.js
+++ b/packages/dialtone-vue2/recipes/chips/grouped_chip/grouped_chip.test.js
@@ -34,7 +34,7 @@ describe('DtRecipeGroupedChip Tests', () => {
 
   // Helpers
   const _setChildWrappers = () => {
-    rootElement = wrapper.find('[data-qa="grouped-chip"]');
+    rootElement = wrapper.find('[data-qa="dt-recipe-grouped-chip"]');
 
     leftChipIconElement = wrapper.find('[data-qa="left-grouped-chip-icon"]');
     rightChipIconElement = wrapper.find('[data-qa="right-grouped-chip-icon"]');

--- a/packages/dialtone-vue2/recipes/chips/grouped_chip/grouped_chip.vue
+++ b/packages/dialtone-vue2/recipes/chips/grouped_chip/grouped_chip.vue
@@ -1,12 +1,11 @@
 <template>
   <div
-    data-qa="grouped-chip"
+    data-qa="dt-recipe-grouped-chip"
     class="d-recipe-grouped-chip"
   >
     <dt-chip
       :hide-close="true"
       :interactive="false"
-      content-class="d-fs100"
       size="xs"
       :grouped-chip="true"
       class="d-recipe-grouped-chip__content d-recipe-grouped-chip__content-left"
@@ -38,7 +37,6 @@
     <dt-chip
       :hide-close="true"
       :interactive="false"
-      content-class="d-fs100"
       size="xs"
       :grouped-chip="true"
       class="d-recipe-grouped-chip__content d-recipe-grouped-chip__content-right"

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -51,7 +51,10 @@
           ref="input"
           v-model="value"
           class="d-recipe-combobox-multi-select__input"
-          :input-class="[inputClass, { 'd-fc-transparent': hideInputText }]"
+          :input-class="[
+            inputClass, {
+              'd-recipe-combobox-multi-select__input--hidden': hideInputText,
+            }]"
           :input-wrapper-class="inputWrapperClass"
           :aria-label="label"
           :label="labelVisible ? label : ''"

--- a/packages/dialtone-vue2/recipes/conversation_view/attachment_carousel/attachment_carousel_constants.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/attachment_carousel/attachment_carousel_constants.js
@@ -1,5 +1,0 @@
-export const DEFAULT_CONSTANTS = null;
-
-export default {
-  DEFAULT_CONSTANTS,
-};

--- a/packages/dialtone-vue2/recipes/conversation_view/attachment_carousel/index.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/attachment_carousel/index.js
@@ -1,2 +1,1 @@
 export { default as DtRecipeAttachmentCarousel } from './attachment_carousel.vue';
-export {} from './attachment_carousel_constants';

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-restricted-class -->
 <template>
   <div
 

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -1,16 +1,17 @@
 <!-- eslint-disable vue/no-restricted-class -->
 <template>
   <div
+
+    class="d-recipe-editor"
     data-qa="dt-recipe-editor"
     role="presentation"
-    class="d-d-flex d-fd-column"
     @click="$refs.richTextEditor.focusEditor()"
   >
     <!-- Section for the top UI -->
     <dt-stack
+      class="d-recipe-editor__top-bar"
       direction="row"
       gap="450"
-      class="d-p8 d-recipe-editor__top-bar-background"
     >
       <dt-stack
         v-for="buttonGroup in buttonGroups"
@@ -26,12 +27,12 @@
         >
           <template #anchor>
             <dt-button
+              :active="$refs.richTextEditor?.editor?.isActive(button.selector)"
+              :aria-label="button.tooltipMessage"
               :data-qa="button.dataQA"
               importance="clear"
               kind="muted"
-              :active="$refs.richTextEditor?.editor?.isActive(button.selector)"
               size="xs"
-              :aria-label="button.tooltipMessage"
               @click="button.onClick()"
             >
               <template #icon>
@@ -53,14 +54,15 @@
       >
         <dt-popover
           :open.sync="showLinkInput"
-          placement="bottom-start"
+          :show-close-button="false"
           :visually-hidden-close="true"
           :visually-hidden-close-label="'Close link input popover'"
           data-qa="dt-recipe-editor-link-input-popover"
-          :show-close-button="false"
+          padding="none"
+          placement="bottom-start"
           @click="onInputFocus"
-          @click.native.stop="onInputFocus"
           @opened="updateInput"
+          @click.native.stop="onInputFocus"
         >
           <template #anchor>
             <dt-tooltip
@@ -70,20 +72,18 @@
             >
               <template #anchor>
                 <dt-button
+                  :active="$refs.richTextEditor?.editor?.isActive(linkButton.selector)"
+                  :aria-label="linkButton.tooltipMessage"
                   :data-qa="linkButton.dataQA"
                   importance="clear"
                   kind="muted"
-                  class="d-ol-none"
-                  :active="$refs.richTextEditor?.editor?.isActive(linkButton.selector)"
                   size="xs"
-                  :aria-label="linkButton.tooltipMessage"
                   @click="linkButton.onClick()"
                 >
                   <template #icon>
                     <component
                       :is="linkButton.icon"
                       size="200"
-                      class="d-fw-bold"
                     />
                   </template>
                 </dt-button>
@@ -92,57 +92,60 @@
           </template>
 
           <template #content>
-            <span
-              v-if="showAddLink.setLinkTitle.length > 0"
-            >
-              {{ showAddLink.setLinkTitle }}
-            </span>
-            <dt-input
-              v-model="linkInput"
-              :input-aria-label="showAddLink.setLinkInputAriaLabel"
-              data-qa="dt-recipe-editor-link-input"
-              :placeholder="setLinkPlaceholder"
-              input-wrapper-class="d-bgc-secondary d-mt6 d-bar5 d-ba d-baw1 d-bc-default d-py2 d-ol-none"
-              @click="onInputFocus"
-              @click.native.stop="onInputFocus"
-              @focus="onInputFocus"
-              @keydown.enter="setLink"
-            />
+            <div class="d-recipe-editor__popover-content">
+              <span
+                v-if="showAddLink.setLinkTitle.length > 0"
+              >
+                {{ showAddLink.setLinkTitle }}
+              </span>
+              <dt-input
+                v-model="linkInput"
+                :input-aria-label="showAddLink.setLinkInputAriaLabel"
+                :placeholder="setLinkPlaceholder"
+                data-qa="dt-recipe-editor-link-input"
+                input-wrapper-class="d-recipe-editor-link__input-wrapper"
+                @click="onInputFocus"
+                @focus="onInputFocus"
+                @click.native.stop="onInputFocus"
+                @keydown.enter="setLink"
+              />
+            </div>
           </template>
           <template #footerContent>
-            <div class="d-ml8 d-mr12">
+            <dt-stack
+              direction="row"
+              gap="300"
+              class="d-recipe-editor__popover-footer"
+            >
               <dt-button
-                class="d-mx2"
                 :aria-label="removeLinkButton.ariaLabel"
+                data-qa="dt-recipe-editor-remove-link-btn"
                 importance="clear"
                 kind="muted"
                 size="sm"
-                data-qa="dt-recipe-editor-remove-link-btn"
                 @click="removeLink"
               >
                 {{ removeLinkButton.label }}
               </dt-button>
               <dt-button
-                class="d-mx2"
                 :aria-label="cancelSetLinkButton.ariaLabel"
+                data-qa="dt-recipe-editor-set-link-cancel-btn"
                 importance="clear"
                 kind="muted"
                 size="sm"
-                data-qa="dt-recipe-editor-set-link-cancel-btn"
                 @click="closeLinkInput"
               >
                 {{ cancelSetLinkButton.label }}
               </dt-button>
               <dt-button
-                class="d-mx2"
-                size="sm"
                 :aria-label="confirmSetLinkButton.ariaLabel"
                 data-qa="dt-recipe-editor-set-link-confirm-btn"
+                size="sm"
                 @click="setLink"
               >
                 {{ confirmSetLinkButton.label }}
               </dt-button>
-            </div>
+            </dt-stack>
           </template>
         </dt-popover>
       </dt-stack>
@@ -150,25 +153,25 @@
 
     <!-- Some wrapper to restrict the height and show the scrollbar -->
     <div
-      class="d-of-auto d-mx16 d-mt8 d-mb16 d-c-text"
       :style="{ 'max-height': maxHeight }"
+      class="d-recipe-editor__content"
     >
       <dt-rich-text-editor
         ref="richTextEditor"
         v-model="internalInputValue"
-        data-qa="dt-rich-text-editor"
+        :allow-inline-images="true"
+        :allow-line-breaks="true"
+        :auto-focus="autoFocus"
         :editable="editable"
         :input-aria-label="inputAriaLabel"
-        :input-class="`d-ml16 d-ol-none d-my6 ${inputClass}`"
-        :output-format="htmlOutputFormat"
-        :auto-focus="autoFocus"
-        :placeholder="placeholder"
-        :allow-line-breaks="true"
-        :allow-inline-images="true"
+        :input-class="`d-recipe-editor__content-input ${inputClass}`"
         :link="true"
+        :output-format="htmlOutputFormat"
+        :placeholder="placeholder"
+        data-qa="dt-rich-text-editor"
         v-bind="$attrs"
-        @focus="onFocus"
         @blur="onBlur"
+        @focus="onFocus"
         @input="onInput($event)"
       />
     </div>
@@ -487,7 +490,7 @@ export default {
      * Quick replies button
      * pressed event
      * @event quick-replies-click
-    */
+     */
     'quick-replies-click',
   ],
 
@@ -497,7 +500,7 @@ export default {
       hasFocus: false,
 
       linkOptions: {
-        class: 'd-link d-c-text d-d-inline-block',
+        class: 'd-recipe-editor__link',
       },
 
       showLinkInput: false,
@@ -520,7 +523,7 @@ export default {
 
     showingAlignmentButtons () {
       return this.showAlignLeftButton || this.showAlignCenterButton ||
-          this.showAlignRightButton || this.showAlignJustifyButton;
+        this.showAlignRightButton || this.showAlignJustifyButton;
     },
 
     showingListButtons () {
@@ -543,44 +546,143 @@ export default {
 
     newButtons () {
       return [
-        { showBtn: this.showQuickRepliesButton, label: 'Quick reply', selector: 'quickReplies', icon: DtIconLightningBolt, dataQA: 'dt-recipe-editor-quick-replies-btn', tooltipMessage: 'Quick Reply', onClick: this.onQuickRepliesClick },
+        {
+          showBtn: this.showQuickRepliesButton,
+          label: 'Quick reply',
+          selector: 'quickReplies',
+          icon: DtIconLightningBolt,
+          dataQA: 'dt-recipe-editor-quick-replies-btn',
+          tooltipMessage: 'Quick Reply',
+          onClick: this.onQuickRepliesClick,
+        },
       ].filter(button => button.showBtn);
     },
 
     textFormatButtons () {
       return [
-        { showBtn: this.showBoldButton, selector: 'bold', icon: DtIconBold, dataQA: 'dt-recipe-editor-bold-btn', tooltipMessage: 'Bold', onClick: this.onBoldTextToggle },
-        { showBtn: this.showItalicsButton, selector: 'italic', icon: DtIconItalic, dataQA: 'dt-recipe-editor-italics-btn', tooltipMessage: 'Italics', onClick: this.onItalicTextToggle },
-        { showBtn: this.showUnderlineButton, selector: 'underline', icon: DtIconUnderline, dataQA: 'dt-recipe-editor-underline-btn', tooltipMessage: 'Underline', onClick: this.onUnderlineTextToggle },
-        { showBtn: this.showStrikeButton, selector: 'strike', icon: DtIconStrikethrough, dataQA: 'dt-recipe-editor-strike-btn', tooltipMessage: 'Strike', onClick: this.onStrikethroughTextToggle },
+        {
+          showBtn: this.showBoldButton,
+          selector: 'bold',
+          icon: DtIconBold,
+          dataQA: 'dt-recipe-editor-bold-btn',
+          tooltipMessage: 'Bold',
+          onClick: this.onBoldTextToggle,
+        },
+        {
+          showBtn: this.showItalicsButton,
+          selector: 'italic',
+          icon: DtIconItalic,
+          dataQA: 'dt-recipe-editor-italics-btn',
+          tooltipMessage: 'Italics',
+          onClick: this.onItalicTextToggle,
+        },
+        {
+          showBtn: this.showUnderlineButton,
+          selector: 'underline',
+          icon: DtIconUnderline,
+          dataQA: 'dt-recipe-editor-underline-btn',
+          tooltipMessage: 'Underline',
+          onClick: this.onUnderlineTextToggle,
+        },
+        {
+          showBtn: this.showStrikeButton,
+          selector: 'strike',
+          icon: DtIconStrikethrough,
+          dataQA: 'dt-recipe-editor-strike-btn',
+          tooltipMessage: 'Strike',
+          onClick: this.onStrikethroughTextToggle,
+        },
       ].filter(button => button.showBtn);
     },
 
     alignmentButtons () {
       return [
-        { showBtn: this.showAlignLeftButton, selector: { textAlign: 'left' }, icon: DtIconAlignLeft, dataQA: 'dt-recipe-editor-align-left-btn', tooltipMessage: 'Align Left', onClick: () => this.onTextAlign('left') },
-        { showBtn: this.showAlignCenterButton, selector: { textAlign: 'center' }, icon: DtIconAlignCenter, dataQA: 'dt-recipe-editor-align-center-btn', tooltipMessage: 'Align Center', onClick: () => this.onTextAlign('center') },
-        { showBtn: this.showAlignRightButton, selector: { textAlign: 'right' }, icon: DtIconAlignRight, dataQA: 'dt-recipe-editor-align-right-btn', tooltipMessage: 'Align Right', onClick: () => this.onTextAlign('right') },
-        { showBtn: this.showAlignJustifyButton, selector: { textAlign: 'justify' }, icon: DtIconAlignJustify, dataQA: 'dt-recipe-editor-align-justify-btn', tooltipMessage: 'Align Justify', onClick: () => this.onTextAlign('justify') },
+        {
+          showBtn: this.showAlignLeftButton,
+          selector: { textAlign: 'left' },
+          icon: DtIconAlignLeft,
+          dataQA: 'dt-recipe-editor-align-left-btn',
+          tooltipMessage: 'Align Left',
+          onClick: () => this.onTextAlign('left'),
+        },
+        {
+          showBtn: this.showAlignCenterButton,
+          selector: { textAlign: 'center' },
+          icon: DtIconAlignCenter,
+          dataQA: 'dt-recipe-editor-align-center-btn',
+          tooltipMessage: 'Align Center',
+          onClick: () => this.onTextAlign('center'),
+        },
+        {
+          showBtn: this.showAlignRightButton,
+          selector: { textAlign: 'right' },
+          icon: DtIconAlignRight,
+          dataQA: 'dt-recipe-editor-align-right-btn',
+          tooltipMessage: 'Align Right',
+          onClick: () => this.onTextAlign('right'),
+        },
+        {
+          showBtn: this.showAlignJustifyButton,
+          selector: { textAlign: 'justify' },
+          icon: DtIconAlignJustify,
+          dataQA: 'dt-recipe-editor-align-justify-btn',
+          tooltipMessage: 'Align Justify',
+          onClick: () => this.onTextAlign('justify'),
+        },
       ].filter(button => button.showBtn);
     },
 
     listButtons () {
       return [
-        { showBtn: this.showListItemsButton, selector: 'bulletList', icon: DtIconListBullet, dataQA: 'dt-recipe-editor-list-items-btn', tooltipMessage: 'Bullet List', onClick: this.onBulletListToggle },
-        { showBtn: this.showOrderedListButton, selector: 'orderedList', icon: DtIconListOrdered, dataQA: 'dt-recipe-editor-ordered-list-items-btn', tooltipMessage: 'Ordered List', onClick: this.onOrderedListToggle },
+        {
+          showBtn: this.showListItemsButton,
+          selector: 'bulletList',
+          icon: DtIconListBullet,
+          dataQA: 'dt-recipe-editor-list-items-btn',
+          tooltipMessage: 'Bullet List',
+          onClick: this.onBulletListToggle,
+        },
+        {
+          showBtn: this.showOrderedListButton,
+          selector: 'orderedList',
+          icon: DtIconListOrdered,
+          dataQA: 'dt-recipe-editor-ordered-list-items-btn',
+          tooltipMessage: 'Ordered List',
+          onClick: this.onOrderedListToggle,
+        },
       ].filter(button => button.showBtn);
     },
 
     individualButtons () {
       return [
-        { showBtn: this.showQuoteButton, selector: 'blockquote', icon: DtIconQuote, dataQA: 'dt-recipe-editor-blockquote-btn', tooltipMessage: 'Quote', onClick: this.onBlockquoteToggle },
-        { showBtn: this.showCodeBlockButton, selector: 'codeBlock', icon: DtIconCodeBlock, dataQA: 'dt-recipe-editor-code-block-btn', tooltipMessage: 'Code', onClick: this.onCodeBlockToggle },
+        {
+          showBtn: this.showQuoteButton,
+          selector: 'blockquote',
+          icon: DtIconQuote,
+          dataQA: 'dt-recipe-editor-blockquote-btn',
+          tooltipMessage: 'Quote',
+          onClick: this.onBlockquoteToggle,
+        },
+        {
+          showBtn: this.showCodeBlockButton,
+          selector: 'codeBlock',
+          icon: DtIconCodeBlock,
+          dataQA: 'dt-recipe-editor-code-block-btn',
+          tooltipMessage: 'Code',
+          onClick: this.onCodeBlockToggle,
+        },
       ].filter(button => button.showBtn);
     },
 
     linkButton () {
-      return { showBtn: this.showAddLink.showAddLinkButton, selector: 'link', icon: DtIconLink2, dataQA: 'dt-recipe-editor-add-link-btn', tooltipMessage: 'Link', onClick: this.openLinkInput };
+      return {
+        showBtn: this.showAddLink.showAddLinkButton,
+        selector: 'link',
+        icon: DtIconLink2,
+        dataQA: 'dt-recipe-editor-add-link-btn',
+        tooltipMessage: 'Link',
+        onClick: this.openLinkInput,
+      };
     },
   },
 
@@ -631,7 +733,7 @@ export default {
           .focus()
           .insertContentAt(
             selection.anchor,
-            `<a class="${this.linkOptions.class}" href=${this.linkInput}>${this.linkInput}</a>`,
+          `<a class="${this.linkOptions.class}" href=${this.linkInput}>${this.linkInput}</a>`,
           )
           .run();
       } else {

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -7,7 +7,7 @@
     >
       <dt-tooltip
         class="d-recipe-emoji-row__tooltip"
-        content-class="d-wmx464"
+        content-class="d-recipe-emoji-row__tooltip-content"
         sticky="popper"
         @shown="(shown) => emojiHovered(reaction, shown)"
       >

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_pill/feed_item_pill.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_pill/feed_item_pill.vue
@@ -142,7 +142,7 @@ export default {
     },
 
     toggleableClass () {
-      return this.toggleable ? 'd-c-pointer' : '';
+      return this.toggleable ? 'd-recipe-feed-item-pill--toggleable' : '';
     },
 
     borderClass () {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-restricted-class -->
 <template>
   <div
     data-qa="dt-recipe-message-input"

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -138,7 +138,7 @@
           gap="300"
         >
           <!-- @slot Slot for sms count -->
-          <div class="d-d-flex d-ai-center">
+          <div class="d-recipe-message-input__sms-count">
             <slot name="smsCount" />
           </div>
 

--- a/packages/dialtone-vue2/recipes/item_layout/contact_info/contact_info.vue
+++ b/packages/dialtone-vue2/recipes/item_layout/contact_info/contact_info.vue
@@ -27,7 +27,12 @@
             :image-src="avatar.src"
             image-alt=""
             :overlay-text="avatar.text"
-            :avatar-class="[{ 'd-mln24': index > 0, 'd-bc-brand': !!avatar.halo }]"
+            :avatar-class="[
+              {
+                'd-recipe-contact-info__avatar-stacked': index > 0,
+                'd-recipe-contact-info__avatar-halo': !!avatar.halo,
+              },
+            ]"
           >
             <template
               #icon="{ iconSize }"

--- a/packages/dialtone-vue2/recipes/leftbar/contact_row/contact_row.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/contact_row/contact_row.vue
@@ -45,7 +45,7 @@
         <span
           v-if="presenceText"
           data-qa="dt-recipe-leftbar-row-presence-text"
-          :class="['d-recipe-leftbar-row__meta-context', presenceColorClass]"
+          :class="['d-recipe-leftbar-row__meta-context', presenceFontColorClass]"
         >
           {{ presenceText }}
         </span>
@@ -237,17 +237,14 @@ export default {
   ],
 
   computed: {
-    presenceColorClass () {
-      switch (this.avatarPresence) {
-        case 'active':
-          return 'd-fc-success';
-        case 'busy':
-          return 'd-fc-critical';
-        case 'away':
-          return 'd-fc-warning';
-        default:
-          return undefined;
-      }
+    presenceFontColorClass () {
+      const presenceFontColors = {
+        active: 'd-recipe-contact-row--active',
+        busy: 'd-recipe-contact-row--busy',
+        away: 'd-recipe-contact-row--away',
+      };
+
+      return presenceFontColors[this.avatarPresence];
     },
 
     contactDescription () {

--- a/packages/dialtone-vue2/recipes/leftbar/general_row/general_row_constants.js
+++ b/packages/dialtone-vue2/recipes/leftbar/general_row/general_row_constants.js
@@ -16,17 +16,17 @@ export const LEFTBAR_GENERAL_ROW_TYPES = {
 };
 
 export const LEFTBAR_GENERAL_ROW_CONTACT_CENTER_COLORS = {
-  'magenta-200': 'd-bgc-magenta-200',
-  'green-200': 'd-bgc-green-200',
-  'gold-300': 'd-bgc-gold-300',
-  'purple-600': 'd-bgc-purple-600',
-  'magenta-300': 'd-bgc-magenta-300',
-  'purple-300': 'd-bgc-purple-300',
-  'green-500': 'd-bgc-green-500',
-  'purple-100': 'd-bgc-purple-100',
-  'magenta-400': 'd-bgc-magenta-400',
-  'magenta-100': 'd-bgc-magenta-100',
-  'black-300': 'd-bgc-black-300',
+  'magenta-100': 'd-recipe-leftbar-general-row__contact-center--magenta-100',
+  'magenta-200': 'd-recipe-leftbar-general-row__contact-center--magenta-200',
+  'magenta-300': 'd-recipe-leftbar-general-row__contact-center--magenta-300',
+  'magenta-400': 'd-recipe-leftbar-general-row__contact-center--magenta-400',
+  'green-200': 'd-recipe-leftbar-general-row__contact-center--green-200',
+  'green-500': 'd-recipe-leftbar-general-row__contact-center--green-500',
+  'gold-300': 'd-recipe-leftbar-general-row__contact-center--gold-300',
+  'purple-100': 'd-recipe-leftbar-general-row__contact-center--purple-100',
+  'purple-300': 'd-recipe-leftbar-general-row__contact-center--purple-300',
+  'purple-600': 'd-recipe-leftbar-general-row__contact-center--purple-600',
+  'black-300': 'd-recipe-leftbar-general-row__contact-center--black-300',
 };
 
 export const LEFTBAR_GENERAL_ROW_CONTACT_CENTER_VALIDATION_ERROR = 'If type is contact center, color must be one' +

--- a/packages/dialtone-vue2/recipes/leftbar/general_row/leftbar_general_row_icon.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/general_row/leftbar_general_row_icon.vue
@@ -10,7 +10,7 @@
   />
   <div
     v-else-if="isDialbotType"
-    :class="dialbotClasses"
+    class="dt-recipe-leftbar-general-row__icon"
     data-qa="general-row-dialbot"
   >
     <dt-icon-dialbot
@@ -117,14 +117,6 @@ export default {
       return [
         'd-recipe-leftbar-row__icon-cc',
         COLORS[this.color],
-      ];
-    },
-
-    dialbotClasses () {
-      return [
-        'd-d-flex',
-        'd-ai-center',
-        'd-jc-center',
       ];
     },
   },

--- a/packages/dialtone-vue2/recipes/leftbar/general_row/leftbar_general_row_icon.vue
+++ b/packages/dialtone-vue2/recipes/leftbar/general_row/leftbar_general_row_icon.vue
@@ -10,7 +10,7 @@
   />
   <div
     v-else-if="isDialbotType"
-    class="dt-recipe-leftbar-general-row__icon"
+    class="d-recipe-leftbar-general-row__icon"
     data-qa="general-row-dialbot"
   >
     <dt-icon-dialbot

--- a/packages/dialtone-vue2/recipes/notices/top_banner_info/top_banner_info.test.js
+++ b/packages/dialtone-vue2/recipes/notices/top_banner_info/top_banner_info.test.js
@@ -68,7 +68,7 @@ describe('DtRecipeTopBannerInfo Tests', () => {
         expect(middleContent.text()).toBe(slots.default);
       });
       it('Should display with default background color', () => {
-        expect(rootElement.classes()).toContain('d-bgc-success');
+        expect(rootElement.classes()).toContain('d-recipe-top-banner-info--success');
       });
     });
 
@@ -78,7 +78,7 @@ describe('DtRecipeTopBannerInfo Tests', () => {
       });
 
       it('Should display with passed background color', () => {
-        expect(rootElement.classes()).toContain('d-bgc-info');
+        expect(rootElement.classes()).toContain('d-recipe-top-banner-info--info');
       });
     });
   });

--- a/packages/dialtone-vue2/recipes/notices/top_banner_info/top_banner_info.vue
+++ b/packages/dialtone-vue2/recipes/notices/top_banner_info/top_banner_info.vue
@@ -45,14 +45,14 @@ export default {
       const bgColors = {
         // these are too specific, so for now I'm at least updating the resultant semantic value
         // TODO: breaking change: update to be more abstract
-        green300: 'd-bgc-success',
-        green100: 'd-bgc-success',
-        red200: 'd-bgc-critical',
-        red100: 'd-bgc-critical',
-        gold200: 'd-bgc-warning',
-        gold100: 'd-bgc-warning',
-        black100: 'd-bgc-info',
-        white: 'd-bgc-primary',
+        green100: 'd-recipe-top-banner-info--success',
+        green300: 'd-recipe-top-banner-info--success',
+        red100: 'd-recipe-top-banner-info--critical',
+        red200: 'd-recipe-top-banner-info--critical',
+        gold100: 'd-recipe-top-banner-info--warning',
+        gold200: 'd-recipe-top-banner-info--warning',
+        black100: 'd-recipe-top-banner-info--info',
+        white: 'd-recipe-top-banner-info--primary',
       };
       return [bgColors[this.colorCode]];
     },

--- a/packages/dialtone-vue3/.eslintrc.cjs
+++ b/packages/dialtone-vue3/.eslintrc.cjs
@@ -1,5 +1,5 @@
 const componentsList = require('../../common/components_list.js');
-componentsList.push('btn', 'select', 'validation-message', 'label', 'description', 'split-btn');
+componentsList.push('btn', 'select', 'validation-message', 'label', 'description', 'split-btn', 'mention-suggestion', 'suggestion-list');
 const componentsNames = componentsList.map(name => name.replace('_', '-').replace('.vue', ''));
 
 module.exports = {

--- a/packages/dialtone-vue3/package.json
+++ b/packages/dialtone-vue3/package.json
@@ -48,9 +48,13 @@
   "devDependencies": {
     "@dialpad/dialtone-css": "workspace:*",
     "@dialpad/generator-dialtone": "workspace:*",
+    "@storybook/addon-a11y": "7.6.20",
+    "@storybook/addon-essentials": "7.6.20",
+    "@storybook/addon-links": "7.6.20",
     "@storybook/vue3": "7.6.20",
     "@storybook/vue3-vite": "7.6.20",
     "@vue/test-utils": "^2.4.0",
+    "storybook-dark-mode": "^3.0.3",
     "vue": "^3.3.4"
   },
   "peerDependencies": {

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button/callbar_button.test.js
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button/callbar_button.test.js
@@ -90,7 +90,6 @@ describe('DtRecipeCallbarButton Tests', () => {
       it('Should display a disabled button when "disabled"', async () => {
         await wrapper.setProps({ disabled: true });
         expect(button.classes().includes('d-btn--disabled')).toBe(true);
-        expect(button.classes().includes('d-bgc-transparent')).toBe(true);
       });
 
       it(

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button/callbar_button.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button/callbar_button.vue
@@ -189,19 +189,17 @@ export default {
       return [
         this.buttonClass,
         'd-recipe-callbar-button',
-        'd-px0',
         {
           'd-recipe-callbar-button--circle': this.circle,
           'd-recipe-callbar-button--active': this.active,
           'd-recipe-callbar-button--danger': this.danger,
-          'd-btn--disabled d-bgc-transparent': this.disabled,
-          'd-fc-primary': !this.disabled,
+          'd-btn--disabled': this.disabled,
         }];
     },
 
     callbarButtonTextClass () {
       return [
-        'd-fs-100 lg:d-d-none md:d-d-none sm:d-d-none',
+        'd-recipe-callbar-button__text',
         this.textClass,
       ];
     },

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -36,7 +36,6 @@
       padding="none"
       class="d-recipe-callbar-button-with-popover__popover-wrapper"
       :dialog-class="['d-recipe-callbar-button-with-popover__popover', contentClass]"
-      header-class="d-d-flex d-ai-center d-fw-normal d-px12"
       v-bind="$attrs"
       :open-popover="showPopover"
       @opened="onModalIsOpened"

--- a/packages/dialtone-vue3/recipes/cards/ivr_node/ivr_node.test.js
+++ b/packages/dialtone-vue3/recipes/cards/ivr_node/ivr_node.test.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import DtRecipeIvrNode from './ivr_node.vue';
 import {
-  IVR_NODE_COLOR_MAPPING, IVR_NODE_HANGUP, IVR_NODE_LABELS,
+  IVR_NODE_CLASS_MAPPING, IVR_NODE_HANGUP, IVR_NODE_LABELS,
 } from '@/recipes/cards/ivr_node/ivr_node_constants';
 
 const baseProps = {
@@ -105,12 +105,7 @@ describe('DtRecipeIvrNode Tests', () => {
         await _setWrappers();
       });
       it('should include selected class', () => {
-        const card = wrapper.find('[data-qa="dt-card"]');
-        const header = wrapper.find('.d-card__header');
-        expect(card.classes().includes(IVR_NODE_COLOR_MAPPING[IVR_NODE_HANGUP].selected)).toBe(true);
-        expect(
-          header.classes().includes(IVR_NODE_COLOR_MAPPING[IVR_NODE_HANGUP].selected),
-        ).toBe(true);
+        expect(wrapper.classes().includes(IVR_NODE_CLASS_MAPPING[IVR_NODE_HANGUP].selected)).toBe(true);
       });
     });
   });

--- a/packages/dialtone-vue3/recipes/cards/ivr_node/ivr_node.vue
+++ b/packages/dialtone-vue3/recipes/cards/ivr_node/ivr_node.vue
@@ -1,6 +1,9 @@
 <template>
   <div
-    class="d-recipe-ivr-node"
+    :class="[
+      'd-recipe-ivr-node',
+      nodeClass,
+    ]"
     v-on="nodeListeners"
   >
     <div
@@ -21,22 +24,7 @@
       class="d-recipe-ivr-node__connector"
       :class="{ 'd-recipe-ivr-node__connector--selected': isSelected }"
     />
-    <dt-card
-      content-class="d-bt d-bc-black-300 d-px12 d-pt8 d-pb12"
-      :container-class="[
-        'd-w100p',
-        { 'd-ba d-bar8 d-baw4': isSelected },
-        headerColor,
-      ]"
-      :header-class="[
-        'd-mtn1',
-        'd-bt',
-        'd-btw4',
-        'd-p0',
-        headerColor,
-        { 'd-btr4': !isSelected },
-      ]"
-    >
+    <dt-card>
       <template #header>
         <!-- node label and icon section on left of the header -->
         <div class="d-recipe-ivr-node__header-left">
@@ -112,7 +100,7 @@ import {
   DtIconMoreVertical,
 } from '@dialpad/dialtone-icons/vue3';
 import {
-  IVR_NODE_COLOR_MAPPING,
+  IVR_NODE_CLASS_MAPPING,
   IVR_NODE_PROMPT_MENU,
   IVR_NODE_PROMPT_COLLECT,
   IVR_NODE_PROMPT_PLAY,
@@ -226,8 +214,8 @@ export default {
       return typeToIcon.get(this.nodeType);
     },
 
-    headerColor () {
-      const { normal, selected } = IVR_NODE_COLOR_MAPPING[this.nodeType];
+    nodeClass () {
+      const { normal, selected } = IVR_NODE_CLASS_MAPPING[this.nodeType];
       return this.isSelected ? selected : normal;
     },
 

--- a/packages/dialtone-vue3/recipes/cards/ivr_node/ivr_node_constants.js
+++ b/packages/dialtone-vue3/recipes/cards/ivr_node/ivr_node_constants.js
@@ -32,29 +32,29 @@ export const IVR_NODE_LABELS = {
   [IVR_NODE_ASSIGN]: 'Assign',
 };
 
-const IVR_NODE_COLORS = {
+const IVR_NODE_CLASSES = {
   PROMPT: {
-    normal: 'd-bc-blue-200',
-    selected: 'd-bc-blue-300',
+    normal: 'd-recipe-ivr-node-prompt',
+    selected: 'd-recipe-ivr-node-prompt--selected',
   },
   LOGIC: {
-    normal: 'd-bc-purple-200',
-    selected: 'd-bc-purple-400',
+    normal: 'd-recipe-ivr-node-logic',
+    selected: 'd-recipe-ivr-node-logic--selected',
   },
   TERMINAL: {
-    normal: 'd-bc-red-100',
-    selected: 'd-bc-red-200',
+    normal: 'd-recipe-ivr-node-terminal',
+    selected: 'd-recipe-ivr-node-terminal--selected',
   },
 };
 
-export const IVR_NODE_COLOR_MAPPING = {
-  [IVR_NODE_PROMPT_MENU]: IVR_NODE_COLORS.PROMPT,
-  [IVR_NODE_PROMPT_COLLECT]: IVR_NODE_COLORS.PROMPT,
-  [IVR_NODE_PROMPT_PLAY]: IVR_NODE_COLORS.PROMPT,
-  [IVR_NODE_EXPERT]: IVR_NODE_COLORS.LOGIC,
-  [IVR_NODE_BRANCH]: IVR_NODE_COLORS.LOGIC,
-  [IVR_NODE_GO_TO]: IVR_NODE_COLORS.LOGIC,
-  [IVR_NODE_ASSIGN]: IVR_NODE_COLORS.LOGIC,
-  [IVR_NODE_TRANSFER]: IVR_NODE_COLORS.TERMINAL,
-  [IVR_NODE_HANGUP]: IVR_NODE_COLORS.TERMINAL,
+export const IVR_NODE_CLASS_MAPPING = {
+  [IVR_NODE_PROMPT_MENU]: IVR_NODE_CLASSES.PROMPT,
+  [IVR_NODE_PROMPT_COLLECT]: IVR_NODE_CLASSES.PROMPT,
+  [IVR_NODE_PROMPT_PLAY]: IVR_NODE_CLASSES.PROMPT,
+  [IVR_NODE_EXPERT]: IVR_NODE_CLASSES.LOGIC,
+  [IVR_NODE_BRANCH]: IVR_NODE_CLASSES.LOGIC,
+  [IVR_NODE_GO_TO]: IVR_NODE_CLASSES.LOGIC,
+  [IVR_NODE_ASSIGN]: IVR_NODE_CLASSES.LOGIC,
+  [IVR_NODE_TRANSFER]: IVR_NODE_CLASSES.TERMINAL,
+  [IVR_NODE_HANGUP]: IVR_NODE_CLASSES.TERMINAL,
 };

--- a/packages/dialtone-vue3/recipes/chips/grouped_chip/grouped_chip.test.js
+++ b/packages/dialtone-vue3/recipes/chips/grouped_chip/grouped_chip.test.js
@@ -28,7 +28,7 @@ describe('DtRecipeGroupedChip Tests', () => {
 
   // Helpers
   const _setChildWrappers = () => {
-    rootElement = wrapper.find('[data-qa="grouped-chip"]');
+    rootElement = wrapper.find('[data-qa="dt-recipe-grouped-chip"]');
 
     leftChipIconElement = wrapper.find('[data-qa="left-grouped-chip-icon"]');
     rightChipIconElement = wrapper.find('[data-qa="right-grouped-chip-icon"]');

--- a/packages/dialtone-vue3/recipes/chips/grouped_chip/grouped_chip.vue
+++ b/packages/dialtone-vue3/recipes/chips/grouped_chip/grouped_chip.vue
@@ -1,12 +1,11 @@
 <template>
   <div
-    data-qa="grouped-chip"
+    data-qa="dt-recipe-grouped-chip"
     class="d-recipe-grouped-chip"
   >
     <dt-chip
       :hide-close="true"
       :interactive="false"
-      content-class="d-fs100"
       size="xs"
       :grouped-chip="true"
       class="d-recipe-grouped-chip__content d-recipe-grouped-chip__content-left"
@@ -38,7 +37,6 @@
     <dt-chip
       :hide-close="true"
       :interactive="false"
-      content-class="d-fs100"
       size="xs"
       :grouped-chip="true"
       class="d-recipe-grouped-chip__content d-recipe-grouped-chip__content-right"

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -51,7 +51,10 @@
           ref="input"
           v-model="value"
           class="d-recipe-combobox-multi-select__input"
-          :input-class="[inputClass, { 'd-fc-transparent': hideInputText }]"
+          :input-class="[
+            inputClass, {
+              'd-recipe-combobox-multi-select__input--hidden': hideInputText,
+            }]"
           :input-wrapper-class="inputWrapperClass"
           :aria-label="label"
           :label="labelVisible ? label : ''"

--- a/packages/dialtone-vue3/recipes/conversation_view/attachment_carousel/attachment_carousel_constants.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/attachment_carousel/attachment_carousel_constants.js
@@ -1,5 +1,0 @@
-export const DEFAULT_CONSTANTS = null;
-
-export default {
-  DEFAULT_CONSTANTS,
-};

--- a/packages/dialtone-vue3/recipes/conversation_view/attachment_carousel/index.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/attachment_carousel/index.js
@@ -1,2 +1,1 @@
 export { default as DtRecipeAttachmentCarousel } from './attachment_carousel.vue';
-export {} from './attachment_carousel_constants';

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -1,16 +1,16 @@
-<!-- eslint-disable vue/no-restricted-class -->
 <template>
   <div
+
+    class="d-recipe-editor"
     data-qa="dt-recipe-editor"
     role="presentation"
-    class="d-d-flex d-fd-column"
     @click="$refs.richTextEditor.focusEditor()"
   >
     <!-- Section for the top UI -->
     <dt-stack
+      class="d-recipe-editor__top-bar"
       direction="row"
       gap="450"
-      class="d-p8 d-recipe-editor__top-bar-background"
     >
       <dt-stack
         v-for="buttonGroup in buttonGroups"
@@ -26,13 +26,12 @@
         >
           <template #anchor>
             <dt-button
+              :active="$refs.richTextEditor?.editor?.isActive(button.selector)"
+              :aria-label="button.tooltipMessage"
               :data-qa="button.dataQA"
               importance="clear"
               kind="muted"
-              :active="$refs.richTextEditor?.editor?.isActive(button.selector)"
               size="xs"
-              :aria-label="button.tooltipMessage"
-              :class="{ 'd-btn--icon-only': !button.label }"
               @click="button.onClick()"
             >
               <template #icon>
@@ -54,14 +53,15 @@
       >
         <dt-popover
           :open="showLinkInput"
-          placement="bottom-start"
+          :show-close-button="false"
           :visually-hidden-close="true"
           :visually-hidden-close-label="'Close link input popover'"
           data-qa="dt-recipe-editor-link-input-popover"
-          :show-close-button="false"
+          padding="none"
+          placement="bottom-start"
           @click="onInputFocus"
-          @click.stop="onInputFocus"
           @opened="updateInput"
+          @click.stop="onInputFocus"
         >
           <template #anchor>
             <dt-tooltip
@@ -71,22 +71,18 @@
             >
               <template #anchor>
                 <dt-button
+                  :active="$refs.richTextEditor?.editor?.isActive(linkButton.selector)"
+                  :aria-label="linkButton.tooltipMessage"
                   :data-qa="linkButton.dataQA"
                   importance="clear"
                   kind="muted"
-                  class="d-ol-none"
-                  :active="
-                    $refs.richTextEditor?.editor?.isActive(linkButton.selector)
-                  "
                   size="xs"
-                  :aria-label="linkButton.tooltipMessage"
                   @click="linkButton.onClick()"
                 >
                   <template #icon>
                     <component
                       :is="linkButton.icon"
                       size="200"
-                      class="d-fw-bold"
                     />
                   </template>
                 </dt-button>
@@ -95,55 +91,60 @@
           </template>
 
           <template #content>
-            <span v-if="showAddLink.setLinkTitle.length > 0">
-              {{ showAddLink.setLinkTitle }}
-            </span>
-            <dt-input
-              v-model="linkInput"
-              :input-aria-label="showAddLink.setLinkInputAriaLabel"
-              data-qa="dt-recipe-editor-link-input"
-              :placeholder="setLinkPlaceholder"
-              input-wrapper-class="d-bgc-secondary d-mt6 d-bar5 d-ba d-baw1 d-bc-default d-py2 d-ol-none"
-              @click="onInputFocus"
-              @click.stop="onInputFocus"
-              @focus="onInputFocus"
-              @keydown.enter="setLink"
-            />
+            <div class="d-recipe-editor__popover-content">
+              <span
+                v-if="showAddLink.setLinkTitle.length > 0"
+              >
+                {{ showAddLink.setLinkTitle }}
+              </span>
+              <dt-input
+                v-model="linkInput"
+                :input-aria-label="showAddLink.setLinkInputAriaLabel"
+                :placeholder="setLinkPlaceholder"
+                data-qa="dt-recipe-editor-link-input"
+                input-wrapper-class="d-recipe-editor-link__input-wrapper"
+                @click="onInputFocus"
+                @focus="onInputFocus"
+                @click.stop="onInputFocus"
+                @keydown.enter="setLink"
+              />
+            </div>
           </template>
           <template #footerContent>
-            <div class="d-ml8 d-mr12">
+            <dt-stack
+              direction="row"
+              gap="300"
+              class="d-recipe-editor__popover-footer"
+            >
               <dt-button
-                class="d-mx2"
                 :aria-label="removeLinkButton.ariaLabel"
+                data-qa="dt-recipe-editor-remove-link-btn"
                 importance="clear"
                 kind="muted"
                 size="sm"
-                data-qa="dt-recipe-editor-remove-link-btn"
                 @click="removeLink"
               >
                 {{ removeLinkButton.label }}
               </dt-button>
               <dt-button
-                class="d-mx2"
                 :aria-label="cancelSetLinkButton.ariaLabel"
+                data-qa="dt-recipe-editor-set-link-cancel-btn"
                 importance="clear"
                 kind="muted"
                 size="sm"
-                data-qa="dt-recipe-editor-set-link-cancel-btn"
                 @click="closeLinkInput"
               >
                 {{ cancelSetLinkButton.label }}
               </dt-button>
               <dt-button
-                class="d-mx2"
-                size="sm"
                 :aria-label="confirmSetLinkButton.ariaLabel"
                 data-qa="dt-recipe-editor-set-link-confirm-btn"
+                size="sm"
                 @click="setLink"
               >
                 {{ confirmSetLinkButton.label }}
               </dt-button>
-            </div>
+            </dt-stack>
           </template>
         </dt-popover>
       </dt-stack>
@@ -151,25 +152,25 @@
 
     <!-- Some wrapper to restrict the height and show the scrollbar -->
     <div
-      class="d-of-auto d-mx12 d-mt12 d-mb16 d-c-text"
       :style="{ 'max-height': maxHeight }"
+      class="d-recipe-editor__content"
     >
       <dt-rich-text-editor
         ref="richTextEditor"
         v-model="internalInputValue"
-        data-qa="dt-rich-text-editor"
+        :allow-inline-images="true"
+        :allow-line-breaks="true"
+        :auto-focus="autoFocus"
         :editable="editable"
         :input-aria-label="inputAriaLabel"
-        :input-class="`d-ml16 d-ol-none d-my6 ${inputClass}`"
-        :output-format="htmlOutputFormat"
-        :auto-focus="autoFocus"
-        :placeholder="placeholder"
-        :allow-line-breaks="true"
-        :allow-inline-images="true"
+        :input-class="`d-recipe-editor__content-input ${inputClass}`"
         :link="true"
+        :output-format="htmlOutputFormat"
+        :placeholder="placeholder"
+        data-qa="dt-rich-text-editor"
         v-bind="$attrs"
-        @focus="onFocus"
         @blur="onBlur"
+        @focus="onFocus"
         @input="onInput($event)"
       />
     </div>
@@ -500,7 +501,7 @@ export default {
       hasFocus: false,
 
       linkOptions: {
-        class: 'd-link d-c-text d-d-inline-block',
+        class: 'd-recipe-editor__link',
       },
 
       showLinkInput: false,
@@ -518,21 +519,12 @@ export default {
     },
 
     showingTextFormatButtons () {
-      return (
-        this.showBoldButton ||
-        this.showItalicsButton ||
-        this.showStrikeButton ||
-        this.showUnderlineButton
-      );
+      return this.showBoldButton || this.showItalicsButton || this.showStrikeButton || this.showUnderlineButton;
     },
 
     showingAlignmentButtons () {
-      return (
-        this.showAlignLeftButton ||
-        this.showAlignCenterButton ||
-        this.showAlignRightButton ||
-        this.showAlignJustifyButton
-      );
+      return this.showAlignLeftButton || this.showAlignCenterButton ||
+        this.showAlignRightButton || this.showAlignJustifyButton;
     },
 
     showingListButtons () {
@@ -540,19 +532,17 @@ export default {
     },
 
     buttonGroups () {
-      const individualButtonStacks = this.individualButtons.map(
-        (buttonData) => ({
-          key: buttonData.selector,
-          buttonGroup: [buttonData],
-        }),
-      );
+      const individualButtonStacks = this.individualButtons.map(buttonData => ({
+        key: buttonData.selector,
+        buttonGroup: [buttonData],
+      }));
       return [
         { key: 'new', buttonGroup: this.newButtons },
         { key: 'format', buttonGroup: this.textFormatButtons },
         { key: 'alignment', buttonGroup: this.alignmentButtons },
         { key: 'list', buttonGroup: this.listButtons },
         ...individualButtonStacks,
-      ].filter((buttonGroupData) => buttonGroupData.buttonGroup.length > 0);
+      ].filter(buttonGroupData => buttonGroupData.buttonGroup.length > 0);
     },
 
     newButtons () {
@@ -566,7 +556,7 @@ export default {
           tooltipMessage: 'Quick Reply',
           onClick: this.onQuickRepliesClick,
         },
-      ].filter((button) => button.showBtn);
+      ].filter(button => button.showBtn);
     },
 
     textFormatButtons () {
@@ -603,7 +593,7 @@ export default {
           tooltipMessage: 'Strike',
           onClick: this.onStrikethroughTextToggle,
         },
-      ].filter((button) => button.showBtn);
+      ].filter(button => button.showBtn);
     },
 
     alignmentButtons () {
@@ -640,7 +630,7 @@ export default {
           tooltipMessage: 'Align Justify',
           onClick: () => this.onTextAlign('justify'),
         },
-      ].filter((button) => button.showBtn);
+      ].filter(button => button.showBtn);
     },
 
     listButtons () {
@@ -661,7 +651,7 @@ export default {
           tooltipMessage: 'Ordered List',
           onClick: this.onOrderedListToggle,
         },
-      ].filter((button) => button.showBtn);
+      ].filter(button => button.showBtn);
     },
 
     individualButtons () {
@@ -682,7 +672,7 @@ export default {
           tooltipMessage: 'Code',
           onClick: this.onCodeBlockToggle,
         },
-      ].filter((button) => button.showBtn);
+      ].filter(button => button.showBtn);
     },
 
     linkButton () {
@@ -726,9 +716,7 @@ export default {
       }
 
       // Check if input matches any of the supported link formats
-      const prefix = EDITOR_SUPPORTED_LINK_PROTOCOLS.find((prefixRegex) =>
-        prefixRegex.test(this.linkInput),
-      );
+      const prefix = EDITOR_SUPPORTED_LINK_PROTOCOLS.find(prefixRegex => prefixRegex.test(this.linkInput));
 
       if (!prefix) {
         // If no matching pattern is found, prepend default prefix
@@ -746,7 +734,7 @@ export default {
           .focus()
           .insertContentAt(
             selection.anchor,
-            `<a class="${this.linkOptions.class}" href=${this.linkInput}>${this.linkInput}</a>`,
+          `<a class="${this.linkOptions.class}" href=${this.linkInput}>${this.linkInput}</a>`,
           )
           .run();
       } else {
@@ -770,8 +758,7 @@ export default {
       if (!openedInput) {
         return this.closeLinkInput();
       }
-      this.linkInput =
-        this.$refs.richTextEditor?.editor?.getAttributes('link')?.href;
+      this.linkInput = this.$refs.richTextEditor?.editor?.getAttributes('link')?.href;
     },
 
     closeLinkInput () {
@@ -797,37 +784,19 @@ export default {
     },
 
     onTextAlign (alignment) {
-      if (
-        this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })
-      ) {
+      if (this.$refs.richTextEditor?.editor?.isActive({ textAlign: alignment })) {
         // If this alignment type is already set here, unset it
-        return this.$refs.richTextEditor?.editor
-          .chain()
-          .focus()
-          .unsetTextAlign()
-          .run();
+        return this.$refs.richTextEditor?.editor.chain().focus().unsetTextAlign().run();
       }
-      this.$refs.richTextEditor?.editor
-        .chain()
-        .focus()
-        .setTextAlign(alignment)
-        .run();
+      this.$refs.richTextEditor?.editor.chain().focus().setTextAlign(alignment).run();
     },
 
     onBulletListToggle () {
-      this.$refs.richTextEditor?.editor
-        .chain()
-        .focus()
-        .toggleBulletList()
-        .run();
+      this.$refs.richTextEditor?.editor.chain().focus().toggleBulletList().run();
     },
 
     onOrderedListToggle () {
-      this.$refs.richTextEditor?.editor
-        .chain()
-        .focus()
-        .toggleOrderedList()
-        .run();
+      this.$refs.richTextEditor?.editor.chain().focus().toggleOrderedList().run();
     },
 
     onCodeBlockToggle () {
@@ -839,11 +808,7 @@ export default {
     },
 
     onBlockquoteToggle () {
-      this.$refs.richTextEditor?.editor
-        .chain()
-        .focus()
-        .toggleBlockquote()
-        .run();
+      this.$refs.richTextEditor?.editor.chain().focus().toggleBlockquote().run();
     },
 
     onFocus (event) {
@@ -859,6 +824,7 @@ export default {
     onInput (event) {
       this.$emit('input', event);
     },
+
   },
 };
 </script>

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -7,7 +7,7 @@
     >
       <dt-tooltip
         class="d-recipe-emoji-row__tooltip"
-        content-class="d-wmx464"
+        content-class="d-recipe-emoji-row__tooltip-content"
         sticky="popper"
         @shown="(shown) => emojiHovered(reaction, shown)"
       >

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_pill/feed_item_pill.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_pill/feed_item_pill.vue
@@ -142,7 +142,7 @@ export default {
     },
 
     toggleableClass () {
-      return this.toggleable ? 'd-c-pointer' : '';
+      return this.toggleable ? 'd-recipe-feed-item-pill--toggleable' : '';
     },
 
     borderClass () {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-restricted-class -->
 <template>
   <div
     data-qa="dt-recipe-message-input"
@@ -136,7 +135,7 @@
           gap="300"
         >
           <!-- @slot Slot for sms count -->
-          <div class="d-d-flex d-ai-center">
+          <div class="d-recipe-message-input__sms-count">
             <slot name="smsCount" />
           </div>
 

--- a/packages/dialtone-vue3/recipes/item_layout/contact_info/contact_info.vue
+++ b/packages/dialtone-vue3/recipes/item_layout/contact_info/contact_info.vue
@@ -27,7 +27,12 @@
             :image-src="avatar.src"
             image-alt=""
             :overlay-text="avatar.text"
-            :avatar-class="[{ 'd-mln24': index > 0, 'd-bc-brand': !!avatar.halo }]"
+            :avatar-class="[
+              {
+                'd-recipe-contact-info__avatar-stacked': index > 0,
+                'd-recipe-contact-info__avatar-halo': !!avatar.halo,
+              },
+            ]"
           >
             <template
               #icon="{ iconSize }"

--- a/packages/dialtone-vue3/recipes/leftbar/contact_row/contact_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_row/contact_row.vue
@@ -46,7 +46,7 @@
         <span
           v-if="presenceText"
           data-qa="dt-recipe-leftbar-row-presence-text"
-          :class="['d-recipe-leftbar-row__meta-context', presenceColorClass]"
+          :class="['d-recipe-leftbar-row__meta-context', presenceFontColorClass]"
         >
           {{ presenceText }}
         </span>
@@ -230,17 +230,14 @@ export default {
   ],
 
   computed: {
-    presenceColorClass () {
-      switch (this.avatarPresence) {
-        case 'active':
-          return 'd-fc-success';
-        case 'busy':
-          return 'd-fc-critical';
-        case 'away':
-          return 'd-fc-warning';
-        default:
-          return undefined;
-      }
+    presenceFontColorClass () {
+      const presenceFontColors = {
+        active: 'd-recipe-contact-row--active',
+        busy: 'd-recipe-contact-row--busy',
+        away: 'd-recipe-contact-row--away',
+      };
+
+      return presenceFontColors[this.avatarPresence];
     },
 
     contactRowListeners () {

--- a/packages/dialtone-vue3/recipes/leftbar/general_row/general_row_constants.js
+++ b/packages/dialtone-vue3/recipes/leftbar/general_row/general_row_constants.js
@@ -16,17 +16,17 @@ export const LEFTBAR_GENERAL_ROW_TYPES = {
 };
 
 export const LEFTBAR_GENERAL_ROW_CONTACT_CENTER_COLORS = {
-  'magenta-200': 'd-bgc-magenta-200',
-  'green-200': 'd-bgc-green-200',
-  'gold-300': 'd-bgc-gold-300',
-  'purple-600': 'd-bgc-purple-600',
-  'magenta-300': 'd-bgc-magenta-300',
-  'purple-300': 'd-bgc-purple-300',
-  'green-500': 'd-bgc-green-500',
-  'purple-100': 'd-bgc-purple-100',
-  'magenta-400': 'd-bgc-magenta-400',
-  'magenta-100': 'd-bgc-magenta-100',
-  'black-300': 'd-bgc-black-300',
+  'magenta-100': 'd-recipe-leftbar-general-row__contact-center--magenta-100',
+  'magenta-200': 'd-recipe-leftbar-general-row__contact-center--magenta-200',
+  'magenta-300': 'd-recipe-leftbar-general-row__contact-center--magenta-300',
+  'magenta-400': 'd-recipe-leftbar-general-row__contact-center--magenta-400',
+  'green-200': 'd-recipe-leftbar-general-row__contact-center--green-200',
+  'green-500': 'd-recipe-leftbar-general-row__contact-center--green-500',
+  'gold-300': 'd-recipe-leftbar-general-row__contact-center--gold-300',
+  'purple-100': 'd-recipe-leftbar-general-row__contact-center--purple-100',
+  'purple-300': 'd-recipe-leftbar-general-row__contact-center--purple-300',
+  'purple-600': 'd-recipe-leftbar-general-row__contact-center--purple-600',
+  'black-300': 'd-recipe-leftbar-general-row__contact-center--black-300',
 };
 
 export const LEFTBAR_GENERAL_ROW_CONTACT_CENTER_VALIDATION_ERROR = 'If type is contact center, color must be one' +

--- a/packages/dialtone-vue3/recipes/leftbar/general_row/leftbar_general_row_icon.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/general_row/leftbar_general_row_icon.vue
@@ -10,7 +10,7 @@
   />
   <div
     v-else-if="isDialbotType"
-    :class="dialbotClasses"
+    class="d-recipe-leftbar-general-row__icon"
     data-qa="general-row-dialbot"
   >
     <dt-icon-dialbot
@@ -117,14 +117,6 @@ export default {
       return [
         'd-recipe-leftbar-row__icon-cc',
         COLORS[this.color],
-      ];
-    },
-
-    dialbotClasses () {
-      return [
-        'd-d-flex',
-        'd-ai-center',
-        'd-jc-center',
       ];
     },
   },

--- a/packages/dialtone-vue3/recipes/notices/top_banner_info/top_banner_info.test.js
+++ b/packages/dialtone-vue3/recipes/notices/top_banner_info/top_banner_info.test.js
@@ -70,7 +70,7 @@ describe('DtRecipeTopBannerInfo Tests', function () {
         expect(middleContent.text()).toBe(slots.default);
       });
       it('Should display with default background color', () => {
-        expect(rootElement.classes()).toContain('d-bgc-success');
+        expect(rootElement.classes()).toContain('d-recipe-top-banner-info--success');
       });
     });
 
@@ -80,7 +80,7 @@ describe('DtRecipeTopBannerInfo Tests', function () {
       });
 
       it('Should display with passed background color', () => {
-        expect(rootElement.classes()).toContain('d-bgc-info');
+        expect(rootElement.classes()).toContain('d-recipe-top-banner-info--info');
       });
     });
   });

--- a/packages/dialtone-vue3/recipes/notices/top_banner_info/top_banner_info.vue
+++ b/packages/dialtone-vue3/recipes/notices/top_banner_info/top_banner_info.vue
@@ -45,14 +45,14 @@ export default {
       const bgColors = {
         // these are too specific, so for now I'm at least updating the resultant semantic value
         // TODO: breaking change: update to be more abstract
-        green300: 'd-bgc-success',
-        green100: 'd-bgc-success',
-        red200: 'd-bgc-critical',
-        red100: 'd-bgc-critical',
-        gold200: 'd-bgc-warning',
-        gold100: 'd-bgc-warning',
-        black100: 'd-bgc-info',
-        white: 'd-bgc-primary',
+        green100: 'd-recipe-top-banner-info--success',
+        green300: 'd-recipe-top-banner-info--success',
+        red100: 'd-recipe-top-banner-info--critical',
+        red200: 'd-recipe-top-banner-info--critical',
+        gold100: 'd-recipe-top-banner-info--warning',
+        gold200: 'd-recipe-top-banner-info--warning',
+        black100: 'd-recipe-top-banner-info--info',
+        white: 'd-recipe-top-banner-info--primary',
       };
       return [bgColors[this.colorCode]];
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -778,6 +778,15 @@ importers:
       '@dialpad/generator-dialtone':
         specifier: workspace:*
         version: link:../../generator-dialtone
+      '@storybook/addon-a11y':
+        specifier: 7.6.20
+        version: 7.6.20
+      '@storybook/addon-essentials':
+        specifier: 7.6.20
+        version: 7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addon-links':
+        specifier: 7.6.20
+        version: 7.6.20(react@17.0.2)
       '@storybook/vue':
         specifier: 7.6.20
         version: 7.6.20(@babel/core@7.23.2)(css-loader@6.8.1(webpack@5.95.0(@swc/core@1.3.96)(esbuild@0.18.20)))(encoding@0.1.13)(vue@2.7.16)
@@ -787,6 +796,9 @@ importers:
       '@vue/test-utils':
         specifier: '1.3'
         version: 1.3.6(vue-template-compiler@2.7.16(vue@2.7.16))(vue@2.7.16)
+      storybook-dark-mode:
+        specifier: ^3.0.3
+        version: 3.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       vue:
         specifier: ^2.7.15
         version: 2.7.16
@@ -890,6 +902,15 @@ importers:
       '@dialpad/generator-dialtone':
         specifier: workspace:*
         version: link:../../generator-dialtone
+      '@storybook/addon-a11y':
+        specifier: 7.6.20
+        version: 7.6.20
+      '@storybook/addon-essentials':
+        specifier: 7.6.20
+        version: 7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addon-links':
+        specifier: 7.6.20
+        version: 7.6.20(react@17.0.2)
       '@storybook/vue3':
         specifier: 7.6.20
         version: 7.6.20(encoding@0.1.13)(vue@3.4.15(typescript@5.6.3))
@@ -899,6 +920,9 @@ importers:
       '@vue/test-utils':
         specifier: ^2.4.0
         version: 2.4.2(@vue/server-renderer@3.4.15(vue@3.4.15(typescript@5.6.3)))(vue@3.4.15(typescript@5.6.3))
+      storybook-dark-mode:
+        specifier: ^3.0.3
+        version: 3.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       vue:
         specifier: ^3.3.4
         version: 3.4.15(typescript@5.6.3)
@@ -15989,8 +16013,8 @@ packages:
   vue-component-type-helpers@1.8.24:
     resolution: {integrity: sha512-lqWs/7fdRXoSBAlbouHBX+LNuaY6gI9xWW34m/ZIz9zVPYHEyw0b2/zaCBwlKx0NtKTeF/6pOpvrxVkh7nhIYg==}
 
-  vue-component-type-helpers@2.1.10:
-    resolution: {integrity: sha512-lfgdSLQKrUmADiSV6PbBvYgQ33KF3Ztv6gP85MfGaGaSGMTXORVaHT1EHfsqCgzRNBstPKYDmvAV9Do5CmJ07A==}
+  vue-component-type-helpers@2.2.0:
+    resolution: {integrity: sha512-cYrAnv2me7bPDcg9kIcGwjJiSB6Qyi08+jLDo9yuvoFQjzHiPTzML7RnkJB1+3P6KMsX/KbCD4QE3Tv/knEllw==}
 
   vue-demi@0.14.7:
     resolution: {integrity: sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==}
@@ -17748,6 +17772,10 @@ snapshots:
     dependencies:
       react: 16.14.0
 
+  '@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@17.0.2)':
+    dependencies:
+      react: 17.0.2
+
   '@es-joy/jsdoccomment@0.36.1':
     dependencies:
       comment-parser: 1.3.1
@@ -18150,6 +18178,12 @@ snapshots:
       '@floating-ui/dom': 1.5.3
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
+
+  '@floating-ui/react-dom@2.0.4(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@floating-ui/dom': 1.5.3
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
 
   '@floating-ui/utils@0.1.6': {}
 
@@ -18741,6 +18775,12 @@ snapshots:
       '@types/mdx': 2.0.10
       '@types/react': 17.0.83
       react: 16.14.0
+
+  '@mdx-js/react@2.3.0(react@17.0.2)':
+    dependencies:
+      '@types/mdx': 2.0.10
+      '@types/react': 17.0.83
+      react: 17.0.2
 
   '@microsoft/api-extractor-model@7.29.4(@types/node@20.16.5)':
     dependencies:
@@ -19421,6 +19461,16 @@ snapshots:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
 
+  '@radix-ui/react-arrow@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
   '@radix-ui/react-collection@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
@@ -19434,10 +19484,30 @@ snapshots:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
 
+  '@radix-ui/react-collection@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.37)(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
   '@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.37)(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
       react: 16.14.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+
+  '@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      react: 17.0.2
     optionalDependencies:
       '@types/react': 18.2.37
 
@@ -19448,10 +19518,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.37
 
+  '@radix-ui/react-context@1.0.1(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      react: 17.0.2
+    optionalDependencies:
+      '@types/react': 18.2.37
+
   '@radix-ui/react-direction@1.0.1(@types/react@18.2.37)(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
       react: 16.14.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+
+  '@radix-ui/react-direction@1.0.1(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      react: 17.0.2
     optionalDependencies:
       '@types/react': 18.2.37
 
@@ -19469,10 +19553,31 @@ snapshots:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
 
+  '@radix-ui/react-dismissable-layer@1.0.4(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.2.37)(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
   '@radix-ui/react-focus-guards@1.0.1(@types/react@18.2.37)(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
       react: 16.14.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+
+  '@radix-ui/react-focus-guards@1.0.1(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      react: 17.0.2
     optionalDependencies:
       '@types/react': 18.2.37
 
@@ -19488,11 +19593,31 @@ snapshots:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
 
+  '@radix-ui/react-focus-scope@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
   '@radix-ui/react-id@1.0.1(@types/react@18.2.37)(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.37)(react@16.14.0)
       react: 16.14.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+
+  '@radix-ui/react-id@1.0.1(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      react: 17.0.2
     optionalDependencies:
       '@types/react': 18.2.37
 
@@ -19515,6 +19640,25 @@ snapshots:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
 
+  '@radix-ui/react-popper@1.1.2(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@floating-ui/react-dom': 2.0.4(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-use-rect': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/rect': 1.0.1
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
   '@radix-ui/react-portal@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
@@ -19525,12 +19669,32 @@ snapshots:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
 
+  '@radix-ui/react-portal@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
   '@radix-ui/react-primitive@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
       '@radix-ui/react-slot': 1.0.2(@types/react@18.2.37)(react@16.14.0)
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
+  '@radix-ui/react-primitive@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.37)(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     optionalDependencies:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
@@ -19549,6 +19713,24 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.37)(react@16.14.0)
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
+  '@radix-ui/react-roving-focus@1.0.4(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     optionalDependencies:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
@@ -19583,6 +19765,36 @@ snapshots:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
 
+  '@radix-ui/react-select@1.2.2(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/number': 1.0.1
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-popper': 1.1.2(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-portal': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      aria-hidden: 1.2.3
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      react-remove-scroll: 2.5.5(@types/react@18.2.37)(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
   '@radix-ui/react-separator@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
@@ -19593,11 +19805,29 @@ snapshots:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
 
+  '@radix-ui/react-separator@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
   '@radix-ui/react-slot@1.0.2(@types/react@18.2.37)(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@16.14.0)
       react: 16.14.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+
+  '@radix-ui/react-slot@1.0.2(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      react: 17.0.2
     optionalDependencies:
       '@types/react': 18.2.37
 
@@ -19617,6 +19847,22 @@ snapshots:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
 
+  '@radix-ui/react-toggle-group@1.0.4(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-toggle': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
   '@radix-ui/react-toggle@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
@@ -19625,6 +19871,18 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.37)(react@16.14.0)
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
+  '@radix-ui/react-toggle@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     optionalDependencies:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
@@ -19645,10 +19903,33 @@ snapshots:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
 
+  '@radix-ui/react-toolbar@1.0.4(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-separator': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-toggle-group': 1.0.4(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
   '@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.37)(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
       react: 16.14.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+
+  '@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      react: 17.0.2
     optionalDependencies:
       '@types/react': 18.2.37
 
@@ -19660,11 +19941,27 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.37
 
+  '@radix-ui/react-use-controllable-state@1.0.1(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      react: 17.0.2
+    optionalDependencies:
+      '@types/react': 18.2.37
+
   '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.2.37)(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.37)(react@16.14.0)
       react: 16.14.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+
+  '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      react: 17.0.2
     optionalDependencies:
       '@types/react': 18.2.37
 
@@ -19675,10 +19972,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.37
 
+  '@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      react: 17.0.2
+    optionalDependencies:
+      '@types/react': 18.2.37
+
   '@radix-ui/react-use-previous@1.0.1(@types/react@18.2.37)(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
       react: 16.14.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+
+  '@radix-ui/react-use-previous@1.0.1(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      react: 17.0.2
     optionalDependencies:
       '@types/react': 18.2.37
 
@@ -19690,11 +20001,27 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.37
 
+  '@radix-ui/react-use-rect@1.0.1(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/rect': 1.0.1
+      react: 17.0.2
+    optionalDependencies:
+      '@types/react': 18.2.37
+
   '@radix-ui/react-use-size@1.0.1(@types/react@18.2.37)(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.23.2
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.37)(react@16.14.0)
       react: 16.14.0
+    optionalDependencies:
+      '@types/react': 18.2.37
+
+  '@radix-ui/react-use-size@1.0.1(@types/react@18.2.37)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.37)(react@17.0.2)
+      react: 17.0.2
     optionalDependencies:
       '@types/react': 18.2.37
 
@@ -19704,6 +20031,16 @@ snapshots:
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
+    optionalDependencies:
+      '@types/react': 18.2.37
+      '@types/react-dom': 17.0.25
+
+  '@radix-ui/react-visually-hidden@1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     optionalDependencies:
       '@types/react': 18.2.37
       '@types/react-dom': 17.0.25
@@ -20273,6 +20610,19 @@ snapshots:
       - react-dom
       - supports-color
 
+  '@storybook/addon-controls@7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@storybook/blocks': 7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      lodash: 4.17.21
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - encoding
+      - react
+      - react-dom
+      - supports-color
+
   '@storybook/addon-docs@7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(encoding@0.1.13)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@jest/transform': 29.7.0
@@ -20293,6 +20643,35 @@ snapshots:
       fs-extra: 11.1.1
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
+      remark-external-links: 8.0.0
+      remark-slug: 6.1.0
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - encoding
+      - supports-color
+
+  '@storybook/addon-docs@7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@jest/transform': 29.7.0
+      '@mdx-js/react': 2.3.0(react@17.0.2)
+      '@storybook/blocks': 7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/client-logger': 7.6.20
+      '@storybook/components': 7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/csf-plugin': 7.6.20
+      '@storybook/csf-tools': 7.6.20
+      '@storybook/global': 5.0.0
+      '@storybook/mdx2-csf': 1.1.0
+      '@storybook/node-logger': 7.6.20
+      '@storybook/postinstall': 7.6.20
+      '@storybook/preview-api': 7.6.20
+      '@storybook/react-dom-shim': 7.6.20(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 7.6.20(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/types': 7.6.20
+      fs-extra: 11.1.1
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
       remark-external-links: 8.0.0
       remark-slug: 6.1.0
       ts-dedent: 2.2.0
@@ -20326,6 +20705,30 @@ snapshots:
       - encoding
       - supports-color
 
+  '@storybook/addon-essentials@7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@storybook/addon-actions': 7.6.20
+      '@storybook/addon-backgrounds': 7.6.20
+      '@storybook/addon-controls': 7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addon-docs': 7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addon-highlight': 7.6.20
+      '@storybook/addon-measure': 7.6.20
+      '@storybook/addon-outline': 7.6.20
+      '@storybook/addon-toolbars': 7.6.20
+      '@storybook/addon-viewport': 7.6.20
+      '@storybook/core-common': 7.6.20(encoding@0.1.13)
+      '@storybook/manager-api': 7.6.20(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/node-logger': 7.6.20
+      '@storybook/preview-api': 7.6.20
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - encoding
+      - supports-color
+
   '@storybook/addon-highlight@7.6.20':
     dependencies:
       '@storybook/global': 5.0.0
@@ -20337,6 +20740,14 @@ snapshots:
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 16.14.0
+
+  '@storybook/addon-links@7.6.20(react@17.0.2)':
+    dependencies:
+      '@storybook/csf': 0.1.2
+      '@storybook/global': 5.0.0
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      react: 17.0.2
 
   '@storybook/addon-mdx-gfm@7.6.20':
     dependencies:
@@ -20370,6 +20781,14 @@ snapshots:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
 
+  '@storybook/addons@7.5.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@storybook/manager-api': 7.5.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/preview-api': 7.5.3
+      '@storybook/types': 7.5.3
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+
   '@storybook/blocks@7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(encoding@0.1.13)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@storybook/channels': 7.6.20
@@ -20393,6 +20812,39 @@ snapshots:
       react: 16.14.0
       react-colorful: 5.6.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       react-dom: 16.14.0(react@16.14.0)
+      telejson: 7.2.0
+      tocbot: 4.22.0
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - encoding
+      - supports-color
+
+  '@storybook/blocks@7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@storybook/channels': 7.6.20
+      '@storybook/client-logger': 7.6.20
+      '@storybook/components': 7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/core-events': 7.6.20
+      '@storybook/csf': 0.1.2
+      '@storybook/docs-tools': 7.6.20(encoding@0.1.13)
+      '@storybook/global': 5.0.0
+      '@storybook/manager-api': 7.6.20(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/preview-api': 7.6.20
+      '@storybook/theming': 7.6.20(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/types': 7.6.20
+      '@types/lodash': 4.14.201
+      color-convert: 2.0.1
+      dequal: 2.0.3
+      lodash: 4.17.21
+      markdown-to-jsx: 7.3.2(react@17.0.2)
+      memoizerific: 1.11.3
+      polished: 4.2.2
+      react: 17.0.2
+      react-colorful: 5.6.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react-dom: 17.0.2(react@17.0.2)
       telejson: 7.2.0
       tocbot: 4.22.0
       ts-dedent: 2.2.0
@@ -20561,6 +21013,24 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  '@storybook/components@7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@radix-ui/react-select': 1.2.2(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@radix-ui/react-toolbar': 1.0.4(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/client-logger': 7.6.20
+      '@storybook/csf': 0.1.2
+      '@storybook/global': 5.0.0
+      '@storybook/theming': 7.6.20(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/types': 7.6.20
+      memoizerific: 1.11.3
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      use-resize-observer: 9.1.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      util-deprecate: 1.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
   '@storybook/core-client@7.6.20':
     dependencies:
       '@storybook/client-logger': 7.6.20
@@ -20717,6 +21187,26 @@ snapshots:
       telejson: 7.2.0
       ts-dedent: 2.2.0
 
+  '@storybook/manager-api@7.5.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@storybook/channels': 7.5.3
+      '@storybook/client-logger': 7.5.3
+      '@storybook/core-events': 7.5.3
+      '@storybook/csf': 0.1.2
+      '@storybook/global': 5.0.0
+      '@storybook/router': 7.5.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 7.5.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/types': 7.5.3
+      dequal: 2.0.3
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      semver: 7.6.3
+      store2: 2.14.2
+      telejson: 7.2.0
+      ts-dedent: 2.2.0
+
   '@storybook/manager-api@7.6.20(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@storybook/channels': 7.6.20
@@ -20726,6 +21216,26 @@ snapshots:
       '@storybook/global': 5.0.0
       '@storybook/router': 7.6.20
       '@storybook/theming': 7.6.20(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@storybook/types': 7.6.20
+      dequal: 2.0.3
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      store2: 2.14.2
+      telejson: 7.2.0
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@storybook/manager-api@7.6.20(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@storybook/channels': 7.6.20
+      '@storybook/client-logger': 7.6.20
+      '@storybook/core-events': 7.6.20
+      '@storybook/csf': 0.1.2
+      '@storybook/global': 5.0.0
+      '@storybook/router': 7.6.20
+      '@storybook/theming': 7.6.20(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@storybook/types': 7.6.20
       dequal: 2.0.3
       lodash: 4.17.21
@@ -20786,6 +21296,11 @@ snapshots:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
 
+  '@storybook/react-dom-shim@7.6.20(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+
   '@storybook/router@7.5.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@storybook/client-logger': 7.5.3
@@ -20793,6 +21308,14 @@ snapshots:
       qs: 6.12.3
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
+
+  '@storybook/router@7.5.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@storybook/client-logger': 7.5.3
+      memoizerific: 1.11.3
+      qs: 6.12.3
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
 
   '@storybook/router@7.6.20':
     dependencies:
@@ -20869,6 +21392,15 @@ snapshots:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
 
+  '@storybook/theming@7.5.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@17.0.2)
+      '@storybook/client-logger': 7.5.3
+      '@storybook/global': 5.0.0
+      memoizerific: 1.11.3
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+
   '@storybook/theming@7.6.20(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@16.14.0)
@@ -20877,6 +21409,15 @@ snapshots:
       memoizerific: 1.11.3
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
+
+  '@storybook/theming@7.6.20(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@17.0.2)
+      '@storybook/client-logger': 7.6.20
+      '@storybook/global': 5.0.0
+      memoizerific: 1.11.3
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
 
   '@storybook/types@7.5.3':
     dependencies:
@@ -20945,7 +21486,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.15(typescript@5.6.3)
-      vue-component-type-helpers: 2.1.10
+      vue-component-type-helpers: 2.2.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -29191,6 +29732,10 @@ snapshots:
     dependencies:
       react: 16.14.0
 
+  markdown-to-jsx@7.3.2(react@17.0.2):
+    dependencies:
+      react: 17.0.2
+
   markdownlint-cli@0.35.0:
     dependencies:
       commander: 11.0.0
@@ -32249,6 +32794,11 @@ snapshots:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
 
+  react-colorful@5.6.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+    dependencies:
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+
   react-dom@16.14.0(react@16.14.0):
     dependencies:
       loose-envify: 1.4.0
@@ -32263,7 +32813,6 @@ snapshots:
       object-assign: 4.1.1
       react: 17.0.2
       scheduler: 0.20.2
-    optional: true
 
   react-is@16.13.1: {}
 
@@ -32279,6 +32828,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.37
 
+  react-remove-scroll-bar@2.3.4(@types/react@18.2.37)(react@17.0.2):
+    dependencies:
+      react: 17.0.2
+      react-style-singleton: 2.2.1(@types/react@18.2.37)(react@17.0.2)
+      tslib: 2.6.2
+    optionalDependencies:
+      '@types/react': 18.2.37
+
   react-remove-scroll@2.5.5(@types/react@18.2.37)(react@16.14.0):
     dependencies:
       react: 16.14.0
@@ -32290,11 +32847,31 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.37
 
+  react-remove-scroll@2.5.5(@types/react@18.2.37)(react@17.0.2):
+    dependencies:
+      react: 17.0.2
+      react-remove-scroll-bar: 2.3.4(@types/react@18.2.37)(react@17.0.2)
+      react-style-singleton: 2.2.1(@types/react@18.2.37)(react@17.0.2)
+      tslib: 2.6.2
+      use-callback-ref: 1.3.0(@types/react@18.2.37)(react@17.0.2)
+      use-sidecar: 1.1.2(@types/react@18.2.37)(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 18.2.37
+
   react-style-singleton@2.2.1(@types/react@18.2.37)(react@16.14.0):
     dependencies:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 16.14.0
+      tslib: 2.6.2
+    optionalDependencies:
+      '@types/react': 18.2.37
+
+  react-style-singleton@2.2.1(@types/react@18.2.37)(react@17.0.2):
+    dependencies:
+      get-nonce: 1.0.1
+      invariant: 2.2.4
+      react: 17.0.2
       tslib: 2.6.2
     optionalDependencies:
       '@types/react': 18.2.37
@@ -32309,7 +32886,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    optional: true
 
   read-cache@1.0.0:
     dependencies:
@@ -32886,7 +33462,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    optional: true
 
   schema-utils@3.3.0:
     dependencies:
@@ -33534,6 +34109,23 @@ snapshots:
     optionalDependencies:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  storybook-dark-mode@3.0.3(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+    dependencies:
+      '@storybook/addons': 7.5.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/components': 7.6.20(@types/react-dom@17.0.25)(@types/react@18.2.37)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/core-events': 7.6.20
+      '@storybook/global': 5.0.0
+      '@storybook/manager-api': 7.6.20(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 7.6.20(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      fast-deep-equal: 3.1.3
+      memoizerific: 1.11.3
+    optionalDependencies:
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -34853,16 +35445,37 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.37
 
+  use-callback-ref@1.3.0(@types/react@18.2.37)(react@17.0.2):
+    dependencies:
+      react: 17.0.2
+      tslib: 2.6.2
+    optionalDependencies:
+      '@types/react': 18.2.37
+
   use-resize-observer@9.1.0(react-dom@16.14.0(react@16.14.0))(react@16.14.0):
     dependencies:
       '@juggle/resize-observer': 3.4.0
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
 
+  use-resize-observer@9.1.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+    dependencies:
+      '@juggle/resize-observer': 3.4.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+
   use-sidecar@1.1.2(@types/react@18.2.37)(react@16.14.0):
     dependencies:
       detect-node-es: 1.1.0
       react: 16.14.0
+      tslib: 2.6.2
+    optionalDependencies:
+      '@types/react': 18.2.37
+
+  use-sidecar@1.1.2(@types/react@18.2.37)(react@17.0.2):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 17.0.2
       tslib: 2.6.2
     optionalDependencies:
       '@types/react': 18.2.37
@@ -35217,7 +35830,7 @@ snapshots:
 
   vue-component-type-helpers@1.8.24: {}
 
-  vue-component-type-helpers@2.1.10: {}
+  vue-component-type-helpers@2.2.0: {}
 
   vue-demi@0.14.7(vue@3.4.15(typescript@5.6.3)):
     dependencies:


### PR DESCRIPTION
# Remove utility classes from recipe components

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjI3a3AyOWZjZnI2N21lanRuZmc0eHFza3Q1dXVyN3IxZDJndm92bCZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/r0ThviDbmCglq/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [x] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2123

## :book: Description

- Removed Dialtone CSS utility classes from recipe components.

## :bulb: Context

- We're removing all the utility classes from dialtone components/recipes.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.