### PR TITLE
docs: DLT-2411 suppress-old-brand-icons

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/views/IconCatalog.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/views/IconCatalog.vue
@@ -129,6 +129,15 @@ const isModalOpen = ref(false);
 const isPopoverOpen = ref({});
 const filteredIconsList = ref({});
 const selectedIcon = ref(undefined);
+const excludedIcons = [
+  'brand-dialpad-meetings',
+  'brand-dialpad',
+  'dialpad-ai-color-reversed',
+  'dialpad-ai-color',
+  'dialpad-ai-reversed',
+  'dialpad-ai',
+  'dialpad-logomark',
+];
 
 const searchIcon = () => {
   debounce(() => {
@@ -178,7 +187,7 @@ const hasSearchResults = computed(() => Object.keys(filteredIconsList.value).len
  * In each category, iterate over the icons and filter by the search text or bypass it if the search in empty
  * If category has icons after filter, gets added to the categories Object.
  *
- * The filteredIconsList gets updated with a freezed object to improve performance.
+ * The filteredIconsList gets updated with a frozen object to improve performance.
  * @returns void
  */
 const filterIconList = () => {
@@ -189,7 +198,7 @@ const filterIconList = () => {
       const filteredCategory = Object.entries(categories[category])
         .filter(([name, keywords]) => {
           if (!search.value) return true;
-          return regex.test(name) || regex.test(keywords.join(' '));
+          return !excludedIcons.includes(name) && (regex.test(name) || regex.test(keywords.join(' ')));
         })
         .reduce((acc, [name, _]) => Object.assign(acc, { [name]: Object.freeze(categories[category][name]) }), {});
 


### PR DESCRIPTION
# Suppress old brand icons

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/VmgerEC33uLNWDqe11/giphy.gif?cid=790b7611ftg4ivkl57x3o8lnfrok1v003r8gx3n8wftp0utz&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2411

## :book: Description

- Added excludedIcons list to be able to exclude certain icons.

## :bulb: Context

- We need to hide the old brand icons

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

## :camera: Screenshots / GIFs

<img width="1496" alt="Screenshot 2025-03-23 at 8 41 46 p m" src="https://github.com/user-attachments/assets/91a27fa2-da15-48e7-846a-701460789175" />