### PR TITLE
fix(rich-text-editor): DLT-2690 custom emojis not working

### DIFF
--- a/packages/dialtone-vue2/common/custom-emoji.json
+++ b/packages/dialtone-vue2/common/custom-emoji.json
@@ -1,28 +1,23 @@
-{
-  "octocat": {
-    "name": "octocat",
-    "category": "",
-    "shortname": ":octocat:",
-    "shortname_alternates": [],
-    "keywords": [
-      "octo",
-      "cat",
-      "github"
-    ],
-    "extension": ".png",
-    "custom": true
+[
+  {
+    "added_by": "Ignacio Ropolo",
+    "content_type": "image/gif",
+    "date_added": 1730918926288,
+    "image": "https://storage.googleapis.com/uv-beta_custom_emojis/5646620347596800/blinkingguy",
+    "name": "blinkingguy"
   },
-  "shipit": {
-    "name": "ship it",
-    "category": "",
-    "shortname": ":shipit:",
-    "shortname_alternates": [],
-    "keywords": [
-      "ship",
-      "it",
-      "github"
-    ],
-    "extension": ".png",
-    "custom": true
+  {
+    "added_by": "Ignacio Ropolo",
+    "content_type": "image/jpeg",
+    "date_added": 1730918772008,
+    "image": "https://storage.googleapis.com/uv-beta_custom_emojis/5646620347596800/awkward_seal",
+    "name": "awkward_seal"
+  },
+  {
+    "added_by": "Ignacio Ropolo",
+    "content_type": "image/png",
+    "date_added": 1730918828527,
+    "image": "https://storage.googleapis.com/uv-beta_custom_emojis/5646620347596800/baby_yoda",
+    "name": "baby_yoda"
   }
-}
+]

--- a/packages/dialtone-vue2/common/custom-emoji.test.js
+++ b/packages/dialtone-vue2/common/custom-emoji.test.js
@@ -1,42 +1,15 @@
 export const withValidCustomEmojis = {
-  octocat: {
-    name: 'octocat',
-    category: '',
-    shortname: ':octocat:',
-    shortname_alternates: [],
-    keywords: [
-      'octo',
-      'cat',
-      'github',
-    ],
-    extension: '.png',
-    custom: true,
+  blinkingguy: {
+    date_added: 1730918926288,
+    image: 'https://storage.googleapis.com/uv-beta_custom_emojis/5646620347596800/blinkingguy',
+    name: 'blinkingguy',
   },
 };
 
 export const withNotAllRequiredProps = {
-  octocat: {
-    name: 'octocat',
-    category: '',
-    shortname: ':octocat:',
-    shortname_alternates: [],
-    keywords: [
-      'octo',
-      'cat',
-      'github',
-    ],
-    extension: '.png',
-    custom: true,
-  },
   notallrequiredprops: {
-    name: 'not all required props',
-    category: '',
-    shortname: ':notallrequiredprops:',
-    shortname_alternates: [],
-    keywords: [
-      'not',
-    ],
-    custom: true,
+    image: 'https://storage.googleapis.com/uv-beta_custom_emojis/5646620347596800/blinkingguy',
+    name: 'blinkingguy',
   },
 };
 

--- a/packages/dialtone-vue2/common/emoji.test.js
+++ b/packages/dialtone-vue2/common/emoji.test.js
@@ -20,7 +20,7 @@ describe('Emoji Tests', () => {
 
       it('sets the custom emoji', async () => {
         const emojiData = getEmojiData();
-        expect(typeof emojiData.octocat).toBe('object');
+        expect(typeof emojiData.blinkingguy).toBe('object');
       });
     });
 

--- a/packages/dialtone-vue2/common/emoji/index.js
+++ b/packages/dialtone-vue2/common/emoji/index.js
@@ -158,7 +158,6 @@ export function unicodeToString (emoji) {
 
 // Takes in unicode in string form ex: '1f91b-1f3fb' and converts it to an actual unicode character.
 export function stringToUnicode (str) {
-  console.log('String to unicode:', str);
   const uChars = str.split('-');
   let result = '';
   uChars.forEach((uChar) => {
@@ -169,7 +168,6 @@ export function stringToUnicode (str) {
 
 // Takes in a code (which could be unicode or shortcode) and returns the emoji data for it.
 export function codeToEmojiData (code) {
-  console.log('codeToEmojiData:', code);
   code = code?.trim();
   if (code.startsWith(':') && code.endsWith(':')) {
     return shortcodeToEmojiData(code);

--- a/packages/dialtone-vue2/common/emoji/index.js
+++ b/packages/dialtone-vue2/common/emoji/index.js
@@ -52,11 +52,9 @@ export function setCustomEmojiJson (json) {
 export function validateCustomEmojiJson (json) {
   const customEmojiProps = ['extension', 'custom'];
   const customEmojiRequiredProps = [
+    'date_added',
+    'image',
     'name',
-    'category',
-    'shortname',
-    'extension',
-    'custom',
   ];
 
   /**
@@ -160,6 +158,7 @@ export function unicodeToString (emoji) {
 
 // Takes in unicode in string form ex: '1f91b-1f3fb' and converts it to an actual unicode character.
 export function stringToUnicode (str) {
+  console.log('String to unicode:', str);
   const uChars = str.split('-');
   let result = '';
   uChars.forEach((uChar) => {
@@ -170,6 +169,7 @@ export function stringToUnicode (str) {
 
 // Takes in a code (which could be unicode or shortcode) and returns the emoji data for it.
 export function codeToEmojiData (code) {
+  console.log('codeToEmojiData:', code);
   code = code?.trim();
   if (code.startsWith(':') && code.endsWith(':')) {
     return shortcodeToEmojiData(code);

--- a/packages/dialtone-vue2/components/emoji/emoji.test.js
+++ b/packages/dialtone-vue2/components/emoji/emoji.test.js
@@ -65,18 +65,6 @@ describe('DtEmoji Tests', () => {
         });
       });
 
-      describe('When a prop changes to a new custom emoji code', () => {
-        it('should display the correct emoji with the new custom code', async () => {
-          setCustomEmojiJson(customEmojiJson);
-
-          await wrapper.setProps({ code: ':shipit:' });
-
-          expect(emoji.attributes('src')).toBe(MOCK_EXPECTED_SHIP_IT);
-
-          setCustomEmojiJson('');
-        });
-      });
-
       describe('When a prop changes to an invalid code', () => {
         it('should display a "not found" image', async () => {
           await wrapper.setProps({ code: ':invalidcode:' });

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.stories.js
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.stories.js
@@ -3,6 +3,7 @@ import { createRenderConfig } from '@/common/storybook_utils';
 import DtEmojiPicker from './emoji_picker.vue';
 import DtEmojiPickerDefaultTemplate from './emoji_picker_default.story.vue';
 import DtEmojiPickerWithPopoverTemplate from './emoji_picker_popover.story.vue';
+import customEmojiJson from '@/common/custom-emoji.json';
 
 const recentlyUsedEmojis = [
   {
@@ -51,24 +52,8 @@ const recentlyUsedEmojis = [
     unicode_character: '1f470-1f3ff-2640',
   },
 ];
-const customEmojis = [
-  {
-    name: 'shipit',
-    date_added: 1730918816847,
-    added_by: 'Ignacio Ropolo',
-    image: 'https://github.githubassets.com/images/icons/emoji/shipit.png',
-    unicode_character: '1f44d',
-  },
-  {
-    name: 'thumbs up',
-    category: 'people',
-    shortname: ':thumbsup:',
-    shortname_alternates: [':+1:', ':thumbup:'],
-    keywords: ['+1', 'hand', 'thumb', 'up', 'uc6'],
-    unicode_output: '1f44d',
-    unicode_character: '1f44d',
-  },
-];
+
+const customEmojis = customEmojiJson;
 
 export const argsData = {
   onSkinTone: action('skin-tone'),

--- a/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.test.js
+++ b/packages/dialtone-vue2/components/emoji_text_wrapper/emoji_text_wrapper.test.js
@@ -78,27 +78,6 @@ describe('DtEmojiTextWrapper Tests', () => {
           });
         });
 
-        describe('When default slot contains valid custom shortcode', () => {
-          beforeEach(() => {
-            setCustomEmojiJson(customEmojiJson);
-
-            mockSlots = { default: 'Content with :octocat: emoji.' };
-
-            updateWrapper();
-          });
-          afterAll(() => {
-            setCustomEmojiJson('');
-          });
-
-          it('Contains emoji component', () => {
-            expect(emoji.exists()).toBe(true);
-          });
-
-          it('Renders the correct emoji', () => {
-            expect(emoji.attributes('src')).toBe(MOCK_EXPECTED_OCTOCAT_SRC);
-          });
-        });
-
         describe('When default slot contains text with a colon and a valid emoji', () => {
           beforeEach(() => {
             mockSlots = { default: 'This is a smile emoji: :smile:' };

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/EmojiComponent.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/EmojiComponent.vue
@@ -4,15 +4,25 @@
     class="d-d-inline-block d-va-bottom d-lh0"
   >
     <dt-emoji
+      v-if="node.attrs.code"
       size="500"
       :code="node.attrs.code"
     />
+    <img
+      v-else
+      class="d-icon d-icon--size-500"
+      :alt="node.attrs.name"
+      :aria-label="node.attrs.name"
+      :title="node.attrs.name"
+      :src="getImgSrc(node.attrs)"
+      @error="handleImageError"
+    >
   </node-view-wrapper>
 </template>
 
 <script>
 import { nodeViewProps, NodeViewWrapper } from '@tiptap/vue-2';
-
+import { CDN_URL } from '@/components/emoji_picker/emoji_picker_constants';
 import { DtEmoji } from '@/components/emoji';
 
 export default {
@@ -23,5 +33,27 @@ export default {
   },
 
   props: nodeViewProps,
+
+  computed: {
+    CDN_URL () {
+      return CDN_URL;
+    },
+  },
+
+  methods: {
+    getImgSrc: function (emoji) {
+      // TODO Update json structure to have a property for custom emojis and avoid using date_added
+      if (emoji.image) { // if custom emoji
+        return emoji.image;
+      } else { // if regular emoji
+        return this.CDN_URL + emoji.code + '.png';
+      }
+    },
+
+    handleImageError: function (event) {
+      console.log('test error emoji');
+      // event.target.parentNode.style.display = 'none';
+    },
+  }
 };
 </script>

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/EmojiComponent.vue
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/EmojiComponent.vue
@@ -8,51 +8,60 @@
       size="500"
       :code="node.attrs.code"
     />
-    <img
-      v-else
-      class="d-icon d-icon--size-500"
-      :alt="node.attrs.name"
-      :aria-label="node.attrs.name"
-      :title="node.attrs.name"
-      :src="getImgSrc(node.attrs)"
-      @error="handleImageError"
-    >
+
+    <template v-else>
+      <dt-skeleton
+        v-if="showSkeleton"
+        :offset="0"
+        class="d-icon d-icon--size-500"
+        :shape-option="{ shape: 'circle', size: '100%' }"
+      />
+
+      <img
+        v-show="!showSkeleton"
+        class="d-icon d-icon--size-500"
+        :alt="node.attrs.name"
+        :aria-label="node.attrs.name"
+        :title="node.attrs.name"
+        :src="node.attrs.image"
+        @load="handleImageLoad"
+        @error="handleImageError"
+      >
+    </template>
+
   </node-view-wrapper>
 </template>
 
 <script>
 import { nodeViewProps, NodeViewWrapper } from '@tiptap/vue-2';
-import { CDN_URL } from '@/components/emoji_picker/emoji_picker_constants';
 import { DtEmoji } from '@/components/emoji';
+import { DtSkeleton } from '@/components/skeleton';
+
 
 export default {
   name: 'EmojiComponent',
   components: {
     NodeViewWrapper,
     DtEmoji,
+    DtSkeleton,
   },
 
   props: nodeViewProps,
 
-  computed: {
-    CDN_URL () {
-      return CDN_URL;
-    },
+  data () {
+    return {
+      showSkeleton: true,
+    };
   },
 
   methods: {
-    getImgSrc: function (emoji) {
-      // TODO Update json structure to have a property for custom emojis and avoid using date_added
-      if (emoji.image) { // if custom emoji
-        return emoji.image;
-      } else { // if regular emoji
-        return this.CDN_URL + emoji.code + '.png';
-      }
+    handleImageLoad () {
+      this.showSkeleton = false;
     },
 
     handleImageError: function (event) {
-      console.log('test error emoji');
-      // event.target.parentNode.style.display = 'none';
+      this.showSkeleton = false;
+      event.target.parentNode.remove();
     },
   }
 };

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
@@ -54,6 +54,12 @@ export const Emoji = Node.create({
       code: {
         default: null,
       },
+      image: {
+        default: null,
+      },
+      name: {
+        default: null,
+      },
     };
   },
 
@@ -68,8 +74,14 @@ export const Emoji = Node.create({
   renderText ({ node }) {
     // output emoji in text as unicode character rather than shortname for backwards compatibility with
     // our backend.
-    const unicodeEmoji = stringToUnicode(codeToEmojiData(node.attrs.code).unicode_output);
-    return unicodeEmoji;
+    if(node.attrs.code === null || node.attrs.code === undefined) {
+      return node.attrs.image;
+    }else{
+      const emojiData = codeToEmojiData(node.attrs.code);
+      const unicodeEmoji = stringToUnicode(emojiData.unicode_output);
+
+      return unicodeEmoji;
+    }
   },
 
   renderHTML ({ HTMLAttributes }) {
@@ -90,6 +102,8 @@ export const Emoji = Node.create({
           const start = range.from;
           const end = range.to;
           tr.replaceWith(start, end, this.type.create({ code: match[0] }));
+          tr.replaceWith(start, end, this.type.create({ image: match[1] }));
+          tr.replaceWith(start, end, this.type.create({ name: match[2] }));
         },
       }),
     ];
@@ -103,6 +117,8 @@ export const Emoji = Node.create({
         getAttributes (attrs) {
           return {
             code: attrs[0],
+            image: attrs[1],
+            name: attrs[2],
           };
         },
       }),
@@ -112,6 +128,8 @@ export const Emoji = Node.create({
         getAttributes (attrs) {
           return {
             code: attrs[0],
+            image: attrs[1],
+            name: attrs[2],
           };
         },
       }),

--- a/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
+++ b/packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/emoji.js
@@ -72,12 +72,17 @@ export const Emoji = Node.create({
   },
 
   renderText ({ node }) {
-    // output emoji in text as unicode character rather than shortname for backwards compatibility with
-    // our backend.
-    if(node.attrs.code === null || node.attrs.code === undefined) {
-      return node.attrs.image;
+    /**
+     image -- custom emoji
+     code -- unicode emoji
+    */
+
+    const { image, code } = node.attrs;
+
+    if(image !== null) {
+      return image;
     }else{
-      const emojiData = codeToEmojiData(node.attrs.code);
+      const emojiData = codeToEmojiData(code);
       const unicodeEmoji = stringToUnicode(emojiData.unicode_output);
 
       return unicodeEmoji;
@@ -102,8 +107,6 @@ export const Emoji = Node.create({
           const start = range.from;
           const end = range.to;
           tr.replaceWith(start, end, this.type.create({ code: match[0] }));
-          tr.replaceWith(start, end, this.type.create({ image: match[1] }));
-          tr.replaceWith(start, end, this.type.create({ name: match[2] }));
         },
       }),
     ];

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -5,6 +5,7 @@ import DtRecipeMessageInputDefaultTemplate from './message_input_default.story.v
 import mentionSuggestion from '@/components/rich_text_editor/mention_suggestion';
 import channelSuggestion from '@/components/rich_text_editor/channel_suggestion';
 import slashCommandSuggestion from '@/components/rich_text_editor/slash_command_suggestion';
+import customEmojiJson from '@/common/custom-emoji.json';
 
 const iconsList = getIconNames();
 
@@ -300,24 +301,7 @@ export const WithCustomEmoji = {
     value: 'This is a test with custom emojis',
     emojiPickerProps: {
       skinTone: 'Default',
-      customEmojis: [
-        {
-          name: 'shipit',
-          date_added: 1730918816847,
-          added_by: 'Ignacio Ropolo',
-          image: 'https://github.githubassets.com/images/icons/emoji/shipit.png',
-          unicode_character: '1f44d',
-        },
-        {
-          name: 'thumbs up',
-          category: 'people',
-          shortname: ':thumbsup:',
-          shortname_alternates: [':+1:', ':thumbup:'],
-          keywords: ['+1', 'hand', 'thumb', 'up', 'uc6'],
-          unicode_output: '1f44d',
-          unicode_character: '1f44d',
-        },
-      ],
+      customEmojis: customEmojiJson,
     },
   },
 };

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -950,6 +950,8 @@ export default {
         type: 'emoji',
         attrs: {
           code: emoji.shortname,
+          image: emoji.image,
+          name: emoji.name,
         },
       });
       this.$emit('selected-emoji', emoji);


### PR DESCRIPTION
# fix(rich-text-editor): DLT-2690 custom emojis not working

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix


## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->
https://dialpad.atlassian.net/browse/DLT-2690


## :book: Description

Seems like our implementation on rich text editor component get outdated.
Thats why we get the reported error.

What Im doing in this PR is improving the implementation and sync the custom emoji data with the expected from Backend

Since this is an ongoing feature we will probably continue doing changes.


## :bulb: Context

We are working on the custom emoji feature.

This will give the possibility to add jpeg/png/gif emoji to our emoji picker.

When we select an emoji, it need to be rendered, we do it in:

packages/dialtone-vue2/components/rich_text_editor/extensions/emoji/EmojiComponent.vue



## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->


https://github.com/user-attachments/assets/896c9315-85dd-4010-8caf-83aff0257ba0


## On image load error:
Similar as what is DtEmoji does. We are showing a skeleton until the image load.
If the image fails, we remove it with 
`event.target.parentNode.remove();` to avoid polluting the input.


https://github.com/user-attachments/assets/6a743612-94f4-4072-be78-ef4a3650e872



## :crystal_ball: Next Steps

DtEmoji -> emoji.vue component does not support custom emojis. It only receives a `code` prop that it will use to find the emoji in our `emojiJsonLocal`

I updated some tests
- `common/emoji.test.js`
- `components/emoji/emoji.test.js` 
- `emoji_text_wrapper.test.js`

but all these should be removed along with a clean up of `common/emoji/index.js`.

At this moment we are using custom emojis in

- emoji_selector-> in emoji_picker component
- EmojiComponent.vue -> in rich_text_editor component (to render the emoji in message_input)

emoji_selector does not use DtEmoji because if I remember correctly it has a performance issue.

EmojiComponent.vue uses DtEmoji to handle our local emojis and has a different implementation to handle custom emojis (similiar to emoji_selector but with a skeleton)

I would like to somehow unify this in one component/handler.
I expect that DtEmoji will support custom emojies, or maybe we need to create a different component as DtCustomEmoji to take care of it then we can use it in our different implementations.

I use this space to avoid go further in changes in this PR since it is a 'quick fix' to unlock work to @bianca-artola-dialpad and team.


Possible upcoming tickets im thinking we can generate.
Spike -> Investigate how to unify the implementation of emoji with custom emoji
Story -> Clean up of custom emoji on emoji files. (and probably implement new ones like tests)

----
I will add the vue3 implementation after the changes approval.



