### PR TITLE
docs: NO-JIRA fix font weight variables

### DIFF
--- a/apps/dialtone-documentation/docs/_data/type.json
+++ b/apps/dialtone-documentation/docs/_data/type.json
@@ -507,18 +507,22 @@
   ],
   "weight": [
     {
+      "class": "normal",
       "name": "normal",
       "output": "400"
     },
     {
+      "class": "medium",
       "name": "medium",
       "output": "500"
     },
     {
-      "name": "semibold",
+      "class": "semibold",
+      "name": "semi-bold",
       "output": "600"
     },
     {
+      "class": "bold",
       "name": "bold",
       "output": "700"
     }

--- a/apps/dialtone-documentation/docs/utilities/typography/font-weight.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-weight.md
@@ -37,10 +37,6 @@ Use `d-fw-{n}` to change an element's font-weight.
 <p class="d-fw-bold">...</p>
 ```
 
-<script setup>
-  import { weight } from '@data/type.json';
-</script>
-
 ## Variables
 
 <div v-dt-scrollbar class="d-hmx464 d-bar8 d-ba d-bc-subtle">
@@ -48,13 +44,13 @@ Use `d-fw-{n}` to change an element's font-weight.
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
           <tr>
-              <th scope="col" class="d-p0 d-bbw0 d-w25p"><div class="d-p16 d-bb d-bc-default d-bbw1">Variable</div></th>
+              <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Variable</div></th>
               <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
           </tr>
       </thead>
       <tbody>
         <tr v-for="{ name, output } in weight">
-          <th scope="row" class="d-code--sm d-docsite-code">var(--fw-{{ name }})</th>
+          <th scope="row" class="d-code--sm d-docsite-code">var(--dt-font-weight-{{ name }})</th>
           <td class="d-code--sm">{{ output }}</td>
         </tr>
       </tbody>
@@ -67,14 +63,18 @@ Use `d-fw-{n}` to change an element's font-weight.
 <utility-class-table>
   <template #content>
     <tbody>
-      <tr v-for="{ name, output } in weight">
+      <tr v-for="{ name, class: className, output } in weight">
         <th scope="row" class="d-code--sm d-docsite-code">
-          .d-fw-{{ name }}
+          .d-fw-{{ className }}
         </th>
         <td class="d-code--sm">
-          font-weight: var(--fw-{{ name }}) !important;
+          font-weight: var(--dt-font-weight-{{ name }}) !important;
         </td>
       </tr>
     </tbody>
   </template>
 </utility-class-table>
+
+<script setup>
+  import { weight } from '@data/type.json';
+</script>


### PR DESCRIPTION
# Fix font weight variables

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXRoNGt0ZW8wcTk5OHNna3Nkc2xub3ByNTU0dHp3YXJxNG5kaXp3MCZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/YnBntKOgnUSBkV7bQH/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Description

- Fixed outdated font weight variables

## :bulb: Context

Outdated font weight variables were found on the documentation.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.