### PR TITLE
ci: NO-JIRA update workflows

### DIFF
--- a/.github/workflows/a11y_tests.yml
+++ b/.github/workflows/a11y_tests.yml
@@ -6,8 +6,15 @@ on:
       - staging
       - production
 
+    paths:
+      - 'packages/dialtone-vue2/**'
+      - 'packages/dialtone-vue3/**'
+
   pull_request:
-    types: ['opened', 'synchronize']
+    types:
+      - opened
+      - synchronize
+
     paths:
       - 'packages/dialtone-vue2/**'
       - 'packages/dialtone-vue3/**'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,8 @@ on:
           - vue3
           - eslint-plugin
           - stylelint-plugin
-  push:
-    branches:
-      - production
-      - alpha
-      - beta
-      - next
+  release:
+    types: [published]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' || github.event.inputs.package == 'all' || github.event.inputs.package == 'dialtone' }}
         run: pnpm nx run postcss-responsive-variations:release
 
-  push:
+  update-production:
     needs: [ release ]
     if: ${{ needs.get-branch-name.outputs.current_branch == 'staging' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Update Workflows

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbTF3ZXI0MWhmN3Y4d2Vuazk4YWx6anh5c2xtZGVoeXhmYmRnZjN0eCZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/JlpjgShzDsrMIyFu5U/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] CI

## :book: Description

- Updated publish workflow to run after a release has been published instead of on push.
- Added paths to a11y workflow to avoid unnecessary runs.
- Updated job name on release workflow. 

## :bulb: Context

- Found this while working on workflows, should improve the stability and reduce costs of our workflows by running only when necessary.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.
