### PR TITLE
fix(rich-text-editor): DLT-2544 fix memory leak

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -686,7 +686,7 @@ export default {
     this.createEditor();
   },
 
-  beforeUnmount () {
+  beforeDestroy () {
     this.destroyEditor();
   },
 


### PR DESCRIPTION
# fix(rich-text-editor): fix memory leak

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbXJjeHB5dDE4cmV5NGhrdHRudzZkbmhsZGk4MDhmOHVsM2VxeTlwMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fUQ4rhUZJYiQsas6WD/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2544

## :book: Description

converted the incorrect `beforeUnmount` to `beforeDestroy` in Vue 2 rich-text-editor

## :bulb: Context

This was causing the tiptap editor instance to never be destroyed when the component was unmounted, instead taking up more memory every time the component was mounted.

Thanks to @noellelevydialpad for finding the fix for this issue.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
