### PR TITLE
docs: NO-JIRA automate utility classes extraction

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/NewUtilityClassTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/NewUtilityClassTable.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="d-hmx464 d-of-y-auto d-bb d-bc-black-200">
+    <table class="d-table dialtone-doc-table d-fc-primary">
+      <thead>
+        <tr>
+          <th class="d-w25p" scope="col">
+            Class
+          </th>
+          <th scope="col">
+            Output
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="(value, className) in classes"
+          :key="className"
+        >
+          <th
+            scope="row"
+            class="d-code--sm d-fc-purple-400"
+            v-text="className"
+          />
+          <td
+            class="d-code--sm d-ws-break-spaces"
+          >
+            <div class="d-d-flex d-jc-space-between d-ai-center d-gg16">
+              <span class="d-fl-grow1 d-code--sm" v-text="value" />
+              <slot name="example" :class-name="className" />
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup>
+defineOptions({
+  name: 'NewUtilityClassTable',
+});
+
+const { classes } = defineProps({
+  classes: {
+    type: Object,
+    required: true,
+  },
+});
+</script>

--- a/apps/dialtone-documentation/docs/.vuepress/client.js
+++ b/apps/dialtone-documentation/docs/.vuepress/client.js
@@ -10,6 +10,7 @@ import Overview from './views/Overview.vue';
 // Base components
 import CodeWellHeader from './baseComponents/CodeWellHeader.vue';
 import UtilityClassTable from './baseComponents/UtilityClassTable.vue';
+import NewUtilityClassTable from './baseComponents/NewUtilityClassTable.vue';
 import ComponentClassTable from './baseComponents/ComponentClassTable.vue';
 import TokenTable from './baseComponents/tokens/TokenTable.vue';
 import ComponentVueApi from './baseComponents/ComponentVueApi.vue';
@@ -31,6 +32,7 @@ export default defineClientConfig({
     // Base components
     app.component('CodeWellHeader', CodeWellHeader);
     app.component('UtilityClassTable', UtilityClassTable);
+    app.component('NewUtilityClassTable', NewUtilityClassTable);
     app.component('ComponentClassTable', ComponentClassTable);
     app.component('TokenTable', TokenTable);
     app.component('ComponentVueApi', ComponentVueApi);

--- a/apps/dialtone-documentation/docs/.vuepress/common/utilities.js
+++ b/apps/dialtone-documentation/docs/.vuepress/common/utilities.js
@@ -50,7 +50,20 @@ export const ReleaseNoteFormatter = {
   },
 };
 
+export function extractUtilityClasses (utilityClassDocs, prefix) {
+  return Object.keys(utilityClassDocs)
+    .filter(className => className.startsWith(prefix))
+    .reduce((result, className) => {
+      result[className] = utilityClassDocs[className]
+        .values
+        .map(declaration => `${declaration.prop}: ${declaration.value};`)
+        .join('\n');
+      return result;
+    }, {});
+}
+
 export default {
   debounce,
   ReleaseNoteFormatter,
+  extractUtilityClasses,
 };

--- a/apps/dialtone-documentation/docs/.vuepress/config.js
+++ b/apps/dialtone-documentation/docs/.vuepress/config.js
@@ -110,6 +110,7 @@ export default defineUserConfig({
     '@baseComponents': path.resolve(__dirname, './baseComponents'),
     '@views': path.resolve(__dirname, './views'),
     '@mixins': path.resolve(__dirname, './common/mixins/'),
+    '@utilities': path.resolve(__dirname, './common/utilities.js'),
     '@projectRoot': path.resolve(__dirname, '../../'),
     '@': path.resolve(__dirname, '../'),
     '@workspaceRoot': path.resolve(__dirname, '../../../../'),

--- a/apps/dialtone-documentation/docs/.vuepress/theme/client.js
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/client.js
@@ -43,6 +43,7 @@ export default defineClientConfig({
       await registerDialtoneVue(app);
       // await registerDialtoneCombinator(app);
       await registerDialtoneIcons(app);
+      await importDocumentation(app);
     }
     router.options.scrollBehavior = async (to, from, savedPosition) => {
       if (to.hash) {
@@ -128,4 +129,15 @@ async function registerDialtoneIcons (app) {
 
   app.provide('dialtoneIcons', dialtoneIcons);
   app.provide('dialtoneIllustrations', dialtoneIllustrations);
+}
+
+async function importDocumentation (app) {
+  try {
+    console.info('Importing Utility Class documentation');
+    const importedModule = await import('../../../node_modules/@dialpad/dialtone-css/lib/dist/dialtone-docs.json');
+
+    app.provide('utilityClassDocs', importedModule.default);
+  } catch (error) {
+    console.error(`Couldn't import dialtone documentation: ${error}`);
+  }
 }

--- a/packages/dialtone-css/postcss/dialtone-docs.cjs
+++ b/packages/dialtone-css/postcss/dialtone-docs.cjs
@@ -107,7 +107,7 @@ module.exports = () => {
       });
     },
     async Rule (rule) {
-      if (!/^\.(d-|\w{2}\\:)/.test(rule.selector) | exclusionRegex.test(rule.selector)) return;
+      if (!/^\.(d-|\w{2}\\:)/.test(rule.selector) || exclusionRegex.test(rule.selector)) return;
       generateDocumentation(rule);
     },
     async OnceExit () {


### PR DESCRIPTION
# Automate utility classes extraction

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExM3Q5aDc1cDBlNWd5aG9hd3ZvZG04cWM2ZTN4aTVkdTU5Y2Y2MThvcSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/393kszFi2PuCEopURN/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Jira Ticket

NO-JIRA

## :book: Description

- Added NewUtilityClassTable and a util function to `extractUtilityClasses` from dialtone utility classes documentation

## :bulb: Context

I did this for https://dialpad.atlassian.net/browse/DLT-1208 which I moved to backlog due to a priority change, but I need this functionality to make sure all the utility classes exists on our documentation site for https://dialpad.atlassian.net/browse/DLT-2350 So moving this to staging as it doesn't affect how the current documentation is being generated and I can incrementally do the changes required to get all the documentation generated automatically in the future.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.