### PR TITLE
chore: DLT-2468 update README and tests for postcss-responsive-variations

### DIFF
--- a/packages/postcss-responsive-variations/README.md
+++ b/packages/postcss-responsive-variations/README.md
@@ -48,7 +48,7 @@
 npm install --save-dev postcss @dialpad/postcss-responsive-variations
 ```
 
-**Step 2:** Check you project for existing PostCSS config: `postcss.config.js`
+**Step 2:** Check your project for existing PostCSS config: `postcss.config.js`
 in the project root, `"postcss"` section in `package.json`
 or `postcss` in bundle config.
 
@@ -66,7 +66,7 @@ module.exports = {
 }
 ```
 
-**Step 4:** Create the responsive breakpoints and the classes you need and pass it to the plugin argument. Note: if you don't pass the breakpoints, the plugin will use the default ones, which are the ones shown in this example.
+**Step 4:** Create the responsive breakpoints and the classes you need and pass them to the plugin argument. Note: if you don't pass the breakpoints, the plugin will use the default ones, which are the ones shown in this example.
 
 ```diff
 +const breakpoints = [

--- a/packages/postcss-responsive-variations/README.md
+++ b/packages/postcss-responsive-variations/README.md
@@ -15,25 +15,25 @@
   .background-color: red;
 }
 
-@media (max-width: 480px){
+@media (min-width: 480px){
   .sm\:foo {
     .background-color: red;
   }
 }
 
-@media (max-width: 640px){
+@media (min-width: 640px){
   .md\:foo {
   .background-color: red;
   }
 }
 
-@media (max-width: 980px){
+@media (min-width: 980px){
   .lg\:foo {
   .background-color: red;
   }
 }
 
-@media (max-width: 1264px){
+@media (min-width: 1264px){
   .xl\:foo {
   .background-color: red;
   }
@@ -66,14 +66,14 @@ module.exports = {
 }
 ```
 
-**Step 4:** Create the responsive breakpoints and the classes you need and pass it to the plugin argument.
+**Step 4:** Create the responsive breakpoints and the classes you need and pass it to the plugin argument. Note: if you don't pass the breakpoints, the plugin will use the default ones, which are the ones shown in this example.
 
 ```diff
 +const breakpoints = [
-+  { prefix: 'sm\\:', mediaQuery: '(max-width: 480px)' },
-+  { prefix: 'md\\:', mediaQuery: '(max-width: 640px)' },
-+  { prefix: 'lg\\:', mediaQuery: '(max-width: 980px)' },
-+  { prefix: 'xl\\:', mediaQuery: '(max-width: 1264px)' },
++  { prefix: 'sm\\:', mediaQuery: '(min-width: 480px)' },
++  { prefix: 'md\\:', mediaQuery: '(min-width: 640px)' },
++  { prefix: 'lg\\:', mediaQuery: '(min-width: 980px)' },
++  { prefix: 'xl\\:', mediaQuery: '(min-width: 1264px)' },
 +];
 
 +const classes = [

--- a/packages/postcss-responsive-variations/README.md
+++ b/packages/postcss-responsive-variations/README.md
@@ -48,14 +48,14 @@
 npm install --save-dev postcss @dialpad/postcss-responsive-variations
 ```
 
-**Step 2:** Check you project for existed PostCSS config: `postcss.config.js`
+**Step 2:** Check you project for existing PostCSS config: `postcss.config.js`
 in the project root, `"postcss"` section in `package.json`
 or `postcss` in bundle config.
 
-If you do not use PostCSS, add it according to [official docs](https://github.com/postcss/postcss#usage)
+If you do not use PostCSS, add it according to the [official docs](https://github.com/postcss/postcss#usage)
 and set this plugin in settings.
 
-**Step 3:** Add the plugin to plugins list:
+**Step 3:** Add the plugin to the plugins list:
 
 ```diff
 module.exports = {

--- a/packages/postcss-responsive-variations/index.test.js
+++ b/packages/postcss-responsive-variations/index.test.js
@@ -12,72 +12,72 @@ async function run (input, output, opts = { }) {
 
 it('creates small responsive variation for .foo class', async () => {
   const breakpoints = [
-    { prefix: 'sm\\:', mediaQuery: '(max-width: 480px)' },
+    { prefix: 'sm\\:', mediaQuery: '(min-width: 480px)' },
   ];
   const classes = [
     '.foo',
   ];
   const input = '.foo {background-color: red;}';
-  const output = '.foo {background-color: red;}@media (max-width: 480px) {.sm\\:foo {background-color: red;}}';
+  const output = '.foo {background-color: red;}@media (min-width: 480px) {.sm\\:foo {background-color: red;}}';
   await run(input, output, { breakpoints, classes });
 });
 
 it('creates small responsive variation for .foo class but no for .bar class', async () => {
   const breakpoints = [
-    { prefix: 'sm\\:', mediaQuery: '(max-width: 480px)' },
+    { prefix: 'sm\\:', mediaQuery: '(min-width: 480px)' },
   ];
   const classes = [
     '.foo',
     '.bar',
   ];
   const input = '.foo {background-color: red;}';
-  const output = '.foo {background-color: red;}@media (max-width: 480px) {.sm\\:foo {background-color: red;}}';
+  const output = '.foo {background-color: red;}@media (min-width: 480px) {.sm\\:foo {background-color: red;}}';
   await run(input, output, { breakpoints, classes });
 });
 
 it('creates all responsive variations for classes', async () => {
   const breakpoints = [
-    { prefix: 'sm\\:', mediaQuery: '(max-width: 480px)' },
-    { prefix: 'md\\:', mediaQuery: '(max-width: 640px)' },
-    { prefix: 'lg\\:', mediaQuery: '(max-width: 960px)' },
-    { prefix: 'xl\\:', mediaQuery: '(max-width: 1264px)' },
+    { prefix: 'sm\\:', mediaQuery: '(min-width: 480px)' },
+    { prefix: 'md\\:', mediaQuery: '(min-width: 640px)' },
+    { prefix: 'lg\\:', mediaQuery: '(min-width: 960px)' },
+    { prefix: 'xl\\:', mediaQuery: '(min-width: 1264px)' },
   ];
   const classes = [
     '.foo',
   ];
   const input = '.foo {background-color: red;}';
-  const output = '.foo {background-color: red;}@media (max-width: 480px) {.sm\\:foo {background-color: red;}}@media (max-width: 640px) {.md\\:foo {background-color: red;}}@media (max-width: 960px) {.lg\\:foo {background-color: red;}}@media (max-width: 1264px) {.xl\\:foo {background-color: red;}}';
+  const output = '.foo {background-color: red;}@media (min-width: 480px) {.sm\\:foo {background-color: red;}}@media (min-width: 640px) {.md\\:foo {background-color: red;}}@media (min-width: 960px) {.lg\\:foo {background-color: red;}}@media (min-width: 1264px) {.xl\\:foo {background-color: red;}}';
   await run(input, output, { breakpoints, classes });
 });
 
 it('creates responsive variations from regex expresion', async () => {
   const breakpoints = [
-    { prefix: 'sm\\:', mediaQuery: '(max-width: 480px)' },
+    { prefix: 'sm\\:', mediaQuery: '(min-width: 480px)' },
   ];
   const classes = [
     /\.foo-*/,
   ];
   const input = '.foo-1 {background-color: red;}.foo-2 {background-color: green;}';
-  const output = '.foo-1 {background-color: red;}.foo-2 {background-color: green;}@media (max-width: 480px) {.sm\\:foo-1 {background-color: red;}.sm\\:foo-2 {background-color: green;}}';
+  const output = '.foo-1 {background-color: red;}.foo-2 {background-color: green;}@media (min-width: 480px) {.sm\\:foo-1 {background-color: red;}.sm\\:foo-2 {background-color: green;}}';
   await run(input, output, { breakpoints, classes });
 });
 
 it('overrides existing media query', async () => {
   const breakpoints = [
-    { prefix: 'sm\\:', mediaQuery: '(max-width: 480px)' },
+    { prefix: 'sm\\:', mediaQuery: '(min-width: 480px)' },
   ];
   const classes = [
     '.foo',
   ];
-  const input = '.foo {background-color: red;}@media (max-width: 480px) {.bar {background-color: green;}}';
-  const output = '.foo {background-color: red;}@media (max-width: 480px) {.bar {background-color: green;}.sm\\:foo {background-color: red;}}';
+  const input = '.foo {background-color: red;}@media (min-width: 480px) {.bar {background-color: green;}}';
+  const output = '.foo {background-color: red;}@media (min-width: 480px) {.bar {background-color: green;}.sm\\:foo {background-color: red;}}';
   await run(input, output, { breakpoints, classes });
 });
 
 it('uses default breakpoints', async () => {
   const classes = ['.foo'];
   const input = '.foo {background-color: red;}';
-  const output = '.foo {background-color: red;}@media (max-width: 480px) {.sm\\:foo {background-color: red;}}@media (max-width: 640px) {.md\\:foo {background-color: red;}}@media (max-width: 960px) {.lg\\:foo {background-color: red;}}@media (max-width: 1264px) {.xl\\:foo {background-color: red;}}';
+  const output = '.foo {background-color: red;}@media (min-width: 480px) {.sm\\:foo {background-color: red;}}@media (min-width: 640px) {.md\\:foo {background-color: red;}}@media (min-width: 960px) {.lg\\:foo {background-color: red;}}@media (min-width: 1264px) {.xl\\:foo {background-color: red;}}';
   await run(input, output, { classes });
 });
 
@@ -89,19 +89,19 @@ it('works with no arguments', async () => {
 
 it('overrides default breakpoints', async () => {
   const breakpoints = [
-    { prefix: 'sm\\:', mediaQuery: '(max-width: 1000px)' },
+    { prefix: 'sm\\:', mediaQuery: '(min-width: 1000px)' },
   ];
   const classes = [
     '.foo',
   ];
   const input = '.foo {background-color: red;}';
-  const output = '.foo {background-color: red;}@media (max-width: 1000px) {.sm\\:foo {background-color: red;}}';
+  const output = '.foo {background-color: red;}@media (min-width: 1000px) {.sm\\:foo {background-color: red;}}';
   await run(input, output, { breakpoints, classes });
 });
 
 it('creates small responsive variation for a composed class', async () => {
   const breakpoints = [
-    { prefix: 'sm\\:', mediaQuery: '(max-width: 480px)' },
+    { prefix: 'sm\\:', mediaQuery: '(min-width: 480px)' },
   ];
   const classes = [
     '.foo',
@@ -109,6 +109,6 @@ it('creates small responsive variation for a composed class', async () => {
     /\.bar-[0-9]$/,
   ];
   const input = '.foo, .h\\:foo:hover, .f\\:foo:focus, .bar {background-color: red;}';
-  const output = '.foo, .h\\:foo:hover, .f\\:foo:focus, .bar {background-color: red;}@media (max-width: 480px) {.sm\\:foo {background-color: red;}.sm\\:bar {background-color: red;}}';
+  const output = '.foo, .h\\:foo:hover, .f\\:foo:focus, .bar {background-color: red;}@media (min-width: 480px) {.sm\\:foo {background-color: red;}.sm\\:bar {background-color: red;}}';
   await run(input, output, { breakpoints, classes });
 });


### PR DESCRIPTION
[DLT-2468]

Most of the documentation already shows the updated breakpoints. 
Here I am updating the README and tests for `postcss-responsive-variations`

[DLT-2468]: https://dialpad.atlassian.net/browse/DLT-2468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ