### PR TITLE
ci: NO-JIRA remove unneeded release branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,11 +6,8 @@ on:
     branches:
       - alpha
       - beta
-      - legacy
-      - next
       - production
       - staging
-      - rebrand-2025-beta
 
     paths:
       - 'packages/**'
@@ -80,8 +77,8 @@ jobs:
       DIALTONE_BUCKET_DIRECTORY: dialtone.dialpad.com${{ github.ref == 'refs/heads/production' && '/' || format('/{0}/', needs.get-branch-name.outputs.current_branch) }}
       DIALTONE_VUE_2_BUCKET_DIRECTORY: dialtone.dialpad.com/vue${{ github.ref == 'refs/heads/production' && '/' || format('/{0}/', needs.get-branch-name.outputs.current_branch) }}
       DIALTONE_VUE_3_BUCKET_DIRECTORY: dialtone.dialpad.com/vue3${{ github.ref == 'refs/heads/production' && '/' || format('/{0}/', needs.get-branch-name.outputs.current_branch) }}
-      DIALTONE_BUCKET_CLEANUP_EXCLUDE: '/alpha/|/beta/|/legacy/|/next/|/deploy-previews/|/vue/|/vue3/|/staging/|/rebrand-2025-beta/'
-      DIALTONE_VUE_BUCKET_CLEANUP_EXCLUDE: '/alpha/|/beta/|/legacy/|/next/|/deploy-previews/|/staging/|/rebrand-2025-beta/'
+      DIALTONE_BUCKET_CLEANUP_EXCLUDE: '/alpha/|/beta/|/deploy-previews/|/vue/|/vue3/|/staging/'
+      DIALTONE_VUE_BUCKET_CLEANUP_EXCLUDE: '/alpha/|/beta/|/deploy-previews/|/staging/'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -14,7 +14,6 @@ on:
   push:
     branches:
       - production
-      - rebrand-2025-beta
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -24,8 +24,6 @@ on:
       - production
       - alpha
       - beta
-      - next
-      - rebrand-2025-beta
 
 env:
   HUSKY: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
   release:
     needs: [get-branch-name, check-dialpad-member]
-    if: ${{ contains(fromJSON('["staging", "next", "alpha", "beta", "rebrand-2025-beta"]'), needs.get-branch-name.outputs.current_branch) }}
+    if: ${{ contains(fromJSON('["staging", "alpha", "beta"]'), needs.get-branch-name.outputs.current_branch) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -2,7 +2,7 @@ name: Visual Tests
 
 on:
   push:
-    branches: [ staging, rebrand-2025-beta ]
+    branches: [ staging ]
   pull_request:
     types: [ unlabeled, labeled, synchronize, opened ]
 
@@ -93,5 +93,5 @@ jobs:
       - name: Run Dialtone-vue 2 Visual Tests
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          PERCY_TARGET_BRANCH: ${{ needs.get-branch-name.outputs.current_branch == 'rebrand-2025-beta' && 'staging' || github.base_ref }}
+          PERCY_TARGET_BRANCH: ${{ github.base_ref }}
         run: pnpm nx run --verbose dialtone-vue2:test:visual

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ npm run dev
 
 Currently, Dialtone packages are being released in two different ways: `scheduled` and `manually`.
 The `scheduled` release will only release changes to `production` while `manually` you can choose to release
-`alpha`, `beta` or `next` branches.
+`alpha` or `beta` branches.
 
 #### Production
 
@@ -433,11 +433,11 @@ This will trigger the [release action](.github/workflows/release.yml), release c
 3. Push the `production` branch.
 4. The [publish action](https://github.com/dialpad/dialtone/actions/workflows/publish.yml) will publish the packages with its corresponding tag.
 
-#### Alpha/Beta/Next
+#### Alpha/Beta
 
 1. Merge your changes to the branch you want to release, commit and push to origin. (Note: If your dialtone version number is behind the last production release number, it may fail. Merge in staging or update the version number manually.)
 2. Go to [GitHub](https://github.com/dialpad/dialtone/actions/workflows/release.yml) and click on `Run workflow`.
-3. Select `alpha`, `beta` or `next` branch.
+3. Select `alpha` or `beta` branch.
 4. Select the `package` that you want to release or leave it empty to release all of them.
 
 This will trigger the [release action](.github/workflows/release.yml), release changes on the selected branch and automatically publish the selected packages following the next steps:

--- a/packages/combinator/release-ci.config.cjs
+++ b/packages/combinator/release-ci.config.cjs
@@ -41,7 +41,6 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,

--- a/packages/dialtone-css/release-ci.config.cjs
+++ b/packages/dialtone-css/release-ci.config.cjs
@@ -41,7 +41,6 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,

--- a/packages/dialtone-emojis/release-ci.config.cjs
+++ b/packages/dialtone-emojis/release-ci.config.cjs
@@ -47,17 +47,12 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,
     },
     {
       name: 'alpha',
-      prerelease: true,
-    },
-    {
-      name: 'rebrand-2025-beta',
       prerelease: true,
     },
   ],

--- a/packages/dialtone-icons/release-ci.config.cjs
+++ b/packages/dialtone-icons/release-ci.config.cjs
@@ -51,17 +51,12 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,
     },
     {
       name: 'alpha',
-      prerelease: true,
-    },
-    {
-      name: 'rebrand-2025-beta',
       prerelease: true,
     },
   ],

--- a/packages/dialtone-tokens/release-ci.config.cjs
+++ b/packages/dialtone-tokens/release-ci.config.cjs
@@ -45,17 +45,12 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,
     },
     {
       name: 'alpha',
-      prerelease: true,
-    },
-    {
-      name: 'rebrand-2025-beta',
       prerelease: true,
     },
   ],

--- a/packages/dialtone-vue2/release-ci.config.cjs
+++ b/packages/dialtone-vue2/release-ci.config.cjs
@@ -41,7 +41,6 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,

--- a/packages/dialtone-vue3/release-ci.config.cjs
+++ b/packages/dialtone-vue3/release-ci.config.cjs
@@ -41,7 +41,6 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,

--- a/packages/eslint-plugin-dialtone/release-ci.config.cjs
+++ b/packages/eslint-plugin-dialtone/release-ci.config.cjs
@@ -41,7 +41,6 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,

--- a/packages/language-server/server/release-ci.config.cjs
+++ b/packages/language-server/server/release-ci.config.cjs
@@ -41,7 +41,6 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,

--- a/packages/language-server/vscode/release-ci.config.cjs
+++ b/packages/language-server/vscode/release-ci.config.cjs
@@ -48,7 +48,6 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,

--- a/packages/postcss-responsive-variations/release-ci.config.cjs
+++ b/packages/postcss-responsive-variations/release-ci.config.cjs
@@ -41,7 +41,6 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,

--- a/packages/stylelint-plugin-dialtone/release-ci.config.cjs
+++ b/packages/stylelint-plugin-dialtone/release-ci.config.cjs
@@ -41,7 +41,6 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,

--- a/release-ci.config.cjs
+++ b/release-ci.config.cjs
@@ -42,17 +42,12 @@ module.exports = {
   ],
   branches: [
     'staging',
-    'next',
     {
       name: 'beta',
       prerelease: true,
     },
     {
       name: 'alpha',
-      prerelease: true,
-    },
-    {
-      name: 'rebrand-2025-beta',
       prerelease: true,
     },
   ],


### PR DESCRIPTION
# Remove unneeded release branches

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbm5teXp4eTVkNG93MHRwbTh5czlyajRwMG1ndm40djZqaW4zbHd3cSZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/JltOMwYmi0VrO/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [x] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Description

- Removed `next` and `rebrand-2025-beta` release branches as they're no longer needed and might cause issues with release tags.

## :bulb: Context

- Issues with release versioning tags are occurring due to releases made from `next` branch.
- `rebrand-2025-beta` branch is no longer needed.


## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.
