### PR TITLE
feat(message-input): DLT-2358 add slot for custom action icons

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -34,6 +34,14 @@ export const argTypesData = {
       type: 'text',
     },
   },
+  customActionIcons: {
+    table: {
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'text',
+    },
+  },
   middle: {
     table: {
       type: { summary: 'VNode' },
@@ -183,6 +191,7 @@ export const argsData = {
   top: '',
   middle: '',
   emojiGiphyPicker: '',
+  customActionIcons: '',
   sendButton: '',
   smsCount: '',
   placeholder: 'New message',

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -164,6 +164,8 @@
           </dt-popover>
           <!-- @slot Slot for emojiGiphy picker -->
           <slot name="emojiGiphyPicker" />
+          <!-- @slot Slot for custom action icons -->
+          <slot name="customActionIcons" />
         </dt-stack>
       </div>
       <!-- Right content -->

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -164,8 +164,8 @@
           </dt-popover>
           <!-- @slot Slot for emojiGiphy picker -->
           <slot name="emojiGiphyPicker" />
-          <!-- @slot Slot for custom action icons -->
-          <slot name="customActionIcons" />
+          <!-- @slot Slot to add extra action icons next to default ones -->
+        <slot name="customActionIcons" />
         </dt-stack>
       </div>
       <!-- Right content -->

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -61,6 +61,12 @@
           <span v-html="$attrs.emojiGiphyPicker" />
         </template>
         <template
+          v-if="$attrs.customActionIcons"
+          #customActionIcons
+        >
+          <span v-html="$attrs.customActionIcons" />
+        </template>
+        <template
           v-if="$attrs.middle"
           #middle
         >

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -34,6 +34,14 @@ export const argTypesData = {
       type: 'text',
     },
   },
+  customActionIcons: {
+    table: {
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'text',
+    },
+  },
   middle: {
     table: {
       type: { summary: 'VNode' },
@@ -183,6 +191,7 @@ export const argsData = {
   top: '',
   middle: '',
   emojiGiphyPicker: '',
+  customActionIcons: '',
   sendButton: '',
   smsCount: '',
   placeholder: 'New message',

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -163,6 +163,8 @@
           </dt-popover>
           <!-- @slot Slot for emojiGiphy picker -->
           <slot name="emojiGiphyPicker" />
+          <!-- @slot Slot for custom action icons -->
+          <slot name="customActionIcons" />
         </dt-stack>
       </div>
       <!-- Right content -->

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -163,7 +163,7 @@
           </dt-popover>
           <!-- @slot Slot for emojiGiphy picker -->
           <slot name="emojiGiphyPicker" />
-          <!-- @slot Slot for custom action icons -->
+          <!-- @slot Slot to add extra action icons next to default ones -->
           <slot name="customActionIcons" />
         </dt-stack>
       </div>

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -60,6 +60,12 @@
         <span v-html="$attrs.emojiGiphyPicker" />
       </template>
       <template
+        v-if="$attrs.customActionIcons"
+        #customActionIcons
+        >
+        <span v-html="$attrs.customActionIcons" />
+      </template>
+      <template
         v-if="$attrs.middle"
         #middle
       >


### PR DESCRIPTION
# feat(message-input): DLT-2358 add slot for custom action icons

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExdHZqMnVjMDU5Z3duZHY1MXJ4amsyMGRiMWRkMTdhb3kycjJ6bTUydiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/lg23waF4O25ot2cRIF/giphy.gif)


## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2358

## :book: Description

This pull request adds a new slot to the message input component that will allow any custom icon needs to be added on the product side.

## :bulb: Context

For a new project called quick replies we need to add a new icon on the message input. Design:
![Screenshot 2025-02-21 at 10 23 37 AM](https://github.com/user-attachments/assets/4e743c95-0ef1-480d-aa91-72d61ff0908e)
