### PR TITLE
feat(component): DLT-2232 callbar button with dropdown

### DIFF
--- a/packages/dialtone-css/lib/build/less/dialtone.less
+++ b/packages/dialtone-css/lib/build/less/dialtone.less
@@ -76,6 +76,7 @@
 @import 'recipes/attachment_carousel';
 @import 'recipes/callbar_button';
 @import 'recipes/callbar_button_with_popover';
+@import 'recipes/callbar_button_with_dropdown';
 @import 'recipes/callbox';
 @import 'recipes/combobox_multi_select';
 @import 'recipes/combobox_with_popover';

--- a/packages/dialtone-css/lib/build/less/recipes/callbar_button_with_dropdown.less
+++ b/packages/dialtone-css/lib/build/less/recipes/callbar_button_with_dropdown.less
@@ -1,0 +1,52 @@
+.dt-recipe--callbar-button-with-dropdown--arrow {
+  width: var(--dt-size-500);
+  height: var(--dt-size-500);
+  margin-top: var(--dt-space-450);
+  margin-left: calc(var(--dt-space-300-negative) * 5);
+  padding: var(--dt-space-400);
+  border-radius: var(--dt-size-300);
+
+  &.d-btn--active {
+    background: var(--dt-color-surface-moderate-opaque);
+  }
+
+  &--large {
+    margin-left: var(--dt-space-550-negative);
+  }
+
+  &__icon {
+    color: var(--dt-color-black-800);
+  }
+}
+
+.dt-recipe--callbar-button-with-dropdown--dropdown {
+  .d-popover__header {
+    color: var(--dt-color-foreground-primary-inverted);
+    background: var(--dt-color-surface-contrast);
+
+    .d-btn {
+      color: var(--dt-color-foreground-primary-inverted);
+    }
+  }
+}
+
+.dt-recipe--callbar-button-with-dropdown--button .d-tab--selected::after,
+.dt-recipe--callbar-button-with-dropdown--button .d-tab--selected:hover::after {
+  --tab--bgc: var(--dt-color-surface-contrast);
+}
+
+.dt-recipe--callbar-button-with-dropdown--button .tab-group {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.dt-recipe--callbar-button-with-dropdown--button .tab-content {
+  flex: 1 1 100%;
+  overflow-y: auto;
+}
+
+.dt-recipe--callbar-button-with-dropdown {
+  display: flex;
+  align-items: flex-start;
+}

--- a/packages/dialtone-vue2/index.js
+++ b/packages/dialtone-vue2/index.js
@@ -76,6 +76,7 @@ export * from './directives/scrollbar';
 /// Recipes
 export * from './recipes/buttons/callbar_button';
 export * from './recipes/buttons/callbar_button_with_popover';
+export * from './recipes/buttons/callbar_button_with_dropdown';
 export * from './recipes/cards/ivr_node';
 export * from './recipes/chips/grouped_chip';
 export * from './recipes/comboboxes/combobox_multi_select';

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.stories.js
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.stories.js
@@ -1,0 +1,192 @@
+import { action } from '@storybook/addon-actions';
+import { createRenderConfig, getIconNames } from '@/common/storybook_utils';
+import DtRecipeCallbarButtonWithDropdown from './callbar_button_with_dropdown.vue';
+
+import DtRecipeCallbarButtonWithDropdownDefaultTemplate from './callbar_button_with_dropdown_default.story.vue';
+
+import {
+  POPOVER_DIRECTIONS,
+} from '@/components/popover/popover_constants';
+import { CALLBAR_BUTTON_VALID_WIDTH_SIZE } from '@/recipes/buttons/callbar_button/callbar_button_constants';
+
+const iconsList = getIconNames();
+
+// Default Prop Values
+export const argsData = {
+  buttonWidthSize: 'xl',
+  onArrowClick: action('arrow-click'),
+  onClick: action('click'),
+  onOpened: action('opened'),
+};
+
+export const argTypesData = {
+  // Button Slots
+  default: {
+    name: 'default',
+    description: 'Slot default content. This will be the button label',
+    control: 'text',
+    table: {
+      category: 'slots',
+      type: {
+        summary: 'text/html',
+      },
+    },
+  },
+  icon: {
+    name: 'icon',
+    description: 'Slot for button icon',
+    options: iconsList,
+    table: {
+      category: 'slots',
+      type: {
+        summary: 'VNode',
+      },
+    },
+    control: {
+      type: 'select',
+      labels: {
+        undefined: '(empty)',
+      },
+    },
+  },
+  tooltip: {
+    name: 'tooltip',
+    description: 'Slot tooltip',
+    control: 'text',
+    table: {
+      category: 'slots',
+      type: {
+        summary: 'text/html',
+      },
+    },
+  },
+  active: {
+    control: 'boolean',
+  },
+  danger: {
+    control: 'boolean',
+  },
+  disabled: {
+    control: 'boolean',
+  },
+  buttonClass: {
+    table: {
+      type: {
+        summary: ['string', 'array', 'object'],
+      },
+    },
+    control: 'text',
+  },
+  buttonWidthSize: {
+    options: CALLBAR_BUTTON_VALID_WIDTH_SIZE,
+    control: {
+      type: 'select',
+    },
+  },
+  textClass: {
+    table: {
+      type: {
+        summary: ['string', 'array', 'object'],
+      },
+    },
+    control: 'text',
+  },
+
+  // Popover slots
+  list: {
+    description: 'Slot for dropdown list',
+    control: {
+      type: {},
+    },
+    table: {
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+
+  // Action Event Handlers
+  'arrow-click': {
+    description: 'Triggered when the arrow is clicked',
+    table: {
+      disable: false,
+      type: {
+        summary: 'event',
+      },
+    },
+  },
+  onArrowClick: {
+    table: {
+      disable: true,
+    },
+  },
+  click: {
+    description: 'Triggered when the button is clicked',
+    table: {
+      disable: false,
+      type: {
+        summary: 'event',
+      },
+    },
+  },
+  onClick: {
+    table: {
+      disable: true,
+    },
+  },
+  opened: {
+    table: {
+      disable: false,
+      type: {
+        summary: 'event',
+      },
+    },
+  },
+  onOpened: {
+    table: {
+      disable: true,
+    },
+  },
+
+  id: {
+    table: {
+      defaultValue: {
+        summary: 'generated unique ID',
+      },
+    },
+  },
+
+  placement: {
+    options: POPOVER_DIRECTIONS,
+    control: {
+      type: 'select',
+    },
+  },
+};
+
+// Story Collection
+export default {
+  title: 'Recipes/Buttons/Callbar Button With Dropdown',
+  component: DtRecipeCallbarButtonWithDropdown,
+  args: argsData,
+  argTypes: argTypesData,
+  excludeStories: /.*Data$/,
+};
+
+// Templates
+const defaultArgs = {
+  default: 'Button',
+  tooltip: 'Tooltip Text',
+  ariaLabel: 'Button',
+  arrowButtonLabel: 'Open dropdown',
+  list: 'Dropdown body content',
+  forceShowArrow: false,
+  icon: 'dialpad-ai',
+};
+
+export const Default = {
+  render: (argsData) =>
+    createRenderConfig(DtRecipeCallbarButtonWithDropdown, DtRecipeCallbarButtonWithDropdownDefaultTemplate, argsData),
+
+  args: defaultArgs,
+};

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
@@ -1,0 +1,291 @@
+<template>
+  <div
+    class="dt-recipe--callbar-button-with-dropdown"
+  >
+    <dt-recipe-callbar-button
+      :aria-label="ariaLabel"
+      :disabled="disabled"
+      :active="active"
+      :danger="danger"
+      :button-class="buttonClass"
+      :button-width-size="buttonWidthSize"
+      :text-class="textClass"
+      class="dt-recipe--callbar-button-with-dropdown--main-button"
+      @click="buttonClick"
+    >
+      <template #icon>
+        <slot name="icon" />
+      </template>
+      <template #tooltip>
+        <slot name="tooltip" />
+      </template>
+      <slot />
+    </dt-recipe-callbar-button>
+    <dt-dropdown
+      v-if="showArrowButton"
+      :id="id"
+      :open="open"
+      :placement="placement"
+      :fallback-placements="fallbackPlacements"
+      padding="none"
+      class="dt-recipe--callbar-button-with-dropdown--dropdown-wrapper"
+      v-bind="$attrs"
+      @opened="onModalIsOpened"
+    >
+      <template #anchor>
+        <dt-button
+          circle
+          importance="clear"
+          size="lg"
+          :class="['dt-recipe--callbar-button-with-dropdown--arrow',
+                   { 'dt-recipe--callbar-button-with-dropdown--arrow--large': !isCompactMode }]"
+          width="2rem"
+          :aria-label="arrowButtonLabel"
+          :active="open"
+          @click="arrowClick"
+        >
+          <template #icon>
+            <dt-icon-chevron-up
+              class="dt-recipe--callbar-button-with-dropdown--arrow__icon"
+              size="200"
+            />
+          </template>
+        </dt-button>
+      </template>
+      <template #list>
+        <slot name="list" />
+      </template>
+    </dt-dropdown>
+  </div>
+</template>
+
+<script>
+import { DtButton } from '@/components/button';
+import { DtDropdown } from '@/components/dropdown';
+import { DtIconChevronUp } from '@dialpad/dialtone-icons/vue2';
+import { DtRecipeCallbarButton, CALLBAR_BUTTON_VALID_WIDTH_SIZE } from '../callbar_button';
+import utils, { warnIfUnmounted } from '@/common/utils';
+
+export default {
+  name: 'DtRecipeCallbarButtonWithDropdown',
+
+  components: { DtRecipeCallbarButton, DtDropdown, DtButton, DtIconChevronUp },
+
+  /* inheritAttrs: false is generally an option we want to set on library
+    components. This allows any attributes passed in that are not recognized
+    as props to be passed down to another element or component using v-bind:$attrs
+    more info: https://vuejs.org/v2/api/#inheritAttrs */
+  inheritAttrs: false,
+
+  props: {
+    /**
+     * Id for the item.
+     */
+    id: {
+      type: String,
+      default () {
+        return utils.getUniqueString();
+      },
+    },
+
+    /**
+     * Aria label for the button. If empty, it takes its value from the default slot.
+     */
+    ariaLabel: {
+      type: String,
+      default: null,
+      validator: (label) => {
+        return label || this.$slots.default;
+      },
+    },
+
+    /**
+     * Aria label for the arrow. Cannot be empty.
+     */
+    arrowButtonLabel: {
+      type: String,
+      required: true,
+      validator: (label) => {
+        return !!label;
+      },
+    },
+
+    /**
+     * The direction the dropdown displays relative to the anchor.
+     * @values 'bottom', 'bottom-start', 'bottom-end',
+     *         'right', 'right-start', 'right-end',
+     *         'left', 'left-start', 'left-end',
+     *         'top', 'top-start', 'top-end'
+     * @default 'top'
+     */
+    placement: {
+      type: String,
+      default: 'top',
+    },
+
+    /**
+     * If the dropdown does not fit in the direction described by "placement",
+     * it will attempt to change it's direction to the "fallbackPlacements".
+     *
+     * @values top, top-start, top-end,
+     * right, right-start, right-end,
+     * left, left-start, left-end,
+     * bottom, bottom-start, bottom-end,
+     * auto, auto-start, auto-end
+     * */
+    fallbackPlacements: {
+      type: Array,
+      default: () => {
+        return ['auto'];
+      },
+    },
+
+    /**
+     * Determines whether the button should be disabled
+     * default is false.
+     * @values true, false
+     */
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Forces showing the arrow, even if the button is disabled.
+     * default is false
+     * @values true, false
+     */
+    forceShowArrow: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Determines whether the button should have active styling
+     * default is false.
+     * @values true, false
+     * @see https://dialtone.dialpad.com/components/button/
+     */
+    active: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Determines whether the button should have danger styling
+     * default is false.
+     * @values true, false
+     * @see https://dialtone.dialpad.com/components/button/
+     */
+    danger: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Additional class name for the button wrapper element.
+     */
+    buttonClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
+    /**
+     * Additional class name for the button text.
+     */
+    textClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
+    /*
+     * Width size. Valid values are: 'xl', 'lg', 'md' and 'sm'.
+     */
+    buttonWidthSize: {
+      type: String,
+      default: 'xl',
+      validator: size => CALLBAR_BUTTON_VALID_WIDTH_SIZE.includes(size),
+    },
+  },
+
+  emits: [
+    /**
+     * Emitted when the arrow is clicked
+     */
+    'arrow-click',
+
+    /**
+     * Native click event
+     *
+     * @event click
+     * @type {PointerEvent | KeyboardEvent}
+     */
+    'click',
+
+    /**
+     * Emitted when modal dropdown is opened or closed.
+     */
+    'opened',
+  ],
+
+  data () {
+    return {
+      open: false,
+    };
+  },
+
+  computed: {
+    showArrowButton () {
+      return this.forceShowArrow || !this.disabled;
+    },
+
+    isCompactMode () {
+      return this.buttonWidthSize === 'sm' || this.buttonWidthSize === 'md';
+    },
+
+    showDropdown () {
+      if (!this.openDropdown || this.open) {
+        this.syncOpenState();
+        return false;
+      }
+
+      return this.toggleOpen();
+    },
+  },
+
+  mounted () {
+    warnIfUnmounted(this.$el, this.$options.name);
+  },
+
+  methods: {
+    arrowClick (ev) {
+      this.$emit('arrow-click', ev);
+      return this.toggleOpen();
+    },
+
+    toggleOpen () {
+      return (this.open = !this.open);
+    },
+
+    syncOpenState () {
+      this.open = this.openDropdown;
+    },
+
+    buttonClick (ev) {
+      // If no listener for the click event, the button click opens the dropdown
+      // the same as if the arrow was clicked.
+      if (!this.$listeners.click) {
+        this.arrowClick(ev);
+      } else {
+        this.$emit('click', ev);
+      }
+    },
+
+    onModalIsOpened (isOpened) {
+      this.open = isOpened;
+      this.$emit('opened', isOpened);
+    },
+  },
+
+};
+</script>

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown_default.story.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown_default.story.vue
@@ -1,0 +1,81 @@
+<template>
+  <dt-recipe-callbar-button-with-dropdown
+    :id="$attrs.id"
+    :aria-label="$attrs.ariaLabel"
+    :arrow-button-label="$attrs.arrowButtonLabel"
+    :placement="$attrs.placement"
+    :fallback-placements="$attrs.fallbackPlacements"
+    :disabled="$attrs.disabled"
+    :force-show-arrow="$attrs.forceShowArrow"
+    :active="$attrs.active"
+    :danger="$attrs.danger"
+    :button-class="$attrs.buttonClass"
+    :button-width-size="$attrs.buttonWidthSize"
+    :text-class="$attrs.textClass"
+    @arrow-click="$attrs.onArrowClick"
+    @click="$attrs.onClick"
+    @opened="$attrs.onOpened"
+  >
+    <span
+      v-if="$attrs.default"
+      v-html="$attrs.default"
+    />
+    <template
+      v-if="$attrs.icon"
+      #icon
+    >
+      <dt-icon :name="$attrs.icon" />
+    </template>
+    <template
+      v-if="$attrs.tooltip"
+      #tooltip
+    >
+      <span v-html="$attrs.tooltip" />
+    </template>
+    <template #list>
+      <dt-list-item-group
+        heading-class="d-py4 d-px8 d-fw-semibold d-c-default"
+        heading="Menu Heading A"
+      >
+        <dt-list-item
+          role="menuitem"
+          navigation-type="arrow-keys"
+        >
+          Menu Item 1
+        </dt-list-item>
+        <dt-dropdown-separator />
+        <dt-list-item
+          role="menuitem"
+          navigation-type="arrow-keys"
+        >
+          Menu Item 2
+        </dt-list-item>
+      </dt-list-item-group>
+      <dt-dropdown-separator />
+      <dt-list-item-group
+        heading-class="d-py4 d-px8 d-fw-semibold d-c-default"
+        heading="Menu Heading B"
+      >
+        <dt-list-item
+          role="menuitem"
+          navigation-type="arrow-keys"
+        >
+          Menu Item 3
+        </dt-list-item>
+      </dt-list-item-group>
+    </template>
+  </dt-recipe-callbar-button-with-dropdown>
+</template>
+
+<script>
+import DtRecipeCallbarButtonWithDropdown from './callbar_button_with_dropdown.vue';
+import { DtIcon } from '@/components/icon';
+import { DtListItem } from '@/components/list_item';
+import { DtListItemGroup } from '@/components/list_item_group';
+import { DtDropdownSeparator } from '@/components/dropdown';
+
+export default {
+  name: 'DtRecipeCallbarButtonWithPopoverDefault',
+  components: { DtRecipeCallbarButtonWithDropdown, DtIcon, DtListItem, DtListItemGroup, DtDropdownSeparator },
+};
+</script>

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/index.js
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/index.js
@@ -1,0 +1,1 @@
+export { default as DtRecipeCallbarButtonWithDropdown } from './callbar_button_with_dropdown.vue';

--- a/packages/dialtone-vue3/index.js
+++ b/packages/dialtone-vue3/index.js
@@ -77,6 +77,7 @@ export * from './directives/scrollbar';
 /// Recipes
 export * from './recipes/buttons/callbar_button';
 export * from './recipes/buttons/callbar_button_with_popover';
+export * from './recipes/buttons/callbar_button_with_dropdown';
 export * from './recipes/cards/ivr_node';
 export * from './recipes/chips/grouped_chip';
 export * from './recipes/comboboxes/combobox_multi_select';

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.stories.js
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.stories.js
@@ -1,0 +1,202 @@
+import { action } from '@storybook/addon-actions';
+import { createTemplateFromVueFile, getIconNames } from '@/common/storybook_utils';
+import DtRecipeCallbarButtonWithDropdown from './callbar_button_with_dropdown.vue';
+
+import DtRecipeCallbarButtonWithDropdownDefaultTemplate from './callbar_button_with_dropdown_default.story.vue';
+
+import {
+  POPOVER_DIRECTIONS,
+} from '@/components/popover/popover_constants';
+import { CALLBAR_BUTTON_VALID_WIDTH_SIZE } from '@/recipes/buttons/callbar_button/callbar_button_constants';
+
+const iconsList = getIconNames();
+
+// Default Prop Values
+export const argsData = {
+  buttonWidthSize: 'xl',
+  onArrowClick: action('arrow-click'),
+  onClick: action('click'),
+  onOpened: action('opened'),
+};
+
+export const argTypesData = {
+  // Button Slots
+  default: {
+    name: 'default',
+    description: 'Slot default content. This will be the button label',
+    control: 'text',
+    table: {
+      category: 'slots',
+      type: {
+        summary: 'text/html',
+      },
+    },
+  },
+  icon: {
+    name: 'icon',
+    description: 'Slot for button icon',
+    options: iconsList,
+    table: {
+      category: 'slots',
+      type: {
+        summary: 'VNode',
+      },
+    },
+    control: {
+      type: 'select',
+      labels: {
+        undefined: '(empty)',
+      },
+    },
+  },
+  tooltip: {
+    name: 'tooltip',
+    description: 'Slot tooltip',
+    control: 'text',
+    table: {
+      category: 'slots',
+      type: {
+        summary: 'text/html',
+      },
+    },
+  },
+  active: {
+    control: 'boolean',
+  },
+  danger: {
+    control: 'boolean',
+  },
+  disabled: {
+    control: 'boolean',
+  },
+  buttonClass: {
+    table: {
+      type: {
+        summary: ['string', 'array', 'object'],
+      },
+    },
+    control: 'text',
+  },
+  buttonWidthSize: {
+    options: CALLBAR_BUTTON_VALID_WIDTH_SIZE,
+    control: {
+      type: 'select',
+    },
+  },
+  textClass: {
+    table: {
+      type: {
+        summary: ['string', 'array', 'object'],
+      },
+    },
+    control: 'text',
+  },
+  contentClass: {
+    table: {
+      type: {
+        summary: ['string', 'array', 'object'],
+      },
+    },
+    control: 'text',
+  },
+
+  // Popover slots
+  list: {
+    description: 'Slot for dropdown list',
+    control: 'text',
+    table: {
+      type: {
+        summary: 'VNode',
+      },
+    },
+  },
+
+  // Action Event Handlers
+  'arrow-click': {
+    description: 'Triggered when the arrow is clicked',
+    table: {
+      disable: false,
+      type: {
+        summary: 'event',
+      },
+    },
+  },
+  onArrowClick: {
+    table: {
+      disable: true,
+    },
+  },
+  click: {
+    description: 'Triggered when the button is clicked',
+    table: {
+      disable: false,
+      type: {
+        summary: 'event',
+      },
+    },
+  },
+  onClick: {
+    table: {
+      disable: true,
+    },
+  },
+  opened: {
+    table: {
+      disable: false,
+      type: {
+        summary: 'event',
+      },
+    },
+  },
+  onOpened: {
+    table: {
+      disable: true,
+    },
+  },
+
+  id: {
+    table: {
+      defaultValue: {
+        summary: 'generated unique ID',
+      },
+    },
+  },
+
+  placement: {
+    options: POPOVER_DIRECTIONS,
+    control: {
+      type: 'select',
+    },
+  },
+};
+
+// Story Collection
+export default {
+  title: 'Recipes/Buttons/Callbar Button With Dropdown',
+  component: DtRecipeCallbarButtonWithDropdown,
+  args: argsData,
+  argTypes: argTypesData,
+  excludeStories: /.*Data$/,
+};
+
+// Templates
+const defaultArgs = {
+  default: 'Button',
+  tooltip: 'Tooltip Text',
+  ariaLabel: 'Button',
+  arrowButtonLabel: 'Open dropdown',
+  list: 'Dropdown body content',
+  forceShowArrow: false,
+  icon: 'dialpad-ai',
+};
+
+const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  DtRecipeCallbarButtonWithDropdownDefaultTemplate,
+);
+
+export const Default = {
+  render: DefaultTemplate,
+  args: defaultArgs,
+};

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.stories.js
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.stories.js
@@ -91,19 +91,13 @@ export const argTypesData = {
     },
     control: 'text',
   },
-  contentClass: {
-    table: {
-      type: {
-        summary: ['string', 'array', 'object'],
-      },
-    },
-    control: 'text',
-  },
 
   // Popover slots
   list: {
     description: 'Slot for dropdown list',
-    control: 'text',
+    control: {
+      type: {},
+    },
     table: {
       type: {
         summary: 'VNode',

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
@@ -1,0 +1,305 @@
+<template>
+  <div
+    class="dt-recipe--callbar-button-with-dropdown"
+  >
+    <dt-recipe-callbar-button
+      :aria-label="ariaLabel"
+      :disabled="disabled"
+      :active="active"
+      :danger="danger"
+      :button-class="buttonClass"
+      :button-width-size="buttonWidthSize"
+      :text-class="textClass"
+      class="dt-recipe--callbar-button-with-dropdown--main-button"
+      @click="buttonClick"
+    >
+      <template #icon>
+        <slot name="icon" />
+      </template>
+      <template #tooltip>
+        <slot name="tooltip" />
+      </template>
+      <slot />
+    </dt-recipe-callbar-button>
+    <dt-dropdown
+      v-if="showArrowButton"
+      :id="id"
+      :open="open"
+      :placement="placement"
+      :fallback-placements="fallbackPlacements"
+      padding="none"
+      class="dt-recipe--callbar-button-with-dropdown--dropdown-wrapper"
+      v-bind="$attrs"
+      @opened="onModalIsOpened"
+    >
+      <template #anchor>
+        <dt-button
+          circle
+          importance="clear"
+          size="lg"
+          :class="['dt-recipe--callbar-button-with-dropdown--arrow',
+                   { 'dt-recipe--callbar-button-with-dropdown--arrow--large': !isCompactMode }]"
+          width="2rem"
+          :aria-label="arrowButtonLabel"
+          :active="open"
+          @click="arrowClick"
+        >
+          <template #icon>
+            <dt-icon-chevron-up
+              class="dt-recipe--callbar-button-with-dropdown--arrow__icon"
+              size="200"
+            />
+          </template>
+        </dt-button>
+      </template>
+      <template #list>
+        <slot name="list" />
+      </template>
+    </dt-dropdown>
+  </div>
+</template>
+
+<script>
+import { DtButton } from '@/components/button';
+import { DtDropdown } from '@/components/dropdown';
+import { DtIconChevronUp } from '@dialpad/dialtone-icons/vue3';
+import { DtRecipeCallbarButton, CALLBAR_BUTTON_VALID_WIDTH_SIZE } from '../callbar_button';
+import utils, { warnIfUnmounted } from '@/common/utils';
+
+export default {
+  name: 'DtRecipeCallbarButtonWithDropdown',
+
+  components: { DtRecipeCallbarButton, DtDropdown, DtButton, DtIconChevronUp },
+
+  /* inheritAttrs: false is generally an option we want to set on library
+    components. This allows any attributes passed in that are not recognized
+    as props to be passed down to another element or component using v-bind:$attrs
+    more info: https://vuejs.org/v2/api/#inheritAttrs */
+  inheritAttrs: false,
+
+  props: {
+    /**
+     * Id for the item.
+     */
+    id: {
+      type: String,
+      default () {
+        return utils.getUniqueString();
+      },
+    },
+
+    /**
+     * Aria label for the button. If empty, it takes its value from the default slot.
+     */
+    ariaLabel: {
+      type: String,
+      default: null,
+      validator: (label) => {
+        return label || this.$slots.default;
+      },
+    },
+
+    /**
+     * Aria label for the arrow. Cannot be empty.
+     */
+    arrowButtonLabel: {
+      type: String,
+      required: true,
+      validator: (label) => {
+        return !!label;
+      },
+    },
+
+    /**
+     * The direction the dropdown displays relative to the anchor.
+     * @values 'bottom', 'bottom-start', 'bottom-end',
+     *         'right', 'right-start', 'right-end',
+     *         'left', 'left-start', 'left-end',
+     *         'top', 'top-start', 'top-end'
+     * @default 'top'
+     */
+    placement: {
+      type: String,
+      default: 'top',
+    },
+
+    /**
+     * If the dropdown does not fit in the direction described by "placement",
+     * it will attempt to change it's direction to the "fallbackPlacements".
+     *
+     * @values top, top-start, top-end,
+     * right, right-start, right-end,
+     * left, left-start, left-end,
+     * bottom, bottom-start, bottom-end,
+     * auto, auto-start, auto-end
+     * */
+    fallbackPlacements: {
+      type: Array,
+      default: () => {
+        return ['auto'];
+      },
+    },
+
+    /**
+     * Determines whether the button should be disabled
+     * default is false.
+     * @values true, false
+     */
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Forces showing the arrow, even if the button is disabled.
+     * default is false
+     * @values true, false
+     */
+    forceShowArrow: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Determines whether the button should have active styling
+     * default is false.
+     * @values true, false
+     * @see https://dialtone.dialpad.com/components/button/
+     */
+    active: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * Determines whether the button should have danger styling
+     * default is false.
+     * @values true, false
+     * @see https://dialtone.dialpad.com/components/button/
+     */
+    danger: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * We need this declaration because of how Vue3 informs the component about a listener.
+     * Spoiler alert: it doesn't.
+     * Vue3 intends to work as a real pub-sub, meaning the publisher has not a clue of who the subscribers are.
+     * This makes it impossible from the regular declaration (emits: ['click']) to check whether
+     * we actually have a click handler or not.
+     * We're hacking it by adding an onClick prop: https://github.com/vuejs/core/issues/5220
+    */
+    /* eslint-disable-next-line vue/no-unused-properties */
+    onClick: {
+      type: Function,
+      default: null,
+    },
+
+    /**
+     * Additional class name for the button wrapper element.
+     */
+    buttonClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
+    /**
+     * Additional class name for the button text.
+     */
+    textClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
+    /*
+     * Width size. Valid values are: 'xl', 'lg', 'md' and 'sm'.
+     */
+    buttonWidthSize: {
+      type: String,
+      default: 'xl',
+      validator: size => CALLBAR_BUTTON_VALID_WIDTH_SIZE.includes(size),
+    },
+  },
+
+  emits: [
+    /**
+     * Emitted when the arrow is clicked
+     */
+    'arrow-click',
+
+    /**
+     * Native click event
+     *
+     * @event click
+     * @type {PointerEvent | KeyboardEvent}
+     */
+    'click',
+
+    /**
+     * Emitted when modal dropdown is opened or closed.
+     */
+    'opened',
+  ],
+
+  data () {
+    return {
+      open: false,
+    };
+  },
+
+  computed: {
+    showArrowButton () {
+      return this.forceShowArrow || !this.disabled;
+    },
+
+    isCompactMode () {
+      return this.buttonWidthSize === 'sm' || this.buttonWidthSize === 'md';
+    },
+
+    showDropdown () {
+      if (!this.openDropdown || this.open) {
+        this.syncOpenState();
+        return false;
+      }
+
+      return this.toggleOpen();
+    },
+  },
+
+  mounted () {
+    warnIfUnmounted(this.$el, this.$options.name);
+  },
+
+  methods: {
+    arrowClick (ev) {
+      this.$emit('arrow-click', ev);
+      return this.toggleOpen();
+    },
+
+    toggleOpen () {
+      return (this.open = !this.open);
+    },
+
+    syncOpenState () {
+      this.open = this.openDropdown;
+    },
+
+    buttonClick (ev) {
+      // If no listener for the click event, the button click opens the dropdown
+      // the same as if the arrow was clicked.
+      if (!this.$props.onClick) {
+        this.arrowClick(ev);
+      } else {
+        this.$emit('click', ev);
+      }
+    },
+
+    onModalIsOpened (isOpened) {
+      this.open = isOpened;
+      this.$emit('opened', isOpened);
+    },
+  },
+
+};
+</script>

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown_default.story.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown_default.story.vue
@@ -1,0 +1,84 @@
+<template>
+  <dt-recipe-callbar-button-with-dropdown
+    :id="$attrs.id"
+    :aria-label="$attrs.ariaLabel"
+    :arrow-button-label="$attrs.arrowButtonLabel"
+    :placement="$attrs.placement"
+    :fallback-placements="$attrs.fallbackPlacements"
+    :disabled="$attrs.disabled"
+    :force-show-arrow="$attrs.forceShowArrow"
+    :active="$attrs.active"
+    :danger="$attrs.danger"
+    :button-class="$attrs.buttonClass"
+    :button-width-size="$attrs.buttonWidthSize"
+    :text-class="$attrs.textClass"
+    @arrow-click="$attrs.onArrowClick"
+    @click="$attrs.onClick"
+    @opened="$attrs.onOpened"
+  >
+    <span
+      v-if="defaultSlot"
+      v-html="defaultSlot"
+    />
+    <template
+      v-if="$attrs.icon"
+      #icon
+    >
+      <dt-icon :name="$attrs.icon" />
+    </template>
+    <template
+      v-if="$attrs.tooltip"
+      #tooltip
+    >
+      <span v-html="$attrs.tooltip" />
+    </template>
+    <template #list>
+      <dt-list-item-group
+        heading-class="d-py4 d-px8 d-fw-semibold d-c-default"
+        heading="Menu Heading A"
+      >
+        <dt-list-item
+          role="menuitem"
+          navigation-type="arrow-keys"
+          @click="close"
+        >
+          Menu Item 1
+        </dt-list-item>
+        <dt-dropdown-separator />
+        <dt-list-item
+          role="menuitem"
+          navigation-type="arrow-keys"
+          @click="close"
+        >
+          Menu Item 2
+        </dt-list-item>
+      </dt-list-item-group>
+      <dt-dropdown-separator />
+      <dt-list-item-group
+        heading-class="d-py4 d-px8 d-fw-semibold d-c-default"
+        heading="Menu Heading B"
+      >
+        <dt-list-item
+          role="menuitem"
+          navigation-type="arrow-keys"
+          @click="close"
+        >
+          Menu Item 3
+        </dt-list-item>
+      </dt-list-item-group>
+    </template>
+  </dt-recipe-callbar-button-with-dropdown>
+</template>
+
+<script>
+import DtRecipeCallbarButtonWithDropdown from './callbar_button_with_dropdown.vue';
+import { DtIcon } from '@/components/icon';
+import { DtListItem } from '@/components/list_item';
+import { DtListItemGroup } from '@/components/list_item_group';
+import { DtDropdownSeparator } from '@/components/dropdown';
+
+export default {
+  name: 'DtRecipeCallbarButtonWithPopoverDefault',
+  components: { DtRecipeCallbarButtonWithDropdown, DtIcon, DtListItem, DtListItemGroup, DtDropdownSeparator },
+};
+</script>

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/index.js
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/index.js
@@ -1,0 +1,1 @@
+export { default as DtRecipeCallbarButtonWithDropdown } from './callbar_button_with_dropdown.vue';


### PR DESCRIPTION
# feat(component): callbar button with dropdown

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExMmRvdjJsejN0dmJzN2wyYTZ6aW9mcHN2d2I5azd1aDVha3NxamZpZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3o6Mb3vhJYHNaNwwow/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Description

https://dialpad.atlassian.net/browse/DLT-2232

New component callbar button with dropdown. Very similar to callbar button with popover but uses dropdown instead. There may be a way to make the original component more robust and be able to use either popover or dropdown, however that would take significantly more effort, so this is a good quick solution for now.

## :bulb: Context

Promised to do this component for DPM team before christmas and then launch-a-thon / christmas / new year got in the way.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

If new component:

<!--- There are lots of things to remember when adding a new component to the system! This is so you don't forget any of them. -->

- I am exporting any new components or constants:
  - [x] from the index.js in the component directory.
  - [x] from the index.js in the root (either `packages/dialtone-vue2` or `packages/dialtone-vue3`).
- [x] I have added the styles for the new component to the `packages/dialtone-css` package.
- [x] I have created a component story in storybook
- [x] I have created story / stories for any relevant component variants in storybook
- [x] I have checked that changing all props/slots via the UI in storybook works as expected.
