### PR TITLE
docs(localization): add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,6 @@ import DtIllustrationBlankSpace from '@dialpad/dialtone-icons/vue3/blank-space';
 
 - Vue 2
 
-> ⚠️ Important ⚠️
->
-> You MUST initialize the localization plugin before using any Dialtone-vue component to avoid issues.
->
-> Refer to [Localization docs](https://dialtone.dialpad.com/vue/index.html?path=/docs/utilities-localization--docs) for more information.
-
 ```js
 // Named import
 import { DtButton } from "@dialpad/dialtone/vue2"

--- a/README.md
+++ b/README.md
@@ -131,11 +131,17 @@ import DtIllustrationBlankSpace from '@dialpad/dialtone-icons/vue3/blank-space';
 
 - Vue 2
 
+> ⚠️ Important ⚠️
+>
+> You MUST initialize the localization plugin before using any Dialtone-vue component to avoid issues.
+>
+> Refer to [Localization docs](https://dialtone.dialpad.com/vue/index.html?path=/docs/utilities-localization--docs) for more information.
+
 ```js
 // Named import
 import { DtButton } from "@dialpad/dialtone/vue2"
 
-// Default import (Prefered if using webpack as it is tree-shakeable by default)
+// Default import (Preferred if using webpack as it is tree-shakeable by default)
 import { DtButton } from "@dialpad/dialtone/vue2/lib/button"
 ```
 

--- a/packages/dialtone-vue2/.storybook/main.js
+++ b/packages/dialtone-vue2/.storybook/main.js
@@ -4,7 +4,7 @@ import { mergeConfig } from 'vite';
 const config = {
   stories: [
     '../@(components|directives|recipes|prototypes|localization)/**/*.stories.@(js|jsx|ts|tsx)',
-    '../@(components|directives|docs|functions|recipes)/**/*.mdx',
+    '../@(components|directives|docs|functions|recipes|localization)/**/*.mdx',
   ],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-a11y', 'storybook-dark-mode'],
   framework: {

--- a/packages/dialtone-vue2/localization/localization.mdx
+++ b/packages/dialtone-vue2/localization/localization.mdx
@@ -1,35 +1,136 @@
-import { Meta, Subtitle, Canvas, Story } from '@storybook/blocks';
+import {Meta, Subtitle, Canvas, Story} from '@storybook/blocks';
 import * as LocalizationStories from './localization.stories.js';
 
-<Meta of={LocalizationStories} />
+<Meta of={LocalizationStories}/>
 
-# Dialtone-vue localization plugin
+# Dialtone-vue localization
 
 <Subtitle>
-  Enables Dialtone-vue components localization.
-  It is very simple and powerful as it allows you to quickly switch between languages and requires minimal setup.
-  <br/>
-  ⚠️ You MUST initialize the localization plugin before using any Dialtone-vue component to avoid issues.
+    Localization capabilities are included within some dialtone-vue components by default.
+    Mostly on aria-labels available only to screen readers, but some others might include localized text that's visible.
 </Subtitle>
 
 <Canvas>
-  <Story of={LocalizationStories.Default} />
+    <Story of={LocalizationStories.Default}/>
 </Canvas>
 
-## Usage
+## Included components
 
-### Import
+Here’s a list with some of the components that include localization, not all of them might be listed here, this
+list is not exhaustive and might change in the future.
 
-#### Named import
+<ul>
+    <li className={"d-lst-disc"}>
+        <b>DtButton</b>
+        loading state aria label
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtChip</b>
+        close button
+        <i>(aria label and title)</i>
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtDatepicker</b>
+        close button
+        <i>(aria labels, tooltip texts and displayed text)</i>
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtEmojiPicker</b>
+        buttons
+        <i>(aria labels, tooltip texts and displayed text like tab labels, search placeholder, etc)</i>
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtIcon</b>
+        svg
+        <i>(aria label)</i>
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtPagination</b>
+        buttons
+        <i>(aria label)</i>
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtRichTextEditor</b>
+        Bubble menu
+        <i>(displayed text)</i>
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtModal, DtPopover, DtDropdown, DtNotice, DtImageViewer</b>
+        Close button (Visible and screen reader only)
+        <i>(aria-label and title)</i>
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtRecipeAttachmentCarousel</b>
+        buttons
+        <i>(aria-label and title)</i>
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtRecipeEditor</b> buttons
+        [Quick reply, Bold, Italics, Underline, etc]
+        <i>(aria-label and title)</i>
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtRecipeEmojiRow</b>
+        [Reaction count]
+        <i>(aria-label and tooltip text)</i>
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtRecipeGeneralRow</b>
+        [Typing icon, Active voice chat icon, unread count, dnd text, call button]
+        <i>(tooltip text, aria-label)</i>
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtRecipeGroupRow</b>
+        buttons
+        <i>(aria-label, tooltip-text)</i>
+    </li>
+    <li className={"d-lst-disc"}>
+        <b>DtRecipeUnreadPill</b>
+        [Default slot]
+        <i>(Default text)</i>
+    </li>
+</ul>
 
-`import { DialtoneLocalizationPlugin } from '@dialpad/dialtone/vue2';`
+## Import
 
-#### Default import
+### Named import
+
+`import { DialtoneLocalization } from '@dialpad/dialtone/vue2';`
+
+### Default import
 
 Preferred if using webpack as it is tree-shakeable by default
 
-`import { DialtoneLocalizationPlugin } from '@dialpad/dialtone/vue2/localization';`
+`import { DialtoneLocalization } from '@dialpad/dialtone/vue2/localization';`
 
-### Install
+## Usage
 
-`Vue.use(DialtoneLocalizationPlugin);`
+The `DialtoneLocalization` is a class, and it is exported from the package as a singleton,
+the dialtone components that include localization will use the instance or initialize it if
+it doesn't exist.
+
+However, you can also use the class directly to get some properties or change the current locale.
+
+### Initializing
+
+`const dialtonei18n = new DialtoneLocalization();`
+
+You can pass in a locale to the constructor. The default is `en-US`, e.g:
+
+`const dialtonei18n = new DialtoneLocalization('es-LA');`
+
+### Set the current locale
+
+`dialtonei18n.currentLocale = 'en-US';`
+
+### Get the current locale
+
+`dialtonei18n.currentLocale`
+
+### Get the allowed locales
+
+`dialtonei18n.allowedLocales`
+
+## Update Localized strings process
+
+TODO...

--- a/packages/dialtone-vue2/localization/localization.mdx
+++ b/packages/dialtone-vue2/localization/localization.mdx
@@ -1,0 +1,35 @@
+import { Meta, Subtitle, Canvas, Story } from '@storybook/blocks';
+import * as LocalizationStories from './localization.stories.js';
+
+<Meta of={LocalizationStories} />
+
+# Dialtone-vue localization plugin
+
+<Subtitle>
+  Enables Dialtone-vue components localization.
+  It is very simple and powerful as it allows you to quickly switch between languages and requires minimal setup.
+  <br/>
+  ⚠️ You MUST initialize the localization plugin before using any Dialtone-vue component to avoid issues.
+</Subtitle>
+
+<Canvas>
+  <Story of={LocalizationStories.Default} />
+</Canvas>
+
+## Usage
+
+### Import
+
+#### Named import
+
+`import { DialtoneLocalizationPlugin } from '@dialpad/dialtone/vue2';`
+
+#### Default import
+
+Preferred if using webpack as it is tree-shakeable by default
+
+`import { DialtoneLocalizationPlugin } from '@dialpad/dialtone/vue2/localization';`
+
+### Install
+
+`Vue.use(DialtoneLocalizationPlugin);`


### PR DESCRIPTION
# Add Dialtone i18n documentation

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/UYBXiQpLs0UsU/giphy.gif?cid=82a1493bu4pg9l2nhi84xb3bn7guinw1ezrcan0qnca061gj&ep=v1_gifs_trending&rid=giphy.gif&ct=g)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2460

## :book: Description

Added i18n documentation, still need to update the documentation on the translations process, but that'd be a separate PR.

## :bulb: Context

Dialtone localization was missing the documentation.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.