### PR TITLE
ci: NO-JIRA refactor publish workflows

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,0 +1,120 @@
+name: Publish Android
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Select the package you want to publish'
+        required: true
+        default: 'dialtone-tokens'
+        type: 'choice'
+        options:
+          - dialtone-tokens
+          - dialtone-icons
+  push:
+    branches:
+      - production
+      - rebrand-2025-beta
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  filter-actions:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.filter.outputs.changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Filter actions by path
+        if: ${{ github.event_name == 'push' }}
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          base: ${{ github.ref }}
+          list-files: 'json'
+          filters: |
+            dialtone-icons:
+              - 'packages/dialtone-icons/android/gradle.properties'
+            dialtone-tokens:
+              - 'packages/dialtone-tokens/gradle.properties'
+
+      - name: Filter actions by input
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        id: filter
+        run: |
+          echo 'changes=["${{ github.event.inputs.package }}"]' >> $GITHUB_OUTPUT
+
+  check-dialpad-member:
+    runs-on: ubuntu-latest
+    steps:
+      # Will prevent the rest of the steps from running on fail
+      - name: Check if user is a dialpad member
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /orgs/dialpad/members/${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.DIALTONE_CI_TOKEN }}
+
+  publish:
+    needs: [ check-dialpad-member, filter-actions ]
+    strategy:
+      matrix:
+        package: ${{ fromJSON(needs.filter-actions.outputs.packages) }}
+        include:
+          - package: dialtone-icons
+            dir: ./packages/dialtone-icons/android
+          - package: dialtone-tokens
+            dir: ./packages/dialtone-tokens
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Use pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: "${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: 'gradle'
+          cache-dependency-path: |
+            ${{ matrix.dir }}/*.gradle*
+            ${{ matrix.dir }}/**/gradle-wrapper.properties
+
+      - name: Build ${{ matrix.package }}
+        run: pnpm nx run ${{ matrix.package }}:build:android
+
+      - name: Publish ${{ matrix.package }}
+        working-directory: ${{ matrix.dir }}
+        env:
+          GITHUB_USER: braddialpad
+        run: ./gradlew publish

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -1,0 +1,71 @@
+name: Publish packages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - production
+    paths:
+      - 'packages/dialtone-tokens/dist_ios/**'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  check-dialpad-member:
+    runs-on: ubuntu-latest
+    steps:
+      # Will prevent the rest of the steps from running on fail
+      - name: Check if user is a dialpad member
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /orgs/dialpad/members/${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.DIALTONE_CI_TOKEN }}
+  publish:
+    needs: [ check-dialpad-member ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Use pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: "${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build swift
+        run: pnpm nx run dialtone-tokens:build:ios
+
+      - name: Publish production - Swift
+        uses: cpina/github-action-push-to-another-repository@v1.5.1
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.DIALTONE_CI_TOKEN }}
+        with:
+          user-email: 'dialtone@dialpad.com'
+          source-directory: 'packages/dialtone-tokens/dist_ios'
+          destination-repository-name: 'dialtone-tokens-swift'
+          destination-github-username: 'dialpad'
+          commit-message: "dialtone-tokens-swift release"

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -45,7 +45,7 @@ jobs:
   filter-actions:
     runs-on: ubuntu-latest
     outputs:
-      packages: ${{ github.event_name == 'push' && steps.filter-path.outputs.changes || steps.filter-input.outputs.package }}
+      packages: ${{ steps.filter.outputs.changes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
       - name: Filter actions by path
         if: ${{ github.event_name == 'push' }}
         uses: dorny/paths-filter@v3
-        id: filter-path
+        id: filter
         with:
           base: ${{ github.ref }}
           list-files: 'json'
@@ -77,12 +77,11 @@ jobs:
             stylelint-plugin-dialtone:
               - 'packages/stylelint-plugin-dialtone/package.json'
 
-
       - name: Filter actions by input
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        id: filter-input
+        id: filter
         run: |
-          echo 'package=["${{ github.event.inputs.package }}"]' >> $GITHUB_OUTPUT
+          echo 'changes=["${{ github.event.inputs.package }}"]' >> $GITHUB_OUTPUT
 
   check-dialpad-member:
     runs-on: ubuntu-latest
@@ -156,66 +155,3 @@ jobs:
           pnpm nx run ${{ matrix.package }}:publish
           --publish-branch=${{ needs.variables-setup.outputs.current_branch }}
           --tag=${{ env.RELEASE_TAG }}
-
-      # Publish iOS
-      - name: Build swift
-        if: ${{ needs.variables-setup.outputs.current_branch == 'production' && matrix.package == 'dialtone-tokens' }}
-        run: pnpm nx run dialtone-tokens:publish:ios-package
-
-      - name: Publish production - Swift
-        if: ${{ needs.variables-setup.outputs.current_branch == 'production' && matrix.package == 'dialtone-tokens' }}
-        uses: cpina/github-action-push-to-another-repository@v1.5.1
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.DIALTONE_CI_TOKEN }}
-        with:
-          user-email: 'dialtone@dialpad.com'
-          source-directory: 'packages/dialtone-tokens/dist_ios'
-          destination-repository-name: 'dialtone-tokens-swift'
-          destination-github-username: 'dialpad'
-          commit-message: "dialtone-tokens-swift release"
-
-      # Publish Android tokens
-      - name: Setup Java
-        if: ${{ needs.variables-setup.outputs.current_branch == 'production' && matrix.package == 'dialtone-tokens' }}
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'gradle'
-          cache-dependency-path: |
-            packages/dialtone-tokens/*.gradle*
-            packages/dialtone-tokens/**/gradle-wrapper.properties
-
-      - name: Build android tokens
-        if: ${{ needs.variables-setup.outputs.current_branch == 'production' && matrix.package == 'dialtone-tokens' }}
-        run: pnpm nx run dialtone-tokens:publish:android-package
-
-      - name: Publish android tokens - Gradle
-        if: ${{ needs.variables-setup.outputs.current_branch == 'production' && matrix.package == 'dialtone-tokens' }}
-        working-directory: ./packages/dialtone-tokens
-        env:
-          GITHUB_USER: braddialpad
-        run: ./gradlew publish
-
-      # Publish Android icons
-      - name: Setup Java
-        if: ${{ needs.variables-setup.outputs.current_branch == 'production' && matrix.package == 'dialtone-icons' }}
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'gradle'
-          cache-dependency-path: |
-            packages/dialtone-icons/android/*.gradle*
-            packages/dialtone-icons/android/**/gradle-wrapper.properties
-
-      - name: Build android icons
-        if: ${{ needs.variables-setup.outputs.current_branch == 'production' && matrix.package == 'dialtone-icons' }}
-        run: pnpm nx run dialtone-icons:publish:android-package
-
-      - name: Publish android icons - Gradle
-        if: ${{ needs.variables-setup.outputs.current_branch == 'production' && matrix.package == 'dialtone-icons' }}
-        working-directory: ./packages/dialtone-icons/android
-        env:
-          GITHUB_USER: braddialpad
-        run: ./gradlew publish

--- a/packages/dialtone-icons/project.json
+++ b/packages/dialtone-icons/project.json
@@ -6,12 +6,8 @@
       "options": {
         "cwd": "{projectRoot}",
         "commands": [
-          {
-            "command": "pnpm exec gulp"
-          },
-          {
-            "command": "nx run-many --target=build --projects=dialtone-icons-vue2,dialtone-icons-vue3,dialtone-icons-android --parallel=3 --output-style=stream"
-          }
+          "pnpm exec gulp",
+          "nx run-many --target=build --projects=dialtone-icons-vue2,dialtone-icons-vue3 --parallel=2 --output-style=stream"
         ],
         "parallel": false
       },
@@ -28,6 +24,18 @@
         "{projectRoot}/vue3/dist"
       ]
     },
+    "build:android": {
+      "dependsOn": ["dialtone-icons-android:build"],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}/android",
+        "command": "./gradlew publishToMavenLocal"
+      },
+      "outputs": [
+        "{projectRoot}/android/src/kotlin/icons",
+        "{projectRoot}/android/src/res/raw"
+      ]
+    },
     "publish": {
       "executor": "nx:run-commands",
       "options": {
@@ -38,16 +46,6 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "pnpm semantic-release-plus --extends ./packages/dialtone-icons/release-ci.config.cjs && sleep 3",
-        "parallel": false
-      }
-    },
-    "publish:android-package": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "{projectRoot}/android",
-        "commands": [
-          "./gradlew publishToMavenLocal"
-        ],
         "parallel": false
       }
     }

--- a/packages/dialtone-tokens/.github/CONTRIBUTING.md
+++ b/packages/dialtone-tokens/.github/CONTRIBUTING.md
@@ -62,7 +62,13 @@ You can access the NPM package here: [@dialpad/dialtone-tokens](https://www.npmj
 
 ### Android
 
-Upon build, the Android source code is output to `dist/android` folder. If we are looking to publish the package, this source must be compiled into an Android package. This is done via Gradle by running `publish:android-package`. The compiled package will contain kotlin as well as resource files for Dialtone's tokens. The Android package is served through GitHub Packages and can be found here: [design.dialpad.tokens.dialtone-tokens](https://github.com/dialpad/dialtone-tokens/packages/1646082). You do not have to run this command locally unless you are looking to debug something related to the Android package. The android package will be built and released on CI via our regular release process.
+Upon build, the Android source code is output to `dist/android` folder.
+If we are looking to publish the package, this source must be compiled into an Android package.
+This is done via Gradle by running `build:android`.
+The compiled package will contain kotlin as well as resource files for Dialtone's tokens.
+The Android package is served through GitHub Packages and can be found here: [design.dialpad.tokens.dialtone-tokens](https://github.com/dialpad/dialtone-tokens/packages/1646082).
+You do not have to run this command locally unless you are looking to debug something related to the Android package.
+The android package will be built and released on CI via our regular release process.
 
 If you would like to build the Android package locally for debugging purposes you will need to:
 
@@ -76,6 +82,10 @@ sdk.dir=PATH_TO_YOUR_ANDROID_SDK_GOES_HERE
 
 ### iOS
 
-Upon build the iOS swift source code is output to the `dist/ios` folder. The contents of the Swift package are included in `dist_ios` when running `publish:ios-package`. Swift packages are hosted directly from github repositories so we have a separate repository we deploy to to serve this package. This can be found here: [dialtone-tokens-swift](https://github.com/dialpad/dialtone-tokens-swift)
+Upon build the iOS swift source code is output to the `dist/ios` folder.
+The contents of the Swift package are included in `dist_ios` when running `build:ios`.
+Swift packages are hosted directly from github repositories so we have a separate repository we deploy to to serve this package.
+This can be found here: [dialtone-tokens-swift](https://github.com/dialpad/dialtone-tokens-swift)
 
-The deploy process is performed by the github actions workflow `.github/workflows/release.yml` and is triggered whenever we push the production branch. For more info on how to release, see [RELEASING.md](RELEASING.md)
+The deploy process is performed by the github actions workflow `.github/workflows/release.yml` and is triggered whenever we push the production branch.
+For more info on how to release, see [RELEASING.md](RELEASING.md)

--- a/packages/dialtone-tokens/package.json
+++ b/packages/dialtone-tokens/package.json
@@ -4,8 +4,6 @@
   "description": "Design tokens for Dialtone.",
   "type": "module",
   "scripts": {
-    "publish:android-package": "cp ./AndroidManifest.xml dist/android && ./gradlew publishToMavenLocal -Pversion=$npm_package_version",
-    "publish:ios-package": "./build-ios.js",
     "sync:tokens-to-figma": "tsx sync-scripts/sync_tokens_to_figma.ts",
     "sync:figma-to-tokens": "tsx sync-scripts/sync_figma_to_tokens.ts"
   },

--- a/packages/dialtone-tokens/project.json
+++ b/packages/dialtone-tokens/project.json
@@ -32,18 +32,24 @@
         "parallel": false
       }
     },
-    "publish:android-package": {
-      "executor": "nx:run-script",
+    "build:android": {
+      "dependsOn": ["build"],
+      "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "script": "publish:android-package"
+        "commands": [
+          "cp ./AndroidManifest.xml dist/android",
+          "./gradlew publishToMavenLocal"
+        ],
+        "parallel": false
       }
     },
-    "publish:ios-package": {
-      "executor": "nx:run-script",
+    "build:ios": {
+      "dependsOn": ["build"],
+      "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "script": "publish:ios-package"
+        "command": "node ./build-ios.js"
       }
     },
     "publish": {


### PR DESCRIPTION
# Refactor publish workflows

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/12Ge3LuCAofm2A/giphy.gif?cid=82a1493bheeuv67n9k4gzhjv26lc5mrzwouq1ma35isi27jy&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] CI

## :book: Description

- Refactor publish workflows into separate files
- Fix a build issue due to the recent addition of the android dialtone-icons package being built on the main dialtone-icons build.

## :bulb: Context

- While I was working on publishing a beta version of tokens realized that android and iOS publishing should be running from a separate workflows as they have different running conditions, such as production only release (iOS) and only tokens/icons (Android). I think with this changes, it'd be more maintainable and it's easier to read and follow up what's going on with those workflows. 

- Building the android icons is not necessary for our main build as we're not using them, separated that built to `build:android` tasks to make it clear you're building android specific projects that might require external dependencies like JAVA and the android SDK

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.