### PR TITLE
docs(color): DLT-2626 fix broken link in color page

### DIFF
--- a/apps/dialtone-documentation/docs/design/colors/palette/index.md
+++ b/apps/dialtone-documentation/docs/design/colors/palette/index.md
@@ -1,5 +1,6 @@
 ---
 title: Color Palette
+shortTitle: palette
 description: A functional, personal, and accessible color palette.
 figma_url: https://www.figma.com/design/VjrRh4vvfONSmBQxnZrL3u/DT9-Design-Tokens--Rebrand-2025-?node-id=7712-1472&t=D8g6K4TrMGXNsvLT-11
 ---


### PR DESCRIPTION
Fix card link within color page that leads to the "color palette" page.

# docs(color): DLT-2626 fix broken link in color page

## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2626

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.