### PR TITLE
feat: DLT-2419 hideEdges + watcher on active page prop

### DIFF
--- a/packages/dialtone-vue2/components/pagination/pagination.stories.js
+++ b/packages/dialtone-vue2/components/pagination/pagination.stories.js
@@ -10,6 +10,7 @@ export const argsData = {
   totalPages: 5,
   activePage: 1,
   maxVisible: 5,
+  hideEdges: false,
   ariaLabel: 'pagination',
   prevAriaLabel: 'previous',
   nextAriaLabel: 'next',
@@ -31,6 +32,11 @@ export const argTypesData = {
   maxVisible: {
     control: {
       type: 'number',
+    },
+  },
+  hideEdges: {
+    control: {
+      type: 'boolean',
     },
   },
   ariaLabel: {

--- a/packages/dialtone-vue2/components/pagination/pagination.test.js
+++ b/packages/dialtone-vue2/components/pagination/pagination.test.js
@@ -129,6 +129,51 @@ describe('DtPagination Tests', () => {
         expect(pages.length).toBe(7);
       });
     });
+
+    describe('When hideEdges is true', () => {
+      it('shouldn\'t render hidden pages which are the first and last when in middle', () => {
+        mockProps = {
+          totalPages: 15,
+          activePage: 7,
+          maxVisible: 5,
+          hideEdges: true,
+        };
+
+        updateWrapper();
+
+        expect(pages.length).toBe(7);
+        expect(pages.at(1).text()).toBe('5');
+        expect(pages.at(5).text()).toBe('9');
+      });
+
+      it('shouldn\'t render hidden pages which is the last page when at start', () => {
+        mockProps = {
+          totalPages: 15,
+          activePage: 1,
+          maxVisible: 5,
+          hideEdges: true,
+        };
+
+        updateWrapper();
+
+        expect(pages.length).toBe(7);
+        expect(pages.at(6).text()).not.toBe('15');
+      });
+
+      it('shouldn\'t render hidden pages which is the first page when at end', () => {
+        mockProps = {
+          totalPages: 15,
+          activePage: 14,
+          maxVisible: 5,
+          hideEdges: true,
+        };
+
+        updateWrapper();
+
+        expect(pages.length).toBe(7);
+        expect(pages.at(0).text()).not.toBe('1');
+      });
+    });
   });
 
   describe('Interactivity Tests', () => {

--- a/packages/dialtone-vue2/components/pagination/pagination.vue
+++ b/packages/dialtone-vue2/components/pagination/pagination.vue
@@ -187,32 +187,51 @@ export default {
         return this.range(1, this.totalPages);
       }
 
-      const start = this.maxVisible - 1;
-      const end = this.totalPages - start + 1;
+      let start = this.maxVisible - 1;
+      let end = this.totalPages - start + 1;
+
+      // if hideEdges is true, modify the start and
+      // end to account for the hidden pages
+      if (this.hideEdges) {
+        start = start + 1;
+        end = end - 1;
+      }
 
       if (this.currentPage < start) {
-        if (this.hideEdges) {
-          return [...this.range(1, start + 1), '...'];
+        const pages = [...this.range(1, start), '...'];
+        if (!this.hideEdges) {
+          // add last page to the end
+          pages.push(this.totalPages);
         }
-        return [...this.range(1, start), '...', this.totalPages];
+        return pages;
       }
 
       if (this.currentPage > end) {
-        if (this.hideEdges) {
-          return ['...', ...this.range(end - 1, this.totalPages)];
+        const pages = ['...', ...this.range(end, this.totalPages)];
+        if (!this.hideEdges) {
+          // add first page to the beginning
+          pages.unshift(1);
         }
-        return [1, '...', ...this.range(end, this.totalPages)];
+        return pages;
       }
 
       // rounding to the nearest odd according to the maxlength to always show the page number in the middle.
       const total = this.maxVisible - (3 - this.maxVisible % 2);
       const centerIndex = Math.floor(total / 2);
-      const left = this.currentPage - centerIndex;
-      const right = this.currentPage + centerIndex;
+      let left = this.currentPage - centerIndex;
+      let right = this.currentPage + centerIndex;
+
+      // if hideEdge is true, modify the left and right to account for the hidden pages
       if (this.hideEdges) {
-        return ['...', ...this.range(left - 1, right + 1), '...'];
+        left = left - 1;
+        right = right + 1;
       }
-      return [1, '...', ...this.range(left, right), '...', this.totalPages];
+
+      const pages = ['...', ...this.range(left, right), '...'];
+      if (!this.hideEdges) {
+        return [1, ...pages, this.totalPages];
+      }
+      return pages;
     },
   },
 

--- a/packages/dialtone-vue2/components/pagination/pagination.vue
+++ b/packages/dialtone-vue2/components/pagination/pagination.vue
@@ -142,6 +142,16 @@ export default {
       type: Number,
       default: 5,
     },
+
+    /**
+     * Sometimes you may need to hide start and end page number buttons when moving in between.
+     * This prop will be used to hide the first and last page buttons when not near the edges.
+     * This is useful when your backend does not support offset and you can only use cursor based pagination.
+     */
+    hideEdges: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   emits: [
@@ -181,10 +191,16 @@ export default {
       const end = this.totalPages - start + 1;
 
       if (this.currentPage < start) {
+        if (this.hideEdges) {
+          return [...this.range(1, start + 1), '...'];
+        }
         return [...this.range(1, start), '...', this.totalPages];
       }
 
       if (this.currentPage > end) {
+        if (this.hideEdges) {
+          return ['...', ...this.range(end - 1, this.totalPages)];
+        }
         return [1, '...', ...this.range(end, this.totalPages)];
       }
 
@@ -193,7 +209,16 @@ export default {
       const centerIndex = Math.floor(total / 2);
       const left = this.currentPage - centerIndex;
       const right = this.currentPage + centerIndex;
+      if (this.hideEdges) {
+        return ['...', ...this.range(left - 1, right + 1), '...'];
+      }
       return [1, '...', ...this.range(left, right), '...', this.totalPages];
+    },
+  },
+
+  watch: {
+    activePage () {
+      this.currentPage = this.activePage;
     },
   },
 

--- a/packages/dialtone-vue2/components/pagination/pagination_default.story.vue
+++ b/packages/dialtone-vue2/components/pagination/pagination_default.story.vue
@@ -3,6 +3,7 @@
     :total-pages="$attrs.totalPages"
     :active-page="$attrs.activePage"
     :max-visible="$attrs.maxVisible"
+    :hide-edges="$attrs.hideEdges"
     :aria-label="$attrs.ariaLabel"
     :prev-aria-label="$attrs.prevAriaLabel"
     :next-aria-label="$attrs.nextAriaLabel"

--- a/packages/dialtone-vue2/components/pagination/pagination_variants.story.vue
+++ b/packages/dialtone-vue2/components/pagination/pagination_variants.story.vue
@@ -38,6 +38,20 @@
         :page-number-aria-label="getPageNumberAriaLabel"
       />
     </div>
+    <div class="d-m32">
+      <p class="d-my16 d-fs-200 d-fw-bold">
+        Hide edges
+      </p>
+      <dt-pagination
+        :total-pages="10"
+        :active-page="5"
+        :aria-label="'pagination with separator on both sides'"
+        :prev-aria-label="'previous'"
+        :next-aria-label="'next'"
+        :page-number-aria-label="getPageNumberAriaLabel"
+        :hide-edges="true"
+      />
+    </div>
   </div>
 </template>
 

--- a/packages/dialtone-vue2/components/pagination/pagination_variants.story.vue
+++ b/packages/dialtone-vue2/components/pagination/pagination_variants.story.vue
@@ -6,9 +6,9 @@
       </p>
       <dt-pagination
         :total-pages="10"
-        :aria-label="'pagination with separator in the end'"
-        :prev-aria-label="'previous'"
-        :next-aria-label="'next'"
+        aria-label="pagination with separator in the end"
+        prev-aria-label="previous"
+        next-aria-label="next"
         :page-number-aria-label="getPageNumberAriaLabel"
       />
     </div>
@@ -19,9 +19,9 @@
       <dt-pagination
         :total-pages="15"
         :active-page="13"
-        :aria-label="'pagination with separator in the beginning'"
-        :prev-aria-label="'previous'"
-        :next-aria-label="'next'"
+        aria-label="pagination with separator in the beginning"
+        prev-aria-label="previous"
+        next-aria-label="next"
         :page-number-aria-label="getPageNumberAriaLabel"
       />
     </div>
@@ -32,9 +32,9 @@
       <dt-pagination
         :total-pages="10"
         :active-page="5"
-        :aria-label="'pagination with separator on both sides'"
-        :prev-aria-label="'previous'"
-        :next-aria-label="'next'"
+        aria-label="pagination with separator on both sides"
+        prev-aria-label="previous"
+        next-aria-label="next"
         :page-number-aria-label="getPageNumberAriaLabel"
       />
     </div>
@@ -45,9 +45,9 @@
       <dt-pagination
         :total-pages="10"
         :active-page="5"
-        :aria-label="'pagination with separator on both sides'"
-        :prev-aria-label="'previous'"
-        :next-aria-label="'next'"
+        aria-label="pagination with separator on both sides"
+        prev-aria-label="previous"
+        next-aria-label="next"
         :page-number-aria-label="getPageNumberAriaLabel"
         :hide-edges="true"
       />

--- a/packages/dialtone-vue3/components/pagination/pagination.stories.js
+++ b/packages/dialtone-vue3/components/pagination/pagination.stories.js
@@ -33,6 +33,11 @@ export const argTypesData = {
       type: 'number',
     },
   },
+  hideEdges: {
+    control: {
+      type: 'boolean',
+    },
+  },
   ariaLabel: {
     control: {
       type: 'text',

--- a/packages/dialtone-vue3/components/pagination/pagination.test.js
+++ b/packages/dialtone-vue3/components/pagination/pagination.test.js
@@ -123,6 +123,51 @@ describe('DtPagination Tests', () => {
         expect(pages.length).toBe(7);
       });
     });
+
+    describe('When hideEdges is true', () => {
+      it('shouldn\'t render hidden pages which are the first and last when in middle', () => {
+        mockProps = {
+          totalPages: 15,
+          activePage: 7,
+          maxVisible: 5,
+          hideEdges: true,
+        };
+
+        updateWrapper();
+
+        expect(pages.length).toBe(7);
+        expect(pages.at(1).text()).toBe('5');
+        expect(pages.at(5).text()).toBe('9');
+      });
+
+      it('shouldn\'t render hidden pages which is the last page when at start', () => {
+        mockProps = {
+          totalPages: 15,
+          activePage: 1,
+          maxVisible: 5,
+          hideEdges: true,
+        };
+
+        updateWrapper();
+
+        expect(pages.length).toBe(7);
+        expect(pages.at(6).text()).not.toBe('15');
+      });
+
+      it('shouldn\'t render hidden pages which is the first page when at end', () => {
+        mockProps = {
+          totalPages: 15,
+          activePage: 14,
+          maxVisible: 5,
+          hideEdges: true,
+        };
+
+        updateWrapper();
+
+        expect(pages.length).toBe(7);
+        expect(pages.at(0).text()).not.toBe('1');
+      });
+    });
   });
 
   describe('Interactivity Tests', () => {

--- a/packages/dialtone-vue3/components/pagination/pagination.vue
+++ b/packages/dialtone-vue3/components/pagination/pagination.vue
@@ -188,32 +188,52 @@ export default {
         return this.range(1, this.totalPages);
       }
 
-      const start = this.maxVisible - 1;
-      const end = this.totalPages - start + 1;
+      let start = this.maxVisible - 1;
+      let end = this.totalPages - start + 1;
+
+      // if hideEdges is true, modify the start and
+      // end to account for the hidden pages
+      if (this.hideEdges) {
+        start = start + 1;
+        end = end - 1;
+      }
 
       if (this.currentPage < start) {
-        if (this.hideEdges) {
-          return [...this.range(1, start + 1), '...'];
+        const pages = [...this.range(1, start), '...'];
+        if (!this.hideEdges) {
+          // add last page to the end
+          pages.push(this.totalPages);
         }
-        return [...this.range(1, start), '...', this.totalPages];
+        return pages;
       }
 
       if (this.currentPage > end) {
-        if (this.hideEdges) {
-          return ['...', ...this.range(end - 1, this.totalPages)];
+        console.log('END=', end);
+        const pages = ['...', ...this.range(end, this.totalPages)];
+        if (!this.hideEdges) {
+          // add first page to the beginning
+          pages.unshift(1);
         }
-        return [1, '...', ...this.range(end, this.totalPages)];
+        return pages;
       }
 
       // rounding to the nearest odd according to the maxlength to always show the page number in the middle.
       const total = this.maxVisible - (3 - this.maxVisible % 2);
       const centerIndex = Math.floor(total / 2);
-      const left = this.currentPage - centerIndex;
-      const right = this.currentPage + centerIndex;
+      let left = this.currentPage - centerIndex;
+      let right = this.currentPage + centerIndex;
+
+      // if hideEdge is true, modify the left and right to account for the hidden pages
       if (this.hideEdges) {
-        return ['...', ...this.range(left - 1, right + 1), '...'];
+        left = left - 1;
+        right = right + 1;
       }
-      return [1, '...', ...this.range(left, right), '...', this.totalPages];
+
+      const pages = ['...', ...this.range(left, right), '...'];
+      if (!this.hideEdges) {
+        return [1, ...pages, this.totalPages];
+      }
+      return pages;
     },
   },
 

--- a/packages/dialtone-vue3/components/pagination/pagination.vue
+++ b/packages/dialtone-vue3/components/pagination/pagination.vue
@@ -143,6 +143,16 @@ export default {
       type: Number,
       default: 5,
     },
+
+    /**
+     * Sometimes you may need to hide start and end page number buttons when moving in between.
+     * This prop will be used to hide the first and last page buttons when not near the edges.
+     * This is useful when your backend does not support offset and you can only use cursor based pagination.
+     */
+    hideEdges: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   emits: [
@@ -182,10 +192,16 @@ export default {
       const end = this.totalPages - start + 1;
 
       if (this.currentPage < start) {
+        if (this.hideEdges) {
+          return [...this.range(1, start + 1), '...'];
+        }
         return [...this.range(1, start), '...', this.totalPages];
       }
 
       if (this.currentPage > end) {
+        if (this.hideEdges) {
+          return ['...', ...this.range(end - 1, this.totalPages)];
+        }
         return [1, '...', ...this.range(end, this.totalPages)];
       }
 
@@ -194,7 +210,16 @@ export default {
       const centerIndex = Math.floor(total / 2);
       const left = this.currentPage - centerIndex;
       const right = this.currentPage + centerIndex;
+      if (this.hideEdges) {
+        return ['...', ...this.range(left - 1, right + 1), '...'];
+      }
       return [1, '...', ...this.range(left, right), '...', this.totalPages];
+    },
+  },
+
+  watch: {
+    activePage () {
+      this.currentPage = this.activePage;
     },
   },
 

--- a/packages/dialtone-vue3/components/pagination/pagination_default.story.vue
+++ b/packages/dialtone-vue3/components/pagination/pagination_default.story.vue
@@ -4,6 +4,7 @@
     :total-pages="$attrs.totalPages"
     :active-page="$attrs.activePage"
     :max-visible="$attrs.maxVisible"
+    :hide-edges="$attrs.hideEdges"
     :prev-aria-label="$attrs.prevAriaLabel"
     :next-aria-label="$attrs.nextAriaLabel"
     :page-number-aria-label="getPageNumberAriaLabel"

--- a/packages/dialtone-vue3/components/pagination/pagination_variants.story.vue
+++ b/packages/dialtone-vue3/components/pagination/pagination_variants.story.vue
@@ -38,6 +38,20 @@
         :page-number-aria-label="getPageNumberAriaLabel"
       />
     </div>
+    <div class="d-m32">
+      <p class="d-my16 d-fs-200 d-fw-bold">
+        Hide edges
+      </p>
+      <dt-pagination
+        :total-pages="10"
+        :active-page="5"
+        :aria-label="'pagination with separator on both sides'"
+        :prev-aria-label="'previous'"
+        :next-aria-label="'next'"
+        :page-number-aria-label="getPageNumberAriaLabel"
+        :hide-edges="true"
+      />
+    </div>
   </div>
 </template>
 

--- a/packages/dialtone-vue3/components/pagination/pagination_variants.story.vue
+++ b/packages/dialtone-vue3/components/pagination/pagination_variants.story.vue
@@ -6,9 +6,9 @@
       </p>
       <dt-pagination
         :total-pages="10"
-        :aria-label="'pagination with separator in the end'"
-        :prev-aria-label="'previous'"
-        :next-aria-label="'next'"
+        aria-label="pagination with separator in the end"
+        prev-aria-label="previous"
+        next-aria-label="next"
         :page-number-aria-label="getPageNumberAriaLabel"
       />
     </div>
@@ -19,9 +19,9 @@
       <dt-pagination
         :total-pages="15"
         :active-page="13"
-        :aria-label="'pagination with separator in the beginning'"
-        :prev-aria-label="'previous'"
-        :next-aria-label="'next'"
+        aria-label="pagination with separator in the beginning"
+        prev-aria-label="previous"
+        next-aria-label="next"
         :page-number-aria-label="getPageNumberAriaLabel"
       />
     </div>
@@ -32,9 +32,9 @@
       <dt-pagination
         :total-pages="10"
         :active-page="5"
-        :aria-label="'pagination with separator on both sides'"
-        :prev-aria-label="'previous'"
-        :next-aria-label="'next'"
+        aria-label="pagination with separator on both sides"
+        prev-aria-label="previous"
+        next-aria-label="next"
         :page-number-aria-label="getPageNumberAriaLabel"
       />
     </div>
@@ -45,9 +45,9 @@
       <dt-pagination
         :total-pages="10"
         :active-page="5"
-        :aria-label="'pagination with separator on both sides'"
-        :prev-aria-label="'previous'"
-        :next-aria-label="'next'"
+        aria-label="pagination with separator on both sides"
+        prev-aria-label="previous"
+        next-aria-label="next"
         :page-number-aria-label="getPageNumberAriaLabel"
         :hide-edges="true"
       />


### PR DESCRIPTION
# feat: hideEdges for lazy loading pagination and watcher on active page prop

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![test](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExN3pidXo1Z214NmFqZnY1Z2Z2dTUxcGUyMnN4eHUyZWNuZjlqcnhmbyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/61fRAw91kSw9iGygu3/giphy.gif)

![test](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExNHAwZnc4MnR5b3B0MmVjZ2J3Nmc2cTR2MmpoN2FoNTNnYnFtZ2dwbSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/cO9GE1nMdrFl1gpz0e/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2419

## :book: Description

activePage prop is not reactive since its assigned to data on init, so we cannot control the pagination from outside this component which is needed sometimes.

Sometimes you may need to hide start and end page number buttons when moving in between.
This prop will be used to hide the first and last page buttons when not near the edges.
This is useful when your backend does not support offset and you can only use cursor based pagination.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.
