### PR TITLE
feat(utilities): DLT-2396 word-break: break-word and word-wrap: anywhere

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/common/utilities.js
+++ b/apps/dialtone-documentation/docs/.vuepress/common/utilities.js
@@ -53,7 +53,6 @@ export const ReleaseNoteFormatter = {
 export function extractUtilityClasses (utilityClassDocs, prefix) {
   return Object.keys(utilityClassDocs)
     .filter(className => className.startsWith(prefix))
-    .sort(colorSorter)
     .reduce((result, className) => {
       result[className] = utilityClassDocs[className]
         .values
@@ -71,12 +70,16 @@ export function extractCSSVariableName (propValue) {
 
 /**
  * Sorts the colors putting the base colors at the bottom of the list.
- * @param {string} a
- * @returns {number}
+ * @param {Object} colorUtilityClasses
+ * @returns {Object}
  */
-export function colorSorter (a) {
-  if (/\d{2,4}$/.test(a)) return 1;
-  return -1;
+export function sortBaseColors (colorUtilityClasses) {
+  return Object.keys(colorUtilityClasses)
+    .sort((color) => (/\d{2,4}$/.test(color) ? 1 : -1))
+    .reduce((obj, key) => {
+      obj[key] = colorUtilityClasses[key];
+      return obj;
+    }, {});
 }
 
 export default {
@@ -84,5 +87,5 @@ export default {
   ReleaseNoteFormatter,
   extractUtilityClasses,
   extractCSSVariableName,
-  colorSorter,
+  sortBaseColors,
 };

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/color.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/color.md
@@ -123,17 +123,12 @@ Use `d-bgo{stop}` to change an element's background color opacity. You can also 
 
 <script setup>
   import { inject } from 'vue';
-  import { extractUtilityClasses } from '@utilities';
+  import { extractUtilityClasses, sortBaseColors } from '@utilities';
 
   /*Excluded classes that have incorrect naming, should be renamed to `d-bgclip` to avoid conflicts*/
   const excludedClasses = ['d-bgc-border-box', 'd-bgc-content-box', 'd-bgc-padding-box', 'd-bgc-text'];
 
   const utilityClassDocs = inject('utilityClassDocs');
   const colors = extractUtilityClasses(utilityClassDocs, 'd-bgc-');
-  const backgroundColors = Object.keys(colors)
-    .filter(className => !excludedClasses.includes(className))
-    .reduce((obj, key) => {
-      obj[key] = colors[key];
-      return obj;
-    }, {});
+  const backgroundColors = sortBaseColors(colors);
 </script>

--- a/apps/dialtone-documentation/docs/utilities/borders/color.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/color.md
@@ -181,8 +181,9 @@ You can also change the border color opacity value on `:hover`
 
 <script setup>
   import { inject } from 'vue';
-  import { extractUtilityClasses } from '@utilities';
+  import { extractUtilityClasses, sortBaseColors } from '@utilities';
 
   const utilityClassDocs = inject('utilityClassDocs');
-  const borderColors = extractUtilityClasses(utilityClassDocs, 'd-bc-');
+  const colors = extractUtilityClasses(utilityClassDocs, 'd-bc-');
+  const borderColors = sortBaseColors(colors);
 </script>

--- a/apps/dialtone-documentation/docs/utilities/borders/divide-color.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/divide-color.md
@@ -62,8 +62,9 @@ Use `d-divide-x{n}` to create a divider between an element's child items.
 
 <script setup>
   import { inject } from 'vue';
-  import { extractUtilityClasses } from '@utilities';
+  import { extractUtilityClasses, sortBaseColors } from '@utilities';
 
   const utilityClassDocs = inject('utilityClassDocs');
-  const divideColors = extractUtilityClasses(utilityClassDocs, 'd-divide-');
+  const colors = extractUtilityClasses(utilityClassDocs, 'd-divide-');
+  const divideColors = sortBaseColors(colors);
 </script>

--- a/apps/dialtone-documentation/docs/utilities/typography/font-color.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-color.md
@@ -3,7 +3,8 @@ title: Font Color
 description: Utilities to change an element's font-color.
 ---
 
-All font colors pass the WCAG 2.1 Level AA contrast ratio requirements (ratio >= 4.5:1) and most pass WCAG 2.1 Level AAA requirements (ratio >= 7:1).
+All font colors pass the WCAG 2.1 Level AA contrast ratio requirements (ratio >= 4.5:1) and most pass WCAG 2.1 Level AAA
+requirements (ratio >= 7:1).
 The contrast ratio value is noted with the colors below.
 Please use **only** these colors or variations of these colors which pass WCAG 2.1 Level AA contrast ratio requirements.
 
@@ -32,6 +33,7 @@ Use `h:d-fc-{color}` to change an element's text color `:hover` state.
 </code-well-header>
 
 ```html
+
 <dt-button kind="unstyled" class="d-fc-critical h:d-fc-success">Hover over me</dt-button>
 ```
 
@@ -44,6 +46,7 @@ Use `f:d-fc-{color}` to change an element's text color `:focus` and `:focus-with
 </code-well-header>
 
 ```html
+
 <dt-button kind="unstyled" class="d-fc-critical f:d-fc-success">Focus me</dt-button>
 ```
 
@@ -56,12 +59,14 @@ Use `fv:d-fc-{color}` to change an element's text color on `:focus-visible` stat
 </code-well-header>
 
 ```html
+
 <dt-button kind="unstyled" class="d-fc-critical fv:d-fc-success">Keyboard focus me</dt-button>
 ```
 
 ## Changing Opacity
 
-Use `d-fco{n}` to change an element's text color opacity. You can also change font color opacity on `:hover`, `:focus`, `:focus-visible` by using the respective `h:d-fco{n}`, `f:d-fco{n}`, `fv:d-fco{n}` prefixes.
+Use `d-fco{n}` to change an element's text color opacity. You can also change font color opacity on `:hover`, `:focus`,
+`:focus-visible` by using the respective `h:d-fco{n}`, `f:d-fco{n}`, `fv:d-fco{n}` prefixes.
 
 <code-well-header>
   <p class="d-fc-critical">The quick brown fox jumps over the lazy dog.</p>
@@ -89,7 +94,7 @@ Use `d-fco{n}` to change an element's text color opacity. You can also change fo
 
 ## Classes
 
-<new-utility-class-table :classes="colors">
+<new-utility-class-table :classes="fontColors">
   <template #example="{ className }">
     <div
       class="d-fl-shrink0 d-h42 d-w42 d-bar-circle d-ba d-bc-moderate d-d-flex d-ai-center d-jc-center"
@@ -106,8 +111,9 @@ Use `d-fco{n}` to change an element's text color opacity. You can also change fo
 
 <script setup>
   import { inject } from 'vue';
-  import { extractUtilityClasses } from '@utilities';
+  import { extractUtilityClasses, sortBaseColors } from '@utilities';
 
   const utilityClassDocs = inject('utilityClassDocs');
   const colors = extractUtilityClasses(utilityClassDocs, 'd-fc-');
+  const fontColors = sortBaseColors(colors);
 </script>

--- a/apps/dialtone-documentation/docs/utilities/typography/word-break.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/word-break.md
@@ -19,7 +19,9 @@ Use `d-wb-normal` to reset an element's line break rule.
 
 ## Break All
 
-Use `d-wb-break-all` on an element to insert word breaks between any two characters (excluding Chinese, Japanese, or Korean text) to prevent text from overflowing. The break between any two characters can lead to awkward line breaks in the middle of short words, for a more conservative way to handle it see [`d-ww-break-word`](./word-wrap.md#break-word).
+Use `d-wb-break-all` on an element to insert word breaks between any two characters (excluding Chinese, Japanese, or
+Korean text) to prevent text from overflowing. The break between any two characters can lead to awkward line breaks in
+the middle of short words, for a more conservative way to handle it see [`d-ww-break-word`](./word-wrap.md#break-word).
 
 <code-well-header>
   <div class="d-bgc-moderate d-py8 d-px16 d-bar8 lg:d-w216 d-w332">
@@ -31,9 +33,26 @@ Use `d-wb-break-all` on an element to insert word breaks between any two charact
 <p class="d-wb-break-all">...</p>
 ```
 
+## Break Word
+
+Use `d-wb-break-word` on an element to insert word breaks between any two characters (including Chinese, Japanese, or
+Korean text) to prevent text from overflowing. The break between any two characters can lead to awkward line breaks in
+the middle of short words, for a more conservative way to handle it see [`d-ww-break-word`](./word-wrap.md#break-word).
+
+<code-well-header>
+  <div class="d-bgc-moderate d-py8 d-px16 d-bar8 lg:d-w216 d-w332">
+    qwqqd<p class="d-wb-break-all">Here's an example sentence to show how word-break works. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
+  </div>
+</code-well-header>
+
+```html
+<p class="d-wb-break-word">...</p>
+```
+
 ## Keep All
 
-Use `d-wb-keep-all` on an element to not use word breaks for Chinese, Japanese, or Korean (CJK) text. Non-CJK text behavior is set to normal.
+Use `d-wb-keep-all` on an element to not use word breaks for Chinese, Japanese, or Korean (CJK) text. Non-CJK text
+behavior is set to normal.
 
 <code-well-header>
   <div class="d-bgc-moderate d-py8 d-px16 d-bar8 lg:d-w216 d-w332">
@@ -47,13 +66,12 @@ Use `d-wb-keep-all` on an element to not use word breaks for Chinese, Japanese, 
 
 ## Classes
 
-<utility-class-table>
-  <template #content>
-    <tbody>
-      <tr v-for="i in ['normal', 'break-all', 'keep-all', 'unset']">
-        <th scope="row" class="d-code--sm d-docsite-code">.d-wb-{{ i }}</th>
-        <td class="d-code--sm">word-break: {{ i }} !important;</td>
-      </tr>
-    </tbody>
-  </template>
-</utility-class-table>
+<new-utility-class-table :classes="wordBreak"></new-utility-class-table>
+
+<script setup>
+  import { inject } from 'vue';
+  import { extractUtilityClasses } from '@utilities';
+
+  const utilityClassDocs = inject('utilityClassDocs');
+  const wordBreak = extractUtilityClasses(utilityClassDocs, 'd-wb-');
+</script>

--- a/apps/dialtone-documentation/docs/utilities/typography/word-wrap.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/word-wrap.md
@@ -31,6 +31,20 @@ Use `d-ww-break-word` to allow unbreakable words to be broken. Is a more conserv
 <p class="d-ww-break-word">...</p>
 ```
 
+## Anywhere
+
+Use `d-ww-anywhere` to break words at any point in the string (not just at allowed break points) to prevent long strings from overflowing their container.
+
+<code-well-header>
+  <div class="d-bgc-moderate d-py8 d-px16 d-bar8 lg:d-w216 d-w332">
+    <p class="d-ww-break-word">Here's an example sentence to show how word-wrap works. Thisisasignlewordtodenotethedifferencebetweenthedifferentwaytowrapaword. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
+  </div>
+</code-well-header>
+
+```html
+<p class="d-ww-anywhere">...</p>
+```
+
 ## Initial
 
 Use `d-ww-initial`to set this property to its default value.
@@ -61,13 +75,12 @@ Use `d-ww-inherit` to inherit this property from its parent element.
 
 ## Classes
 
-<utility-class-table>
-  <template #content>
-    <tbody>
-      <tr v-for="i in ['normal', 'break-word', 'initial', 'inherit']">
-        <th scope="row" class="d-code--sm d-docsite-code">.d-ww-{{ i }}</th>
-        <td class="d-code--sm">word-wrap: {{ i }} !important;</td>
-      </tr>
-    </tbody>
-  </template>
-</utility-class-table>
+<new-utility-class-table :classes="wordWrap"></new-utility-class-table>
+
+<script setup>
+  import { inject } from 'vue';
+  import { extractUtilityClasses } from '@utilities';
+
+  const utilityClassDocs = inject('utilityClassDocs');
+  const wordWrap = extractUtilityClasses(utilityClassDocs, 'd-ww-');
+</script>

--- a/packages/dialtone-css/lib/build/less/utilities/typography.less
+++ b/packages/dialtone-css/lib/build/less/utilities/typography.less
@@ -431,8 +431,9 @@ ul {
 //  ============================================================================
 //  $$  WORD WRAP
 //  ----------------------------------------------------------------------------
-.d-ww-break-word { word-wrap: break-word !important; }
 .d-ww-normal { word-wrap: normal !important; }
+.d-ww-break-word { word-wrap: break-word !important; }
+.d-ww-anywhere { word-wrap: anywhere !important; }
 .d-ww-initial { word-wrap: initial !important; }
 .d-ww-inherit { word-wrap: inherit !important; }
 

--- a/packages/dialtone-css/lib/build/less/utilities/typography.less
+++ b/packages/dialtone-css/lib/build/less/utilities/typography.less
@@ -425,6 +425,7 @@ ul {
 //  ----------------------------------------------------------------------------
 .d-wb-normal { word-break: normal !important; }
 .d-wb-break-all { word-break: break-all !important; }
+.d-wb-break-word { word-break: break-word !important; }
 .d-wb-keep-all { word-break: keep-all !important; }
 .d-wb-unset { word-break: unset !important; }
 


### PR DESCRIPTION
# Add `word-break: break-word` and `word-wrap: anywhere` utility classes

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3MGo5enRmeGw0eWQxczR1djZiMXp0emp6NzFqcXk4YW1kZm1ucThpOSZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/O43Y9lYhdjNXM5eZ4I/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2396

## :book: Description

- Added `word-beak: break-word` utility class
- Added `word-wrap: anywhere` utility class
- Fixed an issue with the sorting of base color utility classes. 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

## :camera: Screenshots / GIFs

<img width="2558" height="1294" alt="Captura de pantalla 2025-08-07 a las 1 46 28 p m" src="https://github.com/user-attachments/assets/9320e7b5-af2f-4fed-b104-f991885aa69f" />

<img width="2558" height="1291" alt="Captura de pantalla 2025-08-07 a las 1 47 41 p m" src="https://github.com/user-attachments/assets/26dcd9ad-dc3e-422b-9ce2-9c9cced8be26" />