### PR TITLE
fix(tokens): DLT-2233 correct math on android tokens

### DIFF
--- a/packages/dialtone-tokens/build-sd-transforms.js
+++ b/packages/dialtone-tokens/build-sd-transforms.js
@@ -133,9 +133,9 @@ export async function run () {
           ],
         },
         android_xml: {
-          transforms: ['attribute/cti', 'name/snake', 'dt/android/xml/color', 'size/remToSp', 'size/remToDp'],
+          transforms: ['attribute/cti', 'name/snake', 'dt/android/xml/size/resolveMath', 'dt/android/xml/color', 'dt/android/xml/size/pxToDp'],
           actions: ['buildDocJson'],
-          prefix: `dt_${themeName}`,
+          prefix: 'dt_',
           theme: themeName,
           buildPath: 'dist/android/res/values/',
           files: [
@@ -144,6 +144,8 @@ export async function run () {
               format: 'android/resources',
               resourceType: 'color',
               filter: function (token) {
+                if (token.value.startsWith('linear-gradient')) return false;
+                if (token.path.includes('shadow')) return false;
                 return ['color'].includes(token.type) && token.isSource;
               },
             },
@@ -152,7 +154,8 @@ export async function run () {
               format: 'android/resources',
               resourceType: 'dimen',
               filter: function (token) {
-                if (['dtColorGradientMagentaPurple'].includes(token.name)) return false;
+                if (token.value.startsWith('linear-gradient')) return false;
+                if (token.path.includes('shadow')) return false;
                 return ['dimension'].includes(token.type) && token.isSource;
               },
             },
@@ -160,13 +163,13 @@ export async function run () {
         },
         android_compose: {
           transforms: [
+            'dt/android/compose/size/resolveMath',
             'dt/android/compose/fonts/transformToStack',
             'dt/android/compose/fonts/weight',
             'dt/android/compose/lineHeight/percentToDecimal',
             'dt/android/compose/opacity/percentToFloat',
             'dt/android/compose/size/pxToDp',
             'dt/android/compose/size/pxToSp',
-            'dt/android/compose/size/resolveMath',
             'dt/android/compose/color',
             'dt/stringify',
             'attribute/cti',
@@ -188,6 +191,7 @@ export async function run () {
 
               filter: function (token) {
                 if (token.value.startsWith('linear-gradient')) return false;
+                if (token.path.includes('shadow')) return false;
                 return token.isSource;
               },
             },

--- a/packages/dialtone-tokens/build-sd-transforms.js
+++ b/packages/dialtone-tokens/build-sd-transforms.js
@@ -135,7 +135,7 @@ export async function run () {
         android_xml: {
           transforms: ['attribute/cti', 'name/snake', 'dt/android/xml/size/resolveMath', 'dt/android/xml/color', 'dt/android/xml/size/pxToDp'],
           actions: ['buildDocJson'],
-          prefix: 'dt_',
+          prefix: `dt_${themeName}`,
           theme: themeName,
           buildPath: 'dist/android/res/values/',
           files: [

--- a/packages/dialtone-tokens/dialtone-transforms.js
+++ b/packages/dialtone-tokens/dialtone-transforms.js
@@ -65,6 +65,40 @@ export function registerDialtoneTransforms (styleDictionary) {
   });
 
   styleDictionary.registerTransform({
+    name: 'dt/android/xml/size/resolveMath',
+    type: 'value',
+    transitive: true,
+    filter: function (token) {
+      return [...SPACING_IDENTIFIERS, ...SIZE_IDENTIFIERS].includes(token.type);
+    },
+    transform: (token) => {
+      // replace unmathable characters with empty string
+      const mathString = token.value.replace(/dp|sp|em|px|%/g, '');
+      // eslint-disable-next-line no-eval
+      const result = eval(mathString).toFixed(2);
+      return `${result}dp`;
+    },
+  });
+
+  styleDictionary.registerTransform({
+    name: 'dt/android/xml/size/pxToDp',
+    type: 'value',
+    transitive: true,
+    filter: function (token) {
+      return [...SPACING_IDENTIFIERS, ...SIZE_IDENTIFIERS].includes(token.type);
+    },
+    transform: (token) => {
+      const floatVal = parseFloat(token.value);
+
+      if (isNaN(floatVal)) {
+        throwSizeError(token.path, token.value, 'dp');
+      }
+
+      return `${floatVal.toFixed(2)}dp`;
+    },
+  });
+
+  styleDictionary.registerTransform({
     name: 'dt/android/xml/color',
     type: 'value',
     filter: function (token) {
@@ -129,6 +163,7 @@ export function registerDialtoneTransforms (styleDictionary) {
   styleDictionary.registerTransform({
     name: 'dt/android/compose/size/pxToDp',
     type: 'value',
+    transitive: true,
     filter: function (token) {
       return [...SPACING_IDENTIFIERS, ...SIZE_IDENTIFIERS].includes(token.type);
     },
@@ -147,6 +182,7 @@ export function registerDialtoneTransforms (styleDictionary) {
   styleDictionary.registerTransform({
     name: 'dt/android/compose/size/pxToSp',
     type: 'value',
+    transitive: true,
     filter: function (token) {
       return [...FONT_SIZE_IDENTIFIERS].includes(token.type);
     },
@@ -174,7 +210,7 @@ export function registerDialtoneTransforms (styleDictionary) {
       if (token.value.includes('.dp')) unit = 'dp';
       if (token.value.includes('.sp')) unit = 'sp';
       if (token.value.includes('.em')) unit = 'em';
-      const mathString = token.value.replace(/\.dp|\.sp|\.em/g, '');
+      const mathString = token.value.replace(/\.dp|\.sp|\.em|px|%/g, '');
       // eslint-disable-next-line no-eval
       const result = eval(mathString);
       return `${result}.${unit}`;


### PR DESCRIPTION
# DLT-2233(tokens): correct math on android tokens

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3B3OTVsMWU2b3l1MTc0N2RjZmE5cjAwbmlla21lbTByYnQwMG1yYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3WCNY2RhcmnwGbKbCi/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2233

## :book: Description

- Fixed incorrect tokens, some which were displaying sp instead of dp and some that were not resolving math correctly
- remove some tokens that android does not use

## :bulb: Context

Some android tokens were incorrect and the files were not compiling.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
