### PR TITLE
fix(button): DLT-2310 fix colors for circle button

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -226,20 +226,7 @@
 .d-btn--circle {
   --button-padding-x: var(--button-padding-y-md);
   --button-padding-y: var(--button-padding-y-md);
-  --button-color-text: var(--dt-action-color-foreground-muted-default);
   --button-border-radius: var(--dt-size-radius-circle);
-
-  &:hover:not([disabled]) {
-    --button-color-text: var(--dt-action-color-foreground-muted-hover);
-    --button-color-background: var(--dt-action-color-background-muted-hover);
-  }
-
-  &:active:not([disabled]),
-  &.d-btn--active:not([disabled]),
-  &.d-btn--active:active:not([disabled]) {
-    --button-color-text: var(--dt-action-color-foreground-muted-active);
-    --button-color-background: var(--dt-action-color-background-muted-active);
-  }
 
   .d-btn__icon {
     margin: unset;
@@ -247,10 +234,6 @@
 
   &.d-btn__label {
     display: none;
-  }
-
-  &.d-btn--outlined {
-    --button-color-border: var(--dt-action-color-border-muted-outlined-default);
   }
 
   // Adjust padding based on sizes


### PR DESCRIPTION
# Fix colors for circle button

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/l41lPaVXzvGGMuAQ8/giphy.gif?cid=790b7611cvqily1h1w0ux9g3aqoi3d1s8sbtjjmasrc0o6o4&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
[DLT-2310]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
In the circle button, the colors for border, background and text where incorrect.

**Variant Outlined, Default**
Previous:
<img width="83" alt="image" src="https://github.com/user-attachments/assets/818b6839-9c57-4c24-9c1a-c2a36b834a61" />

Now:
<img width="77" alt="image" src="https://github.com/user-attachments/assets/453229d9-73e2-4dbc-b395-b8dcfda06476" />

**Variant Clear, Default**
Previous:
<img width="61" alt="image" src="https://github.com/user-attachments/assets/3976766f-e6a7-4f64-941b-671882b8b0c0" />

Now: 
<img width="59" alt="image" src="https://github.com/user-attachments/assets/f6cf8cfb-adf3-49c1-a003-f9d98c17fd33" />



<!--- Add any links to external reference material -->


[DLT-2310]: https://dialpad.atlassian.net/browse/DLT-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ