### PR TITLE
docs(select-menu): NO-JIRA use default instead of options

### DIFF
--- a/apps/dialtone-documentation/docs/components/select-menu.md
+++ b/apps/dialtone-documentation/docs/components/select-menu.md
@@ -426,7 +426,7 @@ vueCode='
   @input="onInput"
   @change="onChange"
 >
-  <template #options>
+  <template #default>
     <option
       v-for="option in options"
       :key="`with-slotted-options-${option.value}`"


### PR DESCRIPTION
# docs(select-menu): NO-JIRA use default instead of options

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMW1mdzFvbzlrZWNmZjJpMjN3bDNxeDd1bHVxb2lzcWt3djNyaDN4OSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/9OzKXHsqvbh3G/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)


## :book: Description

- We use `default` for the options slot https://github.com/dialpad/dialtone/blob/master/packages/dialtone-vue2/components/select_menu/select_menu.vue#L311-L315, so a small nitpick by adjusting the doc

## :camera: Screenshots / GIFs

<img width="961" height="614" alt="image" src="https://github.com/user-attachments/assets/6a26ed44-8b1b-43ce-9db3-89437a8161d6" />
