### PR TITLE
fix(toast): NO-JIRA put z-index on wrapper

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/toast.less
+++ b/packages/dialtone-css/lib/build/less/components/toast.less
@@ -29,6 +29,7 @@
     --toast-color-shadow: hsla(var(--dt-color-black-900-hsl) / 0.15);
     --toast-box-shadow: 0 0 0 var(--dt-size-100) var(--toast-color-shadow) inset, var(--dt-shadow-medium);
 
+    z-index: var(--zi-notification);
     display: block;
     max-width: var(--dt-size-975);
     word-break: normal;

--- a/packages/dialtone-css/lib/build/less/components/toast.less
+++ b/packages/dialtone-css/lib/build/less/components/toast.less
@@ -13,6 +13,7 @@
   position: absolute;
   top: var(--dt-space-600); // 32
   left: 50%;
+  z-index: var(--zi-notification);
   display: flex;
   flex-direction: column;
   gap: var(--dt-space-500);
@@ -28,7 +29,6 @@
     --toast-color-shadow: hsla(var(--dt-color-black-900-hsl) / 0.15);
     --toast-box-shadow: 0 0 0 var(--dt-size-100) var(--toast-color-shadow) inset, var(--dt-shadow-medium);
 
-    z-index: var(--zi-notification);
     display: block;
     max-width: var(--dt-size-975);
     word-break: normal;


### PR DESCRIPTION
# fix(toast): put z-index on wrapper

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

move z-index to wrapper

## :bulb: Context

If the z-index is not on the outer container, it's pretty useless.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
