### PR TITLE
fix: NO-JIRA not show unmounted warning in dev or prod environments

### DIFF
--- a/packages/dialtone-vue2/common/utils/index.js
+++ b/packages/dialtone-vue2/common/utils/index.js
@@ -380,7 +380,7 @@ export function capitalizeFirstLetter (str, locale = 'en-US') {
 // eslint-disable-next-line complexity
 export function warnIfUnmounted (componentRef, componentName) {
   if (typeof process === 'undefined') return;
-  if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'test') return;
+  if (process.env.NODE_ENV !== 'test') return;
   if (!componentRef || !(componentRef instanceof HTMLElement) || !document?.body) return;
   if (!document.body.contains(componentRef)) {
     console.warn(`The ${componentName} component is not attached to the document body. This may cause issues.`);

--- a/packages/dialtone-vue2/common/utils/index.js
+++ b/packages/dialtone-vue2/common/utils/index.js
@@ -377,7 +377,9 @@ export function capitalizeFirstLetter (str, locale = 'en-US') {
  * @param {HTMLElement} componentRef - the component reference
  * @param {string} componentName - the component name
  */
+// eslint-disable-next-line complexity
 export function warnIfUnmounted (componentRef, componentName) {
+  if (typeof process === 'undefined') return;
   if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'test') return;
   if (!componentRef || !(componentRef instanceof HTMLElement) || !document?.body) return;
   if (!document.body.contains(componentRef)) {

--- a/packages/dialtone-vue3/common/utils/index.js
+++ b/packages/dialtone-vue3/common/utils/index.js
@@ -398,7 +398,9 @@ export function capitalizeFirstLetter (str, locale = 'en-US') {
  * @param {HTMLElement} componentRef - the component reference
  * @param {string} componentName - the component name
  */
+// eslint-disable-next-line complexity
 export function warnIfUnmounted (componentRef, componentName) {
+  if (typeof process === 'undefined') return;
   if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'test') return;
   if (!componentRef || !(componentRef instanceof HTMLElement) || !document?.body) return;
   if (!document.body.contains(componentRef)) {

--- a/packages/dialtone-vue3/common/utils/index.js
+++ b/packages/dialtone-vue3/common/utils/index.js
@@ -401,7 +401,7 @@ export function capitalizeFirstLetter (str, locale = 'en-US') {
 // eslint-disable-next-line complexity
 export function warnIfUnmounted (componentRef, componentName) {
   if (typeof process === 'undefined') return;
-  if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'test') return;
+  if (process.env.NODE_ENV !== 'test') return;
   if (!componentRef || !(componentRef instanceof HTMLElement) || !document?.body) return;
   if (!document.body.contains(componentRef)) {
     console.warn(`The ${componentName} component is not attached to the document body. This may cause issues.`);


### PR DESCRIPTION
# fix: NO-JIRA not show unmounted warning in dev or prod environments

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/L2ZFBlX3vj5NO07vo9/giphy.gif?cid=82a1493bfvqf45wgg80jhe2xcr99ata7mqkykqja9s64tnzl&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
NO JIRA
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
The problem is that `process.env` is not defined in the browser, that's why the warning was appearing.
You can check in Beta:
<img width="1182" alt="image" src="https://github.com/user-attachments/assets/d193079c-6054-4eed-a75e-268943a6a83f" />

With this fix:
<img width="929" alt="image" src="https://github.com/user-attachments/assets/1f44dbb3-de83-49cd-9c56-8e042a5500a8" />


<!--- Describe specifically what the changes are -->

## :bulb: Context
This warning is only intended for test envs.
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.



<!--- Add any links to external reference material -->
