### PR TITLE
fix(tokens): DLT-2629 corrected tmo inverted surface colors

### DIFF
--- a/packages/dialtone-tokens/tokens/semantic/tmo/dark.json
+++ b/packages/dialtone-tokens/tokens/semantic/tmo/dark.json
@@ -50,6 +50,18 @@
       "brand-strong": {
         "value": "#FFB2DA",
         "type": "color"
+      },
+      "brand-inverted": {
+        "value": "#FFCCE6",
+        "type": "color"
+      },
+      "brand-subtle-inverted": {
+        "value": "#FFF0F8",
+        "type": "color"
+      },
+      "brand-strong-inverted": {
+        "value": "#E20074",
+        "type": "color"
       }
     },
     "border": {

--- a/packages/dialtone-tokens/tokens/semantic/tmo/dark.json
+++ b/packages/dialtone-tokens/tokens/semantic/tmo/dark.json
@@ -88,6 +88,32 @@
             }
           }
         }
+      },
+      "brand-opaque-inverted": {
+        "value": "#FDBEDF",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": "0.8",
+              "space": "hsl"
+            }
+          }
+        }
+      },
+      "brand-subtle-opaque-inverted": {
+        "value": "#FDBEDF",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": ".25",
+              "space": "hsl"
+            }
+          }
+        }
       }
     },
     "border": {

--- a/packages/dialtone-tokens/tokens/semantic/tmo/dark.json
+++ b/packages/dialtone-tokens/tokens/semantic/tmo/dark.json
@@ -62,6 +62,32 @@
       "brand-strong-inverted": {
         "value": "#E20074",
         "type": "color"
+      },
+      "brand-opaque": {
+        "value": "#4B0027",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": "0.8",
+              "space": "hsl"
+            }
+          }
+        }
+      },
+      "brand-subtle-opaque": {
+        "value": "#35001C",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": "0.9",
+              "space": "hsl"
+            }
+          }
+        }
       }
     },
     "border": {

--- a/packages/dialtone-tokens/tokens/semantic/tmo/default.json
+++ b/packages/dialtone-tokens/tokens/semantic/tmo/default.json
@@ -52,7 +52,7 @@
         "type": "color"
       },
       "brand-opaque": {
-        "value": "#4B0027",
+        "value": "#FDBEDF",
         "type": "color",
         "$extensions": {
           "studio.tokens": {
@@ -65,13 +65,13 @@
         }
       },
       "brand-subtle-opaque": {
-        "value": "#35001C",
+        "value": "#FDBEDF",
         "type": "color",
         "$extensions": {
           "studio.tokens": {
             "modify": {
               "type": "alpha",
-              "value": "0.9",
+              "value": "0.25",
               "space": "hsl"
             }
           }

--- a/packages/dialtone-tokens/tokens/semantic/tmo/default.json
+++ b/packages/dialtone-tokens/tokens/semantic/tmo/default.json
@@ -90,7 +90,7 @@
         "type": "color"
       },
       "brand-opaque-inverted": {
-        "value": "4B0027",
+        "value": "#4B0027",
         "type": "color",
         "$extensions": {
           "studio.tokens": {

--- a/packages/dialtone-tokens/tokens/semantic/tmo/default.json
+++ b/packages/dialtone-tokens/tokens/semantic/tmo/default.json
@@ -52,26 +52,64 @@
         "type": "color"
       },
       "brand-opaque": {
-        "value": "#E20074",
+        "value": "#4B0027",
         "type": "color",
         "$extensions": {
           "studio.tokens": {
             "modify": {
               "type": "alpha",
-              "value": "0.11",
+              "value": "0.8",
               "space": "hsl"
             }
           }
         }
       },
       "brand-subtle-opaque": {
-        "value": "#E20074",
+        "value": "#35001C",
         "type": "color",
         "$extensions": {
           "studio.tokens": {
             "modify": {
               "type": "alpha",
-              "value": "0.05",
+              "value": "0.9",
+              "space": "hsl"
+            }
+          }
+        }
+      },
+      "brand-inverted": {
+        "value": "#3D001F",
+        "type": "color"
+      },
+      "brand-subtle-inverted": {
+        "value": "#2E0018",
+        "type": "color"
+      },
+      "brand-strong-inverted": {
+        "value": "#FFB2DA",
+        "type": "color"
+      },
+      "brand-opaque-inverted": {
+        "value": "4B0027",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": ".8",
+              "space": "hsl"
+            }
+          }
+        }
+      },
+      "brand-subtle-opaque-inverted": {
+        "value": "#35001C",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": ".9",
               "space": "hsl"
             }
           }


### PR DESCRIPTION
# Corrected TMO inverted surface colors

https://github.com/user-attachments/assets/528c6911-379c-4a90-9742-9a4b890e6ae8

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2629

## :book: Description

More inverted surface colors were created, including for `brand`, but a TMO-equivalent was omitted. Reported by @johnp-dialpad, https://dialpad.com/app/messages/agxzfnViZXItdm9pY2VyGAsSC1RleHRNZXNzYWdlGICAp_T9t60JDA

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
