### PR TITLE
fix(localization): NO-JIRA add validation

### DIFF
--- a/packages/dialtone-vue2/localization/index.js
+++ b/packages/dialtone-vue2/localization/index.js
@@ -59,23 +59,30 @@ export class DialtoneLocalization {
 
     localeManager.install(dialtoneNamespace);
 
-    /**
-     * @description
-     * When the browser storage changes, update the current locale
-     * @param event
-     */
-    window.onstorage = (event) => {
-      if (event.key === 'user-locale') {
-        this.currentLocale = event.newValue;
-      }
-    };
-
     DialtoneLocalization.instance = this;
+
+    if (typeof window !== 'undefined') {
+      /**
+       * @description
+       * When the browser storage changes, update the current locale
+       * @param event
+       */
+      window.onstorage = (event) => {
+        if (event.key === 'user-locale') {
+          this.currentLocale = event.newValue;
+        }
+      };
+    }
+
     return this;
   }
 
   static getPreferredLocale () {
-    const localStorageLanguage = localStorage.getItem('user-locale');
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return fallbackLocale;
+    }
+
+    const localStorageLanguage = window.localStorage.getItem('user-locale');
 
     // Get the first two letters of the navigator language and check if it's in the allowed locales
     const navigatorLanguage = Object.values(allowedLocales)

--- a/packages/dialtone-vue3/localization/index.js
+++ b/packages/dialtone-vue3/localization/index.js
@@ -61,23 +61,30 @@ export class DialtoneLocalization {
 
     localeManager.install(app, dialtoneNamespace);
 
-    /**
-     * @description
-     * When the browser storage changes, update the current locale
-     * @param event
-     */
-    window.onstorage = (event) => {
-      if (event.key === 'user-locale') {
-        this.currentLocale = event.newValue;
-      }
-    };
-
     DialtoneLocalization.instance = this;
+
+    if (typeof window !== 'undefined') {
+      /**
+       * @description
+       * When the browser storage changes, update the current locale
+       * @param event
+       */
+      window.onstorage = (event) => {
+        if (event.key === 'user-locale') {
+          this.currentLocale = event.newValue;
+        }
+      };
+    }
+
     return this;
   }
 
   static getPreferredLocale () {
-    const localStorageLanguage = localStorage.getItem('user-locale');
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return fallbackLocale;
+    }
+
+    const localStorageLanguage = window.localStorage.getItem('user-locale');
 
     // Get the first two letters of the navigator language and check if it's in the allowed locales
     const navigatorLanguage = Object.values(allowedLocales)


### PR DESCRIPTION
# Fix localization - localStorage is not defined on server

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYWN5ejM5c3J5b3h4dmQ1am9jaHIwdzAzaXRtazczYnY4dHkwdWs3aiZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/zIOdLMZDcBDc2gk6vV/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Description

Added a validation to avoid trying to call `localStorage` on node environments (testing)

## :bulb: Context

Issues with tests on DP were reported 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.