### PR TITLE
fix(emoji-picker): NO-JIRA fix emoji tabs being removed

### DIFF
--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
@@ -103,7 +103,6 @@ export default {
         { label: EMOJI_PICKER_CATEGORIES.OBJECTS, icon: DtIconLightbulb },
         { label: EMOJI_PICKER_CATEGORIES.SYMBOLS, icon: DtIconHeart },
         { label: EMOJI_PICKER_CATEGORIES.FLAGS, icon: DtIconFlag },
-        { label: EMOJI_PICKER_CATEGORIES.CUSTOM, icon: DtIconTiktok },
       ],
     };
   },
@@ -112,9 +111,9 @@ export default {
     tabs () {
       // if showRecentlyUsedTab is false remove first index of TABS_DATA
       const tabsData = this.showRecentlyUsedTab ? this.TABS_DATA : this.TABS_DATA.slice(1);
-      // if showCustomEmojisTab is false remove last index of TABS_DATA
-      if (!this.showCustomEmojisTab) {
-        tabsData.pop();
+      // if showCustomEmojisTab is true add custom emoji tab
+      if (this.showCustomEmojisTab) {
+        tabsData.push({ label: EMOJI_PICKER_CATEGORIES.CUSTOM, icon: DtIconTiktok });
       }
 
       return tabsData.map((tab, index) => ({


### PR DESCRIPTION
# fix(emoji-picker): NO-JIRA fix emoji tabs being removed 

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExNXJjd3VsZmdoOHF4cG85aTN6cDc0ZTRjMGRsdmdleWdxamcwZjNzYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3RpO1aavTktTKVHjGg/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description
Fixes an intermittent bug introduced by the custom emoji changes ([#602](https://www.google.com/search?q=https://github.com/dialpad/dialtone/pull/602)). The emoji tab was intermittently disappearing from the tabset.

Explanation: [Comment](https://www.google.com/search?q=%5Bhttps://github.com/dialpad/dialtone/pull/602/files%23r2103121591%5D(https://github.com/dialpad/dialtone/pull/602/files%23r2103121591))