### PR TITLE
fix(rich-text-editor): DP-134543 patchfix paste

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -671,7 +671,25 @@ export default {
           handlePaste: (_, event) => {
             // When having link and customLink props we should maintain default paste behavior
             if (!this.link && !this.customLink) {
+              const regex = /^https?:\/\//;
+
+              if (!event?.clipboardData) {
+                return false;
+              }
               const pastedContent = event.clipboardData.getData('text');
+
+              // Check if the pasted content is a valid URL (starting with http:// or https://)
+              // If it's not a URL, allow the default paste behavior
+              if (!regex.test(pastedContent)) {
+                return false;
+              }
+
+              // If `text/html` is missing from clipboard data, it's a plain link
+              // In this case, allow the default paste behavior
+              if (!event.clipboardData.getData('text/html')) {
+                return false;
+              }
+
               this.editor.chain().focus().insertContent(pastedContent).run();
               return true; // Prevent the default paste behavior
             }

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -673,7 +673,25 @@ export default {
           handlePaste: (_, event) => {
             // When having link and customLink props we should maintain default paste behavior
             if (!this.link && !this.customLink) {
+              const regex = /^https?:\/\//;
+
+              if (!event?.clipboardData) {
+                return false;
+              }
               const pastedContent = event.clipboardData.getData('text');
+
+              // Check if the pasted content is a valid URL (starting with http:// or https://)
+              // If it's not a URL, allow the default paste behavior
+              if (!regex.test(pastedContent)) {
+                return false;
+              }
+
+              // If `text/html` is missing from clipboard data, it's a plain link
+              // In this case, allow the default paste behavior
+              if (!event.clipboardData.getData('text/html')) {
+                return false;
+              }
+
               this.editor.chain().focus().insertContent(pastedContent).run();
               return true; // Prevent the default paste behavior
             }


### PR DESCRIPTION
# fix(rich-text-editor): DP-134543 patchfix paste

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExZWQzaTFuZ2s3MnNoY2c2eWlmZHc0aTlldGM5Z2F5eHN4d2NocnpkOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3orieWNwitLzDsyCT6/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DP-134569
https://dialpad.atlassian.net/browse/DP-134543
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

The initial issue that was reported was an issue with links on Edge. With some investigation, we realized that when copying and pasting links from edge brings some html data inside that makes links not working as the other ones. 

**Technical details**

I added these logs to see the behavior:
```
      console.log(event.clipboardData);
      console.log("Text:", event.clipboardData.getData("text/plain")); // Plain text
      console.log("HTML:", event.clipboardData.getData("text/html"));  // HTML formatted text (if available)
      console.log("Files:", event.clipboardData.files);               // List of files (if any)
```

This is what happened when pasting an edge link:
<img width="917" alt="Screenshot 2025-03-20 at 9 32 01 AM" src="https://github.com/user-attachments/assets/23ba27eb-5c6a-4e61-b2ad-001dc2098b96" />

vs pasting a link from any other place:
<img width="924" alt="Screenshot 2025-03-20 at 9 32 06 AM" src="https://github.com/user-attachments/assets/70322235-69a4-4aa9-bd8a-401401c08f3c" />


but i don't think we can do something with that as we also get text/html when pasting for example a piece of code. 

The original issue was with edge links -> we can identify those links with a **regex** and also we can also do the special handlePaste when the text/html section from the clipboardData is not null which we saw is the case for edge. Then, for all the other cases, we can just return and go into the normal paste behavior (in that way, we will avoid the new issues with pasting that were generated after my changes, like losing formatting or not working okey for pasting code).

I know it's no clean but it will give us more time to launch the link into the input with all the cases covered and tested.

## :bulb: Context
We are receiving reports saying that the paste functionality is not working fine on the message input; this was caused by https://github.com/dialpad/dialtone/pull/653. We initially think on reverting those changes and using the link extension instead, but as we noticed some unexpected behavior with it I think adding this patch fix will be the easiest and most quick patch fix we can do to fix both errors. 

Link PR for future: https://github.com/dialpad/dialtone/pull/674

Let me know what you think team!