### PR TITLE
docs(css-utilities): NO-JIRA update css utilities demo to emphasize semantic

### DIFF
--- a/apps/dialtone-documentation/docs/guides/getting-started/index.md
+++ b/apps/dialtone-documentation/docs/guides/getting-started/index.md
@@ -32,18 +32,20 @@ A general overview of Dialtone's utility classes, CSS components, and Vue compon
 Dialtone's CSS library offers a framework of utility-first classes. Each class is a small, [atomic style](https://css-tricks.com/lets-define-exactly-atomic-css/) declaration that, when chained together, should mitigate most situations in which custom CSS must be written. Just write these classes right in your mark-up and you're all set!
 
 <code-well-header>
-  <div class="d-p16 d-bgc-black-600 d-fc-primary-inverted">Box</div>
+  <div class="d-body--sm d-p8 d-bgc-contrast d-fc-primary-inverted d-bar8">Box</div>
 </code-well-header>
 
 ```html
-<div class="d-p16 d-bgc-black-600 d-fc-primary-inverted">Box</div>
+<div class="d-body--sm d-p8 d-bgc-contrast d-fc-primary-inverted d-bar8">Box</div>
 ```
 
 In the above example, we used:
 
-- Our [padding utility class](/utilities/spacing/padding.md) `.d-p16` to add 16px of padding
-- Our [background color utility class](/utilities/backgrounds/color.md) `.d-bgc-black-600` to add a purple background
-- Our [font color utility class](/utilities/typography/font-color.md) `.d-fc-primary-inverted` to change the font color to the inverted primary text color
+- Our [padding utility class](/utilities/spacing/padding.md) `.d-p8` to add 8px of padding on all sides.
+- Our [background color utility class](/utilities/backgrounds/color.md) `.d-bgc-contrast`.
+- Our [font color utility class](/utilities/typography/font-color.md) `.d-fc-primary-inverted` to change the font color to the inverted primary text color.
+- Our [border radius](/utilities/borders/radius.md) `.d-bar8` for rounded corners.
+- Our [text style](/design/typography/index.md) `.d-body--sm`.
 
 Though an atomic CSS approach comes with many advantages, we know it also offers a notable disadvantage: reducing the CSS cascade. This is especially true for repeated UI elements, which can end up creating redundant mark-up. For these instances, Dialtone offers components.
 
@@ -60,7 +62,7 @@ In the event Dialtone Vue doesn't suit your needs, Dialtone's CSS library offers
 <button class="d-btn d-btn--primary">Primary Button</button>
 ```
 
-### Writing CSS
+### Authoring Custom Style
 
 In the event you need to write CSS, use [BEM (Block Element Modifier)](http://getbem.com/). This is a simple, common naming convention that helps make our CSS easier to read and understand. If you aren't familiar with the approach, here's a [quick synposis](http://getbem.com/introduction/):
 
@@ -89,6 +91,7 @@ In the event you need to write CSS, use [BEM (Block Element Modifier)](http://ge
   display: flex;
   flex-direction: column;
   background-color: var(--card-color-background);
+  border: var(--dt-size-border-100) solid var(--dt-color-border-default);
 
   // Modifier for block
   &--featured {

--- a/apps/dialtone-documentation/docs/utilities/index.md
+++ b/apps/dialtone-documentation/docs/utilities/index.md
@@ -41,14 +41,14 @@ While an atomic CSS approach comes with many advantages, we recognize it also of
 
 ### Border Color
 
-`d-bc-purple-400` applies a border (`b`) color (`c`) of [Purple 400](/design/colors/index.md#purple).
+`d-bc-critical` applies a [critical](/design/colors/index.md#borders) border (`b`) color (`c`).
 
 <code-well-header>
-  <div class="d-bt d-btw4 d-bc-purple-400">Box</div>
+  <div class="d-bt d-btw4 d-bc-critical">Box</div>
 </code-well-header>
 
 ```html
-<div class="d-bt d-btw4 d-bc-purple-400">Box</div>
+<div class="d-bt d-btw4 d-bc-critical">Box</div>
 ```
 
 ## Tutorial
@@ -67,126 +67,324 @@ A basic example styling a container by combining Dialtone's CSS utilities. Follo
 
 ### 2. Apply a Dark Background Color
 
-Add `d-bgc-black-900` from the list of [background color utility classes]/utilities/backgrounds/color/index.md).
+Apply a [**Primary Inverted** Surface Color](/utilities/backgrounds/color/index.md#classes).
 
 <code-well-header>
-  <div class="d-bgc-black-900">Box</div>
+  <div class="d-bgc-primary-inverted">Box</div>
 </code-well-header>
 
 ```html
-<div class="d-bgc-black-900">Box</div>
+<div class="d-bgc-primary-inverted">Box</div>
 ```
 
 ### 3. Apply Color to the Foreground Text
 
-Since this is primary content on a dark background, let's use `d-fc-primary-inverted` from the [font color utilities]/utilities/typography/color/index.md).
+Since this will be primary content on a dark surface, let's use `d-fc-primary-inverted` from the [font color utilities](/utilities/typography/color/index.md).
 
 <code-well-header>
-  <div class="d-bgc-black-600 d-fc-primary-inverted">Box</div>
+  <div class="d-bgc-primary-inverted d-fc-primary-inverted">Box</div>
 </code-well-header>
 
 ```html
-<div class="d-bgc-black-600 d-fc-primary-inverted">Box</div>
+<div class="d-bgc-primary-inverted d-fc-primary-inverted">Box</div>
 ```
 
 ### 4. Apply Some Padding
 
-Let's use `d-px16` for horizontal padding (right and left), and `d-py8` for vertical padding (top and bottom), from the list of [padding utility classes]/utilities/spacing/padding/index.md).
+Let's use `d-p8` padding for all four sides, from the list of [padding utility classes](/utilities/spacing/padding/index.md).
 
 <code-well-header>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box</div>
+  <div class="d-bgc-primary-inverted d-fc-primary-inverted d-p8">Box</div>
 </code-well-header>
 
 ```html
-<div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box</div>
+<div class="d-bgc-primary-inverted d-fc-primary-inverted d-p8">Box</div>
 ```
 
 ### 5. List a Bunch of Boxes
 
-Let's wrap a repeating set of boxes in a new container.
+Let's repeat them in a [Stack](/components/stack.md) component. Note that I've moved the surface and foreground colors to the parent container so they may inherit.
 
 <code-well-header>
-  <div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box 1</div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box the 2nd</div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box third</div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box IV</div>
-  </div>
+  <dt-stack class="d-bgc-primary-inverted d-fc-primary-inverted">
+    <div class="d-p8">Box 1</div>
+    <div class="d-p8">Box the 2nd</div>
+    <div class="d-p8">Box third</div>
+    <div class="d-p8">Box IV</div>
+  </dt-stack>
 </code-well-header>
 
 ```html
-<div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box 1</div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box the 2nd</div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box third</div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box IV</div>
-</div>
+<dt-stack class="d-bgc-primary-inverted d-fc-primary-inverted">
+  <div class="d-p8">Box 1</div>
+  <div class="d-p8">Box the 2nd</div>
+  <div class="d-p8">Box third</div>
+  <div class="d-p8">Box IV</div>
+</dt-stack>
 ```
 
 ### 6. Render Them Horizontally
 
-Convert it to a `flex` container by adding `class="d-d-flex"`.
+Let's add the `direction` prop to make them flow horizontally.
 
 <code-well-header>
-  <div class="d-d-flex">
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box 1</div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box the 2nd</div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box third</div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box IV</div>
-  </div>
+  <dt-stack direction="row" class="d-bgc-primary-inverted d-fc-primary-inverted">
+    <div class="d-p8">Box 1</div>
+    <div class="d-p8">Box the 2nd</div>
+    <div class="d-p8">Box third</div>
+    <div class="d-p8">Box IV</div>
+  </dt-stack>
 </code-well-header>
 
 ```html
-<div class="d-d-flex">
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box 1</div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box the 2nd</div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box third</div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box IV</div>
-</div>
+<dt-stack direction="row" class="d-bgc-primary-inverted d-fc-primary-inverted">
+  <div class="d-p8">Box 1</div>
+  <div class="d-p8">Box the 2nd</div>
+  <div class="d-p8">Box third</div>
+  <div class="d-p8">Box IV</div>
+</dt-stack>
 ```
 
 ### 7. Add Borders to Segment Each
 
-Add a border to each box by applying `d-divide-x` (horizontal borders) to the surrounding container from the list of [divide width classes](/utilities/borders/divide-width.md).
+Add a border between each item with `d-divide-x`. Its default color is `currentColor`.
 
 <code-well-header>
-  <div class="d-d-flex d-divide-x">
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box 1</div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box the 2nd</div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box third</div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box IV</div>
-  </div>
+  <dt-stack direction="row" class="d-bgc-primary-inverted d-fc-primary-inverted d-divide-x">
+    <div class="d-p8">Box 1</div>
+    <div class="d-p8">Box the 2nd</div>
+    <div class="d-p8">Box third</div>
+    <div class="d-p8">Box IV</div>
+  </dt-stack>
 </code-well-header>
 
 ```html
-<div class="d-d-flex d-divide-x">
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box 1</div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box the 2nd</div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box third</div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box IV</div>
-</div>
+<dt-stack direction="row" class="d-bgc-primary-inverted d-fc-primary-inverted d-divide-x">
+  <div class="d-p8">Box 1</div>
+  <div class="d-p8">Box the 2nd</div>
+  <div class="d-p8">Box third</div>
+  <div class="d-p8">Box IV</div>
+</dt-stack>
 ```
 
 ### 8. And Change the Border Color
 
-Since the border color of `d-divide-x` inherits the color of the parent's foreground (implicitly `currentColor`), let's soften it with `d-divide-black-400`, from the list of [divide color classes](/utilities/borders/divide-color.md).
+Since the border color inherits the color of the parent's foreground (implicitly `currentColor`), let's soften it with a bold inverted border color `d-divide-moderate-inverted`.
 
 <code-well-header>
-  <div class="d-d-flex d-divide-x d-divide-black-400">
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box 1</div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box the 2nd</div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box third</div>
-    <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box IV</div>
-  </div>
+  <dt-stack direction="row" class="d-bgc-primary-inverted d-fc-primary-inverted d-divide-x d-divide-moderate-inverted">
+    <div class="d-p8">Box 1</div>
+    <div class="d-p8">Box the 2nd</div>
+    <div class="d-p8">Box third</div>
+    <div class="d-p8">Box IV</div>
+  </dt-stack>
 </code-well-header>
 
 ```html
-<div class="d-d-flex d-divide-x d-divide-black-400">
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box 1</div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box the 2nd</div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box third</div>
-  <div class="d-bgc-black-600 d-fc-primary-inverted d-px16 d-py8">Box IV</div>
-</div>
+<dt-stack direction="row" class="d-bgc-primary-inverted d-fc-primary-inverted d-divide-x d-divide-moderate-inverted">
+  <div class="d-p8">Box 1</div>
+  <div class="d-p8">Box the 2nd</div>
+  <div class="d-p8">Box third</div>
+  <div class="d-p8">Box IV</div>
+</dt-stack>
+```
+
+### 9. How about some icons
+
+Add some [icons](/design/icons/index.md).
+
+<code-well-header>
+  <dt-stack direction="row" class="d-bgc-primary-inverted d-fc-primary-inverted d-divide-x d-divide-moderate-inverted">
+    <dt-stack direction="row" gap="400" class="d-p8">
+      <dt-icon name="alert-triangle" size="200" />
+      Box 1
+    </dt-stack>
+    <dt-stack direction="row" gap="400" class="d-p8">
+      <dt-icon name="info" size="200" />
+      Box the 2nd
+    </dt-stack>
+    <dt-stack direction="row" gap="400" class="d-p8">
+      <dt-icon name="alert-circle" size="200" />
+      Box third
+    </dt-stack>
+    <dt-stack direction="row" gap="400" class="d-p8">
+      <dt-icon name="check-circle" size="200" />
+      Box IV
+    </dt-stack>
+  </dt-stack>
+</code-well-header>
+
+```html
+<dt-stack direction="row" class="d-bgc-primary-inverted d-fc-primary-inverted d-divide-x d-divide-moderate-inverted">
+  <dt-stack direction="row" gap="400" class="d-p8">
+    <dt-icon name="alert-triangle" size="200" />
+    Box 1
+  </dt-stack>
+  <dt-stack direction="row" gap="400" class="d-p8">
+    <dt-icon name="info" size="200" />
+    Box the 2nd
+  </dt-stack>
+  <dt-stack direction="row" gap="400" class="d-p8">
+    <dt-icon name="alert-circle" size="200" />
+    Box third
+  </dt-stack>
+  <dt-stack direction="row" gap="400" class="d-p8">
+    <dt-icon name="check-circle" size="200" />
+    Box IV
+  </dt-stack>
+</dt-stack>
+```
+
+### 10. Let's use some real color
+
+Apply a [semantic surface color](/utilities/backgrounds/color.md) to convey some meaning to them, e.g. `d-bgc-critical-strong`.
+
+<code-well-header>
+  <dt-stack direction="row" gap="400" class="d-fc-primary-inverted">
+    <dt-stack direction="row" gap="400" class="d-bgc-critical-strong d-p8">
+      <dt-icon name="alert-triangle" size="200" />
+      Critical
+    </dt-stack>
+    <dt-stack direction="row" gap="400" class="d-bgc-info-strong d-p8">
+      <dt-icon name="alert-circle" size="200" />
+      Info
+    </dt-stack>
+    <dt-stack direction="row" gap="400" class="d-bgc-success-strong d-p8">
+      <dt-icon name="check-circle" size="200" />
+      Success
+    </dt-stack>
+  </dt-stack>
+</code-well-header>
+
+```html
+<dt-stack direction="row" gap="400" class="d-fc-primary-inverted">
+  <dt-stack direction="row" gap="400" class="d-bgc-critical-strong d-p8">
+    <dt-icon name="alert-triangle" size="200" />
+    Critical
+  </dt-stack>
+  <dt-stack direction="row" gap="400" class="d-bgc-info-strong d-p8">
+    <dt-icon name="alert-circle" size="200" />
+    Info
+  </dt-stack>
+  <dt-stack direction="row" gap="400" class="d-bgc-success-strong d-p8">
+    <dt-icon name="check-circle" size="200" />
+    Success
+  </dt-stack>
+</dt-stack>
+```
+
+### 11. Apply an appropriate text style
+
+Choose a [text style](/design/typography/). Text styles combine multiple text properties, i.e. `font size`, `font-family`, `font-weight`, etc.
+
+<code-well-header>
+  <dt-stack direction="row" gap="400" class="d-fc-primary-inverted">
+    <dt-stack direction="row" gap="400" class="d-label--sm d-bgc-critical-strong d-p8">
+      <dt-icon name="alert-triangle" size="200" />
+      Critical
+    </dt-stack>
+    <dt-stack direction="row" gap="400" class="d-label--sm d-bgc-info-strong d-p8">
+      <dt-icon name="alert-circle" size="200" />
+      Info
+    </dt-stack>
+    <dt-stack direction="row" gap="400" class="d-label--sm d-bgc-success-strong d-p8">
+      <dt-icon name="check-circle" size="200" />
+      Success
+    </dt-stack>
+  </dt-stack>
+</code-well-header>
+
+```html
+<dt-stack direction="row" gap="400" class="d-fc-primary-inverted">
+  <dt-stack direction="row" gap="400" class="d-label--sm d-bgc-critical-strong d-p8">
+    <dt-icon name="alert-triangle" size="200" />
+    Critical
+  </dt-stack>
+  <dt-stack direction="row" gap="400" class="d-label--sm d-bgc-info-strong d-p8">
+    <dt-icon name="alert-circle" size="200" />
+    Info
+  </dt-stack>
+  <dt-stack direction="row" gap="400" class="d-label--sm d-bgc-success-strong d-p8">
+    <dt-icon name="check-circle" size="200" />
+    Success
+  </dt-stack>
+</dt-stack>
+```
+
+### 12. Tweak the spacing
+
+Refine the spacing by adusting the [Stack](/components/stack.md) `gap` prop and padding utilities for horizontal and vertical padding.
+
+<code-well-header>
+  <dt-stack direction="row" gap="400" class="d-fc-primary-inverted">
+    <dt-stack direction="row" gap="300" class="d-label--sm d-bgc-critical-strong d-py4 d-px8">
+      <dt-icon name="alert-triangle" size="200" />
+      Critical
+    </dt-stack>
+    <dt-stack direction="row" gap="300" class="d-label--sm d-bgc-info-strong d-py4 d-px8">
+      <dt-icon name="alert-circle" size="200" />
+      Info
+    </dt-stack>
+    <dt-stack direction="row" gap="300" class="d-label--sm d-bgc-success-strong d-py4 d-px8">
+      <dt-icon name="check-circle" size="200" />
+      Success
+    </dt-stack>
+  </dt-stack>
+</code-well-header>
+
+```html
+<dt-stack direction="row" gap="400" class="d-fc-primary-inverted">
+  <dt-stack direction="row" gap="300" class="d-label--sm d-bgc-critical-strong d-py4 d-px8">
+    <dt-icon name="alert-triangle" size="200" />
+    Critical
+  </dt-stack>
+  <dt-stack direction="row" gap="300" class="d-label--sm d-bgc-info-strong d-py4 d-px8">
+    <dt-icon name="alert-circle" size="200" />
+    Info
+  </dt-stack>
+  <dt-stack direction="row" gap="300" class="d-label--sm d-bgc-success-strong d-py4 d-px8">
+    <dt-icon name="check-circle" size="200" />
+    Success
+  </dt-stack>
+</dt-stack>
+```
+
+### 13. Round it out!
+
+Add `d-bar4` to each item for subtle rounded corners.
+
+<code-well-header>
+  <dt-stack direction="row" gap="400" class="d-fc-primary-inverted">
+    <dt-stack direction="row" gap="300" class="d-bar4 d-label--sm d-bgc-critical-strong d-py4 d-px8">
+      <dt-icon name="alert-triangle" size="200" />
+      Critical
+    </dt-stack>
+    <dt-stack direction="row" gap="300" class="d-bar4 d-label--sm d-bgc-info-strong d-py4 d-px8">
+      <dt-icon name="alert-circle" size="200" />
+      Info
+    </dt-stack>
+    <dt-stack direction="row" gap="300" class="d-bar4 d-label--sm d-bgc-success-strong d-py4 d-px8">
+      <dt-icon name="check-circle" size="200" />
+      Success
+    </dt-stack>
+  </dt-stack>
+</code-well-header>
+
+```html
+<dt-stack direction="row" gap="400" class="d-fc-primary-inverted">
+  <dt-stack direction="row" gap="300" class="d-bar4 d-label--sm d-bgc-critical-strong d-py4 d-px8">
+    <dt-icon name="alert-triangle" size="200" />
+    Critical
+  </dt-stack>
+  <dt-stack direction="row" gap="300" class="d-bar4 d-label--sm d-bgc-info-strong d-py4 d-px8">
+    <dt-icon name="alert-circle" size="200" />
+    Info
+  </dt-stack>
+  <dt-stack direction="row" gap="300" class="d-bar4 d-label--sm d-bgc-success-strong d-py4 d-px8">
+    <dt-icon name="check-circle" size="200" />
+    Success
+  </dt-stack>
+</dt-stack>
 ```
 
 ### Keep Exploring!


### PR DESCRIPTION
# Update CSS Utilities demo to emphasize semantic

The CSS Utilities intro pages uses base colors. Need to stress semantic, as well make for a slightly nicer demo end result.

<img width="923" alt="image" src="https://github.com/user-attachments/assets/86c4f5e9-104d-4883-8dcd-0b77c7049183" />

## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.