### PR TITLE
feat(editor): DLT-2338 add method to insert content in editor

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.test.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.test.js
@@ -450,6 +450,15 @@ describe('DtRecipeEditor tests', () => {
       });
     });
 
+    describe('When calling insert in message body', () => {
+      it('message content is inserted at current caret position', async () => {
+        await wrapper.vm.setCursorPosition(19);
+        await wrapper.vm.$nextTick();
+        await wrapper.vm.insertInMessageBody('all things considered, ');
+        expect(editor.html()).toContain('<p>In the beginning, all things considered, it was a nice day.</p>');
+      });
+    });
+
     describe('When italics font button is clicked', () => {
       it('editor output should be enclosed in italics html tags', async () => {
         await italicsFormatBtn.trigger('click');

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -813,6 +813,10 @@ export default {
       this.$refs.richTextEditor?.editor.chain().focus().insertContent(messageContent).run();
     },
 
+    setCursorPosition (position = null) {
+      this.$refs.richTextEditor?.editor.chain().focus(position).run();
+    },
+
     onFocus (event) {
       this.hasFocus = true;
       this.$emit('focus', event);

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -809,6 +809,10 @@ export default {
       this.$refs.richTextEditor?.editor.chain().focus().toggleBlockquote().run();
     },
 
+    insertInMessageBody (messageContent) {
+      this.$refs.richTextEditor?.editor.chain().focus().insertContent(messageContent).run();
+    },
+
     onFocus (event) {
       this.hasFocus = true;
       this.$emit('focus', event);

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.test.js
@@ -445,6 +445,15 @@ describe('DtRecipeEditor tests', () => {
       });
     });
 
+    describe('When calling insert in message body', () => {
+      it('message content is inserted at current caret position', async () => {
+        await wrapper.vm.setCursorPosition(19);
+        await wrapper.vm.$nextTick();
+        await wrapper.vm.insertInMessageBody('all things considered, ');
+        expect(editor.html()).toContain('<p>In the beginning, all things considered, it was a nice day.</p>');
+      });
+    });
+
     describe('When italics font button is clicked', () => {
       it('editor output should be enclosed in italics html tags', async () => {
         await italicsFormatBtn.trigger('click');

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -811,6 +811,10 @@ export default {
       this.$refs.richTextEditor?.editor.chain().focus().insertContent(messageContent).run();
     },
 
+    setCursorPosition (position = null) {
+      this.$refs.richTextEditor?.editor.chain().focus(position).run();
+    },
+
     onBlockquoteToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleBlockquote().run();
     },

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -807,6 +807,10 @@ export default {
       this.$emit('quick-replies-click');
     },
 
+    insertInMessageBody (messageContent) {
+      this.$refs.richTextEditor?.editor.chain().focus().insertContent(messageContent).run();
+    },
+
     onBlockquoteToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleBlockquote().run();
     },


### PR DESCRIPTION
# feat(editor): DLT-2338 add method to insert content in editor

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMGdxaXppd3QxZThpZnk0ajQ1cjZ2bWN4eW1yaTE1MTUwbTkzeHZqMCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/LXfpI3nNbfCm91llsA/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

[JIRA TICKET](https://dialpad.atlassian.net/browse/DLT-2338)

## :book: Description

<!--- Describe specifically what the changes are -->

## :bulb: Context

A few weeks back I added everything to allow for agents to edit email quotes and to forward emails. As part of those changes, we need to insert different things into the email editor before the agent even starts typing, which we were able to do just by using the bind. However, as part of that, we found that, because we didn't have this method, things like quick replies were being appended always at the end. So we need a method that we can interface with, in order to be able to add text at current caret position.

I've already tested using this since I initially referenced the internal editor in my PR: https://github.com/dialpad/firespotter/pull/52256/files

But as part of the review it was suggested that it would be cleaner to add the method here in the component, and I agree. [See comment here](https://github.com/dialpad/firespotter/pull/52256/files#r1937635085).

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs
 
I link here the video of the inner editor method being called from [ubervoice](https://drive.google.com/file/d/1LxgRNQiyP4rgP1_oIQu__wHoSerocHmV/view?usp=sharing)

## :link: Sources

Insert content [tiptap docs](https://tiptap.dev/docs/editor/api/commands/content/insert-content)