### PR TITLE
fix(rich-text-editor): DP-150683 allow enter on preventTyping

### DIFF
--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.test.js
@@ -356,6 +356,153 @@ describe('DtRichTextEditor tests', () => {
     });
   });
 
+  describe('Interactivity Tests', () => {
+    describe('handleKeyDown functionality', () => {
+      let mockKeyEvent;
+      let mockView;
+
+      beforeEach(() => {
+        mockView = { state: { schema: {} } };
+        mockKeyEvent = {
+          key: '',
+          shiftKey: false,
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn(),
+        };
+      });
+
+      describe('When preventTyping is false', () => {
+        beforeEach(async () => {
+          await wrapper.setProps({ preventTyping: false });
+        });
+
+        it('should allow letter keys by returning false', () => {
+          const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+          mockKeyEvent.key = 'a';
+          expect(handleKeyDown(mockView, mockKeyEvent)).toBe(false);
+        });
+
+        it('should allow Enter key by returning false', () => {
+          const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+          mockKeyEvent.key = 'Enter';
+          expect(handleKeyDown(mockView, mockKeyEvent)).toBe(false);
+        });
+
+        it('should allow Backspace key by returning false', () => {
+          const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+          mockKeyEvent.key = 'Backspace';
+          expect(handleKeyDown(mockView, mockKeyEvent)).toBe(false);
+        });
+
+        it('should allow Space key by returning false', () => {
+          const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+          mockKeyEvent.key = 'Space';
+          expect(handleKeyDown(mockView, mockKeyEvent)).toBe(false);
+        });
+      });
+
+      describe('When preventTyping is true', () => {
+        beforeEach(async () => {
+          await wrapper.setProps({ preventTyping: true });
+        });
+
+        describe('Backspace key', () => {
+          it('should always allow Backspace key', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Backspace';
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(false);
+          });
+        });
+
+        describe('Enter key with allowLineBreaks false', () => {
+          beforeEach(async () => {
+            await wrapper.setProps({
+              preventTyping: true,
+              allowLineBreaks: false,
+            });
+          });
+
+          it('should allow Enter key when shift is not pressed', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Enter';
+            mockKeyEvent.shiftKey = false;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(false);
+          });
+
+          it('should block Enter key when shift is pressed', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Enter';
+            mockKeyEvent.shiftKey = true;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+          });
+        });
+
+        describe('Enter key with allowLineBreaks true', () => {
+          beforeEach(async () => {
+            await wrapper.setProps({
+              preventTyping: true,
+              allowLineBreaks: true,
+            });
+          });
+
+          it('should block Enter key when shift is not pressed', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Enter';
+            mockKeyEvent.shiftKey = false;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+          });
+
+          it('should block Enter key when shift is pressed', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Enter';
+            mockKeyEvent.shiftKey = true;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+          });
+        });
+
+        describe('Other keys', () => {
+          it('should block letter keys', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'a';
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+          });
+
+          it('should block Tab key', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Tab';
+            mockKeyEvent.shiftKey = false;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+
+            mockKeyEvent.shiftKey = true;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+          });
+
+          it('should block Delete key', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Delete';
+            mockKeyEvent.shiftKey = false;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+
+            mockKeyEvent.shiftKey = true;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+          });
+        });
+      });
+    });
+  });
+
   describe('Accessibility Tests', () => {
     it('should have aria-multiline attribute', () => {
       expect(editor.attributes('aria-multiline')).toBe('true');

--- a/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/rich_text_editor.vue
@@ -737,11 +737,14 @@ export default {
           },
 
           handleKeyDown: (view, event) => {
-            // When preventTyping is true, only allow backspace to take effect
-            if (this.preventTyping && event.key !== 'Backspace') {
-              return true; // Prevent the event from being processed
+            if (!this.preventTyping) return false;
+
+            const allowedKeys = ['Backspace'];
+            if (!this.allowLineBreaks && !event.shiftKey) {
+              allowedKeys.push('Enter');
             }
-            return false; // Allow the event to be processed normally
+
+            return !allowedKeys.includes(event.key);
           },
 
           handlePaste: (view, event, slice) => {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.test.js
@@ -379,8 +379,155 @@ describe('DtRichTextEditor tests', () => {
     });
   });
 
-  describe('Accessibility Tests', function () {
-    it('should have aria-multiline attribute', function () {
+  describe('Interactivity Tests', () => {
+    describe('handleKeyDown functionality', () => {
+      let mockKeyEvent;
+      let mockView;
+
+      beforeEach(() => {
+        mockView = { state: { schema: {} } };
+        mockKeyEvent = {
+          key: '',
+          shiftKey: false,
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn(),
+        };
+      });
+
+      describe('When preventTyping is false', () => {
+        beforeEach(async () => {
+          await wrapper.setProps({ preventTyping: false });
+        });
+
+        it('should allow letter keys by returning false', () => {
+          const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+          mockKeyEvent.key = 'a';
+          expect(handleKeyDown(mockView, mockKeyEvent)).toBe(false);
+        });
+
+        it('should allow Enter key by returning false', () => {
+          const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+          mockKeyEvent.key = 'Enter';
+          expect(handleKeyDown(mockView, mockKeyEvent)).toBe(false);
+        });
+
+        it('should allow Backspace key by returning false', () => {
+          const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+          mockKeyEvent.key = 'Backspace';
+          expect(handleKeyDown(mockView, mockKeyEvent)).toBe(false);
+        });
+
+        it('should allow Space key by returning false', () => {
+          const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+          mockKeyEvent.key = 'Space';
+          expect(handleKeyDown(mockView, mockKeyEvent)).toBe(false);
+        });
+      });
+
+      describe('When preventTyping is true', () => {
+        beforeEach(async () => {
+          await wrapper.setProps({ preventTyping: true });
+        });
+
+        describe('Backspace key', () => {
+          it('should always allow Backspace key', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Backspace';
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(false);
+          });
+        });
+
+        describe('Enter key with allowLineBreaks false', () => {
+          beforeEach(async () => {
+            await wrapper.setProps({
+              preventTyping: true,
+              allowLineBreaks: false,
+            });
+          });
+
+          it('should allow Enter key when shift is not pressed', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Enter';
+            mockKeyEvent.shiftKey = false;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(false);
+          });
+
+          it('should block Enter key when shift is pressed', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Enter';
+            mockKeyEvent.shiftKey = true;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+          });
+        });
+
+        describe('Enter key with allowLineBreaks true', () => {
+          beforeEach(async () => {
+            await wrapper.setProps({
+              preventTyping: true,
+              allowLineBreaks: true,
+            });
+          });
+
+          it('should block Enter key when shift is not pressed', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Enter';
+            mockKeyEvent.shiftKey = false;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+          });
+
+          it('should block Enter key when shift is pressed', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Enter';
+            mockKeyEvent.shiftKey = true;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+          });
+        });
+
+        describe('Other keys', () => {
+          it('should block letter keys', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'a';
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+          });
+
+          it('should block Tab key', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Tab';
+            mockKeyEvent.shiftKey = false;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+
+            mockKeyEvent.shiftKey = true;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+          });
+
+          it('should block Delete key', () => {
+            const handleKeyDown = wrapper.vm.editor.options.editorProps.handleKeyDown;
+
+            mockKeyEvent.key = 'Delete';
+            mockKeyEvent.shiftKey = false;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+
+            mockKeyEvent.shiftKey = true;
+            expect(handleKeyDown(mockView, mockKeyEvent)).toBe(true);
+          });
+        });
+      });
+    });
+  });
+
+  describe('Accessibility Tests', () => {
+    it('should have aria-multiline attribute', () => {
       expect(editor.attributes('aria-multiline')).toBe('true');
     });
 

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -736,11 +736,14 @@ export default {
           },
 
           handleKeyDown: (view, event) => {
-            // When preventTyping is true, only allow backspace to take effect
-            if (this.preventTyping && event.key !== 'Backspace') {
-              return true; // Prevent the event from being processed
+            if (!this.preventTyping) return false;
+
+            const allowedKeys = ['Backspace'];
+            if (!this.allowLineBreaks && !event.shiftKey) {
+              allowedKeys.push('Enter');
             }
-            return false; // Allow the event to be processed normally
+
+            return !allowedKeys.includes(event.key);
           },
 
           handlePaste: (view, event, slice) => {


### PR DESCRIPTION
# fix(rich-text-editor): DP-150683 allow enter on preventTyping

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExOG5ld2s5azk1OGpscW50N2syNWdvZjFlNmRkMnAycHNqMG9tcGdjaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/0GtVKtagi2GvWuY3vm/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-150683

## :book: Description

Allow pressing enter when preventTyping is false so message can be sent

## :bulb: Context

In the last fix for slash command prevented all keys except backspace, which meant that the user could not hit enter to send the message (clicking the send button still worked). This change allows enter to be pressed when allowLineBreaks is set to false so the user can send the message. Also prevents shift+enter as we don't want the user to be able to create newlines.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

CP to beta
