### PR TITLE
fix(tokens): DLT-2348 android font sizes were dp instead of sp

### DIFF
--- a/packages/dialtone-tokens/dialtone-transforms.js
+++ b/packages/dialtone-tokens/dialtone-transforms.js
@@ -6,7 +6,7 @@
 
 import Color from 'tinycolor2';
 
-const SIZE_IDENTIFIERS = ['fontSizes', 'sizing', 'borderWidth', 'borderRadius', 'blur', 'spread', 'x', 'y', 'dimension'];
+const SIZE_IDENTIFIERS = ['sizing', 'borderWidth', 'borderRadius', 'blur', 'spread', 'x', 'y', 'dimension'];
 const SPACING_IDENTIFIERS = ['spacing'];
 const FONT_FAMILY_IDENTIFIERS = ['fontFamily'];
 const FONT_SIZE_IDENTIFIERS = ['fontSizes', 'fontSize'];
@@ -165,7 +165,10 @@ export function registerDialtoneTransforms (styleDictionary) {
     type: 'value',
     transitive: true,
     filter: function (token) {
-      return [...SPACING_IDENTIFIERS, ...SIZE_IDENTIFIERS].includes(token.type);
+      return [...SPACING_IDENTIFIERS, ...SIZE_IDENTIFIERS].includes(token.type) &&
+        // The fontSize token in typography tokens is a 'dimension' type for some reason,
+        // so have this special case to exclude it from this transform.
+        !FONT_SIZE_IDENTIFIERS.includes(token.name);
     },
     transform: (token) => {
       const floatVal = parseFloat(token.value);
@@ -184,7 +187,10 @@ export function registerDialtoneTransforms (styleDictionary) {
     type: 'value',
     transitive: true,
     filter: function (token) {
-      return [...FONT_SIZE_IDENTIFIERS].includes(token.type);
+      return [...FONT_SIZE_IDENTIFIERS].includes(token.type) ||
+        // The fontSize token in typography tokens is a 'dimension' type for some reason,
+        // so have this special case to include it in this transform.
+        FONT_SIZE_IDENTIFIERS.includes(token.name);
     },
     transform: (token) => {
       const floatVal = parseFloat(token.value);


### PR DESCRIPTION
# fix(tokens) DLT-2348: Fix typography font sizes being dp instead of sp for android

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYmZ0N2N5dDljaGhsaWtya2gwOXc2eHludWdvcmdoZXZ3eTZjODEzbSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xT5LMp8DeKsaJ2p2bm/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [X] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2348

## :book: Description

Typography font size tokens were being resolved to `dp` instead of `sp` which is the correct type to use for font size.

## :bulb: Context

For some reason, font sizes in typography tokens are deemed as `dimension` type in tokens-studio which meant that the transform to turn px into dp was being applied to them. The fix is to check the name instead of the type in the filter.

## :pencil: Checklist

For all PRs:

- [X] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [X] I have reviewed my changes.
- [X] I have added all relevant documentation.
- [X] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

Unit tests to ensure font size tokens are in sp. Perhaps by checking the name ends with 'fontSize'
