### PR TITLE
feat(tooltip): DLT-2741 add props support on tooltip directive

### DIFF
--- a/apps/dialtone-documentation/docs/components/tooltip.md
+++ b/apps/dialtone-documentation/docs/components/tooltip.md
@@ -53,6 +53,18 @@ It's possible to change the tooltip default placement with directive arguments, 
 <dt-button v-dt-tooltip:bottom-start="`Tooltip text`">Placeholder Button</dt-button>
 ```
 
+#### With Object Syntax
+
+It's possible to change any property of the tooltip with object syntax.
+
+<code-well-header class='d-hmn164'>
+<dt-button v-dt-tooltip="{ message: 'Tooltip text', placement: 'bottom-start', delay: false }">Placeholder Button</dt-button>
+</code-well-header>
+
+```javascript
+<dt-button v-dt-tooltip="{ message: 'Tooltip text', placement: 'bottom-start', delay: false }">Placeholder Button</dt-button>
+```
+
 ### Import
 
 Import the directive from dialtone-vue

--- a/packages/dialtone-vue2/directives/tooltip_directive/tooltip.js
+++ b/packages/dialtone-vue2/directives/tooltip_directive/tooltip.js
@@ -1,4 +1,4 @@
-import { DtTooltip } from '@/components/tooltip';
+import { DtTooltip, TOOLTIP_DIRECTIONS } from '@/components/tooltip';
 import { getUniqueString } from '@/common/utils';
 
 export const DtTooltipDirective = {
@@ -18,15 +18,14 @@ export const DtTooltipDirective = {
       },
 
       methods: {
-        addOrUpdateTooltip (id, message, placement) {
+        addOrUpdateTooltip (id, tooltipConfig) {
           const index = this.tooltips.findIndex(tooltip => tooltip.id === id);
           if (index !== -1) {
             // Update existing tooltip
-            this.tooltips[index].message = message;
-            this.tooltips[index].placement = placement;
+            this.tooltips.splice(index, 1, { id, ...tooltipConfig });
           } else {
             // Add new tooltip
-            this.tooltips.push({ id, message, placement });
+            this.tooltips.push({ id, ...tooltipConfig });
           }
         },
 
@@ -41,17 +40,16 @@ export const DtTooltipDirective = {
             domProps: { id: 'dt-tooltip-directive-app' },
           },
           [
-            this.tooltips.map(({ id, message, placement }) => {
+            this.tooltips.map(({ id, ...tooltipProps }) => {
               return h(DtTooltip, {
                 key: id,
                 props: {
-                  message,
-                  placement,
-                  sticky: true,
+                  ...tooltipProps,
+                  sticky: tooltipProps.sticky !== undefined ? tooltipProps.sticky : true,
                   /**
                    * Set the delay to false when running tests only.
                    */
-                  delay: process.env.NODE_ENV !== 'test',
+                  delay: tooltipProps.delay !== undefined ? tooltipProps.delay : (process.env.NODE_ENV !== 'test'),
                   externalAnchor: `[data-dt-tooltip-id="${id}"]`,
                 },
               });
@@ -81,11 +79,44 @@ export const DtTooltipDirective = {
 
     function setupTooltip (anchor, binding) {
       const tooltipId = anchor.getAttribute('data-dt-tooltip-id') || getUniqueString();
-      const message = binding.value;
-      const placement = binding.arg || DEFAULT_PLACEMENT;
+
+      let tooltipConfig;
+      if (typeof binding.value === 'string') {
+        tooltipConfig = {
+          message: binding.value,
+          placement: binding.arg || DEFAULT_PLACEMENT,
+        };
+      } else if (typeof binding.value === 'object' && binding.value !== null) {
+        tooltipConfig = {
+          placement: binding.arg || binding.value.placement || DEFAULT_PLACEMENT,
+          ...binding.value,
+        };
+      } else {
+        console.error('DtTooltipDirective: binding value must be a string or object');
+        return;
+      }
+
+      Object.keys(binding.modifiers).forEach(modifier => {
+        switch (modifier) {
+          case 'inverted':
+            tooltipConfig.inverted = true;
+            break;
+          case 'no-delay':
+            tooltipConfig.delay = false;
+            break;
+          case 'no-transition':
+            tooltipConfig.transition = false;
+            break;
+          default:
+            if (TOOLTIP_DIRECTIONS.includes(modifier)) {
+              tooltipConfig.placement = modifier;
+            }
+            break;
+        }
+      });
 
       anchor.setAttribute('data-dt-tooltip-id', tooltipId);
-      DtTooltipDirectiveApp.addOrUpdateTooltip(tooltipId, message, placement);
+      DtTooltipDirectiveApp.addOrUpdateTooltip(tooltipId, tooltipConfig);
     }
   },
 };

--- a/packages/dialtone-vue2/directives/tooltip_directive/tooltip.test.js
+++ b/packages/dialtone-vue2/directives/tooltip_directive/tooltip.test.js
@@ -4,11 +4,19 @@ import { getUniqueString, flushPromises } from '@/common/utils';
 
 const MOCK_TOOLTIP_TEXT = 'Tooltip text content';
 const MOCK_ANCHOR_TEXT = 'Button placeholder';
+const MOCK_TOOLTIP_PROPS = {
+  placement: 'bottom-start',
+  delay: false,
+  message: MOCK_TOOLTIP_TEXT,
+};
 
 const WrapperComponent = {
   name: 'wrapper-component',
   template: `
-    <button :key="id" v-dt-tooltip:[placement]="MOCK_TOOLTIP_TEXT">{{MOCK_ANCHOR_TEXT}}</button>
+    <div>
+      <button :key="id" data-qa="dt-tooltip-placement" v-dt-tooltip:[placement]="MOCK_TOOLTIP_TEXT">{{MOCK_ANCHOR_TEXT}}</button>
+      <button :key="id + '-object'" data-qa="dt-tooltip-object" v-dt-tooltip="MOCK_TOOLTIP_PROPS">{{MOCK_ANCHOR_TEXT}}</button>
+    </div>
   `,
 
   props: {
@@ -23,6 +31,7 @@ const WrapperComponent = {
       id: getUniqueString(),
       MOCK_ANCHOR_TEXT,
       MOCK_TOOLTIP_TEXT,
+      MOCK_TOOLTIP_PROPS,
     };
   },
 };
@@ -35,7 +44,8 @@ const testContext = {};
 
 describe('DtTooltipDirective Tests', () => {
   let wrapper;
-  let anchor;
+  let anchorButtonPlacement;
+  let anchorButtonObject;
 
   const updateWrapper = () => {
     wrapper = mount(WrapperComponent, {
@@ -44,7 +54,8 @@ describe('DtTooltipDirective Tests', () => {
       attachTo: document.body,
     });
 
-    anchor = wrapper.find('button');
+    anchorButtonPlacement = wrapper.find('[data-qa="dt-tooltip-placement"]');
+    anchorButtonObject = wrapper.find('[data-qa="dt-tooltip-object"]');
   };
 
   afterEach(() => {
@@ -68,11 +79,11 @@ describe('DtTooltipDirective Tests', () => {
   });
 
   describe('Presentation Tests', () => {
-    describe('when tooltip is open', () => {
+    describe('when tooltip with placement modifier is open', () => {
       beforeEach(async () => {
         await updateWrapper();
         await flushPromises();
-        await anchor.trigger('mouseenter');
+        await anchorButtonPlacement.trigger('mouseenter');
       });
 
       it('should render the component', () => {
@@ -84,7 +95,31 @@ describe('DtTooltipDirective Tests', () => {
       });
 
       it('should render the anchor', () => {
-        expect(anchor.text()).toBe(MOCK_ANCHOR_TEXT);
+        expect(anchorButtonPlacement.text()).toBe(MOCK_ANCHOR_TEXT);
+      });
+
+      it('should render the message', () => {
+        expect(document.body.querySelector('[data-qa="dt-tooltip"]').textContent.trim()).toBe(MOCK_TOOLTIP_TEXT);
+      });
+    });
+
+    describe('when tooltip with object argument is open', () => {
+      beforeEach(async () => {
+        await updateWrapper();
+        await flushPromises();
+        await anchorButtonObject.trigger('mouseenter');
+      });
+
+      it('should render the component', () => {
+        expect(wrapper.exists()).toBe(true);
+      });
+
+      it('should render the tooltip', () => {
+        expect(document.body.querySelectorAll('[data-qa="dt-tooltip"]').length).toBe(1);
+      });
+
+      it('should render the anchor', () => {
+        expect(anchorButtonObject.text()).toBe(MOCK_ANCHOR_TEXT);
       });
 
       it('should render the message', () => {

--- a/packages/dialtone-vue3/directives/tooltip_directive/tooltip.js
+++ b/packages/dialtone-vue3/directives/tooltip_directive/tooltip.js
@@ -1,4 +1,4 @@
-import { DtTooltip } from '@/components/tooltip';
+import { DtTooltip, TOOLTIP_DIRECTIONS } from '@/components/tooltip';
 import { getUniqueString } from '@/common/utils';
 import { createApp, getCurrentInstance, h } from 'vue';
 
@@ -19,20 +19,19 @@ export const DtTooltipDirective = {
         };
       },
 
-      mounted () {
+      created () {
         tooltipInstance = getCurrentInstance();
       },
 
       methods: {
-        addOrUpdateTooltip (id, message, placement) {
+        addOrUpdateTooltip (id, tooltipConfig) {
           const index = this.tooltips.findIndex(tooltip => tooltip.id === id);
           if (index !== -1) {
             // Update existing tooltip
-            this.tooltips[index].message = message;
-            this.tooltips[index].placement = placement;
+            this.tooltips.splice(index, 1, { id, ...tooltipConfig });
           } else {
             // Add new tooltip
-            this.tooltips.push({ id, message, placement });
+            this.tooltips.push({ id, ...tooltipConfig });
           }
         },
 
@@ -43,16 +42,15 @@ export const DtTooltipDirective = {
 
       render () {
         return h('div',
-          this.tooltips.map(({ id, message, placement }) => {
+          this.tooltips.map(({ id, ...tooltipProps }) => {
             return h(DtTooltip, {
               key: id,
-              message,
-              placement,
-              sticky: true,
+              ...tooltipProps,
+              sticky: tooltipProps.sticky !== undefined ? tooltipProps.sticky : true,
               /**
                * Set the delay to false when running tests only.
                */
-              delay: process.env.NODE_ENV !== 'test',
+              delay: tooltipProps.delay !== undefined ? tooltipProps.delay : (process.env.NODE_ENV !== 'test'),
               externalAnchor: `[data-dt-tooltip-id="${id}"]`,
             });
           }),
@@ -80,12 +78,44 @@ export const DtTooltipDirective = {
 
     function setupTooltip (anchor, binding) {
       const tooltipId = anchor.getAttribute('data-dt-tooltip-id') || getUniqueString();
-      const message = binding.value;
-      const placement = binding.arg || DEFAULT_PLACEMENT;
+
+      let tooltipConfig;
+      if (typeof binding.value === 'string') {
+        tooltipConfig = {
+          message: binding.value,
+          placement: binding.arg || DEFAULT_PLACEMENT,
+        };
+      } else if (typeof binding.value === 'object' && binding.value !== null) {
+        tooltipConfig = {
+          placement: binding.arg || binding.value.placement || DEFAULT_PLACEMENT,
+          ...binding.value,
+        };
+      } else {
+        console.error('DtTooltipDirective: binding value must be a string or object');
+        return;
+      }
+
+      Object.keys(binding.modifiers).forEach(modifier => {
+        switch (modifier) {
+          case 'inverted':
+            tooltipConfig.inverted = true;
+            break;
+          case 'no-delay':
+            tooltipConfig.delay = false;
+            break;
+          case 'no-transition':
+            tooltipConfig.transition = false;
+            break;
+          default:
+            if (TOOLTIP_DIRECTIONS.includes(modifier)) {
+              tooltipConfig.placement = modifier;
+            }
+            break;
+        }
+      });
 
       anchor.setAttribute('data-dt-tooltip-id', tooltipId);
-
-      tooltipInstance.ctx.addOrUpdateTooltip(tooltipId, message, placement);
+      tooltipInstance.ctx.addOrUpdateTooltip(tooltipId, tooltipConfig);
     }
   },
 };

--- a/packages/dialtone-vue3/directives/tooltip_directive/tooltip.test.js
+++ b/packages/dialtone-vue3/directives/tooltip_directive/tooltip.test.js
@@ -4,11 +4,19 @@ import { getUniqueString } from '@/common/utils';
 
 const MOCK_TOOLTIP_TEXT = 'Tooltip text content';
 const MOCK_ANCHOR_TEXT = 'Button placeholder';
+const MOCK_TOOLTIP_PROPS = {
+  placement: 'bottom-start',
+  delay: false,
+  message: MOCK_TOOLTIP_TEXT,
+};
 
 const WrapperComponent = {
   name: 'wrapper-component',
   template: `
-    <button :key="id" v-dt-tooltip:[placement]="MOCK_TOOLTIP_TEXT">{{MOCK_ANCHOR_TEXT}}</button>
+    <div>
+      <button :key="id" data-qa="dt-tooltip-placement" v-dt-tooltip:[placement]="MOCK_TOOLTIP_TEXT">{{MOCK_ANCHOR_TEXT}}</button>
+      <button :key="id" data-qa="dt-tooltip-object" v-dt-tooltip="MOCK_TOOLTIP_PROPS">{{MOCK_ANCHOR_TEXT}}</button>
+    </div>
   `,
 
   props: {
@@ -23,6 +31,7 @@ const WrapperComponent = {
       id: getUniqueString(),
       MOCK_ANCHOR_TEXT,
       MOCK_TOOLTIP_TEXT,
+      MOCK_TOOLTIP_PROPS,
     };
   },
 };
@@ -33,7 +42,8 @@ let mockProps = {};
 
 describe('DtTooltipDirective Tests', () => {
   let wrapper;
-  let anchor;
+  let anchorButtonPlacement;
+  let anchorButtonObject;
 
   const updateWrapper = () => {
     wrapper = mount(WrapperComponent, {
@@ -47,7 +57,8 @@ describe('DtTooltipDirective Tests', () => {
       attachTo: document.body,
     });
 
-    anchor = wrapper.find('button');
+    anchorButtonPlacement = wrapper.find('[data-qa="dt-tooltip-placement"]');
+    anchorButtonObject = wrapper.find('[data-qa="dt-tooltip-object"]');
   };
 
   afterEach(() => {
@@ -69,11 +80,11 @@ describe('DtTooltipDirective Tests', () => {
   });
 
   describe('Presentation Tests', () => {
-    describe('when tooltip is open', () => {
+    describe('when tooltip with placement modifier is open', () => {
       beforeEach(async () => {
         await updateWrapper();
         await flushPromises();
-        await anchor.trigger('mouseenter');
+        await anchorButtonPlacement.trigger('mouseenter');
       });
 
       it('should render the component', () => {
@@ -85,7 +96,31 @@ describe('DtTooltipDirective Tests', () => {
       });
 
       it('should render the anchor', () => {
-        expect(anchor.text()).toBe(MOCK_ANCHOR_TEXT);
+        expect(anchorButtonPlacement.text()).toBe(MOCK_ANCHOR_TEXT);
+      });
+
+      it('should render the message', () => {
+        expect(document.body.querySelector('[data-qa="dt-tooltip"]').textContent.trim()).toBe(MOCK_TOOLTIP_TEXT);
+      });
+    });
+
+    describe('when tooltip with object argument is open', () => {
+      beforeEach(async () => {
+        await updateWrapper();
+        await flushPromises();
+        await anchorButtonObject.trigger('mouseenter');
+      });
+
+      it('should render the component', () => {
+        expect(wrapper.exists()).toBe(true);
+      });
+
+      it('should render the tooltip', () => {
+        expect(document.body.querySelectorAll('[data-qa="dt-tooltip"]').length).toBe(1);
+      });
+
+      it('should render the anchor', () => {
+        expect(anchorButtonObject.text()).toBe(MOCK_ANCHOR_TEXT);
       });
 
       it('should render the message', () => {


### PR DESCRIPTION
# Add props support on tooltip directive

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Hi](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExMnRta2Y1MHR1Y2ZoaGY5cGhveHI4emJwZTB4ZDN0NzRjMzlhNmg3ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT9IgG50Fb7Mi0prBC/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Description

Changes made to the tooltip directive to allow passing props as an object syntax.

## :bulb: Context

We want to deprecate the custom tooltip directive that we have implemented in the app, so we should extend the `DtTooltipDirective` to allow a few more customizations while using it, currently we only support setting the `placement`.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [] I have validated components with a screen reader.
- [] I have validated components keyboard navigation.