### PR TITLE
fix(modal): NO-JIRA prevent losing focus when clicking inside the modal

### DIFF
--- a/packages/dialtone-vue2/components/modal/modal.vue
+++ b/packages/dialtone-vue2/components/modal/modal.vue
@@ -343,8 +343,14 @@ export default {
         ...this.$listeners,
 
         click: event => {
-          if (!this.closeOnClick) return;
-          (event.target === event.currentTarget) && this.close();
+          // Handle backdrop clicks for closing modal
+          if (this.closeOnClick && event.target === event.currentTarget) {
+            this.close();
+          } else if (this.show && event.target !== event.currentTarget) {
+            // Ensure focus stays within modal when clicking inside it
+            this.handleModalClick(event);
+          }
+
           this.$emit('click', event);
         },
 
@@ -361,9 +367,9 @@ export default {
           this.$emit('keydown', event);
         },
 
-        'after-enter': event => {
+        'after-enter': async () => {
           this.$emit('update:show', true);
-          (event.target === event.currentTarget) && this.setFocusAfterTransition();
+          await this.setFocusAfterTransition();
         },
       };
     },
@@ -407,11 +413,11 @@ export default {
       this.$emit('update:show', false);
     },
 
-    setFocusAfterTransition () {
+    async setFocusAfterTransition () {
       if (this.initialFocusElement === 'first') {
-        this.focusFirstElement();
+        await this.focusFirstElement();
       } else if (this.initialFocusElement.startsWith('#')) {
-        this.focusElementById(this.initialFocusElement);
+        await this.focusElementById(this.initialFocusElement);
       } else if (this.initialFocusElement instanceof HTMLElement) {
         this.initialFocusElement.focus();
       }
@@ -420,6 +426,20 @@ export default {
     trapFocus (e) {
       if (this.show) {
         this.focusTrappedTabPress(e);
+      }
+    },
+
+    handleModalClick (event) {
+      // Ensure focus stays within modal when clicking inside it
+      const clickedElement = event.target;
+      const focusableElements = this._getFocusableElements();
+
+      // If the clicked element is not focusable, ensure focus stays in modal
+      if (focusableElements.length && !focusableElements.includes(clickedElement)) {
+        // Check if current active element is still within the modal
+        if (!focusableElements.includes(document.activeElement)) {
+          this.focusFirstElement();
+        }
       }
     },
   },

--- a/packages/dialtone-vue3/components/modal/modal.vue
+++ b/packages/dialtone-vue3/components/modal/modal.vue
@@ -371,8 +371,14 @@ export default {
     modalListeners () {
       return {
         click: event => {
-          if (!this.closeOnClick) return;
-          (event.target === event.currentTarget) && this.close();
+          // Handle backdrop clicks for closing modal
+          if (this.closeOnClick && event.target === event.currentTarget) {
+            this.close();
+          } else if (this.show && event.target !== event.currentTarget) {
+            // Ensure focus stays within modal when clicking inside it
+            this.handleModalClick(event);
+          }
+
           this.$emit('click', event);
         },
 
@@ -389,9 +395,17 @@ export default {
           this.$emit('keydown', event);
         },
 
-        'after-enter': event => {
+        'after-enter': async () => {
           this.$emit('update:show', true);
-          (event.target === event.currentTarget) && this.setFocusAfterTransition();
+          await this.setFocusAfterTransition();
+        },
+
+        focusin: event => {
+          // Ensure focus stays within modal
+          if (this.show && !this.$el.contains(event.target)) {
+            event.preventDefault();
+            this.focusFirstElement();
+          }
         },
       };
     },
@@ -439,11 +453,11 @@ export default {
       this.$emit('update:show', false);
     },
 
-    setFocusAfterTransition () {
+    async setFocusAfterTransition () {
       if (this.initialFocusElement === 'first') {
-        this.focusFirstElement();
+        await this.focusFirstElement();
       } else if (this.initialFocusElement.startsWith('#')) {
-        this.focusElementById(this.initialFocusElement);
+        await this.focusElementById(this.initialFocusElement);
       } else if (this.initialFocusElement instanceof HTMLElement) {
         this.initialFocusElement.focus();
       }
@@ -452,6 +466,20 @@ export default {
     trapFocus (e) {
       if (this.show) {
         this.focusTrappedTabPress(e);
+      }
+    },
+
+    handleModalClick (event) {
+      // Ensure focus stays within modal when clicking inside it
+      const clickedElement = event.target;
+      const focusableElements = this._getFocusableElements();
+
+      // If the clicked element is not focusable, ensure focus stays in modal
+      if (focusableElements.length && !focusableElements.includes(clickedElement)) {
+        // Check if current active element is still within the modal
+        if (!focusableElements.includes(document.activeElement)) {
+          this.focusFirstElement();
+        }
       }
     },
 


### PR DESCRIPTION
# fix(modal): NO-JIRA prevent losing focus when clicking inside the modal

When working on [this PR](https://github.com/dialpad/firespotter/pull/60607) I came across these small issues in the modal component.

1- When clicking inside the modal, the focus would go to the background
2- The parameter for Vue transition `after-enter` callback is the element, not the event, so I removed this condition `(event.target === event.currentTarget)`. It was always true because both `event.target` and `event.currentTarget` are undefined always (check https://vuejs.org/guide/built-ins/transition)

Also added `await` for async functions.

## Before
Open the modal and click inside of it (for example in the title)
![modal-click](https://github.com/user-attachments/assets/035ce188-82ea-4667-a5ca-416494a23036)

## With this fix
![modal-click-pr](https://github.com/user-attachments/assets/d27f6225-01b0-495d-91cd-7fa735ae877f)
