### PR TITLE
fix(button): NO-JIRA remove v-bind attrs from button

### DIFF
--- a/packages/dialtone-vue3/components/button/button.vue
+++ b/packages/dialtone-vue3/components/button/button.vue
@@ -10,7 +10,6 @@
     :style="{ width: width }"
     :aria-live="computedAriaLive"
     :aria-label="loading ? 'loading' : $attrs['aria-label']"
-    v-bind="$attrs"
     v-on="buttonListeners"
   >
     <!-- NOTE(cormac): This span is needed since we can't apply styles to slots. -->
@@ -65,8 +64,6 @@ import { LINK_KIND_MODIFIERS, getLinkKindModifier } from '@/components/link';
 export default {
   compatConfig: { MODE: 3 },
   name: 'DtButton',
-
-  inheritAttrs: false,
 
   props: {
     /**


### PR DESCRIPTION
# fix(button): remove v-bind attrs from button

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Remove v-bind attrs from button root element since this is the exact same as default behaviour. Vue 3 only.

## :bulb: Context

Pointed out by @noellelevydialpad

## :link: Sources

https://vuejs.org/guide/components/attrs
