### PR TITLE
fix: NO-JIRA dialtone icons android build

### DIFF
--- a/packages/dialtone-icons/project.json
+++ b/packages/dialtone-icons/project.json
@@ -1,15 +1,11 @@
 {
   "name": "dialtone-icons",
   "targets": {
-    "build": {
+    "pre-build": {
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "pnpm exec gulp",
-          "nx run-many --target=build --projects=dialtone-icons-vue2,dialtone-icons-vue3 --parallel=2 --output-style=stream"
-        ],
-        "parallel": false
+        "command": "pnpm exec gulp"
       },
       "inputs": [
         "{projectRoot}/src/**/*",
@@ -19,13 +15,28 @@
       "outputs": [
         "{projectRoot}/src/icons",
         "{projectRoot}/src/illustrations",
-        "{projectRoot}/dist",
+        "{projectRoot}/dist"
+      ]
+    },
+    "build": {
+      "dependsOn": ["pre-build"],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "nx run-many --target=build --projects=dialtone-icons-vue2,dialtone-icons-vue3 --parallel=2 --output-style=stream"
+      },
+      "inputs": [
+        "{projectRoot}/src/**/*",
+        "{projectRoot}/transformSVGtoVue.cjs",
+        "{projectRoot}/gulpfile.cjs"
+      ],
+      "outputs": [
         "{projectRoot}/vue2/dist",
         "{projectRoot}/vue3/dist"
       ]
     },
     "build:android": {
-      "dependsOn": ["dialtone-icons-android:build"],
+      "dependsOn": ["pre-build", "dialtone-icons-android:build"],
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}/android",


### PR DESCRIPTION
# Fix Dialtone Icons Android Build

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExemUxOXJlNXhsMG40YXF2emtxeGUzeGJyZWN5Y2kzdTlya2p4a213aSZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/pyHTKJ4G9WGQKd12cl/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Description

- Refactored `build` target and extracted a common `pre-build` step to reuse it while building web and android icons library

## :bulb: Context

- Android icons build was not being updated as the `gulp` command was not being run before building the Android library

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.
