### PR TITLE
fix(message-input): DP-131613 fix pasting links when no rich-text

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
@@ -155,5 +155,6 @@ export const WithCustomExtensions = {
     allowUnderline: false,
     allowCode: false,
     allowCodeblock: false,
+    link: false,
   },
 };

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -655,7 +655,6 @@ export default {
   },
 
   methods: {
-
     createEditor () {
       // For all available options, see https://tiptap.dev/api/editor#settings
       this.editor = new Editor({
@@ -667,6 +666,17 @@ export default {
           attributes: {
             ...this.inputAttrs,
             class: this.inputClass,
+          },
+
+          handlePaste: (_, event) => {
+            // When having link and customLink props we should maintain default paste behavior
+            if (!this.link && !this.customLink) {
+              const pastedContent = event.clipboardData.getData('text');
+              this.editor.chain().focus().insertContent(pastedContent).run();
+              return true; // Prevent the default paste behavior
+            }
+
+            return false; // Allow the default paste behavior
           },
 
           // Moves the <br /> tags inside the previous closing tag to avoid

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -946,6 +946,11 @@ export default {
         const files = [...e.clipboardData.files];
         this.$emit('paste-media', files);
       }
+
+      // Handle link paste when no rich-text
+      if (!this.richText) {
+
+      }
     },
 
     onSkinTone (skinTone) {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -946,11 +946,6 @@ export default {
         const files = [...e.clipboardData.files];
         this.$emit('paste-media', files);
       }
-
-      // Handle link paste when no rich-text
-      if (!this.richText) {
-
-      }
     },
 
     onSkinTone (skinTone) {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -162,5 +162,6 @@ export const WithCustomExtensions = {
     allowUnderline: false,
     allowCode: false,
     allowCodeblock: false,
+    link: false,
   },
 };

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -670,6 +670,17 @@ export default {
             class: this.inputClass,
           },
 
+          handlePaste: (_, event) => {
+            // When having link and customLink props we should maintain default paste behavior
+            if (!this.link && !this.customLink) {
+              const pastedContent = event.clipboardData.getData('text');
+              this.editor.chain().focus().insertContent(pastedContent).run();
+              return true; // Prevent the default paste behavior
+            }
+
+            return false; // Allow the default paste behavior
+          },
+
           // Moves the <br /> tags inside the previous closing tag to avoid
           // Prosemirror wrapping them within another </p> tag.
           transformPastedHTML (html) {


### PR DESCRIPTION
# [fix(message-input): DP-131613 Fix pasting links when no rich-text](https://github.com/dialpad/dialtone/commit/e993dec8b2684f0e88c81d214fb50e56da38c7f3)

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExZzNyNWlmdGl2Y2Rsd2dvcnZobjJ0amF2b3IwZXI1MnFidzc4YmtreSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/RKA9WE5HGkLi8/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DP-131613
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

Clients reported an issue where, due to certain settings in Microsoft Edge, links were not being copied correctly when pasted into the new message input field.

Previous Behavior:
[View video](https://github.com/user-attachments/assets/db9abe15-e2b7-42a7-aeae-b42e1fc467ca)

This update resolves the issue, allowing users to copy and paste these links without any problems. Notably, this problem only affected the message input field when the link extension was disabled. When the link extension was enabled, the issue did not occur.

Updated Behavior (Fix Applied):
[View Screenshot](https://github.com/user-attachments/assets/ef0729cb-d527-4640-bd5a-b9bebd8f96ab)
