### PR TITLE
fix: NO-JIRA vue 3 v-model corrections

### DIFF
--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2025-4-15.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2025-4-15.md
@@ -1,0 +1,100 @@
+---
+heading: Vue 3 input components v-model breaking change
+author: Brad Paugh
+posted: '2025-4-15'
+---
+
+<BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">
+
+Hello all Dialtone users! There is a small breaking change that has just been released in the latest version of Dialtone. This breaking change only applies to Dialtone Vue 3 input components.
+
+The standard in Vue 3 is to use the prop name modelValue instead of value for components that use v-model and map to input components. For checkbox/radio components modelValue maps to the checked attribute instead of value. We were not consistent on this in the initial migration to Dialtone Vue 3, so we are fixing it now. This has now been updated for all Dialtone Vue 3 input components. Please see the breaking change in the Vue 3 migration guide for more info: <https://v3-migration.vuejs.org/breaking-changes/v-model.html#_3-x-syntax>
+
+You will only need to migrate components that were referencing the value/checked prop directly. If you were using v-model on the component already, you will not need to make any changes.
+
+## Affected Components
+
+The following components are affected by this change:
+
+- Input
+- Select Menu
+- Editor
+- Checkbox
+- Radio
+- Radio Group
+- Toggle
+
+## Migration steps for Input, Select Menu, Editor
+
+Any instances of value being set on the affected components will need to be changed to modelValue.
+
+Before:
+
+```html
+<dt-input :value="myValue" label="Test input" />
+```
+
+After:
+
+```html
+<dt-input :model-value="myValue" label="Test input" />
+```
+
+## Migration steps for Radio, Checkbox, Toggle
+
+Any instances of checked being set on the affected components will need to be changed to modelValue.
+
+Before:
+
+```html
+<dt-checkbox checked label="Test checkbox" />
+```
+
+After:
+
+```html
+<dt-checkbox :model-value="true" label="Test checkbox" />
+```
+
+## Migration steps for Radio Group
+
+Any instances of value being set on the outer Radio Group component will need to be changed to modelValue.
+
+Before:
+
+```html
+<dt-radio-group
+  value="apple"
+  legend="Fruits"
+>
+  <dt-radio value="apple"><span>Apple</span></dt-radio>
+  <dt-radio value="banana"><span>Banana</span></dt-radio>
+  <dt-radio value="other"><span>Other</span></dt-radio>
+</dt-radio-group>
+```
+
+After:
+
+```html
+<dt-radio-group
+  model-value="apple"
+  legend="Fruits"
+>
+  <dt-radio value="apple"><span>Apple</span></dt-radio>
+  <dt-radio value="banana"><span>Banana</span></dt-radio>
+  <dt-radio value="other"><span>Other</span></dt-radio>
+</dt-radio-group>
+```
+
+Note the individual dt-radio's within do not need to be changed, as their modelValue references checked rather than value.
+
+Again, if you are using v-model instead of value, you do not need to make any changes.
+
+Thanks! Dialtone Team 💜
+
+</BlogPost>
+
+<script setup>
+import BlogPost from '@baseComponents/BlogPost.vue';
+import { parse } from 'date-fns';
+</script>

--- a/apps/dialtone-documentation/docs/components/checkbox.md
+++ b/apps/dialtone-documentation/docs/components/checkbox.md
@@ -157,7 +157,7 @@ vueCode='
   name="checked"
   value="Value"
   label="Checkbox label"
-  checked
+  :model-value="true"
 />
 <!-- Disabled -->
 <dt-checkbox
@@ -171,7 +171,7 @@ vueCode='
   name="disabled-checked"
   value="Value"
   label="Checkbox label"
-  checked
+  :model-value="true"
   disabled
 />
 '
@@ -240,7 +240,7 @@ vueCode='
   name="indeterminate-disabled"
   value="Value"
   label="Indeterminate checkbox disabled"
-  checked
+  :model-value="true"
   disabled
   indeterminate
 />

--- a/apps/dialtone-documentation/docs/components/input.md
+++ b/apps/dialtone-documentation/docs/components/input.md
@@ -190,7 +190,8 @@ htmlCode='
 '
 vueCode='
 <dt-input label="Label" placeholder="Placeholder" />
-<dt-input label="Label" value="Value" />
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
+<dt-input label="Label" model-value="Value" />
 <dt-input label="Label" placeholder="Placeholder" disabled />
 '
 showHtmlWarning />
@@ -220,7 +221,8 @@ htmlCode='
 '
 vueCode='
 <dt-input label="Label" placeholder="Placeholder" type="textarea" />
-<dt-input label="Label" type="textarea" value="Value" />
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
+<dt-input label="Label" type="textarea" model-value="Value" />
 <dt-input label="Label" placeholder="Placeholder" type="textarea" disabled />
 '
 showHtmlWarning />
@@ -292,9 +294,10 @@ htmlCode='
 </div>
 '
 vueCode='
-<dt-input label="Label" type="email" value="Value" :messages="[messages.error]"/>
-<dt-input label="Label" type="email" value="Value" :messages="[messages.success]"/>
-<dt-input label="Label" type="email" value="Value" :messages="[messages.warning]"/>
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
+<dt-input label="Label" type="email" model-value="Value" :messages="[messages.error]"/>
+<dt-input label="Label" type="email" model-value="Value" :messages="[messages.success]"/>
+<dt-input label="Label" type="email" model-value="Value" :messages="[messages.warning]"/>
 '
 showHtmlWarning />
 
@@ -325,9 +328,10 @@ htmlCode='
 </div>
 '
 vueCode='
-<dt-input label="Label" type="textarea" value="Value" :messages="[messages.error]"/>
-<dt-input label="Label" type="textarea" value="Value" :messages="[messages.success]"/>
-<dt-input label="Label" type="textarea" value="Value" :messages="[messages.warning]"/>
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
+<dt-input label="Label" type="textarea" model-value="Value" :messages="[messages.error]"/>
+<dt-input label="Label" type="textarea" model-value="Value" :messages="[messages.success]"/>
+<dt-input label="Label" type="textarea" model-value="Value" :messages="[messages.warning]"/>
 '
 showHtmlWarning />
 
@@ -342,7 +346,8 @@ showHtmlWarning />
 <code-example-tabs
 :htmlCode='() => $refs.multipleMessages'
 vueCode='
-<dt-input label="Label" type="email" value="Value" :messages="multipleMessages" />
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
+<dt-input label="Label" type="email" model-value="Value" :messages="multipleMessages" />
 '
 />
 

--- a/apps/dialtone-documentation/docs/components/radio-group.md
+++ b/apps/dialtone-documentation/docs/components/radio-group.md
@@ -9,7 +9,7 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-radio-group-
 
 <code-well-header>
   <dt-radio-group
-    value=""
+    model-value=""
     class="d-input-group__fieldset"
     name="fruits-radio-group-00"
     legend="Fruits"
@@ -26,7 +26,7 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-radio-group-
 
 <code-well-header>
   <dt-radio-group
-    value=""
+    model-value=""
     name="fruits-radio-group-01"
     class="d-input-group__fieldset"
     legend="Fruits"
@@ -77,7 +77,7 @@ htmlCode='
 '
 vueCode='
 <dt-radio-group
-  value=""
+  model-value=""
   name="fruits-radio-group-01"
   legend="Fruits"
 >

--- a/apps/dialtone-documentation/docs/components/radio.md
+++ b/apps/dialtone-documentation/docs/components/radio.md
@@ -54,7 +54,7 @@ Radio buttons are a common way to allow users to make a single selection from a 
   <fieldset class="d-input-group__fieldset d-stack8">
     <dt-radio name="Value" value="Value" label="Radio label"/>
     <dt-radio name="Disabled" value="Disabled" label="Radio label thats been disabled" disabled/>
-    <dt-radio name="CheckedDisabled" value="Checked" label="Radio label thats been disabled & checked" checked disabled />
+    <dt-radio name="CheckedDisabled" value="Checked" label="Radio label thats been disabled & checked" :model-value="true" disabled />
   </fieldset>
 </code-well-header>
 
@@ -94,7 +94,7 @@ htmlCode='
 vueCode='
 <dt-radio name="Value" value="Value" label="Radio label"/>
 <dt-radio name="Disabled" value="Disabled" label="Radio label thats been disabled" disabled/>
-<dt-radio name="CheckedDisabled" value="Checked" label="Radio label thats been disabled & checked" checked disabled />
+<dt-radio name="CheckedDisabled" value="Checked" label="Radio label thats been disabled & checked" :model-value="true" disabled />
 '
 showHtmlWarning />
 

--- a/apps/dialtone-documentation/docs/components/select-menu.md
+++ b/apps/dialtone-documentation/docs/components/select-menu.md
@@ -21,6 +21,7 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 
 - Use sparingly — only when a user needs to choose from about seven to 15 possible options, and you have limited space to display the options.
 </template>
+
 <template #dont>
 
 - For site navigation.
@@ -29,6 +30,7 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 - Avoid using the `multiple` attribute. Users often don’t understand how to select multiple items from the select element (e.g. by holding down a modifier key).
 - For selecting an action that takes immediate effect. A `select` is for selecting a choice that is only confirmed by a separate submit action (much like a [Checkbox](checkbox.md)). For immediate actions consider the [Dropdown](dropdown.md) component.
 </template>
+
 </dialtone-usage>
 
 ### Best Practices
@@ -80,6 +82,7 @@ htmlCode='
 </div>
 '
 vueCode='
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
 <dt-select-menu
   :options="[
         { value: ``, label: `Please select one` },
@@ -88,7 +91,7 @@ vueCode='
         { value: `3`, label: `Option 3` },
       ]"
   label="Default"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 />
@@ -101,7 +104,7 @@ vueCode='
       ]"
   label="Disabled"
   disabled
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 />
@@ -132,6 +135,7 @@ htmlCode='
 </div>
 '
 vueCode='
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
 <dt-select-menu
   :options="[
         { value: ``, label: `Please select one` },
@@ -141,7 +145,7 @@ vueCode='
       ]"
   label="Label"
   description="Optional description text"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 />
@@ -221,6 +225,7 @@ htmlCode='
 </div>
 '
 vueCode='
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
 <dt-select-menu
   :options="[
     { value: ``, label: `Please select one` },
@@ -230,7 +235,7 @@ vueCode='
   ]"
   :messages="[{ message: `Error validation message`, type: `error` }]"
   label="Label"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 />
@@ -243,7 +248,7 @@ vueCode='
   ]"
   :messages="[{ message: `Success validation message`, type: `success` }]"
   label="Label"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 />
@@ -256,7 +261,7 @@ vueCode='
   ]"
   :messages="[{ message: `Warning validation message`, type: `warning` }]"
   label="Label"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 />
@@ -288,6 +293,7 @@ showHtmlWarning />
 <code-example-tabs
 :htmlCode="() => $refs.messagesHidden"
 vueCode='
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
 <dt-select-menu
   :options="[
     { value: ``, label: `Please select one` },
@@ -297,21 +303,21 @@ vueCode='
   ]"
   :messages="[{ message: `Error validation message`, type: `error` }]"
   label="Label"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
   :show-messages="false"
 />
 <dt-select-menu
   :options="[
-    { value: ``, label: `Please select one` },
+    { value:``, label: `Please select one` },
     { value: `1`, label: `Option 1` },
     { value: `2`, label: `Option 2` },
     { value: `3`, label: `Option 3` },
   ]"
   :messages="[{ message: `Success validation message`, type: `success` }]"
   label="Label"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
   :show-messages="false"
@@ -325,7 +331,7 @@ vueCode='
   ]"
   :messages="[{ message: `Warning validation message`, type: `warning` }]"
   label="Label"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
   :show-messages="false"
@@ -346,6 +352,7 @@ vueCode='
 <code-example-tabs
 :htmlCode="() => $refs.slottedLabel"
 vueCode='
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
 <dt-select-menu
   :options="[
     { value: ``, label: `Please select one` },
@@ -353,7 +360,7 @@ vueCode='
     { value: `2`, label: `Option 2` },
     { value: `3`, label: `Option 3` },
   ]"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 >
@@ -377,6 +384,7 @@ vueCode='
 <code-example-tabs
 :htmlCode="() => $refs.slottedDescription"
 vueCode='
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
 <dt-select-menu
   :options="[
     { value: ``, label: `Please select one` },
@@ -384,7 +392,7 @@ vueCode='
     { value: `2`, label: `Option 2` },
     { value: `3`, label: `Option 3` },
   ]"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 >
@@ -412,8 +420,9 @@ vueCode='
 <code-example-tabs
 :htmlCode="() => $refs.slottedOptions"
 vueCode='
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
 <dt-select-menu
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 >
@@ -512,6 +521,7 @@ htmlCode='
 </div>
 '
 vueCode='
+<!-- IMPORTANT NOTE: Change model-value to just value in Vue 2 -->
 <dt-select-menu
   :options="[
     { value: ``, label: `Please select one` },
@@ -521,7 +531,7 @@ vueCode='
   ]"
   label="Label"
   size="xs"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 />
@@ -534,7 +544,7 @@ vueCode='
   ]"
   label="Label"
   size="sm"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 />
@@ -547,7 +557,7 @@ vueCode='
   ]"
   label="Label"
   size="md"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 />
@@ -560,7 +570,7 @@ vueCode='
   ]"
   label="Label"
   size="lg"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 />
@@ -573,7 +583,7 @@ vueCode='
   ]"
   label="Label"
   size="xl"
-  :value="value"
+  :model-value="modelValue"
   @input="onInput"
   @change="onChange"
 />

--- a/apps/dialtone-documentation/docs/components/toggle.md
+++ b/apps/dialtone-documentation/docs/components/toggle.md
@@ -49,11 +49,11 @@ The Toggle component acts as a way to allow the User to switch between two mutua
 <code-well-header>
   <dt-stack as="fieldset" gap="400">
     <dt-toggle label-class="d-mr6">Unchecked Toggle</dt-toggle>
-    <dt-toggle checked label-class="d-mr6">Checked Toggle</dt-toggle>
+    <dt-toggle :model-value="true" label-class="d-mr6">Checked Toggle</dt-toggle>
     <dt-toggle disabled label-class="d-mr6">Unchecked Disabled</dt-toggle>
-    <dt-toggle checked disabled label-class="d-mr6">Checked Disabled</dt-toggle>
-    <dt-toggle checked="mixed" label-class="d-mr6">Indeterminate Toggle</dt-toggle>
-    <dt-toggle checked="mixed" label-class="d-mr6" disabled>Indeterminate Disabled</dt-toggle>
+    <dt-toggle :model-value="true" disabled label-class="d-mr6">Checked Disabled</dt-toggle>
+    <dt-toggle :model-value="mixed" label-class="d-mr6">Indeterminate Toggle</dt-toggle>
+    <dt-toggle :model-value="mixed" label-class="d-mr6" disabled>Indeterminate Disabled</dt-toggle>
     <dt-toggle label-class="d-mr6" :show-icon="false">Without icon</dt-toggle>
   </dt-stack>
 </code-well-header>
@@ -92,19 +92,19 @@ vueCode='
 <dt-toggle>
   Unchecked Toggle
 </dt-toggle>
-<dt-toggle :checked="true">
+<dt-toggle :model-value="true">
   Checked Toggle
 </dt-toggle>
 <dt-toggle :disabled="true">
   Unchecked Disabled
 </dt-toggle>
-<dt-toggle :checked="true" :disabled="true">
+<dt-toggle :model-value="true" :disabled="true">
   Checked Disabled
 </dt-toggle>
-<dt-toggle checked="mixed">
+<dt-toggle model-value="mixed">
   Indeterminate Toggle
 </dt-toggle>
-<dt-toggle checked="mixed" :disabled="true">
+<dt-toggle model-value="mixed" :disabled="true">
   Indeterminate Disabled
 </dt-toggle>
 <dt-toggle :show-icon="false">

--- a/packages/dialtone-vue3/common/mixins/input.js
+++ b/packages/dialtone-vue3/common/mixins/input.js
@@ -29,7 +29,6 @@ export const InputMixin = {
 
     /**
      * The value of the input
-     * @model value
      */
     value: {
       type: [String, Number, Boolean, Object],
@@ -151,16 +150,12 @@ export const InputMixin = {
  * @displayName Checkable Mixin
  */
 export const CheckableMixin = {
-  model: {
-    prop: 'checked',
-  },
-
   props: {
     /**
-     * Used to set the state of the checkable input
-     * @model checked
+     * Used to set the checked state of the checkable input
+     * @model modelValue
      */
-    checked: {
+    modelValue: {
       type: Boolean,
       default: false,
     },
@@ -182,13 +177,13 @@ export const CheckableMixin = {
 
   data () {
     return {
-      internalChecked: this.checked,
+      internalChecked: this.modelValue,
       internalIndeterminate: this.indeterminate,
     };
   },
 
   watch: {
-    checked (newChecked) {
+    modelValue (newChecked) {
       // update internal checked when the prop changes
       this.internalChecked = newChecked;
     },

--- a/packages/dialtone-vue3/components/checkbox/checkbox.stories.js
+++ b/packages/dialtone-vue3/components/checkbox/checkbox.stories.js
@@ -53,7 +53,7 @@ export const argTypesData = {
       type: 'text',
     },
   },
-  checked: {
+  modelValue: {
     description: 'Used to set the initial state of the checkbox',
     control: 'boolean',
     table: {

--- a/packages/dialtone-vue3/components/checkbox/checkbox.test.js
+++ b/packages/dialtone-vue3/components/checkbox/checkbox.test.js
@@ -172,7 +172,7 @@ describe('DtCheckbox Tests', () => {
 
     describe('When checked', () => {
       it('should be checked', () => {
-        mockProps = { checked: true };
+        mockProps = { modelValue: true };
 
         updateWrapper();
 
@@ -248,7 +248,7 @@ describe('DtCheckbox Tests', () => {
       describe('When checked', () => {
         describe('When the checkbox is clicked', () => {
           it('Should emit an input event', async () => {
-            mockProps = { checked: true };
+            mockProps = { modelValue: true };
 
             updateWrapper();
 
@@ -288,7 +288,7 @@ describe('DtCheckbox Tests', () => {
       describe('When checked', () => {
         describe('When the checkbox is clicked', () => {
           it('Should emit an input event', async () => {
-            mockProps = { checked: true };
+            mockProps = { modelValue: true };
 
             updateWrapper();
 

--- a/packages/dialtone-vue3/components/checkbox/checkbox.vue
+++ b/packages/dialtone-vue3/components/checkbox/checkbox.vue
@@ -88,6 +88,13 @@ export default {
      * @type {Boolean}
      */
     'input',
+    /**
+     * Event fired to sync the modelValue prop with the parent component
+     *
+     * @event update:modelValue
+     * @type {Boolean}
+     */
+    'update:modelValue',
 
     /**
      * Native input focusin event
@@ -176,6 +183,7 @@ export default {
 
       // emit the state of the checkbox
       this.$emit('input', checked);
+      this.$emit('update:modelValue', checked);
     },
 
     runValidations () {

--- a/packages/dialtone-vue3/components/checkbox/checkbox_default.story.vue
+++ b/packages/dialtone-vue3/components/checkbox/checkbox_default.story.vue
@@ -3,7 +3,7 @@
     :label="$attrs.label"
     :name="$attrs.name"
     :value="$attrs.value"
-    :checked="$attrs.checked"
+    :model-value="$attrs.modelValue"
     :description="$attrs.description"
     :validation-state="$attrs.validationState"
     :disabled="$attrs.disabled"

--- a/packages/dialtone-vue3/components/checkbox_group/checkbox_group.test.js
+++ b/packages/dialtone-vue3/components/checkbox_group/checkbox_group.test.js
@@ -230,7 +230,7 @@ describe('Checkbox Group Tests', () => {
   });
 
   describe('Validation Tests', () => {
-    const MOCK_PROP = DtCheckboxGroup.props.value;
+    const MOCK_PROP = DtCheckboxGroup.props.modelValue;
 
     describe('When a value is not provided', () => {
       it('passes custom prop validation', () => {

--- a/packages/dialtone-vue3/components/checkbox_group/checkbox_group.vue
+++ b/packages/dialtone-vue3/components/checkbox_group/checkbox_group.vue
@@ -14,15 +14,11 @@ export default {
 
   extends: DtInputGroup,
 
-  model: {
-    prop: 'selectedValues',
-  },
-
   props: {
     /**
      * Not supported by this component, please use selectedValues
      */
-    value: {
+    modelValue: {
       type: [],
       default: null,
       validator: value => {
@@ -31,7 +27,7 @@ export default {
         }
 
         warn(
-          'Component uses selectedValues to initialize the model, value is not supported by this component',
+          'Component uses selectedValues to initialize the model, modelValue is not supported by this component',
           this,
         );
 
@@ -83,6 +79,13 @@ export default {
      * @type {Array}
      */
     'input',
+    /**
+     * Selected values for the checkbox group
+     *
+     * @event input
+     * @type {Array}
+     */
+    'update:selectedValues',
   ],
 
   data () {
@@ -122,6 +125,7 @@ export default {
       }
 
       this.$emit('input', this.internalValue);
+      this.$emit('update:selectedValues', this.internalValue);
     },
 
     getMessageKey (type, index) {

--- a/packages/dialtone-vue3/components/input_group/decorators/input.vue
+++ b/packages/dialtone-vue3/components/input_group/decorators/input.vue
@@ -52,6 +52,13 @@ export default {
      * @type {String}
      */
     'input',
+    /**
+     * Event fired to sync the modelValue prop with the parent component
+     *
+     * @event update:modelValue
+     * @type {String}
+     */
+    'update:modelValue',
   ],
 
   computed: {
@@ -76,7 +83,7 @@ export default {
       handler (newGroupValue) {
         if (this.hasGroup) {
           // update internal value when the input group value changes
-          this.internalChecked = newGroupValue === this.value;
+          this.internalChecked = newGroupValue === this.modelValue;
         }
       },
     },
@@ -89,6 +96,7 @@ export default {
         this.setGroupValue(value);
 
         this.$emit('input', value);
+        this.$emit('update:modelValue', value);
       }
     },
   },

--- a/packages/dialtone-vue3/components/radio/radio.stories.js
+++ b/packages/dialtone-vue3/components/radio/radio.stories.js
@@ -54,7 +54,7 @@ export const argTypesData = {
       type: 'text',
     },
   },
-  checked: {
+  modelValue: {
     description: 'Used to set the initial state of the radio',
     control: 'boolean',
     table: {

--- a/packages/dialtone-vue3/components/radio/radio.test.js
+++ b/packages/dialtone-vue3/components/radio/radio.test.js
@@ -137,7 +137,7 @@ describe('DtRadio Tests', () => {
 
     describe('When checked', () => {
       it('should be checked', () => {
-        mockProps = { checked: true };
+        mockProps = { modelValue: true };
 
         updateWrapper();
 

--- a/packages/dialtone-vue3/components/radio/radio.vue
+++ b/packages/dialtone-vue3/components/radio/radio.vue
@@ -94,6 +94,13 @@ export default {
      * @type {String | Number}
      */
     'input',
+    /**
+     * Event fired to sync the modelValue prop with the parent component
+     *
+     * @event input
+     * @type {String | Number}
+     */
+    'update:modelValue',
 
     /**
      * Native input focus event
@@ -177,8 +184,8 @@ export default {
       if (value !== this.radioGroupValue) {
         // update provided value if injected
         this.setGroupValue(value);
-
         this.$emit('input', value);
+        this.$emit('update:modelValue', value);
       }
     },
   },

--- a/packages/dialtone-vue3/components/radio/radio_default.story.vue
+++ b/packages/dialtone-vue3/components/radio/radio_default.story.vue
@@ -3,7 +3,7 @@
     :label="$attrs.label"
     :name="$attrs.name"
     :value="$attrs.value"
-    :checked="$attrs.checked"
+    :model-value="$attrs.modelValue"
     :description="$attrs.description"
     :validation-state="$attrs.validationState"
     :disabled="$attrs.disabled"

--- a/packages/dialtone-vue3/components/radio_group/radio_group.stories.js
+++ b/packages/dialtone-vue3/components/radio_group/radio_group.stories.js
@@ -57,7 +57,7 @@ export const argTypesData = {
       type: 'text',
     },
   },
-  value: {
+  modelValue: {
     description: 'A provided value for the radio group',
     control: 'text',
     table: {

--- a/packages/dialtone-vue3/components/radio_group/radio_group.test.js
+++ b/packages/dialtone-vue3/components/radio_group/radio_group.test.js
@@ -13,7 +13,7 @@ const MOCK_PROP_VALUE = 'prop';
 
 const baseProps = {
   name: 'test-radio-group',
-  value: '',
+  modelValue: '',
 };
 const baseAttrs = { 'aria-label': 'Test Radio Group' };
 const baseSlots = {};
@@ -153,9 +153,9 @@ describe('DtRadioGroup Tests', () => {
       updateWrapper();
     });
 
-    describe('When an initial value is provided', () => {
+    describe('When an initial modelValue is provided', () => {
       it('updates provide object', () => {
-        mockProps = { value: MOCK_SELECTED_VALUE };
+        mockProps = { modelValue: MOCK_SELECTED_VALUE };
 
         updateWrapper();
 

--- a/packages/dialtone-vue3/components/radio_group/radio_group.vue
+++ b/packages/dialtone-vue3/components/radio_group/radio_group.vue
@@ -16,7 +16,7 @@ export default {
      * A provided value for the radio group
      * @model value
      */
-    value: {
+    modelValue: {
       type: [String, Number],
       default: '',
     },
@@ -54,16 +54,23 @@ export default {
      * @type {String | Number}
      */
     'input',
+    /**
+     * Native input event
+     *
+     * @event input
+     * @type {String | Number}
+     */
+    'update:modelValue',
   ],
 
   data () {
     return {
-      internalValue: this.value,
+      internalValue: this.modelValue,
     };
   },
 
   watch: {
-    value (newValue) {
+    modelValue (newValue) {
       this.internalValue = newValue;
     },
 
@@ -87,6 +94,7 @@ export default {
      */
     setGroupValue (newValue) {
       this.$emit('input', newValue);
+      this.$emit('update:modelValue', newValue);
     },
 
     getMessageKey (type, index) {

--- a/packages/dialtone-vue3/components/radio_group/radio_group_default.story.vue
+++ b/packages/dialtone-vue3/components/radio_group/radio_group_default.story.vue
@@ -3,7 +3,7 @@
     :id="$attrs.id"
     :name="$attrs.name"
     :legend="$attrs.legend"
-    :value="$attrs.value"
+    :model-value="$attrs.modelValue"
     :disabled="$attrs.disabled"
     :messages="$attrs.messages"
     :show-messages="$attrs.showMessages"

--- a/packages/dialtone-vue3/components/select_menu/select_menu.stories.js
+++ b/packages/dialtone-vue3/components/select_menu/select_menu.stories.js
@@ -19,7 +19,7 @@ export const argsData = {
   size: 'md',
   name: '',
   disabled: false,
-  value: SELECT_OPTIONS[0].value,
+  modelValue: SELECT_OPTIONS[0].value,
   options: SELECT_OPTIONS,
   onInput: action('input'),
   onChange: action('change'),
@@ -150,7 +150,7 @@ export const argTypesData = {
   },
 
   // HTML attributes
-  value: {
+  modelValue: {
     description: 'HTML select value attribute. Provides a value for the select',
     options: SELECT_OPTIONS.map((option) => option.value),
     control: {

--- a/packages/dialtone-vue3/components/select_menu/select_menu.vue
+++ b/packages/dialtone-vue3/components/select_menu/select_menu.vue
@@ -231,6 +231,14 @@ export default {
     'input',
 
     /**
+     * Event fired to sync the modelValue prop with the parent component
+     *
+     * @event input
+     * @type {String | Number}
+     */
+    'update:modelValue',
+
+    /**
      * Native change event
      *
      * @event change
@@ -305,6 +313,7 @@ export default {
     removeClassStyleAttrs,
     addClassStyleAttrs,
     emitValue (value, event) {
+      this.$emit('update:modelValue', value, event);
       this.$emit('input', value, event);
       this.$emit('change', value, event);
     },

--- a/packages/dialtone-vue3/components/select_menu/select_menu_default.story.vue
+++ b/packages/dialtone-vue3/components/select_menu/select_menu_default.story.vue
@@ -7,7 +7,7 @@
     :show-messages="$attrs.showMessages"
     :messages="$attrs.messages"
     :name="$attrs.name"
-    :value="$attrs.value"
+    :model-value="$attrs.modelValue"
     :disabled="$attrs.disabled"
     :label-class="$attrs.labelClass"
     :description-class="$attrs.descriptionClass"

--- a/packages/dialtone-vue3/components/toggle/toggle.stories.js
+++ b/packages/dialtone-vue3/components/toggle/toggle.stories.js
@@ -9,7 +9,7 @@ import { TOGGLE_CHECKED_VALUES, TOGGLE_SIZE_MODIFIERS } from '@/components/toggl
 // Default Prop Values
 export const argsData = {
   default: 'Toggle Default',
-  checked: false,
+  modelValue: false,
   onChange: action('change'),
   labelClass: 'd-mr6',
 };
@@ -28,7 +28,7 @@ export const argTypesData = {
   },
 
   // Props
-  checked: {
+  modelValue: {
     description:
       'Used to set the initial state of the toggle. Setting "mixed" means it gets the indeterminate state.',
     options: TOGGLE_CHECKED_VALUES,

--- a/packages/dialtone-vue3/components/toggle/toggle.test.js
+++ b/packages/dialtone-vue3/components/toggle/toggle.test.js
@@ -92,7 +92,7 @@ describe('DtToggle Tests', () => {
 
     describe('Unchecked Toggle', () => {
       beforeEach(() => {
-        mockProps = { checked: false };
+        mockProps = { modelValue: false };
 
         updateWrapper();
       });
@@ -102,7 +102,7 @@ describe('DtToggle Tests', () => {
       });
 
       describe('checked behaviour', () => {
-        it('should set correct checked attributes when checked prop is false', () => {
+        it('should set correct checked attributes when modelValue prop is false', () => {
           expect(button.attributes('aria-checked')).toBe('false');
           expect(button.classes().includes('d-toggle--checked')).toBe(false);
         });
@@ -122,7 +122,7 @@ describe('DtToggle Tests', () => {
     describe('Checked Toggle', () => {
       beforeEach(() => {
         mockProps = {
-          checked: true,
+          modelValue: true,
           disabled: false,
         };
 
@@ -153,7 +153,7 @@ describe('DtToggle Tests', () => {
 
     describe('Indeterminate Toggle', () => {
       beforeEach(() => {
-        mockProps = { checked: 'mixed' };
+        mockProps = { modelValue: 'mixed' };
 
         updateWrapper();
       });

--- a/packages/dialtone-vue3/components/toggle/toggle.vue
+++ b/packages/dialtone-vue3/components/toggle/toggle.vue
@@ -47,11 +47,6 @@ export default {
 
   inheritAttrs: false,
 
-  model: {
-    prop: 'checked',
-    event: 'change',
-  },
-
   props: {
 
     /**
@@ -73,10 +68,10 @@ export default {
 
     /**
      * Value of the toggle
-     * @model checked
+     * @model modelValue
      * @values true, false, 'mixed'
      */
-    checked: {
+    modelValue: {
       type: [Boolean, String],
       default: false,
       validator: (v) => TOGGLE_CHECKED_VALUES.includes(v),
@@ -137,11 +132,20 @@ export default {
      * @model change
      */
     'change',
+
+    /**
+     * v-model event event
+     *
+     * @event change
+     * @type {Boolean}
+     * @model change
+     */
+    'update:modelValue',
   ],
 
   data () {
     return {
-      internalChecked: this.checked,
+      internalChecked: this.modelValue,
       hasSlotContent,
     };
   },
@@ -176,7 +180,7 @@ export default {
   },
 
   watch: {
-    checked (newChecked) {
+    modelValue (newChecked) {
       this.internalChecked = newChecked;
     },
   },
@@ -189,6 +193,7 @@ export default {
     addClassStyleAttrs,
     toggleCheckedValue () {
       this.$emit('change', !this.internalChecked);
+      this.$emit('update:modelValue', !this.internalChecked);
 
       if (this.toggleOnClick) {
         this.internalChecked = !this.internalChecked;

--- a/packages/dialtone-vue3/components/toggle/toggle_default.story.vue
+++ b/packages/dialtone-vue3/components/toggle/toggle_default.story.vue
@@ -1,6 +1,6 @@
 <template>
   <dt-toggle
-    :checked="$attrs.checked"
+    :model-value="$attrs.modelValue"
     :disabled="$attrs.disabled"
     :size="$attrs.size"
     :show-icon="$attrs.showIcon"

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.stories.js
@@ -54,7 +54,7 @@ export const argTypesData = {
 
 // Set default values at the story level here.
 export const argsData = {
-  value: 'In the beginning, it was a nice day',
+  modelValue: 'In the beginning, it was a nice day',
   placeholder: 'New message',
   inputAriaLabel: 'Input text field',
   maxHeight: '40vh',

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.test.js
@@ -24,7 +24,7 @@ const testText = 'In the beginning, it was a nice day.';
 
 // Constants
 const baseProps = {
-  value: testText,
+  modelValue: testText,
   inputAriaLabel: 'aria-label text',
   inputClass: 'qa-editor',
   autoFocus: 'all',

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -251,7 +251,7 @@ export default {
      * Value of the input. The object format should match TipTap's JSON
      * document structure: https://tiptap.dev/guide/output#option-1-json
      */
-    value: {
+    modelValue: {
       type: [Object, String],
       default: '',
     },
@@ -510,6 +510,13 @@ export default {
     'input',
 
     /**
+     * Event fired to sync the modelValue prop with the parent component
+     * @event input
+     * @type {String|JSON}
+     */
+    'update:modelValue',
+
+    /**
      * Quick replies button
      * pressed event
      * @event quick-replies-click
@@ -525,7 +532,7 @@ export default {
 
   data () {
     return {
-      internalInputValue: this.value, // internal input content
+      internalInputValue: this.modelValue, // internal input content
       hasFocus: false,
 
       linkOptions: {
@@ -725,7 +732,7 @@ export default {
   },
 
   watch: {
-    value (newValue) {
+    modelValue (newValue) {
       this.internalInputValue = newValue;
     },
   },
@@ -879,6 +886,7 @@ export default {
 
     onInput (event) {
       this.$emit('input', event);
+      this.$emit('update:modelValue', event);
     },
 
   },

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
@@ -2,7 +2,7 @@
   <div>
     <dt-recipe-editor
       ref="editor"
-      v-model="value"
+      v-model="modelValue"
       class="d-mb32"
       :input-aria-label="$attrs.inputAriaLabel"
       :auto-focus="$attrs.autoFocus"
@@ -49,7 +49,7 @@ export default {
   components: { DtRecipeEditor },
   data () {
     return {
-      value: this.$attrs.value,
+      modelValue: this.$attrs.modelValue,
     };
   },
 };


### PR DESCRIPTION
# fix: NO-JIRA vue 3 v-model corrections

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ3pxODQxeHVqY3JpNXd0MzJhZWwzdzM3Ymw3MXVnNHcwa2ptMXlzaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SmaYvew52UlC9MmB6l/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Migrated input components to use the correct conventions for v-model as specified in https://v3-migration.vuejs.org/breaking-changes/v-model.html#_3-x-syntax

- on input / select components modelValue maps to "value"
- on checkbox / radio / toggle components modelValue maps to "checked"

## :bulb: Context

Noticed during vue 3 migration of Dialpad that the way we were using v-model in vue 3 was not the standard/recommended way of using it. This will be a possible breaking change for vue 3 consumers if they were referencing value / checked props directly rather than using v-model so I've written a blog post for it.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.

## :crystal_ball: Next Steps

Update in vue 3 migration branch

## :link: Sources

https://v3-migration.vuejs.org/breaking-changes/v-model.html#_3-x-syntax
