### PR TITLE
feat(editor): DP-131851 added editor support to encase text with div tags

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/div/div.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/div/div.js
@@ -1,0 +1,17 @@
+import { mergeAttributes } from '@tiptap/core';
+import Paragraph from '@tiptap/extension-paragraph';
+
+/** Extension for div tag support
+ * Replaces the default p tags when typing text to div tags
+ * Extends the following extension: https://github.com/ueberdosis/tiptap/blob/main/packages/extension-paragraph/src/paragraph.ts
+ */
+export const DivParagraph = Paragraph.extend({
+  parseHTML () {
+    return [{ tag: 'div' }];
+  },
+
+  renderHTML ({ HTMLAttributes }) {
+    return ['div', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  },
+
+});

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/div/index.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/div/index.js
@@ -1,0 +1,3 @@
+import { DivParagraph } from './div';
+
+export default DivParagraph;

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
@@ -156,5 +156,6 @@ export const WithCustomExtensions = {
     allowCode: false,
     allowCodeblock: false,
     link: false,
+    useDivTags: false,
   },
 };

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -78,6 +78,7 @@ import History from '@tiptap/extension-history';
 import Emoji from './extensions/emoji';
 import CustomLink from './extensions/custom_link';
 import ConfigurableImage from './extensions/image';
+import DivParagraph from './extensions/div';
 import { MentionPlugin } from './extensions/mentions/mention';
 import { ChannelPlugin } from './extensions/channels/channel';
 import { SlashCommandPlugin } from './extensions/slash_command/slash_command';
@@ -367,6 +368,14 @@ export default {
       type: Boolean,
       default: false,
     },
+
+    /**
+     * Show text in HTML div tags instead of paragraph tags
+     */
+    useDivTags: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   emits: [
@@ -466,7 +475,8 @@ export default {
     // eslint-disable-next-line complexity
     extensions () {
       // These are the default extensions needed just for plain text.
-      const extensions = [Document, Paragraph, Text, History, HardBreak];
+      const extensions = [Document, Text, History, HardBreak];
+      extensions.push(this.useDivTags ? DivParagraph : Paragraph);
 
       if (this.allowBlockquote) {
         extensions.push(Blockquote);

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor_default.story.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor_default.story.vue
@@ -23,6 +23,7 @@
     :allow-underline="$attrs.allowUnderline"
     :additional-extensions="$attrs.additionalExtensions"
     :hide-link-bubble-menu="$attrs.hideLinkBubbleMenu"
+    :use-div-tags="$attrs.useDivTags"
     @blur="$attrs.onBlur"
     @input="$attrs.onInput"
     @edit-link="$attrs.onEditLink"

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.test.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.test.js
@@ -597,5 +597,17 @@ describe('DtRecipeEditor tests', () => {
         expect('quick-replies-click' in wrapper.emitted()).toBeTruthy();
       });
     });
+
+    describe('When use div tags is enabled', () => {
+      beforeEach(async () => {
+        _mountWrapper();
+        await wrapper.setProps({ useDivTags: true });
+        await wrapper.vm.$nextTick();
+        _setChildWrappers();
+      });
+      it('should contain the initial value in div tags', function () {
+        expect(editor.html()).toContain(`<div>${testText}</div>`);
+      });
+    });
   });
 });

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -168,6 +168,7 @@
         :link="true"
         :output-format="htmlOutputFormat"
         :placeholder="placeholder"
+        :use-div-tags="useDivTags"
         data-qa="dt-rich-text-editor"
         v-bind="$attrs"
         @blur="onBlur"
@@ -461,6 +462,14 @@ export default {
         setLinkTitle: 'Add a link',
         setLinkInputAriaLabel: 'Input field to add link',
       }),
+    },
+
+    /**
+     * Use div tags instead of paragraph tags to show text
+     */
+    useDivTags: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor_default.story.vue
@@ -15,6 +15,7 @@
       :cancel-set-link-button="$attrs.cancelSetLinkButton"
       :confirm-set-link-button="$attrs.confirmSetLinkButton"
       :remove-link-button="$attrs.removeLinkButton"
+      :use-div-tags="$attrs.useDivTags"
       :show-bold-button="$attrs.showBoldButton"
       :show-italics-button="$attrs.showItalicsButton"
       :show-strike-button="$attrs.showStrikeButton"

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/div/div.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/div/div.js
@@ -1,0 +1,17 @@
+import { mergeAttributes } from '@tiptap/core';
+import Paragraph from '@tiptap/extension-paragraph';
+
+/** Extension for div tag support
+ * Replaces the default p tags when typing text to div tags
+ * Extends the following extension: https://github.com/ueberdosis/tiptap/blob/main/packages/extension-paragraph/src/paragraph.ts
+ */
+export const DivParagraph = Paragraph.extend({
+  parseHTML () {
+    return [{ tag: 'div' }];
+  },
+
+  renderHTML ({ HTMLAttributes }) {
+    return ['div', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  },
+
+});

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/div/index.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/div/index.js
@@ -1,0 +1,3 @@
+import { DivParagraph } from './div';
+
+export default DivParagraph;

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -163,5 +163,6 @@ export const WithCustomExtensions = {
     allowCode: false,
     allowCodeblock: false,
     link: false,
+    useDivTags: false,
   },
 };

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -78,6 +78,7 @@ import History from '@tiptap/extension-history';
 import Emoji from './extensions/emoji';
 import CustomLink from './extensions/custom_link';
 import ConfigurableImage from './extensions/image';
+import DivParagraph from './extensions/div';
 import { MentionPlugin } from './extensions/mentions/mention';
 import { ChannelPlugin } from './extensions/channels/channel';
 import { SlashCommandPlugin } from './extensions/slash_command/slash_command';
@@ -368,6 +369,14 @@ export default {
       type: Boolean,
       default: false,
     },
+
+    /**
+     * Show text in HTML div tags instead of paragraph tags
+     */
+    useDivTags: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   emits: [
@@ -467,7 +476,8 @@ export default {
     // eslint-disable-next-line complexity
     extensions () {
       // These are the default extensions needed just for plain text.
-      const extensions = [Document, Paragraph, Text, History, HardBreak];
+      const extensions = [Document, Text, History, HardBreak];
+      extensions.push(this.useDivTags ? DivParagraph : Paragraph);
 
       if (this.allowBlockquote) {
         extensions.push(Blockquote);

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
@@ -23,6 +23,7 @@
     :allow-underline="$attrs.allowUnderline"
     :additional-extensions="$attrs.additionalExtensions"
     :hide-link-bubble-menu="$attrs.hideLinkBubbleMenu"
+    :use-div-tags="$attrs.useDivTags"
     @blur="$attrs.onBlur"
     @input="$attrs.onInput"
     @edit-link="$attrs.onEditLink"

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.test.js
@@ -556,5 +556,17 @@ describe('DtRecipeEditor tests', () => {
         expect('quick-replies-click' in wrapper.emitted()).toBeTruthy();
       });
     });
+
+    describe('When use div tags is enabled', () => {
+      beforeEach(async () => {
+        _mountWrapper();
+        await wrapper.setProps({ useDivTags: true });
+        await wrapper.vm.$nextTick();
+        _setChildWrappers();
+      });
+      it('should contain the initial value in div tags', function () {
+        expect(editor.html()).toContain(`<div>${testText}</div>`);
+      });
+    });
   });
 });

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -168,6 +168,7 @@
         :link="true"
         :output-format="htmlOutputFormat"
         :placeholder="placeholder"
+        :use-div-tags="useDivTags"
         data-qa="dt-rich-text-editor"
         v-bind="$attrs"
         @blur="onBlur"
@@ -464,6 +465,14 @@ export default {
         setLinkTitle: 'Add a link',
         setLinkInputAriaLabel: 'Input field to add link',
       }),
+    },
+
+    /**
+     * Use div tags instead of paragraph tags to show text
+     */
+    useDivTags: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
@@ -15,6 +15,7 @@
       :cancel-set-link-button="$attrs.cancelSetLinkButton"
       :confirm-set-link-button="$attrs.confirmSetLinkButton"
       :remove-link-button="$attrs.removeLinkButton"
+      :use-div-tags="$attrs.useDivTags"
       :show-bold-button="$attrs.showBoldButton"
       :show-italics-button="$attrs.showItalicsButton"
       :show-strike-button="$attrs.showStrikeButton"


### PR DESCRIPTION
# Dialtone Recipe Editor Support For Encasing Text With Div Tags

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExZHNhd2JndXYzd2d6bTBydmp2ZGR4ZjZrZmM5b256am91Znd2anB6bCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ROlbnsc7aCIL6Icq6h/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

[<!--- Enter the URL of the Jira ticket associated with this PR -->]()
https://dialpad.atlassian.net/browse/DP-131851

## :book: Description

1. Introduced a new extension that extends the existing tiptap paragraph extension that adds div tags to text instead of p tags
2. Added a property to rich text editor to toggle the use of this extension. Default uses the paragraph tags, when enabled it adds the div extension to the editor instead of the paragraph extension
3. Added the same property to the DtRecipeEditor. This way ubervoice can send the property to the component to toggle the extension.

## :bulb: Context
Agent Experience is currently using Dialtone's Recipe Editor (DtRecipeEditor) for composing emails. One of our requirements by our customer is to match the behavior of outlook/gmail when composing emails. In outlook, and gmail when a user starts typing text the text is encased in div tags rather than the paragraph tags used by DtRecipeEditor which uses tiptap to implement the editor. This PR introduces a new extension that replaces the paragraph tags with a div tag. And enabling it when a property is sent to the recipe editor.

<!--- Describe the purpose of the changes -->
Purpose: We want the behavior of the editor to be similar to an editor in outlook or gmail.
<!--- Why did we make these changes? -->
Why: Customers were complaining that the email formatting was different in dialpad vs gmail and outlook because dialpad uses p tags and outlook and gmail uses div tags
<!--- What problem(s) do they solve? -->
Problems Solved: Customer will have a similar editing experience in both dialpad and other email clients like outlook and gmail. 

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->
<img width="1510" alt="Screenshot 2025-03-27 at 3 02 00 PM" src="https://github.com/user-attachments/assets/7f066f24-ae73-4b18-8632-556066a963a0" />
<img width="1510" alt="Screenshot 2025-03-27 at 3 02 43 PM" src="https://github.com/user-attachments/assets/0fd5e05d-128e-4a59-86f6-7d0caeabd54a" />

Screenshots of the imported component in ubervoice
<img width="1510" alt="Screenshot 2025-03-27 at 11 22 17 AM" src="https://github.com/user-attachments/assets/a5d1630c-ec67-4251-ab31-d1ba5b61592b" />
<img width="1510" alt="Screenshot 2025-03-27 at 11 22 57 AM" src="https://github.com/user-attachments/assets/1303019d-d897-4f4e-83f8-5b72874b66ee" />
<img width="1510" alt="Screenshot 2025-03-27 at 11 23 23 AM" src="https://github.com/user-attachments/assets/9977e0e0-321a-48e5-acc5-6b93167f74fd" />
<img width="1510" alt="Screenshot 2025-03-27 at 11 23 44 AM" src="https://github.com/user-attachments/assets/e3fab23a-5682-4650-9abd-804127fada52" />
