### PR TITLE
feat(editor): DP-130987 insert inline image through editor

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.stories.js
@@ -44,6 +44,12 @@ export const argTypesData = {
       disable: true,
     },
   },
+
+  onInlineImageClick: {
+    table: {
+      disable: true,
+    },
+  },
 };
 
 // Set default values at the story level here.
@@ -56,6 +62,7 @@ export const argsData = {
   onBlur: action('blur'),
   onInput: action('input'),
   onQuickRepliesClick: action('quick-replies-click'),
+  onInlineImageClick: action('inline-image-click'),
 };
 
 // Story Collection

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -202,6 +202,7 @@ import {
   DtIconAlignRight,
   DtIconBold,
   DtIconCodeBlock,
+  DtIconImage,
   DtIconItalic,
   DtIconLightningBolt,
   DtIconLink2,
@@ -236,6 +237,7 @@ export default {
     DtIconQuote,
     DtIconCodeBlock,
     DtIconLink2,
+    DtIconImage,
   },
 
   inheritAttrs: false,
@@ -453,6 +455,14 @@ export default {
     },
 
     /**
+     * Show button to add an inline image
+     */
+    showInlineImageButton: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
      * Show add link default config.
      */
     showAddLink: {
@@ -501,6 +511,12 @@ export default {
      * @event quick-replies-click
      */
     'quick-replies-click',
+
+    /**
+     * Emit when inline image button is clicked
+     * @event inline-image-click
+     */
+    'inline-image-click',
   ],
 
   data () {
@@ -680,6 +696,14 @@ export default {
           tooltipMessage: 'Code',
           onClick: this.onCodeBlockToggle,
         },
+        {
+          showBtn: this.showInlineImageButton,
+          selector: 'image',
+          icon: DtIconImage,
+          dataQA: 'dt-recipe-editor-inline-image-btn',
+          tooltipMessage: 'Image',
+          onClick: this.onInsertInlineImageClick,
+        },
       ].filter(button => button.showBtn);
     },
 
@@ -813,6 +837,14 @@ export default {
 
     onQuickRepliesClick () {
       this.$emit('quick-replies-click');
+    },
+
+    onInsertInlineImageClick () {
+      this.$emit('inline-image-click');
+    },
+
+    insertInlineImage (imageUrl) {
+      this.$refs.richTextEditor?.editor.chain().focus().setImage({ src: imageUrl }).run();
     },
 
     onBlockquoteToggle () {

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor_default.story.vue
@@ -28,11 +28,13 @@
       :show-align-justify-button="$attrs.showAlignJustifyButton"
       :show-quote-button="$attrs.showQuoteButton"
       :show-quick-replies-button="$attrs.showQuickRepliesButton"
+      :show-inline-image-button="$attrs.showInlineImageButton"
       :show-code-block-button="$attrs.showCodeBlockButton"
       @focus="$attrs.onFocus"
       @blur="$attrs.onBlur"
       @input="$attrs.onInput"
       @quick-replies-click="$attrs.onQuickRepliesClick"
+      @inline-image-click="$attrs.onInlineImageClick"
     />
     <p><strong>Editor content is:</strong></p>
     <span>{{ value }}</span>

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.stories.js
@@ -44,6 +44,12 @@ export const argTypesData = {
       disable: true,
     },
   },
+
+  onInlineImageClick: {
+    table: {
+      disable: true,
+    },
+  },
 };
 
 // Set default values at the story level here.
@@ -56,6 +62,7 @@ export const argsData = {
   onBlur: action('blur'),
   onInput: action('input'),
   onQuickRepliesClick: action('quick-replies-click'),
+  onInlineImageClick: action('inline-image-click'),
 };
 
 // Story Collection

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -202,6 +202,7 @@ import {
   DtIconAlignRight,
   DtIconBold,
   DtIconCodeBlock,
+  DtIconImage,
   DtIconItalic,
   DtIconLightningBolt,
   DtIconLink2,
@@ -237,6 +238,7 @@ export default {
     DtIconQuote,
     DtIconCodeBlock,
     DtIconLink2,
+    DtIconImage,
   },
 
   mixins: [],
@@ -456,6 +458,14 @@ export default {
     },
 
     /**
+     * Show button to add an inline image
+     */
+    showInlineImageButton: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
      * Show add link default config.
      */
     showAddLink: {
@@ -504,6 +514,12 @@ export default {
      * @event quick-replies-click
      */
     'quick-replies-click',
+
+    /**
+     * Emit when inline image button is clicked
+     * @event inline-image-click
+     */
+    'inline-image-click',
   ],
 
   data () {
@@ -683,6 +699,15 @@ export default {
           tooltipMessage: 'Code',
           onClick: this.onCodeBlockToggle,
         },
+        {
+          showBtn: this.showInlineImageButton,
+          selector: 'image',
+          icon: DtIconImage,
+          dataQA: 'dt-recipe-editor-inline-image-btn',
+          tooltipMessage: 'Image',
+          // Handle getting image
+          onClick: this.onInsertInlineImageClick,
+        },
       ].filter(button => button.showBtn);
     },
 
@@ -816,6 +841,14 @@ export default {
 
     onQuickRepliesClick () {
       this.$emit('quick-replies-click');
+    },
+
+    onInsertInlineImageClick () {
+      this.$emit('inline-image-click');
+    },
+
+    insertInlineImage (imageUrl) {
+      this.$refs.richTextEditor?.editor.chain().focus().setImage({ src: imageUrl }).run();
     },
 
     insertInMessageBody (messageContent) {

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -462,7 +462,7 @@ export default {
      */
     showInlineImageButton: {
       type: Boolean,
-      default: true,
+      default: false,
     },
 
     /**

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
@@ -29,10 +29,12 @@
       :show-quote-button="$attrs.showQuoteButton"
       :show-quick-replies-button="$attrs.showQuickRepliesButton"
       :show-code-block-button="$attrs.showCodeBlockButton"
+      :show-inline-image-button="$attrs.showInlineImageButton"
       @focus="$attrs.onFocus"
       @blur="$attrs.onBlur"
       @input="$attrs.onInput"
       @quick-replies-click="$attrs.onQuickRepliesClick"
+      @inline-image-click="$attrs.onInlineImageClick"
     />
     <p><strong>Editor content is:</strong></p>
     <span>{{ value }}</span>


### PR DESCRIPTION
# feat: Insert Inline image through editor

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

![Warhammer](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExYnhxZDI4d2pra3o0bmd1bjB3aDUxc3BicjBjdDVhaTIxdXZiNzlxeiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/BZy4US4yNLoAr0bdAP/giphy.gif)

## :hammer_and_wrench: Type Of Change


These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-130987

## :book: Description

- Image button and event when clicked
- Method to directly insert inline image at the current position in editor.

## :bulb: Context

With omnichannel quick replies, we need a way to upload images to uv backend, grab the URL and paste it inline into the editor. Provide a button, event and method to help with this.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [ ] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [ ] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

If new component:

<!--- There are lots of things to remember when adding a new component to the system! This is so you don't forget any of them. -->

- I am exporting any new components or constants:
  - [ ] from the index.js in the component directory.
  - [ ] from the index.js in the root (either `packages/dialtone-vue2` or `packages/dialtone-vue3`).
- [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
- [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
- [ ] I have added the new component to `common/components_list.js`
- [ ] I have created a component story in storybook
- [ ] I have created story / stories for any relevant component variants in storybook
- [ ] I have created a docs page for the component in storybook.
- [ ] I have checked that changing all props/slots via the UI in storybook works as expected.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
