### PR TITLE
fix(hovercard): DP-142048 remove hovercard when anchor is removed from the DOM

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/popover.less
+++ b/packages/dialtone-css/lib/build/less/components/popover.less
@@ -49,6 +49,7 @@
     border: var(--popover-border-width) solid var(--popover-color-border);
     border-radius: var(--popover-border-radius);
     box-shadow: var(--popover-shadow);
+    visibility: visible;
 
     // to be set on the dialog when it is modal
     &--modal {
@@ -99,5 +100,11 @@
   &__footer {
     grid-row: 3;
     border-top: var(--popover-border-width) solid var(--popover-color-border);
+  }
+}
+
+.tippy-box[data-popper-reference-hidden] {
+  .d-popover__dialog {
+    visibility: hidden;
   }
 }

--- a/packages/dialtone-vue2/components/hovercard/hovercard.test.js
+++ b/packages/dialtone-vue2/components/hovercard/hovercard.test.js
@@ -120,6 +120,21 @@ describe('DtHovercard Tests', () => {
         expect(content).toBeNull();
       });
     });
+
+    describe('When anchor is removed from DOM', () => {
+      it('hovercardOpen is set to false', async () => {
+        vi.useFakeTimers();
+        await anchor.trigger('mouseenter');
+        await vi.runAllTimers();
+
+        // Remove anchor from DOM
+        anchor.element.parentNode.removeChild(anchor.element);
+        // Advance timers to allow hovercard to react
+        await vi.runAllTimers();
+
+        expect(wrapper.vm.hovercardOpen).toBe(false);
+      });
+    });
   });
 
   describe('Accessibility Tests', () => {

--- a/packages/dialtone-vue2/components/hovercard/hovercard.vue
+++ b/packages/dialtone-vue2/components/hovercard/hovercard.vue
@@ -1,6 +1,7 @@
 <template>
   <dt-popover
     :id="id"
+    ref="popover"
     :open="hovercardOpen"
     :placement="placement"
     :content-class="contentClass"
@@ -213,6 +214,8 @@ export default {
   data () {
     return {
       hovercardOpen: this.open,
+      anchorEl: null,
+      observer: null,
       inTimer: null,
       outTimer: null,
     };
@@ -226,6 +229,33 @@ export default {
 
       immediate: true,
     },
+  },
+
+  mounted () {
+    this.$nextTick(() => {
+      this.anchorEl = this.$refs.popover?.$refs?.anchor;
+
+      this.observer = new MutationObserver(() => {
+        if (this.anchorEl && !this.anchorEl.isConnected) {
+          // If the anchor element is removed from the DOM, close the hovercard
+          this.hovercardOpen = false;
+        }
+      });
+
+      this.observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+      });
+    });
+  },
+
+  beforeDestroy () {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+
+    clearTimeout(this.inTimer);
+    clearTimeout(this.outTimer);
   },
 
   methods: {

--- a/packages/dialtone-vue2/components/hovercard/hovercard.vue
+++ b/packages/dialtone-vue2/components/hovercard/hovercard.vue
@@ -233,7 +233,7 @@ export default {
 
   mounted () {
     this.$nextTick(() => {
-      this.anchorEl = this.$refs.popover?.$refs?.anchor;
+      this.anchorEl = this.$refs.popover?.$refs?.anchor?.firstElementChild;
 
       this.observer = new MutationObserver(() => {
         if (this.anchorEl && !this.anchorEl.isConnected) {

--- a/packages/dialtone-vue3/components/hovercard/hovercard.test.js
+++ b/packages/dialtone-vue3/components/hovercard/hovercard.test.js
@@ -117,6 +117,21 @@ describe('DtHovercard Tests', () => {
         expect(content).toBeNull();
       });
     });
+
+    describe('When anchor is removed from DOM', () => {
+      it('hovercardOpen is set to false', async () => {
+        vi.useFakeTimers();
+        await anchor.trigger('mouseenter');
+        await vi.runAllTimers();
+
+        // Remove anchor from DOM
+        anchor.element.parentNode.removeChild(anchor.element);
+        // Advance timers to allow hovercard to react
+        await vi.runAllTimers();
+
+        expect(wrapper.vm.hovercardOpen).toBe(false);
+      });
+    });
   });
 
   describe('Accessibility Tests', () => {

--- a/packages/dialtone-vue3/components/hovercard/hovercard.vue
+++ b/packages/dialtone-vue3/components/hovercard/hovercard.vue
@@ -2,6 +2,7 @@
 <template>
   <dt-popover
     :id="id"
+    ref="popover"
     :open="hovercardOpen"
     :placement="placement"
     :content-class="contentClass"
@@ -48,7 +49,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, watch, nextTick, onMounted, onBeforeUnmount } from 'vue';
 import { POPOVER_APPEND_TO_VALUES, POPOVER_PADDING_CLASSES, DtPopover } from '@/components/popover/index.js';
 import { TOOLTIP_DIRECTIONS, TOOLTIP_DELAY_MS } from '@/components/tooltip/index.js';
 import { getUniqueString } from '@/common/utils';
@@ -212,7 +213,34 @@ defineEmits([
 const hovercardOpen = ref(props.open);
 const inTimer = ref(null);
 const outTimer = ref(null);
+const anchorEl = ref(null);
+const observer = ref(null);
+const popover = ref(null);
 
+onMounted(() => {
+  nextTick(() => {
+    anchorEl.value = popover.value?.$refs?.anchor;
+
+    observer.value = new MutationObserver(() => {
+      if (anchorEl.value && !anchorEl.value.isConnected) {
+        hovercardOpen.value = false;
+      }
+    });
+
+    observer.value.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  });
+});
+
+onBeforeUnmount(() => {
+  if (observer.value) {
+    observer.value.disconnect();
+  }
+  clearTimeout(inTimer);
+  clearTimeout(outTimer);
+});
 watch(() => props.open, (open) => {
   hovercardOpen.value = open;
 }, { immediate: true });

--- a/packages/dialtone-vue3/components/hovercard/hovercard.vue
+++ b/packages/dialtone-vue3/components/hovercard/hovercard.vue
@@ -219,7 +219,7 @@ const popover = ref(null);
 
 onMounted(() => {
   nextTick(() => {
-    anchorEl.value = popover.value?.$refs?.anchor;
+    anchorEl.value = popover.value?.$refs?.anchor?.firstElementChild;
 
     observer.value = new MutationObserver(() => {
       if (anchorEl.value && !anchorEl.value.isConnected) {


### PR DESCRIPTION
# fix(hovercard): DP-142048 remove hovercard when anchor is removed from the DOM 

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/XreQmk7ETCak0/giphy.gif?cid=82a1493b01psjxeuwdzs4s9ela5jy1xokk4kag6pa9ewzjtj&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DP-142048]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
The closing of the hovercard was done on `mouseleave`, but there are cases in which the event is not triggered but we want to close the hovercard as in the example from [DP-142048]. In this fix I added an observer to detect if the anchor is removed from the DOM, and in that case, set `hovercardOpen` to false.
<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

### Before

![May-20-2025 16-34-45](https://github.com/user-attachments/assets/0561455f-3446-4545-ae53-c7a6f6c1ec74)

### With this fix

![May-20-2025 15-39-28](https://github.com/user-attachments/assets/8a179aa7-c999-4fb6-97cc-a02188d81138)

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->
<!--- Add any links to external reference material -->


[DP-142048]: https://dialpad.atlassian.net/browse/DP-142048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DP-142048]: https://dialpad.atlassian.net/browse/DP-142048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ