### PR TITLE
fix(tooltip): DLT-2644 fix z-index

### DIFF
--- a/packages/dialtone-vue2/components/tooltip/tooltip.test.js
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.test.js
@@ -12,6 +12,8 @@ const MOCK_TRANSITION_STUB = () => ({
   },
 });
 
+const MOCK_GET_ROOT_NODE = () => document;
+
 // jsdom doesn't like this.anchor?.getRootNode() so use document.body.
 const baseProps = { delay: false, appendTo: document.body };
 const baseSlots = {
@@ -51,6 +53,9 @@ describe('DtTooltip tests', () => {
     tippyContent = document.body.querySelector('.tippy-content');
     tippyBox = document.body.querySelector('.tippy-box');
     anchor = wrapper.find('[data-qa="dt-tooltip-anchor"]');
+
+    // Mock getRootNode after wrapper is created
+    wrapper.vm.$el.getRootNode = MOCK_GET_ROOT_NODE;
   };
 
   beforeAll(() => {
@@ -208,6 +213,92 @@ describe('DtTooltip tests', () => {
 
           expect(tippyContent).toBeNull();
         });
+      });
+    });
+
+    describe('Z-index behavior with modals', () => {
+      afterEach(() => {
+        // Clean up any modal elements added during tests
+        const modals = document.querySelectorAll('.d-modal, .d-modal--transparent');
+        modals.forEach(modal => modal.remove());
+      });
+
+      it('should have higher z-index when modal is present', async () => {
+        // Create a mock modal element in the DOM
+        const modalElement = document.createElement('div');
+        modalElement.className = 'd-modal';
+        modalElement.setAttribute('aria-hidden', 'false');
+        document.body.appendChild(modalElement);
+
+        mockProps = { show: true };
+        updateWrapper();
+        await flushPromises();
+
+        tippyBox = document.body.querySelector('.tippy-box');
+        expect(tippyBox).not.toBeNull();
+
+        // Get the z-index from the tooltip component's calculated value
+        const tooltipZIndex = wrapper.vm.calculateAnchorZindex();
+
+        // Modal z-index is 600, modal-element is 650, so tooltip should be 651
+        expect(tooltipZIndex).toBe(651);
+        expect(tooltipZIndex).toBeGreaterThan(650); // Greater than modal-element z-index
+      });
+
+      it('should have higher z-index when transparent modal is present', async () => {
+        // Create a mock transparent modal element in the DOM
+        const modalElement = document.createElement('div');
+        modalElement.className = 'd-modal--transparent';
+        modalElement.setAttribute('aria-hidden', 'false');
+        document.body.appendChild(modalElement);
+
+        mockProps = { show: true };
+        updateWrapper();
+        await flushPromises();
+
+        tippyBox = document.body.querySelector('.tippy-box');
+        expect(tippyBox).not.toBeNull();
+
+        // Get the z-index from the tooltip component's calculated value
+        const tooltipZIndex = wrapper.vm.calculateAnchorZindex();
+
+        expect(tooltipZIndex).toBe(651);
+        expect(tooltipZIndex).toBeGreaterThan(650); // Greater than modal-element z-index
+      });
+
+      it('should have higher z-index when modal without aria-hidden is present', async () => {
+        // Create a mock modal element without aria-hidden attribute
+        const modalElement = document.createElement('div');
+        modalElement.className = 'd-modal';
+        document.body.appendChild(modalElement);
+
+        mockProps = { show: true };
+        updateWrapper();
+        await flushPromises();
+
+        tippyBox = document.body.querySelector('.tippy-box');
+        expect(tippyBox).not.toBeNull();
+
+        // Get the z-index from the tooltip component's calculated value
+        const tooltipZIndex = wrapper.vm.calculateAnchorZindex();
+
+        expect(tooltipZIndex).toBe(651);
+        expect(tooltipZIndex).toBeGreaterThan(650); // Greater than modal-element z-index
+      });
+
+      it('should have default z-index when no modal is present', async () => {
+        mockProps = { show: true };
+        updateWrapper();
+        await flushPromises();
+
+        tippyBox = document.body.querySelector('.tippy-box');
+        expect(tippyBox).not.toBeNull();
+
+        // Get the z-index from the tooltip component's calculated value
+        const tooltipZIndex = wrapper.vm.calculateAnchorZindex();
+
+        // Default tooltip z-index should be 400
+        expect(tooltipZIndex).toBe(400);
       });
     });
   });

--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -376,7 +376,11 @@ export default {
     calculateAnchorZindex () {
       // if a modal is currently active render at modal-element z-index, otherwise at tooltip z-index
       if (this.$el.getRootNode()
-        .querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"]') ||
+        .querySelector(
+          `.d-modal[aria-hidden="false"],
+          .d-modal--transparent[aria-hidden="false"],
+          .d-modal:not([aria-hidden]),
+          .d-modal--transparent:not([aria-hidden])`) ||
         // Special case because we don't have any dialtone drawer component yet. Render at 651 when
         // anchor of popover is within a drawer.
         this.$el.closest('.d-zi-drawer')) {

--- a/packages/dialtone-vue3/components/tooltip/tooltip.test.js
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.test.js
@@ -5,6 +5,8 @@ import {
   TOOLTIP_DIRECTIONS,
 } from './tooltip_constants';
 
+const MOCK_GET_ROOT_NODE = () => document;
+
 // jsdom doesn't like this.anchor?.getRootNode() so use document.body.
 const baseProps = { delay: false, appendTo: document.body };
 const baseSlots = {
@@ -39,6 +41,9 @@ describe('DtTooltip tests', () => {
     tippyContent = document.body.querySelector('.tippy-content');
     tippyBox = document.body.querySelector('.tippy-box');
     anchor = wrapper.find('[data-qa="dt-tooltip-anchor"]');
+
+    // Mock getRootNode after wrapper is created
+    wrapper.vm.$el.getRootNode = MOCK_GET_ROOT_NODE;
   };
 
   beforeAll(() => {
@@ -194,6 +199,92 @@ describe('DtTooltip tests', () => {
 
           expect(tippyContent).toBeNull();
         });
+      });
+    });
+
+    describe('Z-index behavior with modals', () => {
+      afterEach(() => {
+        // Clean up any modal elements added during tests
+        const modals = document.querySelectorAll('.d-modal, .d-modal--transparent');
+        modals.forEach(modal => modal.remove());
+      });
+
+      it('should have higher z-index when modal is present', async () => {
+        // Create a mock modal element in the DOM
+        const modalElement = document.createElement('div');
+        modalElement.className = 'd-modal';
+        modalElement.setAttribute('aria-hidden', 'false');
+        document.body.appendChild(modalElement);
+
+        mockProps = { show: true };
+        updateWrapper();
+        await flushPromises();
+
+        tippyBox = document.body.querySelector('.tippy-box');
+        expect(tippyBox).not.toBeNull();
+
+        // Get the z-index from the tooltip component's calculated value
+        const tooltipZIndex = wrapper.vm.calculateAnchorZindex();
+
+        // Modal z-index is 600, modal-element is 650, so tooltip should be 651
+        expect(tooltipZIndex).toBe(651);
+        expect(tooltipZIndex).toBeGreaterThan(650); // Greater than modal-element z-index
+      });
+
+      it('should have higher z-index when transparent modal is present', async () => {
+        // Create a mock transparent modal element in the DOM
+        const modalElement = document.createElement('div');
+        modalElement.className = 'd-modal--transparent';
+        modalElement.setAttribute('aria-hidden', 'false');
+        document.body.appendChild(modalElement);
+
+        mockProps = { show: true };
+        updateWrapper();
+        await flushPromises();
+
+        tippyBox = document.body.querySelector('.tippy-box');
+        expect(tippyBox).not.toBeNull();
+
+        // Get the z-index from the tooltip component's calculated value
+        const tooltipZIndex = wrapper.vm.calculateAnchorZindex();
+
+        expect(tooltipZIndex).toBe(651);
+        expect(tooltipZIndex).toBeGreaterThan(650); // Greater than modal-element z-index
+      });
+
+      it('should have higher z-index when modal without aria-hidden is present', async () => {
+        // Create a mock modal element without aria-hidden attribute
+        const modalElement = document.createElement('div');
+        modalElement.className = 'd-modal';
+        document.body.appendChild(modalElement);
+
+        mockProps = { show: true };
+        updateWrapper();
+        await flushPromises();
+
+        tippyBox = document.body.querySelector('.tippy-box');
+        expect(tippyBox).not.toBeNull();
+
+        // Get the z-index from the tooltip component's calculated value
+        const tooltipZIndex = wrapper.vm.calculateAnchorZindex();
+
+        expect(tooltipZIndex).toBe(651);
+        expect(tooltipZIndex).toBeGreaterThan(650); // Greater than modal-element z-index
+      });
+
+      it('should have default z-index when no modal is present', async () => {
+        mockProps = { show: true };
+        updateWrapper();
+        await flushPromises();
+
+        tippyBox = document.body.querySelector('.tippy-box');
+        expect(tippyBox).not.toBeNull();
+
+        // Get the z-index from the tooltip component's calculated value
+        const tooltipZIndex = wrapper.vm.calculateAnchorZindex();
+
+        // Default tooltip z-index should be 400
+        expect(tooltipZIndex).toBe(400);
       });
     });
   });

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -378,7 +378,11 @@ export default {
     calculateAnchorZindex () {
       // if a modal is currently active render at modal-element z-index, otherwise at tooltip z-index
       if (returnFirstEl(this.$el).getRootNode()
-        .querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"]') ||
+        .querySelector(
+          `.d-modal[aria-hidden="false"],
+          .d-modal--transparent[aria-hidden="false"],
+          .d-modal:not([aria-hidden]),
+          .d-modal--transparent:not([aria-hidden])`) ||
         // Special case because we don't have any dialtone drawer component yet. Render at 651 when
         // anchor of popover is within a drawer.
         returnFirstEl(this.$el).closest('.d-zi-drawer')) {


### PR DESCRIPTION
# Fix tooltip z-index when a modal is present

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DLT-2644]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Z-index assigned to the tooltip was lower than the modals. 
The default z-index values are as follow:

```
Z_INDEX: {
    hide: -1,
    base: 0,
    base1: 1,
    selected: 25,
    active: 50,
    navigation: 100,
    'navigation-fixed': 150,
    dropdown: 200,
    popover: 300,
    tooltip: 400,
    drawer: 500,
    modal: 600,
    'modal-element': 650,
    notification: 700,
  }
  ```
  
I am not sure if this is correct, seems like the tooltips should be above all. I didn't want to break anything so I left this as it was.

<!--- Describe specifically what the changes are -->

## :bulb: Context
This is breaking a use case in the product: https://dialpad.atlassian.net/browse/DP-149075
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

### Before

<img width="686" height="225" alt="image" src="https://github.com/user-attachments/assets/818be46e-0fb6-4b0e-a191-c782e9be73e1" />

### Now

<img width="695" height="227" alt="image" src="https://github.com/user-attachments/assets/34f81aea-4581-4b2a-9151-399363a29ed3" />

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->


[DLT-2644]: https://dialpad.atlassian.net/browse/DLT-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ