### PR TITLE
fix(rich-text-editor): DP-135726 fix pasting issues

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -699,8 +699,11 @@ export default {
               if (!event.clipboardData.getData('text/html')) {
                 return false;
               }
+              const htmlContent = pastedContent
+              .replace(/\n/g, '<br>') // Convert newlines to <br>
+              .replace(/ {2}/g, '&nbsp;&nbsp;'); // Convert multiple spaces
 
-              this.editor.chain().focus().insertContent(pastedContent).run();
+              this.editor.chain().focus().insertContent(htmlContent).run();
               return true; // Prevent the default paste behavior
             }
 

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -702,7 +702,11 @@ export default {
                 return false;
               }
 
-              this.editor.chain().focus().insertContent(pastedContent).run();
+              const htmlContent = pastedContent
+              .replace(/\n/g, '<br>') // Convert newlines to <br>
+              .replace(/ {2}/g, '&nbsp;&nbsp;'); // Convert multiple spaces
+
+              this.editor.chain().focus().insertContent(htmlContent).run();
               return true; // Prevent the default paste behavior
             }
 


### PR DESCRIPTION
# fix(rich-text-editor): DP-135726 fix pasting issues

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExNHA1amE0OWtyMDQybGU2eHU2aXhjN3VoYnJtYm13MDR3NG50OHk2MyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/33zX3zllJBGY8/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DP-135726
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
This update addresses the formatting issues when pasting text into the input component. After this fix, formatting should be preserved consistently across all pasted text.
For now, I'm keeping the additional checks introduced in [#676](https://github.com/dialpad/dialtone/pull/676) in place. We've received several customer complaints related to this bug, and I want to minimize the risk of regressions in this area.

## :bulb: Context
Recently, changes were made to how links are handled when pasted into the new message input (rich-text-editor). These changes unintentionally introduced a bug where formatting was lost after typing into pasted content.

In [#676](https://github.com/dialpad/dialtone/pull/676), we addressed this issue for most non-URL pasted content. However, I missed a specific edge case: when a user pastes a URL along with other formatted text. As described in the ticket, formatting was still being lost in those cases.

This fix ensures that those mixed-content cases are handled correctly. The original request from [DP-131613](https://dialpad.atlassian.net/browse/DP-131613) should still work as expected after this update.

[DP-131613]: https://dialpad.atlassian.net/browse/DP-131613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ