### PR TITLE
chore: NO-JIRA fix esm import error

### DIFF
--- a/common/utils/client.mjs
+++ b/common/utils/client.mjs
@@ -43,5 +43,5 @@ export default {
   getUniqueString,
   kebabCaseToPascalCase,
   flushPromises,
-  PascalCaseToKebabCase
+  PascalCaseToKebabCase,
 };

--- a/packages/dialtone-css/postcss/dialtone-docs.cjs
+++ b/packages/dialtone-css/postcss/dialtone-docs.cjs
@@ -1,18 +1,17 @@
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
-// eslint-disable-next-line no-unused-vars
-const { Rule } = require('postcss');
-const serverUtils = require(path.resolve(__dirname, '../../../common/utils/server.mjs'));
 const tokensDocs = require(path.resolve(__dirname, '../lib/dist/tokens-docs.json'));
 
 /**
  * @returns {RegExp} Regular expresion to match excluding class names
  */
-function generateExclusionRegex () {
-  const componentList = serverUtils.getValidFileList(path.resolve(__dirname, '../../dialtone-vue3/components'));
+async function generateExclusionRegex () {
+  const serverUtilsPath = path.resolve(__dirname, '../../../common/utils/server.mjs');
+  const dialtoneVue3ComponentsPath = path.resolve(__dirname, '../../dialtone-vue3/components');
+  const customList = ['recipe', 'btn', 'zoom', 'select', 'validation-message', 'label', 'description', 'split-btn', 'mention-suggestion', 'suggestion-list', 'context-menu', 'textarea', 'list-group', 'scrollbar']; // Includes special or wrong naming conventions
 
-  // Includes special or wrong naming conventions
-  const customList = ['recipe', 'btn', 'zoom', 'select', 'validation-message', 'label', 'description', 'split-btn', 'mention-suggestion', 'suggestion-list', 'context-menu', 'textarea', 'list-group', 'scrollbar'];
+  const { getValidFileList } = await import(serverUtilsPath);
+  const componentList = getValidFileList(dialtoneVue3ComponentsPath);
 
   return new RegExp([...componentList, ...customList]
     .map(string => {
@@ -24,12 +23,11 @@ function generateExclusionRegex () {
 }
 
 const documentation = {};
-const exclusionRegex = generateExclusionRegex();
 const CSSVarRegex = /var\(([^),]+)\)/g;
 
 /**
  *
- * @param {Rule} rule
+ * @param {import('postcss').Rule} rule
  */
 function generateDocumentation (rule) {
   const className = rule.selector.split(/(,|\s)/)[0].replace(/^\.(.+)/, '$1');
@@ -90,13 +88,17 @@ function replaceVariableValue (variable) {
  * @type {import('postcss').PluginCreator}
  */
 module.exports = () => {
+  let exclusionRegex;
+
   return {
     postcssPlugin: 'postcss-dialtone-documentation',
-    prepare (result) {
+    async Once (root) {
+      exclusionRegex = await Promise.resolve(generateExclusionRegex());
+
       // There are many variables that exists only within dialtone-default-theme.css
       // (Should they be included on dialtone-tokens doc.json?)
       // So we need to walk such declaration and add them to the generated tokensDocs;
-      result.root.walkDecls(decl => {
+      root.walkDecls(decl => {
         const match = /^--(.+)/;
 
         if (!match.test(decl.prop) || tokensDocs[decl.prop]) return;
@@ -104,19 +106,19 @@ module.exports = () => {
         tokensDocs[decl.prop] = { value: decl.value };
       });
     },
-    Rule (rule) {
+    async Rule (rule) {
       if (!/^\.(d-|\w{2}\\:)/.test(rule.selector) | exclusionRegex.test(rule.selector)) return;
       generateDocumentation(rule);
     },
-    OnceExit () {
+    async OnceExit () {
       // Iterate over tokens documentation to replace reference variables with primitive values
       const docs = Object.keys(tokensDocs).map(token => {
         const value = replaceVariableValue(tokensDocs[token].value);
         return { [token]: { value } };
       });
 
-      fs.writeFileSync(path.resolve(__dirname, '../lib/dist/tokens-docs.json'), JSON.stringify(docs), 'utf-8');
-      fs.writeFileSync(path.resolve(__dirname, '../lib/dist/dialtone-docs.json'), JSON.stringify(documentation), 'utf-8');
+      await fs.writeFile(path.resolve(__dirname, '../lib/dist/dialtone-docs.json'), JSON.stringify(documentation), 'utf-8');
+      await fs.writeFile(path.resolve(__dirname, '../lib/dist/tokens-docs.json'), JSON.stringify(docs), 'utf-8');
     },
   };
 };


### PR DESCRIPTION
# Fix ESM require on CJS error

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmVuc3Q1NTExdWplN2wxY3h0MjByaDh5NnhvZ3V4ZzEzc284eXIxYiZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/giFLHb8U7IhLgvB6wC/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Other (chore)

## :book: Description

- Dynamically imported getValidFileList function to avoid Node error.
- Moved to asynchronous methods as noted on the [PostCSS Plugin Guidelines](https://postcss.org/docs/postcss-plugin-guidelines).

## :bulb: Context

- Dialtone docs build process was failing on old node versions as requiring ESM modules on CJS is an experimental feature which was introduced in newer versions and could potentially change in the future so this would make this future proof.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.