### PR TITLE
fix(message-input): DLT-2605 fix slash command and close button

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/slash_command/SlashCommandComponent.test.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/slash_command/SlashCommandComponent.test.js
@@ -1,0 +1,114 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import { Editor } from '@tiptap/vue-2';
+import Document from '@tiptap/extension-document';
+import Text from '@tiptap/extension-text';
+import Paragraph from '@tiptap/extension-paragraph';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import SlashCommandComponent from './SlashCommandComponent.vue';
+import { SlashCommandPlugin } from './slash_command.js';
+
+const baseProps = {
+  node: {
+    attrs: {
+      command: 'test-command',
+    },
+  },
+  editor: null,
+  getPos: () => 0,
+  updateAttributes: vi.fn(),
+  deleteNode: vi.fn(),
+  decorations: {},
+  selected: false,
+  extension: {},
+};
+
+const baseStubs = {
+  'node-view-wrapper': {
+    template: '<div class="d-d-inline-block"><slot /></div>',
+  },
+};
+
+let mockProps = {};
+let mockOnSelectedCommand;
+const testContext = {};
+
+describe('SlashCommandComponent', () => {
+  let wrapper;
+  let editor;
+
+  const updateWrapper = () => {
+    wrapper = mount(SlashCommandComponent, {
+      propsData: { ...baseProps, ...mockProps },
+      stubs: baseStubs,
+      localVue: testContext.localVue,
+    });
+  };
+
+  beforeEach(() => {
+    testContext.localVue = createLocalVue();
+    mockOnSelectedCommand = vi.fn();
+
+    // Create a minimal TipTap editor instance for testing
+    editor = new Editor({
+      extensions: [
+        Document,
+        Text,
+        Paragraph,
+        SlashCommandPlugin.configure({
+          onSelectedCommand: mockOnSelectedCommand,
+          suggestion: {
+            items: () => [
+              { command: 'test', description: 'Test command' },
+              { command: 'example', description: 'Example command' },
+            ],
+          },
+        }),
+      ],
+      content: '',
+    });
+
+    // Set up the editor storage
+    editor.storage['slash-commands'] = {
+      onSelectedCommand: mockOnSelectedCommand,
+    };
+
+    baseProps.editor = editor;
+
+    updateWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.destroy();
+    editor?.destroy();
+    vi.clearAllMocks();
+    mockProps = {};
+  });
+
+  describe('Component Creation', () => {
+    it('should render the component with correct text', () => {
+      expect(wrapper.exists()).toBe(true);
+      expect(wrapper.text()).toBe('/test-command');
+    });
+
+    it('should emit selected-command event when created', () => {
+      const emittedEvents = wrapper.emitted('selected-command');
+      expect(emittedEvents[0][0]).toBe('test-command');
+    });
+
+    it('should call onSelectedCommand callback when available in editor storage', () => {
+      expect(mockOnSelectedCommand).toHaveBeenCalledWith('test-command');
+    });
+
+    it('should handle missing onSelectedCommand callback gracefully', () => {
+      // Remove the callback from editor storage
+      editor.storage['slash-commands'] = {};
+
+      // Update wrapper with modified editor
+      updateWrapper();
+
+      // Should not throw an error and should still emit the component event
+      const emittedEvents = wrapper.emitted('selected-command');
+      expect(emittedEvents[0][0]).toBe('test-command');
+    });
+  });
+});

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/slash_command/SlashCommandComponent.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/slash_command/SlashCommandComponent.vue
@@ -16,7 +16,9 @@ export default {
     NodeViewWrapper,
   },
 
-  props: nodeViewProps,
+  props: {
+    ...nodeViewProps,
+  },
 
   emits: ['selected-command'],
 
@@ -27,7 +29,16 @@ export default {
   },
 
   created () {
-    this.$parent.$emit('selected-command', this.$props.node.attrs.command);
+    const command = this.$props.node.attrs.command;
+
+    // First emit the event using the component's own emit
+    this.$emit('selected-command', command);
+
+    // Access the callback from the editor's storage
+    const onSelectedCommand = this.editor?.storage?.['slash-commands']?.onSelectedCommand;
+    if (onSelectedCommand && typeof onSelectedCommand === 'function') {
+      onSelectedCommand(command);
+    }
   },
 };
 </script>

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/slash_command/slash_command.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/slash_command/slash_command.js
@@ -26,6 +26,19 @@ export const SlashCommandPlugin = Mention.extend({
   group: 'inline',
   inline: true,
 
+  addOptions () {
+    return {
+      ...this.parent?.(),
+      onSelectedCommand: null,
+    };
+  },
+
+  addStorage () {
+    return {
+      onSelectedCommand: this.options.onSelectedCommand,
+    };
+  },
+
   addNodeView () {
     return VueNodeViewRenderer(SlashCommandComponent);
   },

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.stories.js
@@ -27,6 +27,7 @@ export const argsData = {
   onHtmlInput: action('html-input'),
   onTextInput: action('text-input'),
   onEditLink: action('edit-link'),
+  onSelectedCommand: action('selected-command'),
 };
 
 export const argTypesData = {
@@ -107,6 +108,11 @@ export const argTypesData = {
     },
   },
   onEditLink: {
+    table: {
+      disable: true,
+    },
+  },
+  onSelectedCommand: {
     table: {
       disable: true,
     },

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.test.js
@@ -406,4 +406,73 @@ describe('DtRichTextEditor tests', () => {
       });
     });
   });
+
+  describe('Slash Command Event Tests', function () {
+    describe('When slash command suggestion is enabled', function () {
+      let mockSelectedCommandListener;
+      let slashCommandSuggestion;
+
+      beforeEach(async function () {
+        mockSelectedCommandListener = vi.fn();
+        slashCommandSuggestion = {
+          items: () => [
+            { command: 'test', description: 'Test command' },
+            { command: 'example', description: 'Example command' },
+          ],
+        };
+
+        await wrapper.setProps({
+          slashCommandSuggestion,
+        });
+
+        wrapper.vm.$on?.('selected-command', mockSelectedCommandListener) ||
+        wrapper.vm.$el?.addEventListener?.('selected-command', mockSelectedCommandListener);
+      });
+
+      it('should emit selected-command event when slash command component is created', async function () {
+        // Get the editor instance
+        const editorInstance = wrapper.vm.editor;
+
+        // Manually create a slash command node to simulate selection
+        const slashCommandNode = editorInstance.schema.nodes['slash-commands'].create({
+          command: 'test',
+        });
+
+        // Insert the node into the editor
+        const tr = editorInstance.state.tr.insert(0, slashCommandNode);
+        editorInstance.view.dispatch(tr);
+
+        await wrapper.vm.$nextTick();
+
+        // Check if the selected-command event was emitted
+        const emittedEvents = wrapper.emitted('selected-command');
+        expect(emittedEvents[0][0]).toBe('test');
+      });
+
+      it('should handle different slash commands correctly', async function () {
+        const editorInstance = wrapper.vm.editor;
+
+        // Test with different command
+        const slashCommandNode = editorInstance.schema.nodes['slash-commands'].create({
+          command: 'example',
+        });
+
+        const tr = editorInstance.state.tr.insert(0, slashCommandNode);
+        editorInstance.view.dispatch(tr);
+
+        await wrapper.vm.$nextTick();
+
+        const emittedEvents = wrapper.emitted('selected-command');
+        expect(emittedEvents[0][0]).toBe('example');
+      });
+    });
+
+    describe('When slash command suggestion is not enabled', function () {
+      it('should not emit selected-command events', function () {
+        // Default props don't include slashCommandSuggestion
+        const emittedEvents = wrapper.emitted('selected-command');
+        expect(emittedEvents).toBeFalsy();
+      });
+    });
+  });
 });

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -481,6 +481,13 @@ export default {
      * @type {String}
      */
     'selected',
+
+    /**
+     * Event fired when a slash command is selected
+     * @event selected-command
+     * @type {String}
+     */
+    'selected-command',
   ],
 
   data () {
@@ -599,7 +606,12 @@ export default {
       if (this.slashCommandSuggestion) {
         // Add both the suggestion plugin as well as means for user to add suggestion items to the plugin
         const suggestionObject = { ...this.slashCommandSuggestion, ...slashCommandSuggestion };
-        extensions.push(SlashCommandPlugin.configure({ suggestion: suggestionObject }));
+        extensions.push(SlashCommandPlugin.configure({
+          suggestion: suggestionObject,
+          onSelectedCommand: (command) => {
+            this.$emit('selected-command', command);
+          },
+        }));
       }
 
       // Emoji has some interactions with Enter key

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor_default.story.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor_default.story.vue
@@ -31,6 +31,7 @@
     @json-input="$attrs.onJsonInput"
     @html-input="$attrs.onHtmlInput"
     @text-input="$attrs.onTextInput"
+    @selected-command="$attrs.onSelectedCommand"
     @focus="$attrs.onFocus"
     @enter="$attrs.onEnter"
   />

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/extensions/meeting_pill/MeetingPill.test.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/extensions/meeting_pill/MeetingPill.test.js
@@ -1,0 +1,270 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import { Editor } from '@tiptap/vue-2';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Document from '@tiptap/extension-document';
+import Text from '@tiptap/extension-text';
+import Paragraph from '@tiptap/extension-paragraph';
+import MeetingPill from './MeetingPill.vue';
+import MeetingPillExtension from './meeting_pill.js';
+
+const baseProps = {
+  node: {
+    attrs: {
+      text: 'Test Meeting',
+      'close-button-aria-label': 'Close meeting',
+    },
+  },
+  editor: null,
+  getPos: () => 0,
+  updateAttributes: vi.fn(),
+  deleteNode: vi.fn(),
+  decorations: {},
+  selected: false,
+  extension: {},
+};
+
+const baseStubs = {
+  'dt-item-layout': {
+    template: '<div class="d-recipe-message-input-meeting-pill__layout"><slot name="left" /><slot /><slot name="right" /></div>',
+  },
+  'dt-button': {
+    template: '<button @click="$emit(\'click\', $event)" :aria-label="$attrs[\'aria-label\']" :title="$attrs.title"><slot name="icon" /></button>',
+    inheritAttrs: false,
+  },
+  'dt-icon-video': {
+    template: '<div data-testid="video-icon" />',
+  },
+  'dt-icon-close': {
+    template: '<div data-testid="close-icon" />',
+  },
+  'node-view-wrapper': {
+    template: '<div class="d-d-inline-block"><slot /></div>',
+    provide () {
+      return {
+        onDragStart: () => {},
+        decorationClasses: {
+          value: '',
+        },
+      };
+    },
+  },
+};
+
+let mockProps = {};
+const mockStubs = {};
+let mockOnClose;
+const testContext = {};
+
+describe('MeetingPill', () => {
+  let wrapper;
+  let editor;
+
+  const updateWrapper = () => {
+    wrapper = mount(MeetingPill, {
+      propsData: { ...baseProps, ...mockProps },
+      stubs: { ...baseStubs, ...mockStubs },
+      localVue: testContext.localVue,
+      mocks: {
+        i18n: {
+          $t: vi.fn(() => 'Close'),
+        },
+      },
+    });
+  };
+
+  beforeEach(() => {
+    testContext.localVue = createLocalVue();
+    mockOnClose = vi.fn();
+
+    editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        MeetingPillExtension.configure({
+          onClose: mockOnClose,
+        }),
+      ],
+      content: '',
+    });
+
+    // Set up the editor storage properly
+    editor.storage.meetingPill = {
+      onClose: mockOnClose,
+    };
+
+    baseProps.editor = editor;
+
+    updateWrapper();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.destroy();
+    }
+    if (editor) {
+      editor.destroy();
+    }
+    mockProps = {};
+  });
+
+  describe('Rendering', () => {
+    it('renders the meeting pill with correct text', () => {
+      mockProps = {
+        node: {
+          attrs: {
+            text: 'Daily Standup',
+            'close-button-aria-label': 'Close meeting',
+          },
+        },
+      };
+
+      updateWrapper();
+
+      expect(wrapper.text()).toContain('Daily Standup');
+    });
+
+    it('renders the video icon', () => {
+      expect(wrapper.find('[data-testid="video-icon"]').exists()).toBe(true);
+    });
+
+    it('renders the close button with correct aria-label', () => {
+      const closeButton = wrapper.find('button');
+      expect(closeButton.exists()).toBe(true);
+      expect(closeButton.attributes('aria-label')).toBe('Click to close');
+    });
+
+    it('renders the close icon', () => {
+      expect(wrapper.find('[data-testid="close-icon"]').exists()).toBe(true);
+    });
+  });
+
+  describe('Close functionality', () => {
+    it('calls the onClose callback when close button is clicked', async () => {
+      const closeButton = wrapper.find('button');
+      await closeButton.trigger('click');
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the click event to the onClose callback', async () => {
+      const closeButton = wrapper.find('button');
+      await closeButton.trigger('click');
+
+      expect(mockOnClose).toHaveBeenCalledWith(expect.any(Event));
+    });
+
+    it('handles missing onClose callback gracefully', async () => {
+      // Create editor without onClose callback
+      const editorWithoutCallback = new Editor({
+        extensions: [
+          Document,
+          Paragraph,
+          Text,
+          MeetingPillExtension.configure({}),
+        ],
+        content: '',
+      });
+
+      // Don't set up storage or set it as empty
+      editorWithoutCallback.storage.meetingPill = {};
+
+      mockProps = {
+        editor: editorWithoutCallback,
+        node: {
+          attrs: {
+            text: 'Test Meeting',
+            'close-button-aria-label': 'Close meeting',
+          },
+        },
+      };
+
+      updateWrapper();
+
+      const closeButton = wrapper.find('button');
+
+      // Should not throw an error
+      await expect(closeButton.trigger('click')).resolves.not.toThrow();
+
+      editorWithoutCallback.destroy();
+    });
+
+    it('handles editor without storage gracefully', async () => {
+      // Create a mock editor without the storage structure
+      const mockEditor = {
+        storage: {},
+      };
+
+      mockProps = {
+        editor: mockEditor,
+        node: {
+          attrs: {
+            text: 'Test Meeting',
+            'close-button-aria-label': 'Close meeting',
+          },
+        },
+      };
+
+      updateWrapper();
+
+      const closeButton = wrapper.find('button');
+
+      // Should not throw an error
+      await expect(closeButton.trigger('click')).resolves.not.toThrow();
+    });
+  });
+
+  describe('Event Emission', () => {
+    it('emits meeting-pill-close event', () => {
+      // The component declares the emit but the actual emission logic
+      // is handled through the callback, so we verify the event is declared
+      expect(wrapper.vm.$options.emits).toContain('meeting-pill-close');
+    });
+  });
+
+  describe('Props', () => {
+    it('accepts nodeViewProps', () => {
+      expect(wrapper.vm.node).toBeDefined();
+      expect(wrapper.vm.editor).toBeDefined();
+      expect(wrapper.vm.getPos).toBeDefined();
+    });
+
+    it('displays different text based on node attributes', () => {
+      mockProps = {
+        node: {
+          attrs: {
+            text: 'Team Meeting',
+            'close-button-aria-label': 'Close meeting',
+          },
+        },
+      };
+
+      updateWrapper();
+
+      expect(wrapper.text()).toContain('Team Meeting');
+    });
+
+    it('uses different aria-label based on node attributes', () => {
+      // Since the closeButtonTitle is computed from i18n, not from node attrs,
+      // let's test that the closeButtonTitle computed property works
+      expect(wrapper.vm.closeButtonTitle).toBe('Click to close');
+    });
+  });
+
+  describe('Component Structure', () => {
+    it('has the correct component name', () => {
+      expect(wrapper.vm.$options.name).toBe('MeetingPill');
+    });
+
+    it('wraps content in NodeViewWrapper', () => {
+      expect(wrapper.find('.d-recipe-message-input-meeting-pill').exists()).toBe(true);
+    });
+
+    it('uses DtItemLayout for structure', () => {
+      // Since we're stubbing the component, we check for the layout structure
+      // The stubbed dt-item-layout should render as a div with slots
+      const layout = wrapper.find('.d-recipe-message-input-meeting-pill__layout');
+      expect(layout.exists()).toBe(true);
+    });
+  });
+});

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/extensions/meeting_pill/MeetingPill.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/extensions/meeting_pill/MeetingPill.vue
@@ -66,7 +66,12 @@ export default {
 
   methods: {
     close (e) {
-      this.$parent.$emit('meeting-pill-close', e);
+      // Get the callback from extension storage
+      const onCloseCallback = this.editor?.storage?.meetingPill?.onClose;
+
+      if (onCloseCallback && typeof onCloseCallback === 'function') {
+        onCloseCallback(e);
+      }
     },
   },
 };

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/extensions/meeting_pill/meeting_pill.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/extensions/meeting_pill/meeting_pill.js
@@ -3,10 +3,23 @@ import { VueNodeViewRenderer } from '@tiptap/vue-2';
 import MeetingPill from './MeetingPill.vue';
 
 export default Node.create({
+  name: 'meetingPill',
 
   atom: true,
   group: 'inline',
   inline: true,
+
+  addOptions () {
+    return {
+      onClose: () => {},
+    };
+  },
+
+  addStorage () {
+    return {
+      onClose: this.options.onClose,
+    };
+  },
 
   addNodeView () {
     return VueNodeViewRenderer(MeetingPill);

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -75,6 +75,7 @@
         @text-input="onTextInput"
         @enter="onSend"
         @selected="selectedText = $event"
+        @selected-command="$emit('selected-command', $event)"
         @edit-link="initLinkDialog"
         @focus="isFocused = true"
         @blur="isFocused = false"
@@ -755,7 +756,14 @@ export default {
       // If an ordered list is nested within an unordered list, we only want to show the currently selected list as
       // active. This function performs the logic to determine the farthest active node from the root.
       lastActiveNodes,
-      additionalExtensions: [MeetingPill],
+      additionalExtensions: [
+        MeetingPill.configure({
+          onClose: (event) => {
+            this.$emit('meeting-pill-close', event);
+          },
+        }),
+      ],
+
       internalInputValue: this.value, // internal input content
       imagePickerFocus: false,
       emojiPickerFocus: false,
@@ -773,7 +781,6 @@ export default {
   },
 
   computed: {
-
     showSendIcon () {
       return !this.showSend.text;
     },

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -114,12 +114,12 @@ export default {
   components: { DtRecipeMessageInput, DtIcon },
   data () {
     return {
-      value: this.$attrs.modelValue,
+      value: this.$attrs.value,
     };
   },
 
   watch: {
-    '$attrs.modelValue' (value) {
+    '$attrs.value' (value) {
       this.value = value;
     },
   },

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -3,7 +3,7 @@
     <div class="d-h264">
       <dt-recipe-message-input
         ref="input"
-        v-model="$attrs.value"
+        v-model="value"
         :input-aria-label="$attrs.inputAriaLabel"
         :auto-focus="$attrs.autoFocus"
         :rich-text="$attrs.richText"
@@ -112,5 +112,16 @@ import { DtIcon } from '@/components/icon';
 export default {
   name: 'DtRecipeMessageInputDefault',
   components: { DtRecipeMessageInput, DtIcon },
+  data () {
+    return {
+      value: this.$attrs.modelValue,
+    };
+  },
+
+  watch: {
+    '$attrs.modelValue' (value) {
+      this.value = value;
+    },
+  },
 };
 </script>

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/slash_command/SlashCommandComponent.test.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/slash_command/SlashCommandComponent.test.js
@@ -1,0 +1,101 @@
+import { mount } from '@vue/test-utils';
+import { Editor } from '@tiptap/vue-3';
+import Document from '@tiptap/extension-document';
+import Text from '@tiptap/extension-text';
+import Paragraph from '@tiptap/extension-paragraph';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import SlashCommandComponent from './SlashCommandComponent.vue';
+import { SlashCommandPlugin } from './slash_command.js';
+
+const baseProps = {
+  node: {
+    attrs: {
+      command: 'test-command',
+    },
+  },
+  editor: null,
+  getPos: () => 0,
+  updateAttributes: vi.fn(),
+  deleteNode: vi.fn(),
+};
+
+let mockProps = {};
+let mockOnSelectedCommand;
+
+describe('SlashCommandComponent', () => {
+  let wrapper;
+  let editor;
+
+  const updateWrapper = () => {
+    wrapper = mount(SlashCommandComponent, {
+      props: { ...baseProps, ...mockProps },
+    });
+  };
+
+  beforeEach(() => {
+    mockOnSelectedCommand = vi.fn();
+
+    // Create a minimal TipTap editor instance for testing
+    editor = new Editor({
+      extensions: [
+        Document,
+        Text,
+        Paragraph,
+        SlashCommandPlugin.configure({
+          onSelectedCommand: mockOnSelectedCommand,
+          suggestion: {
+            items: () => [
+              { command: 'test', description: 'Test command' },
+              { command: 'example', description: 'Example command' },
+            ],
+          },
+        }),
+      ],
+      content: '',
+    });
+
+    // Set up the editor storage
+    editor.storage['slash-commands'] = {
+      onSelectedCommand: mockOnSelectedCommand,
+    };
+
+    baseProps.editor = editor;
+
+    updateWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    editor?.destroy();
+    vi.clearAllMocks();
+    mockProps = {};
+  });
+
+  describe('Component Creation', () => {
+    it('should render the component with correct text', () => {
+      expect(wrapper.exists()).toBe(true);
+      expect(wrapper.text()).toBe('/test-command');
+    });
+
+    it('should emit selected-command event when created', () => {
+      const emittedEvents = wrapper.emitted('selected-command');
+      expect(emittedEvents[0][0]).toBe('test-command');
+    });
+
+    it('should call onSelectedCommand callback when available in editor storage', () => {
+      expect(mockOnSelectedCommand).toHaveBeenCalledWith('test-command');
+    });
+
+    it('should handle missing onSelectedCommand callback gracefully', () => {
+      // Remove the callback from editor storage
+      editor.storage['slash-commands'] = {};
+
+      // Update wrapper with modified editor
+      updateWrapper();
+
+      // Should not throw an error and should still emit the component event
+      const emittedEvents = wrapper.emitted('selected-command');
+      expect(emittedEvents[0][0]).toBe('test-command');
+    });
+  });
+});

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/slash_command/SlashCommandComponent.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/slash_command/SlashCommandComponent.vue
@@ -17,7 +17,9 @@ export default {
     NodeViewWrapper,
   },
 
-  props: nodeViewProps,
+  props: {
+    ...nodeViewProps,
+  },
 
   emits: ['selected-command'],
 
@@ -28,7 +30,16 @@ export default {
   },
 
   created () {
-    this.$parent.$emit('selected-command', this.$props.node.attrs.command);
+    const command = this.$props.node.attrs.command;
+
+    // First emit the event using the component's own emit
+    this.$emit('selected-command', command);
+
+    // Access the callback from the editor's storage
+    const onSelectedCommand = this.editor?.storage?.['slash-commands']?.onSelectedCommand;
+    if (onSelectedCommand && typeof onSelectedCommand === 'function') {
+      onSelectedCommand(command);
+    }
   },
 };
 </script>

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/slash_command/slash_command.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/slash_command/slash_command.js
@@ -26,6 +26,19 @@ export const SlashCommandPlugin = Mention.extend({
   group: 'inline',
   inline: true,
 
+  addOptions () {
+    return {
+      ...this.parent?.(),
+      onSelectedCommand: null,
+    };
+  },
+
+  addStorage () {
+    return {
+      onSelectedCommand: this.options.onSelectedCommand,
+    };
+  },
+
   addNodeView () {
     return VueNodeViewRenderer(SlashCommandComponent);
   },

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -27,6 +27,7 @@ export const argsData = {
   onHtmlInput: action('html-input'),
   onTextInput: action('text-input'),
   onEditLink: action('edit-link'),
+  onSelectedCommand: action('selected-command'),
 };
 
 export const argTypesData = {
@@ -107,6 +108,11 @@ export const argTypesData = {
     },
   },
   onEditLink: {
+    table: {
+      disable: true,
+    },
+  },
+  onSelectedCommand: {
     table: {
       disable: true,
     },

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.test.js
@@ -434,4 +434,73 @@ describe('DtRichTextEditor tests', () => {
       });
     });
   });
+
+  describe('Slash Command Event Tests', function () {
+    describe('When slash command suggestion is enabled', function () {
+      let mockSelectedCommandListener;
+      let slashCommandSuggestion;
+
+      beforeEach(async function () {
+        mockSelectedCommandListener = vi.fn();
+        slashCommandSuggestion = {
+          items: () => [
+            { command: 'test', description: 'Test command' },
+            { command: 'example', description: 'Example command' },
+          ],
+        };
+
+        await wrapper.setProps({
+          slashCommandSuggestion,
+        });
+
+        wrapper.vm.$on?.('selected-command', mockSelectedCommandListener) ||
+        wrapper.vm.$el?.addEventListener?.('selected-command', mockSelectedCommandListener);
+      });
+
+      it('should emit selected-command event when slash command component is created', async function () {
+        // Get the editor instance
+        const editorInstance = wrapper.vm.editor;
+
+        // Manually create a slash command node to simulate selection
+        const slashCommandNode = editorInstance.schema.nodes['slash-commands'].create({
+          command: 'test',
+        });
+
+        // Insert the node into the editor
+        const tr = editorInstance.state.tr.insert(0, slashCommandNode);
+        editorInstance.view.dispatch(tr);
+
+        await wrapper.vm.$nextTick();
+
+        // Check if the selected-command event was emitted
+        const emittedEvents = wrapper.emitted('selected-command');
+        expect(emittedEvents[0][0]).toBe('test');
+      });
+
+      it('should handle different slash commands correctly', async function () {
+        const editorInstance = wrapper.vm.editor;
+
+        // Test with different command
+        const slashCommandNode = editorInstance.schema.nodes['slash-commands'].create({
+          command: 'example',
+        });
+
+        const tr = editorInstance.state.tr.insert(0, slashCommandNode);
+        editorInstance.view.dispatch(tr);
+
+        await wrapper.vm.$nextTick();
+
+        const emittedEvents = wrapper.emitted('selected-command');
+        expect(emittedEvents[0][0]).toBe('example');
+      });
+    });
+
+    describe('When slash command suggestion is not enabled', function () {
+      it('should not emit selected-command events', function () {
+        // Default props don't include slashCommandSuggestion
+        const emittedEvents = wrapper.emitted('selected-command');
+        expect(emittedEvents).toBeFalsy();
+      });
+    });
+  });
 });

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -479,6 +479,13 @@ export default {
      * @type {String}
      */
     'selected',
+
+    /**
+     * Event fired when a slash command is selected
+     * @event selected-command
+     * @type {String}
+     */
+    'selected-command',
   ],
 
   data () {
@@ -597,7 +604,12 @@ export default {
       if (this.slashCommandSuggestion) {
         // Add both the suggestion plugin as well as means for user to add suggestion items to the plugin
         const suggestionObject = { ...this.slashCommandSuggestion, ...slashCommandSuggestion };
-        extensions.push(SlashCommandPlugin.configure({ suggestion: suggestionObject }));
+        extensions.push(SlashCommandPlugin.configure({
+          suggestion: suggestionObject,
+          onSelectedCommand: (command) => {
+            this.$emit('selected-command', command);
+          },
+        }));
       }
 
       // Emoji has some interactions with Enter key

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
@@ -31,6 +31,7 @@
     @json-input="$attrs.onJsonInput"
     @html-input="$attrs.onHtmlInput"
     @text-input="$attrs.onTextInput"
+    @selected-command="$attrs.onSelectedCommand"
     @focus="$attrs.onFocus"
     @enter="$attrs.onEnter"
   />

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/extensions/meeting_pill/MeetingPill.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/extensions/meeting_pill/MeetingPill.test.js
@@ -1,0 +1,268 @@
+import { mount } from '@vue/test-utils';
+import { Editor } from '@tiptap/vue-3';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Document from '@tiptap/extension-document';
+import Text from '@tiptap/extension-text';
+import Paragraph from '@tiptap/extension-paragraph';
+import MeetingPill from './MeetingPill.vue';
+import MeetingPillExtension from './meeting_pill.js';
+
+const baseProps = {
+  node: {
+    attrs: {
+      text: 'Test Meeting',
+      'close-button-aria-label': 'Close meeting',
+    },
+  },
+  editor: null,
+  getPos: () => 0,
+  updateAttributes: vi.fn(),
+  deleteNode: vi.fn(),
+};
+
+const baseGlobal = {
+  stubs: {
+    'dt-item-layout': {
+      template: '<div><slot name="left" /><slot /><slot name="right" /></div>',
+    },
+    'dt-button': {
+      template: '<button @click="$emit(\'click\', $event)"><slot name="icon" /></button>',
+      emits: ['click'],
+    },
+    'dt-icon-video': {
+      template: '<div data-testid="video-icon" />',
+    },
+    'dt-icon-close': {
+      template: '<div data-testid="close-icon" />',
+    },
+  },
+};
+
+let mockProps = {};
+let mockGlobal = {};
+let mockOnClose;
+
+describe('MeetingPill', () => {
+  let wrapper;
+  let editor;
+
+  const updateWrapper = () => {
+    wrapper = mount(MeetingPill, {
+      props: { ...baseProps, ...mockProps },
+      global: { ...baseGlobal, ...mockGlobal },
+    });
+  };
+
+  beforeEach(() => {
+    mockOnClose = vi.fn();
+
+    editor = new Editor({
+      extensions: [
+        Document,
+        Paragraph,
+        Text,
+        MeetingPillExtension.configure({
+          onClose: mockOnClose,
+        }),
+      ],
+      content: '',
+    });
+
+    baseProps.editor = editor;
+
+    updateWrapper();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+    if (editor) {
+      editor.destroy();
+    }
+    mockProps = {};
+    mockGlobal = {};
+  });
+
+  describe('Rendering', () => {
+    it('renders the meeting pill with correct text', () => {
+      mockProps = {
+        node: {
+          attrs: {
+            text: 'Daily Standup',
+            'close-button-aria-label': 'Close meeting',
+          },
+        },
+      };
+
+      updateWrapper();
+
+      expect(wrapper.text()).toContain('Daily Standup');
+    });
+
+    it('renders the video icon', () => {
+      expect(wrapper.find('[data-testid="video-icon"]').exists()).toBe(true);
+    });
+
+    it('renders the close button with correct aria-label', () => {
+      mockProps = {
+        node: {
+          attrs: {
+            text: 'Test Meeting',
+            'close-button-aria-label': 'Close meeting pill',
+          },
+        },
+      };
+
+      updateWrapper();
+
+      const closeButton = wrapper.find('button');
+      expect(closeButton.exists()).toBe(true);
+      expect(closeButton.attributes('aria-label')).toBe('Close meeting pill');
+    });
+
+    it('renders the close icon', () => {
+      expect(wrapper.find('[data-testid="close-icon"]').exists()).toBe(true);
+    });
+  });
+
+  describe('Close functionality', () => {
+    it('calls the onClose callback when close button is clicked', async () => {
+      const closeButton = wrapper.find('button');
+      await closeButton.trigger('click');
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the click event to the onClose callback', async () => {
+      const closeButton = wrapper.find('button');
+      await closeButton.trigger('click');
+
+      expect(mockOnClose).toHaveBeenCalledWith(expect.any(Event));
+    });
+
+    it('handles missing onClose callback gracefully', async () => {
+      // Create editor without onClose callback
+      const editorWithoutCallback = new Editor({
+        extensions: [
+          Document,
+          Paragraph,
+          Text,
+          MeetingPillExtension.configure({}),
+        ],
+        content: '',
+      });
+
+      mockProps = {
+        editor: editorWithoutCallback,
+        node: {
+          attrs: {
+            text: 'Test Meeting',
+            'close-button-aria-label': 'Close meeting',
+          },
+        },
+      };
+
+      updateWrapper();
+
+      const closeButton = wrapper.find('button');
+
+      // Should not throw an error
+      expect(async () => {
+        await closeButton.trigger('click');
+      }).not.toThrow();
+
+      editorWithoutCallback.destroy();
+    });
+
+    it('handles editor without storage gracefully', async () => {
+      // Create a mock editor without the storage structure
+      const mockEditor = {
+        storage: {},
+      };
+
+      mockProps = {
+        editor: mockEditor,
+        node: {
+          attrs: {
+            text: 'Test Meeting',
+            'close-button-aria-label': 'Close meeting',
+          },
+        },
+      };
+
+      updateWrapper();
+
+      const closeButton = wrapper.find('button');
+
+      // Should not throw an error
+      expect(async () => {
+        await closeButton.trigger('click');
+      }).not.toThrow();
+    });
+  });
+
+  describe('Event Emission', () => {
+    it('emits meeting-pill-close event', () => {
+      // The component declares the emit but the actual emission logic
+      // is handled through the callback, so we verify the event is declared
+      expect(wrapper.vm.$options.emits).toContain('meeting-pill-close');
+    });
+  });
+
+  describe('Props', () => {
+    it('accepts nodeViewProps', () => {
+      expect(wrapper.vm.node).toBeDefined();
+      expect(wrapper.vm.editor).toBeDefined();
+      expect(wrapper.vm.getPos).toBeDefined();
+    });
+
+    it('displays different text based on node attributes', () => {
+      mockProps = {
+        node: {
+          attrs: {
+            text: 'Team Meeting',
+            'close-button-aria-label': 'Close meeting',
+          },
+        },
+      };
+
+      updateWrapper();
+
+      expect(wrapper.text()).toContain('Team Meeting');
+    });
+
+    it('uses different aria-label based on node attributes', () => {
+      mockProps = {
+        node: {
+          attrs: {
+            text: 'Test Meeting',
+            'close-button-aria-label': 'Remove meeting pill',
+          },
+        },
+      };
+
+      updateWrapper();
+
+      const closeButton = wrapper.find('button');
+      expect(closeButton.attributes('aria-label')).toBe('Remove meeting pill');
+    });
+  });
+
+  describe('Component Structure', () => {
+    it('has the correct component name', () => {
+      expect(wrapper.vm.$options.name).toBe('MeetingPill');
+    });
+
+    it('wraps content in NodeViewWrapper', () => {
+      expect(wrapper.find('.d-recipe-message-input-meeting-pill').exists()).toBe(true);
+    });
+
+    it('uses DtItemLayout for structure', () => {
+      // Since we're stubbing the component, we check for the layout structure
+      // The stubbed dt-item-layout should render as a div with slots
+      const layout = wrapper.find('.d-recipe-message-input-meeting-pill__layout');
+      expect(layout.exists()).toBe(true);
+    });
+  });
+});

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/extensions/meeting_pill/MeetingPill.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/extensions/meeting_pill/MeetingPill.vue
@@ -56,7 +56,12 @@ export default {
 
   methods: {
     close (e) {
-      this.$parent.$emit('meeting-pill-close', e);
+      // Get the callback from extension storage
+      const onCloseCallback = this.editor?.storage?.meetingPill?.onClose;
+
+      if (onCloseCallback && typeof onCloseCallback === 'function') {
+        onCloseCallback(e);
+      }
     },
   },
 };

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/extensions/meeting_pill/meeting_pill.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/extensions/meeting_pill/meeting_pill.js
@@ -3,10 +3,23 @@ import { VueNodeViewRenderer } from '@tiptap/vue-3';
 import MeetingPill from './MeetingPill.vue';
 
 export default Node.create({
+  name: 'meetingPill',
 
   atom: true,
   group: 'inline',
   inline: true,
+
+  addOptions () {
+    return {
+      onClose: () => {},
+    };
+  },
+
+  addStorage () {
+    return {
+      onClose: this.options.onClose,
+    };
+  },
 
   addNodeView () {
     return VueNodeViewRenderer(MeetingPill);

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -76,6 +76,7 @@
         @text-input="onTextInput"
         @enter="onSend"
         @selected="selectedText = $event"
+        @selected-command="$emit('selected-command', $event)"
         @edit-link="initLinkDialog"
         @focus="isFocused = true"
         @blur="isFocused = false"

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -789,7 +789,14 @@ export default {
       // If an ordered list is nested within an unordered list, we only want to show the currently selected list as
       // active. This function performs the logic to determine the farthest active node from the root.
       lastActiveNodes,
-      additionalExtensions: [MeetingPill],
+      additionalExtensions: [
+        MeetingPill.configure({
+          onClose: (event) => {
+            this.$emit('meeting-pill-close', event);
+          },
+        }),
+      ],
+
       internalInputValue: this.modelValue, // internal input content
       imagePickerFocus: false,
       emojiPickerFocus: false,
@@ -807,7 +814,6 @@ export default {
   },
 
   computed: {
-
     showSendIcon () {
       return !this.showSend.text;
     },

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -2,7 +2,7 @@
   <div class="d-h264">
     <dt-recipe-message-input
       ref="input"
-      v-model="$attrs.value"
+      v-model="value"
       :input-aria-label="$attrs.inputAriaLabel"
       :auto-focus="$attrs.autoFocus"
       :rich-text="$attrs.richText"
@@ -109,5 +109,16 @@ import { DtIcon } from '@/components/icon';
 export default {
   name: 'DtRecipeMessageInputDefault',
   components: { DtRecipeMessageInput, DtIcon },
+  data () {
+    return {
+      value: this.$attrs.modelValue,
+    };
+  },
+
+  watch: {
+    '$attrs.modelValue' (value) {
+      this.value = value;
+    },
+  },
 };
 </script>


### PR DESCRIPTION
# fix(message-input): DLT-2605 fix slash command and close button

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExaTJqZXlhNHVtcGVkNWtrM3FzMnUwcDc3eTY5b25pMTczb3B1azZzdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ytlPLqdKk0Df2/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2605

## :book: Description

- Fixed slash commands not showing up in storybook (value vs modelValue issue)
- Fixed meeting pill close button not triggering event (cannot use $parent in vue 3)

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

Verify in product

## :camera: Screenshots / GIFs

![Screenshot 2025-06-26 at 12 31 08 PM](https://github.com/user-attachments/assets/933063bc-ffd2-40e6-9a08-aa8a1cd6294b)

## :link: Sources

https://tiptap.dev/docs/editor/extensions/custom-extensions/extend-existing#storage
