### PR TITLE
fix(popover): NO-JIRA remove aria-hidden

### DIFF
--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -4,7 +4,6 @@
     <portal v-if="modal && isOpen">
       <div
         class="d-modal--transparent"
-        :aria-hidden="modal && isOpen ? 'false' : 'true'"
         @click.prevent.stop
       />
     </portal>

--- a/packages/dialtone-vue3/components/popover/popover.vue
+++ b/packages/dialtone-vue3/components/popover/popover.vue
@@ -7,7 +7,6 @@
     >
       <div
         class="d-modal--transparent"
-        :aria-hidden="modal && isOpen ? 'false' : 'true'"
         @click.prevent.stop
       />
     </Teleport>


### PR DESCRIPTION
# fix(popover): NO-JIRA remove aria-hidden

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Removed aria-hidden from popover

## :bulb: Context

aria-hidden was causing warnings in the console like the below. I think this was legacy, we fully remove the element from the dom when closed so aria-hidden is not needed.

![image](https://github.com/user-attachments/assets/873a14b9-9437-4e7c-babb-cc4c328f1dec)

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.