### PR TITLE
fix: NO-JIRA remove localization reexport until packaging works in vue2

### DIFF
--- a/packages/dialtone-vue2/index.js
+++ b/packages/dialtone-vue2/index.js
@@ -98,4 +98,5 @@ export * from './recipes/leftbar/group_row';
 export * from './recipes/leftbar/unread_pill';
 export * from './recipes/notices/top_banner_info';
 
-export { DialtoneLocalizationPlugin } from './localization';
+// disabled while solving packaging issues
+// export { DialtoneLocalizationPlugin } from './localization';


### PR DESCRIPTION
# remove localization reexport until packaging works in vue2

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExdWFtbXg5NTQ5NTFhcmFwZXBobWlrNmt6ZGwxOWg4NWh4dTZybzVjMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3pdHQSDRgZ2qFFGJM6/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Description

Remove the re-export of the localization lib from index.js until packaging for vue2 is fixed.

## :bulb: Context

The localization lib dialtone currently has integrated is incorrectly bundled for vue2, but after marking it as external in dialtone. it just ends up as an unresolved import reachable from the re-export in index.js. 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.


## :crystal_ball: Next Steps

If we stop bundling vue-demi into the localization lib, then ubervoice should be able to use the localization package with a properly installed vue-demi in its own dependencies.
