### PR TITLE
fix(combobox-multi-select): NO-JIRA prevent losing focus on input

### DIFF
--- a/packages/dialtone-vue2/components/chip/chip.test.js
+++ b/packages/dialtone-vue2/components/chip/chip.test.js
@@ -147,7 +147,7 @@ describe('DtChip Tests', () => {
 
     describe('When delete is pressed on a chip', () => {
       it('should emit close event', async () => {
-        await chip.trigger('keyup', { code: 'DELETE' });
+        await chip.trigger('keydown', { code: 'DELETE' });
 
         expect('close' in wrapper.emitted()).toBeTruthy();
       });

--- a/packages/dialtone-vue2/components/chip/chip.vue
+++ b/packages/dialtone-vue2/components/chip/chip.vue
@@ -164,6 +164,14 @@ export default {
      * @type {KeyboardEvent}
      */
     'keyup',
+
+    /**
+     * Native chip key down event
+     *
+     * @event keydown
+     * @type {KeyboardEvent}
+     */
+    'keydown',
   ],
 
   data () {
@@ -181,12 +189,16 @@ export default {
           if (this.interactive) this.$emit('click', event);
         },
 
-        keyup: event => {
+        keydown: event => {
           if (event.code?.toLowerCase() === 'delete') {
             this.onClose();
           } else {
-            this.$emit('keyup', event);
+            this.$emit('keydown', event);
           }
+        },
+
+        keyup: event => {
+          this.$emit('keyup', event);
         },
       };
     },

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.test.js
@@ -150,7 +150,7 @@ describe('DtRecipeComboboxMultiSelect Tests', () => {
 
         describe('When LEFT key is pressed', () => {
           beforeEach(async () => {
-            await secondChip.trigger('keyup', { code: 'arrowleft' });
+            await secondChip.trigger('keydown', { code: 'arrowleft' });
           });
 
           it('should focus the first chip', () => {
@@ -166,7 +166,7 @@ describe('DtRecipeComboboxMultiSelect Tests', () => {
 
         describe('When RIGHT key is pressed', () => {
           beforeEach(async () => {
-            await firstChip.trigger('keyup', { code: 'arrowright' });
+            await firstChip.trigger('keydown', { code: 'arrowright' });
           });
 
           it('should focus the second chip', () => {
@@ -194,7 +194,7 @@ describe('DtRecipeComboboxMultiSelect Tests', () => {
 
         describe('When LEFT key is pressed', () => {
           beforeEach(async () => {
-            input.trigger('keyup', { code: 'arrowleft' });
+            input.trigger('keydown', { code: 'arrowleft' });
           });
 
           it('should focus the last chip', () => {
@@ -202,13 +202,35 @@ describe('DtRecipeComboboxMultiSelect Tests', () => {
           });
         });
 
+        describe('When input contains text and LEFT key is pressed', () => {
+          beforeEach(async () => {
+            await input.setValue('a');
+            input.trigger('keydown', { code: 'arrowleft' });
+          });
+
+          it('should keep focus on the input', () => {
+            expect(document.activeElement).toBe(input.element);
+          });
+        });
+
         describe('When BACKSPACE key is pressed', () => {
           beforeEach(async () => {
-            input.trigger('keyup', { code: 'backspace' });
+            input.trigger('keydown', { code: 'backspace' });
           });
 
           it('should focus the last chip', () => {
             expect(document.activeElement).toBe(lastChip.element);
+          });
+        });
+
+        describe('When input contains text and BACKSPACE key is pressed', () => {
+          beforeEach(async () => {
+            await input.setValue('a');
+            input.trigger('keydown', { code: 'backspace' });
+          });
+
+          it('should keep focus on the input', () => {
+            expect(document.activeElement).toBe(input.element);
           });
         });
       });
@@ -220,7 +242,7 @@ describe('DtRecipeComboboxMultiSelect Tests', () => {
 
         describe('When RIGHT key is pressed', () => {
           beforeEach(async () => {
-            lastChip.trigger('keyup', { code: 'arrowright' });
+            lastChip.trigger('keydown', { code: 'arrowright' });
           });
 
           it('should focus the input', () => {
@@ -241,7 +263,7 @@ describe('DtRecipeComboboxMultiSelect Tests', () => {
       'Should emit "remove" event when close the chip and focus back to input',
       () => {
         const chip = chips.at(0);
-        chip.trigger('keyup', { code: 'delete' });
+        chip.trigger('keydown', { code: 'delete' });
         expect(wrapper.emitted().remove[0][0]).toBe('1');
         expect(document.activeElement).toBe(input.element);
       },

--- a/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue2/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -37,7 +37,7 @@
             :style="{ maxWidth: chipMaxWidth }"
             :size="CHIP_SIZES[size]"
             v-on="chipListeners"
-            @keyup.backspace="onChipRemove(item)"
+            @keydown.backspace="onChipRemove(item)"
             @close="onChipRemove(item)"
           >
             {{ item }}
@@ -62,6 +62,7 @@
           :size="size"
           v-on="inputListeners"
           @input="onInput"
+          @select.stop
         />
 
         <dt-validation-messages
@@ -403,6 +404,14 @@ export default {
     'keyup',
 
     /**
+     * Native keydown event
+     *
+     * @event keydown
+     * @type {KeyboardEvent}
+      */
+    'keydown',
+
+    /**
      * Event fired when combobox item is highlighted
      *
      * @event combobox-highlight
@@ -432,9 +441,9 @@ export default {
     chipListeners () {
       return {
         ...this.$listeners,
-        keyup: event => {
-          this.onChipKeyup(event);
-          this.$emit('keyup', event);
+        keydown: event => {
+          this.onChipKeyDown(event);
+          this.$emit('keydown', event);
         },
       };
     },
@@ -449,8 +458,11 @@ export default {
           }
         },
 
+        keydown: event => {
+          this.onInputKeyDown(event);
+        },
+
         keyup: event => {
-          this.onInputKeyup(event);
           this.$emit('keyup', event);
         },
 
@@ -587,7 +599,7 @@ export default {
       return this.$refs.input?.$refs.input;
     },
 
-    onChipKeyup (event) {
+    onChipKeyDown (event) {
       const key = event.code?.toLowerCase();
       if (key === 'arrowleft') {
         // Move to the previous chip
@@ -603,11 +615,15 @@ export default {
       }
     },
 
-    onInputKeyup (event) {
+    onInputKeyDown (event) {
       const key = event.code?.toLowerCase();
       // If the cursor is at the start of the text,
       // press 'backspace' or 'left' focuses the last chip
       if (this.selectedItems.length > 0 && event.target.selectionStart === 0) {
+        // if there is selected text, do not focus the last chip
+        if (event.target.selectionEnd !== event.target.selectionStart) {
+          return;
+        }
         if (key === 'backspace' || key === 'arrowleft') {
           this.moveFromInputToChip();
         }

--- a/packages/dialtone-vue3/components/chip/chip.test.js
+++ b/packages/dialtone-vue3/components/chip/chip.test.js
@@ -141,7 +141,7 @@ describe('DtChip Tests', () => {
 
     describe('When delete is pressed on a chip', () => {
       it('should emit close event', async () => {
-        await chip.trigger('keyup', { code: 'DELETE' });
+        await chip.trigger('keydown', { code: 'DELETE' });
 
         expect('close' in wrapper.emitted()).toBeTruthy();
       });

--- a/packages/dialtone-vue3/components/chip/chip.vue
+++ b/packages/dialtone-vue3/components/chip/chip.vue
@@ -165,6 +165,14 @@ export default {
      * @type {KeyboardEvent}
      */
     'keyup',
+
+    /**
+     * Native chip key down event
+     *
+     * @event keydown
+     * @type {KeyboardEvent}
+     */
+    'keydown',
   ],
 
   data () {
@@ -182,12 +190,16 @@ export default {
           if (this.interactive) this.$emit('click', event);
         },
 
-        keyup: event => {
+        keydown: event => {
           if (event.code?.toLowerCase() === 'delete') {
             this.onClose();
           } else {
-            this.$emit('keyup', event);
+            this.$emit('keydown', event);
           }
+        },
+
+        keyup: event => {
+          this.$emit('keyup', event);
         },
       };
     },

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.test.js
@@ -156,7 +156,7 @@ describe('DtRecipeComboboxMultiSelect Tests', () => {
 
         describe('When LEFT key is pressed', () => {
           beforeEach(async () => {
-            await secondChip.trigger('keyup', { code: 'arrowleft' });
+            await secondChip.trigger('keydown', { code: 'arrowleft' });
           });
 
           it('should focus the first chip', () => {
@@ -172,7 +172,7 @@ describe('DtRecipeComboboxMultiSelect Tests', () => {
 
         describe('When RIGHT key is pressed', () => {
           beforeEach(async () => {
-            await firstChip.trigger('keyup', { code: 'arrowright' });
+            await firstChip.trigger('keydown', { code: 'arrowright' });
           });
 
           it('should focus the second chip', () => {
@@ -191,26 +191,44 @@ describe('DtRecipeComboboxMultiSelect Tests', () => {
 
       describe('When input is focused', () => {
         beforeEach(async () => {
-          input.trigger('focus');
+          await input.trigger('focus');
         });
 
         describe('When LEFT key is pressed', () => {
           beforeEach(async () => {
-            input.trigger('keyup', { code: 'arrowleft' });
+            input.trigger('keydown', { code: 'arrowleft' });
           });
 
           it('should focus the last chip', () => {
             expect(document.activeElement).toBe(lastChip.element);
+          });
+        });
+
+        describe('When input contains text and LEFT key is pressed', () => {
+          it('should not call moveFromInputToChip when input has text', async () => {
+            const spy = vi.spyOn(wrapper.vm, 'moveFromInputToChip');
+            await input.setValue('a');
+            await input.trigger('keydown', { code: 'arrowleft' });
+            expect(spy).not.toHaveBeenCalled();
           });
         });
 
         describe('When BACKSPACE key is pressed', () => {
           beforeEach(async () => {
-            input.trigger('keyup', { code: 'backspace' });
+            input.trigger('keydown', { code: 'backspace' });
           });
 
           it('should focus the last chip', () => {
             expect(document.activeElement).toBe(lastChip.element);
+          });
+        });
+
+        describe('When input contains text and BACKSPACE key is pressed', () => {
+          it('should not call moveFromInputToChip when input has text', async () => {
+            const spy = vi.spyOn(wrapper.vm, 'moveFromInputToChip');
+            await input.setValue('a');
+            await input.trigger('keydown', { code: 'backspace' });
+            expect(spy).not.toHaveBeenCalled();
           });
         });
       });
@@ -222,7 +240,7 @@ describe('DtRecipeComboboxMultiSelect Tests', () => {
 
         describe('When RIGHT key is pressed', () => {
           beforeEach(async () => {
-            lastChip.trigger('keyup', { code: 'arrowright' });
+            lastChip.trigger('keydown', { code: 'arrowright' });
           });
 
           it('should focus the input', () => {
@@ -243,7 +261,7 @@ describe('DtRecipeComboboxMultiSelect Tests', () => {
       'Should emit "remove" event when close the chip and focus back to input',
       () => {
         const chip = chips.at(0);
-        chip.trigger('keyup', { code: 'delete' });
+        chip.trigger('keydown', { code: 'delete' });
         expect(wrapper.emitted().remove[0][0]).toBe('1');
         expect(document.activeElement).toBe(input.element);
       },

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -37,7 +37,7 @@
             :style="{ maxWidth: chipMaxWidth }"
             :size="CHIP_SIZES[size]"
             v-on="chipListeners"
-            @keyup.backspace="onChipRemove(item)"
+            @keydown.backspace="onChipRemove(item)"
             @close="onChipRemove(item)"
           >
             {{ item }}
@@ -404,6 +404,14 @@ export default {
     'keyup',
 
     /**
+     * Native keydown event
+     *
+     * @event keydown
+     * @type {KeyboardEvent}
+      */
+    'keydown',
+
+    /**
      * Event fired when combobox item is highlighted
      *
      * @event combobox-highlight
@@ -433,9 +441,9 @@ export default {
 
     chipListeners () {
       return {
-        keyup: event => {
-          this.onChipKeyup(event);
-          this.$emit('keyup', event);
+        keydown: event => {
+          this.onChipKeyDown(event);
+          this.$emit('keydown', event);
         },
       };
     },
@@ -449,8 +457,11 @@ export default {
           }
         },
 
+        keydown: event => {
+          this.onInputKeyDown(event);
+        },
+
         keyup: event => {
-          this.onInputKeyup(event);
           this.$emit('keyup', event);
         },
 
@@ -581,7 +592,7 @@ export default {
       return this.$refs.input?.$refs.input;
     },
 
-    onChipKeyup (event) {
+    onChipKeyDown (event) {
       const key = event.code?.toLowerCase();
       if (key === 'arrowleft') {
         // Move to the previous chip
@@ -597,11 +608,15 @@ export default {
       }
     },
 
-    onInputKeyup (event) {
+    onInputKeyDown (event) {
       const key = event.code?.toLowerCase();
       // If the cursor is at the start of the text,
       // press 'backspace' or 'left' focuses the last chip
       if (this.selectedItems.length > 0 && event.target.selectionStart === 0) {
+        // if there is selected text, do not focus the last chip
+        if (event.target.selectionEnd !== event.target.selectionStart) {
+          return;
+        }
         if (key === 'backspace' || key === 'arrowleft') {
           this.moveFromInputToChip();
         }


### PR DESCRIPTION
# fix(combobox-multi-select): NO-JIRA prevent losing focus on input

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket
Related to [DP-153208]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
This fixes the bug described in [this thread](https://dialpad.com/app/messages/agxzfnViZXItdm9pY2VyGAsSC1RleHRNZXNzYWdlGICAt7jvpesLDA).
The problem was that the listener was attached to the `keyup` event and moving the cursor / deleting a character happens on `keydown`. That's why when deleting the last character also the chip was focused and the input no longer on focus.

While working on this component I found other issues like:
- When hitting enter an element is created even if it's not part of the list and I am not sure that is intended, will investigate this
- In Vue 2, when selecting part of the text, a chip is created. This is due to the emitted event named `@select` being the same as the native event `select` that is fired when selecting text in the input. This is low priority since it doesn't happen in Vue 3.
<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

### Before
![multiselect-bef](https://github.com/user-attachments/assets/fe42a57d-cea1-4bbf-b3b9-3fef8490360b)


### Now
![multiselect-now](https://github.com/user-attachments/assets/89fb9dd3-cae4-46ea-9350-b040bac39f4b)

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->


<!--- Add any links to external reference material -->


[DP-153208]: https://dialpad.atlassian.net/browse/DP-153208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ