### PR TITLE
fix(tokens): DLT-2510 remove color tokens with a gradient for mobile

### DIFF
--- a/packages/dialtone-tokens/dialtone-transforms.js
+++ b/packages/dialtone-tokens/dialtone-transforms.js
@@ -4,7 +4,7 @@
  * because sd-transforms handles the transforms for CSS.
  */
 
-import { colorModifiersFilter, DeviceObjectFormat, deviceTransformColorModifiers, tokenColorToDeviceColor } from './transform-util.js';
+import { colorsFilter, colorModifiersFilter, DeviceObjectFormat, deviceTransformColorModifiers, tokenColorToDeviceColor } from './transform-util.js';
 
 const SIZE_IDENTIFIERS = ['sizing', 'borderWidth', 'borderRadius', 'blur', 'spread', 'x', 'y', 'dimension'];
 const SPACING_IDENTIFIERS = ['spacing'];
@@ -101,9 +101,7 @@ export function registerDialtoneTransforms (styleDictionary) {
   styleDictionary.registerTransform({
     name: 'dt/android/xml/color',
     type: 'value',
-    filter: function (token) {
-      return ['color'].includes(token.type);
-    },
+    filter: colorsFilter,
     transform: function (token) {
       return tokenColorToDeviceColor(token.value, DeviceObjectFormat.ANDROID_XML);
     },
@@ -122,9 +120,7 @@ export function registerDialtoneTransforms (styleDictionary) {
   styleDictionary.registerTransform({
     name: 'dt/android/compose/color',
     type: 'value',
-    filter: function (token) {
-      return ['color'].includes(token.type);
-    },
+    filter: colorsFilter,
     transform: (token) => {
       return tokenColorToDeviceColor(token.value, DeviceObjectFormat.ANDROID_COMPOSE);
     },
@@ -297,9 +293,7 @@ export function registerDialtoneTransforms (styleDictionary) {
   styleDictionary.registerTransform({
     name: 'dt/ios/color',
     type: 'value',
-    filter: function (token) {
-      return ['color'].includes(token.type);
-    },
+    filter: colorsFilter,
     transform: (token) => {
       return tokenColorToDeviceColor(token.value, DeviceObjectFormat.IOS_SWIFT);
     },

--- a/packages/dialtone-tokens/transform-util.js
+++ b/packages/dialtone-tokens/transform-util.js
@@ -11,8 +11,14 @@ export const DeviceObjectFormat = Object.freeze({
   IOS_SWIFT: 'ios/swift',
 });
 
-export const colorModifiersFilter = (token) => {
+export const colorsFilter = (token) => {
   return (token.$type ?? token.type) === 'color' &&
+    // Don't transform linear-gradient colors so they can be identified and removed by the file filter
+    !(token.$value ?? token.value).startsWith('linear-gradient');
+};
+
+export const colorModifiersFilter = (token) => {
+  return colorsFilter(token) &&
             token.$extensions &&
             token.$extensions['studio.tokens']?.modify;
 };


### PR DESCRIPTION
# PR Title

fix(tokens): DLT-2510 Remove color tokens with a gradient for mobile

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/OYkL7u4u6oqsYuxWZT/giphy.gif?cid=ecf05e47p2fydmue6obpvm5s5wtmqmm9o8ue1qq12cezoj6r&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [X] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2348

## :book: Description

Color tokens with a gradient do not work on mobile as they do not translate. These were being filtered out but a recent change meant some slipped through. This fixes that.

## :pencil: Checklist

For all PRs:

- [X] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [X] I have reviewed my changes.
- [X] I have added all relevant documentation.
- [X] I have considered the performance impact of my change.
