### PR TITLE
feat(design-tokens): NO-JIRA experimental deca token set update for reds

### DIFF
--- a/packages/dialtone-tokens/tokens/base/deca-dark.json
+++ b/packages/dialtone-tokens/tokens/base/deca-dark.json
@@ -254,7 +254,7 @@
     },
     "red": {
       "100": {
-        "value": "#410214",
+        "value": "#2D010E",
         "type": "color"
       },
       "150": {
@@ -265,20 +265,20 @@
         "value": "#93173A",
         "type": "color"
       },
-      "300": {
+      "250": {
         "value": "#AF0032",
         "type": "color"
       },
-      "325": {
+      "300": {
         "value": "#E10040",
         "type": "color"
       },
-      "375": {
-        "value": "#FA0047",
+      "350": {
+        "value": "#FF1356",
         "type": "color"
       },
       "400": {
-        "value": "#FF1356",
+        "value": "#FF415B",
         "type": "color"
       },
       "450": {

--- a/packages/dialtone-tokens/tokens/base/deca.json
+++ b/packages/dialtone-tokens/tokens/base/deca.json
@@ -265,15 +265,15 @@
         "value": "#FF716F",
         "type": "color"
       },
+      "250": {
+        "value": "#FF415B",
+        "type": "color"
+      },
       "300": {
         "value": "#FF1356",
         "type": "color"
       },
-      "325": {
-        "value": "#FA0047",
-        "type": "color"
-      },
-      "375": {
+      "350": {
         "value": "#E10040",
         "type": "color"
       },

--- a/packages/dialtone-tokens/tokens/semantic/deca/dark.json
+++ b/packages/dialtone-tokens/tokens/semantic/deca/dark.json
@@ -564,7 +564,7 @@
         "type": "color"
       },
       "critical-inverted": {
-        "value": "{color.red.325}",
+        "value": "{color.red.350}",
         "type": "color"
       },
       "critical-strong-inverted": {

--- a/packages/dialtone-tokens/tokens/semantic/deca/default.json
+++ b/packages/dialtone-tokens/tokens/semantic/deca/default.json
@@ -35,7 +35,7 @@
         "description": "Used for text paired with disabled content or components, like the form elements."
       },
       "critical": {
-        "value": "{color.red.325}",
+        "value": "{color.red.350}",
         "type": "color",
         "description": "Expresses an error, danger, or otherwise critical state."
       },
@@ -1032,11 +1032,11 @@
               "type": "color"
             },
             "hover": {
-              "value": "{color.red.325}",
+              "value": "{color.red.350}",
               "type": "color"
             },
             "active": {
-              "value": "{color.red.375}",
+              "value": "{color.red.400}",
               "type": "color"
             }
           }


### PR DESCRIPTION
# Experimental Design Token "deca" brand, round 2.1: reds

Quick correction to https://github.com/dialpad/dialtone/pull/617, focusing on the oh-so-contentious red.


<img width="249" alt="image" src="https://github.com/user-attachments/assets/ac2bb4fd-afb8-43ce-9351-5d63c89cbdd0" />

## :hammer_and_wrench: Type Of Change

- [ ] Feature

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.