### PR TITLE
feat(list-item): DLT-2505 add wrapper class

### DIFF
--- a/packages/dialtone-vue2/components/list_item/list_item.test.js
+++ b/packages/dialtone-vue2/components/list_item/list_item.test.js
@@ -23,6 +23,7 @@ const testContext = {};
 
 describe('DtListItem tests', () => {
   let wrapper;
+  let listItemWrapper;
 
   const updateWrapper = () => {
     wrapper = mount(DtListItem, {
@@ -31,6 +32,8 @@ describe('DtListItem tests', () => {
       provide: { ...baseProvide, ...mockProvide },
       localVue: testContext.localVue,
     });
+
+    listItemWrapper = wrapper.find('[data-qa="dt-list-item-wrapper"]');
   };
 
   beforeAll(() => {
@@ -180,6 +183,18 @@ describe('DtListItem tests', () => {
         await wrapper.trigger('mouseleave');
 
         expect(wrapper.emitted().mouseleave.length).toBe(1);
+      });
+    });
+  });
+
+  describe('Extendability Tests', () => {
+    describe('When type is "default" and "wrapperClass" prop is provided', () => {
+      beforeEach(async () => {
+        await wrapper.setProps({ wrapperClass: 'custom-class' });
+      });
+
+      it('should apply the provided class to the wrapper.', () => {
+        expect(listItemWrapper.element.classList.contains('custom-class')).toBe(true);
       });
     });
   });

--- a/packages/dialtone-vue2/components/list_item/list_item.vue
+++ b/packages/dialtone-vue2/components/list_item/list_item.vue
@@ -17,7 +17,7 @@
     <dt-item-layout
       v-if="isDefaultType"
       unstyled
-      class="d-list-item__wrapper"
+      :class="['d-list-item__wrapper', wrapperClass]"
       left-class="d-list-item__left"
       content-class="d-list-item__content"
       title-class="d-list-item__title"
@@ -131,6 +131,15 @@ export default {
       type: Boolean,
       default: false,
     },
+
+    /**
+     * Class to apply to the wrapper element,
+     * note: it only applies to "default" type
+     */
+    wrapperClass: {
+      type: String,
+      default: '',
+    },
   },
 
   emits: [
@@ -176,8 +185,7 @@ export default {
 
   computed: {
     isDefaultType () {
-      if (this.type === LIST_ITEM_TYPES.DEFAULT) return true;
-      return false;
+      return this.type === LIST_ITEM_TYPES.DEFAULT;
     },
 
     listItemListeners () {

--- a/packages/dialtone-vue2/components/list_item/list_item.vue
+++ b/packages/dialtone-vue2/components/list_item/list_item.vue
@@ -25,6 +25,7 @@
       bottom-class="d-list-item__bottom"
       right-class="d-list-item__right"
       selected-class="d-list-item__selected"
+      data-qa="dt-list-item-wrapper"
     >
       <template
         v-for="(_, slotName) in $slots"

--- a/packages/dialtone-vue2/components/list_item/list_item.vue
+++ b/packages/dialtone-vue2/components/list_item/list_item.vue
@@ -134,11 +134,13 @@ export default {
     },
 
     /**
-     * Class to apply to the wrapper element,
-     * note: it only applies to "default" type
+     * Additional Classes to apply to the wrapper element,
+     * note: it only applies on "default" type
+     * Can accept all of: String, Object, and Array, i.e. has the
+     * same api as Vue's built-in handling of the class attribute.
      */
     wrapperClass: {
-      type: String,
+      type: [String, Object, Array],
       default: '',
     },
   },

--- a/packages/dialtone-vue2/components/list_item/list_item_default.story.vue
+++ b/packages/dialtone-vue2/components/list_item/list_item_default.story.vue
@@ -9,6 +9,7 @@
       :type="$attrs.type"
       :navigation-type="$attrs.navigationType"
       :selected="$attrs.selected"
+      :wrapper-class="$attrs.wrapperClass"
       @click="$attrs.onClick"
     >
       <template slot="left">

--- a/packages/dialtone-vue3/components/list_item/list_item.test.js
+++ b/packages/dialtone-vue3/components/list_item/list_item.test.js
@@ -22,6 +22,7 @@ let mockProvide = {};
 
 describe('DtListItem tests', () => {
   let wrapper;
+  let listItemWrapper;
 
   const updateWrapper = () => {
     wrapper = mount(DtListItem, {
@@ -31,6 +32,8 @@ describe('DtListItem tests', () => {
         provide: { ...baseProvide, ...mockProvide },
       },
     });
+
+    listItemWrapper = wrapper.find('[data-qa="dt-list-item-wrapper"]');
   };
 
   beforeEach(() => {
@@ -176,6 +179,18 @@ describe('DtListItem tests', () => {
         await wrapper.trigger('mouseleave');
 
         expect(wrapper.emitted().mouseleave.length).toBe(1);
+      });
+    });
+  });
+
+  describe('Extendability Tests', () => {
+    describe('When type is "default" and "wrapperClass" prop is provided', () => {
+      beforeEach(async () => {
+        await wrapper.setProps({ wrapperClass: 'custom-class' });
+      });
+
+      it('should apply the provided class to the wrapper.', () => {
+        expect(listItemWrapper.element.classList.contains('custom-class')).toBe(true);
       });
     });
   });

--- a/packages/dialtone-vue3/components/list_item/list_item.vue
+++ b/packages/dialtone-vue3/components/list_item/list_item.vue
@@ -135,11 +135,13 @@ export default {
     },
 
     /**
-     * Class to apply to the wrapper element,
-     * note: it only applies to "default" type
+     * Additional Classes to apply to the wrapper element,
+     * note: it only applies on "default" type
+     * Can accept all of: String, Object, and Array, i.e. has the
+     * same api as Vue's built-in handling of the class attribute.
      */
     wrapperClass: {
-      type: String,
+      type: [String, Object, Array],
       default: '',
     },
   },

--- a/packages/dialtone-vue3/components/list_item/list_item.vue
+++ b/packages/dialtone-vue3/components/list_item/list_item.vue
@@ -25,6 +25,7 @@
       bottom-class="d-list-item__bottom"
       right-class="d-list-item__right"
       selected-class="d-list-item__selected"
+      data-qa="dt-list-item-wrapper"
     >
       <template
         v-for="(_, slotName) in $slots"

--- a/packages/dialtone-vue3/components/list_item/list_item.vue
+++ b/packages/dialtone-vue3/components/list_item/list_item.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vuejs-accessibility/mouse-events-have-key-events -->
 <template>
   <component
     :is="elementType"
@@ -18,7 +17,7 @@
     <dt-item-layout
       v-if="isDefaultType"
       unstyled
-      class="d-list-item__wrapper"
+      :class="['d-list-item__wrapper', wrapperClass]"
       left-class="d-list-item__left"
       content-class="d-list-item__content"
       title-class="d-list-item__title"
@@ -133,6 +132,15 @@ export default {
       type: Boolean,
       default: false,
     },
+
+    /**
+     * Class to apply to the wrapper element,
+     * note: it only applies to "default" type
+     */
+    wrapperClass: {
+      type: String,
+      default: '',
+    },
   },
 
   emits: [
@@ -159,13 +167,6 @@ export default {
      * @type {MouseEvent}
      */
     'mouseleave',
-
-    /**
-     * Mouse down event
-     *
-     * @event mousedown
-     */
-    'mousedown',
   ],
 
   data () {

--- a/packages/dialtone-vue3/components/list_item/list_item_default.story.vue
+++ b/packages/dialtone-vue3/components/list_item/list_item_default.story.vue
@@ -9,6 +9,7 @@
       :type="$attrs.type"
       :navigation-type="$attrs.navigationType"
       :selected="$attrs.selected"
+      :wrapper-class="$attrs.wrapperClass"
     >
       <template #left>
         <dt-icon :name="$attrs.left" />


### PR DESCRIPTION
# Add wrapper class to list item

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTgyYTE0OTNiMnM1MWFwYjN5bDF3Ynp5NGlvejhtOHRzYjhwemFicGs0bTByY2N0MiZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/xdH0MjQ83lGFVv7gjR/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2505

## :book: Description

- Added wrapper class to list item
- Updated unit tests

## :bulb: Context

We were lacking on the ability to add a wrapper class to the list item.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.
