### PR TITLE
fix(eslint-plugin): DLT-2390 bound filename by slash

### DIFF
--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-component.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-component.js
@@ -69,7 +69,7 @@ module.exports = {
         let foundIndex;
 
         deprecatedComponents.forEach(item => {
-          const regex = new RegExp(`^.*${item.fileName}(?:\\.vue)?$`, 'g');
+          const regex = new RegExp(`^.*/${item.fileName}(?:\\.vue)?$`, 'g');
           foundIndex = node.source.value.toLowerCase().search(regex);
 
           if (foundIndex !== -1) {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-component.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-component.js
@@ -26,6 +26,10 @@ ruleTester.run("deprecated-component", rule, {
             name: 'Component that contains select_menu in the filename, but is not the file we are looking for',
             code: "import SelectMenuOption from '../components/select_menu_option';",
         },
+        {
+            name: 'Component that contains checkbox at the end of the name',
+            code: "import Checkbox from './components/app_settings_checkbox';",
+        },
     ],
 
     invalid: [


### PR DESCRIPTION
# fix(eslint-plugin): DLT-2390 bound filename by slash

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3o3ZXhhdHpnd3JubHY4ZzBoZDBubHUzN3NrcHZwNng2cjJ1NzM0eSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ibolLe3mOqHE3PQTtk/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2390

## :book: Description

added a preceding slash into the regex for deprecated components

## :bulb: Context

The current regex had `.*` before checking the filename, which means it was only checking for the word "checkbox" within the entire string. By adding a literal slash after the `.*` this allows us to limit our check to the entirety of the filename, which was the original intention of this check.
