### PR TITLE
PROTOTYPE: playground ui (née combinator)

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
@@ -110,8 +110,8 @@ const highlightedHtml = computed(() => {
   return typeof props.htmlCode === 'string' ? Prism.highlight(props.htmlCode.trim(), Prism.languages.html, 'html') : '';
 });
 
-const trimmedVueCode = props.vueCode.replace(/^\n/gm, '');
-const highlightedVue = Prism.highlight(props.vueCode.trim(), Prism.languages.html, 'html');
+const trimmedVueCode = computed(() => props.vueCode.replace(/^\n/gm, ''));
+const highlightedVue = computed(() => Prism.highlight(props.vueCode.trim(), Prism.languages.html, 'html'));
 
 const vueTabId = getUniqueString();
 const vuePanelId = getUniqueString();

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -69,8 +69,6 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
             </template>
           </dt-button>
         </dt-stack>
-        <dt-input v-model="buttonLabel" label="Label" type="text" size="sm" />
-        <dt-input v-model="buttonLabelClass" label="Label class" type="text" size="sm" />
         <dt-select-menu
           :disabled="isLink"
           v-model="buttonSize"
@@ -109,9 +107,6 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           ]"
           label="Kind"
         />
-        <dt-toggle :disabled="isLink" v-model="isActive" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
-          Active
-        </dt-toggle>
         <dt-stack gap="400">
           <dt-toggle
             :disabled="isLink"
@@ -205,12 +200,17 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         <dt-toggle v-model="isLinkInverted" v-show="isLink && !hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Link Inverted
         </dt-toggle>
+        <dt-toggle :disabled="isLink" v-model="isActive" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+          Active
+        </dt-toggle>
         <dt-toggle :disabled="isLink" v-model="isLoading" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Loading
         </dt-toggle>
         <dt-toggle v-model="isDisabled" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Disabled
         </dt-toggle>
+        <dt-input v-model="buttonLabel" label="Label" type="text" size="sm" />
+        <dt-input v-model="buttonLabelClass" label="Label class" type="text" size="sm" />
       </dt-stack>
     </div>
   </div>

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -22,8 +22,8 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
       </div>
       <dt-button
         :size="buttonSize"
-        importance="clear"
-        kind="default"
+        :importance="buttonImportance"
+        :kind="buttonKind"
         ref="component-default"
       >
         {{ buttonLabel }}
@@ -41,12 +41,14 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           :options="[
             { value: `xs`, label: `xs` },
             { value: `sm`, label: `sm` },
+            { value: `md`, label: `md` },
             { value: `lg`, label: `lg` },
             { value: `xl`, label: `xl` },
           ]"
           label="Size"
         />
         <dt-select-menu
+          v-model="buttonImportance"
           size="sm"
           :options="[
             { value: `clear`, label: `clear` },
@@ -56,6 +58,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           label="Importance"
         />
         <dt-select-menu
+          v-model="buttonKind"
           size="sm"
           :options="[
             { value: `default`, label: `default` },
@@ -80,6 +83,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
             Icon
           </dt-toggle>
           <dt-select-menu
+            v-model="iconName"
             v-show="hasIcon"
             size="sm"
             labelClass="d-vi-visible-sr"
@@ -96,6 +100,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           />
         </dt-stack>
         <dt-select-menu
+          v-model="iconPosition"
           v-show="hasIcon"
           size="sm"
           :options="[
@@ -116,6 +121,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           Link
         </dt-toggle>
         <dt-select-menu
+          v-model="linkKind"
           v-show="isLink && !hasIcon"
           size="sm"
           :options="[
@@ -1255,6 +1261,11 @@ const isLink = ref(false);
 const isFullscreen = ref(false);
 const buttonLabel = ref('Place Call');
 const buttonSize = ref('xs');
+const buttonImportance = ref('clear');
+const buttonKind = ref('default');
+const iconName = ref('activity');
+const iconPosition = ref('left');
+const linkKind = ref('default');
 
 // Toggle fullscreen mode
 const toggleFullscreen = () => {

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -21,12 +21,12 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         </dt-button>
       </div>
       <dt-button
-        size="xs"
+        :size="buttonSize"
         importance="clear"
         kind="default"
         ref="component-default"
       >
-        Place Call
+        {{ buttonLabel }}
       </dt-button>
     </div>
     <div class="dialtone-playground__controls" v-dt-scrollbar>
@@ -34,8 +34,9 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         <div v-show="isFullscreen" class="d-headline--md">
           DtButton
         </div>
-        <dt-input label="Label" type="text" value="Place Call" size="sm" />
+        <dt-input v-model="buttonLabel" label="Label" type="text" size="sm" />
         <dt-select-menu
+          v-model="buttonSize"
           size="sm"
           :options="[
             { value: `xs`, label: `xs` },
@@ -1252,6 +1253,8 @@ import { ref } from 'vue';
 const hasIcon = ref(false);
 const isLink = ref(false);
 const isFullscreen = ref(false);
+const buttonLabel = ref('Place Call');
+const buttonSize = ref('xs');
 
 // Toggle fullscreen mode
 const toggleFullscreen = () => {

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -21,10 +21,11 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         </dt-button>
       </div>
       <dt-button
+        ref="component-default"
         :size="buttonSize"
         :importance="buttonImportance"
         :kind="buttonKind"
-        ref="component-default"
+        :active="isActive"
       >
         {{ buttonLabel }}
       </dt-button>
@@ -70,7 +71,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           ]"
           label="Kind"
         />
-        <dt-toggle labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle v-model="isActive" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Active
         </dt-toggle>
         <dt-stack gap="400">
@@ -1260,12 +1261,13 @@ const hasIcon = ref(false);
 const isLink = ref(false);
 const isFullscreen = ref(false);
 const buttonLabel = ref('Place Call');
-const buttonSize = ref('xs');
-const buttonImportance = ref('clear');
+const buttonSize = ref('md');
+const buttonImportance = ref('primary');
 const buttonKind = ref('default');
 const iconName = ref('activity');
 const iconPosition = ref('left');
 const linkKind = ref('default');
+const isActive = ref(false);
 
 // Toggle fullscreen mode
 const toggleFullscreen = () => {

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -52,6 +52,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         <dt-select-menu
           v-model="buttonSize"
           size="sm"
+          value="md"
           :options="[
             { value: `xs`, label: `xs` },
             { value: `sm`, label: `sm` },
@@ -188,15 +189,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
   </div>
   <div class="dialtone-playground__end">
 <code-example-tabs
-vueCode='
-<dt-button
-  size="xs"
-  importance="clear"
-  kind="default"
->
-  Place Call
-</dt-button>
-'
+:vueCode="dynamicVueCode"
 :htmlCode="() => $refs['component-default']"
 showHtmlWarning />
   </div>
@@ -1293,7 +1286,7 @@ We provide the following branded buttons for log-in and sign-up workflows.
 
 <script setup>
 import ButtonVariantsTable from '@baseComponents/ButtonVariantsTable.vue';
-import { ref, watch } from 'vue';
+import { ref, watch, computed } from 'vue';
 
 // Playground reactive data
 const hasIcon = ref(false);
@@ -1341,6 +1334,58 @@ watch(buttonLabel, (newValue) => {
     // When label has content, turn off icon only
     isIconOnly.value = false;
   }
+});
+
+// Computed property for dynamic Vue code generation
+const dynamicVueCode = computed(() => {
+  const props = [];
+
+  // Always show core button props
+  props.push(`  size="${buttonSize.value}"`);
+  props.push(`  importance="${buttonImportance.value}"`);
+  props.push(`  kind="${buttonKind.value}"`);
+
+  // Add active if true
+  if (isActive.value) {
+    props.push(`  active`);
+  }
+
+  // Add icon-related props
+  if (hasIcon.value) {
+    if (iconPosition.value !== 'left') {
+      props.push(`  iconPosition="${iconPosition.value}"`);
+    }
+    if (isCircle.value) {
+      props.push(`  circle`);
+    }
+  }
+
+  // Add link-related props
+  if (isLink.value) {
+    props.push(`  link`);
+    if (linkKind.value !== 'default') {
+      props.push(`  linkKind="${linkKind.value}"`);
+    }
+    if (isLinkInverted.value) {
+      props.push(`  linkInverted`);
+    }
+  }
+
+  // Add loading if true
+  if (isLoading.value) {
+    props.push(`  loading`);
+  }
+
+  // Add disabled if true
+  if (isDisabled.value) {
+    props.push(`  disabled`);
+  }
+
+  const propsString = props.length > 0 ? '\n' + props.join('\n') + '\n' : '';
+  const iconTemplate = hasIcon.value ? `\n  <template #icon="{ iconSize }">\n    <dt-icon\n      name="${iconName.value}"\n      :size="iconSize"\n    />\n  </template>` : '';
+  const labelContent = buttonLabel.value || 'Place Call';
+
+  return `<dt-button${propsString}>${iconTemplate}\n  ${labelContent}\n</dt-button>`;
 });
 </script>
 

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -8,6 +8,8 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-button--defa
 figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Library--Rebrand-2025-?node-id=19800-32233
 ---
 
+
+
 <style lang="less">
 .dialtone-playground {
   background-color: var(--dt-color-surface-secondary);
@@ -69,6 +71,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
     v-dt-scrollbar:never
   >
     <dt-stack gap="500">
+      <dt-input id="playground-prop-label" label="Label" type="text" value="Place Call" size="sm" />
       <dt-select-menu
         id="playground-prop-size"
         size="sm"
@@ -103,15 +106,21 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
             ]"
         label="Kind"
       />
-      <dt-input id="playground-prop-label" label="Label" type="text" value="Place Call" size="sm" />
       <dt-toggle id="playground-prop-active" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
         Active
       </dt-toggle>
       <dt-stack gap="400">
-        <dt-toggle id="playground-prop-icon" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle
+          v-model="hasIcon"
+          id="playground-prop-icon"
+          labelClass="d-label--sm"
+          size="sm"
+          wrapperClass="d-jc-space-between"
+        >
           Icon
         </dt-toggle>
         <dt-select-menu
+          v-show="hasIcon"
           id="playground-prop-icon-name"
           size="sm"
           labelClass="d-vi-visible-sr"
@@ -127,13 +136,14 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           label="Icon name"
         />
       </dt-stack>
-      <dt-toggle id="playground-prop-icon-only" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-toggle v-show="hasIcon" id="playground-prop-icon-only" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
         Icon only
       </dt-toggle>
-      <dt-toggle id="playground-prop-circle" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-toggle v-show="hasIcon" id="playground-prop-circle" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
         Circle
       </dt-toggle>
       <dt-select-menu
+        v-show="hasIcon"
         id="playground-prop-icon-position"
         size="sm"
         :options="[
@@ -144,13 +154,14 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
             ]"
         label="Icon Position"
       />
-      <dt-toggle id="playground-prop-link" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-toggle v-show="!hasIcon" id="playground-prop-link" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
         Link
       </dt-toggle>
-      <dt-toggle id="playground-prop-link-inverted" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-toggle v-show="!hasIcon" id="playground-prop-link-inverted" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
         Link Inverted
       </dt-toggle>
       <dt-select-menu
+        v-show="!hasIcon"
         id="playground-prop-link-kind"
         size="sm"
         :options="[
@@ -1276,4 +1287,13 @@ We provide the following branded buttons for log-in and sign-up workflows.
 
 <script setup>
 import ButtonVariantsTable from '@baseComponents/ButtonVariantsTable.vue';
+import { ref, watch } from 'vue';
+
+// Playground reactive data
+const hasIcon = ref(false);
+
+// Debug reactivity
+watch(hasIcon, (newValue) => {
+  console.log('hasIcon changed to:', newValue);
+});
 </script>

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -27,6 +27,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         :kind="buttonKind"
         :active="isActive"
         :iconPosition="iconPosition"
+        :circle="isCircle"
       >
         <template v-if="hasIcon" #icon="{ iconSize }">
           <dt-icon
@@ -148,7 +149,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         <dt-toggle v-model="isIconOnly" v-show="hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Icon only
         </dt-toggle>
-        <dt-toggle v-show="isIconOnly" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle v-model="isCircle" v-show="isIconOnly" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Circle
         </dt-toggle>
         <dt-toggle v-model="isLink" v-show="!hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
@@ -1302,6 +1303,7 @@ const iconPosition = ref('left');
 const linkKind = ref('default');
 const isActive = ref(false);
 const isIconOnly = ref(false);
+const isCircle = ref(false);
 
 // Store previous label for restoration
 let previousLabel = '';
@@ -1318,10 +1320,11 @@ watch(isIconOnly, (newValue) => {
     previousLabel = buttonLabel.value;
     buttonLabel.value = '';
   } else {
-    // When icon only is turned off, restore the previous label
+    // When icon only is turned off, restore the previous label and turn off circle
     if (previousLabel) {
       buttonLabel.value = previousLabel;
     }
+    isCircle.value = false;
   }
 });
 

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -148,7 +148,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         <dt-toggle v-model="isIconOnly" v-show="hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Icon only
         </dt-toggle>
-        <dt-toggle v-show="hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle v-show="isIconOnly" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Circle
         </dt-toggle>
         <dt-toggle v-model="isLink" v-show="!hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -7,6 +7,7 @@ image: assets/images/components/button.png
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-button--default
 figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Library--Rebrand-2025-?node-id=19800-32233
 ---
+
 <div class="dialtone-playground" :class="{ 'dialtone-playground--fullscreen': isFullscreen }">
   <div class="dialtone-playground__start">
     <div class="dialtone-playground__component">
@@ -33,6 +34,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         :linkInverted="isLinkInverted"
         :loading="isLoading"
         :disabled="isDisabled"
+        :labelClass="buttonLabelClass"
       >
         <template v-if="hasIcon" #icon="{ iconSize }">
           <dt-icon
@@ -45,14 +47,13 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
     </div>
     <div class="dialtone-playground__controls" v-dt-scrollbar>
       <dt-stack gap="500">
-        <div v-show="isFullscreen" class="d-headline--md">
-          DtButton
-        </div>
+        <h2 v-show="isFullscreen" class="d-headline--lg">DtButton</h2>
         <dt-input v-model="buttonLabel" label="Label" type="text" size="sm" />
+        <dt-input v-model="buttonLabelClass" label="Label class" type="text" size="sm" />
         <dt-select-menu
+          :disabled="isLink"
           v-model="buttonSize"
           size="sm"
-          value="md"
           :options="[
             { value: `xs`, label: `xs` },
             { value: `sm`, label: `sm` },
@@ -63,6 +64,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           label="Size"
         />
         <dt-select-menu
+          :disabled="isLink"
           v-model="buttonImportance"
           size="sm"
           :options="[
@@ -73,6 +75,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           label="Importance"
         />
         <dt-select-menu
+          :disabled="isLink"
           v-model="buttonKind"
           size="sm"
           :options="[
@@ -85,11 +88,12 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           ]"
           label="Kind"
         />
-        <dt-toggle v-model="isActive" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle :disabled="isLink" v-model="isActive" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Active
         </dt-toggle>
         <dt-stack gap="400">
           <dt-toggle
+            :disabled="isLink"
             v-model="hasIcon"
             labelClass="d-label--sm d-fc-secondary"
             size="sm"
@@ -98,6 +102,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
             Icon
           </dt-toggle>
           <dt-select-menu
+            :disabled="isLink"
             v-model="iconName"
             v-show="hasIcon"
             size="sm"
@@ -141,6 +146,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           />
         </dt-stack>
         <dt-select-menu
+          :disabled="isLink"
           v-model="iconPosition"
           v-show="hasIcon"
           size="sm"
@@ -152,10 +158,10 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           ]"
           label="Icon Position"
         />
-        <dt-toggle v-model="isIconOnly" v-show="hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle :disabled="isLink" v-model="isIconOnly" v-show="hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Icon only
         </dt-toggle>
-        <dt-toggle v-model="isCircle" v-show="isIconOnly" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle :disabled="isLink" v-model="isCircle" v-show="isIconOnly" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Circle
         </dt-toggle>
         <dt-toggle v-model="isLink" v-show="!hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
@@ -178,7 +184,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         <dt-toggle v-model="isLinkInverted" v-show="isLink && !hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Link Inverted
         </dt-toggle>
-        <dt-toggle v-model="isLoading" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle :disabled="isLink" v-model="isLoading" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Loading
         </dt-toggle>
         <dt-toggle v-model="isDisabled" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
@@ -1293,7 +1299,8 @@ const hasIcon = ref(false);
 const isLink = ref(false);
 const isFullscreen = ref(false);
 const buttonLabel = ref('Place Call');
-const buttonSize = ref('md');
+const buttonLabelClass = ref('');
+const buttonSize = ref('xs');
 const buttonImportance = ref('primary');
 const buttonKind = ref('default');
 const iconName = ref('activity');
@@ -1380,6 +1387,11 @@ const dynamicVueCode = computed(() => {
   if (isDisabled.value) {
     props.push(`  disabled`);
   }
+  
+  // Add labelClass if not empty
+  if (buttonLabelClass.value && buttonLabelClass.value.trim() !== '') {
+    props.push(`  labelClass="${buttonLabelClass.value}"`);
+  }
 
   const propsString = props.length > 0 ? '\n' + props.join('\n') + '\n' : '';
   const iconTemplate = hasIcon.value ? `\n  <template #icon="{ iconSize }">\n    <dt-icon\n      name="${iconName.value}"\n      :size="iconSize"\n    />\n  </template>` : '';
@@ -1403,6 +1415,7 @@ const dynamicVueCode = computed(() => {
   &__end {
     .dialtone-playground--fullscreen & {
       background-color: var(--dt-color-surface-secondary-opaque);
+      height: 33vh;
     }
   }
 

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -145,7 +145,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           ]"
           label="Icon Position"
         />
-        <dt-toggle v-show="hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle v-model="isIconOnly" v-show="hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Icon only
         </dt-toggle>
         <dt-toggle v-show="hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
@@ -1287,7 +1287,7 @@ We provide the following branded buttons for log-in and sign-up workflows.
 
 <script setup>
 import ButtonVariantsTable from '@baseComponents/ButtonVariantsTable.vue';
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 
 // Playground reactive data
 const hasIcon = ref(false);
@@ -1301,11 +1301,27 @@ const iconName = ref('activity');
 const iconPosition = ref('left');
 const linkKind = ref('default');
 const isActive = ref(false);
+const isIconOnly = ref(false);
 
 // Toggle fullscreen mode
 const toggleFullscreen = () => {
   isFullscreen.value = !isFullscreen.value;
 };
+
+// Two-way sync between icon only and button label
+watch(isIconOnly, (newValue) => {
+  if (newValue) {
+    // When icon only is turned on, clear the label
+    buttonLabel.value = '';
+  }
+});
+
+watch(buttonLabel, (newValue) => {
+  if (newValue && newValue.trim() !== '') {
+    // When label has content, turn off icon only
+    isIconOnly.value = false;
+  }
+});
 </script>
 
 <style lang="less">

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -11,12 +11,21 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
 
 
 <style lang="less">
-.dialtone-playground {
+/*#asdfasdf {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   background-color: var(--dt-color-surface-secondary);
-  display: flex;
-  flex-direction: row;
-  border-radius: var(--dt-size-radius-400);
-  overflow: hidden;
+}*/
+.dialtone-playground {
+  & {
+    background-color: var(--dt-color-surface-secondary);
+    display: flex;
+    flex-direction: row;
+    border-radius: var(--dt-size-radius-400);
+    overflow: hidden;
+  }
 
   &__component {
     padding: var(--dt-space-500);
@@ -43,7 +52,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
 }
 </style>
 
-<div id="combinator-playground">
+<div id="asdfasdf">
   <div class="dialtone-playground">
     <div class="dialtone-playground__component">
       <div class="dialtone-playground__fullscreen-toggle">

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -76,44 +76,44 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         id="playground-prop-size"
         size="sm"
         :options="[
-              { value: `xs`, label: `xs` },
-              { value: `sm`, label: `sm` },
-              { value: `lg`, label: `lg` },
-              { value: `xl`, label: `xl` },
-            ]"
+          { value: `xs`, label: `xs` },
+          { value: `sm`, label: `sm` },
+          { value: `lg`, label: `lg` },
+          { value: `xl`, label: `xl` },
+        ]"
         label="Size"
       />
       <dt-select-menu
         id="playground-prop-importance"
         size="sm"
         :options="[
-              { value: `clear`, label: `clear` },
-              { value: `outlined`, label: `outlined` },
-              { value: `primary`, label: `primary` },
-            ]"
+          { value: `clear`, label: `clear` },
+          { value: `outlined`, label: `outlined` },
+          { value: `primary`, label: `primary` },
+        ]"
         label="Importance"
       />
       <dt-select-menu
         id="playground-prop-kind"
         size="sm"
         :options="[
-              { value: `default`, label: `default` },
-              { value: `muted`, label: `muted` },
-              { value: `danger`, label: `danger` },
-              { value: `positive`, label: `positive` },
-              { value: `inverted`, label: `inverted` },
-              { value: `unstyled`, label: `unstyled` },
-            ]"
+          { value: `default`, label: `default` },
+          { value: `muted`, label: `muted` },
+          { value: `danger`, label: `danger` },
+          { value: `positive`, label: `positive` },
+          { value: `inverted`, label: `inverted` },
+          { value: `unstyled`, label: `unstyled` },
+        ]"
         label="Kind"
       />
-      <dt-toggle id="playground-prop-active" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-toggle id="playground-prop-active" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
         Active
       </dt-toggle>
       <dt-stack gap="400">
         <dt-toggle
           v-model="hasIcon"
           id="playground-prop-icon"
-          labelClass="d-label--sm"
+          labelClass="d-label--sm d-fc-secondary"
           size="sm"
           wrapperClass="d-jc-space-between"
         >
@@ -125,59 +125,59 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           size="sm"
           labelClass="d-vi-visible-sr"
           :options="[
-                { value: `activity`, label: `activity` },
-                { value: `add`, label: `add` },
-                { value: `add-circle`, label: `add-circle` },
-                { value: `add-circle-outline`, label: `add-circle-outline` },
-                { value: `add-task`, label: `add-task` },
-                { value: `...`, label: `...` },
-                { value: `...`, label: `...` },
-              ]"
+            { value: `activity`, label: `activity` },
+            { value: `add`, label: `add` },
+            { value: `add-circle`, label: `add-circle` },
+            { value: `add-circle-outline`, label: `add-circle-outline` },
+            { value: `add-task`, label: `add-task` },
+            { value: `...`, label: `...` },
+            { value: `...`, label: `...` },
+          ]"
           label="Icon name"
         />
       </dt-stack>
-      <dt-toggle v-show="hasIcon" id="playground-prop-icon-only" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
-        Icon only
-      </dt-toggle>
-      <dt-toggle v-show="hasIcon" id="playground-prop-circle" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
-        Circle
-      </dt-toggle>
       <dt-select-menu
         v-show="hasIcon"
         id="playground-prop-icon-position"
         size="sm"
         :options="[
-              { value: `left`, label: `left` },
-              { value: `right`, label: `right` },
-              { value: `top`, label: `top` },
-              { value: `bottom`, label: `bottom` },
-            ]"
+          { value: `left`, label: `left` },
+          { value: `right`, label: `right` },
+          { value: `top`, label: `top` },
+          { value: `bottom`, label: `bottom` },
+        ]"
         label="Icon Position"
       />
-      <dt-toggle v-show="!hasIcon" id="playground-prop-link" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-toggle v-show="hasIcon" id="playground-prop-icon-only" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        Icon only
+      </dt-toggle>
+      <dt-toggle v-show="hasIcon" id="playground-prop-circle" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        Circle
+      </dt-toggle>
+      <dt-toggle v-model="isLink" v-show="!hasIcon" id="playground-prop-link" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
         Link
       </dt-toggle>
-      <dt-toggle v-show="!hasIcon" id="playground-prop-link-inverted" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
-        Link Inverted
-      </dt-toggle>
       <dt-select-menu
-        v-show="!hasIcon"
+        v-show="isLink && !hasIcon"
         id="playground-prop-link-kind"
         size="sm"
         :options="[
-              { value: `default`, label: `default` },
-              { value: `warning`, label: `warning` },
-              { value: `danger`, label: `danger` },
-              { value: `success`, label: `success` },
-              { value: `muted`, label: `muted` },
-              { value: `mention`, label: `mention` },
-            ]"
+          { value: `default`, label: `default` },
+          { value: `warning`, label: `warning` },
+          { value: `danger`, label: `danger` },
+          { value: `success`, label: `success` },
+          { value: `muted`, label: `muted` },
+          { value: `mention`, label: `mention` },
+        ]"
         label="Link Kind"
       />
-      <dt-toggle id="playground-prop-loading" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-toggle v-show="isLink && !hasIcon" id="playground-prop-link-inverted" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        Link Inverted
+      </dt-toggle>
+      <dt-toggle id="playground-prop-loading" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
         Loading
       </dt-toggle>
-      <dt-toggle id="playground-prop-disabled" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-toggle id="playground-prop-disabled" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
         Disabled
       </dt-toggle>
     </dt-stack>
@@ -1287,13 +1287,9 @@ We provide the following branded buttons for log-in and sign-up workflows.
 
 <script setup>
 import ButtonVariantsTable from '@baseComponents/ButtonVariantsTable.vue';
-import { ref, watch } from 'vue';
+import { ref } from 'vue';
 
 // Playground reactive data
 const hasIcon = ref(false);
-
-// Debug reactivity
-watch(hasIcon, (newValue) => {
-  console.log('hasIcon changed to:', newValue);
-});
+const isLink = ref(false);
 </script>

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -1486,7 +1486,7 @@ const dynamicHtmlCode = computed(() => {
   &__end {
     .dialtone-playground--fullscreen & {
       background-color: var(--dt-color-surface-secondary-opaque);
-      height: 33vh;
+      block-size: 33vh;
     }
   }
 
@@ -1505,7 +1505,7 @@ const dynamicHtmlCode = computed(() => {
     overflow: hidden;
 
     .dialtone-playground--fullscreen & {
-      border-bottom: 1px solid var(--dt-color-border-subtle)
+      border-block-end: var(--dt-size-border-100) solid var(--dt-color-border-subtle)
     }
   }
 
@@ -1515,7 +1515,7 @@ const dynamicHtmlCode = computed(() => {
     flex: 1;
     align-items: center;
     justify-content: center;
-    min-height: var(--dt-size-925);
+    min-block-size: var(--dt-size-925);
     position: relative;
   }
 
@@ -1528,12 +1528,12 @@ const dynamicHtmlCode = computed(() => {
   &__controls {
     padding: var(--dt-space-500);
     background-color: var(--dt-color-surface-secondary-opaque);
-    width: var(--dt-size-875);
-    max-height: var(--dt-size-950);
+    inline-size: var(--dt-size-875);
+    max-block-size: var(--dt-size-950);
 
     .dialtone-playground--fullscreen & {
-      max-height: 100%;
-      width: var(--dt-size-900);
+      max-block-size: 100%;
+      inline-size: var(--dt-size-900);
     }
   }
 }

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -27,6 +27,12 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         :kind="buttonKind"
         :active="isActive"
       >
+        <template v-if="hasIcon" #icon="{ iconSize }">
+          <dt-icon
+            :name="iconName"
+            :size="iconSize"
+          />
+        </template>
         {{ buttonLabel }}
       </dt-button>
     </div>
@@ -90,12 +96,38 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
             labelClass="d-vi-visible-sr"
             :options="[
               { value: `activity`, label: `activity` },
-              { value: `add`, label: `add` },
-              { value: `add-circle`, label: `add-circle` },
-              { value: `add-circle-outline`, label: `add-circle-outline` },
               { value: `add-task`, label: `add-task` },
+              { value: `agent-assist`, label: `agent-assist` },
+              { value: `ai-notes`, label: `ai-notes` },
+              { value: `ai-write`, label: `ai-write` },
+              { value: `airplay`, label: `airplay` },
+              { value: `airtable`, label: `airtable` },
+              { value: `alarm-check`, label: `alarm-check` },
+              { value: `alarm-clock-off`, label: `alarm-clock-off` },
+              { value: `alarm-minus`, label: `alarm-minus` },
+              { value: `alarm-plus`, label: `alarm-plus` },
+              { value: `album`, label: `album` },
+              { value: `alert-circle`, label: `alert-circle` },
+              { value: `alert-triangle`, label: `alert-triangle` },
+              { value: `align-center`, label: `align-center` },
+              { value: `align-justify`, label: `align-justify` },
+              { value: `align-left`, label: `align-left` },
+              { value: `align-right`, label: `align-right` },
+              { value: `amex`, label: `amex` },
+              { value: `app-store-badge`, label: `app-store-badge` },
+              { value: `apple`, label: `apple` },
+              { value: `archive`, label: `archive` },
+              { value: `archive-restore`, label: `archive-restore` },
+              { value: `arrow-down`, label: `arrow-down` },
+              { value: `arrow-down-left`, label: `arrow-down-left` },
+              { value: `arrow-down-right`, label: `arrow-down-right` },
+              { value: `arrow-left`, label: `arrow-left` },
+              { value: `arrow-left-right`, label: `arrow-left-right` },
+              { value: `arrow-right`, label: `arrow-right` },
+              { value: `arrow-up`, label: `arrow-up` },
               { value: `...`, label: `...` },
-              { value: `...`, label: `...` },
+              { value: `zoom-in`, label: `zoom-in` },
+              { value: `zoom-out`, label: `zoom-out` },
             ]"
             label="Icon name"
           />

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -7,11 +7,11 @@ image: assets/images/components/button.png
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-button--default
 figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Library--Rebrand-2025-?node-id=19800-32233
 ---
-<div class="dialtone-playground">
+<div class="dialtone-playground" :class="{ 'dialtone-playground--fullscreen': isFullscreen }">
   <div class="dialtone-playground__start">
     <div class="dialtone-playground__component">
       <div class="dialtone-playground__fullscreen-toggle">
-        <dt-button v-dt-tooltip="`Fullscreen`" kind="muted" importance="clear" size="sm">
+        <dt-button @click="toggleFullscreen" v-dt-tooltip="`Fullscreen`" kind="muted" importance="clear" size="sm">
           <template #icon="{ iconSize }">
             <dt-icon
               name="expand"
@@ -1255,6 +1255,12 @@ import { ref } from 'vue';
 // Playground reactive data
 const hasIcon = ref(false);
 const isLink = ref(false);
+const isFullscreen = ref(false);
+
+// Toggle fullscreen mode
+const toggleFullscreen = () => {
+  isFullscreen.value = !isFullscreen.value;
+};
 </script>
 
 <style lang="less">

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -28,6 +28,9 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         :active="isActive"
         :iconPosition="iconPosition"
         :circle="isCircle"
+        :link="isLink"
+        :linkKind="linkKind"
+        :linkInverted="isLinkInverted"
       >
         <template v-if="hasIcon" #icon="{ iconSize }">
           <dt-icon
@@ -169,7 +172,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           ]"
           label="Link Kind"
         />
-        <dt-toggle v-show="isLink && !hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle v-model="isLinkInverted" v-show="isLink && !hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Link Inverted
         </dt-toggle>
         <dt-toggle labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
@@ -1304,6 +1307,7 @@ const linkKind = ref('default');
 const isActive = ref(false);
 const isIconOnly = ref(false);
 const isCircle = ref(false);
+const isLinkInverted = ref(false);
 
 // Store previous label for restoration
 let previousLabel = '';

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -14,7 +14,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         <dt-button @click="toggleFullscreen" v-dt-tooltip="`Fullscreen`" kind="muted" importance="clear" size="sm">
           <template #icon="{ iconSize }">
             <dt-icon
-              name="expand"
+              :name="isFullscreen ? 'minimize' : 'expand'"
               :size="iconSize"
             />
           </template>
@@ -31,9 +31,11 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
     </div>
     <div class="dialtone-playground__controls" v-dt-scrollbar>
       <dt-stack gap="500">
-        <dt-input id="playground-prop-label" label="Label" type="text" value="Place Call" size="sm" />
+        <div v-show="isFullscreen" class="d-headline--md">
+          DtButton
+        </div>
+        <dt-input label="Label" type="text" value="Place Call" size="sm" />
         <dt-select-menu
-          id="playground-prop-size"
           size="sm"
           :options="[
             { value: `xs`, label: `xs` },
@@ -44,7 +46,6 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           label="Size"
         />
         <dt-select-menu
-          id="playground-prop-importance"
           size="sm"
           :options="[
             { value: `clear`, label: `clear` },
@@ -54,7 +55,6 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           label="Importance"
         />
         <dt-select-menu
-          id="playground-prop-kind"
           size="sm"
           :options="[
             { value: `default`, label: `default` },
@@ -66,13 +66,12 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           ]"
           label="Kind"
         />
-        <dt-toggle id="playground-prop-active" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Active
         </dt-toggle>
         <dt-stack gap="400">
           <dt-toggle
             v-model="hasIcon"
-            id="playground-prop-icon"
             labelClass="d-label--sm d-fc-secondary"
             size="sm"
             wrapperClass="d-jc-space-between"
@@ -81,7 +80,6 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           </dt-toggle>
           <dt-select-menu
             v-show="hasIcon"
-            id="playground-prop-icon-name"
             size="sm"
             labelClass="d-vi-visible-sr"
             :options="[
@@ -98,7 +96,6 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         </dt-stack>
         <dt-select-menu
           v-show="hasIcon"
-          id="playground-prop-icon-position"
           size="sm"
           :options="[
             { value: `left`, label: `left` },
@@ -108,18 +105,17 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           ]"
           label="Icon Position"
         />
-        <dt-toggle v-show="hasIcon" id="playground-prop-icon-only" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle v-show="hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Icon only
         </dt-toggle>
-        <dt-toggle v-show="hasIcon" id="playground-prop-circle" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle v-show="hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Circle
         </dt-toggle>
-        <dt-toggle v-model="isLink" v-show="!hasIcon" id="playground-prop-link" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle v-model="isLink" v-show="!hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Link
         </dt-toggle>
         <dt-select-menu
           v-show="isLink && !hasIcon"
-          id="playground-prop-link-kind"
           size="sm"
           :options="[
             { value: `default`, label: `default` },
@@ -131,13 +127,13 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
           ]"
           label="Link Kind"
         />
-        <dt-toggle v-show="isLink && !hasIcon" id="playground-prop-link-inverted" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle v-show="isLink && !hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Link Inverted
         </dt-toggle>
-        <dt-toggle id="playground-prop-loading" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Loading
         </dt-toggle>
-        <dt-toggle id="playground-prop-disabled" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Disabled
         </dt-toggle>
       </dt-stack>

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -32,6 +32,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         :linkKind="linkKind"
         :linkInverted="isLinkInverted"
         :loading="isLoading"
+        :disabled="isDisabled"
       >
         <template v-if="hasIcon" #icon="{ iconSize }">
           <dt-icon
@@ -179,7 +180,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         <dt-toggle v-model="isLoading" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Loading
         </dt-toggle>
-        <dt-toggle labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle v-model="isDisabled" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Disabled
         </dt-toggle>
       </dt-stack>
@@ -1310,6 +1311,7 @@ const isIconOnly = ref(false);
 const isCircle = ref(false);
 const isLinkInverted = ref(false);
 const isLoading = ref(false);
+const isDisabled = ref(false);
 
 // Store previous label for restoration
 let previousLabel = '';

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -8,9 +8,174 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-button--defa
 figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Library--Rebrand-2025-?node-id=19800-32233
 ---
 
-<code-well-header>
-  <dt-button> Place Call </dt-button>
-</code-well-header>
+<style lang="less">
+.dialtone-playground {
+  background-color: var(--dt-color-surface-secondary);
+  display: flex;
+  flex-direction: row;
+  border-radius: var(--dt-size-radius-400);
+  overflow: hidden;
+
+  &__component {
+    padding: var(--dt-space-500);
+    display: grid;
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+    min-height: var(--dt-size-925);
+    position: relative;
+  }
+
+  &__fullscreen-toggle {
+    position: absolute;
+    inset-block-start: var(--dt-space-400);
+    inset-inline-end: var(--dt-space-400);
+  }
+
+  &__controls {
+    padding: var(--dt-space-500);
+    background-color: var(--dt-color-surface-secondary-opaque);
+    width: var(--dt-size-875);
+    max-height: var(--dt-size-950);
+  }
+}
+</style>
+
+<div class="dialtone-playground">
+  <div class="dialtone-playground__component">
+    <div class="dialtone-playground__fullscreen-toggle">
+      <dt-button v-dt-tooltip="`Fullscreen`" kind="muted" importance="clear" size="sm" circle>
+        <template #icon="{ iconSize }">
+          <dt-icon
+            name="expand"
+            :size="iconSize"
+          />
+        </template>
+      </dt-button>
+    </div>
+    <dt-button
+      size="xs"
+      importance="clear"
+      kind="default"
+      ref="component-default"
+    >
+      Place Call
+    </dt-button>
+  </div>
+  <div
+    class="
+      dialtone-playground__controls
+    "
+    v-dt-scrollbar:never
+  >
+    <dt-stack gap="500">
+      <dt-select-menu
+        size="sm"
+        :options="[
+              { value: `xs`, label: `xs` },
+              { value: `sm`, label: `sm` },
+              { value: `lg`, label: `lg` },
+              { value: `xl`, label: `xl` },
+            ]"
+        label="Size"
+      />
+      <dt-select-menu
+        size="sm"
+        :options="[
+              { value: `clear`, label: `clear` },
+              { value: `outlined`, label: `outlined` },
+              { value: `primary`, label: `primary` },
+            ]"
+        label="Importance"
+      />
+      <dt-select-menu
+        size="sm"
+        :options="[
+              { value: `default`, label: `default` },
+              { value: `muted`, label: `muted` },
+              { value: `danger`, label: `danger` },
+              { value: `positive`, label: `positive` },
+              { value: `inverted`, label: `inverted` },
+              { value: `unstyled`, label: `unstyled` },
+            ]"
+        label="Kind"
+      />
+      <dt-input label="Label" type="text" value="Place Call" size="sm" />
+      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+        Active
+      </dt-toggle>
+      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+        Circle
+      </dt-toggle>
+      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+        Icon
+      </dt-toggle>
+      <dt-select-menu
+        size="sm"
+        labelClass="d-vi-visible-sr"
+        :options="[
+              { value: `activity`, label: `activity` },
+              { value: `add`, label: `add` },
+              { value: `add-circle`, label: `add-circle` },
+              { value: `add-circle-outline`, label: `add-circle-outline` },
+              { value: `add-task`, label: `add-task` },
+              { value: `...`, label: `...` },
+              { value: `...`, label: `...` },
+            ]"
+        label="Icon name"
+      />
+      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+        Icon only
+      </dt-toggle>
+      <dt-select-menu
+        size="sm"
+        :options="[
+              { value: `left`, label: `left` },
+              { value: `right`, label: `right` },
+              { value: `top`, label: `top` },
+              { value: `bottom`, label: `bottom` },
+            ]"
+        label="Icon Position"
+      />
+      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+        Link
+      </dt-toggle>
+      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+        Link Inverted
+      </dt-toggle>
+      <dt-select-menu
+        size="sm"
+        :options="[
+              { value: `default`, label: `default` },
+              { value: `warning`, label: `warning` },
+              { value: `danger`, label: `danger` },
+              { value: `success`, label: `success` },
+              { value: `muted`, label: `muted` },
+              { value: `mention`, label: `mention` },
+            ]"
+        label="Link Kind"
+      />
+      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+        Loading
+      </dt-toggle>
+      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+        Disabled
+      </dt-toggle>
+    </dt-stack>
+  </div>
+</div>
+<code-example-tabs
+vueCode='
+<dt-button
+  size="xs"
+  importance="clear"
+  kind="default"
+>
+  Place Call
+</dt-button>
+'
+:htmlCode="() => $refs['component-default']"
+showHtmlWarning />
 
 <!-- <component-combinator component-name="DtButton" /> -->
 

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -1533,6 +1533,7 @@ const dynamicHtmlCode = computed(() => {
 
     .dialtone-playground--fullscreen & {
       max-height: 100%;
+      width: var(--dt-size-900);
     }
   }
 }

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -47,7 +47,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
     </div>
     <div class="dialtone-playground__controls" v-dt-scrollbar>
       <dt-stack gap="500">
-        <h2 v-show="isFullscreen" class="d-headline--lg">DtButton</h2>
+        <h2 v-show="isFullscreen" class="d-headline--lg">Button</h2>
         <dt-input v-model="buttonLabel" label="Label" type="text" size="sm" />
         <dt-input v-model="buttonLabelClass" label="Label class" type="text" size="sm" />
         <dt-select-menu
@@ -196,7 +196,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
   <div class="dialtone-playground__end">
 <code-example-tabs
 :vueCode="dynamicVueCode"
-:htmlCode="() => $refs['component-default']"
+:htmlCode="dynamicHtmlCode"
 showHtmlWarning />
   </div>
 </div>
@@ -1387,7 +1387,7 @@ const dynamicVueCode = computed(() => {
   if (isDisabled.value) {
     props.push(`  disabled`);
   }
-  
+
   // Add labelClass if not empty
   if (buttonLabelClass.value && buttonLabelClass.value.trim() !== '') {
     props.push(`  labelClass="${buttonLabelClass.value}"`);
@@ -1398,6 +1398,77 @@ const dynamicVueCode = computed(() => {
   const labelContent = buttonLabel.value || 'Place Call';
 
   return `<dt-button${propsString}>${iconTemplate}\n  ${labelContent}\n</dt-button>`;
+});
+
+// Computed property for dynamic HTML code generation
+const dynamicHtmlCode = computed(() => {
+  const classNames = ['base-button', 'base-button__button'];
+
+  // Add size class
+  if (buttonSize.value) {
+    classNames.push(`d-btn--${buttonSize.value}`);
+  }
+
+  // Add importance class
+  if (buttonImportance.value && buttonImportance.value !== 'primary') {
+    classNames.push(`d-btn--${buttonImportance.value}`);
+  } else if (buttonImportance.value === 'primary') {
+    classNames.push('d-btn--primary');
+  }
+
+  // Add kind class
+  if (buttonKind.value && buttonKind.value !== 'default') {
+    classNames.push(`d-btn--${buttonKind.value}`);
+  }
+
+  // Add state classes
+  if (isActive.value) {
+    classNames.push('d-btn--active');
+  }
+
+  if (isCircle.value) {
+    classNames.push('d-btn--circle');
+  }
+
+  if (isLink.value) {
+    classNames.push('d-btn--link');
+    if (linkKind.value && linkKind.value !== 'default') {
+      classNames.push(`d-btn--link-${linkKind.value}`);
+    }
+    if (isLinkInverted.value) {
+      classNames.push('d-btn--link-inverted');
+    }
+  }
+
+  if (isLoading.value) {
+    classNames.push('d-btn--loading');
+  }
+
+  // Build attributes
+  const attributes = [];
+  if (isDisabled.value) {
+    attributes.push('disabled="disabled"');
+  }
+  attributes.push('type="button"');
+
+  const classAttr = `class="${classNames.join(' ')}"`;
+  const attributesString = [classAttr, ...attributes].join(' ');
+
+  // Build content
+  let content = '';
+  if (hasIcon.value) {
+    const iconHtml = `<svg>...</svg>`;
+    if (isIconOnly.value) {
+      content = iconHtml;
+    } else {
+      const labelSpan = `<span class="base-button__label${buttonLabelClass.value ? ' ' + buttonLabelClass.value : ''}">${buttonLabel.value || 'Place Call'}</span>`;
+      content = iconPosition.value === 'right' ? `${labelSpan}\n  ${iconHtml}` : `${iconHtml}\n  ${labelSpan}`;
+    }
+  } else {
+    content = `<span class="base-button__label${buttonLabelClass.value ? ' ' + buttonLabelClass.value : ''}">${buttonLabel.value || 'Place Call'}</span>`;
+  }
+
+  return `<button ${attributesString}>\n  ${content}\n</button>`;
 });
 </script>
 

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -1344,6 +1344,7 @@ watch(buttonLabel, (newValue) => {
 });
 
 // Computed property for dynamic Vue code generation
+// ‼️ ⚠️ This is all totally FAKE, it's just a prototype to fake the Vues
 const dynamicVueCode = computed(() => {
   const props = [];
 
@@ -1401,8 +1402,9 @@ const dynamicVueCode = computed(() => {
 });
 
 // Computed property for dynamic HTML code generation
+// ‼️ ⚠️ This is all totally FAKE, it's just a prototype to fake the rendered HTML
 const dynamicHtmlCode = computed(() => {
-  const classNames = ['base-button', 'base-button__button'];
+  const classNames = ['d-btn'];
 
   // Add size class
   if (buttonSize.value) {

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -70,6 +70,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
   >
     <dt-stack gap="500">
       <dt-select-menu
+        id="playground-prop-size"
         size="sm"
         :options="[
               { value: `xs`, label: `xs` },
@@ -80,6 +81,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         label="Size"
       />
       <dt-select-menu
+        id="playground-prop-importance"
         size="sm"
         :options="[
               { value: `clear`, label: `clear` },
@@ -89,6 +91,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         label="Importance"
       />
       <dt-select-menu
+        id="playground-prop-kind"
         size="sm"
         :options="[
               { value: `default`, label: `default` },
@@ -100,34 +103,38 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
             ]"
         label="Kind"
       />
-      <dt-input label="Label" type="text" value="Place Call" size="sm" />
-      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-input id="playground-prop-label" label="Label" type="text" value="Place Call" size="sm" />
+      <dt-toggle id="playground-prop-active" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
         Active
       </dt-toggle>
-      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
-        Circle
-      </dt-toggle>
-      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
-        Icon
-      </dt-toggle>
-      <dt-select-menu
-        size="sm"
-        labelClass="d-vi-visible-sr"
-        :options="[
-              { value: `activity`, label: `activity` },
-              { value: `add`, label: `add` },
-              { value: `add-circle`, label: `add-circle` },
-              { value: `add-circle-outline`, label: `add-circle-outline` },
-              { value: `add-task`, label: `add-task` },
-              { value: `...`, label: `...` },
-              { value: `...`, label: `...` },
-            ]"
-        label="Icon name"
-      />
-      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-stack gap="400">
+        <dt-toggle id="playground-prop-icon" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+          Icon
+        </dt-toggle>
+        <dt-select-menu
+          id="playground-prop-icon-name"
+          size="sm"
+          labelClass="d-vi-visible-sr"
+          :options="[
+                { value: `activity`, label: `activity` },
+                { value: `add`, label: `add` },
+                { value: `add-circle`, label: `add-circle` },
+                { value: `add-circle-outline`, label: `add-circle-outline` },
+                { value: `add-task`, label: `add-task` },
+                { value: `...`, label: `...` },
+                { value: `...`, label: `...` },
+              ]"
+          label="Icon name"
+        />
+      </dt-stack>
+      <dt-toggle id="playground-prop-icon-only" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
         Icon only
       </dt-toggle>
+      <dt-toggle id="playground-prop-circle" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+        Circle
+      </dt-toggle>
       <dt-select-menu
+        id="playground-prop-icon-position"
         size="sm"
         :options="[
               { value: `left`, label: `left` },
@@ -137,13 +144,14 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
             ]"
         label="Icon Position"
       />
-      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-toggle id="playground-prop-link" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
         Link
       </dt-toggle>
-      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-toggle id="playground-prop-link-inverted" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
         Link Inverted
       </dt-toggle>
       <dt-select-menu
+        id="playground-prop-link-kind"
         size="sm"
         :options="[
               { value: `default`, label: `default` },
@@ -155,10 +163,10 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
             ]"
         label="Link Kind"
       />
-      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-toggle id="playground-prop-loading" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
         Loading
       </dt-toggle>
-      <dt-toggle labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
+      <dt-toggle id="playground-prop-disabled" labelClass="d-label--sm" size="sm" wrapperClass="d-jc-space-between">
         Disabled
       </dt-toggle>
     </dt-stack>

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -7,53 +7,8 @@ image: assets/images/components/button.png
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-button--default
 figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Library--Rebrand-2025-?node-id=19800-32233
 ---
-
-
-
-<style lang="less">
-/*#asdfasdf {
-  position: fixed;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  background-color: var(--dt-color-surface-secondary);
-}*/
-.dialtone-playground {
-  & {
-    background-color: var(--dt-color-surface-secondary);
-    display: flex;
-    flex-direction: row;
-    border-radius: var(--dt-size-radius-400);
-    overflow: hidden;
-  }
-
-  &__component {
-    padding: var(--dt-space-500);
-    display: grid;
-    flex: 1;
-    align-items: center;
-    justify-content: center;
-    min-height: var(--dt-size-925);
-    position: relative;
-  }
-
-  &__fullscreen-toggle {
-    position: absolute;
-    inset-block-start: var(--dt-space-400);
-    inset-inline-end: var(--dt-space-400);
-  }
-
-  &__controls {
-    padding: var(--dt-space-500);
-    background-color: var(--dt-color-surface-secondary-opaque);
-    width: var(--dt-size-875);
-    max-height: var(--dt-size-950);
-  }
-}
-</style>
-
-<div id="asdfasdf">
-  <div class="dialtone-playground">
+<div class="dialtone-playground">
+  <div class="dialtone-playground__start">
     <div class="dialtone-playground__component">
       <div class="dialtone-playground__fullscreen-toggle">
         <dt-button v-dt-tooltip="`Fullscreen`" kind="muted" importance="clear" size="sm">
@@ -74,7 +29,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         Place Call
       </dt-button>
     </div>
-    <div class="dialtone-playground__controls" v-dt-scrollbar:never>
+    <div class="dialtone-playground__controls" v-dt-scrollbar>
       <dt-stack gap="500">
         <dt-input id="playground-prop-label" label="Label" type="text" value="Place Call" size="sm" />
         <dt-select-menu
@@ -188,18 +143,20 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
       </dt-stack>
     </div>
   </div>
-  <code-example-tabs
-  vueCode='
-  <dt-button
-    size="xs"
-    importance="clear"
-    kind="default"
-  >
-    Place Call
-  </dt-button>
-  '
-  :htmlCode="() => $refs['component-default']"
-  showHtmlWarning />
+  <div class="dialtone-playground__end">
+<code-example-tabs
+vueCode='
+<dt-button
+  size="xs"
+  importance="clear"
+  kind="default"
+>
+  Place Call
+</dt-button>
+'
+:htmlCode="() => $refs['component-default']"
+showHtmlWarning />
+  </div>
 </div>
 
 <!-- <component-combinator component-name="DtButton" /> -->
@@ -1299,3 +1256,68 @@ import { ref } from 'vue';
 const hasIcon = ref(false);
 const isLink = ref(false);
 </script>
+
+<style lang="less">
+.dialtone-playground {
+  & {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__start {
+    flex-grow: 1;
+  }
+
+  &__end {
+    .dialtone-playground--fullscreen & {
+      background-color: var(--dt-color-surface-secondary-opaque);
+    }
+  }
+
+  &--fullscreen {
+    position: fixed;
+    inset: 0;
+    z-index: var(--zi-modal-element);
+    background-color: var(--dt-color-surface-secondary);
+  }
+
+  &__start {
+    background-color: var(--dt-color-surface-secondary);
+    display: flex;
+    flex-direction: row;
+    border-radius: var(--dt-size-radius-400);
+    overflow: hidden;
+
+    .dialtone-playground--fullscreen & {
+      border-bottom: 1px solid var(--dt-color-border-subtle)
+    }
+  }
+
+  &__component {
+    padding: var(--dt-space-500);
+    display: grid;
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+    min-height: var(--dt-size-925);
+    position: relative;
+  }
+
+  &__fullscreen-toggle {
+    position: absolute;
+    inset-block-start: var(--dt-space-400);
+    inset-inline-end: var(--dt-space-400);
+  }
+
+  &__controls {
+    padding: var(--dt-space-500);
+    background-color: var(--dt-color-surface-secondary-opaque);
+    width: var(--dt-size-875);
+    max-height: var(--dt-size-950);
+
+    .dialtone-playground--fullscreen & {
+      max-height: 100%;
+    }
+  }
+}
+</style>

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -26,6 +26,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         :importance="buttonImportance"
         :kind="buttonKind"
         :active="isActive"
+        :iconPosition="iconPosition"
       >
         <template v-if="hasIcon" #icon="{ iconSize }">
           <dt-icon

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -11,16 +11,6 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
 <div class="dialtone-playground" :class="{ 'dialtone-playground--fullscreen': isFullscreen }">
   <div class="dialtone-playground__start">
     <div class="dialtone-playground__component">
-      <div class="dialtone-playground__fullscreen-toggle">
-        <dt-button @click="toggleFullscreen" v-dt-tooltip="`Fullscreen`" kind="muted" importance="clear" size="sm">
-          <template #icon="{ iconSize }">
-            <dt-icon
-              :name="isFullscreen ? 'minimize' : 'expand'"
-              :size="iconSize"
-            />
-          </template>
-        </dt-button>
-      </div>
       <dt-button
         ref="component-default"
         :size="buttonSize"
@@ -47,7 +37,22 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
     </div>
     <div class="dialtone-playground__controls" v-dt-scrollbar>
       <dt-stack gap="500">
-        <h2 v-show="isFullscreen" class="d-headline--lg">Button</h2>
+        <dt-stack direction="row" gap="500">
+          <h2
+            class="d-fl1"
+            :class="isFullscreen ? 'd-headline--lg' : 'd-headline--md'"
+          >
+            Button
+          </h2>
+          <dt-button @click="toggleFullscreen" v-dt-tooltip="`Fullscreen`" kind="muted" importance="clear" size="sm">
+            <template #icon="{ iconSize }">
+              <dt-icon
+                :name="isFullscreen ? 'minimize' : 'expand'"
+                :size="iconSize"
+              />
+            </template>
+          </dt-button>
+        </dt-stack>
         <dt-input v-model="buttonLabel" label="Label" type="text" size="sm" />
         <dt-input v-model="buttonLabelClass" label="Label class" type="text" size="sm" />
         <dt-select-menu
@@ -1345,6 +1350,8 @@ watch(buttonLabel, (newValue) => {
 
 // Computed property for dynamic Vue code generation
 // ‼️ ⚠️ This is all totally FAKE, it's just a prototype to fake the Vues
+// ‼️ ⚠️ This is all totally FAKE, it's just a prototype to fake the Vues
+// ‼️ ⚠️ This is all totally FAKE, it's just a prototype to fake the Vues
 const dynamicVueCode = computed(() => {
   const props = [];
 
@@ -1402,6 +1409,8 @@ const dynamicVueCode = computed(() => {
 });
 
 // Computed property for dynamic HTML code generation
+// ‼️ ⚠️ This is all totally FAKE, it's just a prototype to fake the rendered HTML
+// ‼️ ⚠️ This is all totally FAKE, it's just a prototype to fake the rendered HTML
 // ‼️ ⚠️ This is all totally FAKE, it's just a prototype to fake the rendered HTML
 const dynamicHtmlCode = computed(() => {
   const classNames = ['d-btn'];
@@ -1463,11 +1472,11 @@ const dynamicHtmlCode = computed(() => {
     if (isIconOnly.value) {
       content = iconHtml;
     } else {
-      const labelSpan = `<span class="base-button__label${buttonLabelClass.value ? ' ' + buttonLabelClass.value : ''}">${buttonLabel.value || 'Place Call'}</span>`;
+      const labelSpan = `<span class="d-btn__label${buttonLabelClass.value ? ' ' + buttonLabelClass.value : ''}">${buttonLabel.value || 'Place Call'}</span>`;
       content = iconPosition.value === 'right' ? `${labelSpan}\n  ${iconHtml}` : `${iconHtml}\n  ${labelSpan}`;
     }
   } else {
-    content = `<span class="base-button__label${buttonLabelClass.value ? ' ' + buttonLabelClass.value : ''}">${buttonLabel.value || 'Place Call'}</span>`;
+    content = `<span class="d-btn__label${buttonLabelClass.value ? ' ' + buttonLabelClass.value : ''}">${buttonLabel.value || 'Place Call'}</span>`;
   }
 
   return `<button ${attributesString}>\n  ${content}\n</button>`;

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -31,6 +31,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         :link="isLink"
         :linkKind="linkKind"
         :linkInverted="isLinkInverted"
+        :loading="isLoading"
       >
         <template v-if="hasIcon" #icon="{ iconSize }">
           <dt-icon
@@ -175,7 +176,7 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
         <dt-toggle v-model="isLinkInverted" v-show="isLink && !hasIcon" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Link Inverted
         </dt-toggle>
-        <dt-toggle labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+        <dt-toggle v-model="isLoading" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
           Loading
         </dt-toggle>
         <dt-toggle labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
@@ -1308,6 +1309,7 @@ const isActive = ref(false);
 const isIconOnly = ref(false);
 const isCircle = ref(false);
 const isLinkInverted = ref(false);
+const isLoading = ref(false);
 
 // Store previous label for restoration
 let previousLabel = '';

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -1303,6 +1303,9 @@ const linkKind = ref('default');
 const isActive = ref(false);
 const isIconOnly = ref(false);
 
+// Store previous label for restoration
+let previousLabel = '';
+
 // Toggle fullscreen mode
 const toggleFullscreen = () => {
   isFullscreen.value = !isFullscreen.value;
@@ -1311,8 +1314,14 @@ const toggleFullscreen = () => {
 // Two-way sync between icon only and button label
 watch(isIconOnly, (newValue) => {
   if (newValue) {
-    // When icon only is turned on, clear the label
+    // When icon only is turned on, save current label and clear it
+    previousLabel = buttonLabel.value;
     buttonLabel.value = '';
+  } else {
+    // When icon only is turned off, restore the previous label
+    if (previousLabel) {
+      buttonLabel.value = previousLabel;
+    }
   }
 });
 

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -37,14 +37,30 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
     </div>
     <div class="dialtone-playground__controls" v-dt-scrollbar>
       <dt-stack gap="500">
-        <dt-stack direction="row" gap="500">
+        <dt-stack
+          direction="row"
+          gap="500"
+          class="
+            d-mtn8
+            d-mbn8
+            d-mrn4
+            d-d-none
+            md:d-d-flex
+          "
+        >
           <h2
             class="d-fl1"
             :class="isFullscreen ? 'd-headline--lg' : 'd-headline--md'"
           >
             Button
           </h2>
-          <dt-button @click="toggleFullscreen" v-dt-tooltip="`Fullscreen`" kind="muted" importance="clear" size="sm">
+          <dt-button
+            @click="toggleFullscreen"
+            v-dt-tooltip="`Fullscreen`"
+            kind="muted"
+            importance="clear"
+            size="sm"
+          >
             <template #icon="{ iconSize }">
               <dt-icon
                 :name="isFullscreen ? 'minimize' : 'expand'"
@@ -1492,6 +1508,18 @@ const dynamicHtmlCode = computed(() => {
 
   &__start {
     flex-grow: 1;
+    background-color: var(--dt-color-surface-secondary);
+    border-radius: var(--dt-size-radius-400);
+
+    @media screen and (min-width: 640px) {
+      display: flex;
+      overflow: hidden;
+      flex-direction: row;
+    }
+
+    .dialtone-playground--fullscreen & {
+      border-block-end: var(--dt-size-border-100) solid var(--dt-color-border-subtle)
+    }
   }
 
   &__end {
@@ -1508,44 +1536,35 @@ const dynamicHtmlCode = computed(() => {
     background-color: var(--dt-color-surface-secondary);
   }
 
-  &__start {
-    background-color: var(--dt-color-surface-secondary);
-    display: flex;
-    flex-direction: row;
-    border-radius: var(--dt-size-radius-400);
-    overflow: hidden;
-
-    .dialtone-playground--fullscreen & {
-      border-block-end: var(--dt-size-border-100) solid var(--dt-color-border-subtle)
-    }
-  }
-
   &__component {
     padding: var(--dt-space-500);
     display: grid;
     flex: 1;
     align-items: center;
     justify-content: center;
-    min-block-size: var(--dt-size-925);
     position: relative;
-  }
 
-  &__fullscreen-toggle {
-    position: absolute;
-    inset-block-start: var(--dt-space-400);
-    inset-inline-end: var(--dt-space-400);
+    @media screen and (min-width: 640px) {
+      min-block-size: var(--dt-size-925);
+    }
   }
 
   &__controls {
     padding: var(--dt-space-500);
     background-color: var(--dt-color-surface-secondary-opaque);
-    inline-size: var(--dt-size-875);
-    max-block-size: var(--dt-size-950);
+
+    @media screen and (min-width: 640px) {
+      inline-size: var(--dt-size-875);
+      max-block-size: var(--dt-size-950);
+    }
 
     .dialtone-playground--fullscreen & {
-      max-block-size: 100%;
-      inline-size: var(--dt-size-900);
+      @media screen and (min-width: 640px) {
+        max-block-size: 100%;
+        inline-size: var(--dt-size-900);
+      }
     }
+
   }
 }
 </style>

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -43,158 +43,155 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
 }
 </style>
 
-<div class="dialtone-playground">
-  <div class="dialtone-playground__component">
-    <div class="dialtone-playground__fullscreen-toggle">
-      <dt-button v-dt-tooltip="`Fullscreen`" kind="muted" importance="clear" size="sm" circle>
-        <template #icon="{ iconSize }">
-          <dt-icon
-            name="expand"
-            :size="iconSize"
-          />
-        </template>
+<div id="combinator-playground">
+  <div class="dialtone-playground">
+    <div class="dialtone-playground__component">
+      <div class="dialtone-playground__fullscreen-toggle">
+        <dt-button v-dt-tooltip="`Fullscreen`" kind="muted" importance="clear" size="sm">
+          <template #icon="{ iconSize }">
+            <dt-icon
+              name="expand"
+              :size="iconSize"
+            />
+          </template>
+        </dt-button>
+      </div>
+      <dt-button
+        size="xs"
+        importance="clear"
+        kind="default"
+        ref="component-default"
+      >
+        Place Call
       </dt-button>
     </div>
-    <dt-button
-      size="xs"
-      importance="clear"
-      kind="default"
-      ref="component-default"
-    >
-      Place Call
-    </dt-button>
-  </div>
-  <div
-    class="
-      dialtone-playground__controls
-    "
-    v-dt-scrollbar:never
-  >
-    <dt-stack gap="500">
-      <dt-input id="playground-prop-label" label="Label" type="text" value="Place Call" size="sm" />
-      <dt-select-menu
-        id="playground-prop-size"
-        size="sm"
-        :options="[
-          { value: `xs`, label: `xs` },
-          { value: `sm`, label: `sm` },
-          { value: `lg`, label: `lg` },
-          { value: `xl`, label: `xl` },
-        ]"
-        label="Size"
-      />
-      <dt-select-menu
-        id="playground-prop-importance"
-        size="sm"
-        :options="[
-          { value: `clear`, label: `clear` },
-          { value: `outlined`, label: `outlined` },
-          { value: `primary`, label: `primary` },
-        ]"
-        label="Importance"
-      />
-      <dt-select-menu
-        id="playground-prop-kind"
-        size="sm"
-        :options="[
-          { value: `default`, label: `default` },
-          { value: `muted`, label: `muted` },
-          { value: `danger`, label: `danger` },
-          { value: `positive`, label: `positive` },
-          { value: `inverted`, label: `inverted` },
-          { value: `unstyled`, label: `unstyled` },
-        ]"
-        label="Kind"
-      />
-      <dt-toggle id="playground-prop-active" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
-        Active
-      </dt-toggle>
-      <dt-stack gap="400">
-        <dt-toggle
-          v-model="hasIcon"
-          id="playground-prop-icon"
-          labelClass="d-label--sm d-fc-secondary"
+    <div class="dialtone-playground__controls" v-dt-scrollbar:never>
+      <dt-stack gap="500">
+        <dt-input id="playground-prop-label" label="Label" type="text" value="Place Call" size="sm" />
+        <dt-select-menu
+          id="playground-prop-size"
           size="sm"
-          wrapperClass="d-jc-space-between"
-        >
-          Icon
+          :options="[
+            { value: `xs`, label: `xs` },
+            { value: `sm`, label: `sm` },
+            { value: `lg`, label: `lg` },
+            { value: `xl`, label: `xl` },
+          ]"
+          label="Size"
+        />
+        <dt-select-menu
+          id="playground-prop-importance"
+          size="sm"
+          :options="[
+            { value: `clear`, label: `clear` },
+            { value: `outlined`, label: `outlined` },
+            { value: `primary`, label: `primary` },
+          ]"
+          label="Importance"
+        />
+        <dt-select-menu
+          id="playground-prop-kind"
+          size="sm"
+          :options="[
+            { value: `default`, label: `default` },
+            { value: `muted`, label: `muted` },
+            { value: `danger`, label: `danger` },
+            { value: `positive`, label: `positive` },
+            { value: `inverted`, label: `inverted` },
+            { value: `unstyled`, label: `unstyled` },
+          ]"
+          label="Kind"
+        />
+        <dt-toggle id="playground-prop-active" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+          Active
         </dt-toggle>
+        <dt-stack gap="400">
+          <dt-toggle
+            v-model="hasIcon"
+            id="playground-prop-icon"
+            labelClass="d-label--sm d-fc-secondary"
+            size="sm"
+            wrapperClass="d-jc-space-between"
+          >
+            Icon
+          </dt-toggle>
+          <dt-select-menu
+            v-show="hasIcon"
+            id="playground-prop-icon-name"
+            size="sm"
+            labelClass="d-vi-visible-sr"
+            :options="[
+              { value: `activity`, label: `activity` },
+              { value: `add`, label: `add` },
+              { value: `add-circle`, label: `add-circle` },
+              { value: `add-circle-outline`, label: `add-circle-outline` },
+              { value: `add-task`, label: `add-task` },
+              { value: `...`, label: `...` },
+              { value: `...`, label: `...` },
+            ]"
+            label="Icon name"
+          />
+        </dt-stack>
         <dt-select-menu
           v-show="hasIcon"
-          id="playground-prop-icon-name"
+          id="playground-prop-icon-position"
           size="sm"
-          labelClass="d-vi-visible-sr"
           :options="[
-            { value: `activity`, label: `activity` },
-            { value: `add`, label: `add` },
-            { value: `add-circle`, label: `add-circle` },
-            { value: `add-circle-outline`, label: `add-circle-outline` },
-            { value: `add-task`, label: `add-task` },
-            { value: `...`, label: `...` },
-            { value: `...`, label: `...` },
+            { value: `left`, label: `left` },
+            { value: `right`, label: `right` },
+            { value: `top`, label: `top` },
+            { value: `bottom`, label: `bottom` },
           ]"
-          label="Icon name"
+          label="Icon Position"
         />
+        <dt-toggle v-show="hasIcon" id="playground-prop-icon-only" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+          Icon only
+        </dt-toggle>
+        <dt-toggle v-show="hasIcon" id="playground-prop-circle" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+          Circle
+        </dt-toggle>
+        <dt-toggle v-model="isLink" v-show="!hasIcon" id="playground-prop-link" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+          Link
+        </dt-toggle>
+        <dt-select-menu
+          v-show="isLink && !hasIcon"
+          id="playground-prop-link-kind"
+          size="sm"
+          :options="[
+            { value: `default`, label: `default` },
+            { value: `warning`, label: `warning` },
+            { value: `danger`, label: `danger` },
+            { value: `success`, label: `success` },
+            { value: `muted`, label: `muted` },
+            { value: `mention`, label: `mention` },
+          ]"
+          label="Link Kind"
+        />
+        <dt-toggle v-show="isLink && !hasIcon" id="playground-prop-link-inverted" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+          Link Inverted
+        </dt-toggle>
+        <dt-toggle id="playground-prop-loading" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+          Loading
+        </dt-toggle>
+        <dt-toggle id="playground-prop-disabled" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
+          Disabled
+        </dt-toggle>
       </dt-stack>
-      <dt-select-menu
-        v-show="hasIcon"
-        id="playground-prop-icon-position"
-        size="sm"
-        :options="[
-          { value: `left`, label: `left` },
-          { value: `right`, label: `right` },
-          { value: `top`, label: `top` },
-          { value: `bottom`, label: `bottom` },
-        ]"
-        label="Icon Position"
-      />
-      <dt-toggle v-show="hasIcon" id="playground-prop-icon-only" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
-        Icon only
-      </dt-toggle>
-      <dt-toggle v-show="hasIcon" id="playground-prop-circle" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
-        Circle
-      </dt-toggle>
-      <dt-toggle v-model="isLink" v-show="!hasIcon" id="playground-prop-link" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
-        Link
-      </dt-toggle>
-      <dt-select-menu
-        v-show="isLink && !hasIcon"
-        id="playground-prop-link-kind"
-        size="sm"
-        :options="[
-          { value: `default`, label: `default` },
-          { value: `warning`, label: `warning` },
-          { value: `danger`, label: `danger` },
-          { value: `success`, label: `success` },
-          { value: `muted`, label: `muted` },
-          { value: `mention`, label: `mention` },
-        ]"
-        label="Link Kind"
-      />
-      <dt-toggle v-show="isLink && !hasIcon" id="playground-prop-link-inverted" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
-        Link Inverted
-      </dt-toggle>
-      <dt-toggle id="playground-prop-loading" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
-        Loading
-      </dt-toggle>
-      <dt-toggle id="playground-prop-disabled" labelClass="d-label--sm d-fc-secondary" size="sm" wrapperClass="d-jc-space-between">
-        Disabled
-      </dt-toggle>
-    </dt-stack>
+    </div>
   </div>
+  <code-example-tabs
+  vueCode='
+  <dt-button
+    size="xs"
+    importance="clear"
+    kind="default"
+  >
+    Place Call
+  </dt-button>
+  '
+  :htmlCode="() => $refs['component-default']"
+  showHtmlWarning />
 </div>
-<code-example-tabs
-vueCode='
-<dt-button
-  size="xs"
-  importance="clear"
-  kind="default"
->
-  Place Call
-</dt-button>
-'
-:htmlCode="() => $refs['component-default']"
-showHtmlWarning />
 
 <!-- <component-combinator component-name="DtButton" /> -->
 


### PR DESCRIPTION
# PROTOTYPE: Playground UI (née combinator)

A POC for the general idea of its UI. **Not mergable**, purely a prototype (read: hacky hacking code) meant to set the initial UI direction of [the combinator](https://dialpad.github.io/dialtone-combinator/) on a component doc page.

https://github.com/user-attachments/assets/7a94c779-cfb7-4aa7-a773-8acbc8564c1a

