### PR TITLE
fix(localization): NO-JIRA missing locale manager error

### DIFF
--- a/packages/dialtone-vue2/.storybook/preview.jsx
+++ b/packages/dialtone-vue2/.storybook/preview.jsx
@@ -16,7 +16,6 @@ import { dialtoneDarkTheme, dialtoneLightTheme } from './dialtone-themes.js';
 import { DtTooltipDirective } from '@/directives/tooltip';
 import { faker } from '@faker-js/faker';
 import { DtScrollbarDirective } from '@/directives/scrollbar';
-import { DialtoneLocalizationPlugin } from '@/localization';
 
 setTheme(DpLight);
 
@@ -33,7 +32,6 @@ setCustomEmojiJson(customEmojiJson);
 
 Vue.use(DtTooltipDirective);
 Vue.use(DtScrollbarDirective);
-Vue.use(DialtoneLocalizationPlugin);
 
 // Fixes method "toJSON" is not defined on click event in Sb 6.5.11
 // See https://github.com/storybookjs/storybook/issues/14933#issuecomment-920578274

--- a/packages/dialtone-vue2/common/mixins/index.js
+++ b/packages/dialtone-vue2/common/mixins/index.js
@@ -11,3 +11,7 @@ export {
 export {
   default as DtKeyboardListNavigationMixin,
 } from './keyboard_list_navigation';
+
+export {
+  default as DtLocalizationMixin,
+} from './localization.js';

--- a/packages/dialtone-vue2/common/mixins/localization.js
+++ b/packages/dialtone-vue2/common/mixins/localization.js
@@ -1,0 +1,14 @@
+import { DialtoneLocalizationPlugin } from '@/localization';
+import { useI18N } from '@dialpad/i18n-vue2';
+import Vue from 'vue';
+
+Vue.use(DialtoneLocalizationPlugin);
+
+export default {
+  computed: {
+    $t: () => useI18N().$t,
+    $ta: () => useI18N().$ta,
+    currentLocale: () => useI18N().currentLocale,
+    setI18N: () => useI18N().setI18N,
+  },
+};

--- a/packages/dialtone-vue2/components/popover/popover_header_footer.vue
+++ b/packages/dialtone-vue2/components/popover/popover_header_footer.vue
@@ -43,8 +43,7 @@
 <script>
 import { DtButton } from '@/components/button';
 import { DtIconClose } from '@dialpad/dialtone-icons/vue2';
-import { useI18N } from '@dialpad/i18n-vue2';
-const { $ta } = useI18N();
+import { DtLocalizationMixin } from '@/common/mixins';
 
 export default {
   name: 'PopoverHeaderFooter',
@@ -52,6 +51,8 @@ export default {
     DtButton,
     DtIconClose,
   },
+
+  mixins: [DtLocalizationMixin],
 
   props: {
     // eslint-disable-next-line vue/require-default-prop
@@ -91,8 +92,6 @@ export default {
   ],
 
   methods: {
-    $ta,
-
     focusCloseButton () {
       const closeButton = this.$refs['popover__close-button']?.$el;
       closeButton?.focus();

--- a/packages/dialtone-vue2/package.json
+++ b/packages/dialtone-vue2/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@dialpad/dialtone-emojis": "workspace:*",
     "@dialpad/dialtone-icons": "workspace:*",
-    "@dialpad/i18n-services": "1.2.0-beta.v6",
-    "@dialpad/i18n-vue2": "1.0.2-beta.v8",
+    "@dialpad/i18n-services": "1.2.0-beta.v17",
+    "@dialpad/i18n-vue2": "1.0.2-beta.v30",
     "@linusborg/vue-simple-portal": "0.1.5",
     "@tiptap/core": "^2.6.6",
     "@tiptap/extension-blockquote": "^2.6.6",

--- a/packages/dialtone-vue2/tests/setupTests.js
+++ b/packages/dialtone-vue2/tests/setupTests.js
@@ -1,9 +1,7 @@
 import Vue from 'vue';
-import { DialtoneLocalizationPlugin } from '@/localization';
 
 Vue.config.productionTip = false;
 Vue.config.devtools = false;
-Vue.use(DialtoneLocalizationPlugin);
 
 // Mock IntersectionObserver
 class MockObserver {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -649,11 +649,11 @@ importers:
         specifier: workspace:*
         version: link:../dialtone-icons
       '@dialpad/i18n-services':
-        specifier: 1.2.0-beta.v6
-        version: 1.2.0-beta.v6(@vue/composition-api@1.7.2(vue@2.7.16))(vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16))(vue@2.7.16)
+        specifier: 1.2.0-beta.v17
+        version: 1.2.0-beta.v17(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
       '@dialpad/i18n-vue2':
-        specifier: 1.0.2-beta.v8
-        version: 1.0.2-beta.v8(vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16))(vue@2.7.16)
+        specifier: 1.0.2-beta.v30
+        version: 1.0.2-beta.v30(vue@2.7.16)
       '@linusborg/vue-simple-portal':
         specifier: 0.1.5
         version: 0.1.5(vue@2.7.16)
@@ -1838,16 +1838,15 @@ packages:
     resolution: {integrity: sha512-TLsyNwTUmGK6TtvdoC4SE/13Ae501pdzhSIyOV9V3HOVf8YrVTOgLUJ/l97kZSxcTOeRbFeRjbWfH7W3ixn36g==, tarball: https://npm.pkg.github.com/download/@dialpad/conventional-changelog-angular/1.1.1/1c54240f941b2d02d73e4ca2d4e53420d128bbf6}
     engines: {node: '>=10'}
 
-  '@dialpad/i18n-services@1.2.0-beta.v6':
-    resolution: {integrity: sha512-3QQ5zpfe4fgv7lhvEEId6wdfWugVGjaSb1GXCNpvskAxqS++FGLgfZKuNWbhblmsZOhVC55NqRY0dDxVYL12kA==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-services/1.2.0-beta.v6/a61204e17e4b1737a940bdfc318498cd05509c62}
+  '@dialpad/i18n-services@1.2.0-beta.v17':
+    resolution: {integrity: sha512-3f78SDvOus72y9ygYl+fG2NGOmDX6RQe07qApOu7kkEfAuMXhkrsmAdtZTuMxLWooF7pMmkLn6sANvNHNB2bxg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-services/1.2.0-beta.v17/1c8ae817efdf43dace74faab5f94873441196a41}
     hasBin: true
     peerDependencies:
-      '@vue/composition-api': 1.7.2
+      '@vue/composition-api': '>=1.0.0-rc.1'
       vue: ^2.0.0 || >=3.0.0
-      vue-demi: 0.14.10
 
-  '@dialpad/i18n-vue2@1.0.2-beta.v8':
-    resolution: {integrity: sha512-ko+usBfZjOEBWfb19aktLrcuw7pLYcnyZ+kOj+BXyhiShHSLJ4b1tapWV9gEjInUV2dNtFElUCrNumuVGaW9iQ==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-vue2/1.0.2-beta.v8/a8d4a563261a66c7730da5f157480feed99723e9}
+  '@dialpad/i18n-vue2@1.0.2-beta.v30':
+    resolution: {integrity: sha512-4o0xPcX/mCLrddN/82bCRkPlR6E7+XzENX7XC8pqtcfKZqo6X0M5UUP9WNlPH2yDShM3jKDZHALpp/R+M6Hang==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-vue2/1.0.2-beta.v30/0292fbf4ffaa1ec14fececb99bcf4dbe111804c7}
     peerDependencies:
       vue: ^2.0.0
 
@@ -17468,7 +17467,7 @@ snapshots:
       compare-func: 2.0.0
       q: 1.5.1
 
-  '@dialpad/i18n-services@1.2.0-beta.v6(@vue/composition-api@1.7.2(vue@2.7.16))(vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16))(vue@2.7.16)':
+  '@dialpad/i18n-services@1.2.0-beta.v17(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)':
     dependencies:
       '@fluent/bundle': 0.17.1
       '@fluent/syntax': 0.19.0
@@ -17478,13 +17477,11 @@ snapshots:
       vue: 2.7.16
       vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
 
-  '@dialpad/i18n-vue2@1.0.2-beta.v8(vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16))(vue@2.7.16)':
+  '@dialpad/i18n-vue2@1.0.2-beta.v30(vue@2.7.16)':
     dependencies:
-      '@dialpad/i18n-services': 1.2.0-beta.v6(@vue/composition-api@1.7.2(vue@2.7.16))(vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16))(vue@2.7.16)
+      '@dialpad/i18n-services': 1.2.0-beta.v17(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
       '@vue/composition-api': 1.7.2(vue@2.7.16)
       vue: 2.7.16
-    transitivePeerDependencies:
-      - vue-demi
 
   '@dialpad/semantic-release-changelog-json@1.0.0(semantic-release@21.1.2(typescript@5.4.2))':
     dependencies:


### PR DESCRIPTION
# Fix missing locale manager error

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZW56M2QwazF2cGg0NWFybWpybmtjejJyc2Q1eDdrNmZnN2t0NmhkdCZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/eYilisUwipOEM/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Description

- Created a mixin to initialize the localization manager on component level instead of letting the client initialize it.
- As we're using Vue.use(...) the plugin should be initialized once per Vue instance so no performance issues expected on that end.

## :bulb: Context

- Locale Manager needed to be initialized on the client side, making this hard to set up on  DP.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.
