### PR TITLE
feat(message-input): DLT-2714 add scroll-bottom-reached event on input

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -191,7 +191,7 @@ export const argTypesData = {
     },
   },
 
-  onScrollBottomReached: {
+  onEmojiScrollBottomReached: {
     table: {
       disable: true,
     },
@@ -243,7 +243,7 @@ export const argsData = {
   onNoticeClose: action('notice-close'),
   onSkinTone: action('skin-tone'),
   onCancel: action('cancel'),
-  onScrollBottomReached: action('scroll-bottom-reached'),
+  onEmojiScrollBottomReached: action('emoji-scroll-bottom-reached'),
 };
 
 // Story Collection

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -190,6 +190,12 @@ export const argTypesData = {
       disable: true,
     },
   },
+
+  onScrollBottomReached: {
+    table: {
+      disable: true,
+    },
+  },
 };
 
 // Set default values at the story level here.
@@ -237,6 +243,7 @@ export const argsData = {
   onNoticeClose: action('notice-close'),
   onSkinTone: action('skin-tone'),
   onCancel: action('cancel'),
+  onScrollBottomReached: action('scroll-bottom-reached'),
 };
 
 // Story Collection

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -162,6 +162,7 @@
                 @add-emoji="$emit('add-emoji')"
                 @skin-tone="onSkinTone"
                 @selected-emoji="(emoji) => onSelectEmoji(emoji, close)"
+                @scroll-bottom-reached="$emit('scroll-bottom-reached')"
               />
             </template>
           </dt-popover>
@@ -747,6 +748,12 @@ export default {
      * @type {Boolean}
      */
     'add-emoji',
+
+    /**
+     * Emitted when the emoji picker scroll reaches the bottom
+     * @event scroll-bottom-reached
+     */
+    'scroll-bottom-reached',
   ],
 
   data () {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.vue
@@ -162,7 +162,7 @@
                 @add-emoji="$emit('add-emoji')"
                 @skin-tone="onSkinTone"
                 @selected-emoji="(emoji) => onSelectEmoji(emoji, close)"
-                @scroll-bottom-reached="$emit('scroll-bottom-reached')"
+                @scroll-bottom-reached="$emit('emoji-scroll-bottom-reached')"
               />
             </template>
           </dt-popover>
@@ -751,9 +751,9 @@ export default {
 
     /**
      * Emitted when the emoji picker scroll reaches the bottom
-     * @event scroll-bottom-reached
+     * @event emoji-scroll-bottom-reached
      */
-    'scroll-bottom-reached',
+    'emoji-scroll-bottom-reached',
   ],
 
   data () {

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -54,7 +54,7 @@
         @paste-media="$attrs.onPasteMedia"
         @notice-close="$attrs.onNoticeClose"
         @cancel="$attrs.onCancel"
-        @scroll-bottom-reached="$attrs.onScrollBottomReached"
+        @emoji-scroll-bottom-reached="$attrs.onEmojiScrollBottomReached"
       >
         <template
           v-if="$attrs.emojiGiphyPicker"

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -54,6 +54,7 @@
         @paste-media="$attrs.onPasteMedia"
         @notice-close="$attrs.onNoticeClose"
         @cancel="$attrs.onCancel"
+        @scroll-bottom-reached="$attrs.onScrollBottomReached"
       >
         <template
           v-if="$attrs.emojiGiphyPicker"

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -191,7 +191,7 @@ export const argTypesData = {
     },
   },
 
-  onScrollBottomReached: {
+  onEmojiScrollBottomReached: {
     table: {
       disable: true,
     },
@@ -243,7 +243,7 @@ export const argsData = {
   onNoticeClose: action('notice-close'),
   onSkinTone: action('skin-tone'),
   onCancel: action('cancel'),
-  onScrollBottomReached: action('scroll-bottom-reached'),
+  onEmojiScrollBottomReached: action('emoji-scroll-bottom-reached'),
 };
 
 // Story Collection

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -190,6 +190,12 @@ export const argTypesData = {
       disable: true,
     },
   },
+
+  onScrollBottomReached: {
+    table: {
+      disable: true,
+    },
+  },
 };
 
 // Set default values at the story level here.
@@ -237,6 +243,7 @@ export const argsData = {
   onNoticeClose: action('notice-close'),
   onSkinTone: action('skin-tone'),
   onCancel: action('cancel'),
+  onScrollBottomReached: action('scroll-bottom-reached'),
 };
 
 // Story Collection

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -162,6 +162,7 @@
                 @add-emoji="$emit('add-emoji')"
                 @skin-tone="onSkinTone"
                 @selected-emoji="(emoji) => onSelectEmoji(emoji, close)"
+                @scroll-bottom-reached="$emit('scroll-bottom-reached')"
               />
             </template>
           </dt-popover>
@@ -745,6 +746,12 @@ export default {
      * @type {Boolean}
      */
     'add-emoji',
+
+    /**
+     * Emitted when the emoji picker scroll reaches the bottom
+     * @event scroll-bottom-reached
+     */
+    'scroll-bottom-reached',
   ],
 
   data () {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.vue
@@ -162,7 +162,7 @@
                 @add-emoji="$emit('add-emoji')"
                 @skin-tone="onSkinTone"
                 @selected-emoji="(emoji) => onSelectEmoji(emoji, close)"
-                @scroll-bottom-reached="$emit('scroll-bottom-reached')"
+                @scroll-bottom-reached="$emit('emoji-scroll-bottom-reached')"
               />
             </template>
           </dt-popover>
@@ -749,9 +749,9 @@ export default {
 
     /**
      * Emitted when the emoji picker scroll reaches the bottom
-     * @event scroll-bottom-reached
+     * @event emoji-scroll-bottom-reached
      */
-    'scroll-bottom-reached',
+    'emoji-scroll-bottom-reached',
   ],
 
   data () {

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -53,7 +53,7 @@
       @paste-media="$attrs.onPasteMedia"
       @notice-close="$attrs.onNoticeClose"
       @cancel="$attrs.onCancel"
-      @scroll-bottom-reached="$attrs.onScrollBottomReached"
+      @emoji-scroll-bottom-reached="$attrs.onEmojiScrollBottomReached"
     >
       <template
         v-if="$attrs.emojiGiphyPicker"

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -53,6 +53,7 @@
       @paste-media="$attrs.onPasteMedia"
       @notice-close="$attrs.onNoticeClose"
       @cancel="$attrs.onCancel"
+      @scroll-bottom-reached="$attrs.onScrollBottomReached"
     >
       <template
         v-if="$attrs.emojiGiphyPicker"


### PR DESCRIPTION
# feat(message-input): DLT-2714 add scroll-bottom-reached event on input

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExdDV2anl4ZnFuMXpkY3pvdm5wZDc5c3M4eGJsdWU1cHN4dnlneDN6aSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/9GI7UlOQ6uU95v82q7/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-2714
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

This pull request adds the ability to notify when they have scrolled to the bottom of the emoji picker in the message input.

## :bulb: Context

When using the message input component on the Firespotter side, some use cases require the emoji picker provided by Dialtone (which doesn't include a Giphy picker). In these situations, we need to know when a user has reached the end of the custom emoji list so we can continue fetching more emojis.

The scroll-bottom-reached event will only be emitted on the picker for cases where it is handled separately from the input.