### PR TITLE
build: NO-JIRA fix pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 . "$(dirname "$0")/_/husky.sh"
 
-if [ -n "$(git diff -s --exit-code packages/dialtone-icons/src)" ]; then
+if [ -n "$(git diff -s --exit-code --staged packages/dialtone-icons/src)" ]; then
   pnpm nx run dialtone-icons:build;
   node ./packages/dialtone-vue2/localization/sync-icons.js;
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 . "$(dirname "$0")/_/husky.sh"
 
+if [ -n "$(git diff -s --exit-code packages/dialtone-icons/src)" ]; then
+  pnpm nx run dialtone-icons:build
+fi
+
 pnpm exec lint-staged --relative

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 . "$(dirname "$0")/_/husky.sh"
 
-if [ -n "$(git diff -s --exit-code --staged packages/dialtone-icons/src)" ]; then
+echo "Running pre-commit hook"
+
+if ! git diff --staged --quiet packages/dialtone-icons/src; then
+  echo "Detected changes to icons, rebuilding..."
   pnpm nx run dialtone-icons:build;
-  node ./packages/dialtone-vue2/localization/sync-icons.js;
+  git add packages/dialtone-icons/src/keywords-*;
 fi
 
 pnpm exec lint-staged --relative

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,8 @@
 . "$(dirname "$0")/_/husky.sh"
 
 if [ -n "$(git diff -s --exit-code packages/dialtone-icons/src)" ]; then
-  pnpm nx run dialtone-icons:build
+  pnpm nx run dialtone-icons:build;
+  node ./packages/dialtone-vue2/localization/sync-icons.js;
 fi
 
 pnpm exec lint-staged --relative

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,8 +1,9 @@
 module.exports = {
-  '*.{vue}': [
+  '*.{js,mjs,cjs,vue}': [
+    'eslint --fix',
     'vitest related --run',
   ],
-  '*.{vue,js,mjs,cjs,json}': [
+  '*.json': [
     'eslint --fix',
   ],
   '*.less': [

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,11 +1,8 @@
 module.exports = {
-  '*.{js,mjs,cjs,vue}': [
-    'eslint --fix',
+  '*.{vue}': [
     'vitest related --run',
   ],
-  // using function syntax here so we can run the command without lint staged automatically passing filenames to it.
-  '**/dialtone-icons/src/keywords-*.json': (filenames) => 'nx run dialtone-icons:build --skip-nx-cache',
-  '*.json': [
+  '*.{vue,js,mjs,cjs,json}': [
     'eslint --fix',
   ],
   '*.less': [

--- a/packages/dialtone-icons/README.md
+++ b/packages/dialtone-icons/README.md
@@ -60,12 +60,12 @@ import illustrationsList from '@dialpad/dialtone-icons/illustrations.js';
 
 ## Committing
 
-1. Place the `.svg` files into the category folder inside these directory depending if it's an icon or an illustration:
+1. Place the `.svg` files into the category folder inside these directory depending on if it's an icon or an illustration:
 
     - icon: `src/svg/icons`
     - illustration: `src/svg/illustrations`
 
-2. Run `nx run dialtone-icons:build`
+2. Add necessary keywords to the `keywords-icons.json` or `keywords-illustrations.json` file.
 3. Commit and push your changes.
 
 ## Requesting features / reporting bugs


### PR DESCRIPTION
# Fix pre-commit hook

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3YwYmJmb3Q4ZXR4NmI4eXRxMjEyd2QxN2NkM2txdXpmZ2pzdHp0byZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/x5MLR0lEzWP7Mi3p1u/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [x] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Description

- Removed building icons on lint-staged when a change to `keywords-*.json` under `packages/dialtone-icons` is made.
- Added a script to pre-commit hook to build icons and commit `keywords-*.json` files if a change under `packages/dialtone-icons` is detected.

## :bulb: Context

lint-staged runs the command in parallel, this was causing issues when merging commits that contained changes to `keywords-*.json` and Vue files, as lint-staged would build icons and run the vue tests in parallel, causing the mentioned issues.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

## :link: Sources

- [lint-staged - Task Concurrency](https://github.com/lint-staged/lint-staged?tab=readme-ov-file#task-concurrency)
