### PR TITLE
fix(background-clip, font-family, font-style, font-weight): conflicting class names

### DIFF
--- a/apps/dialtone-documentation/docs/_data/type.json
+++ b/apps/dialtone-documentation/docs/_data/type.json
@@ -220,23 +220,15 @@
     },
     {
       "var": "sans",
-      "output": "-apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Cantarell, Ubuntu, Roboto, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
+      "output": "-apple-system, BlinkMacSystemFont, \"SF Pro\", \"Segoe UI Adjusted\", \"Segoe UI\", SFMono, \"Helvetica Neue\", Cantarell, Ubuntu, Roboto, Arial, \"Noto Sans\", sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\""
     },
     {
       "var": "mono",
-      "output": "\"SFMono-Regular\", Consolas, \"Liberation Mono\", Menlo, Courier, monospace"
+      "output": "SFMono-Regular, \"SF Mono\", Consolas, \"Liberation Mono\", Menlo, Courier, monospace"
     },
     {
       "var": "marketing",
-      "output": "\"Season Mix\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Cantarell, Ubuntu, Roboto, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
-    },
-    {
-      "var": "marketing-semi-expanded",
-      "output": "\"Season Mix\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Cantarell, Ubuntu, Roboto, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
-    },
-    {
-      "var": "marketing-expanded",
-      "output": "\"Season Mix\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Cantarell, Ubuntu, Roboto, Arial,  sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
+      "output": "\"Season Mix\", -apple-system, BlinkMacSystemFont, \"SF Pro\", \"Segoe UI Adjusted\", \"Segoe UI\", SFMono, \"Helvetica Neue\", Cantarell, Ubuntu, Roboto, Arial, \"Noto Sans\", sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\""
     },
     {
       "var": "unset",

--- a/apps/dialtone-documentation/docs/design/colors/index.md
+++ b/apps/dialtone-documentation/docs/design/colors/index.md
@@ -106,11 +106,6 @@ import DesignColorTable from '@baseComponents/DesignColorTable.vue';
 import ThemeColorTable from '@baseComponents/ThemeColorTable.vue';
 import ColorsCatalog from '@views/ColorsCatalog.vue';
 
-/*
-* Remove unwanted background-clip classes
-*@TODO: Remove this once background-clip classes are refactored to d-bgclip https://dialpad.atlassian.net/browse/DLT-2439
-*/
-const surfaceColorsExclusionList = ['box', 'text'];
 const textColorsExclusionList = ['critical',  'success',  'warning',  'info'];
 const statusTextColorsExclusionList = [
   'current',

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/clip.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/clip.md
@@ -5,33 +5,33 @@ description: Utilities for controlling whether an element's background extends u
 
 ## Usage
 
-Use `d-bgc-{name}` to control which box an element's background is clipped by.
+Use `d-bgclip-{name}` to control which box an element's background is clipped by.
 
 <code-well-header>
   <dt-stack direction="row" gap="400">
-    <div class="d-bgc-border-box d-p16 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8 d-bc-default">border-box</div>
-    <div class="d-bgc-padding-box d-p16 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8 d-bc-default">padding-box</div>
-    <div class="d-bgc-content-box d-p16 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8 d-bc-default">content-box</div>
+    <div class="d-bgclip-border-box d-p16 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8 d-bc-default">border-box</div>
+    <div class="d-bgclip-padding-box d-p16 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8 d-bc-default">padding-box</div>
+    <div class="d-bgclip-content-box d-p16 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8 d-bc-default">content-box</div>
   </dt-stack>
 </code-well-header>
 
 ```html
 
-<div class="d-bgc-border-box">...</div>
-<div class="d-bgc-padding-box">...</div>
-<div class="d-bgc-content-box">...</div>
+<div class="d-bgclip-border-box">...</div>
+<div class="d-bgclip-padding-box">...</div>
+<div class="d-bgclip-content-box">...</div>
 ```
 
 ## Clipping Text
 
-Use `d-bgc-text` to clip the background color(s) within the foreground text.
+Use `d-bgclip-text` to clip the background color(s) within the foreground text.
 
 <code-well-header>
-  <div class="d-ba d-bgc-text d-bgg-to-r d-bgg-from-magenta-400 d-bgg-to-purple-400 d-headline--xl">Magic stuff happens.</div>
+  <div class="d-ba d-bgclip-text d-bgg-to-r d-bgg-from-magenta-400 d-bgg-to-purple-400 d-headline--xl">Magic stuff happens.</div>
 </code-well-header>
 
 ```html
-<div class="d-ba d-bgc-text d-bgg-to-r d-bgg-from-magenta-400 d-bgg-to-purple-400 d-headline--xl">...</div>
+<div class="d-ba d-bgclip-text d-bgg-to-r d-bgg-from-magenta-400 d-bgg-to-purple-400 d-headline--xl">...</div>
 ```
 
 ## Classes
@@ -40,7 +40,7 @@ Use `d-bgc-text` to clip the background color(s) within the foreground text.
   <template #content>
     <tbody>
         <tr v-for="i in ['unset', 'border-box', 'padding-box', 'content-box', 'text']">
-          <th scope="row" class="d-code--sm d-docsite-code">.d-bgc-{{ i }}</th>
+          <th scope="row" class="d-code--sm d-docsite-code">.d-bgclip-{{ i }}</th>
           <td class="d-code--sm">background-clip: {{ i }} !important;</td>
         </tr>
     </tbody>

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/color.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/color.md
@@ -125,13 +125,9 @@ Use `d-bgo{stop}` to change an element's background color opacity. You can also 
   import { inject } from 'vue';
   import { extractUtilityClasses } from '@utilities';
 
-  /*Excluded classes that have incorrect naming, should be renamed to `d-bgclip` to avoid conflicts*/
-  const excludedClasses = ['d-bgc-border-box', 'd-bgc-content-box', 'd-bgc-padding-box', 'd-bgc-text'];
-
   const utilityClassDocs = inject('utilityClassDocs');
   const colors = extractUtilityClasses(utilityClassDocs, 'd-bgc-');
   const backgroundColors = Object.keys(colors)
-    .filter(className => !excludedClasses.includes(className))
     .reduce((obj, key) => {
       obj[key] = colors[key];
       return obj;

--- a/apps/dialtone-documentation/docs/utilities/typography/font-family.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-family.md
@@ -15,26 +15,26 @@ description: Utilities to change an element's font-family.
 
 ## Sans-Serif
 
-Use `d-ff-sans` to apply a Sans-Serif font stack.
+Use `d-font-family-sans` to apply a Sans-Serif font stack.
 
 <code-well-header>
-  <p class="d-ff-sans">The quick brown fox jumps over the lazy dog.</p>
+  <p class="d-font-family-sans">The quick brown fox jumps over the lazy dog.</p>
 </code-well-header>
 
 ```html
-<p class="d-ff-sans">...</p>
+<p class="d-font-family-sans">...</p>
 ```
 
 ## Mono
 
-Use `d-ff-mono` to apply a Monospace font stack.
+Use `d-font-family-mono` to apply a Monospace font stack.
 
 <code-well-header>
-  <p class="d-ff-mono">The quick brown fox jumps over the lazy dog.</p>
+  <p class="d-font-family-mono">The quick brown fox jumps over the lazy dog.</p>
 </code-well-header>
 
 ```html
-<p class="d-ff-mono">...</p>
+<p class="d-font-family-mono">...</p>
 ```
 
 ## Marketing
@@ -42,15 +42,20 @@ Use `d-ff-mono` to apply a Monospace font stack.
 Dialtone supports select marketing fonts and weights. Use the following combinations to apply the marketing font stack.
 
 <code-well-header>
-  <p class="d-ff-marketing">The quick brown fox jumps over the lazy dog.</p>
+  <p class="d-font-family-marketing">The quick brown fox jumps over the lazy dog.</p>
 </code-well-header>
 
 ```html
-<p class="d-ff-marketing">...</p>
+<p class="d-font-family-marketing">...</p>
 ```
 
 <script setup>
   import { fontFamily } from '@data/type.json';
+  const cssVariables = {
+    'sans': 'body',
+    'mono': 'mono',
+    marketing: 'expressive',
+  }
 </script>
 
 ## CSS Variables
@@ -65,8 +70,8 @@ Dialtone supports select marketing fonts and weights. Use the following combinat
         </tr>
       </thead>
       <tbody>
-        <tr v-for="{ var: varName, output } in fontFamily.slice(0, -1)">
-          <td class="d-code--sm d-docsite-code">var(--ff-{{ varName }})</td>
+        <tr v-for="{ var: varName, output } in fontFamily.slice(1, -1)">
+          <td class="d-code--sm d-docsite-code">var(--dt-font-family-{{ cssVariables[varName] }})</td>
           <td class="d-code--sm">{{ output }}</td>
         </tr>
       </tbody>
@@ -87,7 +92,7 @@ Dialtone supports select marketing fonts and weights. Use the following combinat
       </thead>
       <tbody>
         <tr v-for="{ var: varName, output } in fontFamily">
-          <td class="d-code--sm d-docsite-code">.d-ff-{{ varName }}</td>
+          <td class="d-code--sm d-docsite-code">.d-font-family-{{ varName }}</td>
           <td class="d-code--sm">font-family: {{ output }} !important;</td>
         </tr>
       </tbody>

--- a/apps/dialtone-documentation/docs/utilities/typography/font-style.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-style.md
@@ -5,38 +5,38 @@ description: Utilities to change an element's font styles.
 
 ## Normal
 
-Use `d-fs-normal` to change an element's font-style.
+Use `d-font-style-normal` to change an element's font-style.
 
 <code-well-header>
-  <p class="d-fs-normal">The quick brown fox jumps over the lazy dog.</p>
+  <p class="d-font-style-normal">The quick brown fox jumps over the lazy dog.</p>
 </code-well-header>
 
 ```html
-<p class="d-fs-normal">...</p>
+<p class="d-font-style-normal">...</p>
 ```
 
 ## Italics
 
-Use `d-fs-italic` to change an element's font-style.
+Use `d-font-style-italic` to change an element's font-style.
 
 <code-well-header>
-  <p class="d-fs-italic">The quick brown fox jumps over the lazy dog.</p>
+  <p class="d-font-style-italic">The quick brown fox jumps over the lazy dog.</p>
 </code-well-header>
 
 ```html
-<p class="d-fs-italic">...</p>
+<p class="d-font-style-italic">...</p>
 ```
 
 ## No Italics
 
-Use `d-fs-none` to remove an element's font-style.
+Use `d-font-style-none` to remove an element's font-style.
 
 <code-well-header>
-  <p class="d-fs-none">The quick brown fox jumps over the lazy dog.</p>
+  <p class="d-font-style-none">The quick brown fox jumps over the lazy dog.</p>
 </code-well-header>
 
 ```html
-<p class="d-fs-none">...</p>
+<p class="d-font-style-none">...</p>
 ```
 
 <script setup>
@@ -49,7 +49,7 @@ Use `d-fs-none` to remove an element's font-style.
   <template #content>
     <tbody>
       <tr v-for="i in style">
-        <th scope="row" class="d-code--sm d-docsite-code">.d-fs-{{ i }}</th>
+        <th scope="row" class="d-code--sm d-docsite-code">.d-font-style-{{ i }}</th>
         <td class="d-code--sm">font-style: {{ i }} !important;</td>
       </tr>
     </tbody>

--- a/apps/dialtone-documentation/docs/utilities/typography/font-weight.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-weight.md
@@ -15,26 +15,29 @@ description: Utilities to change an element's font-weight.
 
 ## Usage
 
-Use `d-fw-{n}` to change an element's font-weight.
+Use `d-font-weight-{n}` to change an element's font-weight.
 
 <code-well-header>
-  <div class="d-d-grid d-g16 d-ai-center" style="grid-template-columns: 11rem 1fr">
-    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-fw-normal</div>
-    <div><p class="d-fw-normal">The quick brown fox jumps over the lazy dog.</p></div>
-    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-fw-medium</div>
-    <div><p class="d-fw-medium">The quick brown fox jumps over the lazy dog.</p></div>
-    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-fw-semibold</div>
-    <div><p class="d-fw-semibold">The quick brown fox jumps over the lazy dog.</p></div>
-    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-fw-bold</div>
-    <div><p class="d-fw-bold">The quick brown fox jumps over the lazy dog.</p></div>
+  <div class="d-d-grid d-g16 d-ai-center" style="grid-template-columns: 20rem 1fr">
+    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-font-weight-normal</div>
+    <div><p class="d-font-weight-normal">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-font-weight-medium</div>
+    <div><p class="d-font-weight-medium">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-font-weight-semibold</div>
+    <div><p class="d-font-weight-semibold">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-font-weight-bold</div>
+    <div><p class="d-font-weight-bold">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-font-weight-unset</div>
+    <div><p class="d-font-weight-unset">The quick brown fox jumps over the lazy dog.</p></div>
   </div>
 </code-well-header>
 
 ```html
-<p class="d-fw-normal">...</p>
-<p class="d-fw-medium">...</p>
-<p class="d-fw-semibold">...</p>
-<p class="d-fw-bold">...</p>
+<p class="d-font-weight-normal">...</p>
+<p class="d-font-weight-medium">...</p>
+<p class="d-font-weight-semibold">...</p>
+<p class="d-font-weight-bold">...</p>
+<p class="d-font-weight-unset">...</p>
 ```
 
 ## Variables
@@ -65,10 +68,18 @@ Use `d-fw-{n}` to change an element's font-weight.
     <tbody>
       <tr v-for="{ name, class: className, output } in weight">
         <th scope="row" class="d-code--sm d-docsite-code">
-          .d-fw-{{ className }}
+          .d-font-weight-{{ className }}
         </th>
         <td class="d-code--sm">
           font-weight: var(--dt-font-weight-{{ name }}) !important;
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" class="d-code--sm d-docsite-code">
+          .d-font-weight-unset
+        </th>
+        <td class="d-code--sm">
+          font-weight: unset !important;
         </td>
       </tr>
     </tbody>

--- a/packages/dialtone-css/lib/build/less/utilities/backgrounds.less
+++ b/packages/dialtone-css/lib/build/less/utilities/backgrounds.less
@@ -26,11 +26,11 @@
 //  ============================================================================
 //  $  BACKGROUND CLIP
 //  ----------------------------------------------------------------------------
-.d-bgc-border-box { background-clip: border-box !important; }
-.d-bgc-padding-box { background-clip: padding-box !important; }
-.d-bgc-content-box { background-clip: content-box !important; }
+.d-bgclip-border-box { background-clip: border-box !important; }
+.d-bgclip-padding-box { background-clip: padding-box !important; }
+.d-bgclip-content-box { background-clip: content-box !important; }
 
-.d-bgc-text {
+.d-bgclip-text {
   color: transparent !important;
   -webkit-background-clip: text !important;
   background-clip: text !important;

--- a/packages/dialtone-css/lib/build/less/utilities/backgrounds.less
+++ b/packages/dialtone-css/lib/build/less/utilities/backgrounds.less
@@ -137,11 +137,3 @@
 .d-bgg-pattern-slanted-stripes-light { --bgg-pattern: var(--bgg-pattern-slanted-stripes-light) !important; }
 .d-bgg-pattern-steps-light { --bgg-pattern: var(--bgg-pattern-steps-light) !important; }
 .d-bgg-pattern-stripe-light { --bgg-pattern: var(--bgg-pattern-stripe-light) !important; }
-
-//  ============================================================================
-//  $ Background linear gradient
-//  ----------------------------------------------------------------------------
-
-.d-bgc-ai {
-    background-image: var(--dt-color-surface-ai) !important;
-}

--- a/packages/dialtone-css/lib/build/less/utilities/borders.less
+++ b/packages/dialtone-css/lib/build/less/utilities/borders.less
@@ -229,14 +229,6 @@
 //  $$ Border linear gradient
 //  ----------------------------------------------------------------------------
 
-/*
- * Note: border-image is not compatible with border-radius, but it's the easiest way to get a linear gradient border.
- * https://dev.to/afif/border-with-gradient-and-radius-387f
- */
-.d-bc-ai {
-  border-image: var(--dt-color-border-ai) 1 !important;
-}
-
 .d-divide-ai > * + * {
   border-image: var(--dt-color-border-ai) 1 !important;
 }

--- a/packages/dialtone-css/lib/build/less/utilities/colors.less
+++ b/packages/dialtone-css/lib/build/less/utilities/colors.less
@@ -32,8 +32,20 @@
   background-image: unset !important;
 }
 
+.d-bgc-ai {
+  background-image: var(--dt-color-surface-ai) !important;
+}
+
 //  $$  BORDER COLORS
 //  ----------------------------------------------------------------------------
 .d-bc-transparent { border-color: transparent !important; }
 .d-bc-current { border-color: currentColor !important; }
 .d-bc-unset { border-color: unset !important; }
+
+/*
+ * Note: border-image is not compatible with border-radius, but it's the easiest way to get a linear gradient border.
+ * https://dev.to/afif/border-with-gradient-and-radius-387f
+ */
+.d-bc-ai {
+  border-image: var(--dt-color-border-ai) 1 !important;
+}

--- a/packages/dialtone-css/lib/build/less/utilities/typography.less
+++ b/packages/dialtone-css/lib/build/less/utilities/typography.less
@@ -27,11 +27,11 @@
 //  ============================================================================
 //  $   FONT FAMILY
 //  ----------------------------------------------------------------------------
-.d-ff-custom { font-family: var(--dt-font-family-body) !important; }
-.d-ff-sans { font-family: var(--dt-font-family-body) !important; }
-.d-ff-mono { font-family: var(--dt-font-family-mono) !important; }
-.d-ff-marketing { font-family: var(--dt-font-family-expressive) !important; }
-.d-ff-unset { font-family: unset !important; }
+.d-font-family-custom { font-family: var(--dt-font-family-body) !important; }
+.d-font-family-sans { font-family: var(--dt-font-family-body) !important; }
+.d-font-family-mono { font-family: var(--dt-font-family-mono) !important; }
+.d-font-family-marketing { font-family: var(--dt-font-family-expressive) !important; }
+.d-font-family-unset { font-family: unset !important; }
 
 //  ============================================================================
 //  $   RESET HEADERS & PARAGRAPH MARGINS
@@ -276,19 +276,19 @@ ul {
 //  ============================================================================
 //  $$  FONT STYLE
 //  ----------------------------------------------------------------------------
-.d-fs-normal { font-style: normal !important; }
-.d-fs-italic { font-style: italic !important; }
-.d-fs-unset { font-style: unset !important; }
+.d-font-style-normal { font-style: normal !important; }
+.d-font-style-italic { font-style: italic !important; }
+.d-font-style-unset { font-style: unset !important; }
 
 
 //  ============================================================================
 //  $$  FONT WEIGHT
 //  ----------------------------------------------------------------------------
-.d-fw-normal { font-weight: var(--dt-font-weight-normal) !important; }
-.d-fw-medium { font-weight: var(--dt-font-weight-medium) !important; }
-.d-fw-semibold { font-weight: var(--dt-font-weight-semi-bold) !important; }
-.d-fw-bold { font-weight: var(--dt-font-weight-bold) !important; }
-.d-fw-unset { font-weight: unset !important; }
+.d-font-weight-normal { font-weight: var(--dt-font-weight-normal) !important; }
+.d-font-weight-medium { font-weight: var(--dt-font-weight-medium) !important; }
+.d-font-weight-semibold { font-weight: var(--dt-font-weight-semi-bold) !important; }
+.d-font-weight-bold { font-weight: var(--dt-font-weight-bold) !important; }
+.d-font-weight-unset { font-weight: unset !important; }
 
 
 //  ============================================================================


### PR DESCRIPTION
# Fix conflicting background-clip utility classes

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/brHaCdJqCXijm/giphy.gif?cid=82a1493bxb9mwb0f4fizn37m4l5w1o2ah54j3dvv3v1vagc0&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2439

## :book: Description

- Renamed conflicting classes
  - background-clip utility classes from `d-bgc-*` to `d-bgclip-*` was conflicting with background colors
  - font-family from `d-ff-*` to `d-font-family-*` was conflicting with flex flow
  - font-style from `d-fs-*` to `d-font-style-*` was conflicting with font size
  - font-weight from `d-fw-*` to `d-font-weight-*` was conflicting with flex wrap
- Updated documentation accordingly

## :bulb: Context

- Found some conflicting utility classes that either had the same prefix or even the same naming.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

## :camera: Screenshots / GIFs

![Screenshot 2025-05-26 at 6 48 19 p m](https://github.com/user-attachments/assets/de4f2233-7b58-49a2-8469-fd9f8cc629b2)
![Screenshot 2025-05-28 at 1 40 40 p m](https://github.com/user-attachments/assets/d451ca2a-5afb-4f13-81bd-ead7c63be0b1)
![Screenshot 2025-05-28 at 1 41 11 p m](https://github.com/user-attachments/assets/98f2e980-0d96-4b46-b921-7985e938a198)
![Screenshot 2025-05-28 at 1 41 25 p m](https://github.com/user-attachments/assets/40069311-2e29-456f-8dfc-890986e413ed)

