### PR TITLE
fix(ci): NO-JIRA changelog release order

### DIFF
--- a/packages/combinator/release-ci.config.cjs
+++ b/packages/combinator/release-ci.config.cjs
@@ -19,11 +19,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [

--- a/packages/dialtone-css/release-ci.config.cjs
+++ b/packages/dialtone-css/release-ci.config.cjs
@@ -19,11 +19,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [

--- a/packages/dialtone-emojis/release-ci.config.cjs
+++ b/packages/dialtone-emojis/release-ci.config.cjs
@@ -25,11 +25,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [

--- a/packages/dialtone-icons/release-ci.config.cjs
+++ b/packages/dialtone-icons/release-ci.config.cjs
@@ -25,11 +25,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [

--- a/packages/dialtone-tokens/release-ci.config.cjs
+++ b/packages/dialtone-tokens/release-ci.config.cjs
@@ -19,11 +19,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [

--- a/packages/dialtone-vue2/release-ci.config.cjs
+++ b/packages/dialtone-vue2/release-ci.config.cjs
@@ -19,11 +19,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [

--- a/packages/dialtone-vue3/release-ci.config.cjs
+++ b/packages/dialtone-vue3/release-ci.config.cjs
@@ -19,11 +19,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [

--- a/packages/eslint-plugin-dialtone/release-ci.config.cjs
+++ b/packages/eslint-plugin-dialtone/release-ci.config.cjs
@@ -19,11 +19,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [

--- a/packages/language-server/server/release-ci.config.cjs
+++ b/packages/language-server/server/release-ci.config.cjs
@@ -18,11 +18,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [

--- a/packages/language-server/vscode/release-ci.config.cjs
+++ b/packages/language-server/vscode/release-ci.config.cjs
@@ -18,11 +18,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [

--- a/packages/postcss-responsive-variations/release-ci.config.cjs
+++ b/packages/postcss-responsive-variations/release-ci.config.cjs
@@ -19,11 +19,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [

--- a/packages/stylelint-plugin-dialtone/release-ci.config.cjs
+++ b/packages/stylelint-plugin-dialtone/release-ci.config.cjs
@@ -19,11 +19,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [

--- a/release-ci.config.cjs
+++ b/release-ci.config.cjs
@@ -19,11 +19,11 @@ module.exports = {
     ['@semantic-release/release-notes-generator', {
       config: '@dialpad/conventional-changelog-angular',
     }],
+    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@dialpad/semantic-release-changelog-json', {
       changelogFile: `${srcRoot}/CHANGELOG.md`,
       changelogJsonFile: `${srcRoot}/CHANGELOG.json`,
     }],
-    ['@semantic-release/changelog', { changelogFile: `${srcRoot}/CHANGELOG.md` }],
     ['@semantic-release/npm', { npmPublish: false }],
     ['@semantic-release/git', {
       assets: [


### PR DESCRIPTION
# fix(ci): NO-JIRA changelog release order 

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExZmExY3MwanE0d2ltbm9reGg4ZXV3bzV2d2xrbG82Z2hwdmQ2d2s1ciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1dleENJlcN72BbFMJ2/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Changed md to generate before the json

## :bulb: Context

the json file is always one version behind on production, but the md file is correct.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
