### PR TITLE
fix(pagination): DLT-2373 invalid prop combination on end buttons

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/pagination.less
+++ b/packages/dialtone-css/lib/build/less/components/pagination.less
@@ -25,6 +25,11 @@
 .d-pagination__button {
   padding-right: var(--dt-space-400);
   padding-left: var(--dt-space-400);
+
+  &:disabled {
+    color: var(--dt-color-foreground-secondary-inverted);
+    background-color: var(--dt-color-neutral-transparent);
+  }
 }
 
 //  ============================================================================

--- a/packages/dialtone-vue2/components/pagination/pagination.vue
+++ b/packages/dialtone-vue2/components/pagination/pagination.vue
@@ -7,10 +7,9 @@
       class="d-pagination__button"
       data-qa="dt-pagination-prev"
       :aria-label="prevAriaLabel"
-      :kind="isFirstPage ? 'default' : 'muted'"
-      :importance="isFirstPage ? 'primary' : 'clear'"
+      kind="muted"
+      importance="clear"
       :disabled="isFirstPage"
-      :class="isFirstPage ? 'd-fc-black-300 d-bgc-transparent' : 'd-fc-tertiary'"
       @click="changePage(currentPage - 1)"
     >
       <template #icon>
@@ -53,8 +52,7 @@
       :aria-label="nextAriaLabel"
       :disabled="isLastPage"
       kind="muted"
-      :importance="isLastPage ? 'primary' : 'clear'"
-      :class="isLastPage ? 'd-fc-black-300 d-bgc-transparent' : 'd-fc-tertiary'"
+      importance="clear"
       @click="changePage(currentPage + 1)"
     >
       <template #icon>

--- a/packages/dialtone-vue3/components/pagination/pagination.vue
+++ b/packages/dialtone-vue3/components/pagination/pagination.vue
@@ -7,10 +7,9 @@
       class="d-pagination__button"
       data-qa="dt-pagination-prev"
       :aria-label="prevAriaLabel"
-      :kind="isFirstPage ? 'default' : 'muted'"
-      :importance="isFirstPage ? 'primary' : 'clear'"
+      kind="muted"
+      importance="clear"
       :disabled="isFirstPage"
-      :class="isFirstPage ? 'd-fc-black-300 d-bgc-transparent' : 'd-fc-tertiary'"
       @click="changePage(currentPage - 1)"
     >
       <template #icon>
@@ -53,8 +52,7 @@
       :aria-label="nextAriaLabel"
       :disabled="isLastPage"
       kind="muted"
-      :importance="isLastPage ? 'primary' : 'clear'"
-      :class="isLastPage ? 'd-fc-black-300 d-bgc-transparent' : 'd-fc-tertiary'"
+      importance="clear"
       @click="changePage(currentPage + 1)"
     >
       <template #icon>
@@ -208,7 +206,6 @@ export default {
       }
 
       if (this.currentPage > end) {
-        console.log('END=', end);
         const pages = ['...', ...this.range(end, this.totalPages)];
         if (!this.hideEdges) {
           // add first page to the beginning


### PR DESCRIPTION
# [fix(pagination): DLT-2373 invalid prop combination on end buttons](https://github.com/dialpad/dialtone/commit/2a0f5031105af69681607119374cbd80051bbe4f)

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExMThta2tiZXpkYmhwYmR5ZDNhaXBhMGZsdm94MnB4a2lhcG05bDA2ZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JT7Td5xRqkvHQvTdEu/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2373

## :book: Description

Removed unnecessary conditionals from kind and importance props on the end "arrow" buttons in the pagination component.

## :bulb: Context

It was possible for the pagination component end buttons to display a "primary muted" button which is an invalid combination. Found that the kind and importance conditionals for the end buttons were not even needed anyways.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
