### PR TITLE
build: NO-JIRA fix build for first time contributors

### DIFF
--- a/packages/dialtone-vue2/project.json
+++ b/packages/dialtone-vue2/project.json
@@ -31,7 +31,8 @@
       "dependsOn": [
         "dialtone-css:build",
         "dialtone-icons:build",
-        "dialtone-tokens:build"
+        "dialtone-tokens:build",
+        "build-functions"
       ],
       "inputs": [
         "{projectRoot}/.storybook/*",
@@ -50,16 +51,22 @@
         "{projectRoot}/vite.config.js"
       ],
       "outputs": [
-        "{projectRoot}/storybook-static",
-        "{projectRoot}/functions/generated"
+        "{projectRoot}/storybook-static"
       ],
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "pnpm exec typedoc --plugin typedoc-plugin-markdown",
-          "STORYBOOK_ENV=production pnpm exec storybook build"
-        ],
-        "parallel": false
+        "command": "STORYBOOK_ENV=production pnpm exec storybook build"
+      }
+    },
+    "build-functions": {
+      "executor": "nx:run-commands",
+      "inputs": [
+        "{projectRoot}/common/**/*"
+      ],
+      "outputs": [ "{projectRoot}/functions/generated" ],
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "pnpm exec typedoc --plugin typedoc-plugin-markdown"
       }
     },
     "publish": {
@@ -80,7 +87,8 @@
       "dependsOn": [
         "dialtone-css:build",
         "dialtone-icons:build",
-        "dialtone-tokens:build"
+        "dialtone-tokens:build",
+        "build-functions"
       ],
       "options": {
         "cwd": "{projectRoot}",

--- a/packages/dialtone-vue3/project.json
+++ b/packages/dialtone-vue3/project.json
@@ -30,7 +30,8 @@
       "dependsOn": [
         "dialtone-css:build",
         "dialtone-icons:build",
-        "dialtone-tokens:build"
+        "dialtone-tokens:build",
+        "build-functions"
       ],
       "inputs": [
         "{projectRoot}/.storybook/*",
@@ -49,16 +50,22 @@
         "{projectRoot}/vite.config.js"
       ],
       "outputs": [
-        "{projectRoot}/storybook-static",
-        "{projectRoot}/functions/generated"
+        "{projectRoot}/storybook-static"
       ],
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "pnpm exec typedoc --plugin typedoc-plugin-markdown",
-          "STORYBOOK_ENV=production pnpm exec storybook build"
-        ],
-        "parallel": false
+        "command": "STORYBOOK_ENV=production pnpm exec storybook build"
+      }
+    },
+    "build-functions": {
+      "executor": "nx:run-commands",
+      "inputs": [
+        "{projectRoot}/common/**/*"
+      ],
+      "outputs": [ "{projectRoot}/functions/generated" ],
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "pnpm exec typedoc --plugin typedoc-plugin-markdown"
       }
     },
     "publish": {
@@ -79,7 +86,8 @@
       "dependsOn": [
         "dialtone-css:build",
         "dialtone-icons:build",
-        "dialtone-tokens:build"
+        "dialtone-tokens:build",
+        "build-functions"
       ],
       "options": {
         "cwd": "{projectRoot}",


### PR DESCRIPTION
# Fix build for first time contributors

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTgyYTE0OTNiM2g4MWQ2NXFuMDcyemd4ajkyY2V5NWh2OGR4OTlzeXF5dzl4cjlncyZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/oUYDwyQ3xUgo0/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [x] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Description

- Added a common step "build-functions" to dialtone-vue2 and dialtone-vue3 which builds the `functions/generated` folder

## :bulb: Context

The `functions/generated` folder was created only while running the `build-storybook` command which it's not ok as it is needed for running storybook locally so first time contributors like @belumontoya which reported the issue had errors while trying to run storybook.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.
