### PR TITLE
fix(message-input): DP-134543 fix pasting behavior

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
@@ -155,6 +155,5 @@ export const WithCustomExtensions = {
     allowUnderline: false,
     allowCode: false,
     allowCodeblock: false,
-    link: false,
   },
 };

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
@@ -155,5 +155,21 @@ export const WithCustomExtensions = {
     allowUnderline: false,
     allowCode: false,
     allowCodeblock: false,
+    link: false
+  },
+};
+
+export const OnlyLinkExtension = {
+  render: (argsData) => createRenderConfig(DtRichTextEditor, DtRichTextEditorDefaultTemplate, argsData),
+  args: {
+    allowBlockquote: false,
+    allowBold: false,
+    allowBulletList: false,
+    allowItalic: false,
+    allowStrike: false,
+    allowUnderline: false,
+    allowCode: false,
+    allowCodeblock: false,
+    link: true
   },
 };

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -536,6 +536,7 @@ export default {
           },
           openOnClick: false,
           autolink: true,
+          linkOnPaste: false,
           protocols: RICH_TEXT_EDITOR_SUPPORTED_LINK_PROTOCOLS,
         }));
       }

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -655,6 +655,7 @@ export default {
   },
 
   methods: {
+
     createEditor () {
       // For all available options, see https://tiptap.dev/api/editor#settings
       this.editor = new Editor({
@@ -666,17 +667,6 @@ export default {
           attributes: {
             ...this.inputAttrs,
             class: this.inputClass,
-          },
-
-          handlePaste: (_, event) => {
-            // When having link and customLink props we should maintain default paste behavior
-            if (!this.link && !this.customLink) {
-              const pastedContent = event.clipboardData.getData('text');
-              this.editor.chain().focus().insertContent(pastedContent).run();
-              return true; // Prevent the default paste behavior
-            }
-
-            return false; // Allow the default paste behavior
           },
 
           // Moves the <br /> tags inside the previous closing tag to avoid

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -656,7 +656,6 @@ export default {
   },
 
   methods: {
-
     createEditor () {
       // For all available options, see https://tiptap.dev/api/editor#settings
       this.editor = new Editor({

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -302,3 +302,11 @@ export const WithMeetingPill = {
     preventTyping: true,
   },
 };
+
+export const WithoutExtensionsButWithLink = {
+  render: (argsData) => createRenderConfig(DtRecipeMessageInput, DtRecipeMessageInputDefaultTemplate, argsData),
+  args: {
+    richText: false,
+    link: true
+  },
+};

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -53,7 +53,7 @@
         :input-class="inputClass"
         :output-format="outputFormat"
         :auto-focus="autoFocus"
-        :link="richText"
+        :link="link"
         :placeholder="placeholder"
         :prevent-typing="preventTyping"
         :mention-suggestion="mentionSuggestion"
@@ -323,6 +323,14 @@ export default {
     richText: {
       type: Boolean,
       default: true,
+    },
+
+    /**
+     * Enables the TipTap Link extension and optionally passes configurations to it
+     */
+     link: {
+      type: [Boolean, Object],
+      default: false,
     },
 
     /**

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -37,6 +37,7 @@
         :remove-link-button="$attrs.removeLinkButton"
         :cancel-set-link-button="$attrs.cancelSetLinkButton"
         :set-link-placeholder="$attrs.setLinkPlaceholder"
+        :link="$attrs.link"
         @submit="$attrs.onSubmit"
         @focus="$attrs.onFocus"
         @blur="$attrs.onBlur"

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -162,6 +162,5 @@ export const WithCustomExtensions = {
     allowUnderline: false,
     allowCode: false,
     allowCodeblock: false,
-    link: false,
   },
 };

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -162,5 +162,21 @@ export const WithCustomExtensions = {
     allowUnderline: false,
     allowCode: false,
     allowCodeblock: false,
+    link: false
+  },
+};
+
+export const OnlyLinkExtension = {
+  ...Default,
+  args: {
+    allowBlockquote: false,
+    allowBold: false,
+    allowBulletList: false,
+    allowItalic: false,
+    allowStrike: false,
+    allowUnderline: false,
+    allowCode: false,
+    allowCodeblock: false,
+    link: true
   },
 };

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -670,17 +670,6 @@ export default {
             class: this.inputClass,
           },
 
-          handlePaste: (_, event) => {
-            // When having link and customLink props we should maintain default paste behavior
-            if (!this.link && !this.customLink) {
-              const pastedContent = event.clipboardData.getData('text');
-              this.editor.chain().focus().insertContent(pastedContent).run();
-              return true; // Prevent the default paste behavior
-            }
-
-            return false; // Allow the default paste behavior
-          },
-
           // Moves the <br /> tags inside the previous closing tag to avoid
           // Prosemirror wrapping them within another </p> tag.
           transformPastedHTML (html) {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -537,6 +537,7 @@ export default {
           },
           openOnClick: false,
           autolink: true,
+          linkOnPaste: false,
           protocols: RICH_TEXT_EDITOR_SUPPORTED_LINK_PROTOCOLS,
         }));
       }

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -309,3 +309,11 @@ export const WithMeetingPill = {
     preventTyping: true,
   },
 };
+
+export const WithoutExtensionsButWithLink = {
+  render: DefaultTemplate,
+  args: {
+    richText: false,
+    link: true
+  },
+};

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -322,6 +322,14 @@ export default {
     },
 
     /**
+     * Enables the TipTap Link extension and optionally passes configurations to it
+     */
+     link: {
+      type: [Boolean, Object],
+      default: false,
+    },
+
+    /**
      * Value of the input. The object format should match TipTap's JSON
      * document structure: https://tiptap.dev/guide/output#option-1-json
      */

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -25,6 +25,7 @@
       :channel-suggestion="$attrs.channelSuggestion"
       :slash-command-suggestion="$attrs.slashCommandSuggestion"
       :show-emoji-picker="$attrs.showEmojiPicker"
+      :link="$attrs.link"
       :emoji-picker-props="$attrs.emojiPickerProps"
       :emoji-tooltip-message="$attrs.emojiTooltipMessage"
       :emoji-button-aria-label="$attrs.emojiButtonAriaLabel"


### PR DESCRIPTION
# fix(message-input): DP-134543 fix pasting behavior

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjRtNzQ3dGtybHdkdzE1Zm41aDRkdjg5N2Nrd2libHV3cjRqamNxciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/76Nahzjx4Y6WXP2APE/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

<!--- Describe specifically what the changes are -->

## :bulb: Context

We are receiving reports saying that the paste functionality is not working fine on the message input so we are planning to revert the chnages that were made as part of [this pull request](https://github.com/dialpad/dialtone/pull/653) and for fixing the original issue we'll start using on product side the link extension.