### PR TITLE
feat: DLT-2370 add before-change event and improve tab behavior

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleTabs.vue
@@ -4,6 +4,7 @@
     :inverted="inverted"
     :borderless="borderless"
     :disabled="disabled"
+    @before-change="confirmBeforeLeave"
   >
     <template #tabs>
       <dt-tab
@@ -89,6 +90,23 @@ export default {
     inverted: {
       type: Boolean,
       default: false,
+    },
+
+    validate: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  methods: {
+    confirmBeforeLeave (event) {
+      if (!this.validate) return;
+
+      const confirmed = confirm('Are you sure to change tab?');
+
+      if (!confirmed) {
+        event.preventDefault();
+      }
     },
   },
 };

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -274,6 +274,64 @@ vueCode='
 '
 showHtmlWarning />
 
+## Advanced Usages
+
+### Validation Before Changing Tabs
+
+If you need to do some validation before changing tabs, you can use the `before-change` event. If the event handler is prevented, the tab change will be cancelled.
+
+<code-well-header>
+  <example-tabs validate />
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<div class="d-tablist d-tablist--sm" role="tablist" aria-label="Label Example Group" tabindex="0">
+  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
+  <button id="base-tab-1" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
+  <button id="base-tab-2" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
+</div>'
+vueCode='
+<dt-tab-group
+  size="sm"
+  @before-change="confirmBeforeLeave"
+>
+  <template #tabs>
+    <dt-tab id="1" panel-id="2" selected>
+      First
+    </dt-tab>
+    <dt-tab id="3" panel-id="4">
+      Second
+    </dt-tab>
+    <dt-tab id="5`" panel-id="6">
+      Third
+    </dt-tab>
+  </template>
+  <template #default>
+    <div>
+      <dt-tab-panel id="2" tab-id="1">
+        <p>First Panel</p>
+      </dt-tab-panel>
+      <dt-tab-panel id="4" tab-id="3">
+        <p>Second Panel</p>
+      </dt-tab-panel>
+      <dt-tab-panel id="6" tab-id="5">
+        <p>Third Panel</p>
+      </dt-tab-panel>
+    </div>
+  </template>
+</dt-tab-group>
+<script setup>
+  function confirmBeforeLeave (event) {
+    const confirmed = confirm("Are you sure to change tab?");
+    if (!confirmed) {
+      event.preventDefault();
+    }
+  }
+</script>
+'
+showHtmlWarning />
+
 ## Vue API
 
 ### Tab Group

--- a/packages/dialtone-vue2/components/tab/tab.test.js
+++ b/packages/dialtone-vue2/components/tab/tab.test.js
@@ -10,7 +10,6 @@ const MOCK_GROUP_CONTEXT = {
   disabled: false,
   selected: '',
 };
-const MOCK_CHANGE_CONTENT_PANEL = vi.fn();
 
 const baseProps = {
   id: MOCK_ID,
@@ -20,8 +19,6 @@ const baseProps = {
 const baseSlots = { default: MOCK_DEFAULT_SLOT };
 const baseProvide = {
   setFocus: vi.fn(),
-  groupContext: MOCK_GROUP_CONTEXT,
-  changeContentPanel: MOCK_CHANGE_CONTENT_PANEL,
 };
 
 let mockProps = {};
@@ -34,6 +31,8 @@ describe('DtTab Tests', () => {
   let tab;
 
   const updateWrapper = () => {
+    baseProvide.groupContext = { ...MOCK_GROUP_CONTEXT };
+
     wrapper = mount(DtTab, {
       propsData: { ...baseProps, ...mockProps },
       slots: { ...baseSlots, ...mockSlots },
@@ -71,16 +70,13 @@ describe('DtTab Tests', () => {
       expect(tab.text()).toBe(MOCK_DEFAULT_SLOT);
     });
 
-    describe('Selected by default', () => {
-      it('changeContentPanel should be called with valid data', () => {
+    describe('Selected Tab by default', () => {
+      it('Group context should have set selected tab', () => {
         mockProps = { selected: true };
 
         updateWrapper();
 
-        expect(MOCK_CHANGE_CONTENT_PANEL).toHaveBeenCalledWith({
-          selected: baseProps.panelId,
-          selectOverride: true,
-        });
+        expect(baseProvide.groupContext.selected).toBe(baseProps.panelId);
       });
     });
 

--- a/packages/dialtone-vue2/components/tab/tab.vue
+++ b/packages/dialtone-vue2/components/tab/tab.vue
@@ -37,7 +37,7 @@ export default {
     DtButton,
   },
 
-  inject: ['changeContentPanel', 'groupContext', 'setFocus'],
+  inject: ['groupContext', 'setFocus'],
 
   inheritAttrs: false,
 
@@ -109,7 +109,6 @@ export default {
         ...this.$listeners,
 
         click: event => {
-          this.selectPanel();
           this.$emit('click', event);
         },
 
@@ -122,22 +121,9 @@ export default {
   },
 
   mounted () {
-    this.setSelectedPanelByDefault();
-  },
-
-  methods: {
-    setSelectedPanelByDefault () {
-      if (this.selected) {
-        this.selectPanel(true);
-      }
-    },
-
-    selectPanel (selectOverride = false) {
-      this.changeContentPanel({
-        selected: this.panelId,
-        selectOverride,
-      });
-    },
+    if (this.selected) {
+      this.groupContext.selected = this.panelId;
+    }
   },
 };
 </script>

--- a/packages/dialtone-vue2/components/tab/tab_group.test.js
+++ b/packages/dialtone-vue2/components/tab/tab_group.test.js
@@ -43,18 +43,18 @@ const optionTabs = [
 ];
 
 const tabPanelComponents = {
-  functional: true,
   render (h) {
-    return optionTabPanel.map(option => h(DtTabPanel, { props: option }, option.slot));
+    return h('div', {}, optionTabPanel.map(option => h(DtTabPanel, { props: { id: option.id, tabId: option.tabId } }, option.slot)));
   },
 };
 
 const tabComponents = {
-  functional: true,
   render (h) {
-    return optionTabs.map(option => h(DtTab, { props: option }, option.slot));
+    return h('div', {}, optionTabs.map(option => h(DtTab, { props: { id: option.id, panelId: option.panelId, selected: option.selected, label: option.label } }, option.slot)));
   },
 };
+
+const baseListeners = {};
 
 describe('DtTabGroup Tests', () => {
   // Wrappers
@@ -62,10 +62,15 @@ describe('DtTabGroup Tests', () => {
   let tabList;
   let tabs;
   let tabPanels;
+  let listeners;
 
   const propsData = {
     label: 'area-label',
   };
+
+  beforeEach(() => {
+    listeners = baseListeners;
+  });
 
   const _setWrappers = () => {
     tabList = wrapper.find('[role="tablist"]');
@@ -82,6 +87,7 @@ describe('DtTabGroup Tests', () => {
         default: tabPanelComponents,
         tabs: tabComponents,
       },
+      listeners,
     });
     _setWrappers();
   };
@@ -187,6 +193,16 @@ describe('DtTabGroup Tests', () => {
       });
     });
 
+    describe('Correct before-change event', () => {
+      beforeEach(() => {
+        tabs.at(1).vm.$el.click();
+      });
+
+      it('should emitted on click', () => {
+        expect(wrapper.emitted('before-change').length).toBe(1);
+      });
+    });
+
     describe('Correct key navigation', () => {
       describe('On keyup left', () => {
         beforeEach(async () => {
@@ -199,22 +215,19 @@ describe('DtTabGroup Tests', () => {
           expect(tabs.at(2).attributes('aria-selected')).toBe('true');
           expect(tabPanels.at(2).attributes('aria-hidden')).toBe('false');
         });
+      });
 
-        describe('On double keyup left and space', () => {
-          beforeEach(async () => {
-            tabs.at(0).vm.$el.focus();
-            await tabList.trigger('keyup.left');
-            await tabList.trigger('keyup.left');
-            await tabList.trigger('keyup.space');
-          });
+      describe('On double keyup left and space', () => {
+        beforeEach(async () => {
+          tabs.at(0).vm.$el.focus();
+          await tabList.trigger('keyup.left');
+          await tabList.trigger('keyup.left');
+          await tabList.trigger('keyup.space');
+        });
 
-          it('aria-selected should be "true"', () => {
-            expect(tabs.at(1).attributes('aria-selected')).toBe('true');
-          });
-
-          it('aria-hidden should be "false"', () => {
-            expect(tabPanels.at(1).attributes('aria-hidden')).toBe('false');
-          });
+        it('selected element should be correct', () => {
+          expect(tabs.at(1).attributes('aria-selected')).toBe('true');
+          expect(tabPanels.at(1).attributes('aria-hidden')).toBe('false');
         });
       });
 
@@ -225,29 +238,23 @@ describe('DtTabGroup Tests', () => {
           await tabList.trigger('keyup.enter');
         });
 
-        it('aria-selected should be "true"', () => {
+        it('selected element should be correct', () => {
           expect(tabs.at(1).attributes('aria-selected')).toBe('true');
-        });
-
-        it('aria-hidden should be "false"', () => {
           expect(tabPanels.at(1).attributes('aria-hidden')).toBe('false');
         });
+      });
 
-        describe('On double keyup right and enter', () => {
-          beforeEach(async () => {
-            tabs.at(0).vm.$el.focus();
-            await tabList.trigger('keyup.right');
-            await tabList.trigger('keyup.right');
-            await tabList.trigger('keyup.enter');
-          });
+      describe('On double keyup right and enter', () => {
+        beforeEach(async () => {
+          tabs.at(0).vm.$el.focus();
+          await tabList.trigger('keyup.right');
+          await tabList.trigger('keyup.right');
+          await tabList.trigger('keyup.enter');
+        });
 
-          it('aria-selected should be "true"', () => {
-            expect(tabs.at(2).attributes('aria-selected')).toBe('true');
-          });
-
-          it('aria-hidden should be "false"', () => {
-            expect(tabPanels.at(2).attributes('aria-hidden')).toBe('false');
-          });
+        it('selected element should be correct', () => {
+          expect(tabs.at(2).attributes('aria-selected')).toBe('true');
+          expect(tabPanels.at(2).attributes('aria-hidden')).toBe('false');
         });
       });
 
@@ -258,11 +265,8 @@ describe('DtTabGroup Tests', () => {
           await tabList.trigger('keyup.enter');
         });
 
-        it('aria-selected should be "true"', () => {
+        it('selected element should be correct', () => {
           expect(tabs.at(0).attributes('aria-selected')).toBe('true');
-        });
-
-        it('aria-hidden should be "false"', () => {
           expect(tabPanels.at(0).attributes('aria-hidden')).toBe('false');
         });
       });
@@ -274,13 +278,28 @@ describe('DtTabGroup Tests', () => {
           await tabList.trigger('keyup.enter');
         });
 
-        it('aria-selected should be "true"', () => {
+        it('selected element should be correct', () => {
           expect(tabs.at(2).attributes('aria-selected')).toBe('true');
-        });
-
-        it('aria-hidden should be "false"', () => {
           expect(tabPanels.at(2).attributes('aria-hidden')).toBe('false');
         });
+      });
+    });
+
+    describe('When before-change prevents default event', () => {
+      beforeEach(async () => {
+        listeners = {
+          'before-change': (event) => {
+            event.preventDefault();
+          },
+        };
+
+        _mountWrapper();
+
+        tabs.at(0).vm.$el.click();
+      });
+
+      it('Should prevent the change event', async () => {
+        expect(wrapper.emitted('change')).toBeUndefined();
       });
     });
   });

--- a/packages/dialtone-vue2/components/tab/tab_group.vue
+++ b/packages/dialtone-vue2/components/tab/tab_group.vue
@@ -20,6 +20,7 @@
       @keyup.right="tabRight"
       @keyup.enter="selectTab"
       @keyup.space="selectTab"
+      @click="selectTab"
       @keydown.home="onHomeButton"
       @keydown.end="onEndButton"
     >
@@ -49,7 +50,6 @@ export default {
   provide () {
     return {
       groupContext: this.provideObj,
-      changeContentPanel: this.changeContentPanel,
       setFocus: this.setFocus,
     };
   },
@@ -135,6 +135,14 @@ export default {
      * @type {Object}
      */
     'change',
+
+    /**
+     * Before change tab event with the event argument, useful to perform validations and prevent changing tabs if neccessary.
+     *
+     * @event before-change
+     * @type {Event}
+     */
+    'before-change',
   ],
 
   data () {
@@ -197,7 +205,7 @@ export default {
           return ({
             context: el,
             panelId: el.getAttribute('aria-controls')?.replace('dt-panel-', ''),
-            id: el.getAttribute('id')?.replace('dt-tab-', ''),
+            tabId: el.getAttribute('id')?.replace('dt-tab-', ''),
             isSelected: el.getAttribute('aria-selected') === 'true',
           });
         });
@@ -207,51 +215,48 @@ export default {
       this.$emit('change', { ...this.provideObj });
     },
 
-    changeContentPanel ({ selected, selectOverride }) {
-      this.provideObj.selected = selected;
-      if (!selectOverride) {
-        this.onChange();
-      }
-    },
-
     tabLeft () {
-      const { index, tabs } = this.getIndexAndTabs();
+      const index = this.getFocusedTabIndex();
       if (index === -1) return;
-      const indexElement = index - 1 < 0 ? tabs.length - 1 : index - 1;
-      this.selectFocusOnTab(indexElement, tabs);
+
+      const indexElement = index - 1 < 0 ? this.tabs.length - 1 : index - 1;
+      this.selectFocusOnTab(indexElement);
     },
 
     tabRight () {
-      const { index, tabs } = this.getIndexAndTabs();
+      const index = this.getFocusedTabIndex();
       if (index === -1) return;
 
-      const indexElement = index + 1 > tabs.length - 1 ? 0 : index + 1;
-      this.selectFocusOnTab(indexElement, tabs);
+      const indexElement = index + 1 > this.tabs.length - 1 ? 0 : index + 1;
+      this.selectFocusOnTab(indexElement);
     },
 
-    selectFocusOnTab (index, tabs) {
-      const { context } = tabs[index];
+    selectFocusOnTab (index) {
+      const { context } = this.tabs[index];
       context.focus();
     },
 
-    selectTab () {
-      const { tabs, index } = this.getIndexAndTabs();
-      this.selectTabByIndex(index, tabs);
+    selectTab (event) {
+      if (this.isSameTabClicked()) return;
+
+      this.$emit('before-change', event);
+      if (event.defaultPrevented) return;
+
+      const index = this.getFocusedTabIndex();
+
+      this.selectTabByIndex(index);
+      this.onChange();
     },
 
-    selectTabByIndex (index, tabs) {
-      const { context, panelId } = tabs[index];
+    selectTabByIndex (index) {
+      const { context, panelId } = this.tabs[index];
       this.provideObj.selected = panelId;
       context.focus();
     },
 
-    getIndexAndTabs () {
-      const index = this.tabs.findIndex((context) =>
-        this.focusId ? context.id === `${this.focusId}` : context.isSelected);
-      return {
-        tabs: this.tabs,
-        index,
-      };
+    getFocusedTabIndex () {
+      return this.tabs.findIndex((context) =>
+        this.focusId ? context.tabId === `${this.focusId}` : context.isSelected);
     },
 
     onHomeButton () {
@@ -262,6 +267,11 @@ export default {
     onEndButton () {
       if (this.tabs.length === 0) return;
       this.tabs[this.tabs.length - 1]?.context?.focus();
+    },
+
+    isSameTabClicked () {
+      const tab = this.tabs[this.getFocusedTabIndex()];
+      return this.provideObj.selected === tab.panelId;
     },
   },
 };

--- a/packages/dialtone-vue2/components/tab/tab_panel.vue
+++ b/packages/dialtone-vue2/components/tab/tab_panel.vue
@@ -10,7 +10,9 @@
     data-qa="dt-tab-panel"
   >
     <!-- @slot Default slot for Tab Panel -->
-    <slot v-show="!hidden" />
+    <div v-show="!hidden">
+      <slot />
+    </div>
   </div>
 </template>
 

--- a/packages/dialtone-vue2/components/tab/tabs_default.story.vue
+++ b/packages/dialtone-vue2/components/tab/tabs_default.story.vue
@@ -11,6 +11,7 @@
       :disabled="$attrs.disabled"
       :tab-list-class="$attrs.tabListClass"
       :tab-list-child-props="$attrs.tabListChildProps"
+      @before-change="validateChange"
       @change="$attrs.onChange"
     >
       <template slot="tabs">
@@ -108,5 +109,13 @@ import DtTabPanel from './tab_panel.vue';
 export default {
   name: 'DtTabsDefault',
   components: { DtTabGroup, DtTab, DtTabPanel },
+
+  methods: {
+    validateChange (event) {
+      if (!confirm('You might loose changes, change tab?')) {
+        event.preventDefault();
+      }
+    },
+  },
 };
 </script>

--- a/packages/dialtone-vue2/components/tab/tabs_variants.story.vue
+++ b/packages/dialtone-vue2/components/tab/tabs_variants.story.vue
@@ -41,7 +41,7 @@
 
         <div
           :class="{
-            'd-fc-neutral-white': variant.propsToBind.inverted,
+            'd-fc-primary-inverted': variant.propsToBind.inverted,
           }"
         >
           <dt-tab-panel
@@ -78,35 +78,36 @@ export default {
   components: { DtTabGroup, DtTab, DtTabPanel },
   data () {
     return {
-      variantsTabs: [{
-        description: 'Default tabs',
-        propsToBind: {},
-      }, {
-        description: 'Inverted tabs',
-        propsToBind: {
-          inverted: true,
+      variantsTabs: [
+        {
+          description: 'Default tabs',
+          propsToBind: {},
         },
-      }, {
-        description: 'Small size tabs',
-        propsToBind: {
-          size: 'sm',
+        {
+          description: 'Inverted tabs',
+          propsToBind: {
+            inverted: true,
+          },
         },
-      }, {
-        description: 'Borderless tabs',
-        propsToBind: {
-          borderless: true,
+        {
+          description: 'Small size tabs',
+          propsToBind: {
+            size: 'sm',
+          },
         },
-      }, {
-        description: 'Importance tabs',
-        propsToBind: {
-          importance: true,
+        {
+          description: 'Borderless tabs',
+          propsToBind: {
+            borderless: true,
+          },
         },
-      }, {
-        description: 'Disabled tabs',
-        propsToBind: {
-          disabled: true,
+        {
+          description: 'Disabled tabs',
+          propsToBind: {
+            disabled: true,
+          },
         },
-      }],
+      ],
     };
   },
 };

--- a/packages/dialtone-vue3/components/tab/tab.test.js
+++ b/packages/dialtone-vue3/components/tab/tab.test.js
@@ -10,7 +10,6 @@ const MOCK_GROUP_CONTEXT = {
   disabled: false,
   selected: '',
 };
-const MOCK_CHANGE_CONTENT_PANEL = vi.fn();
 
 const baseProps = {
   id: MOCK_ID,
@@ -20,8 +19,6 @@ const baseProps = {
 const baseSlots = { default: MOCK_DEFAULT_SLOT };
 const baseProvide = {
   setFocus: vi.fn(),
-  groupContext: MOCK_GROUP_CONTEXT,
-  changeContentPanel: MOCK_CHANGE_CONTENT_PANEL,
 };
 
 let mockProps = {};
@@ -33,6 +30,8 @@ describe('DtTab Tests', () => {
   let tab;
 
   const updateWrapper = () => {
+    baseProvide.groupContext = { ...MOCK_GROUP_CONTEXT };
+
     wrapper = mount(DtTab, {
       props: { ...baseProps, ...mockProps },
       slots: { ...baseSlots, ...mockSlots },
@@ -67,16 +66,13 @@ describe('DtTab Tests', () => {
       expect(tab.text()).toBe(MOCK_DEFAULT_SLOT);
     });
 
-    describe('Selected by default', () => {
-      it('changeContentPanel should be called with valid data', () => {
+    describe('Selected Tab by default', () => {
+      it('Group context should have set selected tab', () => {
         mockProps = { selected: true };
 
         updateWrapper();
 
-        expect(MOCK_CHANGE_CONTENT_PANEL).toHaveBeenCalledWith({
-          selected: baseProps.panelId,
-          selectOverride: true,
-        });
+        expect(baseProvide.groupContext.selected).toBe(baseProps.panelId);
       });
     });
 

--- a/packages/dialtone-vue3/components/tab/tab.vue
+++ b/packages/dialtone-vue3/components/tab/tab.vue
@@ -38,7 +38,7 @@ export default {
     DtButton,
   },
 
-  inject: ['changeContentPanel', 'groupContext', 'setFocus'],
+  inject: ['groupContext', 'setFocus'],
 
   inheritAttrs: false,
 
@@ -122,7 +122,6 @@ export default {
     tabListeners () {
       return {
         click: event => {
-          this.selectPanel();
           this.$emit('click', event);
         },
 
@@ -139,22 +138,9 @@ export default {
   },
 
   mounted () {
-    this.setSelectedPanelByDefault();
-  },
-
-  methods: {
-    setSelectedPanelByDefault () {
-      if (this.selected) {
-        this.selectPanel(true);
-      }
-    },
-
-    selectPanel (selectOverride = false) {
-      this.changeContentPanel({
-        selected: this.panelId,
-        selectOverride,
-      });
-    },
+    if (this.selected) {
+      this.groupContext.selected = this.panelId;
+    }
   },
 };
 </script>

--- a/packages/dialtone-vue3/components/tab/tab_group.test.js
+++ b/packages/dialtone-vue3/components/tab/tab_group.test.js
@@ -44,18 +44,18 @@ const optionTabs = [
 ];
 
 const tabPanelComponents = {
-  functional: true,
   render () {
-    return optionTabPanel.map(option => h(DtTabPanel, option, () => option.slot));
+    return h('div', {}, optionTabPanel.map(option => h(DtTabPanel, { id: option.id, tabId: option.tabId }, () => option.slot)));
   },
 };
 
 const tabComponents = {
-  functional: true,
   render () {
-    return optionTabs.map(option => h(DtTab, option, () => option.slot));
+    return h('div', {}, optionTabs.map(option => h(DtTab, { id: option.id, panelId: option.panelId, selected: option.selected, label: option.label }, () => option.slot)));
   },
 };
+
+const baseAttributes = {};
 
 describe('DtTabGroup Tests', () => {
   // Wrappers
@@ -63,10 +63,15 @@ describe('DtTabGroup Tests', () => {
   let tabList;
   let tabs;
   let tabPanels;
+  let attrs;
 
   const props = {
     label: 'area-label',
   };
+
+  beforeEach(() => {
+    attrs = baseAttributes;
+  });
 
   const _setWrappers = () => {
     tabList = wrapper.find('[role="tablist"]');
@@ -78,6 +83,7 @@ describe('DtTabGroup Tests', () => {
     wrapper = mount(DtTabGroup, {
       attachTo: document.body,
       props,
+      attrs,
       slots: {
         default: tabPanelComponents,
         tabs: tabComponents,
@@ -195,6 +201,16 @@ describe('DtTabGroup Tests', () => {
       });
     });
 
+    describe('Correct before-change event', () => {
+      beforeEach(() => {
+        tabs.at(1).vm.$el.click();
+      });
+
+      it('should emitted on click', () => {
+        expect(wrapper.emitted('before-change').length).toBe(1);
+      });
+    });
+
     describe('Correct key navigation', () => {
       describe('On keyup left', () => {
         beforeEach(async () => {
@@ -207,22 +223,19 @@ describe('DtTabGroup Tests', () => {
           expect(tabs.at(2).attributes('aria-selected')).toBe('true');
           expect(tabPanels.at(2).attributes('aria-hidden')).toBe('false');
         });
+      });
 
-        describe('On double keyup left and space', () => {
-          beforeEach(async () => {
-            tabs.at(0).vm.$el.focus();
-            await tabList.trigger('keyup.left');
-            await tabList.trigger('keyup.left');
-            await tabList.trigger('keyup.space');
-          });
+      describe('On double keyup left and space', () => {
+        beforeEach(async () => {
+          tabs.at(0).vm.$el.focus();
+          await tabList.trigger('keyup.left');
+          await tabList.trigger('keyup.left');
+          await tabList.trigger('keyup.space');
+        });
 
-          it('aria-selected should be "true"', () => {
-            expect(tabs.at(1).attributes('aria-selected')).toBe('true');
-          });
-
-          it('aria-hidden should be "false"', () => {
-            expect(tabPanels.at(1).attributes('aria-hidden')).toBe('false');
-          });
+        it('selected element should be correct', () => {
+          expect(tabs.at(1).attributes('aria-selected')).toBe('true');
+          expect(tabPanels.at(1).attributes('aria-hidden')).toBe('false');
         });
       });
 
@@ -233,29 +246,23 @@ describe('DtTabGroup Tests', () => {
           await tabList.trigger('keyup.enter');
         });
 
-        it('aria-selected should be "true"', () => {
+        it('selected element should be correct', () => {
           expect(tabs.at(1).attributes('aria-selected')).toBe('true');
-        });
-
-        it('aria-hidden should be "false"', () => {
           expect(tabPanels.at(1).attributes('aria-hidden')).toBe('false');
         });
+      });
 
-        describe('On double keyup right and enter', () => {
-          beforeEach(async () => {
-            tabs.at(0).vm.$el.focus();
-            await tabList.trigger('keyup.right');
-            await tabList.trigger('keyup.right');
-            await tabList.trigger('keyup.enter');
-          });
+      describe('On double keyup right and enter', () => {
+        beforeEach(async () => {
+          tabs.at(0).vm.$el.focus();
+          await tabList.trigger('keyup.right');
+          await tabList.trigger('keyup.right');
+          await tabList.trigger('keyup.enter');
+        });
 
-          it('aria-selected should be "true"', () => {
-            expect(tabs.at(2).attributes('aria-selected')).toBe('true');
-          });
-
-          it('aria-hidden should be "false"', () => {
-            expect(tabPanels.at(2).attributes('aria-hidden')).toBe('false');
-          });
+        it('selected element should be correct', () => {
+          expect(tabs.at(2).attributes('aria-selected')).toBe('true');
+          expect(tabPanels.at(2).attributes('aria-hidden')).toBe('false');
         });
       });
 
@@ -266,11 +273,8 @@ describe('DtTabGroup Tests', () => {
           await tabList.trigger('keyup.enter');
         });
 
-        it('aria-selected should be "true"', () => {
+        it('selected element should be correct', () => {
           expect(tabs.at(0).attributes('aria-selected')).toBe('true');
-        });
-
-        it('aria-hidden should be "false"', () => {
           expect(tabPanels.at(0).attributes('aria-hidden')).toBe('false');
         });
       });
@@ -282,13 +286,28 @@ describe('DtTabGroup Tests', () => {
           await tabList.trigger('keyup.enter');
         });
 
-        it('aria-selected should be "true"', () => {
+        it('selected element should be correct', () => {
           expect(tabs.at(2).attributes('aria-selected')).toBe('true');
-        });
-
-        it('aria-hidden should be "false"', () => {
           expect(tabPanels.at(2).attributes('aria-hidden')).toBe('false');
         });
+      });
+    });
+
+    describe('When before-change prevents default event', () => {
+      beforeEach(async () => {
+        attrs = {
+          onBeforeChange: (event) => {
+            event.preventDefault();
+          },
+        };
+
+        _mountWrapper();
+
+        tabs.at(0).vm.$el.click();
+      });
+
+      it('Should prevent the change event', async () => {
+        expect(wrapper.emitted('change')).toBeUndefined();
       });
     });
   });

--- a/packages/dialtone-vue3/components/tab/tab_group.vue
+++ b/packages/dialtone-vue3/components/tab/tab_group.vue
@@ -21,6 +21,7 @@
       @keyup.right="tabRight"
       @keyup.enter="selectTab"
       @keyup.space="selectTab"
+      @click="selectTab"
       @keydown.home="onHomeButton"
       @keydown.end="onEndButton"
     >
@@ -51,7 +52,6 @@ export default {
   provide () {
     return {
       groupContext: this.provideObj,
-      changeContentPanel: this.changeContentPanel,
       setFocus: this.setFocus,
     };
   },
@@ -137,6 +137,14 @@ export default {
      * @type {Object}
      */
     'change',
+
+    /**
+     * Before change tab event with the event argument, useful to perform validations and prevent changing tabs if neccessary.
+     *
+     * @event before-change
+     * @type {Event}
+     */
+    'before-change',
   ],
 
   data () {
@@ -200,7 +208,7 @@ export default {
           return ({
             context: el,
             panelId: el.getAttribute('aria-controls')?.replace('dt-panel-', ''),
-            id: el.getAttribute('id')?.replace('dt-tab-', ''),
+            tabId: el.getAttribute('id')?.replace('dt-tab-', ''),
             isSelected: el.getAttribute('aria-selected') === 'true',
           });
         });
@@ -210,51 +218,48 @@ export default {
       this.$emit('change', { ...this.provideObj });
     },
 
-    changeContentPanel ({ selected, selectOverride }) {
-      this.provideObj.selected = selected;
-      if (!selectOverride) {
-        this.onChange();
-      }
-    },
-
     tabLeft () {
-      const { index, tabs } = this.getIndexAndTabs();
+      const index = this.getFocusedTabIndex();
       if (index === -1) return;
-      const indexElement = index - 1 < 0 ? tabs.length - 1 : index - 1;
-      this.selectFocusOnTab(indexElement, tabs);
+
+      const indexElement = index - 1 < 0 ? this.tabs.length - 1 : index - 1;
+      this.selectFocusOnTab(indexElement);
     },
 
     tabRight () {
-      const { index, tabs } = this.getIndexAndTabs();
+      const index = this.getFocusedTabIndex();
       if (index === -1) return;
 
-      const indexElement = index + 1 > tabs.length - 1 ? 0 : index + 1;
-      this.selectFocusOnTab(indexElement, tabs);
+      const indexElement = index + 1 > this.tabs.length - 1 ? 0 : index + 1;
+      this.selectFocusOnTab(indexElement);
     },
 
-    selectFocusOnTab (index, tabs) {
-      const { context } = tabs[index];
+    selectFocusOnTab (index) {
+      const { context } = this.tabs[index];
       context.focus();
     },
 
-    selectTab () {
-      const { tabs, index } = this.getIndexAndTabs();
-      this.selectTabByIndex(index, tabs);
+    selectTab (event) {
+      if (this.isSameTabClicked()) return;
+
+      this.$emit('before-change', event);
+      if (event.defaultPrevented) return;
+
+      const index = this.getFocusedTabIndex();
+
+      this.selectTabByIndex(index);
+      this.onChange();
     },
 
-    selectTabByIndex (index, tabs) {
-      const { context, panelId } = tabs[index];
+    selectTabByIndex (index) {
+      const { context, panelId } = this.tabs[index];
       this.provideObj.selected = panelId;
       context.focus();
     },
 
-    getIndexAndTabs () {
-      const index = this.tabs.findIndex((context) =>
-        this.focusId ? context.id === `${this.focusId}` : context.isSelected);
-      return {
-        tabs: this.tabs,
-        index,
-      };
+    getFocusedTabIndex () {
+      return this.tabs.findIndex((context) =>
+        this.focusId ? context.tabId === `${this.focusId}` : context.isSelected);
     },
 
     onHomeButton () {
@@ -265,6 +270,11 @@ export default {
     onEndButton () {
       if (this.tabs.length === 0) return;
       this.tabs[this.tabs.length - 1]?.context?.focus();
+    },
+
+    isSameTabClicked () {
+      const tab = this.tabs[this.getFocusedTabIndex()];
+      return this.provideObj.selected === tab.panelId;
     },
   },
 };

--- a/packages/dialtone-vue3/components/tab/tab_panel.vue
+++ b/packages/dialtone-vue3/components/tab/tab_panel.vue
@@ -10,7 +10,9 @@
     data-qa="dt-tab-panel"
   >
     <!-- @slot Default slot for Tab Panel -->
-    <slot />
+    <div v-show="!hidden">
+      <slot />
+    </div>
   </div>
 </template>
 

--- a/packages/dialtone-vue3/components/tab/tabs_default.story.vue
+++ b/packages/dialtone-vue3/components/tab/tabs_default.story.vue
@@ -112,7 +112,7 @@ export default {
 
   methods: {
     validateChange (event) {
-      if (!confirm('You might loose changes, change tab?')) {
+      if (!confirm('You might lose changes, change tab?')) {
         event.preventDefault();
       }
     },

--- a/packages/dialtone-vue3/components/tab/tabs_default.story.vue
+++ b/packages/dialtone-vue3/components/tab/tabs_default.story.vue
@@ -11,6 +11,7 @@
       :disabled="$attrs.disabled"
       :tab-list-class="$attrs.tabListClass"
       :tab-list-child-props="$attrs.tabListChildProps"
+      @before-change="validateChange"
       @change="$attrs.onChange"
     >
       <template #tabs>
@@ -108,5 +109,13 @@ import DtTabPanel from './tab_panel.vue';
 export default {
   name: 'DtTabsDefault',
   components: { DtTabGroup, DtTab, DtTabPanel },
+
+  methods: {
+    validateChange (event) {
+      if (!confirm('You might loose changes, change tab?')) {
+        event.preventDefault();
+      }
+    },
+  },
 };
 </script>

--- a/packages/dialtone-vue3/components/tab/tabs_variants.story.vue
+++ b/packages/dialtone-vue3/components/tab/tabs_variants.story.vue
@@ -41,7 +41,7 @@
 
         <div
           :class="{
-            'd-fc-neutral-white': variant.propsToBind.inverted,
+            'd-fc-primary-inverted': variant.propsToBind.inverted,
           }"
         >
           <dt-tab-panel
@@ -78,35 +78,36 @@ export default {
   components: { DtTabGroup, DtTab, DtTabPanel },
   data () {
     return {
-      variantsTabs: [{
-        description: 'Default tabs',
-        propsToBind: {},
-      }, {
-        description: 'Inverted tabs',
-        propsToBind: {
-          inverted: true,
+      variantsTabs: [
+        {
+          description: 'Default tabs',
+          propsToBind: {},
         },
-      }, {
-        description: 'Small size tabs',
-        propsToBind: {
-          size: 'sm',
+        {
+          description: 'Inverted tabs',
+          propsToBind: {
+            inverted: true,
+          },
         },
-      }, {
-        description: 'Borderless tabs',
-        propsToBind: {
-          borderless: true,
+        {
+          description: 'Small size tabs',
+          propsToBind: {
+            size: 'sm',
+          },
         },
-      }, {
-        description: 'Importance tabs',
-        propsToBind: {
-          importance: true,
+        {
+          description: 'Borderless tabs',
+          propsToBind: {
+            borderless: true,
+          },
         },
-      }, {
-        description: 'Disabled tabs',
-        propsToBind: {
-          disabled: true,
+        {
+          description: 'Disabled tabs',
+          propsToBind: {
+            disabled: true,
+          },
         },
-      }],
+      ],
     };
   },
 };


### PR DESCRIPTION
# Add before-change event and improve DtTab behavior

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/5zQpI3kbBURybqS5lQ/giphy.gif?cid=790b7611gx18llf5lzyqoqphlxpq4dgjxmigcrjkhwoxtpui&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2370

## :book: Description

- Added `before-change` event to DtTab to have a way to prevent the default behavior if needed: e.g do a validation before changing to another tab.
- Removed `changeContentPanel` provide from DtTab to keep that logic within `DtTabGroup`, now the tab click emits the event and `DtTabGroup` handles it.

## :bulb: Context

- Users were not able to prevent the default behavior of a tab click. Context thread: https://dialpad.com/app/messages/agxzfnViZXItdm9pY2VyGAsSC1RleHRNZXNzYWdlGICAk-qzktkKDA

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

![2025-02-14 01 42 00](https://github.com/user-attachments/assets/952251e4-b753-476c-bc29-62735de6e6e5)

## :link: Test links

https://dialtone.dialpad.com/vue/deploy-previews/pr-633/index.html?path=/story/components-tabs--default