### PR TITLE
fix(emoji-text-wrapper): DLT-2455 skip vue3 comment vnodes when extracting text for emojis

### DIFF
--- a/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.test.js
+++ b/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.test.js
@@ -149,6 +149,22 @@ describe('DtEmojiTextWrapper Tests', () => {
           });
         });
       });
+
+      describe('When default slot contains html', () => {
+        beforeEach(() => {
+          mockSlots = { default: 'this <strong>noun</strong> being <em>bolded :star_struck:</em> is <!--slightly--> impressive!' }
+
+          updateWrapper();
+        });
+
+        it('Contains emoji component', () => {
+          expect(emoji.exists()).toBe(true);
+        });
+
+        it('Does not render comments as text', () => {
+          expect(wrapper.text()).not.toContain('slightly');
+        });
+      });
     });
 
     describe('When default slot is not provided', () => {

--- a/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.test.js
+++ b/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.test.js
@@ -143,6 +143,22 @@ describe('DtEmojiTextWrapper Tests', () => {
           });
         });
       });
+
+      describe('When default slot contains html', () => {
+        beforeEach(() => {
+          mockSlots = { default: 'this <strong>noun</strong> being <em>bolded :star_struck:</em> is <!--slightly--> impressive!' }
+
+          updateWrapper();
+        });
+
+        it('Contains emoji component', () => {
+          expect(emoji.exists()).toBe(true);
+        });
+
+        it('Does not render comments as text', () => {
+          expect(wrapper.text()).not.toContain('slightly');
+        });
+      });
     });
 
     describe('When default slot is not provided', () => {

--- a/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -1,8 +1,10 @@
 <script>
 import { DtEmoji } from '../emoji';
 import { findEmojis, findShortCodes } from '@/common/emoji';
-import { h } from 'vue';
+import { h, resolveDynamicComponent } from 'vue';
 import { ICON_SIZE_MODIFIERS } from '@/components/icon/icon_constants';
+
+const COMMENT_TYPE = h(resolveDynamicComponent(null)).type;
 
 /**
  * Wrapper to find and replace shortcodes like :smile: or unicode chars such as 😄 with our custom Emojis implementation.
@@ -77,6 +79,7 @@ export default {
      */
     searchVNodes (VNode) {
       if (typeof VNode === 'string') return this.searchCodes(VNode);
+      if (VNode.type === COMMENT_TYPE) return VNode;
       if (typeof VNode.type === 'symbol') return this.searchCodes(VNode.children);
       if (VNode.props?.innerHTML) return this.searchVNodes(VNode.props.innerHTML);
 


### PR DESCRIPTION
# PR Title

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.tenor.com/m/NJfGgMXQ5egAAAAC/brennan-lee-mulligan-um-actually.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2455

## :book: Description

<!--- Describe specifically what the changes are -->
Skip vue3 comment vnodes when searching for text to emojify. In vue3 internals, comment vnodes look a lot like other html vnodes with text children.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->
The placeholder comments vue produces for v-if elements which were not currently rendering were being placed into the document as the string `v-if` after the emoji processing.


## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.
