### PR TITLE
fix: DLT-2392 add optional chaining to intersection observer disconnect

### DIFF
--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -687,7 +687,7 @@ export default {
 
   beforeDestroy () {
     this.tip?.destroy();
-    this.intersectionObserver.disconnect();
+    this.intersectionObserver?.disconnect();
     this.removeReferences();
     this.removeEventListeners();
   },

--- a/packages/dialtone-vue3/components/popover/popover.vue
+++ b/packages/dialtone-vue3/components/popover/popover.vue
@@ -715,7 +715,7 @@ export default {
 
   beforeUnmount () {
     this.tip?.destroy();
-    this.intersectionObserver.disconnect();
+    this.intersectionObserver?.disconnect();
     this.removeReferences();
     this.removeEventListeners();
   },


### PR DESCRIPTION
# fix: DLT-2392 add optional chaining to intersection observer disconnect

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [x] Other (chore)

## :book: Jira Ticket

[<!--- Enter the URL of the Jira ticket associated with this PR -->](https://dialpad.atlassian.net/browse/DLT-2392)

## :book: Description

Optional chain added to intersection observer disconnect

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.


