### PR TITLE
fix(combobox-multi-select): DLT-2580 input text not hiding

### DIFF
--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -734,22 +734,22 @@ export default {
     async handleInputFocusIn () {
       this.inputFocused = true;
       if (this.collapseOnFocusOut) {
+        this.hideInputText = false;
         await this.$nextTick();
         this.setInputPadding();
-        this.hideInputText = false;
       }
     },
 
     async handleInputFocusOut () {
       this.inputFocused = false;
       if (this.collapseOnFocusOut) {
+        this.hideInputText = true;
         const input = this.getInput();
         if (!input) return;
         // Hide the input text when is not on first line
         if (!input.style.paddingTop) {
           return;
         }
-        this.hideInputText = true;
         this.revertInputPadding(input);
       }
     },

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -728,22 +728,22 @@ export default {
     async handleInputFocusIn () {
       this.inputFocused = true;
       if (this.collapseOnFocusOut) {
+        this.hideInputText = false;
         await this.$nextTick();
         this.setInputPadding();
-        this.hideInputText = false;
       }
     },
 
     async handleInputFocusOut () {
       this.inputFocused = false;
       if (this.collapseOnFocusOut) {
+        this.hideInputText = true;
         const input = this.getInput();
         if (!input) return;
         // Hide the input text when is not on first line
         if (!input.style.paddingTop) {
           return;
         }
-        this.hideInputText = true;
         this.revertInputPadding(input);
       }
     },


### PR DESCRIPTION
# Fix input text not hiding when collapsing on focus out

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZnRqdDVwanZ3ZnUyYTJ0bHFnZTNmaWUwbDZ1NXhpYWtwYXF2N2hlaiZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/j2FvSxxKF0ctNKDaSY/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2580

## :book: Description

Set the `hideInputText` before trying to get the input as it might run into a race condition or not finding the input and then setting the `hideInputText` to false.

## :bulb: Context

The input text was not being hidden when the input was collapsed on focus out.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.