### PR TITLE
ci(i18n): DLT-2451 setup i18n workflows

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,0 +1,22 @@
+name: Setup Environment
+description: Common steps  set up the environment for tasks
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: ".nvmrc"
+        cache: "pnpm"
+        registry-url: "https://npm.pkg.github.com"
+        scope: "dialpad"
+      env:
+        NODE_AUTH_TOKEN: ${{ github.token }}
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - staging
-      - setup-i18n-actions
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -1,0 +1,115 @@
+name: Pull from translation service
+
+on:
+  push:
+    branches:
+      - staging
+      - setup-i18n-actions
+  workflow_dispatch:
+
+jobs:
+  pull-translations:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -o pipefail {0}
+        working-directory: ./packages/dialtone-vue2
+
+    env:
+      SMARTLING_BASE_URL: "https://api.smartling.com"
+      SMARTLING_AUTH_PATH: "/auth-api/v2/authenticate"
+      SMARTLING_FILES_PATH: "/files-api/v2/projects"
+      SMARTLING_PROJECTS_PATH: "/projects-api/v2/projects"
+      SMARTLING_JOBS_PATH: "/jobs-api/v3/projects"
+      SMARTLING_PROJECT_ID: ${{ vars.SMARTLING_PROJECT_ID }}
+      INJECT_PLACEHOLDER_WORKAROUND: ${{ vars.INJECT_PLACEHOLDER_WORKAROUND }}
+      SMARTLING_API_USER: ${{ secrets.SMARTLING_API_USER }}
+      SMARTLING_API_SECRET: ${{ secrets.SMARTLING_API_SECRET }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Check if translations need to be synced
+        id: check_translations
+        run: |
+          result=$(pnpm exec should-pull --use-ftl-flow ${{ vars.USE_FTL_FLOW }} | tail -n 1)
+          echo "should_create_pr=$result" >> $GITHUB_OUTPUT
+
+      - name: Pull translations if needed
+        if: steps.check_translations.outputs.should_create_pr == 'true'
+        run: |
+          pnpm exec pull-translations --use-ftl-flow ${{ vars.USE_FTL_FLOW }}
+
+      - name: Commit changes if there are any
+        if: steps.check_translations.outputs.should_create_pr == 'true'
+        run: |
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          BRANCH_NAME="translation-sync-${TIMESTAMP}"
+
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+          git config --global user.name 'GitHub Actions Bot'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git checkout -b "$BRANCH_NAME"
+          git add .
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          else
+            git commit -m "Sync translations"
+            git push origin "$BRANCH_NAME"
+          fi
+
+      - name: Get commit hash of latest translation sync commit
+        if: steps.check_translations.outputs.should_create_pr == 'true'
+        id: get_commit_hash
+        run: |
+          COMMIT_HASH=$(git log --pretty=format:"%H" --author="github-actions.*" --grep="Sync translations" -n 1)
+          echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+
+      - name: Get open Translation PRs
+        if: steps.check_translations.outputs.should_create_pr == 'true'
+        id: get_open_prs
+        run: |
+          OPEN_PRS=$(gh pr list --state open --search "ci: [Automated] Sync Translations" --json number --jq '.[] | .number' | paste -sd "," -)
+          echo "open_prs=$OPEN_PRS" >> $GITHUB_OUTPUT
+
+      - name: Check if any open PRs have the same commit
+        if: steps.check_translations.outputs.should_create_pr == 'true'
+        id: check_existing_pr
+        run: |
+          echo "Checking open PRs for duplicate Sync Translations commits..."
+
+          IFS=',' read -r -a PRS_ARRAY <<< "${{steps.get_open_prs.outputs.open_prs}}"
+
+          git fetch origin --quiet
+
+          for pr in "${PRS_ARRAY[@]}"; do
+            PR_COMMITS=$(gh pr view $pr --json commits --jq '.commits[].oid')
+            for pr_commit in $PR_COMMITS; do
+              COMMIT_DIFF=$(diff <(git show --pretty=format:"" ${{steps.get_commit_hash.outputs.commit_hash}}) <(git show --pretty=format:"" $pr_commit))
+              if [ -z "$COMMIT_DIFF" ]; then
+                echo "Found duplicate PR with same changes in commit $pr_commit for PR #$pr"
+                echo "pr_exists=true" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            done
+          done
+          echo "No duplicate PR found"
+          echo "pr_exists=false" >> $GITHUB_OUTPUT
+
+      - name: Create PR if no duplicate found
+        if: steps.check_translations.outputs.should_create_pr == 'true' && steps.check_existing_pr.outputs.pr_exists == 'false'
+        run: |
+          PR_URL=$(gh pr create --title "ci: [Automated] Sync Translations" \
+                                --body "This PR updates translations." \
+                                --base main \
+                                --head "$BRANCH_NAME")
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/push-translations.yml
+++ b/.github/workflows/push-translations.yml
@@ -1,0 +1,41 @@
+name: Push to translation service
+
+on:
+  push:
+    branches:
+      - staging
+      - setup-i18n-actions
+    paths:
+      - 'packages/dialtone-vue2/localization/en-US.ftl'
+
+jobs:
+  push-translations:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -o pipefail {0}
+        working-directory: ./packages/dialtone-vue2
+
+    env:
+      SMARTLING_BASE_URL: "https://api.smartling.com"
+      SMARTLING_AUTH_PATH: "/auth-api/v2/authenticate"
+      SMARTLING_FILES_PATH: "/files-api/v2/projects"
+      SMARTLING_PROJECTS_PATH: "/projects-api/v2/projects"
+      SMARTLING_JOBS_PATH: "/jobs-api/v3/projects"
+      SMARTLING_PROJECT_ID: ${{ vars.SMARTLING_PROJECT_ID }}
+      INJECT_PLACEHOLDER_WORKAROUND: ${{ vars.INJECT_PLACEHOLDER_WORKAROUND }}
+      SMARTLING_API_USER: ${{ secrets.SMARTLING_API_USER }}
+      SMARTLING_API_SECRET: ${{ secrets.SMARTLING_API_SECRET }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Convert and upload en-US.ftl to third party service
+        run: pnpm exec upload-translation-service --use-ftl-flow ${{ vars.USE_FTL_FLOW }}

--- a/packages/dialtone-vue2/localization/en-US.ftl
+++ b/packages/dialtone-vue2/localization/en-US.ftl
@@ -7,3 +7,4 @@ SET_LANGUAGE = Set language
 CLOSE_BUTTON =
   .aria-label = Close
   .title = Close
+TEST_WORD = Test

--- a/packages/dialtone-vue2/localization/en-US.ftl
+++ b/packages/dialtone-vue2/localization/en-US.ftl
@@ -7,4 +7,3 @@ SET_LANGUAGE = Set language
 CLOSE_BUTTON =
   .aria-label = Close
   .title = Close
-TEST_WORD = Test


### PR DESCRIPTION
# Setup i18n workflows

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/xdLH51eNWZAHrwy5mf/giphy.gif?cid=82a1493bed9kixkshz9psrnjyxomgtsdshahsrxk3lvnjrdx&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] CI

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2451

## :book: Description

- Added workflows to automatically push and pull translations from smartling

> Note: Branched out of https://github.com/dialpad/dialtone/tree/dlt-2452-setup-i18n to be able to test the actions.

## :bulb: Context

We're setting up i18n on dialtone-vue

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.

## :link: Sources

- https://docs.google.com/document/d/1RZVbFwDqZ4qUQ3C65y9_iUAn6KZ4yfuTPyLIx8qDeyQ/edit?tab=t.0 see step 10.