### PR TITLE
fix(docs): NO-JIRA the class output in divide width docs was backwards

### DIFF
--- a/apps/dialtone-documentation/docs/utilities/borders/divide-width.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/divide-width.md
@@ -118,12 +118,12 @@ px* var(--divide-{{ d }}-reverse)
               border-right: calc(
                 <span v-if="i === 'default'">1</span>
                 <span v-else>{{ i }}</span>
-                px *(1 - var(--divide-{{ d }}-reverse))
+                px*var(--divide-{{ d }}-reverse)
               ) solid !important;<br/>
               border-left: calc(
                 <span v-if="i === 'default'">1</span>
                 <span v-else>{{ i }}</span>
-px* var(--divide-{{ d }}-reverse)
+px*(1 - var(--divide-{{ d }}-reverse))
               ) solid !important;
             </span>
           </td>


### PR DESCRIPTION
# fix(docs): NO-JIRA the class output in divide width docs was backwards

border-right and border-left was reversed when compared to the actual css output.
see: https://dialtone.dialpad.com/utilities/borders/divide-width.html#classes