### PR TITLE
fix(editor): DP-140769 recipe editor throwing console error

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/editor/editor.vue
@@ -26,7 +26,7 @@
         >
           <template #anchor>
             <dt-button
-              :ref="(el) => { buttonRefMap[getButtonRef(buttonGroup.key, button.selector)] = el }"
+              :ref="getButtonRef(buttonGroup.key, button.selector)"
               :active="$refs.richTextEditor?.editor?.isActive(button.selector)"
               :aria-label="button.tooltipMessage"
               :data-qa="button.dataQA"
@@ -75,7 +75,7 @@
             >
               <template #anchor>
                 <dt-button
-                  :ref="(el) => { buttonRefMap[getButtonRef('custom', 'link')] = el }"
+                  :ref="getButtonRef('custom', 'link')"
                   :active="$refs.richTextEditor?.editor?.isActive(linkButton.selector)"
                   :aria-label="linkButton.tooltipMessage"
                   :data-qa="linkButton.dataQA"
@@ -223,7 +223,6 @@ import {
   DtIconStrikethrough,
   DtIconUnderline,
 } from '@dialpad/dialtone-icons/vue2';
-import { ref } from 'vue';
 
 export default {
   name: 'DtRecipeEditor',
@@ -548,7 +547,6 @@ export default {
       showLinkInput: false,
       linkInput: '',
       currentButtonRefIndex: 0,
-      buttonRefMap: ref({}),
     };
   },
 
@@ -934,12 +932,14 @@ export default {
     },
 
     shiftButtonRefIndex (shiftAmount) {
-      const previousRef = this.buttonRefMap[this.orderedRefs[this.currentButtonRefIndex]];
+      const previousRef = this.$refs[this.orderedRefs[this.currentButtonRefIndex]];
+      const previousActionBarBtn = Array.isArray(previousRef) ? previousRef[0] : previousRef;
       const index = (this.currentButtonRefIndex + shiftAmount) % this.orderedRefs.length;
       this.currentButtonRefIndex = index >= 0 ? index : this.orderedRefs.length + index;
-      const currentRef = this.buttonRefMap[this.orderedRefs[this.currentButtonRefIndex]];
-      previousRef.$el.blur();
-      currentRef.$el.focus();
+      const currentRef = this.$refs[this.orderedRefs[this.currentButtonRefIndex]];
+      const currentActionBarBtn = Array.isArray(currentRef) ? currentRef[0] : currentRef;
+      previousActionBarBtn.$el.blur();
+      currentActionBarBtn.$el.focus();
     },
   },
 };

--- a/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/editor/editor.vue
@@ -26,7 +26,7 @@
         >
           <template #anchor>
             <dt-button
-              :ref="(el) => { buttonRefMap[getButtonRef(buttonGroup.key, button.selector)] = el }"
+              :ref="getButtonRef(buttonGroup.key, button.selector)"
               :active="$refs.richTextEditor?.editor?.isActive(button.selector)"
               :aria-label="button.tooltipMessage"
               :data-qa="button.dataQA"
@@ -75,7 +75,7 @@
             >
               <template #anchor>
                 <dt-button
-                  :ref="(el) => { buttonRefMap[getButtonRef('custom', 'link')] = el }"
+                  :ref="getButtonRef('custom', 'link')"
                   :active="$refs.richTextEditor?.editor?.isActive(linkButton.selector)"
                   :aria-label="linkButton.tooltipMessage"
                   :data-qa="linkButton.dataQA"
@@ -224,7 +224,6 @@ import {
   DtIconStrikethrough,
   DtIconUnderline,
 } from '@dialpad/dialtone-icons/vue3';
-import { ref } from 'vue';
 
 export default {
   compatConfig: { MODE: 3 },
@@ -561,7 +560,6 @@ export default {
       showLinkInput: false,
       linkInput: '',
       currentButtonRefIndex: 0,
-      buttonRefMap: ref({}),
     };
   },
 
@@ -952,12 +950,14 @@ export default {
     },
 
     shiftButtonRefIndex (shiftAmount) {
-      const previousRef = this.buttonRefMap[this.orderedRefs[this.currentButtonRefIndex]];
+      const previousRef = this.$refs[this.orderedRefs[this.currentButtonRefIndex]];
+      const previousActionBarBtn = Array.isArray(previousRef) ? previousRef[0] : previousRef;
       const index = (this.currentButtonRefIndex + shiftAmount) % this.orderedRefs.length;
       this.currentButtonRefIndex = index >= 0 ? index : this.orderedRefs.length + index;
-      const currentRef = this.buttonRefMap[this.orderedRefs[this.currentButtonRefIndex]];
-      previousRef.$el.blur();
-      currentRef.$el.focus();
+      const currentRef = this.$refs[this.orderedRefs[this.currentButtonRefIndex]];
+      const currentActionBarBtn = Array.isArray(currentRef) ? currentRef[0] : currentRef;
+      previousActionBarBtn.$el.blur();
+      currentActionBarBtn.$el.focus();
     },
   },
 };


### PR DESCRIPTION
# Recipe Editor Is Unable To Recognize Ref Import In Data Lifecycle Hook

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3MxeWNjcXB6YzRqa3U1Y2dyMWJ5cGFjc2JndjN6ODF3NGpiOHY0cyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/iZ0tdFLjCgE3Y9wAvi/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

[<!--- Enter the URL of the Jira ticket associated with this PR -->](https://dialpad.atlassian.net/browse/DP-140769)

## :book: Description

<!--- Describe specifically what the changes are -->

## :bulb: Context

Recipe Editor use in ubervoice is causing console errors. Additionally the focus functionality on the action bar is not working as intended. The root cause of the problem is the use of ref in data. Ref is not recognized in data therefore all the initial values for reactive properties is undefined. This causes the issue we are seeing in the recipe editor.
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

If new component:

<!--- There are lots of things to remember when adding a new component to the system! This is so you don't forget any of them. -->

- I am exporting any new components or constants:
  - [ ] from the index.js in the component directory.
  - [ ] from the index.js in the root (either `packages/dialtone-vue2` or `packages/dialtone-vue3`).
- [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
- [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
- [ ] I have added the new component to `common/components_list.js`
- [ ] I have created a component story in storybook
- [ ] I have created story / stories for any relevant component variants in storybook
- [ ] I have created a docs page for the component in storybook.
- [ ] I have checked that changing all props/slots via the UI in storybook works as expected.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->
Before:
<img width="789" alt="Screenshot 2025-05-07 at 4 12 18 PM" src="https://github.com/user-attachments/assets/ebe89865-2397-43d1-a943-a6b3b7741b76" />

After:

https://github.com/user-attachments/assets/9f948d25-5036-4deb-b2a1-57280da36523


## :link: Sources

