### PR TITLE
Dp 130987

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.stories.js
@@ -50,6 +50,12 @@ export const argTypesData = {
       disable: true,
     },
   },
+
+  onTextInput: {
+    table: {
+      disable: true,
+    },
+  },
 };
 
 // Set default values at the story level here.
@@ -63,6 +69,7 @@ export const argsData = {
   onInput: action('input'),
   onQuickRepliesClick: action('quick-replies-click'),
   onInlineImageClick: action('inline-image-click'),
+  onTextInput: action('text-input'),
 };
 
 // Story Collection

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.stories.js
@@ -44,6 +44,12 @@ export const argTypesData = {
       disable: true,
     },
   },
+
+  onInlineImageClick: {
+    table: {
+      disable: true,
+    },
+  },
 };
 
 // Set default values at the story level here.
@@ -56,6 +62,7 @@ export const argsData = {
   onBlur: action('blur'),
   onInput: action('input'),
   onQuickRepliesClick: action('quick-replies-click'),
+  onInlineImageClick: action('inline-image-click'),
 };
 
 // Story Collection

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -171,6 +171,7 @@
         :use-div-tags="useDivTags"
         data-qa="dt-rich-text-editor"
         v-bind="$attrs"
+        @text-input="onTextInput"
         @blur="onBlur"
         @focus="onFocus"
         @input="onInput($event)"
@@ -517,6 +518,11 @@ export default {
      * @event inline-image-click
      */
     'inline-image-click',
+
+    /**
+     * Emit when text content changes (not raw html)
+     */
+    'text-input',
   ],
 
   data () {
@@ -857,6 +863,10 @@ export default {
 
     setCursorPosition (position = null) {
       this.$refs.richTextEditor?.editor.chain().focus(position).run();
+    },
+
+    onTextInput (event) {
+      this.$emit('text-input', event);
     },
 
     onFocus (event) {

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -202,6 +202,7 @@ import {
   DtIconAlignRight,
   DtIconBold,
   DtIconCodeBlock,
+  DtIconImage,
   DtIconItalic,
   DtIconLightningBolt,
   DtIconLink2,
@@ -236,6 +237,7 @@ export default {
     DtIconQuote,
     DtIconCodeBlock,
     DtIconLink2,
+    DtIconImage,
   },
 
   inheritAttrs: false,
@@ -453,6 +455,14 @@ export default {
     },
 
     /**
+     * Show button to add an inline image
+     */
+    showInlineImageButton: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
      * Show add link default config.
      */
     showAddLink: {
@@ -501,6 +511,12 @@ export default {
      * @event quick-replies-click
      */
     'quick-replies-click',
+
+    /**
+     * Emit when inline image button is clicked
+     * @event inline-image-click
+     */
+    'inline-image-click',
   ],
 
   data () {
@@ -680,6 +696,14 @@ export default {
           tooltipMessage: 'Code',
           onClick: this.onCodeBlockToggle,
         },
+        {
+          showBtn: this.showInlineImageButton,
+          selector: 'image',
+          icon: DtIconImage,
+          dataQA: 'dt-recipe-editor-inline-image-btn',
+          tooltipMessage: 'Image',
+          onClick: this.onInsertInlineImageClick,
+        },
       ].filter(button => button.showBtn);
     },
 
@@ -813,6 +837,14 @@ export default {
 
     onQuickRepliesClick () {
       this.$emit('quick-replies-click');
+    },
+
+    onInsertInlineImageClick () {
+      this.$emit('inline-image-click');
+    },
+
+    insertInlineImage (imageUrl) {
+      this.$refs.richTextEditor?.editor.chain().focus().setImage({ src: imageUrl }).run();
     },
 
     onBlockquoteToggle () {

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor_default.story.vue
@@ -28,11 +28,13 @@
       :show-align-justify-button="$attrs.showAlignJustifyButton"
       :show-quote-button="$attrs.showQuoteButton"
       :show-quick-replies-button="$attrs.showQuickRepliesButton"
+      :show-inline-image-button="$attrs.showInlineImageButton"
       :show-code-block-button="$attrs.showCodeBlockButton"
       @focus="$attrs.onFocus"
       @blur="$attrs.onBlur"
       @input="$attrs.onInput"
       @quick-replies-click="$attrs.onQuickRepliesClick"
+      @inline-image-click="$attrs.onInlineImageClick"
     />
     <p><strong>Editor content is:</strong></p>
     <span>{{ value }}</span>

--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor_default.story.vue
@@ -35,6 +35,7 @@
       @input="$attrs.onInput"
       @quick-replies-click="$attrs.onQuickRepliesClick"
       @inline-image-click="$attrs.onInlineImageClick"
+      @text-input="$attrs.onTextInput"
     />
     <p><strong>Editor content is:</strong></p>
     <span>{{ value }}</span>

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -60,6 +60,7 @@ import { DtStack } from '../stack';
 import Blockquote from '@tiptap/extension-blockquote';
 import CodeBlock from '@tiptap/extension-code-block';
 import Code from '@tiptap/extension-code';
+import CharacterCount from '@tiptap/extension-character-count';
 import Document from '@tiptap/extension-document';
 import HardBreak from '@tiptap/extension-hard-break';
 import Paragraph from '@tiptap/extension-paragraph';
@@ -476,7 +477,7 @@ export default {
     // eslint-disable-next-line complexity
     extensions () {
       // These are the default extensions needed just for plain text.
-      const extensions = [Document, Text, History, HardBreak];
+      const extensions = [Document, Text, History, HardBreak, CharacterCount];
       extensions.push(this.useDivTags ? DivParagraph : Paragraph);
 
       if (this.allowBlockquote) {

--- a/packages/dialtone-vue3/package.json
+++ b/packages/dialtone-vue3/package.json
@@ -21,6 +21,7 @@
     "@tiptap/extension-bold": "^2.6.6",
     "@tiptap/extension-bubble-menu": "2.6.6",
     "@tiptap/extension-bullet-list": "^2.6.6",
+    "@tiptap/extension-character-count": "2.11.7",
     "@tiptap/extension-code": "^2.6.6",
     "@tiptap/extension-code-block": "^2.6.6",
     "@tiptap/extension-document": "^2.6.6",

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.stories.js
@@ -50,6 +50,12 @@ export const argTypesData = {
       disable: true,
     },
   },
+
+  onTextInput: {
+    table: {
+      disable: true,
+    },
+  },
 };
 
 // Set default values at the story level here.
@@ -63,6 +69,7 @@ export const argsData = {
   onInput: action('input'),
   onQuickRepliesClick: action('quick-replies-click'),
   onInlineImageClick: action('inline-image-click'),
+  onTextInput: action('text-input'),
 };
 
 // Story Collection

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.stories.js
@@ -44,6 +44,12 @@ export const argTypesData = {
       disable: true,
     },
   },
+
+  onInlineImageClick: {
+    table: {
+      disable: true,
+    },
+  },
 };
 
 // Set default values at the story level here.
@@ -56,6 +62,7 @@ export const argsData = {
   onBlur: action('blur'),
   onInput: action('input'),
   onQuickRepliesClick: action('quick-replies-click'),
+  onInlineImageClick: action('inline-image-click'),
 };
 
 // Story Collection

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-
     class="d-recipe-editor"
     data-qa="dt-recipe-editor"
     role="presentation"

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -202,6 +202,7 @@ import {
   DtIconAlignRight,
   DtIconBold,
   DtIconCodeBlock,
+  DtIconImage,
   DtIconItalic,
   DtIconLightningBolt,
   DtIconLink2,
@@ -237,6 +238,7 @@ export default {
     DtIconQuote,
     DtIconCodeBlock,
     DtIconLink2,
+    DtIconImage,
   },
 
   mixins: [],
@@ -456,6 +458,14 @@ export default {
     },
 
     /**
+     * Show button to add an inline image
+     */
+    showInlineImageButton: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
      * Show add link default config.
      */
     showAddLink: {
@@ -504,6 +514,12 @@ export default {
      * @event quick-replies-click
      */
     'quick-replies-click',
+
+    /**
+     * Emit when inline image button is clicked
+     * @event inline-image-click
+     */
+    'inline-image-click',
   ],
 
   data () {
@@ -683,6 +699,15 @@ export default {
           tooltipMessage: 'Code',
           onClick: this.onCodeBlockToggle,
         },
+        {
+          showBtn: this.showInlineImageButton,
+          selector: 'image',
+          icon: DtIconImage,
+          dataQA: 'dt-recipe-editor-inline-image-btn',
+          tooltipMessage: 'Image',
+          // Handle getting image
+          onClick: this.onInsertInlineImageClick,
+        },
       ].filter(button => button.showBtn);
     },
 
@@ -816,6 +841,14 @@ export default {
 
     onQuickRepliesClick () {
       this.$emit('quick-replies-click');
+    },
+
+    onInsertInlineImageClick () {
+      this.$emit('inline-image-click');
+    },
+
+    insertInlineImage (imageUrl) {
+      this.$refs.richTextEditor?.editor.chain().focus().setImage({ src: imageUrl }).run();
     },
 
     insertInMessageBody (messageContent) {

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -462,7 +462,7 @@ export default {
      */
     showInlineImageButton: {
       type: Boolean,
-      default: true,
+      default: false,
     },
 
     /**

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -170,6 +170,7 @@
         :use-div-tags="useDivTags"
         data-qa="dt-rich-text-editor"
         v-bind="$attrs"
+        @text-input="onTextInput"
         @blur="onBlur"
         @focus="onFocus"
         @input="onInput($event)"
@@ -519,6 +520,11 @@ export default {
      * @event inline-image-click
      */
     'inline-image-click',
+
+    /**
+     * Emit when text content changes (not raw html)
+     */
+    'text-input',
   ],
 
   data () {
@@ -860,6 +866,10 @@ export default {
 
     onBlockquoteToggle () {
       this.$refs.richTextEditor?.editor.chain().focus().toggleBlockquote().run();
+    },
+
+    onTextInput (event) {
+      this.$emit('text-input', event);
     },
 
     onFocus (event) {

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
@@ -35,6 +35,7 @@
       @input="$attrs.onInput"
       @quick-replies-click="$attrs.onQuickRepliesClick"
       @inline-image-click="$attrs.onInlineImageClick"
+      @text-input="$attrs.onTextInput"
     />
     <p><strong>Editor content is:</strong></p>
     <span>{{ value }}</span>

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor_default.story.vue
@@ -29,10 +29,12 @@
       :show-quote-button="$attrs.showQuoteButton"
       :show-quick-replies-button="$attrs.showQuickRepliesButton"
       :show-code-block-button="$attrs.showCodeBlockButton"
+      :show-inline-image-button="$attrs.showInlineImageButton"
       @focus="$attrs.onFocus"
       @blur="$attrs.onBlur"
       @input="$attrs.onInput"
       @quick-replies-click="$attrs.onQuickRepliesClick"
+      @inline-image-click="$attrs.onInlineImageClick"
     />
     <p><strong>Editor content is:</strong></p>
     <span>{{ value }}</span>


### PR DESCRIPTION
# html Editor to return text input contents for

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![wolf](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExdDVpbXZ5Y3RiY2ZwZzk2Mm4waDN4cWtubDE0aXp6Mm1wNW91aDk5biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/26BRAfDqmQ0RogLwA/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

Some features require we get the text content from the html editor but since the v-model returns the entire html blob parsing it later lead to performance issue. Its easier to just send the event from tiptap to the parent component to be used as required.

For all PRs:

- [ ] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [ ] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

If new component:

<!--- There are lots of things to remember when adding a new component to the system! This is so you don't forget any of them. -->

- I am exporting any new components or constants:
  - [ ] from the index.js in the component directory.
  - [ ] from the index.js in the root (either `packages/dialtone-vue2` or `packages/dialtone-vue3`).
- [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
- [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
- [ ] I have added the new component to `common/components_list.js`
- [ ] I have created a component story in storybook
- [ ] I have created story / stories for any relevant component variants in storybook
- [ ] I have created a docs page for the component in storybook.
- [ ] I have checked that changing all props/slots via the UI in storybook works as expected.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
