### PR TITLE
fix(contact-centers-row): DLT-2363 update colors on recipes

### DIFF
--- a/packages/dialtone-css/lib/build/less/recipes/leftbar_row.less
+++ b/packages/dialtone-css/lib/build/less/recipes/leftbar_row.less
@@ -296,7 +296,7 @@
   }
 
   &__container--off-duty {
-    background-color: var(--dt-badge-color-background-critical);
+    background-color: var(--dt-color-surface-critical);
     border: var(--dt-size-100) solid var(--dt-color-border-subtle);
     border-radius: var(--dt-size-radius-500);
 


### PR DESCRIPTION
# Update Contact Centers Row off-duty surface color

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/Itk3XIhsekOgBILnkd/giphy.gif?cid=ecf05e47l57qybbh74nx5npou27ogwdqxihdxzq0d7nebpde&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2363

## :book: Description

- Updated off-duty container surface color from `--dt-badge-color-background-critical` to `--dt-color-surface-critical`

## :bulb: Context

- Previously `--dt-badge-color-background-critical` was the same as surface-critical, but with the rebranding those colors were updated so now it doesn't look ok.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :camera: Screenshots / GIFs

| Before | After |
|--------|--------|
| ![Screenshot 2025-03-05 at 12 30 59 p m](https://github.com/user-attachments/assets/30f1afce-a0cd-4873-ba51-21f5640f7435) | ![Screenshot 2025-03-05 at 12 30 23 p m](https://github.com/user-attachments/assets/9f1d0022-ae81-4a34-a88a-45893d59c115) |
