### PR TITLE
fix(tooltip): DP-129564 add overflow-wrap for tooltip

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/tooltip.less
+++ b/packages/dialtone-css/lib/build/less/components/tooltip.less
@@ -74,6 +74,7 @@
   line-height: var(--tooltip-line-height);
   letter-spacing: calc(var(--dt-space-100) * 0.25);
   text-align: center;
+  overflow-wrap: break-word;
   background-color: var(--tooltip-color-background);
   border-radius: var(--tooltip-border-radius);
 


### PR DESCRIPTION
# Add overflow-wrap for tooltip

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
[DP-129564]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
The text is not wrapping correctly when is long and with no spaces like a URL. I fixed it by adding `overflow-wrap: break-word` which will break the word only when overflows the max width of the container.
<!--- Describe specifically what the changes are -->

## :camera: Screenshots / GIFs

| Before | Now |
|-----|------|
|<img width="291" alt="image" src="https://github.com/user-attachments/assets/71532b05-7aca-47bc-92dc-47e9f1b1039d" />|<img width="309" alt="image" src="https://github.com/user-attachments/assets/88688ed6-b937-4b74-880c-eb73e0ebbfd2" />|
<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->


<!--- Add any links to external reference material -->


[DP-129564]: https://dialpad.atlassian.net/browse/DP-129564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ