### PR TITLE
ci: NO-JIRA improve visual test action run

### DIFF
--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -3,8 +3,40 @@ name: Visual Tests
 on:
   push:
     branches: [ staging ]
+    paths:
+      - 'packages/dialtone-css/lib/build/less/**/*.less'
+      - 'packages/dialtone-css/postcss/*.cjs'
+      - 'packages/dialtone-css/gulpfile.cjs'
+      - 'packages/dialtone-emojis/src/**'
+      - 'packages/dialtone-icons/src/**'
+      - 'packages/dialtone-icons/gulpfile.cjs'
+      - 'packages/dialtone-tokens/*.js'
+      - 'packages/dialtone-tokens/postcss/**'
+      - 'packages/dialtone-tokens/themes/**'
+      - 'packages/dialtone-tokens/tokens/**'
+      - 'packages/dialtone-tokens/gulpfile.cjs'
+      - 'packages/dialtone-vue2/**/*.vue'
+      - 'packages/dialtone-vue2/**/*.stories.js'
+      - 'packages/dialtone-vue2/percy.config.js'
+      - '!**/*.test.*js'
   pull_request:
     types: [ unlabeled, labeled, synchronize, opened ]
+    paths:
+      - 'packages/dialtone-css/lib/build/less/**/*.less'
+      - 'packages/dialtone-css/postcss/*.cjs'
+      - 'packages/dialtone-css/gulpfile.cjs'
+      - 'packages/dialtone-emojis/src/**'
+      - 'packages/dialtone-icons/src/**'
+      - 'packages/dialtone-icons/gulpfile.cjs'
+      - 'packages/dialtone-tokens/*.js'
+      - 'packages/dialtone-tokens/postcss/**'
+      - 'packages/dialtone-tokens/themes/**'
+      - 'packages/dialtone-tokens/tokens/**'
+      - 'packages/dialtone-tokens/gulpfile.cjs'
+      - 'packages/dialtone-vue2/**/*.vue'
+      - 'packages/dialtone-vue2/**/*.stories.js'
+      - 'packages/dialtone-vue2/percy.config.js'
+      - '!**/*.test.*js'
 
 env:
   HUSKY: 0
@@ -14,37 +46,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  filter-actions:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      dialtone-vue-2: ${{ steps.filter.outputs.dialtone-vue-2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Filter actions by path
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            dialtone-vue-2:
-              - 'packages/dialtone-css/**'
-              - 'packages/dialtone-icons/**'
-              - 'packages/dialtone-tokens/**'
-              - 'packages/dialtone-vue2/**'
-
   prompt-for-label:
-    needs: filter-actions
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     permissions:
       pull-requests: write
     steps:
       - name: Add label prompt message
         uses: mshick/add-pr-comment@v2
-        if: ${{ github.event_name == 'pull_request' && needs.filter-actions.outputs.dialtone-vue-2 == 'true' && (!contains(github.event.pull_request.labels.*.name, 'visual-test-ready') && !contains(github.event.pull_request.labels.*.name, 'no-visual-test')) }}
+        if: ${{ (!contains(github.event.pull_request.labels.*.name, 'visual-test-ready') && !contains(github.event.pull_request.labels.*.name, 'no-visual-test')) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -54,18 +64,8 @@ jobs:
           message-id: 'missing-visual-test-label'
           refresh-message-position: true
 
-  get-branch-name:
-    runs-on: ubuntu-latest
-    outputs:
-      current_branch: ${{ steps.branch-name.outputs.current_branch }}
-    steps:
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@v8
-
   dialtone-vue-2:
-    needs: [filter-actions, get-branch-name]
-    if: ${{ github.event_name == 'push' || (needs.filter-actions.outputs.dialtone-vue-2 == 'true' && contains(github.event.pull_request.labels.*.name, 'visual-test-ready')) }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'visual-test-ready')) }}
     runs-on: ubuntu-latest
     permissions:
       packages: read
@@ -73,22 +73,8 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v4
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "dialpad"
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
-
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
       - name: Run Dialtone-vue 2 Visual Tests
         env:

--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -43,7 +43,7 @@ env:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   prompt-for-label:


### PR DESCRIPTION
# Improve visual test action run

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaThweXBxNWwyejZtZ281NG91bjlvdDhxc3p3OXo2bjA1cDJ2MnAwZyZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/5IS10wa18fjJwri2af/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [x] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Description

- Added paths filter to the visual test action to avoid running on every push to staging with no changes to the UI, e.g: release commits.
- It will only require the label to be set if a change to the UI has been made.
- Improved conditional logic to avoid getting emails of "cancelled" workflows.

## :bulb: Context

- We should be running the visual test action only when there are changes to the UI.
- I was getting a lot of emails from cancelled workflows while running some actions, I'll be opening PR's to fix that.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

Continue improving other actions and workflows.