### PR TITLE
docs(toggle): DLT-2623 fix vue 3 toggle variants

### DIFF
--- a/packages/dialtone-vue2/components/toggle/toggle_variants.story.vue
+++ b/packages/dialtone-vue2/components/toggle/toggle_variants.story.vue
@@ -6,7 +6,7 @@
       label-class="d-mr6"
       label="Unchecked Initial"
     >
-      Checked Initial
+      Unchecked Initial
     </dt-toggle>
 
     <!-- Checked Initially -->

--- a/packages/dialtone-vue3/components/toggle/toggle_variants.story.vue
+++ b/packages/dialtone-vue3/components/toggle/toggle_variants.story.vue
@@ -6,7 +6,7 @@
       label-class="d-mr6"
       label="Unchecked Initial"
     >
-      Checked Initial
+      Unchecked Initial
     </dt-toggle>
 
     <!-- Checked Initially -->
@@ -14,7 +14,7 @@
       class="d-mt6"
       label-class="d-mr6"
       label="Checked Initial"
-      :checked="true"
+      :model-value="true"
     >
       Checked Initial
     </dt-toggle>
@@ -23,7 +23,7 @@
     <dt-toggle
       class="d-mt6"
       label-class="d-mr6"
-      checked="mixed"
+      model-value="mixed"
     >
       Indeterminate
     </dt-toggle>
@@ -32,7 +32,7 @@
     <dt-toggle
       class="d-mt6"
       label-class="d-mr6"
-      :checked="true"
+      :model-value="true"
       :disabled="true"
     >
       Disabled Checked
@@ -51,7 +51,7 @@
     <dt-toggle
       class="d-mt6"
       label-class="d-mr6"
-      checked="mixed"
+      model-value="mixed"
       :disabled="true"
     >
       Indeterminate Disabled


### PR DESCRIPTION
Simple fix for vue 3 toggle variants in storybook. They were still using checked when they should have been using model-value.

Documentation fix only