### PR TITLE
fix(callbar-button-with-dropdown): DLT-2441 add modal false

### DIFF
--- a/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
+++ b/packages/dialtone-vue2/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
@@ -28,6 +28,7 @@
     <dt-dropdown
       v-if="showArrowButton"
       :id="id"
+      :modal="false"
       :fallback-placements="fallbackPlacements"
       :open="open"
       :placement="placement"

--- a/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
+++ b/packages/dialtone-vue3/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
@@ -31,6 +31,7 @@
       :id="id"
       :fallback-placements="fallbackPlacements"
       :open="open"
+      :modal="false"
       :placement="placement"
       class="dt-recipe--callbar-button-with-dropdown--dropdown-wrapper"
       padding="none"


### PR DESCRIPTION
# fix(callbar-button-with-dropdown): DLT-2441 add modal false

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2441

## :book: Description

callbar_button_with_popover had modal=false set, but with_dropdown did not. Added this to dropdown as well for consistency, and to fix the bug mentioned in ticket.