### PR TITLE
fix(message-input): NO-JIRA add add-emoji event to message input

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -314,23 +314,42 @@ export const WithCustomEmoji = {
   render: (argsData) => createRenderConfig(DtRecipeMessageInput, DtRecipeMessageInputDefaultTemplate, argsData),
   args: {
     value: 'This is a test with custom emojis',
-    customEmojis: [
-      {
-        name: 'shipit',
-        date_added: 1730918816847,
-        added_by: 'Ignacio Ropolo',
-        image: 'https://github.githubassets.com/images/icons/emoji/shipit.png',
-        unicode_character: '1f44d',
-      },
-      {
-        name: 'thumbs up',
-        category: 'people',
-        shortname: ':thumbsup:',
-        shortname_alternates: [':+1:', ':thumbup:'],
-        keywords: ['+1', 'hand', 'thumb', 'up', 'uc6'],
-        unicode_output: '1f44d',
-        unicode_character: '1f44d',
-      },
-    ]
+    emojiPickerProps: {
+      searchNoResultsLabel: 'No results',
+      searchResultsLabel: 'Search results',
+      searchPlaceholderLabel: 'Search...',
+      skinSelectorButtonTooltipLabel: 'Change default skin tone',
+      tabSetLabels: [
+        'Most recently used',
+        'Smileys and people',
+        'Nature',
+        'Food',
+        'Activity',
+        'Travel',
+        'Objects',
+        'Symbols',
+        'Flags',
+        'Custom'
+      ],
+      skinTone: 'Default',
+      customEmojis: [
+        {
+          name: 'shipit',
+          date_added: 1730918816847,
+          added_by: 'Ignacio Ropolo',
+          image: 'https://github.githubassets.com/images/icons/emoji/shipit.png',
+          unicode_character: '1f44d',
+        },
+        {
+          name: 'thumbs up',
+          category: 'people',
+          shortname: ':thumbsup:',
+          shortname_alternates: [':+1:', ':thumbup:'],
+          keywords: ['+1', 'hand', 'thumb', 'up', 'uc6'],
+          unicode_output: '1f44d',
+          unicode_character: '1f44d',
+        }
+      ]
+    }
   },
 };

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -183,6 +183,12 @@ export const argTypesData = {
       disable: true,
     },
   },
+
+  onAddEmoji: {
+    table: {
+      disable: true,
+    },
+  },
 };
 
 // Set default values at the story level here.
@@ -236,6 +242,7 @@ export const argsData = {
   onJsonInput: action('json-input'),
   onHtmlInput: action('html-input'),
   onTextInput: action('text-input'),
+  onAddEmoji: action('add-emoji'),
   onSelectMedia: action('select-media'),
   onSelectedEmoji: action('selected-emoji'),
   onSelectedCommand: action('selected-command'),
@@ -300,5 +307,30 @@ export const WithMeetingPill = {
     },
     value: '<meeting-pill text="Start a meeting" close-button-aria-label="Delete meeting pill"/>',
     preventTyping: true,
+  },
+};
+
+export const WithCustomEmoji = {
+  render: (argsData) => createRenderConfig(DtRecipeMessageInput, DtRecipeMessageInputDefaultTemplate, argsData),
+  args: {
+    value: 'This is a test with custom emojis',
+    customEmojis: [
+      {
+        name: 'shipit',
+        date_added: 1730918816847,
+        added_by: 'Ignacio Ropolo',
+        image: 'https://github.githubassets.com/images/icons/emoji/shipit.png',
+        unicode_character: '1f44d',
+      },
+      {
+        name: 'thumbs up',
+        category: 'people',
+        shortname: ':thumbsup:',
+        shortname_alternates: [':+1:', ':thumbup:'],
+        keywords: ['+1', 'hand', 'thumb', 'up', 'uc6'],
+        unicode_output: '1f44d',
+        unicode_character: '1f44d',
+      },
+    ]
   },
 };

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -157,6 +157,7 @@
             <template #content="{ close }">
               <dt-emoji-picker
                 v-bind="emojiPickerProps"
+                @add-emoji="$emit('add-emoji')"
                 @skin-tone="onSkinTone"
                 @selected-emoji="(emoji) => onSelectEmoji(emoji, close)"
               />
@@ -780,6 +781,13 @@ export default {
      * @type {String}
      */
     'text-input',
+
+    /**
+     * Emitted when the 'Add emoji' button is clicked
+     * @event add-emoji
+     * @type {Boolean}
+     */
+    'add-emoji',
   ],
 
   data () {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -44,6 +44,7 @@
         @json-input="$attrs.onJsonInput"
         @html-input="$attrs.onHtmlInput"
         @text-input="$attrs.onTextInput"
+        @add-emoji="$attrs.onAddEmoji"
         @select-media="$attrs.onSelectMedia"
         @selected-emoji="$attrs.onSelectedEmoji"
         @selected-command="$attrs.onSelectedCommand"


### PR DESCRIPTION
# fix(message-input): NO-JIRA add add-emoji event to message input

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExMzF6OHE2aGlhcnFkeHB4amkycGRkN3dvcTMyY2xvMjU3YjBiMm04MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tqj4m9BRURayxQAIW9/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

To enable the "Add emoji" button within the emoji picker in the message input, an event listener needs to be attached directly to the message input component. This will allow the product side to detect clicks on the button by listening for the event on the message input, thereby triggering the emoji picker modal to open.

<img width="504" alt="Screenshot 2025-05-26 at 9 31 59 AM" src="https://github.com/user-attachments/assets/9248b20e-5235-4f9d-adba-73454709cc79" />

## :bulb: Context
Firespotter utilizes the emoji picker in various locations throughout the application. While some instances of the picker are standalone, others, particularly within the message input, require an additional event listener on the parent element (the message input itself). This ensures that the product-side application can also listen for and respond to events originating from the emoji picker when it's embedded within the message input.

For further details, please refer to the pull request: https://github.com/dialpad/firespotter/pull/57033