### PR TITLE
fix: NO-JIRA vscode extension utility classes

### DIFF
--- a/packages/language-server/server/src/language-plugin.ts
+++ b/packages/language-server/server/src/language-plugin.ts
@@ -28,7 +28,7 @@ function _findEmbeddedLanguages(content: string): { id: string, languageId: stri
 
   if (templateTagMatch) {
     const templateTagStart = templateTagMatch.index + templateTagMatch[0].length;
-    const templateTagEnd = content.indexOf('</template>', templateTagStart);
+    const templateTagEnd = content.lastIndexOf('</template>');
 
     template = content.substring(templateTagStart, templateTagEnd)
 

--- a/packages/language-server/server/src/services/dialtone-classes.ts
+++ b/packages/language-server/server/src/services/dialtone-classes.ts
@@ -2,6 +2,8 @@ import type { LanguageServicePlugin, LanguageServicePluginInstance, MarkupConten
 import { getContent, getCurrentWord, getEmbeddedLanguage } from "../utils";
 import { resolveUtilityClass, utilityClassDocumentation } from "../resolvers/css-utilities";
 
+const classAttributeRegex = /:?(class=)("([^"]*)"|'([^']*)')/
+
 export function create(): LanguageServicePlugin {
     return {
         name: "dialtone-classes",
@@ -24,7 +26,6 @@ export function create(): LanguageServicePlugin {
                     if (!content) return;
 
                     const currentLine: string = content.split('\n')[position.line];
-                    const classAttributeRegex = /:?(class=)"([^"]*)"|'([^']*)'/;
                     const classAttributeMatch = classAttributeRegex.exec(currentLine);
                     if (!classAttributeMatch) return;
 
@@ -52,7 +53,6 @@ export function create(): LanguageServicePlugin {
                     if (!content) return;
 
                     const currentLine: string = content.split('\n')[position.line];
-                    const classAttributeRegex = /:?(class=)"([^"]*)+"|'([^']*)+'/;
                     const classAttributeMatch = classAttributeRegex.exec(currentLine);
                     if (!classAttributeMatch) return;
 

--- a/packages/language-server/server/src/services/dialtone-classes.ts
+++ b/packages/language-server/server/src/services/dialtone-classes.ts
@@ -2,7 +2,8 @@ import type { LanguageServicePlugin, LanguageServicePluginInstance, MarkupConten
 import { getContent, getCurrentWord, getEmbeddedLanguage } from "../utils";
 import { resolveUtilityClass, utilityClassDocumentation } from "../resolvers/css-utilities";
 
-const classAttributeRegex = /:?(class=)("([^"]*)"|'([^']*)')/
+// @TODO: Find and autocomplete classes within :class="[]" and :class="{ 'some-class': true }"
+const classAttributeRegex = /\s(class=)("([^"]*)"|'([^']*)')/
 
 export function create(): LanguageServicePlugin {
     return {
@@ -17,8 +18,6 @@ export function create(): LanguageServicePlugin {
             console.log('Created Dialtone Utility Classes service');
             return {
                 provideCompletionItems(document, position) {
-                    console.log('resolving classes');
-
                     const language = getEmbeddedLanguage(document, context);
                     if (language !== 'template') return;
 
@@ -36,7 +35,7 @@ export function create(): LanguageServicePlugin {
 
                     if (!(isCursorWithinClassAttribute)) return;
 
-                    const classes = new Set(classAttributeMatch[2].split(' '));
+                    const classes = new Set(classAttributeMatch[3].split(' '));
 
                     const currentWord = getCurrentWord(currentLine, position.character);
 
@@ -62,7 +61,7 @@ export function create(): LanguageServicePlugin {
                     const isCursorWithinClassAttribute = position.character > classesStartIndex && position.character < classesEndIndex;
                     if (!(isCursorWithinClassAttribute)) return;
 
-                    const classes = classAttributeMatch[2].split(' ');
+                    const classes = classAttributeMatch[3].split(' ');
                     let currentIndex = classesStartIndex + 1;
 
                     const hoveredClass = classes.find(className => {

--- a/packages/language-server/vscode/README.md
+++ b/packages/language-server/vscode/README.md
@@ -11,23 +11,23 @@ Enhances the Dialtone development experience by providing Visual Studio Code use
 #### Intelligent completion suggestion for [Dialtone components](https://dialtone.dialpad.com/components/)
 
 - type: `<dt-|` to get a list of components.
-![Dialtone components completion example](media/completion/components.png)
+![Dialtone components completion example](https://github.com/dialpad/dialtone/blob/staging/packages/language-server/vscode/media/completion/components.png?raw=true)
 
 - type: `<dt-button |` to get a list of component props, (the list will show up at the bottom of the list) so click the arrow up, to quickly go to the dialtone component props.
-![Dialtone component properties completion example](media/completion/properties.png)
+![Dialtone component properties completion example](https://github.com/dialpad/dialtone/blob/staging/packages/language-server/vscode/media/completion/properties.png?raw=true)
 
 - type: `<dt-button size="|"` to get a list of prop values.
-![Dialtone component property values completion example](media/completion/values.png)
+![Dialtone component property values completion example](https://github.com/dialpad/dialtone/blob/staging/packages/language-server/vscode/media/completion/values.png?raw=true)
 
 #### Intelligent completion suggestion for [Design tokens](https://dialtone.dialpad.com/tokens/)
 
 - type: `var(--dt-|)` to get a list of CSS variables.
-![Dialtone tokens completion example](media/completion/tokens.png)
+![Dialtone tokens completion example](https://github.com/dialpad/dialtone/blob/staging/packages/language-server/vscode/media/completion/tokens.png?raw=true)
 
 #### Intelligent completion suggestion for [CSS utility classes](https://dialtone.dialpad.com/utilities/)
 
 - type: `class="|"` to get a list of CSS variables.
-![CSS utility classes completion example](media/completion/class.gif)
+![CSS utility classes completion example](https://github.com/dialpad/dialtone/blob/staging/packages/language-server/vscode/media/completion/class.gif?raw=true)
 
 ### Hover Preview
 
@@ -35,19 +35,19 @@ Hover over a dialtone component, prop, utility class or token to see documentati
 
 #### Component
 
-![Dialtone component hover example](media/hover/components.gif)
+![Dialtone component hover example](https://github.com/dialpad/dialtone/blob/staging/packages/language-server/vscode/media/hover/components.gif?raw=true)
 
 #### Prop
 
-![Dialtone property hover example](media/hover/properties.gif)
+![Dialtone property hover example](https://github.com/dialpad/dialtone/blob/staging/packages/language-server/vscode/media/hover/properties.gif?raw=true)
 
 #### Utility class
 
-![Dialtone utility class hover example](media/hover/class.gif)
+![Dialtone utility class hover example](https://github.com/dialpad/dialtone/blob/staging/packages/language-server/vscode/media/hover/class.gif?raw=true)
 
 #### Token
 
-![Dialtone token hover example](media/hover/tokens.gif)
+![Dialtone token hover example](https://github.com/dialpad/dialtone/blob/staging/packages/language-server/vscode/media/hover/tokens.gif?raw=true)
 
 ## Extension Commands
 


### PR DESCRIPTION
# Fix VSCode Extension utility classes

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/13JipyoTNNvM2c/giphy.gif?cid=82a1493bbgq1655r3z3wsahlup6y9fgax8qzckba4g1igqgv&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Description

Limited regex to find only `class=""` or `class=''` but not complex `:class="[]"` attributes to avoid errors for now.

## :bulb: Context

Extension was not working on complex vue files, it was due to the vue file having multiple `<template>` tags and complex `:class` attributes

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.