### PR TITLE
feat(toggle): NO-JIRA add wrapperClass vue3 only

### DIFF
--- a/packages/dialtone-vue3/components/toggle/toggle.stories.js
+++ b/packages/dialtone-vue3/components/toggle/toggle.stories.js
@@ -12,6 +12,7 @@ export const argsData = {
   modelValue: false,
   onChange: action('change'),
   labelClass: 'd-mr6',
+  wrapperClass: '',
 };
 
 // Prop Controls

--- a/packages/dialtone-vue3/components/toggle/toggle.vue
+++ b/packages/dialtone-vue3/components/toggle/toggle.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="d-toggle-wrapper"
+    :class="['d-toggle-wrapper', wrapperClass]"
     v-bind="addClassStyleAttrs($attrs)"
   >
     <label
@@ -112,6 +112,14 @@ export default {
     labelClass: {
       type: [String, Array, Object],
       default: '',
+    },
+
+    /**
+     * Additional styling for the wrapper element
+     */
+    wrapperClass: {
+      type: [String, Array, Object],
+      default: undefined,
     },
 
     /**

--- a/packages/dialtone-vue3/components/toggle/toggle_default.story.vue
+++ b/packages/dialtone-vue3/components/toggle/toggle_default.story.vue
@@ -5,6 +5,7 @@
     :size="$attrs.size"
     :show-icon="$attrs.showIcon"
     :label-class="$attrs.labelClass"
+    :wrapper-class="$attrs.wrapperClass"
     :label-child-props="$attrs.labelChildProps"
     :toggle-on-click="$attrs.toggleOnClick"
     @change="$attrs.onChange"


### PR DESCRIPTION
# feat(toggle): add wrapperClass vue3 only

<!--- Feel free to remove any unused sections -->

- [x] Feature

## :book: Description

add wrapperClass to toggle

## :bulb: Context

class attrs changed from vue 2 to vue 3, they now apply to the input element instead of the root, so we need a way to apply classes to the wrapper.
