### PR TITLE
fix(select-menu): NO-JIRA avoid emitting value on mounted (vue 3 only)

### DIFF
--- a/packages/dialtone-vue3/components/select_menu/select_menu.vue
+++ b/packages/dialtone-vue3/components/select_menu/select_menu.vue
@@ -291,17 +291,7 @@ export default {
     },
   },
 
-  watch: {
-    // whenever question changes, this function will run
-    options () {
-      this.$nextTick(() => {
-        this.emitValue(this.$refs.selectElement.value, null);
-      });
-    },
-  },
-
   mounted () {
-    this.emitValue(this.$refs.selectElement.value, null);
     this.validateOptionsPresence();
   },
 


### PR DESCRIPTION
# (Select menu) Avoid emitting value on mounted

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/J4n37PsEYxcsJde692/giphy.gif?cid=ecf05e47wgvux4ewak2d84mcshgic0eg5sa01x3l86m5jxnn&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Description

- Removed the select-menu value from being emitted on mounted.

## :bulb: Context

This is the way it is working on Vue 2 and it is causing issues while migrating DP to Dialtone Vue 3

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.