### PR TITLE
fix: NO-JIRA custom item layout

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/list-item.less
+++ b/packages/dialtone-css/lib/build/less/components/list-item.less
@@ -37,6 +37,7 @@
   gap: var(--dt-space-400);
   min-height: calc(var(--dt-size-550) + var(--dt-size-300));
   padding: var(--dt-space-300) var(--dt-space-400);
+  font-size: var(--dt-font-size-200);
   line-height: var(--dt-font-line-height-300);
 }
 

--- a/packages/dialtone-css/lib/build/less/components/list-item.less
+++ b/packages/dialtone-css/lib/build/less/components/list-item.less
@@ -52,6 +52,10 @@
   align-content: center;
 }
 
+.d-list-item__title {
+  min-width: var(--dt-size-0);
+}
+
 .d-list-item__subtitle {
   margin-top: var(--dt-space-200-negative);
   color: var(--dt-color-foreground-tertiary);


### PR DESCRIPTION
# Fix custom item layout

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/QA88yMhazfDI4/giphy.gif?cid=790b76117ypztsoyr7wk5pe0c1hcyf89kqt96zvpw3rbhjs7&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Description

- Fixed missing font-size
- Fixed missing min-width

## :bulb: Context

Errors reported on product

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.