### PR TITLE
fix(scrollbar): DLT-2552 cleanup OverlayScollbars instances on unbind

### DIFF
--- a/packages/dialtone-vue2/directives/scrollbar_directive/scrollbar.js
+++ b/packages/dialtone-vue2/directives/scrollbar_directive/scrollbar.js
@@ -4,9 +4,10 @@ export const DtScrollbarDirective = {
   name: 'dt-scrollbar-directive',
   install (Vue) {
     OverlayScrollbars.plugin(ClickScrollPlugin);
+    const instances = new WeakMap();
     Vue.directive('dt-scrollbar', {
       inserted (el, binding) {
-        OverlayScrollbars({
+        const os = OverlayScrollbars({
           target: el,
           elements: {
             viewport: el.children[0],
@@ -20,6 +21,10 @@ export const DtScrollbarDirective = {
         });
         el.setAttribute('data-overlayscrollbars-initialize', true);
         el.classList.add('d-scrollbar');
+        instances.set(el, os);
+      },
+      unbind (el) {
+        instances.get(el).destroy();
       },
     });
   },

--- a/packages/dialtone-vue2/directives/scrollbar_directive/scrollbar.test.js
+++ b/packages/dialtone-vue2/directives/scrollbar_directive/scrollbar.test.js
@@ -11,6 +11,12 @@ const WrapperComponent = {
 
 const testContext = {};
 
+const mocks = vi.hoisted(() => {
+  return {
+    destroy: vi.fn(),
+  };
+});
+
 describe('DtScrollbarDirective Tests', () => {
   let wrapper;
   let viewportElement;
@@ -29,6 +35,7 @@ describe('DtScrollbarDirective Tests', () => {
 
   beforeEach(() => {
     OverlayScrollbars.mockClear();
+    mocks.destroy.mockClear();
   });
 
   beforeAll(() => {
@@ -38,7 +45,7 @@ describe('DtScrollbarDirective Tests', () => {
     // Mock the overlayscrollbars plugin
     vi.mock('overlayscrollbars', () => {
       const mockPlugin = vi.fn(); // Mock the plugin method
-      const OverlayScrollbarsMock = vi.fn().mockImplementation(() => ({}));
+      const OverlayScrollbarsMock = vi.fn().mockImplementation(() => ({ destroy: mocks.destroy }));
       OverlayScrollbarsMock.plugin = mockPlugin;
       return {
         OverlayScrollbars: OverlayScrollbarsMock,
@@ -69,6 +76,11 @@ describe('DtScrollbarDirective Tests', () => {
         expect(OverlayScrollbars).toHaveBeenCalledTimes(1);
         expect(wrapper.element.getAttribute('data-overlayscrollbars-initialize')).toBe('true');
         expect(wrapper.element.classList.contains('d-scrollbar')).toBe(true);
+      });
+
+      it('should clean up directive', () => {
+        wrapper.destroy();
+        expect(mocks.destroy).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/packages/dialtone-vue3/directives/scrollbar_directive/scrollbar.js
+++ b/packages/dialtone-vue3/directives/scrollbar_directive/scrollbar.js
@@ -4,9 +4,10 @@ export const DtScrollbarDirective = {
   name: 'dt-scrollbar-directive',
   install (app) {
     OverlayScrollbars.plugin(ClickScrollPlugin);
+    const instances = new WeakMap();
     app.directive('dt-scrollbar', {
       mounted (el, binding) {
-        OverlayScrollbars({
+        const os = OverlayScrollbars({
           target: el,
           elements: {
             viewport: el.children[0],
@@ -20,6 +21,10 @@ export const DtScrollbarDirective = {
         });
         el.setAttribute('data-overlayscrollbars-initialize', true);
         el.classList.add('d-scrollbar');
+        instances.set(el, os);
+      },
+      unmounted (el) {
+        instances.get(el).destroy();
       },
     });
   },

--- a/packages/dialtone-vue3/directives/scrollbar_directive/scrollbar.test.js
+++ b/packages/dialtone-vue3/directives/scrollbar_directive/scrollbar.test.js
@@ -9,6 +9,12 @@ const WrapperComponent = {
   `,
 };
 
+const mocks = vi.hoisted(() => {
+  return {
+    destroy: vi.fn(),
+  };
+});
+
 describe('DtScrollbarDirective Tests', () => {
   let wrapper;
   let viewportElement;
@@ -29,13 +35,14 @@ describe('DtScrollbarDirective Tests', () => {
 
   beforeEach(() => {
     OverlayScrollbars.mockClear();
+    mocks.destroy.mockClear();
   });
 
   beforeAll(() => {
     // Mock the overlayscrollbars plugin
     vi.mock('overlayscrollbars', () => {
       const mockPlugin = vi.fn(); // Mock the plugin method
-      const OverlayScrollbarsMock = vi.fn().mockImplementation(() => ({}));
+      const OverlayScrollbarsMock = vi.fn().mockImplementation(() => ({ destroy: mocks.destroy }));
       OverlayScrollbarsMock.plugin = mockPlugin;
       return {
         OverlayScrollbars: OverlayScrollbarsMock,
@@ -66,6 +73,11 @@ describe('DtScrollbarDirective Tests', () => {
         expect(OverlayScrollbars).toHaveBeenCalledTimes(1);
         expect(wrapper.element.getAttribute('data-overlayscrollbars-initialize')).toBe('true');
         expect(wrapper.element.classList.contains('d-scrollbar')).toBe(true);
+      });
+
+      it('should clean up directive', () => {
+        wrapper.unmount();
+        expect(mocks.destroy).toHaveBeenCalledTimes(1);
       });
     });
   });


### PR DESCRIPTION
# DLT-2552 cleanup OverlayScollbars instances on unbind

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExamdrNjlxejB0Zm10N3J3NWZ3ZHFteXJ0ajY5OXZjN2g5azAwcDFhZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JGunlb6LbQlz2/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2552

## :book: Description

This pr keeps track of created OverlayScrollbars instances and destroys them when the associated dom element is no longer mounted.

## :bulb: Context

The scrollbar directive creates an OverlayScrollbars instance but never destroys it. The event listeners OverlayScrollbars creates keeps the dom element and the associated vue app in memory after it is unmounted.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :link: Sources

https://github.com/KingSora/OverlayScrollbars?tab=readme-ov-file#destroy-void
