### PR TITLE
feat(emoji-picker): DLT-2562 custom emojis feature on vue3 and tests

### DIFF
--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.test.js
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.test.js
@@ -48,6 +48,24 @@ const MOCK_RECENTLY_USED_EMOJIS = [
     unicode_character: '1f470-1f3ff-2640',
   },
 ];
+const MOCK_CUSTOM_EMOJIS = [
+  {
+    name: 'shipit',
+    date_added: 1730918816847,
+    added_by: 'Ignacio Ropolo',
+    image: 'https://github.githubassets.com/images/icons/emoji/shipit.png',
+    unicode_character: '1f44d',
+  },
+  {
+    name: 'thumbs up',
+    category: 'people',
+    shortname: ':thumbsup:',
+    shortname_alternates: [':+1:', ':thumbup:'],
+    keywords: ['+1', 'hand', 'thumb', 'up', 'uc6'],
+    unicode_output: '1f44d',
+    unicode_character: '1f44d',
+  },
+];
 const MOCK_TAB_SET_LABELS = [
   'Most recently used',
   'Smileys and people',
@@ -58,6 +76,7 @@ const MOCK_TAB_SET_LABELS = [
   'Objects',
   'Symbols',
   'Flags',
+  'Custom',
 ];
 const MOCK_SKIN_SELECTOR_BUTTON_TOOLTIP_LABEL = 'Change default skin tone';
 const MOCK_SEARCH_RESULTS_LABEL = 'Search results';
@@ -69,6 +88,7 @@ const baseProps = {
   skinSelectorButtonTooltipLabel: MOCK_SKIN_SELECTOR_BUTTON_TOOLTIP_LABEL,
   tabSetLabels: MOCK_TAB_SET_LABELS,
   recentlyUsedEmojis: MOCK_RECENTLY_USED_EMOJIS,
+  customEmojis: MOCK_CUSTOM_EMOJIS,
   searchResultsLabel: MOCK_SEARCH_RESULTS_LABEL,
   searchNoResultsLabel: MOCK_SEARCH_NO_RESULTS_LABEL,
   searchPlaceholderLabel: MOCK_SEARCH_PLACEHOLDER_LABEL,
@@ -136,6 +156,13 @@ describe('DtEmojiPicker Tests', () => {
       expect(firstButton.attributes('aria-label')).toBe(MOCK_TAB_SET_LABELS[0]);
     });
 
+    it('Should render customs emojis tabset', () => {
+      const lastButton = wrapper.find('.d-tablist').findAll('button').at(MOCK_TAB_SET_LABELS.length - 1);
+
+      expect(lastButton.exists()).toBe(true);
+      expect(lastButton.attributes('aria-label')).toBe(MOCK_TAB_SET_LABELS[MOCK_TAB_SET_LABELS.length - 1]);
+    });
+
     it('Should render provided search placeholder label', () => {
       const searchInput = wrapper.find('.d-emoji-picker__search input');
 
@@ -154,6 +181,13 @@ describe('DtEmojiPicker Tests', () => {
       const TabsCount = wrapper.find('.d-tablist').findAll('button').length;
 
       expect(TabsCount).toBe(MOCK_TAB_SET_LABELS.length);
+    });
+
+    it('Should render add emoji button', () => {
+      const addEmojiButton = wrapper.find('.d-emoji-picker__add-emoji');
+
+      expect(addEmojiButton.exists()).toBe(true);
+      expect(addEmojiButton.attributes('aria-label')).toBe('Add emoji');
     });
 
     describe('Skin tone selector tests', () => {
@@ -338,10 +372,10 @@ describe('DtEmojiPicker Tests', () => {
     });
 
     it('Should jump to skin selector from emoji-selector', async () => {
-      const firstFlags = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(10) button');
+      const firstCustoms = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(11) button');
       const skinSelector = wrapper.find('.d-emoji-picker__skin-selected button');
 
-      await firstFlags.trigger('keydown.tab');
+      await firstCustoms.trigger('keydown.tab');
 
       expect(document.activeElement).toBe(skinSelector.element);
     });

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.test.js
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.test.js
@@ -372,7 +372,7 @@ describe('DtEmojiPicker Tests', () => {
     });
 
     it('Should jump to skin selector from emoji-selector', async () => {
-      const firstCustoms = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(11) button');
+      const firstCustoms = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-last-child(1) button');
       const skinSelector = wrapper.find('.d-emoji-picker__skin-selected button');
 
       await firstCustoms.trigger('keydown.tab');

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
@@ -53,6 +53,7 @@
       <dt-button
         v-if="showCustomEmojisTab && !highlightedEmoji"
         importance="outlined"
+        :aria-label="addEmojiLabel"
         class="d-emoji-picker__add-emoji"
         @click="$emit('add-emoji')"
       >
@@ -176,7 +177,7 @@ export default {
      * @example
      * <dt-emoji-picker
      *  :tabSetLabels="['Most recently used', 'Smileys and people', 'Nature',
-     *    'Food', 'Activity', 'Travel', 'Objects', 'Symbols', 'Flags']" />
+     *    'Food', 'Activity', 'Travel', 'Objects', 'Symbols', 'Flags', 'Custom']" />
      */
     tabSetLabels: {
       type: Array,

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -189,13 +189,27 @@ export default {
     },
 
     tabLabels () {
-      return this.recentlyUsedEmojis.length
-        ? this.tabSetLabels.map((label) => ({ label }))
-        : this.tabSetLabels.slice(1).map((label) => ({ label }));
+      let updateTabLabels = this.tabSetLabels.map((label) => ({ label }));
+
+      if (!this.recentlyUsedEmojis.length) {
+        updateTabLabels = this.tabSetLabels.slice(1).map((label) => ({ label }));
+      }
+
+      if (!this.customEmojis.length) {
+        updateTabLabels.pop();
+      }
+
+      return updateTabLabels;
     },
 
     tabs () {
-      return this.recentlyUsedEmojis.length ? this.TABS_DATA : this.TABS_DATA.slice(1);
+      const updateTabsOrder = this.recentlyUsedEmojis.length ? this.TABS_DATA : this.TABS_DATA.slice(1);
+
+      if (!this.customEmojis.length) {
+        updateTabsOrder.pop();
+      }
+
+      return updateTabsOrder;
     },
   },
 

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_selector.vue
@@ -203,7 +203,7 @@ export default {
     },
 
     tabs () {
-      const updateTabsOrder = this.recentlyUsedEmojis.length ? this.TABS_DATA : this.TABS_DATA.slice(1);
+      const updateTabsOrder = this.recentlyUsedEmojis.length ? this.TABS_DATA.slice() : this.TABS_DATA.slice(1);
 
       if (!this.customEmojis.length) {
         updateTabsOrder.pop();

--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
@@ -103,6 +103,7 @@ export default {
         { label: EMOJI_PICKER_CATEGORIES.OBJECTS, icon: DtIconLightbulb },
         { label: EMOJI_PICKER_CATEGORIES.SYMBOLS, icon: DtIconHeart },
         { label: EMOJI_PICKER_CATEGORIES.FLAGS, icon: DtIconFlag },
+        { label: EMOJI_PICKER_CATEGORIES.CUSTOM, icon: DtIconTiktok },
       ],
     };
   },
@@ -111,9 +112,9 @@ export default {
     tabs () {
       // if showRecentlyUsedTab is false remove first index of TABS_DATA
       const tabsData = this.showRecentlyUsedTab ? this.TABS_DATA : this.TABS_DATA.slice(1);
-      // if showCustomEmojisTab is true add custom emoji tab
-      if (this.showCustomEmojisTab) {
-        tabsData.push({ label: EMOJI_PICKER_CATEGORIES.CUSTOM, icon: DtIconTiktok });
+      // if showCustomEmojisTab is false remove last index of TABS_DATA
+      if (!this.showCustomEmojisTab) {
+        tabsData.pop();
       }
 
       return tabsData.map((tab, index) => ({

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -218,6 +218,7 @@ export const argsData = {
       'Objects',
       'Symbols',
       'Flags',
+      'Custom',
     ],
     skinTone: 'Default',
   },
@@ -329,7 +330,7 @@ export const WithCustomEmoji = {
         'Objects',
         'Symbols',
         'Flags',
-        'Custom'
+        'Custom',
       ],
       skinTone: 'Default',
       customEmojis: [
@@ -348,8 +349,8 @@ export const WithCustomEmoji = {
           keywords: ['+1', 'hand', 'thumb', 'up', 'uc6'],
           unicode_output: '1f44d',
           unicode_character: '1f44d',
-        }
-      ]
-    }
+        },
+      ],
+    },
   },
 };

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.stories.js
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.stories.js
@@ -52,10 +52,31 @@ const recentlyUsedEmojis = [
   },
 ];
 
+const customEmojis = [
+  {
+    name: 'shipit',
+    date_added: 1730918816847,
+    added_by: 'Ignacio Ropolo',
+    image: 'https://github.githubassets.com/images/icons/emoji/shipit.png',
+    unicode_character: '1f44d',
+  },
+  {
+    name: 'thumbs up',
+    category: 'people',
+    shortname: ':thumbsup:',
+    shortname_alternates: [':+1:', ':thumbup:'],
+    keywords: ['+1', 'hand', 'thumb', 'up', 'uc6'],
+    unicode_output: '1f44d',
+    unicode_character: '1f44d',
+  },
+];
+
 export const argsData = {
   onSkinTone: action('skin-tone'),
+  onAddEmoji: action('add-emoji'),
   onSelectedEmoji: action('selected-emoji'),
   onClose: action('close'),
+  onScrollBottomReached: action('scroll-bottom-reached'),
   tabSetLabels: [
     'Most recently used',
     'Smileys and people',
@@ -66,8 +87,11 @@ export const argsData = {
     'Objects',
     'Symbols',
     'Flags',
+    'Custom',
   ],
   recentlyUsedEmojis,
+  customEmojis,
+  addEmojiLabel: 'Add emoji',
   skinSelectorButtonTooltipLabel: 'Change default skin tone',
   searchNoResultsLabel: 'No results',
   searchResultsLabel: 'Search results',
@@ -97,7 +121,17 @@ export const argTypesData = {
       disable: true,
     },
   },
+  onAddEmoji: {
+    table: {
+      disable: true,
+    },
+  },
   onClose: {
+    table: {
+      disable: true,
+    },
+  },
+  onScrollBottomReached: {
     table: {
       disable: true,
     },

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.test.js
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.test.js
@@ -48,6 +48,24 @@ const MOCK_RECENTLY_USED_EMOJIS = [
     unicode_character: '1f470-1f3ff-2640',
   },
 ];
+const MOCK_CUSTOM_EMOJIS = [
+  {
+    name: 'shipit',
+    date_added: 1730918816847,
+    added_by: 'Ignacio Ropolo',
+    image: 'https://github.githubassets.com/images/icons/emoji/shipit.png',
+    unicode_character: '1f44d',
+  },
+  {
+    name: 'thumbs up',
+    category: 'people',
+    shortname: ':thumbsup:',
+    shortname_alternates: [':+1:', ':thumbup:'],
+    keywords: ['+1', 'hand', 'thumb', 'up', 'uc6'],
+    unicode_output: '1f44d',
+    unicode_character: '1f44d',
+  },
+];
 const MOCK_TAB_SET_LABELS = [
   'Most recently used',
   'Smileys and people',
@@ -58,6 +76,7 @@ const MOCK_TAB_SET_LABELS = [
   'Objects',
   'Symbols',
   'Flags',
+  'Custom',
 ];
 const MOCK_SKIN_SELECTOR_BUTTON_TOOLTIP_LABEL = 'Change default skin tone';
 const MOCK_SEARCH_RESULTS_LABEL = 'Search results';
@@ -69,6 +88,7 @@ const baseProps = {
   skinSelectorButtonTooltipLabel: MOCK_SKIN_SELECTOR_BUTTON_TOOLTIP_LABEL,
   tabSetLabels: MOCK_TAB_SET_LABELS,
   recentlyUsedEmojis: MOCK_RECENTLY_USED_EMOJIS,
+  customEmojis: MOCK_CUSTOM_EMOJIS,
   searchResultsLabel: MOCK_SEARCH_RESULTS_LABEL,
   searchNoResultsLabel: MOCK_SEARCH_NO_RESULTS_LABEL,
   searchPlaceholderLabel: MOCK_SEARCH_PLACEHOLDER_LABEL,
@@ -131,6 +151,13 @@ describe('DtEmojiPicker Tests', () => {
       expect(firstButton.attributes('aria-label')).toBe(MOCK_TAB_SET_LABELS[0]);
     });
 
+    it('Should render customs emojis tabset', () => {
+      const lastButton = wrapper.find('.d-tablist').findAll('button').at(MOCK_TAB_SET_LABELS.length - 1);
+
+      expect(lastButton.exists()).toBe(true);
+      expect(lastButton.attributes('aria-label')).toBe(MOCK_TAB_SET_LABELS[MOCK_TAB_SET_LABELS.length - 1]);
+    });
+
     it('Should render provided search placeholder label', () => {
       const searchInput = wrapper.find('.d-emoji-picker__search input');
 
@@ -156,6 +183,13 @@ describe('DtEmojiPicker Tests', () => {
 
       expect(fixedLabel.exists()).toBe(true);
       expect(fixedLabel.text()).toEqual(MOCK_TAB_SET_LABELS[0]);
+    });
+
+    it('Should render add emoji button', () => {
+      const addEmojiButton = wrapper.find('.d-emoji-picker__add-emoji');
+
+      expect(addEmojiButton.exists()).toBe(true);
+      expect(addEmojiButton.attributes('aria-label')).toBe('Add emoji');
     });
 
     describe('Skin tone selector tests', () => {
@@ -215,6 +249,7 @@ describe('DtEmojiPicker Tests', () => {
             'Objects',
             'Symbols',
             'Flags',
+            'Customs',
           ],
         };
 
@@ -227,9 +262,48 @@ describe('DtEmojiPicker Tests', () => {
         expect(firstButton.attributes('aria-label')).toBe(MOCK_TAB_SET_LABELS[1]);
       });
     });
+
+    describe('When customs emojis is not provided', () => {
+      it('Should not render customs emojis tabset', () => {
+        mockProps = {
+          ...baseProps,
+          customEmojis: [],
+          tabSetLabels: [
+            'Most recently used',
+            'Smileys and people',
+            'Nature',
+            'Food',
+            'Activity',
+            'Travel',
+            'Objects',
+            'Symbols',
+            'Flags',
+          ],
+        };
+
+        updateWrapper();
+
+        const lastButton = wrapper.find('.d-tablist').findAll('button').at(MOCK_TAB_SET_LABELS.length - 2);
+
+        expect(lastButton.exists()).toBe(true);
+        expect(lastButton.attributes('aria-label')).not.toBe(MOCK_TAB_SET_LABELS[MOCK_TAB_SET_LABELS.length - 1]);
+        expect(lastButton.attributes('aria-label')).toBe(MOCK_TAB_SET_LABELS[MOCK_TAB_SET_LABELS.length - 2]);
+      });
+    });
   });
 
   describe('Interactivity Tests', () => {
+    it('Should emit add-emoji event when add emoji button is clicked', async () => {
+      const addEmojiButton = wrapper.find('.d-emoji-picker__add-emoji');
+
+      expect(addEmojiButton.exists()).toBe(true);
+
+      await addEmojiButton.trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted('add-emoji')).toBeTruthy();
+    });
+
     it('Should emit selected-emoji event when emoji is clicked', async () => {
       const emoji = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__tab button');
 
@@ -344,6 +418,8 @@ describe('DtEmojiPicker Tests', () => {
       const firstSymbols = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(9) button');
       // White flag - Flags
       const firstFlags = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(10) button');
+      // shipit - Customs
+      const firstCustoms = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(11) button');
 
       await firstRecentlyUsed.trigger('keydown.Tab');
 
@@ -376,13 +452,17 @@ describe('DtEmojiPicker Tests', () => {
       await firstSymbols.trigger('keydown.Tab');
 
       expect(document.activeElement).toBe(firstFlags.element);
+
+      await firstFlags.trigger('keydown.Tab');
+
+      expect(document.activeElement).toBe(firstCustoms.element);
     });
 
     it('Should jump to skin selector from emoji-selector', async () => {
-      const firstFlags = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(10) button');
+      const firstCustoms = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(11) button');
       const skinSelector = wrapper.find('.d-emoji-picker__skin-selected button');
 
-      await firstFlags.trigger('keydown.Tab');
+      await firstCustoms.trigger('keydown.Tab');
 
       expect(document.activeElement).toBe(skinSelector.element);
     });

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.test.js
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.test.js
@@ -419,7 +419,7 @@ describe('DtEmojiPicker Tests', () => {
       // White flag - Flags
       const firstFlags = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(10) button');
       // shipit - Customs
-      const firstCustoms = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(11) button');
+      const firstCustoms = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-last-child(1) button');
 
       await firstRecentlyUsed.trigger('keydown.Tab');
 
@@ -459,7 +459,7 @@ describe('DtEmojiPicker Tests', () => {
     });
 
     it('Should jump to skin selector from emoji-selector', async () => {
-      const firstCustoms = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-child(11) button');
+      const firstCustoms = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__alignment:nth-last-child(1) button');
       const skinSelector = wrapper.find('.d-emoji-picker__skin-selected button');
 
       await firstCustoms.trigger('keydown.Tab');

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
@@ -6,6 +6,7 @@
       <emoji-tabset
         ref="tabsetRef"
         :emoji-filter="internalSearchQuery"
+        :show-custom-emojis-tab="showCustomEmojisTab"
         :show-recently-used-tab="showRecentlyUsedTab"
         :scroll-into-tab="scrollIntoTab"
         :tabset-labels="tabSetLabels"
@@ -36,6 +37,7 @@
         :search-results-label="searchResultsLabel"
         :search-no-results-label="searchNoResultsLabel"
         :recently-used-emojis="recentlyUsedEmojis"
+        :custom-emojis="customEmojis"
         :selected-tabset="selectedTabset"
         @scroll-into-tab="updateScrollIntoTab"
         @highlighted-emoji="updateHighlightedEmoji"
@@ -43,9 +45,19 @@
         @focus-skin-selector="$refs.skinSelectorRef.focusSkinSelector()"
         @focus-search-input="showSearch ? $refs.searchInputRef.focusSearchInput() : $refs.tabsetRef.focusTabset()"
         @keydown.esc="emits('close')"
+        @scroll-bottom-reached="emits('scroll-bottom-reached')"
       />
     </div>
     <div class="d-emoji-picker--footer">
+      <dt-button
+        v-if="showCustomEmojisTab && !highlightedEmoji"
+        importance="outlined"
+        :aria-label="addEmojiLabel"
+        class="d-emoji-picker__add-emoji"
+        @click="emits('add-emoji')"
+      >
+        {{ addEmojiLabel }}
+      </dt-button>
       <emoji-description :emoji="highlightedEmoji" />
       <emoji-skin-selector
         ref="skinSelectorRef"
@@ -67,6 +79,7 @@ import EmojiTabset from './modules/emoji_tabset.vue';
 import EmojiSelector from './modules/emoji_selector.vue';
 import EmojiSkinSelector from './modules/emoji_skin_selector.vue';
 import EmojiDescription from './modules/emoji_description.vue';
+import { DtButton } from '../button';
 import { computed, ref, watch } from 'vue';
 
 const props = defineProps({
@@ -82,6 +95,30 @@ const props = defineProps({
   recentlyUsedEmojis: {
     type: Array,
     default: () => ([]),
+  },
+
+  /**
+     * The array with custom emojis object
+     * This list is necessary to fill the custom tab
+     * @type {Array}
+     * @default []
+     * @example
+     * <dt-emoji-picker :customEmojis="[emojiObject, emojiObject]" />
+     */
+  customEmojis: {
+    type: Array,
+  },
+  /**
+     * The label for the add emoji button
+     * required false because it is still experimental
+     * @type {String}
+     * @example
+     * <dt-emoji-picker :addEmojiLabel="'Add emoji'" />
+     */
+  addEmojiLabel: {
+    type: String,
+    required: false,
+    default: 'Add emoji',
   },
 
   /**
@@ -128,7 +165,7 @@ const props = defineProps({
    * @example
    * <dt-emoji-picker
    *  :tabSetLabels="['Most recently used', 'Smileys and people', 'Nature',
-   *    'Food', 'Activity', 'Travel', 'Objects', 'Symbols', 'Flags']" />
+   *    'Food', 'Activity', 'Travel', 'Objects', 'Symbols', 'Flags', 'Custom']" />
    */
   tabSetLabels: {
     type: Array,
@@ -194,6 +231,13 @@ const emits = defineEmits(
     'selected-emoji',
 
     /**
+   * Emitted when the user reach bottom scroll
+   * This is being handled by handleScroll method
+   * @event scroll-bottom-reached
+   */
+    'scroll-bottom-reached',
+
+    /**
      * It will emit the selected skin tone
      * @event skin-tone
      * @param {String} skin - The selected skin tone from the skin selector
@@ -205,6 +249,12 @@ const emits = defineEmits(
      * @event close
      */
     'close',
+
+    /**
+     * Emitted when the user clicks on the add emoji button
+     * @event add-emoji
+     */
+    'add-emoji',
   ],
 );
 
@@ -214,7 +264,8 @@ const selectedTabset = ref({});
 
 const scrollIntoTab = ref(0);
 
-const showRecentlyUsedTab = computed(() => props.recentlyUsedEmojis.length > 0);
+const showRecentlyUsedTab = computed(() => props.recentlyUsedEmojis?.length > 0);
+const showCustomEmojisTab = computed(() => props.customEmojis?.length > 0);
 
 watch(
   () => props.searchQuery,

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker_constants.js
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker_constants.js
@@ -26,6 +26,7 @@ export const EMOJI_PICKER_CATEGORIES = {
   OBJECTS: 'Objects',
   SYMBOLS: 'Symbols',
   FLAGS: 'Flags',
+  CUSTOM: 'Custom',
 };
 
 export default {

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker_default.story.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker_default.story.vue
@@ -4,6 +4,8 @@
     :skin-selector-button-tooltip-label="$attrs.skinSelectorButtonTooltipLabel"
     :tab-set-labels="$attrs.tabSetLabels"
     :recently-used-emojis="$attrs.recentlyUsedEmojis"
+    :custom-emojis="$attrs.customEmojis"
+    :add-emoji-label="$attrs.addEmojiLabel"
     :search-results-label="$attrs.searchResultsLabel"
     :search-no-results-label="$attrs.searchNoResultsLabel"
     :search-placeholder-label="$attrs.searchPlaceholderLabel"
@@ -11,6 +13,8 @@
     :show-search="$attrs.showSearch"
     @skin-tone="skinTone = $event"
     @selected-emoji="$attrs.selectedEmoji"
+    @scroll-bottom-reached="$attrs.scrollBottomReached"
+    @add-emoji="$attrs.onAddEmoji($event)"
   />
 </template>
 

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_description.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_description.vue
@@ -6,7 +6,7 @@
       :alt="emoji.name"
       :aria-label="emoji.name"
       :title="emoji.name"
-      :src="`${CDN_URL + emoji.unicode_character}.png`"
+      :src="getImgSrc(emoji)"
     >
     <div>{{ emoji?.name }}</div>
   </div>
@@ -26,4 +26,12 @@ defineProps({
     default: null,
   },
 });
+
+function getImgSrc (emoji) {
+  if (emoji.date_added) { // if custom emoji
+    return emoji.image;
+  } else { // if regular emoji
+    return `${CDN_URL + emoji.unicode_character}.png`;
+  }
+}
 </script>

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
@@ -56,7 +56,7 @@
               :alt="emoji.name"
               :aria-label="emoji.name"
               :title="emoji.name"
-              :src="getImgSrc(emoji.unicode_character)"
+              :src="getImgSrc(emoji)"
               @error="handleImageError"
             >
           </button>
@@ -104,7 +104,7 @@
 /* eslint-disable max-len */
 /* eslint-disable max-lines */
 import { emojisGrouped as emojis } from '@dialpad/dialtone-emojis';
-import { computed, onMounted, onUnmounted, ref, watch, nextTick } from 'vue';
+import { computed, onMounted, onBeforeUnmount, ref, watch, nextTick } from 'vue';
 import { CDN_URL, ARROW_KEYS } from '@/components/emoji_picker/emoji_picker_constants';
 import { useKeyboardNavigation } from '@/components/emoji_picker/composables/useKeyboardNavigation';
 
@@ -167,6 +167,15 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
+
+  /**
+   * The list of custom emojis
+   * @type {Array}
+   */
+  customEmojis: {
+    type: Array,
+    default: () => [],
+  },
 });
 
 const emits = defineEmits([
@@ -190,6 +199,13 @@ const emits = defineEmits([
    * @param {Number} tab-index - The tab that was scrolled into
     */
   'scroll-into-tab',
+
+  /**
+   * Emitted when the user reach bottom scroll
+   * This event is used on handleScroll method
+   * @event scroll-bottom-reached
+   */
+  'scroll-bottom-reached',
 
   /**
    * Emitted when the user reach the end of the emoji list
@@ -237,18 +253,26 @@ const tabLabelObserver = ref(null);
  * The list of tabs
  * This is used to display the tabs
  */
-const TABS_DATA = ['Recently used', 'People', 'Nature', 'Food', 'Activity', 'Travel', 'Objects', 'Symbols', 'Flags'];
+const TABS_DATA = ['Recently used', 'People', 'Nature', 'Food', 'Activity', 'Travel', 'Objects', 'Symbols', 'Flags', 'Custom'];
 
 /**
  * The list of tab labels
  * This is used to display the tabs
- * This is a computed property because it will check if the recently used emojis list is empty
- * If it is empty, it will remove the recently used tab
+ * This is a computed property because it will check if the recently used emojis or custom emojis list is empty
+ * If it is empty, it will remove it
  */
 const tabLabels = computed(() => {
-  return props.recentlyUsedEmojis.length
-    ? props.tabsetLabels.map((label) => ({ label, ref: ref(null) }))
-    : props.tabsetLabels.slice(1).map((label) => ({ label, ref: ref(null) }));
+  let updateTabLabels = props.tabsetLabels.map((label) => ({ label, ref: ref(null) }));
+
+  if (props.recentlyUsedEmojis && !props.recentlyUsedEmojis.length) {
+    updateTabLabels = props.tabsetLabels.slice(1).map((label) => ({ label, ref: ref(null) }));
+  }
+
+  if (props.customEmojis && !props.customEmojis.length) {
+    updateTabLabels.pop();
+  }
+
+  return updateTabLabels;
 });
 
 /**
@@ -260,13 +284,19 @@ const fixedLabel = ref(tabLabels.value[0].label);
 /**
  * The list of tabs
  * This is used to display the tabs
- * This is a computed property because it will check if the recently used emojis list is empty
- * If it is empty, it will remove the recently used tab
+ * This is a computed property because it will check if the recently used emojis list or custom emojis is empty
+ * If it is empty, it will remove it
  * The difference between this and the tab labels is that this one will set the structure of tabs
  * and the tab labels will set the labels
  */
 const tabs = computed(() => {
-  return props.recentlyUsedEmojis.length ? TABS_DATA : TABS_DATA.slice(1);
+  const updateTabsOrder = props.recentlyUsedEmojis.length ? TABS_DATA : TABS_DATA.slice(1);
+
+  if (props.customEmojis && !props.customEmojis.length) {
+    updateTabsOrder.pop();
+  }
+
+  return updateTabsOrder;
 });
 
 /**
@@ -305,6 +335,19 @@ const debouncedSearch = debounce(() => {
 });
 
 /**
+ * handleScroll will be defined when user scroll
+ */
+const handleScroll = () => {
+  const container = listRef.value;
+  // TODO -- this will probably need to be updated if we add more emojis.
+  // because the container height will change.
+  // maybe with a nextTick similar of scrollToTab.
+  if (container.scrollTop + container.clientHeight >= container.scrollHeight) {
+    emits('scroll-bottom-reached');
+  }
+};
+
+/**
  * Update the current emojis list on skin tone changes
  * Also update the filtered emojis list
  * @listens skinTone
@@ -320,6 +363,15 @@ watch(currentEmojis, () => {
 watch(() => props.recentlyUsedEmojis,
   () => {
     emojis['Recently used'] = props.recentlyUsedEmojis;
+  }, { immediate: true });
+
+/**
+ * Update the custom emojis list on custom emojis prop changes
+ * @listens customEmojis
+ */
+watch(() => props.customEmojis,
+  () => {
+    emojis.Custom = props.customEmojis;
   }, { immediate: true });
 
 /**
@@ -381,7 +433,12 @@ function debounce (fn, delay = 300) {
 }
 
 function getImgSrc (emoji) {
-  return `${CDN_URL + emoji}.png`;
+  // TODO Update json structure to have a property for custom emojis and avoid using date_added
+  if (emoji.date_added) { // if custom emoji
+    return emoji.image;
+  } else { // if regular emoji
+    return CDN_URL + emoji.unicode_character + '.png';
+  }
 }
 
 /**
@@ -414,6 +471,10 @@ function resetScroll () {
   const container = listRef.value;
 
   container.scrollTop = 0;
+}
+
+function setBottomScrollListener () {
+  listRef.value.addEventListener('scroll', handleScroll);
 }
 
 /**
@@ -545,10 +606,12 @@ function focusLastEmoji () {
 
 onMounted(() => {
   setTabLabelObserver();
+  setBottomScrollListener();
 });
 
-onUnmounted(() => {
+onBeforeUnmount(() => {
   tabLabelObserver.value.disconnect();
+  listRef.value.removeEventListener('scroll', handleScroll);
 });
 
 defineExpose({

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_selector.vue
@@ -290,7 +290,7 @@ const fixedLabel = ref(tabLabels.value[0].label);
  * and the tab labels will set the labels
  */
 const tabs = computed(() => {
-  const updateTabsOrder = props.recentlyUsedEmojis.length ? TABS_DATA : TABS_DATA.slice(1);
+  const updateTabsOrder = props.recentlyUsedEmojis.length ? TABS_DATA.slice() : TABS_DATA.slice(1);
 
   if (props.customEmojis && !props.customEmojis.length) {
     updateTabsOrder.pop();

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
@@ -43,6 +43,7 @@ import {
   DtIconLightbulb,
   DtIconHeart,
   DtIconFlag,
+  DtIconTiktok,
 } from '@dialpad/dialtone-icons/vue3';
 
 const props = defineProps({
@@ -52,6 +53,16 @@ const props = defineProps({
    * @default false
    */
   showRecentlyUsedTab: {
+    type: Boolean,
+    default: false,
+  },
+
+  /**
+   * Whether to show the custom emojis tab or not
+   * @type {Boolean}
+   * @default false
+   */
+  showCustomEmojisTab: {
     type: Boolean,
     default: false,
   },
@@ -99,10 +110,15 @@ const TABS_DATA = [
   { label: EMOJI_PICKER_CATEGORIES.OBJECTS, icon: DtIconLightbulb },
   { label: EMOJI_PICKER_CATEGORIES.SYMBOLS, icon: DtIconHeart },
   { label: EMOJI_PICKER_CATEGORIES.FLAGS, icon: DtIconFlag },
+  { label: EMOJI_PICKER_CATEGORIES.CUSTOM, icon: DtIconTiktok },
 ];
 
 const tabs = computed(() => {
   const tabsData = props.showRecentlyUsedTab ? TABS_DATA : TABS_DATA.slice(1);
+  // if showCustomEmojisTab is false remove last index of TABS_DATA
+  if (!props.showCustomEmojisTab) {
+    tabsData.pop();
+  }
 
   return tabsData.map((tab, index) => ({
     ...tab,

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -212,6 +212,7 @@ export const argsData = {
       'Objects',
       'Symbols',
       'Flags',
+      'Custom',
     ],
     skinTone: 'Default',
   },


### PR DESCRIPTION
# Custom emojis feature on vue3 and tests

- Added tests
- Added some missing configurations needed for custom emojis on `emoji_selector.vue`
- Reverted workaround https://github.com/dialpad/dialtone/pull/773 because no need after this update.
- Since this will behave exactly like `recentlyUsedEmojis` it is required to provide `Custom` label to `tabSetLabels` prop.

This PR move forward custom emoji implementation on product.
Emoji picker component will probably continue receiving improvements till this feature is being released.
Follow up of https://github.com/dialpad/dialtone/pull/602