### PR TITLE
feat(avatar): DLT-2646 avatar clip-path svg

### DIFF
--- a/apps/dialtone-documentation/docs/components/avatar.md
+++ b/apps/dialtone-documentation/docs/components/avatar.md
@@ -282,7 +282,7 @@ Positions the [Presence](/components/presence.md) component at each size.
 
 <code-example-tabs
 htmlCode='
-<div class="d-avatar d-avatar--{$size)">
+<div class="d-avatar d-avatar--{$size) d-avatar--presence">
   <div class="d-avatar__canvas">
     ...
   </div>

--- a/apps/dialtone-documentation/docs/components/avatar.md
+++ b/apps/dialtone-documentation/docs/components/avatar.md
@@ -240,7 +240,7 @@ vueCode='
 
 <code-example-tabs
 htmlCode='
-<div class="d-avatar d-avatar--group">
+<div class="d-avatar d-avatar--group" data-group-count="double">
   <div class="d-avatar__canvas">
     <img class="d-avatar__image" src="/assets/images/person.png" alt="Person Avatar"/>
   </div>

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -312,5 +312,54 @@
 
     width: var(--dt-size-550);
     height: var(--dt-size-550);
+
+    /* Groups need the data-group-count attribute to properly size the masking */
+
+    /* Without the attribute, they will fall back to the old box-shadow color */
+    &[data-group-count="single"] {
+      --avatar-count-color-shadow: transparent;
+
+      .d-avatar__count {
+        width:calc(var(--dt-size-450) + var(--dt-size-200));
+        box-shadow: none;
+      }
+
+      .d-avatar__canvas {
+        clip-path: url("#dt-avatar-group-single-clip");
+        will-change: transform;
+      }
+    }
+
+    &[data-group-count="double"] {
+      --avatar-count-color-shadow: transparent;
+
+      .d-avatar__count {
+        width:calc(var(--dt-size-500) + var(--dt-size-200));
+        box-shadow: none;
+      }
+
+      .d-avatar__canvas {
+        clip-path: url("#dt-avatar-group-double-clip");
+        will-change: transform;
+      }
+    }
+
+    &[data-group-count="triple"] {
+      --avatar-count-color-shadow: transparent;
+
+      .d-avatar__count {
+        width:calc(var(--dt-size-550) + var(--dt-size-200));
+        box-shadow: none;
+      }
+
+      .d-avatar__canvas {
+        clip-path: url("#dt-avatar-group-triple-clip");
+        will-change: transform;
+      }
+    }
+
+    &.d-avatar--clickable {
+      border:none !important;
+    }
   }
 }

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -191,6 +191,20 @@
   }
 
   &:has(.d-presence) {
+    &.d-avatar--clickable {
+      border-color: transparent;
+
+      &::before {
+        position: absolute;
+        background-color: transparent;
+        border: var(--dt-size-border-100) solid var(--avatar-color-border);
+        border-radius: var(--dt-size-radius-circle);
+        content: "";
+        will-change: transform;
+        inset: calc(var(--dt-space-100) * -1);
+      }
+    }
+
     .d-presence {
       --presence-color-border-base: transparent;
     }
@@ -214,6 +228,12 @@
       .d-avatar__overlay {
         clip-path: url("#dt-avatar-xs-presence-clip");
       }
+
+      &.d-avatar--clickable {
+        &::before {
+          clip-path: url("#dt-avatar-xs-presence-clickable-clip");
+        }
+      }
     }
   }
 
@@ -227,6 +247,12 @@
       .d-avatar__canvas,
       .d-avatar__overlay {
         clip-path: url("#dt-avatar-sm-presence-clip");
+      }
+
+      &.d-avatar--clickable {
+        &::before {
+          clip-path: url("#dt-avatar-sm-presence-clickable-clip");
+        }
       }
     }
   }
@@ -242,6 +268,12 @@
       .d-avatar__overlay {
         clip-path: url("#dt-avatar-md-presence-clip");
       }
+
+      &.d-avatar--clickable {
+        &::before {
+          clip-path: url("#dt-avatar-md-presence-clickable-clip");
+        }
+      }
     }
   }
 
@@ -255,6 +287,12 @@
       .d-avatar__canvas,
       .d-avatar__overlay {
         clip-path: url("#dt-avatar-lg-presence-clip");
+      }
+
+      &.d-avatar--clickable:has(.d-presence) {
+        &::before {
+          clip-path: url("#dt-avatar-lg-presence-clickable-clip");
+        }
       }
     }
   }

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -12,6 +12,7 @@
 //    • CHILDREN
 //    • SIZES
 //    • VARIANTS
+//  • RECIPE STYLE OVERRIDES
 //
 //  ============================================================================
 //  $   BASE STYLE
@@ -361,5 +362,21 @@
     &.d-avatar--clickable {
       border:none !important;
     }
+  }
+}
+
+/* -- RECIPE STYLE OVERRIDES -- */
+.d-recipe-leftbar-row--selected .d-avatar,
+.d-recipe-leftbar-row:hover .d-avatar,
+.d-recipe-leftbar-row:focus-within .d-avatar,
+.d-recipe-leftbar-row__primary:hover .d-avatar {
+  // Presence Masking
+  .d-presence {
+    --presence-color-border-base: transparent;
+  }
+
+  // Group Masking
+  &.d-avatar--group .d-avatar__count {
+    --avatar-count-color-shadow: transparent;
   }
 }

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -191,7 +191,75 @@
     }
   }
 
-  &:has(.d-presence) {
+  //  --  SIZES
+  //  ------------------------------------------------------------------------
+
+  &--xs {
+    --avatar-size-shape: calc(var(--dt-size-500) + var(--dt-size-200));
+    --avatar-presence-position-right: var(--dt-space-300-negative);
+    --avatar-presence-position-bottom: var(--dt-space-300-negative);
+  }
+
+  &--sm {
+    --avatar-size-shape: var(--dt-size-550);
+    --avatar-size-text: var(--dt-font-size-100);
+    --avatar-presence-position-right: var(--dt-space-200-negative);
+    --avatar-presence-position-bottom: var(--dt-space-200-negative);
+  }
+
+  &--md {
+    --avatar-size-shape: var(--dt-size-600);
+    --avatar-size-text: var(--dt-font-size-200);
+    --avatar-presence-position-right: var(--dt-space-100-negative);
+    --avatar-presence-position-bottom: var(--dt-space-100-negative);
+  }
+
+  &--lg {
+    --avatar-size-shape: var(--dt-size-650);
+    --avatar-size-text: var(--dt-font-size-300);
+    --avatar-presence-position-right: var(--dt-space-100);
+    --avatar-presence-position-bottom: var(--dt-space-100);
+  }
+
+  &--xl {
+    --avatar-size-shape: var(--dt-size-700);
+    --avatar-size-text: var(--dt-font-size-400);
+    --avatar-presence-position-right: var(--dt-space-300);
+    --avatar-presence-position-bottom: var(--dt-space-300);
+  }
+
+  //  --  PRESENCE
+  //  ------------------------------------------------------------------------
+
+  &--presence {
+    &.d-avatar--xs {
+      .d-avatar__canvas,
+      .d-avatar__overlay {
+        clip-path: url("#dt-avatar-xs-presence-clip");
+      }
+    }
+
+    &.d-avatar--sm {
+      .d-avatar__canvas,
+      .d-avatar__overlay {
+        clip-path: url("#dt-avatar-sm-presence-clip");
+      }
+    }
+
+    &.d-avatar--md {
+      .d-avatar__canvas,
+      .d-avatar__overlay {
+        clip-path: url("#dt-avatar-md-presence-clip");
+      }
+    }
+
+    &.d-avatar--lg {
+      .d-avatar__canvas,
+      .d-avatar__overlay {
+        clip-path: url("#dt-avatar-lg-presence-clip");
+      }
+    }
+
     &.d-avatar--clickable {
       border-color: transparent;
 
@@ -204,6 +272,30 @@
         will-change: transform;
         inset: calc(var(--dt-space-100) * -1);
       }
+
+      &.d-avatar--xs {
+        &::before {
+          clip-path: url("#dt-avatar-xs-presence-clickable-clip");
+        }
+      }
+
+      &.d-avatar--sm {
+        &::before {
+          clip-path: url("#dt-avatar-sm-presence-clickable-clip");
+        }
+      }
+
+      &.d-avatar--md {
+        &::before {
+          clip-path: url("#dt-avatar-md-presence-clickable-clip");
+        }
+      }
+
+      &.d-avatar--lg {
+        &::before {
+          clip-path: url("#dt-avatar-lg-presence-clickable-clip");
+        }
+      }
     }
 
     .d-presence {
@@ -214,95 +306,6 @@
     .d-avatar__overlay {
         will-change: transform;
     }
-  }
-
-  //  --  SIZES
-  //  ------------------------------------------------------------------------
-
-  &--xs {
-    --avatar-size-shape: calc(var(--dt-size-500) + var(--dt-size-200));
-    --avatar-presence-position-right: var(--dt-space-300-negative);
-    --avatar-presence-position-bottom: var(--dt-space-300-negative);
-
-    &:has(.d-presence) {
-      .d-avatar__canvas,
-      .d-avatar__overlay {
-        clip-path: url("#dt-avatar-xs-presence-clip");
-      }
-
-      &.d-avatar--clickable {
-        &::before {
-          clip-path: url("#dt-avatar-xs-presence-clickable-clip");
-        }
-      }
-    }
-  }
-
-  &--sm {
-    --avatar-size-shape: var(--dt-size-550);
-    --avatar-size-text: var(--dt-font-size-100);
-    --avatar-presence-position-right: var(--dt-space-200-negative);
-    --avatar-presence-position-bottom: var(--dt-space-200-negative);
-
-    &:has(.d-presence) {
-      .d-avatar__canvas,
-      .d-avatar__overlay {
-        clip-path: url("#dt-avatar-sm-presence-clip");
-      }
-
-      &.d-avatar--clickable {
-        &::before {
-          clip-path: url("#dt-avatar-sm-presence-clickable-clip");
-        }
-      }
-    }
-  }
-
-  &--md {
-    --avatar-size-shape: var(--dt-size-600);
-    --avatar-size-text: var(--dt-font-size-200);
-    --avatar-presence-position-right: var(--dt-space-100-negative);
-    --avatar-presence-position-bottom: var(--dt-space-100-negative);
-
-    &:has(.d-presence) {
-      .d-avatar__canvas,
-      .d-avatar__overlay {
-        clip-path: url("#dt-avatar-md-presence-clip");
-      }
-
-      &.d-avatar--clickable {
-        &::before {
-          clip-path: url("#dt-avatar-md-presence-clickable-clip");
-        }
-      }
-    }
-  }
-
-  &--lg {
-    --avatar-size-shape: var(--dt-size-650);
-    --avatar-size-text: var(--dt-font-size-300);
-    --avatar-presence-position-right: var(--dt-space-100);
-    --avatar-presence-position-bottom: var(--dt-space-100);
-
-    &:has(.d-presence) {
-      .d-avatar__canvas,
-      .d-avatar__overlay {
-        clip-path: url("#dt-avatar-lg-presence-clip");
-      }
-
-      &.d-avatar--clickable:has(.d-presence) {
-        &::before {
-          clip-path: url("#dt-avatar-lg-presence-clickable-clip");
-        }
-      }
-    }
-  }
-
-  &--xl {
-    --avatar-size-shape: var(--dt-size-700);
-    --avatar-size-text: var(--dt-font-size-400);
-    --avatar-presence-position-right: var(--dt-space-300);
-    --avatar-presence-position-bottom: var(--dt-space-300);
   }
 
   //  --  GROUP

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -102,6 +102,17 @@
     display: flex;
   }
 
+  &__clip {
+    position:absolute;
+    width:var(--dt-space-0);
+    height:var(--dt-space-0);
+    margin: var(--dt-size-100-negative);
+    overflow:hidden;
+    white-space: nowrap;
+    border-width:0;
+    clip: rect(0,0,0,0);
+  }
+
   &__count {
     position: absolute;
     right: var(--dt-space-0);
@@ -179,6 +190,17 @@
     }
   }
 
+  &:has(.d-presence) {
+    .d-presence {
+      --presence-color-border-base: transparent;
+    }
+
+    .d-avatar__canvas,
+    .d-avatar__overlay {
+        will-change: transform;
+    }
+  }
+
   //  --  SIZES
   //  ------------------------------------------------------------------------
 
@@ -186,6 +208,13 @@
     --avatar-size-shape: calc(var(--dt-size-500) + var(--dt-size-200));
     --avatar-presence-position-right: var(--dt-space-300-negative);
     --avatar-presence-position-bottom: var(--dt-space-300-negative);
+
+    &:has(.d-presence) {
+      .d-avatar__canvas,
+      .d-avatar__overlay {
+        clip-path: url("#dt-avatar-xs-presence-clip");
+      }
+    }
   }
 
   &--sm {
@@ -193,6 +222,13 @@
     --avatar-size-text: var(--dt-font-size-100);
     --avatar-presence-position-right: var(--dt-space-200-negative);
     --avatar-presence-position-bottom: var(--dt-space-200-negative);
+
+    &:has(.d-presence) {
+      .d-avatar__canvas,
+      .d-avatar__overlay {
+        clip-path: url("#dt-avatar-sm-presence-clip");
+      }
+    }
   }
 
   &--md {
@@ -200,6 +236,13 @@
     --avatar-size-text: var(--dt-font-size-200);
     --avatar-presence-position-right: var(--dt-space-100-negative);
     --avatar-presence-position-bottom: var(--dt-space-100-negative);
+
+    &:has(.d-presence) {
+      .d-avatar__canvas,
+      .d-avatar__overlay {
+        clip-path: url("#dt-avatar-md-presence-clip");
+      }
+    }
   }
 
   &--lg {
@@ -207,6 +250,13 @@
     --avatar-size-text: var(--dt-font-size-300);
     --avatar-presence-position-right: var(--dt-space-100);
     --avatar-presence-position-bottom: var(--dt-space-100);
+
+    &:has(.d-presence) {
+      .d-avatar__canvas,
+      .d-avatar__overlay {
+        clip-path: url("#dt-avatar-lg-presence-clip");
+      }
+    }
   }
 
   &--xl {

--- a/packages/dialtone-vue2/components/avatar/avatar.test.js
+++ b/packages/dialtone-vue2/components/avatar/avatar.test.js
@@ -255,11 +255,9 @@ describe('DtAvatar Tests', () => {
         expect(presence.classes('d-avatar__presence--lg')).toBe(true);
       });
     });
-
     describe('SVG ClipPath Rendering', () => {
       it('should render the SVG when presence is set', async () => {
         await wrapper.setProps({ presence: 'active' });
-
         const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.exists()).toBe(true);
         expect(svg.find('defs').exists()).toBe(true);
@@ -267,41 +265,68 @@ describe('DtAvatar Tests', () => {
 
       it('should NOT render the SVG when presence is not set', async () => {
         await wrapper.setProps({ presence: null });
-
         const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.exists()).toBe(false);
       });
 
-      it('should render the correct clipPath for xs size', async () => {
-        await wrapper.setProps({ presence: 'active', size: 'xs' });
-
+      // XS
+      it('should render only the regular clipPath for xs size when not clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'xs', clickable: false });
         const svg = wrapper.find('svg.d-avatar__clip');
-        expect(svg.exists()).toBe(true);
         expect(svg.find('#dt-avatar-xs-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-xs-presence-clickable-clip').exists()).toBe(false);
       });
 
-      it('should render the correct clipPath for sm size', async () => {
-        await wrapper.setProps({ presence: 'active', size: 'sm' });
-
+      it('should render both the regular and clickable clipPaths for xs size when clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'xs', clickable: true });
         const svg = wrapper.find('svg.d-avatar__clip');
-        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-xs-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-xs-presence-clickable-clip').exists()).toBe(true);
+      });
+
+      // SM
+      it('should render only the regular clipPath for sm size when not clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'sm', clickable: false });
+        const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.find('#dt-avatar-sm-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-sm-presence-clickable-clip').exists()).toBe(false);
       });
 
-      it('should render the correct clipPath for md size', async () => {
-        await wrapper.setProps({ presence: 'active', size: 'md' });
-
+      it('should render both the regular and clickable clipPaths for sm size when clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'sm', clickable: true });
         const svg = wrapper.find('svg.d-avatar__clip');
-        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-sm-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-sm-presence-clickable-clip').exists()).toBe(true);
+      });
+
+      // MD
+      it('should render only the regular clipPath for md size when not clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'md', clickable: false });
+        const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.find('#dt-avatar-md-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-md-presence-clickable-clip').exists()).toBe(false);
       });
 
-      it('should render the correct clipPath for lg size', async () => {
-        await wrapper.setProps({ presence: 'active', size: 'lg' });
-
+      it('should render both the regular and clickable clipPaths for md size when clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'md', clickable: true });
         const svg = wrapper.find('svg.d-avatar__clip');
-        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-md-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-md-presence-clickable-clip').exists()).toBe(true);
+      });
+
+      // LG
+      it('should render only the regular clipPath for lg size when not clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'lg', clickable: false });
+        const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.find('#dt-avatar-lg-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-lg-presence-clickable-clip').exists()).toBe(false);
+      });
+
+      it('should render both the regular and clickable clipPaths for lg size when clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'lg', clickable: true });
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.find('#dt-avatar-lg-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-lg-presence-clickable-clip').exists()).toBe(true);
       });
     });
   });

--- a/packages/dialtone-vue2/components/avatar/avatar.test.js
+++ b/packages/dialtone-vue2/components/avatar/avatar.test.js
@@ -263,8 +263,8 @@ describe('DtAvatar Tests', () => {
         expect(svg.find('defs').exists()).toBe(true);
       });
 
-      it('should NOT render the SVG when presence is not set', async () => {
-        await wrapper.setProps({ presence: null });
+      it('should NOT render the SVG unless presence or group is set', async () => {
+        await wrapper.setProps({ presence: null, group: null });
         const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.exists()).toBe(false);
       });
@@ -327,6 +327,31 @@ describe('DtAvatar Tests', () => {
         const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.find('#dt-avatar-lg-presence-clip').exists()).toBe(true);
         expect(svg.find('#dt-avatar-lg-presence-clickable-clip').exists()).toBe(true);
+      });
+    });
+    describe('SVG Group ClipPath Rendering', () => {
+      it('should render the single group clipPath for group 2-9', async () => {
+        await wrapper.setProps({ group: 5 });
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.find('#dt-avatar-group-single-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-group-double-clip').exists()).toBe(false);
+        expect(svg.find('#dt-avatar-group-triple-clip').exists()).toBe(false);
+      });
+
+      it('should render the double group clipPath for group 10-99', async () => {
+        await wrapper.setProps({ group: 25 });
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.find('#dt-avatar-group-single-clip').exists()).toBe(false);
+        expect(svg.find('#dt-avatar-group-double-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-group-triple-clip').exists()).toBe(false);
+      });
+
+      it('should render the triple group clipPath for group 100+', async () => {
+        await wrapper.setProps({ group: 100 });
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.find('#dt-avatar-group-single-clip').exists()).toBe(false);
+        expect(svg.find('#dt-avatar-group-double-clip').exists()).toBe(false);
+        expect(svg.find('#dt-avatar-group-triple-clip').exists()).toBe(true);
       });
     });
   });

--- a/packages/dialtone-vue2/components/avatar/avatar.test.js
+++ b/packages/dialtone-vue2/components/avatar/avatar.test.js
@@ -255,6 +255,55 @@ describe('DtAvatar Tests', () => {
         expect(presence.classes('d-avatar__presence--lg')).toBe(true);
       });
     });
+
+    describe('SVG ClipPath Rendering', () => {
+      it('should render the SVG when presence is set', async () => {
+        await wrapper.setProps({ presence: 'active' });
+
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.exists()).toBe(true);
+        expect(svg.find('defs').exists()).toBe(true);
+      });
+
+      it('should NOT render the SVG when presence is not set', async () => {
+        await wrapper.setProps({ presence: null });
+
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.exists()).toBe(false);
+      });
+
+      it('should render the correct clipPath for xs size', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'xs' });
+
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-xs-presence-clip').exists()).toBe(true);
+      });
+
+      it('should render the correct clipPath for sm size', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'sm' });
+
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-sm-presence-clip').exists()).toBe(true);
+      });
+
+      it('should render the correct clipPath for md size', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'md' });
+
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-md-presence-clip').exists()).toBe(true);
+      });
+
+      it('should render the correct clipPath for lg size', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'lg' });
+
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-lg-presence-clip').exists()).toBe(true);
+      });
+    });
   });
 
   describe('Interactivity Tests', () => {

--- a/packages/dialtone-vue2/components/avatar/avatar.test.js
+++ b/packages/dialtone-vue2/components/avatar/avatar.test.js
@@ -254,6 +254,23 @@ describe('DtAvatar Tests', () => {
 
         expect(presence.classes('d-avatar__presence--lg')).toBe(true);
       });
+      it('should add d-avatar--presence when presence is set and not in group mode', async () => {
+        await wrapper.setProps({ presence: 'active', group: undefined });
+        const avatar = wrapper.find('[data-qa="dt-avatar"]');
+        expect(avatar.classes()).toContain('d-avatar--presence');
+      });
+
+      it('should not add d-avatar--presence when presence is not set', async () => {
+        await wrapper.setProps({ presence: undefined, group: undefined });
+        const avatar = wrapper.find('[data-qa="dt-avatar"]');
+        expect(avatar.classes()).not.toContain('d-avatar--presence');
+      });
+
+      it('should not add d-avatar--presence when showGroup is true (group is set)', async () => {
+        await wrapper.setProps({ presence: 'active', group: 5 });
+        const avatar = wrapper.find('[data-qa="dt-avatar"]');
+        expect(avatar.classes()).not.toContain('d-avatar--presence');
+      });
     });
     describe('SVG ClipPath Rendering', () => {
       it('should render the SVG when presence is set', async () => {

--- a/packages/dialtone-vue2/components/avatar/avatar.vue
+++ b/packages/dialtone-vue2/components/avatar/avatar.vue
@@ -73,6 +73,81 @@
       v-bind="presenceProps"
       data-qa="dt-presence"
     />
+    <svg
+      v-if="includeClipPath"
+      width="0"
+      height="0"
+      class="d-avatar__clip"
+    >
+      <defs>
+        <!-- AVATAR PRESENCE CLIPS -->
+        <clipPath
+          v-if="presence && validatedSize === 'xs'"
+          id="dt-avatar-xs-presence-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.57454
+              C0.96524 0.56226 0.92785 0.55556 0.88889 0.55556
+              C0.70479 0.55556 0.55556 0.70479 0.55556 0.88889
+              C0.55556 0.92786 0.56231 0.96524 0.5746 1
+              H0V0H1V0.57454Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="presence && validatedSize === 'sm'"
+          id="dt-avatar-sm-presence-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.64701
+              C0.95565 0.60754 0.8807 0.58333 0.83333 0.58333
+              C0.69391 0.58333 0.58333 0.69391 0.58333 0.83333
+              C0.58333 0.88071 0.60759 0.95565 0.64705 1
+              H0V0H1V0.64701Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="presence && validatedSize === 'md'"
+          id="dt-avatar-md-presence-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.73996
+              C0.96641 0.68962 0.90897 0.65625 0.84375 0.65625
+              C0.73978 0.65625 0.65625 0.73978 0.65625 0.84375
+              C0.65625 0.90898 0.68964 0.96641 0.74002 1
+              H0V0H1V0.73996Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="presence && validatedSize === 'lg'"
+          id="dt-avatar-lg-presence-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 1H0V0H1V1Z
+              M0.85417 0.72917
+              C0.78513 0.72917 0.72917 0.78513 0.72917 0.85417
+              C0.72917 0.9232 0.78513 0.97917 0.85417 0.97917
+              C0.9232 0.97917 0.97917 0.9232 0.97917 0.85417
+              C0.97917 0.78513 0.9232 0.72917 0.85417 0.72917Z
+            "
+          />
+        </clipPath>
+      </defs>
+    </svg>
   </component>
 </template>
 
@@ -333,6 +408,10 @@ export default {
 
     showImage () {
       return this.imageLoadedSuccessfully !== false && this.imageSrc;
+    },
+
+    includeClipPath () {
+      return this.presence && this.presence !== 'none';
     },
   },
 

--- a/packages/dialtone-vue2/components/avatar/avatar.vue
+++ b/packages/dialtone-vue2/components/avatar/avatar.vue
@@ -4,6 +4,7 @@
     :id="id"
     :class="avatarClasses"
     data-qa="dt-avatar"
+    v-bind="groupCountDataAttr"
     @click="handleClick"
   >
     <div
@@ -208,6 +209,56 @@
               C0.72 0.90627 0.77373 0.96 0.84 0.96
               C0.90627 0.96 0.96 0.90627 0.96 0.84
               C0.96 0.77373 0.90627 0.72 0.84 0.72Z
+            "
+          />
+        </clipPath>
+        <!-- AVATAR GROUP CLIPS -->
+        <clipPath
+          v-if="
+            showGroup &&
+              groupCountDataAttr['data-group-count'] !== 'double' &&
+              groupCountDataAttr['data-group-count'] !== 'triple'
+          "
+          id="dt-avatar-group-single-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.44759C0.98176 0.44557 0.96212 0.44444 0.94444 0.44444
+              C0.66817 0.44444 0.44444 0.66817 0.44444 0.94444
+              C0.44444 0.96212 0.44557 0.98176 0.44759 1H0V0H1V0.44759Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="showGroup && groupCountDataAttr['data-group-count'] === 'double'"
+          id="dt-avatar-group-double-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.44759
+              C0.98176 0.44557 0.96323 0.44444 0.94444 0.44444
+              H0.72222
+              C0.44608 0.44444 0.22222 0.6683 0.22222 0.94444
+              C0.22222 0.96323 0.22335 0.98176 0.22537 1
+              H0V0H1V0.44759Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="showGroup && groupCountDataAttr['data-group-count'] === 'triple'"
+          id="dt-avatar-group-triple-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.44759C0.98176 0.44557 0.96211 0.44444 0.94444 0.44444
+              H0.27778C0.175 0.44444 0.07945 0.47546 0 0.52868
+              V0H1V0.44759Z
             "
           />
         </clipPath>
@@ -466,6 +517,21 @@ export default {
       return this.group > 99 ? '99+' : this.group;
     },
 
+    groupCountDataAttr () {
+      if (!this.showGroup) return null;
+
+      let countCategory;
+      if (this.group <= 9) {
+        countCategory = 'single';
+      } else if (this.group <= 99) {
+        countCategory = 'double';
+      } else {
+        countCategory = 'triple';
+      }
+
+      return { 'data-group-count': countCategory };
+    },
+
     validatedSize () {
       // TODO: Group only supports xs size for now. Remove this when we support other sizes.
       return this.group ? 'xs' : this.size;
@@ -476,7 +542,7 @@ export default {
     },
 
     includeClipPath () {
-      return this.presence && this.presence !== 'none';
+      return this.showGroup || (this.presence && this.presence !== 'none');
     },
   },
 

--- a/packages/dialtone-vue2/components/avatar/avatar.vue
+++ b/packages/dialtone-vue2/components/avatar/avatar.vue
@@ -98,6 +98,22 @@
           />
         </clipPath>
         <clipPath
+          v-if="presence && validatedSize === 'xs' && clickable"
+          id="dt-avatar-xs-presence-clickable-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.59019
+              C0.95587 0.56465 0.90465 0.55 0.85 0.55
+              C0.68431 0.55 0.55 0.68431 0.55 0.85
+              C0.55 0.90466 0.56469 0.95586 0.59023 1
+              H0V0H1V0.59019Z
+            "
+          />
+        </clipPath>
+        <clipPath
           v-if="presence && validatedSize === 'sm'"
           id="dt-avatar-sm-presence-clip"
           clipPathUnits="objectBoundingBox"
@@ -110,6 +126,22 @@
               C0.69391 0.58333 0.58333 0.69391 0.58333 0.83333
               C0.58333 0.88071 0.60759 0.95565 0.64705 1
               H0V0H1V0.64701Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="presence && validatedSize === 'sm' && clickable"
+          id="dt-avatar-sm-presence-clickable-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.68025
+              C0.9585 0.61792 0.88735 0.57692 0.80769 0.57692
+              C0.66727 0.57692 0.57692 0.66727 0.57692 0.80769
+              C0.57692 0.88736 0.61796 0.9585 0.68033 1
+              H0V0H1V0.68025Z
             "
           />
         </clipPath>
@@ -130,6 +162,22 @@
           />
         </clipPath>
         <clipPath
+          v-if="presence && validatedSize === 'md' && clickable"
+          id="dt-avatar-md-presence-clickable-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.82353
+              C1 0.72607 0.921 0.64706 0.82353 0.64706
+              C0.72607 0.64706 0.64706 0.72607 0.64706 0.82353
+              C0.64706 0.921 0.72607 1 0.82353 1
+              H0V0H1V0.82353Z
+            "
+          />
+        </clipPath>
+        <clipPath
           v-if="presence && validatedSize === 'lg'"
           id="dt-avatar-lg-presence-clip"
           clipPathUnits="objectBoundingBox"
@@ -143,6 +191,23 @@
               C0.72917 0.9232 0.78513 0.97917 0.85417 0.97917
               C0.9232 0.97917 0.97917 0.9232 0.97917 0.85417
               C0.97917 0.78513 0.9232 0.72917 0.85417 0.72917Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="presence && validatedSize === 'lg' && clickable"
+          id="dt-avatar-lg-presence-clickable-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 1H0V0H1V1Z
+              M0.84 0.72
+              C0.77373 0.72 0.72 0.77373 0.72 0.84
+              C0.72 0.90627 0.77373 0.96 0.84 0.96
+              C0.90627 0.96 0.96 0.90627 0.96 0.84
+              C0.96 0.77373 0.90627 0.72 0.84 0.72Z
             "
           />
         </clipPath>

--- a/packages/dialtone-vue2/components/avatar/avatar.vue
+++ b/packages/dialtone-vue2/components/avatar/avatar.vue
@@ -497,6 +497,7 @@ export default {
           'd-avatar--group': this.showGroup,
           [`d-avatar--color-${this.getColor()}`]: !this.isIconType(),
           'd-avatar--clickable': this.clickable,
+          'd-avatar--presence': this.presence && !this.showGroup,
         },
       ];
     },

--- a/packages/dialtone-vue3/components/avatar/avatar.test.js
+++ b/packages/dialtone-vue3/components/avatar/avatar.test.js
@@ -255,7 +255,6 @@ describe('DtAvatar Tests', () => {
     describe('SVG ClipPath Rendering', () => {
       it('should render the SVG when presence is set', async () => {
         await wrapper.setProps({ presence: 'active' });
-
         const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.exists()).toBe(true);
         expect(svg.find('defs').exists()).toBe(true);
@@ -263,41 +262,68 @@ describe('DtAvatar Tests', () => {
 
       it('should NOT render the SVG when presence is not set', async () => {
         await wrapper.setProps({ presence: null });
-
         const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.exists()).toBe(false);
       });
 
-      it('should render the correct clipPath for xs size', async () => {
-        await wrapper.setProps({ presence: 'active', size: 'xs' });
-
+      // XS
+      it('should render only the regular clipPath for xs size when not clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'xs', clickable: false });
         const svg = wrapper.find('svg.d-avatar__clip');
-        expect(svg.exists()).toBe(true);
         expect(svg.find('#dt-avatar-xs-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-xs-presence-clickable-clip').exists()).toBe(false);
       });
 
-      it('should render the correct clipPath for sm size', async () => {
-        await wrapper.setProps({ presence: 'active', size: 'sm' });
-
+      it('should render both the regular and clickable clipPaths for xs size when clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'xs', clickable: true });
         const svg = wrapper.find('svg.d-avatar__clip');
-        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-xs-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-xs-presence-clickable-clip').exists()).toBe(true);
+      });
+
+      // SM
+      it('should render only the regular clipPath for sm size when not clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'sm', clickable: false });
+        const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.find('#dt-avatar-sm-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-sm-presence-clickable-clip').exists()).toBe(false);
       });
 
-      it('should render the correct clipPath for md size', async () => {
-        await wrapper.setProps({ presence: 'active', size: 'md' });
-
+      it('should render both the regular and clickable clipPaths for sm size when clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'sm', clickable: true });
         const svg = wrapper.find('svg.d-avatar__clip');
-        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-sm-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-sm-presence-clickable-clip').exists()).toBe(true);
+      });
+
+      // MD
+      it('should render only the regular clipPath for md size when not clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'md', clickable: false });
+        const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.find('#dt-avatar-md-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-md-presence-clickable-clip').exists()).toBe(false);
       });
 
-      it('should render the correct clipPath for lg size', async () => {
-        await wrapper.setProps({ presence: 'active', size: 'lg' });
-
+      it('should render both the regular and clickable clipPaths for md size when clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'md', clickable: true });
         const svg = wrapper.find('svg.d-avatar__clip');
-        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-md-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-md-presence-clickable-clip').exists()).toBe(true);
+      });
+
+      // LG
+      it('should render only the regular clipPath for lg size when not clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'lg', clickable: false });
+        const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.find('#dt-avatar-lg-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-lg-presence-clickable-clip').exists()).toBe(false);
+      });
+
+      it('should render both the regular and clickable clipPaths for lg size when clickable', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'lg', clickable: true });
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.find('#dt-avatar-lg-presence-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-lg-presence-clickable-clip').exists()).toBe(true);
       });
     });
   });

--- a/packages/dialtone-vue3/components/avatar/avatar.test.js
+++ b/packages/dialtone-vue3/components/avatar/avatar.test.js
@@ -251,6 +251,24 @@ describe('DtAvatar Tests', () => {
 
         expect(presence.classes('d-avatar__presence--lg')).toBe(true);
       });
+
+      it('should add d-avatar--presence when presence is set and not in group mode', async () => {
+        await wrapper.setProps({ presence: 'active', group: undefined });
+        const avatar = wrapper.find('[data-qa="dt-avatar"]');
+        expect(avatar.classes()).toContain('d-avatar--presence');
+      });
+
+      it('should not add d-avatar--presence when presence is not set', async () => {
+        await wrapper.setProps({ presence: undefined, group: undefined });
+        const avatar = wrapper.find('[data-qa="dt-avatar"]');
+        expect(avatar.classes()).not.toContain('d-avatar--presence');
+      });
+
+      it('should not add d-avatar--presence when showGroup is true (group is set)', async () => {
+        await wrapper.setProps({ presence: 'active', group: 5 });
+        const avatar = wrapper.find('[data-qa="dt-avatar"]');
+        expect(avatar.classes()).not.toContain('d-avatar--presence');
+      });
     });
     describe('SVG ClipPath Rendering', () => {
       it('should NOT render the SVG unless presence or group is set', async () => {

--- a/packages/dialtone-vue3/components/avatar/avatar.test.js
+++ b/packages/dialtone-vue3/components/avatar/avatar.test.js
@@ -252,6 +252,54 @@ describe('DtAvatar Tests', () => {
         expect(presence.classes('d-avatar__presence--lg')).toBe(true);
       });
     });
+    describe('SVG ClipPath Rendering', () => {
+      it('should render the SVG when presence is set', async () => {
+        await wrapper.setProps({ presence: 'active' });
+
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.exists()).toBe(true);
+        expect(svg.find('defs').exists()).toBe(true);
+      });
+
+      it('should NOT render the SVG when presence is not set', async () => {
+        await wrapper.setProps({ presence: null });
+
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.exists()).toBe(false);
+      });
+
+      it('should render the correct clipPath for xs size', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'xs' });
+
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-xs-presence-clip').exists()).toBe(true);
+      });
+
+      it('should render the correct clipPath for sm size', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'sm' });
+
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-sm-presence-clip').exists()).toBe(true);
+      });
+
+      it('should render the correct clipPath for md size', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'md' });
+
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-md-presence-clip').exists()).toBe(true);
+      });
+
+      it('should render the correct clipPath for lg size', async () => {
+        await wrapper.setProps({ presence: 'active', size: 'lg' });
+
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.exists()).toBe(true);
+        expect(svg.find('#dt-avatar-lg-presence-clip').exists()).toBe(true);
+      });
+    });
   });
 
   describe('Interactivity Tests', () => {

--- a/packages/dialtone-vue3/components/avatar/avatar.test.js
+++ b/packages/dialtone-vue3/components/avatar/avatar.test.js
@@ -253,11 +253,10 @@ describe('DtAvatar Tests', () => {
       });
     });
     describe('SVG ClipPath Rendering', () => {
-      it('should render the SVG when presence is set', async () => {
-        await wrapper.setProps({ presence: 'active' });
+      it('should NOT render the SVG unless presence or group is set', async () => {
+        await wrapper.setProps({ presence: null, group: null });
         const svg = wrapper.find('svg.d-avatar__clip');
-        expect(svg.exists()).toBe(true);
-        expect(svg.find('defs').exists()).toBe(true);
+        expect(svg.exists()).toBe(false);
       });
 
       it('should NOT render the SVG when presence is not set', async () => {
@@ -324,6 +323,31 @@ describe('DtAvatar Tests', () => {
         const svg = wrapper.find('svg.d-avatar__clip');
         expect(svg.find('#dt-avatar-lg-presence-clip').exists()).toBe(true);
         expect(svg.find('#dt-avatar-lg-presence-clickable-clip').exists()).toBe(true);
+      });
+    });
+    describe('SVG Group ClipPath Rendering', () => {
+      it('should render the single group clipPath for group 2-9', async () => {
+        await wrapper.setProps({ group: 5 });
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.find('#dt-avatar-group-single-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-group-double-clip').exists()).toBe(false);
+        expect(svg.find('#dt-avatar-group-triple-clip').exists()).toBe(false);
+      });
+
+      it('should render the double group clipPath for group 10-99', async () => {
+        await wrapper.setProps({ group: 25 });
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.find('#dt-avatar-group-single-clip').exists()).toBe(false);
+        expect(svg.find('#dt-avatar-group-double-clip').exists()).toBe(true);
+        expect(svg.find('#dt-avatar-group-triple-clip').exists()).toBe(false);
+      });
+
+      it('should render the triple group clipPath for group 100+', async () => {
+        await wrapper.setProps({ group: 100 });
+        const svg = wrapper.find('svg.d-avatar__clip');
+        expect(svg.find('#dt-avatar-group-single-clip').exists()).toBe(false);
+        expect(svg.find('#dt-avatar-group-double-clip').exists()).toBe(false);
+        expect(svg.find('#dt-avatar-group-triple-clip').exists()).toBe(true);
       });
     });
   });

--- a/packages/dialtone-vue3/components/avatar/avatar.vue
+++ b/packages/dialtone-vue3/components/avatar/avatar.vue
@@ -5,6 +5,7 @@
     :class="avatarClasses"
     :style="$attrs.style"
     data-qa="dt-avatar"
+    v-bind="groupCountDataAttr"
     @click="handleClick"
   >
     <div
@@ -209,6 +210,56 @@
               C0.72 0.90627 0.77373 0.96 0.84 0.96
               C0.90627 0.96 0.96 0.90627 0.96 0.84
               C0.96 0.77373 0.90627 0.72 0.84 0.72Z
+            "
+          />
+        </clipPath>
+        <!-- AVATAR GROUP CLIPS -->
+        <clipPath
+          v-if="
+            showGroup &&
+              groupCountDataAttr['data-group-count'] !== 'double' &&
+              groupCountDataAttr['data-group-count'] !== 'triple'
+          "
+          id="dt-avatar-group-single-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.44759C0.98176 0.44557 0.96212 0.44444 0.94444 0.44444
+              C0.66817 0.44444 0.44444 0.66817 0.44444 0.94444
+              C0.44444 0.96212 0.44557 0.98176 0.44759 1H0V0H1V0.44759Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="showGroup && groupCountDataAttr['data-group-count'] === 'double'"
+          id="dt-avatar-group-double-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.44759
+              C0.98176 0.44557 0.96323 0.44444 0.94444 0.44444
+              H0.72222
+              C0.44608 0.44444 0.22222 0.6683 0.22222 0.94444
+              C0.22222 0.96323 0.22335 0.98176 0.22537 1
+              H0V0H1V0.44759Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="showGroup && groupCountDataAttr['data-group-count'] === 'triple'"
+          id="dt-avatar-group-triple-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.44759C0.98176 0.44557 0.96211 0.44444 0.94444 0.44444
+              H0.27778C0.175 0.44444 0.07945 0.47546 0 0.52868
+              V0H1V0.44759Z
             "
           />
         </clipPath>
@@ -470,6 +521,21 @@ export default {
       return this.group > 99 ? '99+' : this.group;
     },
 
+    groupCountDataAttr () {
+      if (!this.showGroup) return null;
+
+      let countCategory;
+      if (this.group <= 9) {
+        countCategory = 'single';
+      } else if (this.group <= 99) {
+        countCategory = 'double';
+      } else {
+        countCategory = 'triple';
+      }
+
+      return { 'data-group-count': countCategory };
+    },
+
     validatedSize () {
       // TODO: Group only supports xs size for now. Remove this when we support other sizes.
       return this.group ? 'xs' : this.size;
@@ -480,7 +546,7 @@ export default {
     },
 
     includeClipPath () {
-      return this.presence && this.presence !== 'none';
+      return this.showGroup || (this.presence && this.presence !== 'none');
     },
   },
 

--- a/packages/dialtone-vue3/components/avatar/avatar.vue
+++ b/packages/dialtone-vue3/components/avatar/avatar.vue
@@ -501,6 +501,7 @@ export default {
           'd-avatar--group': this.showGroup,
           [`d-avatar--color-${this.getColor()}`]: !this.isIconType(),
           'd-avatar--clickable': this.clickable,
+          'd-avatar--presence': this.presence && !this.showGroup,
         },
       ];
     },

--- a/packages/dialtone-vue3/components/avatar/avatar.vue
+++ b/packages/dialtone-vue3/components/avatar/avatar.vue
@@ -99,6 +99,22 @@
           />
         </clipPath>
         <clipPath
+          v-if="presence && validatedSize === 'xs' && clickable"
+          id="dt-avatar-xs-presence-clickable-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.59019
+              C0.95587 0.56465 0.90465 0.55 0.85 0.55
+              C0.68431 0.55 0.55 0.68431 0.55 0.85
+              C0.55 0.90466 0.56469 0.95586 0.59023 1
+              H0V0H1V0.59019Z
+            "
+          />
+        </clipPath>
+        <clipPath
           v-if="presence && validatedSize === 'sm'"
           id="dt-avatar-sm-presence-clip"
           clipPathUnits="objectBoundingBox"
@@ -111,6 +127,22 @@
               C0.69391 0.58333 0.58333 0.69391 0.58333 0.83333
               C0.58333 0.88071 0.60759 0.95565 0.64705 1
               H0V0H1V0.64701Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="presence && validatedSize === 'sm' && clickable"
+          id="dt-avatar-sm-presence-clickable-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.68025
+              C0.9585 0.61792 0.88735 0.57692 0.80769 0.57692
+              C0.66727 0.57692 0.57692 0.66727 0.57692 0.80769
+              C0.57692 0.88736 0.61796 0.9585 0.68033 1
+              H0V0H1V0.68025Z
             "
           />
         </clipPath>
@@ -131,6 +163,22 @@
           />
         </clipPath>
         <clipPath
+          v-if="presence && validatedSize === 'md' && clickable"
+          id="dt-avatar-md-presence-clickable-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.82353
+              C1 0.72607 0.921 0.64706 0.82353 0.64706
+              C0.72607 0.64706 0.64706 0.72607 0.64706 0.82353
+              C0.64706 0.921 0.72607 1 0.82353 1
+              H0V0H1V0.82353Z
+            "
+          />
+        </clipPath>
+        <clipPath
           v-if="presence && validatedSize === 'lg'"
           id="dt-avatar-lg-presence-clip"
           clipPathUnits="objectBoundingBox"
@@ -144,6 +192,23 @@
               C0.72917 0.9232 0.78513 0.97917 0.85417 0.97917
               C0.9232 0.97917 0.97917 0.9232 0.97917 0.85417
               C0.97917 0.78513 0.9232 0.72917 0.85417 0.72917Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="presence && validatedSize === 'lg' && clickable"
+          id="dt-avatar-lg-presence-clickable-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 1H0V0H1V1Z
+              M0.84 0.72
+              C0.77373 0.72 0.72 0.77373 0.72 0.84
+              C0.72 0.90627 0.77373 0.96 0.84 0.96
+              C0.90627 0.96 0.96 0.90627 0.96 0.84
+              C0.96 0.77373 0.90627 0.72 0.84 0.72Z
             "
           />
         </clipPath>

--- a/packages/dialtone-vue3/components/avatar/avatar.vue
+++ b/packages/dialtone-vue3/components/avatar/avatar.vue
@@ -74,6 +74,81 @@
       v-bind="presenceProps"
       data-qa="dt-presence"
     />
+    <svg
+      v-if="includeClipPath"
+      width="0"
+      height="0"
+      class="d-avatar__clip"
+    >
+      <defs>
+        <!-- AVATAR PRESENCE CLIPS -->
+        <clipPath
+          v-if="presence && validatedSize === 'xs'"
+          id="dt-avatar-xs-presence-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.57454
+              C0.96524 0.56226 0.92785 0.55556 0.88889 0.55556
+              C0.70479 0.55556 0.55556 0.70479 0.55556 0.88889
+              C0.55556 0.92786 0.56231 0.96524 0.5746 1
+              H0V0H1V0.57454Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="presence && validatedSize === 'sm'"
+          id="dt-avatar-sm-presence-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.64701
+              C0.95565 0.60754 0.8807 0.58333 0.83333 0.58333
+              C0.69391 0.58333 0.58333 0.69391 0.58333 0.83333
+              C0.58333 0.88071 0.60759 0.95565 0.64705 1
+              H0V0H1V0.64701Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="presence && validatedSize === 'md'"
+          id="dt-avatar-md-presence-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 0.73996
+              C0.96641 0.68962 0.90897 0.65625 0.84375 0.65625
+              C0.73978 0.65625 0.65625 0.73978 0.65625 0.84375
+              C0.65625 0.90898 0.68964 0.96641 0.74002 1
+              H0V0H1V0.73996Z
+            "
+          />
+        </clipPath>
+        <clipPath
+          v-if="presence && validatedSize === 'lg'"
+          id="dt-avatar-lg-presence-clip"
+          clipPathUnits="objectBoundingBox"
+        >
+          <path
+            clip-rule="evenodd"
+            d="
+              M1 1H0V0H1V1Z
+              M0.85417 0.72917
+              C0.78513 0.72917 0.72917 0.78513 0.72917 0.85417
+              C0.72917 0.9232 0.78513 0.97917 0.85417 0.97917
+              C0.9232 0.97917 0.97917 0.9232 0.97917 0.85417
+              C0.97917 0.78513 0.9232 0.72917 0.85417 0.72917Z
+            "
+          />
+        </clipPath>
+      </defs>
+    </svg>
   </component>
 </template>
 
@@ -337,6 +412,10 @@ export default {
 
     showImage () {
       return this.imageLoadedSuccessfully !== false && this.imageSrc;
+    },
+
+    includeClipPath () {
+      return this.presence && this.presence !== 'none';
     },
   },
 


### PR DESCRIPTION
# Avatar Update - Masking option B with 'clip-path' and SVG paths

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2JiNWl2M2h0dHB2bjI0MWhmczEyNDF6dWVlNXlxNmgzazRmNnE0ciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Hi0tvoUWsdHuQTreMu/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [x] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2646

## :book: Description

Avatar masking technique 2 of 3 -- this technique involves using the CSS clip-path property in tandem with a conditionally rendered SVG that defines the path to clip. Paths are included for each size, slightly larger versions to account for the 'clickable' prop, and three different paths for each group size (single, double, and triple -- represents the number of digits).

## :bulb: Context

The overall goal is to mask out a portion of the avatar component whenever the presence is shown. Currently we use border color and box shadow color to simulate that the presence and group count elements are 'cut out' of the avatar component.

In addition to the normal avatar state masking at each avatar size, this PR also previews:
- 'clickable' prop masking (replaces the border with a pseudo-element that can be masked out)
- 'group' prop masking (includes the addition of a data-attribute for proper sizing)
- Recipe style overrides where the border colors are set for avatar + presence

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

If new component:

<!--- There are lots of things to remember when adding a new component to the system! This is so you don't forget any of them. -->

- I am exporting any new components or constants:
  - [ ] from the index.js in the component directory.
  - [ ] from the index.js in the root (either `packages/dialtone-vue2` or `packages/dialtone-vue3`).
- [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
- [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
- [ ] I have added the new component to `common/components_list.js`
- [ ] I have created a component story in storybook
- [ ] I have created story / stories for any relevant component variants in storybook
- [ ] I have created a docs page for the component in storybook.
- [ ] I have checked that changing all props/slots via the UI in storybook works as expected.

## :crystal_ball: Next Steps

I realize that the documentation for the group prop may need updated to include the possible addition of a data-attribute, and I intend to add that in shortly. More notes to follow as I test more thoroughly.

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->
<img width="898" height="410" alt="Screenshot 2025-07-28 at 4 52 41 PM" src="https://github.com/user-attachments/assets/111a2f66-e918-4bc3-ab49-e83819c267d8" />
<br/><br/>
<img width="896" height="526" alt="Screenshot 2025-07-28 at 4 52 53 PM" src="https://github.com/user-attachments/assets/c814c894-fc66-4268-8e57-cc42e851d257" />
<br/><br/>
<img width="1098" height="597" alt="Screenshot 2025-07-28 at 4 53 11 PM" src="https://github.com/user-attachments/assets/dd606372-0e19-41b7-a13d-38f0f56f2e2d" />

## :link: Sources

<!--- Add any links to external reference material -->
