### PR TITLE
fix(checkbox, radio): NO-JIRA description slot not being reactive

### DIFF
--- a/packages/dialtone-vue2/components/checkbox/checkbox.vue
+++ b/packages/dialtone-vue2/components/checkbox/checkbox.vue
@@ -25,12 +25,12 @@
       </div>
     </label>
     <div
-      v-if="hasDescriptionOrMessages"
+      v-if="$slots.description || description || hasMessages"
       class="d-checkbox__messages"
       data-qa="checkbox-description-messages"
     >
       <div
-        v-if="hasDescription"
+        v-if="$slots.description || description"
         :class="['d-description', descriptionClass]"
         v-bind="descriptionChildProps"
         data-qa="checkbox-description"
@@ -113,14 +113,6 @@ export default {
 
     hasLabel () {
       return !!(this.$slots.default || this.label);
-    },
-
-    hasDescription () {
-      return !!(this.$slots.description || this.description);
-    },
-
-    hasDescriptionOrMessages () {
-      return this.hasDescription || this.hasMessages;
     },
 
     hasMessages () {

--- a/packages/dialtone-vue2/components/radio/radio.vue
+++ b/packages/dialtone-vue2/components/radio/radio.vue
@@ -23,12 +23,12 @@
       </div>
     </label>
     <div
-      v-if="hasDescriptionOrMessages"
+      v-if="$slots.description || description || hasMessages"
       class="d-radio__messages"
       data-qa="radio-description-messages"
     >
       <div
-        v-if="hasDescription"
+        v-if="$slots.description || description"
         :class="['d-description', descriptionClass]"
         v-bind="descriptionChildProps"
         data-qa="radio-description"
@@ -133,14 +133,6 @@ export default {
         input: () => {},
         change: event => this.emitValue(event.target.value),
       };
-    },
-
-    hasDescription () {
-      return !!(this.$slots.description || this.description);
-    },
-
-    hasDescriptionOrMessages () {
-      return this.hasDescription || this.hasMessages;
     },
 
     hasMessages () {

--- a/packages/dialtone-vue3/components/checkbox/checkbox.vue
+++ b/packages/dialtone-vue3/components/checkbox/checkbox.vue
@@ -27,12 +27,12 @@
       </div>
     </label>
     <div
-      v-if="hasDescriptionOrMessages"
+      v-if="$slots.description || description || hasMessages"
       class="d-checkbox__messages"
       data-qa="checkbox-description-messages"
     >
       <div
-        v-if="hasDescription"
+        v-if="$slots.description || description"
         :class="['d-description', descriptionClass]"
         v-bind="descriptionChildProps"
         data-qa="checkbox-description"
@@ -117,14 +117,6 @@ export default {
 
     hasLabel () {
       return !!(this.$slots.default || this.label);
-    },
-
-    hasDescription () {
-      return !!(this.$slots.description || this.description);
-    },
-
-    hasDescriptionOrMessages () {
-      return this.hasDescription || this.hasMessages;
     },
 
     hasMessages () {

--- a/packages/dialtone-vue3/components/radio/radio.vue
+++ b/packages/dialtone-vue3/components/radio/radio.vue
@@ -25,12 +25,12 @@
       </div>
     </label>
     <div
-      v-if="hasDescriptionOrMessages"
+      v-if="$slots.description || description || hasMessages"
       class="d-radio__messages"
       data-qa="radio-description-messages"
     >
       <div
-        v-if="hasDescription"
+        v-if="$slots.description || description"
         :class="['d-description', descriptionClass]"
         v-bind="descriptionChildProps"
         data-qa="radio-description"
@@ -156,14 +156,6 @@ export default {
         focusout: event => this.$emit('focusout', event),
         change: event => this.emitValue(event.target.value),
       };
-    },
-
-    hasDescription () {
-      return !!(this.$slots.description || this.description);
-    },
-
-    hasDescriptionOrMessages () {
-      return this.hasDescription || this.hasMessages;
     },
 
     hasMessages () {


### PR DESCRIPTION
# fix(checkbox, radio): NO-JIRA description slot not being reactive

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExanZ4bGRvZjY0eHZzZTFwdzN4OTVpenQwMWhub2gzMmpzb2V3dWRvcyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/GRk3GLfzduq1NtfGt5/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
No jira, we found out about this with a test failing in Firespotter: https://github.com/dialpad/firespotter/pull/56110

<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Since `$slots` isn't reactive, it doesn't re render the component when passing the `description` slot. Moving the logic back inline instead of in a computed property makes it work again.
<!--- Describe specifically what the changes are -->
<!--- Add any links to external reference material -->
