### PR TITLE
fix(callbar-button-with-dropdown): DLT-2440 add missing slot prop close

### DIFF
--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
@@ -3,17 +3,17 @@
     class="dt-recipe--callbar-button-with-dropdown"
   >
     <dt-recipe-callbar-button
-      :aria-label="ariaLabel"
-      :disabled="disabled"
       :active="active"
-      :danger="danger"
+      :aria-label="ariaLabel"
       :button-class="buttonClass"
       :button-width-size="buttonWidthSize"
-      :text-class="textClass"
+      :danger="danger"
+      :disabled="disabled"
       :inverted-tooltip="invertedTooltip"
       :show-tooltip="showTooltip"
-      :tooltip-text="tooltipText"
+      :text-class="textClass"
       :tooltip-delay="tooltipDelay"
+      :tooltip-text="tooltipText"
       class="dt-recipe--callbar-button-with-dropdown--main-button"
       @click="buttonClick"
     >
@@ -28,24 +28,24 @@
     <dt-dropdown
       v-if="showArrowButton"
       :id="id"
+      :fallback-placements="fallbackPlacements"
       :open="open"
       :placement="placement"
-      :fallback-placements="fallbackPlacements"
-      padding="none"
       class="dt-recipe--callbar-button-with-dropdown--dropdown-wrapper"
+      padding="none"
       v-bind="$attrs"
       @opened="onModalIsOpened"
     >
       <template #anchor>
         <dt-button
+          :active="open"
+          :aria-label="arrowButtonLabel"
+          :class="['dt-recipe--callbar-button-with-dropdown--arrow',
+                   { 'dt-recipe--callbar-button-with-dropdown--arrow--large': !isCompactMode }]"
           circle
           importance="clear"
           size="lg"
-          :class="['dt-recipe--callbar-button-with-dropdown--arrow',
-                   { 'dt-recipe--callbar-button-with-dropdown--arrow--large': !isCompactMode }]"
           width="2rem"
-          :aria-label="arrowButtonLabel"
-          :active="open"
           @click="arrowClick"
         >
           <template #icon>
@@ -56,8 +56,11 @@
           </template>
         </dt-button>
       </template>
-      <template #list>
-        <slot name="list" />
+      <template #list="{ close }">
+        <slot
+          :close="close"
+          name="list"
+        />
       </template>
     </dt-dropdown>
   </div>
@@ -76,9 +79,9 @@ export default {
   components: { DtRecipeCallbarButton, DtDropdown, DtButton, DtIconChevronUp },
 
   /* inheritAttrs: false is generally an option we want to set on library
-    components. This allows any attributes passed in that are not recognized
-    as props to be passed down to another element or component using v-bind:$attrs
-    more info: https://vuejs.org/v2/api/#inheritAttrs */
+   components. This allows any attributes passed in that are not recognized
+   as props to be passed down to another element or component using v-bind:$attrs
+   more info: https://vuejs.org/v2/api/#inheritAttrs */
   inheritAttrs: false,
 
   props: {

--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown_default.story.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown_default.story.vue
@@ -36,7 +36,7 @@
     >
       <span v-html="$attrs.tooltip" />
     </template>
-    <template #list>
+    <template #list="{ close }">
       <dt-list-item-group
         heading-class="d-py4 d-px8 d-fw-semibold d-c-default"
         heading="Menu Heading A"
@@ -44,6 +44,7 @@
         <dt-list-item
           role="menuitem"
           navigation-type="arrow-keys"
+          @click="close"
         >
           Menu Item 1
         </dt-list-item>
@@ -51,6 +52,7 @@
         <dt-list-item
           role="menuitem"
           navigation-type="arrow-keys"
+          @click="close"
         >
           Menu Item 2
         </dt-list-item>
@@ -63,6 +65,7 @@
         <dt-list-item
           role="menuitem"
           navigation-type="arrow-keys"
+          @click="close"
         >
           Menu Item 3
         </dt-list-item>

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
@@ -3,17 +3,17 @@
     class="dt-recipe--callbar-button-with-dropdown"
   >
     <dt-recipe-callbar-button
-      :aria-label="ariaLabel"
-      :disabled="disabled"
       :active="active"
-      :danger="danger"
+      :aria-label="ariaLabel"
       :button-class="buttonClass"
       :button-width-size="buttonWidthSize"
-      :text-class="textClass"
+      :danger="danger"
+      :disabled="disabled"
       :inverted-tooltip="invertedTooltip"
       :show-tooltip="showTooltip"
-      :tooltip-text="tooltipText"
+      :text-class="textClass"
       :tooltip-delay="tooltipDelay"
+      :tooltip-text="tooltipText"
       class="dt-recipe--callbar-button-with-dropdown--main-button"
       @click="buttonClick"
     >
@@ -28,24 +28,24 @@
     <dt-dropdown
       v-if="showArrowButton"
       :id="id"
+      :fallback-placements="fallbackPlacements"
       :open="open"
       :placement="placement"
-      :fallback-placements="fallbackPlacements"
-      padding="none"
       class="dt-recipe--callbar-button-with-dropdown--dropdown-wrapper"
+      padding="none"
       v-bind="$attrs"
       @opened="onModalIsOpened"
     >
       <template #anchor>
         <dt-button
+          :active="open"
+          :aria-label="arrowButtonLabel"
+          :class="['dt-recipe--callbar-button-with-dropdown--arrow',
+                   { 'dt-recipe--callbar-button-with-dropdown--arrow--large': !isCompactMode }]"
           circle
           importance="clear"
           size="lg"
-          :class="['dt-recipe--callbar-button-with-dropdown--arrow',
-                   { 'dt-recipe--callbar-button-with-dropdown--arrow--large': !isCompactMode }]"
           width="2rem"
-          :aria-label="arrowButtonLabel"
-          :active="open"
           @click="arrowClick"
         >
           <template #icon>
@@ -56,8 +56,11 @@
           </template>
         </dt-button>
       </template>
-      <template #list>
-        <slot name="list" />
+      <template #list="{ close }">
+        <slot
+          :close="close"
+          name="list"
+        />
       </template>
     </dt-dropdown>
   </div>
@@ -76,9 +79,9 @@ export default {
   components: { DtRecipeCallbarButton, DtDropdown, DtButton, DtIconChevronUp },
 
   /* inheritAttrs: false is generally an option we want to set on library
-    components. This allows any attributes passed in that are not recognized
-    as props to be passed down to another element or component using v-bind:$attrs
-    more info: https://vuejs.org/v2/api/#inheritAttrs */
+   components. This allows any attributes passed in that are not recognized
+   as props to be passed down to another element or component using v-bind:$attrs
+   more info: https://vuejs.org/v2/api/#inheritAttrs */
   inheritAttrs: false,
 
   props: {
@@ -193,7 +196,7 @@ export default {
      * This makes it impossible from the regular declaration (emits: ['click']) to check whether
      * we actually have a click handler or not.
      * We're hacking it by adding an onClick prop: https://github.com/vuejs/core/issues/5220
-    */
+     */
     /* eslint-disable-next-line vue/no-unused-properties */
     onClick: {
       type: Function,

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown_default.story.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown_default.story.vue
@@ -36,7 +36,7 @@
     >
       <span v-html="$attrs.tooltip" />
     </template>
-    <template #list>
+    <template #list="{ close }">
       <dt-list-item-group
         heading-class="d-py4 d-px8 d-fw-semibold d-c-default"
         heading="Menu Heading A"


### PR DESCRIPTION
# Add missing close slot prop

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExengwcm5tZzJqemdwbjRja3ZvbWZwMHYxcnpwdnRpb202bHRrcGIxeCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l2JehQ2GitHGdVG9y/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2440

## :book: Description

- Added missing close slot prop
- Synced Vue 2 and Vue 3 version of the component

## :bulb: Context

- A bug was reported that the callbar button with dropdown was not closing as expected.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
