### PR TITLE
ci(release-notification): NO-JIRA notify on stable releases only

### DIFF
--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -3,7 +3,7 @@ name: Release notification
 on:
   push:
     tags:
-      - dialtone/v*
+      - 'dialtone/v[0-9]+.[0-9]+.[0-9]+'
 
 env:
   RELEASE_URL: ${{ format('https://github.com/dialpad/dialtone/releases/tag/{0}', github.ref_name) }}


### PR DESCRIPTION
# Update release notification to notify on stable releases only

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeGRlOTYycHBjdnBwZHIxZmRsbXhyamViZW95MTRpd2x4d3huOXZ3dSZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/D1YwKAqQGTysemFJ9E/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] CI

## :book: Description

- Limited the tags the workflow listens to.

## :bulb: Context

Having the release messages about alpha/beta/rebrand releases is noisy and don't make a lot of sense.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

## :link: Sources

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags
