### PR TITLE
fix: NO-JIRA set compat mode 3 on vue 3 components

### DIFF
--- a/packages/dialtone-vue3/components/avatar/avatar.vue
+++ b/packages/dialtone-vue3/components/avatar/avatar.vue
@@ -96,6 +96,7 @@ import { extractInitialsFromName } from './utils';
  * @see https://dialtone.dialpad.com/components/avatar.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtAvatar',
   components: { DtPresence },
 

--- a/packages/dialtone-vue3/components/badge/badge.vue
+++ b/packages/dialtone-vue3/components/badge/badge.vue
@@ -54,6 +54,7 @@ import { hasSlotContent } from '@/common/utils/index.js';
  * @see https://dialtone.dialpad.com/components/badge.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtBadge',
 
   props: {

--- a/packages/dialtone-vue3/components/banner/banner.vue
+++ b/packages/dialtone-vue3/components/banner/banner.vue
@@ -59,6 +59,7 @@ import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
  * @see https://dialtone.dialpad.com/components/banner.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtBanner',
 
   components: {

--- a/packages/dialtone-vue3/components/breadcrumbs/breadcrumbs.vue
+++ b/packages/dialtone-vue3/components/breadcrumbs/breadcrumbs.vue
@@ -32,6 +32,7 @@ import utils from '@/common/utils';
  * @see https://dialtone.dialpad.com/components/breadcrumbs.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtBreadcrumbs',
 
   components: {

--- a/packages/dialtone-vue3/components/button/button.vue
+++ b/packages/dialtone-vue3/components/button/button.vue
@@ -63,6 +63,7 @@ import { LINK_KIND_MODIFIERS, getLinkKindModifier } from '@/components/link';
  * @see https://dialtone.dialpad.com/components/button.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtButton',
 
   inheritAttrs: false,

--- a/packages/dialtone-vue3/components/button_group/button_group.vue
+++ b/packages/dialtone-vue3/components/button_group/button_group.vue
@@ -15,6 +15,7 @@
 import { BUTTON_GROUP_ALIGNMENT } from './button_group_constants';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtButtonGroup',
 
   props: {

--- a/packages/dialtone-vue3/components/button_group/buttons_decorator.vue
+++ b/packages/dialtone-vue3/components/button_group/buttons_decorator.vue
@@ -13,6 +13,7 @@
 import { DtButton } from '../button';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ButtonsDecorator',
   components: { DtButton },
 };

--- a/packages/dialtone-vue3/components/card/card.vue
+++ b/packages/dialtone-vue3/components/card/card.vue
@@ -50,6 +50,7 @@ import { hasSlotContent } from '@/common/utils';
  * @see https://dialtone.dialpad.com/components/card.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtCard',
   props: {
     /**

--- a/packages/dialtone-vue3/components/checkbox/checkbox.vue
+++ b/packages/dialtone-vue3/components/checkbox/checkbox.vue
@@ -68,6 +68,7 @@ import { DtValidationMessages } from '../validation_messages';
  * @see https://dialtone.dialpad.com/components/checkbox.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtCheckbox',
 
   components: { DtValidationMessages },

--- a/packages/dialtone-vue3/components/checkbox_group/checkbox_group.vue
+++ b/packages/dialtone-vue3/components/checkbox_group/checkbox_group.vue
@@ -9,6 +9,7 @@ import { DtInputGroup } from '../input_group';
  * @see https://dialtone.dialpad.com/components/checkbox_group.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtCheckboxGroup',
 
   extends: DtInputGroup,

--- a/packages/dialtone-vue3/components/checkbox_group/checkboxes_decorator.vue
+++ b/packages/dialtone-vue3/components/checkbox_group/checkboxes_decorator.vue
@@ -14,6 +14,7 @@
 import { DtCheckbox } from '../checkbox';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'CheckboxesDecorator',
   components: { DtCheckbox },
   created () {

--- a/packages/dialtone-vue3/components/chip/chip.vue
+++ b/packages/dialtone-vue3/components/chip/chip.vue
@@ -69,6 +69,7 @@ import { getUniqueString, hasSlotContent } from '@/common/utils';
  * @see https://dialtone.dialpad.com/components/chip.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtChip',
 
   components: {

--- a/packages/dialtone-vue3/components/codeblock/codeblock.vue
+++ b/packages/dialtone-vue3/components/codeblock/codeblock.vue
@@ -8,6 +8,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtCodeblock',
 
   props: {

--- a/packages/dialtone-vue3/components/collapsible/collapsible.vue
+++ b/packages/dialtone-vue3/components/collapsible/collapsible.vue
@@ -88,6 +88,7 @@ import { DtIconChevronDown, DtIconChevronRight } from '@dialpad/dialtone-icons/v
  * @see https://dialtone.dialpad.com/components/collapsible.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtCollapsible',
 
   components: {

--- a/packages/dialtone-vue3/components/combobox/combobox.vue
+++ b/packages/dialtone-vue3/components/combobox/combobox.vue
@@ -61,6 +61,7 @@ import { LABEL_SIZES } from '@/components/combobox/combobox_constants';
  * @see https://dialtone.dialpad.com/components/combobox.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtCombobox',
 
   components: {

--- a/packages/dialtone-vue3/components/description_list/description_list.vue
+++ b/packages/dialtone-vue3/components/description_list/description_list.vue
@@ -20,6 +20,7 @@ import { DT_DESCRIPTION_LIST_DIRECTION } from './description_list_constants';
 import { itemsValidator } from './description_list_validators';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtDescriptionList',
 
   props: {

--- a/packages/dialtone-vue3/components/dropdown/dropdown.vue
+++ b/packages/dialtone-vue3/components/dropdown/dropdown.vue
@@ -66,6 +66,7 @@ import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
 import SrOnlyCloseButton from '@/common/sr_only_close_button.vue';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtDropdown',
 
   components: {

--- a/packages/dialtone-vue3/components/dropdown/dropdown_list.vue
+++ b/packages/dialtone-vue3/components/dropdown/dropdown_list.vue
@@ -20,6 +20,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtDropdownList',
   props: {
     /**

--- a/packages/dialtone-vue3/components/dropdown/dropdown_separator.vue
+++ b/packages/dialtone-vue3/components/dropdown/dropdown_separator.vue
@@ -7,6 +7,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtDropdownSeparator',
 };
 </script>

--- a/packages/dialtone-vue3/components/emoji/emoji.vue
+++ b/packages/dialtone-vue3/components/emoji/emoji.vue
@@ -38,6 +38,7 @@ import { DtSkeleton } from '@/components/skeleton';
  * @see https://dialtone.dialpad.com/components/emoji.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtEmoji',
 
   components: {

--- a/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -9,6 +9,7 @@ import { ICON_SIZE_MODIFIERS } from '@/components/icon/icon_constants';
  * @see https://dialtone.dialpad.com/components/emoji_text_wrapper.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtEmojiTextWrapper',
 
   components: {

--- a/packages/dialtone-vue3/components/icon/icon.vue
+++ b/packages/dialtone-vue3/components/icon/icon.vue
@@ -17,6 +17,7 @@ import { ICON_SIZE_MODIFIERS, ICON_NAMES } from './icon_constants';
  * @see https://dialtone.dialpad.com/components/icon.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtIcon',
 
   props: {

--- a/packages/dialtone-vue3/components/image_viewer/image_viewer.vue
+++ b/packages/dialtone-vue3/components/image_viewer/image_viewer.vue
@@ -72,6 +72,7 @@ import { DtIconClose } from '@dialpad/dialtone-icons/vue3';
 import { DtButton } from '@/components/button';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtImageViewer',
 
   components: {

--- a/packages/dialtone-vue3/components/input/input.vue
+++ b/packages/dialtone-vue3/components/input/input.vue
@@ -143,6 +143,7 @@ import { MessagesMixin } from '@/common/mixins/input';
  * @see https://dialtone.dialpad.com/components/input.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtInput',
 
   components: { DtValidationMessages },

--- a/packages/dialtone-vue3/components/input_group/input_group.vue
+++ b/packages/dialtone-vue3/components/input_group/input_group.vue
@@ -38,6 +38,7 @@ import { hasSlotContent } from '@/common/utils';
  * @see https://dialtone.dialpad.com/components/input_group.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtInputGroup',
 
   components: { DtValidationMessages },

--- a/packages/dialtone-vue3/components/item_layout/item_layout.vue
+++ b/packages/dialtone-vue3/components/item_layout/item_layout.vue
@@ -71,6 +71,7 @@
 import { hasSlotContent } from '@/common/utils';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtItemLayout',
   props: {
     /**

--- a/packages/dialtone-vue3/components/keyboard_shortcut/keyboard_shortcut.vue
+++ b/packages/dialtone-vue3/components/keyboard_shortcut/keyboard_shortcut.vue
@@ -65,6 +65,7 @@ const SHORTCUTS_ICON_ALIASES = {
  * @see https://dialtone.dialpad.com/components/keyboard_shortcut.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtKeyboardShortcut',
 
   components: {

--- a/packages/dialtone-vue3/components/lazy_show/lazy_show.vue
+++ b/packages/dialtone-vue3/components/lazy_show/lazy_show.vue
@@ -21,6 +21,7 @@
  * @see https://dialtone.dialpad.com/components/lazy_show.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtLazyShow',
 
   inheritAttrs: false,

--- a/packages/dialtone-vue3/components/link/link.vue
+++ b/packages/dialtone-vue3/components/link/link.vue
@@ -19,6 +19,7 @@ import { LINK_VARIANTS, LINK_KIND_MODIFIERS, getLinkKindModifier } from './link_
  * @see https://dialtone.dialpad.com/components/link.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtLink',
 
   props: {

--- a/packages/dialtone-vue3/components/list_item/list_item.vue
+++ b/packages/dialtone-vue3/components/list_item/list_item.vue
@@ -55,6 +55,7 @@ const ROLES = ['listitem', 'menuitem', 'option'];
  * @see https://dialtone.dialpad.com/components/list_item.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtListItem',
 
   components: {

--- a/packages/dialtone-vue3/components/list_item_group/list_item_group.vue
+++ b/packages/dialtone-vue3/components/list_item_group/list_item_group.vue
@@ -28,6 +28,7 @@ import {} from './list_item_group_constants';
 import { getUniqueString } from '@/common/utils';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtListItemGroup',
 
   props: {

--- a/packages/dialtone-vue3/components/modal/modal.vue
+++ b/packages/dialtone-vue3/components/modal/modal.vue
@@ -136,6 +136,7 @@ import { NOTICE_KINDS } from '@/components/notice';
  * @see https://dialtone.dialpad.com/components/modal.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtModal',
 
   components: {

--- a/packages/dialtone-vue3/components/notice/notice.vue
+++ b/packages/dialtone-vue3/components/notice/notice.vue
@@ -50,6 +50,7 @@ import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
  * @see https://dialtone.dialpad.com/components/notice.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtNotice',
 
   components: {

--- a/packages/dialtone-vue3/components/notice/notice_action.vue
+++ b/packages/dialtone-vue3/components/notice/notice_action.vue
@@ -37,6 +37,7 @@ import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
 import SrOnlyCloseButton from '@/common/sr_only_close_button.vue';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtNoticeAction',
 
   components: {

--- a/packages/dialtone-vue3/components/notice/notice_content.vue
+++ b/packages/dialtone-vue3/components/notice/notice_content.vue
@@ -29,6 +29,7 @@
 import { hasSlotContent } from '@/common/utils';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtNoticeContent',
 
   props: {

--- a/packages/dialtone-vue3/components/notice/notice_icon.vue
+++ b/packages/dialtone-vue3/components/notice/notice_icon.vue
@@ -34,6 +34,7 @@ const kindToIcon = new Map([
 ]);
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtNoticeIcon',
 
   components: {

--- a/packages/dialtone-vue3/components/pagination/pagination.vue
+++ b/packages/dialtone-vue3/components/pagination/pagination.vue
@@ -75,6 +75,7 @@ import { DtIconChevronLeft, DtIconChevronRight, DtIconMoreHorizontal } from '@di
  * @see https://dialtone.dialpad.com/components/pagination.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtPagination',
 
   components: {

--- a/packages/dialtone-vue3/components/popover/popover.vue
+++ b/packages/dialtone-vue3/components/popover/popover.vue
@@ -148,6 +148,7 @@ import SrOnlyCloseButton from '@/common/sr_only_close_button.vue';
  * @see https://dialtone.dialpad.com/components/popover.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtPopover',
 
   /********************

--- a/packages/dialtone-vue3/components/popover/popover_header_footer.vue
+++ b/packages/dialtone-vue3/components/popover/popover_header_footer.vue
@@ -46,6 +46,7 @@ import { DtIconClose } from '@dialpad/dialtone-icons/vue3';
 import { hasSlotContent } from '@/common/utils';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'PopoverHeaderFooter',
   components: {
     DtButton,

--- a/packages/dialtone-vue3/components/presence/presence.vue
+++ b/packages/dialtone-vue3/components/presence/presence.vue
@@ -29,6 +29,7 @@ import { PRESENCE_STATES, PRESENCE_STATES_LIST } from './presence_constants';
  * @see https://dialtone.dialpad.com/components/presence.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtPresence',
   props: {
 

--- a/packages/dialtone-vue3/components/radio/radio.vue
+++ b/packages/dialtone-vue3/components/radio/radio.vue
@@ -65,6 +65,7 @@ import { hasSlotContent } from '@/common/utils';
  * @see https://dialtone.dialpad.com/components/radio.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRadio',
 
   components: { DtValidationMessages },

--- a/packages/dialtone-vue3/components/radio_group/radio_group.vue
+++ b/packages/dialtone-vue3/components/radio_group/radio_group.vue
@@ -6,6 +6,7 @@ import { DtInputGroup } from '../input_group';
  * @see https://dialtone.dialpad.com/components/radio_group.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRadioGroup',
 
   extends: DtInputGroup,

--- a/packages/dialtone-vue3/components/radio_group/radios_decorator.vue
+++ b/packages/dialtone-vue3/components/radio_group/radios_decorator.vue
@@ -14,6 +14,7 @@
 import { DtRadio } from '../radio';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'RadiosDecorator',
   components: { DtRadio },
   created () {

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/channels/ChannelComponent.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/channels/ChannelComponent.vue
@@ -17,6 +17,7 @@ import { nodeViewProps, NodeViewWrapper } from '@tiptap/vue-3';
 import { DtLink } from '@/components/link';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ChannelComponent',
   components: {
     NodeViewWrapper,

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/channels/ChannelSuggestion.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/channels/ChannelSuggestion.vue
@@ -21,6 +21,7 @@ import DtIconHash from '@dialpad/dialtone-icons/vue3/hash';
 import DtIconLock from '@dialpad/dialtone-icons/vue3/lock';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'ChannelSuggestion',
   components: {
     DtStack,

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/EmojiComponent.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/EmojiComponent.vue
@@ -16,6 +16,7 @@ import { nodeViewProps, NodeViewWrapper } from '@tiptap/vue-3';
 import { DtEmoji } from '@/components/emoji';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'EmojiComponent',
   components: {
     NodeViewWrapper,

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/EmojiSuggestion.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/emoji/EmojiSuggestion.vue
@@ -16,6 +16,7 @@ import { DtEmoji } from '@/components/emoji';
 import { DtStack } from '@/components/stack';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'EmojiSuggestion',
   components: {
     DtEmoji,

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionComponent.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionComponent.vue
@@ -17,6 +17,7 @@ import { nodeViewProps, NodeViewWrapper } from '@tiptap/vue-3';
 import { DtLink } from '@/components/link';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'MentionComponent',
   components: {
     NodeViewWrapper,

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
@@ -21,6 +21,7 @@ import { DtAvatar } from '@/components/avatar';
 import { DtStack } from '@/components/stack';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'MentionSuggestion',
   components: {
     DtAvatar,

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/slash_command/SlashCommandComponent.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/slash_command/SlashCommandComponent.vue
@@ -11,6 +11,7 @@
 import { nodeViewProps, NodeViewWrapper } from '@tiptap/vue-3';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'SlashCommandsComponent',
   components: {
     NodeViewWrapper,

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/slash_command/SlashCommandSuggestion.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/slash_command/SlashCommandSuggestion.vue
@@ -12,6 +12,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'SlashCommandSuggestion',
 
   props: {

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/suggestion/SuggestionList.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/suggestion/SuggestionList.vue
@@ -30,6 +30,7 @@
 import { DtListItem } from '@/components/list_item';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'SuggestionList',
   components: {
     DtListItem,

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -95,6 +95,7 @@ import { warnIfUnmounted } from '@/common/utils';
 import deepEqual from 'deep-equal';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRichTextEditor',
 
   components: {

--- a/packages/dialtone-vue3/components/root_layout/root_layout.vue
+++ b/packages/dialtone-vue3/components/root_layout/root_layout.vue
@@ -55,6 +55,7 @@ import { ROOT_LAYOUT_SIDEBAR_POSITIONS, ROOT_LAYOUT_RESPONSIVE_BREAKPOINTS } fro
  * A root layout provides a standardized group of containers to display content at the root level.
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRootLayout',
 
   props: {

--- a/packages/dialtone-vue3/components/select_menu/select_menu.vue
+++ b/packages/dialtone-vue3/components/select_menu/select_menu.vue
@@ -101,6 +101,7 @@ import { DtValidationMessages } from '../validation_messages';
  * @see https://dialtone.dialpad.com/components/select.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtSelectMenu',
 
   components: { DtValidationMessages },

--- a/packages/dialtone-vue3/components/skeleton/skeleton-list-item.vue
+++ b/packages/dialtone-vue3/components/skeleton/skeleton-list-item.vue
@@ -35,6 +35,7 @@ import DtSkeletonShape from './skeleton-shape.vue';
 import DtSkeletonParagraph from './skeleton-paragraph.vue';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtSkeletonListItem',
 
   components: {

--- a/packages/dialtone-vue3/components/skeleton/skeleton-paragraph.vue
+++ b/packages/dialtone-vue3/components/skeleton/skeleton-paragraph.vue
@@ -25,6 +25,7 @@ import DtSkeletonText from './skeleton-text.vue';
 
 const validator = number => number !== '' && !Number.isNaN(Number(number));
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtSkeletonParagraph',
   components: {
     DtSkeletonText,

--- a/packages/dialtone-vue3/components/skeleton/skeleton-shape.vue
+++ b/packages/dialtone-vue3/components/skeleton/skeleton-shape.vue
@@ -22,6 +22,7 @@ import {
 } from './skeleton_constants';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtSkeletonShape',
 
   mixins: [SkeletonAnimation],

--- a/packages/dialtone-vue3/components/skeleton/skeleton-text.vue
+++ b/packages/dialtone-vue3/components/skeleton/skeleton-text.vue
@@ -41,6 +41,7 @@ import { SKELETON_HEADING_HEIGHTS, SKELETON_TEXT_TYPES } from './skeleton_consta
 import SkeletonAnimation from '@/common/mixins/skeleton';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtSkeletonText',
 
   mixins: [SkeletonAnimation],

--- a/packages/dialtone-vue3/components/skeleton/skeleton.vue
+++ b/packages/dialtone-vue3/components/skeleton/skeleton.vue
@@ -48,6 +48,7 @@ import DtSkeletonText from './skeleton-text.vue';
  * @see https://dialtone.dialpad.com/components/skeleton.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtSkeleton',
   components: {
     DtSkeletonText,

--- a/packages/dialtone-vue3/components/split_button/split_button-alpha.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button-alpha.vue
@@ -28,6 +28,7 @@
 import { BUTTON_ICON_SIZES, DtButton } from '@/components/button';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'SplitButtonAlpha',
 
   components: {

--- a/packages/dialtone-vue3/components/split_button/split_button-omega.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button-omega.vue
@@ -29,6 +29,7 @@ import { DtIconChevronDown } from '@dialpad/dialtone-icons/vue3';
 import { getUniqueString } from '@/common/utils';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'SplitButtonOmega',
   components: {
     DtButton,

--- a/packages/dialtone-vue3/components/split_button/split_button.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button.vue
@@ -81,6 +81,7 @@ import { DtDropdown } from '@/components/dropdown';
 import { hasSlotContent, warnIfUnmounted } from '@/common/utils';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtSplitButton',
 
   components: {

--- a/packages/dialtone-vue3/components/stack/stack.vue
+++ b/packages/dialtone-vue3/components/stack/stack.vue
@@ -19,6 +19,7 @@ import { directionValidator, gapValidator } from './validators';
 import { getDefaultDirectionClass, getResponsiveClasses, getDefaultGapClass } from './utils';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtStack',
 
   props: {

--- a/packages/dialtone-vue3/components/tab/tab.vue
+++ b/packages/dialtone-vue3/components/tab/tab.vue
@@ -32,6 +32,7 @@ import { DtButton } from '../button';
  * @see https://dialtone.dialpad.com/components/tabs.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtTab',
   components: {
     DtButton,

--- a/packages/dialtone-vue3/components/tab/tab_group.vue
+++ b/packages/dialtone-vue3/components/tab/tab_group.vue
@@ -45,6 +45,7 @@ import {
  * @see https://dialtone.dialpad.com/components/tabs.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtTabGroup',
 
   provide () {

--- a/packages/dialtone-vue3/components/tab/tab_panel.vue
+++ b/packages/dialtone-vue3/components/tab/tab_panel.vue
@@ -22,6 +22,7 @@ import Modal from '@/common/mixins/modal';
  * @see https://dialtone.dialpad.com/components/tabs.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtTabPanel',
 
   mixins: [Modal],

--- a/packages/dialtone-vue3/components/toast/toast.vue
+++ b/packages/dialtone-vue3/components/toast/toast.vue
@@ -60,6 +60,7 @@ import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
  * @see https://dialtone.dialpad.com/components/toast.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtToast',
 
   components: {

--- a/packages/dialtone-vue3/components/toggle/toggle.vue
+++ b/packages/dialtone-vue3/components/toggle/toggle.vue
@@ -38,6 +38,7 @@ import { TOGGLE_CHECKED_VALUES, TOGGLE_SIZE_MODIFIERS } from '@/components/toggl
  * @see https://dialtone.dialpad.com/components/toggle.html
  */
 export default {
+  compatConfig: { MODE: 3 },
 
   name: 'DtToggle',
 

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -64,6 +64,7 @@ import {
  * @see https://dialtone.dialpad.com/components/tooltip.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtTooltip',
 
   props: {

--- a/packages/dialtone-vue3/components/validation_messages/validation_messages.vue
+++ b/packages/dialtone-vue3/components/validation_messages/validation_messages.vue
@@ -35,6 +35,7 @@ import {
  * @see https://dialtone.dialpad.com/components/validation_messages.html
  */
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtValidationMessages',
 
   props: {

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button/callbar_button.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button/callbar_button.vue
@@ -41,6 +41,7 @@ import { DtTooltip } from '@/components/tooltip';
 import utils, { extractVueListeners } from '@/common/utils';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeCallbarButton',
 
   components: { DtButton, DtTooltip },

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -81,6 +81,7 @@ import { DtRecipeCallbarButton, CALLBAR_BUTTON_VALID_WIDTH_SIZE } from '../callb
 import utils, { warnIfUnmounted } from '@/common/utils';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeCallbarButtonWithPopover',
 
   components: { DtRecipeCallbarButton, DtPopover, DtButton, DtIconChevronUp },

--- a/packages/dialtone-vue3/recipes/cards/ivr_node/ivr_node.vue
+++ b/packages/dialtone-vue3/recipes/cards/ivr_node/ivr_node.vue
@@ -125,6 +125,7 @@ const typeToIcon = new Map([
 ]);
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeIvrNode',
 
   components: {

--- a/packages/dialtone-vue3/recipes/chips/grouped_chip/grouped_chip.vue
+++ b/packages/dialtone-vue3/recipes/chips/grouped_chip/grouped_chip.vue
@@ -68,6 +68,7 @@ import { DtChip } from '@/components/chip';
 import { hasSlotContent } from '@/common/utils';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeGroupedChip',
 
   components: {

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -134,6 +134,7 @@ import {
 import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeComboboxMultiSelect',
 
   components: {

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_with_popover/combobox_with_popover.vue
@@ -120,6 +120,7 @@ import { DROPDOWN_PADDING_CLASSES } from '@/components/dropdown';
 import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeComboboxWithPopover',
 
   components: {

--- a/packages/dialtone-vue3/recipes/conversation_view/attachment_carousel/attachment_carousel.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/attachment_carousel/attachment_carousel.vue
@@ -69,6 +69,7 @@ import DtImageCarousel from './media_components/image_carousel.vue';
 const MEDIA_ITEM_WIDTH = 64;
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeAttachmentCarousel',
 
   components: {

--- a/packages/dialtone-vue3/recipes/conversation_view/attachment_carousel/media_components/image_carousel.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/attachment_carousel/media_components/image_carousel.vue
@@ -48,6 +48,7 @@ import { DtIconClose } from '@dialpad/dialtone-icons/vue3';
 import DtProgressBar from './progress_bar.vue';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtImageCarousel',
 
   components: {

--- a/packages/dialtone-vue3/recipes/conversation_view/attachment_carousel/media_components/progress_bar.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/attachment_carousel/media_components/progress_bar.vue
@@ -1,5 +1,6 @@
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtProgressBar',
   props: {
     progressbarAriaLabel: {

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -212,6 +212,7 @@ import {
 } from '@dialpad/dialtone-icons/vue3';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeEditor',
 
   components: {

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -55,6 +55,7 @@ import { DtEmoji } from '../../../components/emoji';
 import { DtEmojiTextWrapper } from '../../../components/emoji_text_wrapper';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeEmojiRow',
 
   components: { DtTooltip, DtButton, DtEmoji, DtEmojiTextWrapper },

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_pill/feed_item_pill.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_pill/feed_item_pill.vue
@@ -64,6 +64,7 @@ import { DtCollapsible } from '@/components/collapsible';
 import { DtIconChevronDown, DtIconChevronRight } from '@dialpad/dialtone-icons/vue3';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeFeedItemPill',
 
   components: { DtItemLayout, DtCollapsible },

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -132,6 +132,7 @@ import Modal from '@/common/mixins/modal';
 import { DtIconUser } from '@dialpad/dialtone-icons/vue3';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeFeedItemRow',
 
   components: {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -282,6 +282,7 @@ import {
 } from '../editor/editor_constants.js';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeMessageInput',
 
   components: {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_button.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_button.vue
@@ -32,6 +32,7 @@ import { DtTooltip } from '@/components/tooltip';
 import { DtStack } from '@/components/stack';
 import { DtKeyboardShortcut } from '@/components/keyboard_shortcut';
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeMessageInputButton',
   components: {
     DtButton,

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_link.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_link.vue
@@ -109,6 +109,7 @@ import { DtStack } from '@/components/stack';
 import { DtIconLink2 } from '@dialpad/dialtone-icons/vue3';
 import DtRecipeMessageInputButton from './message_input_button.vue';
 export default {
+  compatConfig: { MODE: 3 },
   name: 'MessageInputLink',
 
   components: {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_topbar.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_topbar.vue
@@ -151,6 +151,7 @@ import {
 
 import DtRecipeMessageInputButton from './message_input_button.vue';
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeMesageInputTopbar',
   components: {
     DtStack,

--- a/packages/dialtone-vue3/recipes/conversation_view/time_pill/time_pill.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/time_pill/time_pill.vue
@@ -12,6 +12,7 @@
 import {} from './time_pill_constants';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeTimePill',
 
   props: {

--- a/packages/dialtone-vue3/recipes/header/settings_menu_button/settings_menu_button.vue
+++ b/packages/dialtone-vue3/recipes/header/settings_menu_button/settings_menu_button.vue
@@ -36,6 +36,7 @@ import DtButton from '@/components/button/button.vue';
 import { DtIconMoreVertical } from '@dialpad/dialtone-icons/vue3';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeSettingsMenuButton',
 
   components: {

--- a/packages/dialtone-vue3/recipes/item_layout/contact_info/contact_info.vue
+++ b/packages/dialtone-vue3/recipes/item_layout/contact_info/contact_info.vue
@@ -114,6 +114,7 @@ import DtItemLayout from '@/components/item_layout/item_layout.vue';
 import DtAvatar from '@/components/avatar/avatar.vue';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeContactInfo',
 
   components: {

--- a/packages/dialtone-vue3/recipes/leftbar/callbox/callbox.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/callbox/callbox.vue
@@ -94,6 +94,7 @@ import DtBadge from '@/components/badge/badge.vue';
 import { DtIconPause } from '@dialpad/dialtone-icons/vue3';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeCallbox',
 
   components: { DtBadge, DtAvatar, DtIconPause },

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.vue
@@ -84,6 +84,7 @@ import DtIconChevronDown from '@dialpad/dialtone-icons/vue3/chevron-down';
 import DtIconHeadphones from '@dialpad/dialtone-icons/vue3/headphones';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeContactCentersRow',
 
   components: {

--- a/packages/dialtone-vue3/recipes/leftbar/contact_row/contact_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_row/contact_row.vue
@@ -72,6 +72,7 @@ import { extractVueListeners, safeConcatStrings } from '@/common/utils';
 import { DtIconUser } from '@dialpad/dialtone-icons/vue3';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeContactRow',
 
   components: {

--- a/packages/dialtone-vue3/recipes/leftbar/general_row/general_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/general_row/general_row.vue
@@ -158,6 +158,7 @@ import DtRecipeLeftbarGeneralRowIcon from './leftbar_general_row_icon.vue';
 import { extractVueListeners, safeConcatStrings } from '@/common/utils';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeGeneralRow',
 
   components: {

--- a/packages/dialtone-vue3/recipes/leftbar/general_row/leftbar_general_row_icon.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/general_row/leftbar_general_row_icon.vue
@@ -60,6 +60,7 @@ const typeToIcon = new Map([
 ]);
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeLeftbarGeneralRowIcon',
   components: {
     DtIconDialbot,

--- a/packages/dialtone-vue3/recipes/leftbar/group_row/group_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/group_row/group_row.vue
@@ -24,6 +24,7 @@ import { DtIconUsers } from '@dialpad/dialtone-icons/vue3';
 import { safeConcatStrings, extractVueListeners } from '@/common/utils';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeGroupRow',
 
   components: {

--- a/packages/dialtone-vue3/recipes/leftbar/unread_pill/unread_pill.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/unread_pill/unread_pill.vue
@@ -23,6 +23,7 @@
 import { DtIconArrowUp, DtIconArrowDown } from '@dialpad/dialtone-icons/vue3';
 import { UNREAD_PILL_DIRECTIONS, UNREAD_PILL_KINDS } from './unread_pill_constants';
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeUnreadPill',
 
   components: {

--- a/packages/dialtone-vue3/recipes/notices/top_banner_info/top_banner_info.vue
+++ b/packages/dialtone-vue3/recipes/notices/top_banner_info/top_banner_info.vue
@@ -25,6 +25,7 @@
 import { COLOR_CODES } from './top_banner_info_constants';
 
 export default {
+  compatConfig: { MODE: 3 },
   name: 'DtRecipeTopBannerInfo',
 
   props: {


### PR DESCRIPTION
# fix: set compat mode 3 on vue 3 components

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZXlsZHc4ajhkdTVhYXRodzBuYmh1dHN0cHY4czM4MnI0ZzhhejhpMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/iJa6kOfJ3qN7a/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2312

## :book: Description

Set compat mode 3 on all vue 3 dialtone components

## :bulb: Context

When running vue-compat in compat mode and using a vue 3 library this will force the components to be imported as vue 3, rather than vue 2. Should only need this temporarily for the migration. We can remove it afterwards.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
