### PR TITLE
feat(css-utility): DLT-2715 add default color for border css utilities

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/BlogPostPreview.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/BlogPostPreview.vue
@@ -9,7 +9,7 @@
       @click="(e) => { navigate(e); }"
     >
       <dt-card
-        class="d-mt16 d-bgc-primary d-bs-none h:d-bs-sm d-ba d-bar8 d-bbw1 d-bc-default"
+        class="d-mt16 d-bgc-primary d-bs-none h:d-bs-sm d-ba d-bar8 d-bbw1"
       >
         <template #content>
           <blog-post

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentAccessibleTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentAccessibleTable.vue
@@ -8,7 +8,7 @@
               scope="col"
               class="d-w40p d-p0 d-bbw0"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Item
               </div>
             </th>
@@ -16,7 +16,7 @@
               scope="col"
               class="d-w30p d-p0 d-bbw0"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Applies to
               </div>
             </th>
@@ -24,7 +24,7 @@
               scope="col"
               class="d-p0 d-bbw0"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Description
               </div>
             </th>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentClassTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentClassTable.vue
@@ -8,7 +8,7 @@
               class="d-w40p d-p0 d-bbw0"
               scope="col"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Class
               </div>
             </th>
@@ -16,7 +16,7 @@
               class="d-w30p d-p0 d-bbw0"
               scope="col"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Applies to
               </div>
             </th>
@@ -24,7 +24,7 @@
               class="d-p0 d-bbw0"
               scope="col"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Description
               </div>
             </th>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentVueApiTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentVueApiTable.vue
@@ -15,7 +15,7 @@
               scope="col"
               class="d-p0 d-bbw0"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Name
               </div>
             </th>
@@ -23,7 +23,7 @@
               scope="col"
               class="vue-api-table d-p0 d-bbw0"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Description
               </div>
             </th>
@@ -32,7 +32,7 @@
               scope="col"
               class="d-p0 d-bbw0"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Default
               </div>
             </th>
@@ -128,7 +128,7 @@ const sortedTableDataByName = computed(() => {
 });
 
 const sortDataByKey = (data, nameKey, requiredKey) => {
-  // eslint-disable-next-line complexity
+   
   return data.sort((a, b) => {
     const aIsRequired = !!a[requiredKey];
     const bIsRequired = !!b[requiredKey];

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/DesignColorTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/DesignColorTable.vue
@@ -69,17 +69,17 @@ const colors = processColorsDocs(props.excludedColors, props.classPrefix);
         <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
           <tr>
             <th class="d-p0 d-bbw0" colspan="3" scope="col">
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Color
               </div>
             </th>
             <th class="d-p0 d-bbw0" scope="col">
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 CSS variable
               </div>
             </th>
             <th class="d-p0 d-bbw0" scope="col">
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 CSS utility
               </div>
             </th>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/IconPopoverContent.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/IconPopoverContent.vue
@@ -61,7 +61,7 @@
         aria-label="Copy SVG markup"
       />
     </div>
-    <div class="d-d-flex d-ai-flex-end d-bb d-bc-default d-pb16">
+    <div class="d-d-flex d-ai-flex-end d-bb d-pb16">
       <div class="d-fl-grow1">
         <dt-input
           class="d-ff-mono"

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/NewUtilityClassTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/NewUtilityClassTable.vue
@@ -5,12 +5,12 @@
         <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
           <tr>
             <th class="d-w25p d-p0 d-bbw0" scope="col">
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Class
               </div>
             </th>
             <th class="d-p0 d-bbw0" scope="col">
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Output
               </div>
             </th>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ThemeColorTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ThemeColorTable.vue
@@ -5,27 +5,27 @@
         <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
           <tr>
             <th class="d-p0 d-bbw0" scope="col">
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Color
               </div>
             </th>
             <th class="d-p0 d-bbw0" scope="col">
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Section
               </div>
             </th>
             <th class="d-p0 d-bbw0" scope="col">
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 State
               </div>
             </th>
             <th class="d-p0 d-bbw0" scope="col">
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Property
               </div>
             </th>
             <th class="d-p0 d-bbw0" scope="col">
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Variable
               </div>
             </th>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/UtilityClassTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/UtilityClassTable.vue
@@ -5,12 +5,12 @@
         <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
           <tr>
             <th class="d-w25p d-p0 d-bbw0" scope="col">
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Class
               </div>
             </th>
             <th class="d-p0 d-bbw0" scope="col">
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Output
               </div>
             </th>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenTable.vue
@@ -8,7 +8,7 @@
               scope="col"
               class="d-p0 d-bbw0 d-label--sm-compact d-tt-none"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Preview
               </div>
             </th>
@@ -16,7 +16,7 @@
               scope="col"
               class="d-p0 d-bbw0 d-label--sm-compact d-tt-none"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 Token Name
               </div>
             </th>
@@ -24,7 +24,7 @@
               scope="col"
               class="d-p0 d-bbw0 d-label--sm-compact d-tt-none d-ta-right"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 {{ tokenList ? "REM" : "Value" }}
               </div>
             </th>
@@ -33,7 +33,7 @@
               scope="col"
               class="d-p0 d-bbw0 d-label--sm-compact"
             >
-              <div class="d-p16 d-bb d-bc-default d-bbw1">
+              <div class="d-p16 d-bb d-bbw1">
                 PX
               </div>
             </th>

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/MobileSidebar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/MobileSidebar.vue
@@ -4,7 +4,7 @@
       class="
         d-px16
         d-ps-fixed d-w100p d-bgc-secondary d-h64 d-x0
-        d-d-flex d-bb d-bc-default d-ai-center
+        d-d-flex d-bb d-ai-center
         d-jc-space-between d-t64 lg:d-d-none
       "
     >

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-3-20.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-3-20.md
@@ -48,7 +48,7 @@ class="d-label-plain-small" -> class="d-label--sm-plain"
 
 Replace any instances of the old naming convention with the corresponding new names. Refer to the mapping table below for clarity.
 
-<div class="d-bb d-bc-default">
+<div class="d-bb">
   <table class="d-table">
     <thead>
       <tr>

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-4-15.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-4-15.md
@@ -83,7 +83,7 @@ to avoid having to import them manually.</small>
 
 To migrate, replace any instances of the old imports with the corresponding new imports, please refer to the examples table below for clarity.
 
-<div class="d-bb d-bc-default d-of-x-scroll">
+<div class="d-bb d-of-x-scroll">
   <table class="d-table">
       <thead>
           <tr>

--- a/apps/dialtone-documentation/docs/components/datepicker.md
+++ b/apps/dialtone-documentation/docs/components/datepicker.md
@@ -389,7 +389,7 @@ The following functions are available for date formatting.
         {{ currentSelectedDate }}
       </p>
     </dt-stack>
-    <table class="d-table d-body--sm d-bt d-bc-default d-fl1">
+    <table class="d-table d-body--sm d-bt d-fl1">
       <tr>
         <th scope="row" class="d-code--sm">formatLong</th>
         <td>{{ formatLong(currentSelectedDate) }}</td>

--- a/apps/dialtone-documentation/docs/components/icon.md
+++ b/apps/dialtone-documentation/docs/components/icon.md
@@ -100,7 +100,7 @@ When setting the color of an icon take these into considaration:
 
 <div class="d-gc1">
 <div style="background: var(--dt-color-purple-100)" class="d-p16 d-hmn164 d-bar8 d-d-flex d-ai-center">
-<dt-stack direction="row" as="section" gap="100" class="d-bgc-primary d-bc-default d-bar32 d-py8 d-px16 d-w100p">
+<dt-stack direction="row" as="section" gap="100" class="d-bgc-primary d-bar32 d-py8 d-px16 d-w100p">
 <dt-stack direction="row" as="section" gap="300" class="d-fl1">
 <dt-icon name="headphones" size="300" ariaLabel="Headphones icon" />
 <p class="d-body--md d-truncate d-w100p d-wmx102">Ai Contact Center</p>
@@ -119,7 +119,7 @@ When setting the color of an icon take these into considaration:
 
 <div class="d-gc1">
 <div class="d-bgc-critical-subtle-opaque d-p16 d-hmn164 d-bar8 d-d-flex d-ai-center">
-<dt-stack direction="row" as="section" gap="100" class="d-bgc-primary d-bc-default d-bar32 d-py8 d-px16 d-w100p">
+<dt-stack direction="row" as="section" gap="100" class="d-bgc-primary d-bar32 d-py8 d-px16 d-w100p">
 <dt-stack direction="row" as="section" gap="300" class="d-fl1">
 <dt-icon name="headphones" size="300" ariaLabel="Headphones icon" />
 <p class="d-body--md d-truncate d-w100p d-wmx102">Ai Contact Center</p>

--- a/apps/dialtone-documentation/docs/components/scrollbar.md
+++ b/apps/dialtone-documentation/docs/components/scrollbar.md
@@ -11,7 +11,7 @@ image: assets/images/components/scrollbar.png
 Allows to add overlay scrollbars that will look the same for every browser. The directive sets up the scrollbars from the library [OverlayScrollbars](https://kingsora.github.io/OverlayScrollbars/).
 
 <code-well-header>
-  <div class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar>
+  <div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar>
     <dt-stack>
       <div v-for="item in items" class="item">
         {{ item}}
@@ -22,7 +22,7 @@ Allows to add overlay scrollbars that will look the same for every browser. The 
 
 <code-example-tabs
 htmlCode='
-<div class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default d-scrollbar" data-overlayscrollbars="host"
+<div class="d-hmx164 d-w30p d-bar8 d-ba d-scrollbar" data-overlayscrollbars="host"
   data-overlayscrollbars-initialize="true">
   <div class="os-size-observer">
     <div class="os-size-observer-listener"></div>
@@ -46,7 +46,7 @@ htmlCode='
 </div>
 '
 vueCode='
-<div class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar>
+<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar>
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}
@@ -107,7 +107,7 @@ Show the scrollbar when the mouse enters the scrollable area. This is the defaul
 ```
 
 <code-well-header>
-  <div class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar>
+  <div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar>
     <dt-stack>
       <div v-for="item in items" class="item">
         {{ item}}
@@ -125,7 +125,7 @@ Always show the scrollbar if the region is overflowing the available space.
 ```
 
 <code-well-header>
-  <div class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar:never>
+  <div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar:never>
     <dt-stack>
       <div v-for="item in items" class="item">
         {{ item}}
@@ -143,7 +143,7 @@ Show the scrollbar on scroll.
 ```
 
 <code-well-header>
-  <div class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar:scroll>
+  <div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar:scroll>
     <dt-stack>
       <div v-for="item in items" class="item">
         {{ item}}
@@ -161,7 +161,7 @@ Show the scrollbar when the mouse moves inside the scrollable area.
 ```
 
 <code-well-header>
-  <div class="d-hmx164 d-w30p d-bar8 d-ba d-bc-default" v-dt-scrollbar:move>
+  <div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar:move>
     <dt-stack>
       <div v-for="item in items" class="item">
         {{ item}}

--- a/apps/dialtone-documentation/docs/components/stack.md
+++ b/apps/dialtone-documentation/docs/components/stack.md
@@ -346,16 +346,16 @@ vueCode='
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
           <th scope="col" class="d-p0 d-bbw0">
-            <div class="d-p16 d-bb d-bc-default d-bbw1">Size</div>
+            <div class="d-p16 d-bb d-bbw1">Size</div>
           </th>
           <th scope="col" class="d-p0 d-bbw0">
-            <div class="d-p16 d-bb d-bc-default d-bbw1">Design Token</div>
+            <div class="d-p16 d-bb d-bbw1">Design Token</div>
           </th>
           <th scope="col" class="d-ta-right d-p0 d-bbw0">
-            <div class="d-p16 d-bb d-bc-default d-bbw1">REM</div>
+            <div class="d-p16 d-bb d-bbw1">REM</div>
           </th>
           <th scope="col" class="d-ta-right d-p0 d-bbw0">
-            <div class="d-p16 d-bb d-bc-default d-bbw1">PX</div>
+            <div class="d-p16 d-bb d-bbw1">PX</div>
           </th>
         </tr>
       </thead>
@@ -661,18 +661,18 @@ Stacks row with gap 300 and stacks in row reverse the nested stack with gap 600.
 
 <code-well-header>
     <section class="d-stack d-stack--row d-stack--gap-300 d-bgc-magenta-100 d-ai-stretch">
-      <div class="d-bgc-secondary d-ba d-bc-default">
+      <div class="d-bgc-secondary d-ba">
         Stack item 1
       </div>
       <div>
-        <div class="d-bgc-secondary d-ba d-bc-default">
+        <div class="d-bgc-secondary d-ba">
           Stack item 2
         </div>
         <div class="d-stack d-stack--row-reverse d-stack--gap-600 d-bgc-magenta-100">
-          <div class="d-bgc-secondary d-ba d-bc-default">
+          <div class="d-bgc-secondary d-ba">
             Stack item 3
           </div>
-          <div class="d-bgc-secondary d-ba d-bc-default">
+          <div class="d-bgc-secondary d-ba">
             Stack item 4
           </div>
         </div>

--- a/apps/dialtone-documentation/docs/design/size/index.md
+++ b/apps/dialtone-documentation/docs/design/size/index.md
@@ -34,7 +34,7 @@ When assigning a size to an element, utilize [Size Tokens](#tokens) for the valu
 <div class="d-gc2">
 <code-well-header>
   <div class="d-d-grid d-g24 d-g-cols2 md:d-g-cols1 d-w100p">
-    <div class="d-fl-center d-ba d-bc-default d-js-center" :style="{ width: 'fit-content', minWidth: selectedSize }">
+    <div class="d-fl-center d-ba d-js-center" :style="{ width: 'fit-content', minWidth: selectedSize }">
       Box
     </div>
     <dt-select-menu label="min-width" :options="sizeValues" @change="changeBoxSize" />

--- a/apps/dialtone-documentation/docs/design/space/index.md
+++ b/apps/dialtone-documentation/docs/design/space/index.md
@@ -38,10 +38,10 @@ When setting the gap between elements, utilize [Space Tokens](#tokens) for the g
 <code-well-header>
   <div class="d-d-grid d-g24 d-g-cols2 md:d-g-cols1 d-w100p">
     <div class="d-d-flex d-fd-row" :style="{ gap: selectedSpace }">
-      <div class="d-fl-center d-ba d-bc-default d-w100p">
+      <div class="d-fl-center d-ba d-w100p">
         Element A
       </div>
-      <div class="d-fl-center d-ba d-bc-default d-w100p">
+      <div class="d-fl-center d-ba d-w100p">
         Element B
       </div>
     </div>

--- a/apps/dialtone-documentation/docs/design/typography/index.md
+++ b/apps/dialtone-documentation/docs/design/typography/index.md
@@ -67,7 +67,7 @@ All product UI text can be characterized as one of **Headline**, **Body**, **Lab
 <el class="d-{category}--{size}-{strength}-{density}">...</el>
 ```
 
-<div class="d-bb d-bc-default">
+<div class="d-bb">
   <table class="d-table">
     <thead>
       <tr>
@@ -252,7 +252,7 @@ Code snippets, technical commands, or data values rendered as a monospaced font.
 
 Each typography style is expressed through a shorthand `font` property, and its value's design token contains all font styles, e.g. `font-size`, `line-height`, `font-family`, etc,
 
-<div class="d-hmx464 d-of-y-auto d-bb d-bc-default">
+<div class="d-hmx464 d-of-y-auto d-bb">
   <table class="d-table dialtone-doc-table">
     <thead>
       <tr>

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/clip.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/clip.md
@@ -9,9 +9,9 @@ Use `d-bgc-{name}` to control which box an element's background is clipped by.
 
 <code-well-header>
   <dt-stack direction="row" gap="400">
-    <div class="d-bgc-border-box d-p16 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8 d-bc-default">border-box</div>
-    <div class="d-bgc-padding-box d-p16 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8 d-bc-default">padding-box</div>
-    <div class="d-bgc-content-box d-p16 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8 d-bc-default">content-box</div>
+    <div class="d-bgc-border-box d-p16 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8">border-box</div>
+    <div class="d-bgc-padding-box d-p16 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8">padding-box</div>
+    <div class="d-bgc-content-box d-p16 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8">content-box</div>
   </dt-stack>
 </code-well-header>
 

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/patterns.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/patterns.md
@@ -8,8 +8,8 @@ description: Utilities for adding distinctive background patterns for Department
 Use `d-bgg-pattern-{pattern}-{dark|light}` to apply a pattern.
 
 <code-well-header>
-  <div class="d-d-flex d-ai-center d-w100p d-h32 d-bar4 d-bgg-to-br d-ba d-bc-default d-bgc-moderate d-bgg-pattern d-bgg-pattern-slanted-stripes-dark d-fc-primary">Ted's Call Center</div>
-  <div class="d-d-flex d-ai-center d-w100p d-h32 d-bar4 d-bgg-to-br d-ba d-bc-default d-bgc-moderate d-bgg-pattern d-bgg-pattern-chevrons-dark">Vicky's Department</div>
+  <div class="d-d-flex d-ai-center d-w100p d-h32 d-bar4 d-bgg-to-br d-ba d-bgc-moderate d-bgg-pattern d-bgg-pattern-slanted-stripes-dark d-fc-primary">Ted's Call Center</div>
+  <div class="d-d-flex d-ai-center d-w100p d-h32 d-bar4 d-bgg-to-br d-ba d-bgc-moderate d-bgg-pattern d-bgg-pattern-chevrons-dark">Vicky's Department</div>
 </code-well-header>
 
 ```html

--- a/apps/dialtone-documentation/docs/utilities/borders/color.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/color.md
@@ -27,7 +27,7 @@ Use `d-bc-{color}` to set an element's border color.
 </code-well-header>
 
 ```html
-<div class="d-ba d-bc-default">...</div>
+<div class="d-ba d-bc-{color}">...</div>
 ```
 
 ## Hover
@@ -36,20 +36,20 @@ Use `h:d-bc-{color}` to change an element's border color spot on `:hover`.
 
 <code-well-header>
   <dt-stack direction="row" gap="500">
-    <dt-button kind="unstyled" class="d-p16 d-ba d-baw2 d-bc-default h:d-bc-moderate">
+    <dt-button kind="unstyled" class="d-p16 d-ba d-baw2 h:d-bc-moderate">
       Hover over me
     </dt-button>
-    <dt-button kind="unstyled" class="d-p16 d-ba d-baw2 d-bc-default h:d-bc-critical">
+    <dt-button kind="unstyled" class="d-p16 d-ba d-baw2 h:d-bc-critical">
       Hover over me
     </dt-button>
   </dt-stack>
 </code-well-header>
 
 ```html
-<dt-button kind="unstyled" class="d-p16 d-ba d-baw2 d-bc-default h:d-bc-moderate">
+<dt-button kind="unstyled" class="d-p16 d-ba d-baw2 h:d-bc-moderate">
   Hover over me
 </dt-button>
-<dt-button kind="unstyled" class="d-p16 d-ba d-baw2 d-bc-default h:d-bc-critical">
+<dt-button kind="unstyled" class="d-p16 d-ba d-baw2 h:d-bc-critical">
   Hover over me
 </dt-button>
 ```
@@ -60,20 +60,20 @@ Use `f:d-bc-{color}` to change an element's border color when in `:focus` or `:f
 
 <code-well-header>
   <dt-stack direction="row" gap="500">
-    <dt-button kind="unstyled" class="d-p16 d-ba d-baw2 d-bc-default f:d-bc-moderate">
+    <dt-button kind="unstyled" class="d-p16 d-ba d-baw2 f:d-bc-moderate">
       Focus me
     </dt-button>
-    <dt-button kind="unstyled" class="d-p16 d-ba d-baw2 d-bc-default f:d-bc-critical">
+    <dt-button kind="unstyled" class="d-p16 d-ba d-baw2 f:d-bc-critical">
       Focus me
     </dt-button>
   </dt-stack>
 </code-well-header>
 
 ```html
-<dt-button kind="unstyled" class="d-p16 d-ba d-baw2 d-bc-default f:d-bc-moderate">
+<dt-button kind="unstyled" class="d-p16 d-ba d-baw2 f:d-bc-moderate">
   Focus me
 </dt-button>
-<dt-button kind="unstyled" class="d-p16 d-ba d-baw2 d-bc-default f:d-bc-critical">
+<dt-button kind="unstyled" class="d-p16 d-ba d-baw2 f:d-bc-critical">
   Focus me
 </dt-button>
 ```
@@ -85,20 +85,20 @@ Use `fv:d-bc-{color}` to change an element's border color when in `:focus-visibl
 
 <code-well-header>
   <dt-stack direction="row" gap="500">
-    <dt-button kind="unstyled" class="d-p16 d-ba d-baw2 d-bc-default fv:d-bc-moderate">
+    <dt-button kind="unstyled" class="d-p16 d-ba d-baw2 fv:d-bc-moderate">
       Keyboard focus me
     </dt-button>
-    <dt-button kind="unstyled" class="d-p16 d-ba d-baw2 d-bc-default fv:d-bc-critical">
+    <dt-button kind="unstyled" class="d-p16 d-ba d-baw2 fv:d-bc-critical">
       Keyboard focus me
     </dt-button>
   </dt-stack>
 </code-well-header>
 
 ```html
-<dt-button kind="unstyled" class="d-p16 d-ba d-baw2 d-bc-default fv:d-bc-moderate">
+<dt-button kind="unstyled" class="d-p16 d-ba d-baw2 fv:d-bc-moderate">
   Keyboard focus me
 </dt-button>
-<dt-button kind="unstyled" class="d-p16 d-ba d-baw2 d-bc-default fv:d-bc-critical">
+<dt-button kind="unstyled" class="d-p16 d-ba d-baw2 fv:d-bc-critical">
   Keyboard focus me
 </dt-button>
 ```

--- a/apps/dialtone-documentation/docs/utilities/borders/direction.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/direction.md
@@ -14,7 +14,7 @@ Use `d-ba` to add a border to all sides of your element.
   >
     <div
       v-for="width in [0, 1, 2, 4]"
-      class="d-p16 d-ba d-bc-default d-bgc-primary"
+      class="d-p16 d-ba d-bgc-primary"
       :class="`d-baw${width}`"
     >
       d-baw{{ width }}
@@ -23,10 +23,10 @@ Use `d-ba` to add a border to all sides of your element.
 </code-well-header>
 
 ```html
-<div class="d-p16 d-ba d-baw0 d-bc-default d-bgc-primary">d-baw0</div>
-<div class="d-p16 d-ba d-baw1 d-bc-default d-bgc-primary">d-baw1</div>
-<div class="d-p16 d-ba d-baw2 d-bc-default d-bgc-primary">d-baw2</div>
-<div class="d-p16 d-ba d-baw4 d-bc-default d-bgc-primary">d-baw4</div>
+<div class="d-p16 d-ba d-baw0 d-bgc-primary">d-baw0</div>
+<div class="d-p16 d-ba d-baw1 d-bgc-primary">d-baw1</div>
+<div class="d-p16 d-ba d-baw2 d-bgc-primary">d-baw2</div>
+<div class="d-p16 d-ba d-baw4 d-bgc-primary">d-baw4</div>
 ```
 
 ## Individual Sides
@@ -40,7 +40,7 @@ Use `d-b{t|r|b|l|x|y}` to add a border to only specific sides of your element.
   >
     <div
       v-for="side in ['t', 'r', 'b', 'l', 'x', 'y', 'a']"
-      class="d-p16 d-baw4 d-bc-default d-bgc-primary"
+      class="d-p16 d-baw4 d-bgc-primary"
       :class="`d-b${side}`"
     >
       d-b{{ side }}
@@ -49,13 +49,13 @@ Use `d-b{t|r|b|l|x|y}` to add a border to only specific sides of your element.
 </code-well-header>
 
 ```html
-<div class="d-p16 d-bt d-baw4 d-bc-default d-bgc-primary">d-bt</div>
-<div class="d-p16 d-br d-baw4 d-bc-default d-bgc-primary">d-br</div>
-<div class="d-p16 d-bb d-baw4 d-bc-default d-bgc-primary">d-bb</div>
-<div class="d-p16 d-bl d-baw4 d-bc-default d-bgc-primary">d-bl</div>
-<div class="d-p16 d-bx d-baw4 d-bc-default d-bgc-primary">d-bx</div>
-<div class="d-p16 d-by d-baw4 d-bc-default d-bgc-primary">d-by</div>
-<div class="d-p16 d-ba d-baw4 d-bc-default d-bgc-primary">d-ba</div>
+<div class="d-p16 d-bt d-baw4 d-bgc-primary">d-bt</div>
+<div class="d-p16 d-br d-baw4 d-bgc-primary">d-br</div>
+<div class="d-p16 d-bb d-baw4 d-bgc-primary">d-bb</div>
+<div class="d-p16 d-bl d-baw4 d-bgc-primary">d-bl</div>
+<div class="d-p16 d-bx d-baw4 d-bgc-primary">d-bx</div>
+<div class="d-p16 d-by d-baw4 d-bgc-primary">d-by</div>
+<div class="d-p16 d-ba d-baw4 d-bgc-primary">d-ba</div>
 ```
 
 <script setup>

--- a/apps/dialtone-documentation/docs/utilities/borders/divide-width.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/divide-width.md
@@ -40,19 +40,19 @@ Use `d-divide-{y|x}{n}` to change the divider width between an element's child i
 
 <code-well-header>
   <code>d-divide-x0</code>
-  <dt-stack direction="row" class="d-divide-x d-divide-x0 d-divide-default d-w100p d-ba d-bc-default">
+  <dt-stack direction="row" class="d-divide-x d-divide-x0 d-divide-default d-w100p d-ba">
     <div class="d-fl-center d-w100p d-p16">1</div>
     <div class="d-fl-center d-w100p d-p16">2</div>
     <div class="d-fl-center d-w100p d-p16">3</div>
   </dt-stack>
   <code>d-divide-x2</code>
-  <dt-stack direction="row" class="d-divide-x d-divide-x2 d-divide-default d-w100p d-ba d-bc-default d-baw2">
+  <dt-stack direction="row" class="d-divide-x d-divide-x2 d-divide-default d-w100p d-ba d-baw2">
     <div class="d-fl-center d-w100p d-p16">1</div>
     <div class="d-fl-center d-w100p d-p16">2</div>
     <div class="d-fl-center d-w100p d-p16">3</div>
   </dt-stack>
   <code>d-divide-x4</code>
-  <dt-stack direction="row" class="d-divide-x d-divide-x4 d-divide-default d-w100p d-ba d-bc-default d-baw4">
+  <dt-stack direction="row" class="d-divide-x d-divide-x4 d-divide-default d-w100p d-ba d-baw4">
     <div class="d-fl-center d-w100p d-p16">1</div>
     <div class="d-fl-center d-w100p d-p16">2</div>
     <div class="d-fl-center d-w100p d-p16">3</div>
@@ -60,13 +60,13 @@ Use `d-divide-{y|x}{n}` to change the divider width between an element's child i
 </code-well-header>
 
 ```html
-<dt-stack direction="row" class="d-divide-x d-divide-x0 d-divide-default d-w100p d-ba d-bc-default">
+<dt-stack direction="row" class="d-divide-x d-divide-x0 d-divide-default d-w100p d-ba">
   ...
 </dt-stack>
-<dt-stack direction="row" class="d-divide-x d-divide-x2 d-divide-default d-w100p d-ba d-bc-default d-baw2">
+<dt-stack direction="row" class="d-divide-x d-divide-x2 d-divide-default d-w100p d-ba d-baw2">
   ...
 </dt-stack>
-<dt-stack direction="row" class="d-divide-x d-divide-x4 d-divide-default d-w100p d-ba d-bc-default d-baw4">
+<dt-stack direction="row" class="d-divide-x d-divide-x4 d-divide-default d-w100p d-ba d-baw4">
   ...
 </dt-stack>
 ```
@@ -84,7 +84,7 @@ If an element's `flex-direction` is reversed, apply `d-divide-{y|x}-reverse` to 
 </code-well-header>
 
 ```html
-<dt-stack direction="row-reverse" class="d-divide-x d-divide-default d-divide-x-reverse d-w100p d-ba d-bc-default">
+<dt-stack direction="row-reverse" class="d-divide-x d-divide-default d-divide-x-reverse d-w100p d-ba">
   <div class="d-fl-center d-w100p d-p16">1</div>
   <div class="d-fl-center d-w100p d-p16">2</div>
   <div class="d-fl-center d-w100p d-p16">3</div>

--- a/apps/dialtone-documentation/docs/utilities/borders/radius.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/radius.md
@@ -14,7 +14,7 @@ Use `d-bar{n}` to change the border radius on all corners of your element.
   >
     <div
       v-for="r in [0, 1, 2, 4, 8, 12, 16, 24, 32]"
-      class="d-p16 d-ba d-baw2 d-bc-default d-bgc-primary d-ws-nowrap"
+      class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap"
       :class="`d-bar${r}`"
     >
       d-bar{{ r }}
@@ -45,7 +45,7 @@ Use `d-b{t|r|b|l}r{n}` to change the border radius on a side of your element.
   >
     <div
       v-for="r in [4, 8, 12, 16]"
-      class="d-p16 d-ba d-baw2 d-bc-default d-bgc-primary d-ws-nowrap"
+      class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap"
       :class="`d-btr${r}`"
     >
       d-btr{{ r }}
@@ -69,7 +69,7 @@ Use `d-b{a|t|r|b|l}r-pill` to change the border radius of your element to a pill
     gap="400"
     :direction="{ 'default': 'column', 'md': 'row' }"
   >
-    <div class="d-p16 d-ba d-baw2 d-bc-default d-bgc-primary d-ws-nowrap d-bar-pill">
+    <div class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-pill">
       d-bar-pill
     </div>
   </dt-stack>
@@ -88,7 +88,7 @@ Use `d-b{a|t|r|b|l}r-circle` to change the border radius of your element to a ci
     gap="400"
     :direction="{ 'default': 'column', 'md': 'row' }"
    >
-    <div class="d-fl-center d-p16 d-h128 d-w128 d-ba d-baw2 d-bc-default d-bgc-primary d-ws-nowrap d-bar-circle ">
+    <div class="d-fl-center d-p16 d-h128 d-w128 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-circle ">
       d-bar-circle
     </div>
   </dt-stack>

--- a/apps/dialtone-documentation/docs/utilities/borders/style.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/style.md
@@ -14,7 +14,7 @@ Use `d-b{a|t|r|b|l}s-dashed` to change the border style to dashed on your elemen
   >
     <div
       v-for="style in ['bas', 'bts', 'brs', 'bbs', 'bls']"
-      class="d-p16 d-baw2 d-bc-bold d-bgc-primary d-ws-nowrap"
+      class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap"
       :class="`d-${style}-dashed`"
     >
       d-{{ style }}-dashed
@@ -23,11 +23,11 @@ Use `d-b{a|t|r|b|l}s-dashed` to change the border style to dashed on your elemen
 </code-well-header>
 
 ```html
-<div class="d-p16 d-baw2 d-bc-bold d-bgc-primary d-ws-nowrap d-bas-dashed">...</div>
-<div class="d-p16 d-baw2 d-bc-bold d-bgc-primary d-ws-nowrap d-bts-dashed">...</div>
-<div class="d-p16 d-baw2 d-bc-bold d-bgc-primary d-ws-nowrap d-brs-dashed">...</div>
-<div class="d-p16 d-baw2 d-bc-bold d-bgc-primary d-ws-nowrap d-bbs-dashed">...</div>
-<div class="d-p16 d-baw2 d-bc-bold d-bgc-primary d-ws-nowrap d-bls-dashed">...</div>
+<div class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bas-dashed">...</div>
+<div class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bts-dashed">...</div>
+<div class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-brs-dashed">...</div>
+<div class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bbs-dashed">...</div>
+<div class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bls-dashed">...</div>
 ```
 
 ## Dotted Borders
@@ -41,7 +41,7 @@ Use `d-b{a|t|r|b|l}s-dotted` to change the border style to dotted on your elemen
   >
     <div
       v-for="style in ['bas', 'bts', 'brs', 'bbs', 'bls']"
-      class="d-p16 d-baw2 d-bc-bold d-bgc-primary d-ws-nowrap"
+      class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap"
       :class="`d-${style}-dotted`"
     >
       d-{{ style }}-dotted
@@ -50,11 +50,11 @@ Use `d-b{a|t|r|b|l}s-dotted` to change the border style to dotted on your elemen
 </code-well-header>
 
 ```html
-<div class="d-p16 d-baw2 d-bc-bold d-bgc-primary d-ws-nowrap d-bas-dotted">...</div>
-<div class="d-p16 d-baw2 d-bc-bold d-bgc-primary d-ws-nowrap d-bts-dotted">...</div>
-<div class="d-p16 d-baw2 d-bc-bold d-bgc-primary d-ws-nowrap d-brs-dotted">...</div>
-<div class="d-p16 d-baw2 d-bc-bold d-bgc-primary d-ws-nowrap d-bbs-dotted">...</div>
-<div class="d-p16 d-baw2 d-bc-bold d-bgc-primary d-ws-nowrap d-bls-dotted">...</div>
+<div class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bas-dotted">...</div>
+<div class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bts-dotted">...</div>
+<div class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-brs-dotted">...</div>
+<div class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bbs-dotted">...</div>
+<div class="d-p16 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bls-dotted">...</div>
 ```
 
 ## Classes

--- a/apps/dialtone-documentation/docs/utilities/borders/width.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/width.md
@@ -14,7 +14,7 @@ Use `d-baw{n}` to change the border width on your element.
   >
     <div
       v-for="r in [0, 1, 2, 4]"
-      class="d-p16 d-ba d-bc-default"
+      class="d-p16 d-ba"
       :class="`d-baw${r}`"
     >
       d-baw{{r}}
@@ -40,7 +40,7 @@ Use `d-b{a|t|r|b|l}w{n}` to change the border width of your direction on your el
   >
     <div
       v-for="r in [0, 1, 2, 4]"
-      class="d-p16 d-ba d-baw0 d-bc-default d-bgc-primary"
+      class="d-p16 d-ba d-baw0 d-bgc-primary"
       :class="`d-btw${r}`"
     >
       d-btw{{r}}

--- a/apps/dialtone-documentation/docs/utilities/flex/direction-wrap-flow.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/direction-wrap-flow.md
@@ -40,9 +40,9 @@ The `flex-direction` property declares a flex container’s main axis direction.
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Description</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Description</div></th>
         </tr>
       </thead>
       <tbody>
@@ -83,9 +83,9 @@ The `flex-wrap` property declares a flex container’s wrapping status. The defa
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Description</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Description</div></th>
         </tr>
       </thead>
       <tbody>
@@ -126,9 +126,9 @@ The `flex-flow` property is a shorthand property that sets allows you to quickly
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Description</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Description</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/flex/flex-grow-shrink.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/flex-grow-shrink.md
@@ -29,9 +29,9 @@ control the grow and shrink flex values separately with their own utility classe
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Description</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Description</div></th>
         </tr>
       </thead>
       <tbody>
@@ -75,9 +75,9 @@ The `flex-grow` sets the flex container’s grow factor relative to the parent's
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Description</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Description</div></th>
         </tr>
       </thead>
       <tbody>
@@ -121,9 +121,9 @@ The `flex-shrink` sets the flex container’s shrink factor relative to the pare
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Description</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Description</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/interactivity/resize.md
+++ b/apps/dialtone-documentation/docs/utilities/interactivity/resize.md
@@ -7,7 +7,7 @@ description: Utilities for controlling the resize of an element.
 
 <code-well-header>
   <dt-stack gap="400" class="d-w50p">
-    <div v-for="{ class: className } in resize.slice(0, 4)" :class="className" class="d-of-auto d-p16 d-ba d-bc-default">
+    <div v-for="{ class: className } in resize.slice(0, 4)" :class="className" class="d-of-auto d-p16 d-ba">
       .{{ className }}
     </div>
   </dt-stack>

--- a/apps/dialtone-documentation/docs/utilities/layout/box-sizing.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/box-sizing.md
@@ -9,9 +9,9 @@ All examples below have a 128px height and width. You can see how `.d-box-border
 
 <code-well-header>
   <div class="d-fl-center d-w100p d-flow16">
-    <div class="d-fl-center d-h128 d-w128 d-p8 d-ba d-baw4 d-bas-dashed d-bar4 d-bc-default d-bgc-moderate d-box-border"><div class="d-fl-center d-fl1 d-as-stretch d-p8 d-bgc-moderate-opaque d-bar2 d-code--sm">d-box-border</div></div>
-    <div class="d-fl-center d-h128 d-w128 d-p8 d-ba d-baw4 d-bas-dashed d-bar4 d-bc-default d-bgc-moderate d-box-content"><div class="d-fl-center d-fl1 d-as-stretch d-p8 d-bgc-moderate-opaque d-bar2 d-code--sm">d-box-content</div></div>
-    <div class="d-fl-center d-h128 d-w128 d-p8 d-ba d-baw4 d-bas-dashed d-bar4 d-bc-default d-bgc-moderate d-box-unset"><div class="d-fl-center d-fl1 d-as-stretch d-p8 d-bgc-moderate-opaque d-bar2 d-code--sm">d-box-unset</div></div>
+    <div class="d-fl-center d-h128 d-w128 d-p8 d-ba d-baw4 d-bas-dashed d-bar4 d-bgc-moderate d-box-border"><div class="d-fl-center d-fl1 d-as-stretch d-p8 d-bgc-moderate-opaque d-bar2 d-code--sm">d-box-border</div></div>
+    <div class="d-fl-center d-h128 d-w128 d-p8 d-ba d-baw4 d-bas-dashed d-bar4 d-bgc-moderate d-box-content"><div class="d-fl-center d-fl1 d-as-stretch d-p8 d-bgc-moderate-opaque d-bar2 d-code--sm">d-box-content</div></div>
+    <div class="d-fl-center d-h128 d-w128 d-p8 d-ba d-baw4 d-bas-dashed d-bar4 d-bgc-moderate d-box-unset"><div class="d-fl-center d-fl1 d-as-stretch d-p8 d-bgc-moderate-opaque d-bar2 d-code--sm">d-box-unset</div></div>
   </div>
 </code-well-header>
 

--- a/apps/dialtone-documentation/docs/utilities/layout/display.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/display.md
@@ -7,13 +7,13 @@ description: Utilities for controlling the display box type of an element.
 
 <code-well-header>
   <dt-stack gap="500" class="d-w100p">
-    <div class="d-p8 d-ba d-baw4 d-bar4 d-bc-default d-bgc-moderate d-d-block">
+    <div class="d-p8 d-ba d-baw4 d-bar4 d-bgc-moderate d-d-block">
       <div class="d-fl-center d-fl1 d-as-stretch d-p8 d-bgc-moderate-opaque d-bar2 d-code--sm">d-d-block</div>
     </div>
     <div class="d-d-contents">
       <div class="d-fl-center d-fl1 d-as-stretch d-p8 d-bgc-moderate-opaque d-bar2 d-code--sm">d-d-contents</div>
     </div>
-    <dt-stack direction="row" gap="400" class="d-p8 d-ba d-baw4 d-bar4 d-bc-default d-bgc-moderate">
+    <dt-stack direction="row" gap="400" class="d-p8 d-ba d-baw4 d-bar4 d-bgc-moderate">
       <div>
         <div class="d-fl-center d-fl1 d-as-stretch d-p8 d-bgc-moderate-opaque d-bar2 d-code--sm d-d-inline-block">d-d-inline-block</div>
       </div>
@@ -24,7 +24,7 @@ description: Utilities for controlling the display box type of an element.
         <div class="d-fl-center d-fl1 d-as-stretch d-p8 d-bgc-moderate-opaque d-bar2 d-code--sm d-d-inline-block">d-d-inline-block</div>
       </div>
     </dt-stack>
-    <dt-stack direction="row" gap="400" class="d-p8 d-ba d-baw4 d-bar4 d-bc-default d-bgc-moderate">
+    <dt-stack direction="row" gap="400" class="d-p8 d-ba d-baw4 d-bar4 d-bgc-moderate">
       <div>
         <div class="d-fl-center d-fl1 d-as-stretch d-p4 d-bgc-moderate-opaque d-bar2 d-code--sm d-d-inline">d-d-inline</div>
       </div>

--- a/apps/dialtone-documentation/docs/utilities/layout/overflow.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/overflow.md
@@ -49,9 +49,9 @@ The `overflow` CSS shorthand property sets the desired behavior for how content 
     <table class="d-table dialtone-doc-table">
         <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
             <tr>
-                <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-                <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
-                <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Description</div></th>
+                <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+                <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bbw1">Output</div></th>
+                <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Description</div></th>
             </tr>
         </thead>
         <tbody>

--- a/apps/dialtone-documentation/docs/utilities/layout/z-index.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/z-index.md
@@ -31,9 +31,9 @@ When writing Less, you can set an element's z-index by using a variable (`var(--
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w25p"><div class="d-p16 d-bb d-bc-default d-bbw1">Variable</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Description</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w25p"><div class="d-p16 d-bb d-bbw1">Variable</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Description</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/responsive/breakpoints.md
+++ b/apps/dialtone-documentation/docs/utilities/responsive/breakpoints.md
@@ -186,9 +186,9 @@ To help keep prefixes concise, we use abbreviations. This syntax is used consist
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w25p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class Prefix</div></th>
-          <th scope="col" class="d-p0 d-bbw0 d-w25p"><div class="d-p16 d-bb d-bc-default d-bbw1">Media Query</div></th>
-          <th scope="col" class="d-p0 d-bbw0 "><div class="d-p16 d-bb d-bc-default d-bbw1">Description</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w25p"><div class="d-p16 d-bb d-bbw1">Class Prefix</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w25p"><div class="d-p16 d-bb d-bbw1">Media Query</div></th>
+          <th scope="col" class="d-p0 d-bbw0 "><div class="d-p16 d-bb d-bbw1">Description</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/sizing/height.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/height.md
@@ -118,8 +118,8 @@ Use `d-h-auto` have the browser calculate and select a height.
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/sizing/max-height.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/max-height.md
@@ -28,8 +28,8 @@ Use `d-hmx{n}p` or `d-hmx{n}` to set a maximum height percentage for an element.
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/sizing/max-width.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/max-width.md
@@ -42,8 +42,8 @@ Use `d-wmx{n}` to set a fixed minimum width for an element. This can be combined
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/sizing/min-height.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/min-height.md
@@ -44,8 +44,8 @@ Use `d-hmn{n}` to set a fixed minimum height for an element. This can be combine
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/sizing/min-width.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/min-width.md
@@ -42,8 +42,8 @@ Use `d-wmn{n}` to set a fixed minimum width for an element. This can be combined
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/sizing/width.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/width.md
@@ -114,8 +114,8 @@ Use `d-w-auto` have the browser calculate and select a width.
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w30p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/spacing/auto-spacing.md
+++ b/apps/dialtone-documentation/docs/utilities/spacing/auto-spacing.md
@@ -56,9 +56,9 @@ The Stack and Flow layouts work by using the adjacent sibling combinator (`+`) t
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w25p"><div class="d-p16 d-bb d-bc-default d-bbw1">Value</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Vertical Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Horizontal Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w25p"><div class="d-p16 d-bb d-bbw1">Value</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Vertical Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Horizontal Class</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/typography/font-family.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-family.md
@@ -60,8 +60,8 @@ Dialtone supports select marketing fonts and weights. Use the following combinat
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w40p"><div class="d-p16 d-bb d-bc-default d-bbw1">Variable</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w40p"><div class="d-p16 d-bb d-bbw1">Variable</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>
@@ -81,8 +81,8 @@ Dialtone supports select marketing fonts and weights. Use the following combinat
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w40p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w40p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/typography/font-size.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-size.md
@@ -54,9 +54,9 @@ change in other platforms (mobile, tc8, tv).
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w10p"><div class="d-p16 d-bb d-bc-default d-bbw1">Size</div></th>
-          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w10p"><div class="d-p16 d-bb d-bbw1">Size</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>
@@ -86,9 +86,9 @@ change in other platforms (mobile, tc8, tv).
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w10p"><div class="d-p16 d-bb d-bc-default d-bbw1">Size</div></th>
-          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w10p"><div class="d-p16 d-bb d-bbw1">Size</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>
@@ -118,9 +118,9 @@ change in other platforms (mobile, tc8, tv).
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w10p"><div class="d-p16 d-bb d-bc-default d-bbw1">Size</div></th>
-          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w10p"><div class="d-p16 d-bb d-bbw1">Size</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>
@@ -150,9 +150,9 @@ change in other platforms (mobile, tc8, tv).
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0 d-w10p"><div class="d-p16 d-bb d-bc-default d-bbw1">Size</div></th>
-          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bc-default d-bbw1">Class</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w10p"><div class="d-p16 d-bb d-bbw1">Size</div></th>
+          <th scope="col" class="d-p0 d-bbw0 d-w20p"><div class="d-p16 d-bb d-bbw1">Class</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/typography/font-weight.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-weight.md
@@ -44,8 +44,8 @@ Use `d-fw-{n}` to change an element's font-weight.
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
           <tr>
-              <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Variable</div></th>
-              <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+              <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Variable</div></th>
+              <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
           </tr>
       </thead>
       <tbody>

--- a/apps/dialtone-documentation/docs/utilities/typography/line-height.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-height.md
@@ -67,8 +67,8 @@ Use `d-lh{n}` to fix an element's line-height. This allows you to target a speci
     <table class="d-table dialtone-doc-table">
       <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
         <tr>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Variable</div></th>
-          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bc-default d-bbw1">Output</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Variable</div></th>
+          <th scope="col" class="d-p0 d-bbw0"><div class="d-p16 d-bb d-bbw1">Output</div></th>
         </tr>
       </thead>
       <tbody>

--- a/packages/dialtone-css/lib/build/less/utilities/borders.less
+++ b/packages/dialtone-css/lib/build/less/utilities/borders.less
@@ -22,11 +22,27 @@
 //  ============================================================================
 //  $$ DIRECTION
 //  ----------------------------------------------------------------------------
-.d-ba { border: var(--dt-size-100) solid !important; }
-.d-bt { border-top: var(--dt-size-100) solid !important; }
-.d-br { border-right: var(--dt-size-100) solid !important; }
-.d-bb { border-bottom: var(--dt-size-100) solid !important; }
-.d-bl { border-left: var(--dt-size-100) solid !important; }
+.d-ba {
+  border-color: var(--dt-color-border-default) !important;
+  border-style: solid !important;
+  border-width: var(--dt-size-border-100) !important;
+}
+
+.d-bt {
+  border-top: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+}
+
+.d-br {
+  border-right: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+}
+
+.d-bb {
+  border-bottom: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+}
+
+.d-bl {
+  border-left: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+}
 
 .d-bx { .d-br(); .d-bl(); }
 
@@ -161,29 +177,29 @@
 .d-divide-y > * + * {
     --divide-y-reverse: 0;
 
-    border-top: calc(~'1px * (1 - var(--divide-y-reverse))') solid !important;
-    border-bottom: calc(~'1px * var(--divide-y-reverse)') solid !important;
+    border-top: calc(~'1px * (1 - var(--divide-y-reverse))') solid var(--dt-color-border-default) !important;
+    border-bottom: calc(~'1px * var(--divide-y-reverse)') solid var(--dt-color-border-default) !important;
 }
 
 .d-divide-y0 > * + * {
     --divide-y-reverse: 0;
 
-    border-top: calc(~'0 * (1 - var(--divide-y-reverse))') solid !important;
-    border-bottom: calc(~'0 * var(--divide-y-reverse)') solid !important;
+    border-top: calc(~'0 * (1 - var(--divide-y-reverse))') solid var(--dt-color-border-default) !important;
+    border-bottom: calc(~'0 * var(--divide-y-reverse)') solid var(--dt-color-border-default) !important;
 }
 
 .d-divide-y2 > * + * {
     --divide-y-reverse: 0;
 
-    border-top: calc(~'2px * (1 - var(--divide-y-reverse))') solid !important;
-    border-bottom: calc(~'2px * var(--divide-y-reverse)') solid !important;
+    border-top: calc(~'2px * (1 - var(--divide-y-reverse))') solid var(--dt-color-border-default) !important;
+    border-bottom: calc(~'2px * var(--divide-y-reverse)') solid var(--dt-color-border-default) !important;
 }
 
 .d-divide-y4 > * + * {
     --divide-y-reverse: 0;
 
-    border-top: calc(~'4px * (1 - var(--divide-y-reverse))') solid !important;
-    border-bottom: calc(~'4px * var(--divide-y-reverse)') solid !important;
+    border-top: calc(~'4px * (1 - var(--divide-y-reverse))') solid var(--dt-color-border-default) !important;
+    border-bottom: calc(~'4px * var(--divide-y-reverse)') solid var(--dt-color-border-default) !important;
 }
 .d-divide-y-reverse > * + * { --divide-y-reverse: 1; }
 
@@ -192,29 +208,29 @@
 .d-divide-x > * + * {
     --divide-x-reverse: 0;
 
-    border-right: calc(~'1px * var(--divide-x-reverse)') solid !important;
-    border-left: calc(~'1px * (1 - var(--divide-x-reverse))') solid !important;
+    border-right: calc(~'1px * var(--divide-x-reverse)') solid var(--dt-color-border-default) !important;
+    border-left: calc(~'1px * (1 - var(--divide-x-reverse))') solid var(--dt-color-border-default) !important;
 }
 
 .d-divide-x0 > * + * {
     --divide-x-reverse: 0;
 
-    border-right: calc(~'0 * var(--divide-x-reverse)') solid !important;
-    border-left: calc(~'0 * (1 - var(--divide-x-reverse))') solid !important;
+    border-right: calc(~'0 * var(--divide-x-reverse)') solid var(--dt-color-border-default) !important;
+    border-left: calc(~'0 * (1 - var(--divide-x-reverse))') solid var(--dt-color-border-default) !important;
 }
 
 .d-divide-x2 > * + * {
     --divide-x-reverse: 0;
 
-    border-right: calc(~'2px * var(--divide-x-reverse)') solid !important;
-    border-left: calc(~'2px * (1 - var(--divide-x-reverse))') solid !important;
+    border-right: calc(~'2px * var(--divide-x-reverse)') solid var(--dt-color-border-default) !important;
+    border-left: calc(~'2px * (1 - var(--divide-x-reverse))') solid var(--dt-color-border-default) !important;
 }
 
 .d-divide-x4 > * + * {
     --divide-x-reverse: 0;
 
-    border-right: calc(~'4px * var(--divide-x-reverse)') solid !important;
-    border-left: calc(~'4px * (1 - var(--divide-x-reverse))') solid !important;
+    border-right: calc(~'4px * var(--divide-x-reverse)') solid var(--dt-color-border-default) !important;
+    border-left: calc(~'4px * (1 - var(--divide-x-reverse))') solid var(--dt-color-border-default) !important;
 }
 .d-divide-x-reverse > * + * { --divide-x-reverse: 1; }
 

--- a/packages/dialtone-css/lib/build/less/utilities/borders.less
+++ b/packages/dialtone-css/lib/build/less/utilities/borders.less
@@ -29,19 +29,19 @@
 }
 
 .d-bt {
-  border-top: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
-}
+    border-top: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+  }
 
 .d-br {
-  border-right: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+    border-right: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
 }
 
 .d-bb {
-  border-bottom: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+    border-bottom: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
 }
 
 .d-bl {
-  border-left: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+    border-left: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
 }
 
 .d-bx { .d-br(); .d-bl(); }

--- a/packages/dialtone-css/lib/build/less/utilities/borders.less
+++ b/packages/dialtone-css/lib/build/less/utilities/borders.less
@@ -29,19 +29,19 @@
 }
 
 .d-bt {
-    border-top: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
-  }
+  border-top: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+}
 
 .d-br {
-    border-right: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+  border-right: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
 }
 
 .d-bb {
-    border-bottom: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+  border-bottom: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
 }
 
 .d-bl {
-    border-left: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+  border-left: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
 }
 
 .d-bx { .d-br(); .d-bl(); }

--- a/packages/dialtone-vue2/components/loader/loader_variants.story.vue
+++ b/packages/dialtone-vue2/components/loader/loader_variants.story.vue
@@ -1,6 +1,6 @@
 <template>
   <dt-stack
-    class="d-br d-bc-default d-pr16"
+    class="d-br d-pr16"
     gap="500"
   >
     <h2>Sizes</h2>

--- a/packages/dialtone-vue2/components/split_button/split_button_variants.story.vue
+++ b/packages/dialtone-vue2/components/split_button/split_button_variants.story.vue
@@ -4,16 +4,16 @@
     class="d-px8"
   >
     <h2>Variants</h2>
-    <table class="d-table d-bt d-bb d-bbw2 d-bc-default">
+    <table class="d-table d-bt d-bb d-bbw2">
       <thead>
         <tr>
-          <td class="d-ba d-bc-default">
+          <td class="d-ba">
             &nbsp;
           </td>
           <th
             v-for="importance in importanceList"
             :key="importance"
-            class="d-ta-center d-br d-bc-default"
+            class="d-ta-center d-br"
           >
             {{ importance }}
           </th>
@@ -26,7 +26,7 @@
           :class="{ 'd-bgc-contrast': kind === 'inverted' }"
         >
           <th
-            class="d-ta-right d-ba d-brw2 d-bc-default"
+            class="d-ta-right d-ba d-brw2"
             scope="row"
             :class="{ 'd-bc-default-inverted d-fc-primary-inverted': kind === 'inverted' }"
           >
@@ -85,7 +85,7 @@
       <!-- Sizes  -->
       <dt-stack
         gap="500"
-        class="d-br d-bc-default d-pr16"
+        class="d-br d-pr16"
       >
         <h2>Sizes</h2>
         <dt-stack gap="500">
@@ -110,7 +110,7 @@
       <!-- With alpha icon  -->
       <dt-stack
         gap="500"
-        class="d-br d-bc-default d-pr16"
+        class="d-br d-pr16"
       >
         <h2>With alpha icon</h2>
         <dt-stack gap="500">
@@ -142,7 +142,7 @@
       <!-- With custom omega icon  -->
       <dt-stack
         gap="500"
-        class="d-br d-bc-default d-pr16"
+        class="d-br d-pr16"
       >
         <h2>With custom omega icon</h2>
         <dt-stack gap="500">
@@ -170,7 +170,7 @@
       <!-- Status  -->
       <dt-stack
         gap="500"
-        class="d-br d-bc-default d-pr16"
+        class="d-br d-pr16"
       >
         <h2>Status</h2>
         <dt-stack gap="500">
@@ -211,7 +211,7 @@
       <!-- With tooltip -->
       <dt-stack
         gap="500"
-        class="d-br d-bc-default d-pr16"
+        class="d-br d-pr16"
       >
         <h2>With tooltip</h2>
         <dt-stack gap="500">
@@ -243,7 +243,7 @@
       <!-- Icon-only  -->
       <dt-stack
         gap="500"
-        class="d-br d-bc-default d-pr16"
+        class="d-br d-pr16"
       >
         <h2>Icon only</h2>
         <dt-stack gap="500">

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
@@ -101,7 +101,7 @@
     <template #menu>
       <!-- TODO replace this with DT menu -->
       <div
-        class="d-d-flex d-bgc-primary d-bar-pill d-bc-default d-ba"
+        class="d-d-flex d-bgc-primary d-bar-pill d-ba"
         role="group"
       >
         <dt-button

--- a/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -66,7 +66,7 @@
           >
             <!-- TODO replace this with DT menu -->
             <div
-              class="d-d-flex d-bgc-primary d-bar-pill d-bc-default d-ba"
+              class="d-d-flex d-bgc-primary d-bar-pill d-ba"
               role="group"
             >
               <dt-button

--- a/packages/dialtone-vue3/components/loader/loader_variants.story.vue
+++ b/packages/dialtone-vue3/components/loader/loader_variants.story.vue
@@ -1,6 +1,6 @@
 <template>
   <dt-stack
-    class="d-br d-bc-default d-pr16"
+    class="d-br d-pr16"
     gap="500"
   >
     <h2>Sizes</h2>

--- a/packages/dialtone-vue3/components/split_button/split_button_variants.story.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button_variants.story.vue
@@ -4,16 +4,16 @@
     class="d-px8"
   >
     <h2>Variants</h2>
-    <table class="d-table d-bt d-bb d-bbw2 d-bc-default">
+    <table class="d-table d-bt d-bb d-bbw2">
       <thead>
         <tr>
-          <td class="d-ba d-bc-default">
+          <td class="d-ba">
           &nbsp;
           </td>
           <th
             v-for="importance in importanceList"
             :key="importance"
-            class="d-ta-center d-br d-bc-default"
+            class="d-ta-center d-br"
           >
             {{ importance }}
           </th>
@@ -26,7 +26,7 @@
           :class="{ 'd-bgc-contrast': kind === 'inverted' }"
         >
           <th
-            class="d-ta-right d-ba d-brw2 d-bc-default"
+            class="d-ta-right d-ba d-brw2"
             scope="row"
             :class="{ 'd-bc-default-inverted d-fc-primary-inverted': kind === 'inverted' }"
           >
@@ -85,7 +85,7 @@
       <!-- Sizes  -->
       <dt-stack
         gap="500"
-        class="d-br d-bc-default d-pr16"
+        class="d-br d-pr16"
       >
         <h2>Sizes</h2>
         <dt-stack gap="500">
@@ -110,7 +110,7 @@
       <!-- With alpha icon  -->
       <dt-stack
         gap="500"
-        class="d-br d-bc-default d-pr16"
+        class="d-br d-pr16"
       >
         <h2>With alpha icon</h2>
         <dt-stack gap="500">
@@ -142,7 +142,7 @@
       <!-- With custom omega icon  -->
       <dt-stack
         gap="500"
-        class="d-br d-bc-default d-pr16"
+        class="d-br d-pr16"
       >
         <h2>With custom omega icon</h2>
         <dt-stack gap="500">
@@ -170,7 +170,7 @@
       <!-- Status  -->
       <dt-stack
         gap="500"
-        class="d-br d-bc-default d-pr16"
+        class="d-br d-pr16"
       >
         <h2>Status</h2>
         <dt-stack gap="500">
@@ -211,7 +211,7 @@
       <!-- With tooltip -->
       <dt-stack
         gap="500"
-        class="d-br d-bc-default d-pr16"
+        class="d-br d-pr16"
       >
         <h2>With tooltip</h2>
         <dt-stack gap="500">
@@ -243,7 +243,7 @@
       <!-- Icon-only  -->
       <dt-stack
         gap="500"
-        class="d-br d-bc-default d-pr16"
+        class="d-br d-pr16"
       >
         <h2>Icon only</h2>
         <dt-stack gap="500">

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
@@ -101,7 +101,7 @@
     <template #menu>
       <!-- TODO replace this with DT menu -->
       <div
-        class="d-d-flex d-bgc-primary d-bar-pill d-bc-default d-ba"
+        class="d-d-flex d-bgc-primary d-bar-pill d-ba"
         role="group"
       >
         <dt-button

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -66,7 +66,7 @@
           >
             <!-- TODO replace this with DT menu -->
             <div
-              class="d-d-flex d-bgc-primary d-bar-pill d-bc-default d-ba"
+              class="d-d-flex d-bgc-primary d-bar-pill d-ba"
               role="group"
             >
               <dt-button


### PR DESCRIPTION
# Add default color to border utilities

<img width="398" height="446" alt="image" src="https://github.com/user-attachments/assets/69e8f040-b563-40cd-8d96-941b17b594a1" />


## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2715

## :book: Description

`d-ba` (and other `d-b` utilities) have a default border of `current`, inheriting the foreground color of the element. This is never intended, and always overridden with a `d-bc-{color}`. 

**Solution:** default the border color to `var(--dt-color-border-default)`. This is a likely smart default, and could still be overridden with something else, e.g. `var(--dt-color-border-critical)`.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.