### PR TITLE
fix(design-tokens): NO-JIRA update color.surface.warning reference in dark mode

### DIFF
--- a/packages/dialtone-tokens/tokens/semantic/dp/dark.json
+++ b/packages/dialtone-tokens/tokens/semantic/dp/dark.json
@@ -141,16 +141,7 @@
       },
       "warning-subtle": {
         "value": "{color.gold.100}",
-        "type": "color",
-        "$extensions": {
-          "studio.tokens": {
-            "modify": {
-              "type": "darken",
-              "value": ".5",
-              "space": "hsl"
-            }
-          }
-        }
+        "type": "color"
       },
       "success-subtle": {
         "value": "{color.green.100}",
@@ -290,13 +281,13 @@
         }
       },
       "warning-opaque": {
-        "value": "{color.gold.200}",
+        "value": "{color.gold.300}",
         "type": "color",
         "$extensions": {
           "studio.tokens": {
             "modify": {
               "type": "alpha",
-              "value": ".35",
+              "value": ".55",
               "space": "hsl"
             }
           }
@@ -355,7 +346,7 @@
         }
       },
       "warning-subtle-opaque": {
-        "value": "{color.gold.50}",
+        "value": "{color.gold.100}",
         "type": "color",
         "$extensions": {
           "studio.tokens": {
@@ -511,6 +502,10 @@
             }
           }
         }
+      },
+      "warning": {
+        "value": "{color.gold.200}",
+        "type": "color"
       }
     },
     "border": {


### PR DESCRIPTION
# Update color.surface.warning reference in dark mode

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Description

Update color.surface.warning reference in dark mode

## :bulb: Context

https://dialpad.com/app/messages/agxzfnViZXItdm9pY2VyGAsSC1RleHRNZXNzYWdlGICAm8D12fgKDA

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.