### PR TITLE
fix: NO-JIRA $el in vue 3

### DIFF
--- a/packages/dialtone-vue3/common/mixins/keyboard_list_navigation.js
+++ b/packages/dialtone-vue3/common/mixins/keyboard_list_navigation.js
@@ -1,4 +1,5 @@
 import Dom from './dom';
+import { returnFirstEl } from '@/common/utils';
 
 const ERROR_INVALID_LIST_ELEMENT = (
   'listElementKey is required or the referenced ' +
@@ -74,7 +75,7 @@ export default ({
     // this[listElement]() can return a Vue component, in which case we need to target
     // the $el property, or it can simply be an html element.
     _getListElement () {
-      return this[listElementKey]()?.$el || this[listElementKey]();
+      return returnFirstEl(this[listElementKey]()?.$el) || this[listElementKey]();
     },
 
     // Gets the length of all the items in the list, uses the listItemRole param to determine

--- a/packages/dialtone-vue3/common/mixins/modal.js
+++ b/packages/dialtone-vue3/common/mixins/modal.js
@@ -1,3 +1,5 @@
+import { returnFirstEl } from '@/common/utils';
+
 const focusableAttrs = ':not(:disabled):not([aria-disabled="true"]):not([role="presentation"])';
 const tabbableAttrs = `${focusableAttrs}:not([tabindex="-1"])`;
 const focusableElementsList = `button,[href],input,select,textarea,details,[tabindex]`;
@@ -36,13 +38,13 @@ export default {
      *  will default to the root node of the vue component
      */
     async focusFirstElement (el = this.$el) {
-      const elToFocus = await this.getFirstFocusableElement(el);
+      const elToFocus = await this.getFirstFocusableElement(returnFirstEl(el));
       elToFocus?.focus({ preventScroll: true });
     },
 
     async focusElementById (elementId) {
       await this.$nextTick();
-      const result = this.$el?.querySelector(elementId);
+      const result = returnFirstEl(this.$el)?.querySelector(elementId);
       if (result) {
         result.focus();
         return;
@@ -83,6 +85,7 @@ export default {
      * @param {bool} includeNegativeTabIndex - will include tabindex="-1" in the list of focusable elements.
      */
     _getFocusableElements (el = this.$el, includeNegativeTabIndex = false) {
+      el = returnFirstEl(el);
       if (!el) return [];
       const focusableContent = [...el.querySelectorAll(focusableElementsList)];
       return focusableContent.filter((fc) => {

--- a/packages/dialtone-vue3/common/utils/index.js
+++ b/packages/dialtone-vue3/common/utils/index.js
@@ -202,6 +202,23 @@ export const extractVueListeners = (attrs) => {
   return Object.fromEntries(listeners);
 };
 
+/**
+ * $el works very differently than in vue 2, if the first node in the template is a text node
+ * such as a comment it will return that instead of the first actual element. This function
+ * will recursively return the first element in the template instead of the first node.
+ * @param el
+ * @returns {HTMLElement} The first element in the template
+ */
+export const returnFirstEl = (el) => {
+  if (el?.nodeType === Node.ELEMENT_NODE) {
+    return el;
+  } else if (!el?.nodeType) {
+    return null;
+  } else {
+    return returnFirstEl(el?.nextSibling);
+  }
+};
+
 /*
 * Set's a global timer to debounce the execution of a function.
 * @param { object } func - the function that is going to be called after timeout
@@ -456,6 +473,7 @@ export default {
   flushPromises,
   kebabCaseToPascalCase,
   extractVueListeners,
+  returnFirstEl,
   debounce,
   isOutOfViewPort,
   getPhoneNumberRegex,

--- a/packages/dialtone-vue3/components/datepicker/composables/useCalendar.js
+++ b/packages/dialtone-vue3/components/datepicker/composables/useCalendar.js
@@ -2,6 +2,7 @@ import { computed, ref, watch, nextTick } from 'vue';
 import { getWeekDayNames, calculateNextFocusDate, calculatePrevFocusDate } from '@/components/datepicker/utils.js';
 import { MONTH_FORMAT, WEEK_START } from '@/components/datepicker/datepicker_constants.js';
 import { format, getYear } from 'date-fns';
+import { returnFirstEl } from '@/common/utils';
 
 export function useCalendar (props, emits) {
   const selectedDay = ref(null);
@@ -34,13 +35,13 @@ export function useCalendar (props, emits) {
         event.preventDefault();
         focusDay.value -= 7;
         try {
-          daysRef.value[focusDay.value].el.$el.focus();
+          returnFirstEl(daysRef.value[focusDay.value].el.$el).focus();
         } catch (error) {
           const prevFocusDate = calculatePrevFocusDate(daysRef.value[focusDay.value + 7].day.value);
           emits('go-to-prev-month');
 
           nextTick(() => {
-            daysRef.value[prevFocusDate - 1].el.$el.focus();
+            returnFirstEl(daysRef.value[prevFocusDate - 1].el.$el).focus();
             focusDay.value += prevFocusDate - 1;
           });
         }
@@ -50,13 +51,13 @@ export function useCalendar (props, emits) {
         event.preventDefault();
         focusDay.value += 7;
         try {
-          daysRef.value[focusDay.value].el.$el.focus();
+          returnFirstEl(daysRef.value[focusDay.value].el.$el).focus();
         } catch (error) {
           const nextFocusDate = calculateNextFocusDate(daysRef.value[focusDay.value - 7].day.value);
           emits('go-to-next-month');
 
           nextTick(() => {
-            daysRef.value[nextFocusDate - 1].el.$el.focus();
+            returnFirstEl(daysRef.value[nextFocusDate - 1].el.$el).focus();
             focusDay.value += nextFocusDate - 1;
           });
         }
@@ -66,7 +67,7 @@ export function useCalendar (props, emits) {
         event.preventDefault();
         if (focusDay.value > 0) {
           focusDay.value -= 1;
-          daysRef.value[focusDay.value].el.$el.focus();
+          returnFirstEl(daysRef.value[focusDay.value].el.$el).focus();
         } else {
           // if we are on month first day, jump to last day of prev month
           emits('go-to-prev-month');
@@ -78,7 +79,7 @@ export function useCalendar (props, emits) {
         event.preventDefault();
         if (focusDay.value < daysRef.value.length - 1) {
           focusDay.value += 1;
-          daysRef.value[focusDay.value].el.$el.focus();
+          returnFirstEl(daysRef.value[focusDay.value].el.$el).focus();
         } else {
           // if we are on month last day, jump to first day of next month
           emits('go-to-next-month');
@@ -102,14 +103,14 @@ export function useCalendar (props, emits) {
     focusDay.value = 0;
 
     nextTick(() => {
-      daysRef.value[focusDay.value].el.$el.focus();
+      returnFirstEl(daysRef.value[focusDay.value].el.$el).focus();
     });
   }
 
   function focusLastDay () {
     nextTick(() => {
       focusDay.value = daysRef.value.length - 1;
-      daysRef.value[focusDay.value].el.$el.focus();
+      returnFirstEl(daysRef.value[focusDay.value].el.$el).focus();
     });
   }
 

--- a/packages/dialtone-vue3/components/datepicker/composables/useMonthYearPicker.js
+++ b/packages/dialtone-vue3/components/datepicker/composables/useMonthYearPicker.js
@@ -1,6 +1,7 @@
 import { computed, ref, watch } from 'vue';
 import { addMonths, getDate, getMonth, getYear, set, subMonths } from 'date-fns';
 import { formatMonth, getCalendarDays } from '@/components/datepicker/utils.js';
+import { returnFirstEl } from '@/common/utils';
 
 export function useMonthYearPicker (props, emits) {
   const selectMonth = ref(getMonth(props.selectedDate));
@@ -34,7 +35,7 @@ export function useMonthYearPicker (props, emits) {
   }
 
   function focusMonthYearPicker () {
-    focusRefs.value[0].$el.focus();
+    returnFirstEl(focusRefs.value[0].$el).focus();
   }
 
   function handleKeyDown (event) {
@@ -43,10 +44,10 @@ export function useMonthYearPicker (props, emits) {
         event.preventDefault();
         if (focusPicker.value === 0) {
           focusPicker.value = 3;
-          focusRefs.value[focusPicker.value].$el.focus();
+          returnFirstEl(focusRefs.value[focusPicker.value].$el).focus();
         } else {
           focusPicker.value--;
-          focusRefs.value[focusPicker.value].$el.focus();
+          returnFirstEl(focusRefs.value[focusPicker.value].$el).focus();
         }
         break;
 
@@ -54,10 +55,10 @@ export function useMonthYearPicker (props, emits) {
         event.preventDefault();
         if (focusPicker.value === 3) {
           focusPicker.value = 0;
-          focusRefs.value[focusPicker.value].$el.focus();
+          returnFirstEl(focusRefs.value[focusPicker.value].$el).focus();
         } else {
           focusPicker.value++;
-          focusRefs.value[focusPicker.value].$el.focus();
+          returnFirstEl(focusRefs.value[focusPicker.value].$el).focus();
         }
         break;
 

--- a/packages/dialtone-vue3/components/datepicker/datepicker.vue
+++ b/packages/dialtone-vue3/components/datepicker/datepicker.vue
@@ -37,12 +37,12 @@
 </template>
 
 <script setup>
+import { returnFirstEl, warnIfUnmounted } from '@/common/utils';
 import MonthYearPicker from './modules/month-year-picker.vue';
 import Calendar from './modules/calendar.vue';
 import { DtStack } from '@/components/stack';
 
 import { onMounted, ref, getCurrentInstance } from 'vue';
-import { warnIfUnmounted } from '@/common/utils';
 
 defineProps({
   /**
@@ -157,6 +157,6 @@ function updateCalendarDays (days) {
 
 onMounted(() => {
   const instance = getCurrentInstance();
-  warnIfUnmounted(instance.proxy.$el, 'datepicker');
+  warnIfUnmounted(returnFirstEl(instance.proxy.$el), 'datepicker');
 });
 </script>

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
@@ -31,6 +31,7 @@
 <script setup>
 import { computed, ref, watch } from 'vue';
 import { DtTab, DtTabGroup } from '@/components/tab';
+import { returnFirstEl } from '@/common/utils';
 import { EMOJI_PICKER_CATEGORIES } from '@/components/emoji_picker/emoji_picker_constants.js';
 import {
   DtIconClock,
@@ -148,7 +149,7 @@ function selectTabset (id) {
 function setTabsetRef (ref) {
   // We push the $el, because $el is the button inside the dt-tab component
   // and we need the button to focus it
-  tabsetRef.value.push(ref.$el);
+  tabsetRef.value.push(returnFirstEl(ref.$el));
 }
 
 function focusTabset () {

--- a/packages/dialtone-vue3/components/image_viewer/image_viewer.vue
+++ b/packages/dialtone-vue3/components/image_viewer/image_viewer.vue
@@ -67,6 +67,7 @@
 
 <script>
 import Modal from '@/common/mixins/modal';
+import { returnFirstEl } from '@/common/utils';
 import { EVENT_KEYNAMES } from '@/common/constants';
 import { DtIconClose } from '@dialpad/dialtone-icons/vue3';
 import { DtButton } from '@/components/button';
@@ -244,7 +245,7 @@ export default {
     },
 
     focusAfterOpen () {
-      this.$refs.closeImage?.$el.focus();
+      returnFirstEl(this.$refs.closeImage?.$el)?.focus();
     },
 
     trapFocus (e) {

--- a/packages/dialtone-vue3/components/modal/modal.vue
+++ b/packages/dialtone-vue3/components/modal/modal.vue
@@ -123,7 +123,7 @@ import {
   MODAL_KIND_MODIFIERS,
   MODAL_SIZE_MODIFIERS,
 } from './modal_constants';
-import { getUniqueString, hasSlotContent, disableRootScrolling, enableRootScrolling } from '@/common/utils';
+import { returnFirstEl, getUniqueString, hasSlotContent, disableRootScrolling, enableRootScrolling } from '@/common/utils';
 import { DtLazyShow } from '@/components/lazy_show';
 import { EVENT_KEYNAMES } from '@/common/constants';
 import SrOnlyCloseButtonMixin from '@/common/mixins/sr_only_close_button';
@@ -415,9 +415,9 @@ export default {
         if (isShowing) {
           // Set a reference to the previously-active element, to which we'll return focus on modal close.
           this.previousActiveElement = document.activeElement;
-          disableRootScrolling(this.$el.getRootNode().host);
+          disableRootScrolling(returnFirstEl(this.$el).getRootNode().host);
         } else {
-          enableRootScrolling(this.$el.getRootNode().host);
+          enableRootScrolling(returnFirstEl(this.$el).getRootNode().host);
           // Modal is being hidden, so return focus to the previously active element before clearing the reference.
           this.previousActiveElement?.focus();
           this.previousActiveElement = null;

--- a/packages/dialtone-vue3/components/popover/popover.vue
+++ b/packages/dialtone-vue3/components/popover/popover.vue
@@ -135,7 +135,7 @@ import {
   POPOVER_ROLES,
   POPOVER_STICKY_VALUES,
 } from './popover_constants';
-import { getUniqueString, hasSlotContent, isOutOfViewPort, warnIfUnmounted, disableRootScrolling, enableRootScrolling } from '@/common/utils';
+import { getUniqueString, hasSlotContent, isOutOfViewPort, warnIfUnmounted, disableRootScrolling, enableRootScrolling, returnFirstEl } from '@/common/utils';
 import { DtLazyShow } from '@/components/lazy_show';
 import ModalMixin from '@/common/mixins/modal';
 import { createTippyPopover, getPopperOptions } from './tippy_utils';
@@ -692,13 +692,13 @@ export default {
   },
 
   mounted () {
-    warnIfUnmounted(this.$el, this.$options.name);
+    warnIfUnmounted(returnFirstEl(this.$el), this.$options.name);
 
     const externalAnchorEl = this.externalAnchor
       ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
       : null;
     this.anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
-    this.popoverContentEl = this.$refs.content?.$el;
+    this.popoverContentEl = returnFirstEl(this.$refs.content?.$el);
 
     if (this.isOpen) {
       this.initTippyInstance();
@@ -749,7 +749,7 @@ export default {
 
     calculateAnchorZindex () {
       // if a modal is currently active render at modal-element z-index, otherwise at popover z-index
-      if (this.$el.getRootNode()
+      if (returnFirstEl(this.$el).getRootNode()
         .querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"]') ||
         // Special case because we don't have any dialtone drawer component yet. Render at 650 when
         // anchor of popover is within a drawer.
@@ -906,7 +906,7 @@ export default {
 
     focusInitialElement () {
       if (this.initialFocusElement === 'dialog') {
-        this.$refs.content?.$el?.focus();
+        returnFirstEl(this.$refs.content?.$el)?.focus();
       }
       // find by ID
       if (this.initialFocusElement.startsWith('#')) {
@@ -921,14 +921,14 @@ export default {
     },
 
     focusInitialElementById () {
-      const result = this.$refs.content?.$el?.querySelector(this.initialFocusElement);
+      const result = returnFirstEl(this.$refs.content?.$el)?.querySelector(this.initialFocusElement);
       if (result) {
         result.focus();
       } else {
         console.warn('Could not find the element specified in dt-popover prop "initialFocusElement". ' +
           'Defaulting to focusing the dialog.');
       }
-      result ? result.focus() : this.$refs.content?.$el.focus();
+      result ? result.focus() : returnFirstEl(this.$refs.content?.$el).focus();
     },
 
     onResize () {
@@ -970,7 +970,7 @@ export default {
         this.$refs.popover__header?.focusCloseButton();
       } else {
         // if there are no focusable elements at all focus the dialog itself
-        this.$refs.content?.$el.focus();
+        returnFirstEl(this.$refs.content?.$el).focus();
       }
     },
 

--- a/packages/dialtone-vue3/components/popover/popover_header_footer.vue
+++ b/packages/dialtone-vue3/components/popover/popover_header_footer.vue
@@ -43,7 +43,7 @@
 <script>
 import { DtButton } from '@/components/button';
 import { DtIconClose } from '@dialpad/dialtone-icons/vue3';
-import { hasSlotContent } from '@/common/utils';
+import { hasSlotContent, returnFirstEl } from '@/common/utils';
 
 export default {
   compatConfig: { MODE: 3 },
@@ -107,7 +107,7 @@ export default {
 
   methods: {
     focusCloseButton () {
-      const closeButton = this.$refs['popover__close-button']?.$el;
+      const closeButton = returnFirstEl(this.$refs['popover__close-button']?.$el);
       closeButton?.focus();
     },
   },

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -92,7 +92,7 @@ import { emojiPattern } from 'regex-combined-emojis';
 import mentionSuggestion from './extensions/mentions/suggestion';
 import channelSuggestion from './extensions/channels/suggestion';
 import slashCommandSuggestion from './extensions/slash_command/suggestion';
-import { warnIfUnmounted } from '@/common/utils';
+import { warnIfUnmounted, returnFirstEl } from '@/common/utils';
 import deepEqual from 'deep-equal';
 
 export default {
@@ -457,7 +457,7 @@ export default {
     return {
       editor: null,
       tippyOptions: {
-        appendTo: () => this.$refs.editor.$el.getRootNode()?.querySelector('body'),
+        appendTo: () => returnFirstEl(this.$refs.editor.$el).getRootNode()?.querySelector('body'),
         placement: 'top-start',
       },
     };
@@ -661,7 +661,7 @@ export default {
   },
 
   mounted () {
-    warnIfUnmounted(this.$el, this.$options.name);
+    warnIfUnmounted(returnFirstEl(this.$el), this.$options.name);
     this.processValue(this.modelValue, false);
   },
 

--- a/packages/dialtone-vue3/components/scroller/modules/dynamic_scroller.vue
+++ b/packages/dialtone-vue3/components/scroller/modules/dynamic_scroller.vue
@@ -39,6 +39,7 @@ We have modified it for our own specific use. -->
 <script>
 import CoreScroller from './core_scroller.vue';
 import DtScrollerItem from './scroller_item.vue';
+import { returnFirstEl } from '@/common/utils';
 
 export default {
   name: 'DynamicScroller',
@@ -197,7 +198,7 @@ export default {
     },
 
     itemsWithSize (next, prev) {
-      const scrollTop = this.$el.scrollTop;
+      const scrollTop = returnFirstEl(this.$el).scrollTop;
 
       // Calculate total diff between prev and next sizes
       // over current scroll top. Then add it to scrollTop to
@@ -217,7 +218,7 @@ export default {
         return;
       }
 
-      this.$el.scrollTop += offset;
+      returnFirstEl(this.$el).scrollTop += offset;
     },
   },
 
@@ -254,7 +255,7 @@ export default {
     scrollToBottom () {
       if (this.$_scrollingToBottom) return;
       this.$_scrollingToBottom = true;
-      const el = this.$el;
+      const el = returnFirstEl(this.$el);
       // Item is inserted to the DOM
       this.$nextTick(() => {
         el.scrollTop = el.scrollHeight + 5000;

--- a/packages/dialtone-vue3/components/scroller/modules/scroller_item.vue
+++ b/packages/dialtone-vue3/components/scroller/modules/scroller_item.vue
@@ -4,6 +4,7 @@ This is a code from external library (https://github.com/Akryum/vue-virtual-scro
 We have modified it for our own specific use.
 */
 import { h } from 'vue';
+import { returnFirstEl } from '@/common/utils';
 
 export default {
   name: 'DtScrollerItem',
@@ -70,7 +71,7 @@ export default {
     watchData: 'updateWatchData',
 
     id (value, oldValue) {
-      this.$el.$_vs_id = this.id;
+      returnFirstEl(this.$el).$_vs_id = this.id;
       if (!this.size) {
         this.onDataUpdate();
       }
@@ -182,8 +183,8 @@ export default {
     computeSize (id) {
       this.$nextTick(() => {
         if (this.id === id) {
-          const width = this.$el.offsetWidth;
-          const height = this.$el.offsetHeight;
+          const width = returnFirstEl(this.$el).offsetWidth;
+          const height = returnFirstEl(this.$el).offsetHeight;
           this.applyWidthHeight(width, height);
         }
         this.$_pendingSizeUpdate = null;
@@ -208,7 +209,7 @@ export default {
     observeSize () {
       if (!this.vscrollResizeObserver) return;
       if (this.$_sizeObserved) return;
-      this.vscrollResizeObserver.observe(this.$el);
+      this.vscrollResizeObserver.observe(returnFirstEl(this.$el));
       this.$el.$_vs_id = this.id;
       this.$el.$_vs_onResize = this.onResize;
       this.$_sizeObserved = true;
@@ -217,7 +218,7 @@ export default {
     unobserveSize () {
       if (!this.vscrollResizeObserver) return;
       if (!this.$_sizeObserved) return;
-      this.vscrollResizeObserver.unobserve(this.$el);
+      this.vscrollResizeObserver.unobserve(returnFirstEl(this.$el));
       this.$el.$_vs_onResize = undefined;
       this.$_sizeObserved = false;
     },

--- a/packages/dialtone-vue3/components/split_button/split_button.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button.vue
@@ -78,7 +78,7 @@ import {
 import SplitButtonAlpha from './split_button-alpha.vue';
 import SplitButtonOmega from './split_button-omega.vue';
 import { DtDropdown } from '@/components/dropdown';
-import { hasSlotContent, warnIfUnmounted } from '@/common/utils';
+import { hasSlotContent, warnIfUnmounted, returnFirstEl } from '@/common/utils';
 
 export default {
   compatConfig: { MODE: 3 },
@@ -322,7 +322,7 @@ export default {
   },
 
   mounted () {
-    warnIfUnmounted(this.$el, this.$options.name);
+    warnIfUnmounted(returnFirstEl(this.$el), this.$options.name);
   },
 
   methods: {

--- a/packages/dialtone-vue3/components/tab/tab_group.test.js
+++ b/packages/dialtone-vue3/components/tab/tab_group.test.js
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils';
 import DtTabGroup from './tab_group.vue';
 import DtTabPanel from './tab_panel.vue';
 import DtTab from './tab.vue';
+import { returnFirstEl } from '@/common/utils';
 import { TAB_LIST_KIND_MODIFIERS, TAB_LIST_SIZE_MODIFIERS, TAB_LIST_IMPORTANCE_MODIFIERS } from './tabs_constants';
 import { h } from 'vue';
 
@@ -165,7 +166,7 @@ describe('DtTabGroup Tests', () => {
       beforeEach(async () => {
         _mountWrapper();
         // Simulating the third tab being set programmatically after the second tab was selected by a user.
-        tabs.at(1).vm.$el.click();
+        returnFirstEl(tabs.at(1).vm.$el).click();
         props.selected = optionTabs[2].panelId;
         await wrapper.setProps(props);
       });
@@ -193,7 +194,7 @@ describe('DtTabGroup Tests', () => {
 
     describe('Correct change event', () => {
       beforeEach(() => {
-        tabs.at(1).vm.$el.click();
+        returnFirstEl(tabs.at(1).vm.$el).click();
       });
 
       it('should emitted on click', () => {
@@ -203,7 +204,7 @@ describe('DtTabGroup Tests', () => {
 
     describe('Correct before-change event', () => {
       beforeEach(() => {
-        tabs.at(1).vm.$el.click();
+        returnFirstEl(tabs.at(1).vm.$el).click();
       });
 
       it('should emitted on click', () => {
@@ -214,7 +215,7 @@ describe('DtTabGroup Tests', () => {
     describe('Correct key navigation', () => {
       describe('On keyup left', () => {
         beforeEach(async () => {
-          tabs.at(0).vm.$el.focus();
+          returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keyup.left');
           await tabList.trigger('keyup.space');
         });
@@ -227,7 +228,7 @@ describe('DtTabGroup Tests', () => {
 
       describe('On double keyup left and space', () => {
         beforeEach(async () => {
-          tabs.at(0).vm.$el.focus();
+          returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keyup.left');
           await tabList.trigger('keyup.left');
           await tabList.trigger('keyup.space');
@@ -241,7 +242,7 @@ describe('DtTabGroup Tests', () => {
 
       describe('On right and enter', () => {
         beforeEach(async () => {
-          tabs.at(0).vm.$el.focus();
+          returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keyup.right');
           await tabList.trigger('keyup.enter');
         });
@@ -254,7 +255,7 @@ describe('DtTabGroup Tests', () => {
 
       describe('On double keyup right and enter', () => {
         beforeEach(async () => {
-          tabs.at(0).vm.$el.focus();
+          returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keyup.right');
           await tabList.trigger('keyup.right');
           await tabList.trigger('keyup.enter');
@@ -268,7 +269,7 @@ describe('DtTabGroup Tests', () => {
 
       describe('On keydown home and enter', () => {
         beforeEach(async () => {
-          tabs.at(2).vm.$el.focus();
+          returnFirstEl(tabs.at(2).vm.$el).focus();
           await tabList.trigger('keydown.home');
           await tabList.trigger('keyup.enter');
         });
@@ -281,7 +282,7 @@ describe('DtTabGroup Tests', () => {
 
       describe('On keydown end and enter', () => {
         beforeEach(async () => {
-          tabs.at(0).vm.$el.focus();
+          returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keydown.end');
           await tabList.trigger('keyup.enter');
         });
@@ -303,7 +304,7 @@ describe('DtTabGroup Tests', () => {
 
         _mountWrapper();
 
-        tabs.at(0).vm.$el.click();
+        returnFirstEl(tabs.at(0).vm.$el).click();
       });
 
       it('Should prevent the change event', async () => {
@@ -314,7 +315,7 @@ describe('DtTabGroup Tests', () => {
 
   describe('Accessibility Tests', () => {
     beforeEach(async () => {
-      tabs.at(0).vm.$el.focus();
+      returnFirstEl(tabs.at(0).vm.$el).focus();
       await tabList.trigger('keyup.enter');
     });
 
@@ -332,7 +333,7 @@ describe('DtTabGroup Tests', () => {
         let lastTab;
         let lastPanel;
         beforeEach(async () => {
-          tabs.at(0).vm.$el.focus();
+          returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keyup.left');
           await tabList.trigger('keyup.space');
           lastTab = tabs.at(2).attributes();
@@ -347,7 +348,7 @@ describe('DtTabGroup Tests', () => {
 
       describe('attributes after keyup right', () => {
         beforeEach(async () => {
-          tabs.at(0).vm.$el.focus();
+          returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keyup.right');
           await tabList.trigger('keyup.enter');
         });
@@ -365,7 +366,7 @@ describe('DtTabGroup Tests', () => {
 
       describe('attributes after keydown home', () => {
         beforeEach(async () => {
-          tabs.at(2).vm.$el.focus();
+          returnFirstEl(tabs.at(2).vm.$el).focus();
           await tabList.trigger('keydown.home');
           await tabList.trigger('keyup.enter');
         });
@@ -383,7 +384,7 @@ describe('DtTabGroup Tests', () => {
 
       describe('attributes after keydown end', () => {
         beforeEach(async () => {
-          tabs.at(0).vm.$el.focus();
+          returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keydown.end');
           await tabList.trigger('keyup.enter');
         });

--- a/packages/dialtone-vue3/components/tab/tab_panel.vue
+++ b/packages/dialtone-vue3/components/tab/tab_panel.vue
@@ -16,6 +16,7 @@
 
 <script>
 import Modal from '@/common/mixins/modal';
+import { returnFirstEl } from '@/common/utils';
 
 /**
  * Tabs allow users to navigation between grouped content in different views while within the same page context.
@@ -77,7 +78,7 @@ export default {
   },
 
   async mounted () {
-    const firstFocusableElement = await this.getFirstFocusableElement(this.$el);
+    const firstFocusableElement = await this.getFirstFocusableElement(returnFirstEl(this.$el));
 
     if (!firstFocusableElement) {
       this.isFirstElementFocusable = false;
@@ -99,7 +100,7 @@ export default {
           isFirstElement = false;
           break;
         }
-        current = current.parentNode !== this.$el ? current.parentNode : null;
+        current = current.parentNode !== returnFirstEl(this.$el) ? current.parentNode : null;
       }
 
       return isFirstElement;

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -50,7 +50,7 @@ import {
 import {
   POPOVER_APPEND_TO_VALUES,
 } from '../popover/popover_constants';
-import { flushPromises, getUniqueString, hasSlotContent, warnIfUnmounted } from '@/common/utils';
+import { flushPromises, getUniqueString, hasSlotContent, warnIfUnmounted, returnFirstEl } from '@/common/utils';
 import {
   createTippy,
   getAnchor,
@@ -363,7 +363,7 @@ export default {
       await flushPromises();
       this.addExternalAnchorEventListeners();
     }
-    warnIfUnmounted(this.$el, this.$options.name);
+    warnIfUnmounted(returnFirstEl(this.$el), this.$options.name);
   },
 
   beforeUnmount () {
@@ -377,11 +377,11 @@ export default {
   methods: {
     calculateAnchorZindex () {
       // if a modal is currently active render at modal-element z-index, otherwise at tooltip z-index
-      if (this.$el.getRootNode()
+      if (returnFirstEl(this.$el).getRootNode()
         .querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"]') ||
         // Special case because we don't have any dialtone drawer component yet. Render at 651 when
         // anchor of popover is within a drawer.
-        this.$el.closest('.d-zi-drawer')) {
+        returnFirstEl(this.$el).closest('.d-zi-drawer')) {
         return 651;
       } else {
         return 400;

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
@@ -71,7 +71,7 @@ import { DtButton } from '@/components/button';
 import { DtDropdown } from '@/components/dropdown';
 import { DtIconChevronUp } from '@dialpad/dialtone-icons/vue3';
 import { DtRecipeCallbarButton, CALLBAR_BUTTON_VALID_WIDTH_SIZE } from '../callbar_button';
-import utils, { warnIfUnmounted } from '@/common/utils';
+import utils, { warnIfUnmounted, returnFirstEl } from '@/common/utils';
 
 export default {
   name: 'DtRecipeCallbarButtonWithDropdown',
@@ -311,7 +311,7 @@ export default {
   },
 
   mounted () {
-    warnIfUnmounted(this.$el, this.$options.name);
+    warnIfUnmounted(returnFirstEl(this.$el), this.$options.name);
   },
 
   methods: {

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -79,7 +79,7 @@ import { DtButton } from '@/components/button';
 import { DtPopover } from '@/components/popover';
 import { DtIconChevronUp } from '@dialpad/dialtone-icons/vue3';
 import { DtRecipeCallbarButton, CALLBAR_BUTTON_VALID_WIDTH_SIZE } from '../callbar_button';
-import utils, { warnIfUnmounted } from '@/common/utils';
+import utils, { warnIfUnmounted, returnFirstEl } from '@/common/utils';
 
 export default {
   compatConfig: { MODE: 3 },
@@ -355,7 +355,7 @@ export default {
   },
 
   mounted () {
-    warnIfUnmounted(this.$el, this.$options.name);
+    warnIfUnmounted(returnFirstEl(this.$el), this.$options.name);
   },
 
   methods: {

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -123,7 +123,7 @@ import DtInput from '@/components/input/input.vue';
 import DtChip from '@/components/chip/chip.vue';
 import DtValidationMessages from '@/components/validation_messages/validation_messages.vue';
 import { validationMessageValidator } from '@/common/validators';
-import { hasSlotContent } from '@/common/utils';
+import { hasSlotContent, returnFirstEl } from '@/common/utils';
 import {
   POPOVER_APPEND_TO_VALUES,
 } from '@/components/popover/popover_constants';
@@ -564,11 +564,11 @@ export default {
     },
 
     getChipButtons () {
-      return this.$refs.chips && this.$refs.chips.map(chip => chip.$el.querySelector('button'));
+      return this.$refs.chips && this.$refs.chips.map(chip => returnFirstEl(chip.$el).querySelector('button'));
     },
 
     getChips () {
-      return this.$refs.chips && this.$refs.chips.map(chip => chip.$el);
+      return this.$refs.chips && this.$refs.chips.map(chip => returnFirstEl(chip.$el));
     },
 
     getLastChipButton () {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -277,6 +277,7 @@ import {
 } from '@dialpad/dialtone-icons/vue3';
 import DtRecipeMessageInputTopbar from './message_input_topbar.vue';
 import DtRecipeMessageInputLink from './message_input_link.vue';
+import { returnFirstEl } from '@/common/utils';
 
 import {
   EDITOR_SUPPORTED_LINK_PROTOCOLS,
@@ -930,7 +931,7 @@ export default {
 
     // Mousedown instead of click because it fires before the blur event.
     onMousedown (e) {
-      const isWithinInput = this.$refs.richTextEditor.$el
+      const isWithinInput = returnFirstEl(this.$refs.richTextEditor.$el)
         .querySelector('.tiptap')
         .contains(e.target);
 

--- a/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/contact_centers_row/contact_centers_row.vue
@@ -76,7 +76,7 @@
 </template>
 
 <script>
-import { extractVueListeners, safeConcatStrings } from '@/common/utils';
+import { extractVueListeners, safeConcatStrings, returnFirstEl } from '@/common/utils';
 import { DtBadge } from '@/components/badge';
 import { DtButton } from '@/components/button';
 import DtEmojiTextWrapper from '@/components/emoji_text_wrapper/emoji_text_wrapper.vue';
@@ -210,7 +210,7 @@ export default {
 
   mounted () {
     this.resizeObserver = new ResizeObserver(this.adjustLabelWidth);
-    this.resizeObserver.observe(this.$el);
+    this.resizeObserver.observe(returnFirstEl(this.$el));
     this.adjustLabelWidth();
   },
 
@@ -220,9 +220,9 @@ export default {
 
   methods: {
     adjustLabelWidth () {
-      const labelWidth = this.$el?.querySelector('.d-recipe-leftbar-row__primary')?.clientWidth || 0;
-      const omegaWidth = this.$el?.querySelector('.d-recipe-leftbar-row__omega')?.clientWidth || 0;
-      const alphaWidth = this.$el?.querySelector('.d-recipe-leftbar-row__alpha')?.clientWidth || 0;
+      const labelWidth = returnFirstEl(this.$el)?.querySelector('.d-recipe-leftbar-row__primary')?.clientWidth || 0;
+      const omegaWidth = returnFirstEl(this.$el)?.querySelector('.d-recipe-leftbar-row__omega')?.clientWidth || 0;
+      const alphaWidth = returnFirstEl(this.$el)?.querySelector('.d-recipe-leftbar-row__alpha')?.clientWidth || 0;
       const paddings = 12;
       this.labelWidth = labelWidth - (omegaWidth + alphaWidth + paddings) + 'px';
     },

--- a/packages/dialtone-vue3/recipes/leftbar/general_row/general_row.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/general_row/general_row.vue
@@ -155,7 +155,7 @@ import { DtButton } from '@/components/button';
 import { DtTooltip } from '@/components/tooltip';
 import DtEmojiTextWrapper from '@/components/emoji_text_wrapper/emoji_text_wrapper.vue';
 import DtRecipeLeftbarGeneralRowIcon from './leftbar_general_row_icon.vue';
-import { extractVueListeners, safeConcatStrings } from '@/common/utils';
+import { extractVueListeners, safeConcatStrings, returnFirstEl } from '@/common/utils';
 
 export default {
   compatConfig: { MODE: 3 },
@@ -436,7 +436,7 @@ export default {
 
   mounted () {
     this.resizeObserver = new ResizeObserver(this.adjustLabelWidth);
-    this.resizeObserver.observe(this.$el);
+    this.resizeObserver.observe(returnFirstEl(this.$el));
     this.adjustLabelWidth();
   },
 
@@ -453,9 +453,9 @@ export default {
     },
 
     adjustLabelWidth () {
-      const labelWidth = this.$el?.querySelector('.d-recipe-leftbar-row__primary')?.clientWidth || 0;
-      const omegaWidth = this.$el?.querySelector('.d-recipe-leftbar-row__omega')?.clientWidth || 0;
-      const alphaWidth = this.$el?.querySelector('.d-recipe-leftbar-row__alpha')?.clientWidth || 0;
+      const labelWidth = returnFirstEl(this.$el)?.querySelector('.d-recipe-leftbar-row__primary')?.clientWidth || 0;
+      const omegaWidth = returnFirstEl(this.$el)?.querySelector('.d-recipe-leftbar-row__omega')?.clientWidth || 0;
+      const alphaWidth = returnFirstEl(this.$el)?.querySelector('.d-recipe-leftbar-row__alpha')?.clientWidth || 0;
       const paddings = 16;
       this.labelWidth = labelWidth - (omegaWidth + alphaWidth + paddings) + 'px';
     },


### PR DESCRIPTION
# fix: $el in vue 3

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTV6NzMydnZ2YWJvdHN2bmZucGNlczlmb2trMzd2dmpneTV4YWR2bSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/qAm29QJKl8bQNpBsEN/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Migrated all $el to be wrapped in helper function `returnFirstEl` on vue 3 branch only.

## :bulb: Context

$el works very differently in vue 3 than in vue 2, if the first node in the template is a text node. such as a comment it will return that instead of the first actual element. This function will recursively return the first element in the template instead of the first node making it work similar to how it works in vue 2. Already implemented this product side and it seems to be working well.

The real fix should be to migrate all $el to use template refs but that is a larger refactor and this is a good intermediate step.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :link: Sources

https://vuejs.org/api/component-instance.html#el
