### PR TITLE
fix(mention-suggestion): NO-JIRA add mention suggestions styles on build

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/rich-text-editor.less
+++ b/packages/dialtone-css/lib/build/less/components/rich-text-editor.less
@@ -69,3 +69,27 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+
+.d-mention-suggestion__container {
+  width: 100%;
+}
+.d-mention-suggestion__details-container {
+  width: 90%;
+}
+
+.d-mention-suggestion__presence {
+  min-width: fit-content;
+  margin-left: var(--dt-space-200);
+}
+
+.d-mention-suggestion__status {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: var(--dt-color-foreground-tertiary);
+  margin-left: var(--dt-space-100);
+}
+
+.d-mention-suggestion__divider {
+  color: var(--dt-color-foreground-tertiary);
+}

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
@@ -106,29 +106,3 @@ export default {
   },
 };
 </script>
-
-<style lang="less" scoped>
-.d-mention-suggestion__container {
-  width: 100%;
-}
-.d-mention-suggestion__details-container {
-  width: 90%;
-}
-
-.d-mention-suggestion__presence {
-  min-width: fit-content;
-  margin-left: var(--dt-space-200);
-}
-
-.d-mention-suggestion__status {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  color: var(--dt-color-foreground-tertiary);
-  margin-left: var(--dt-space-100);
-}
-
-.d-mention-suggestion__divider {
-  color: var(--dt-color-foreground-tertiary);
-}
-</style>

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
@@ -107,29 +107,3 @@ export default {
   },
 };
 </script>
-
-<style lang="less" scoped>
-.d-mention-suggestion__container {
-  width: 100%;
-}
-.d-mention-suggestion__details-container {
-  width: 90%;
-}
-
-.d-mention-suggestion__presence {
-  min-width: fit-content;
-  margin-left: var(--dt-space-200);
-}
-
-.d-mention-suggestion__status {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  color: var(--dt-color-foreground-tertiary);
-  margin-left: var(--dt-space-100);
-}
-
-.d-mention-suggestion__divider {
-  color: var(--dt-color-foreground-tertiary);
-}
-</style>


### PR DESCRIPTION
# fix(mention-suggestion): NO-JIRA add mention suggestions styles on build

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGxqaXd2Zm1sc2lsaXNhaDFsMTF3bmNuZm84dHVma21odHZ4ZG5xNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/s2qXK8wAvkHTO/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :bulb: Context
When trying to use the mentions improvements we added as part of https://github.com/dialpad/dialtone/pull/770/files I realized that the styles were not correctly imported in firespotter side.

Dialtone
<img width="961" alt="Screenshot 2025-05-30 at 10 58 54 AM" src="https://github.com/user-attachments/assets/04741fb2-56c7-4b3e-bcb5-37d3b645381b" />

vs firespotter
<img width="1914" alt="Screenshot 2025-05-30 at 10 59 38 AM" src="https://github.com/user-attachments/assets/3a0b0539-9850-4fc3-8795-3d2ddb703469" />
