### PR TITLE
feat(emoji-row): DLT-2248 display larger emoji and inline shortcode in emoji row tooltip

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/emoji-text-wrapper.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji-text-wrapper.less
@@ -1,5 +1,7 @@
 .d-emoji-text-wrapper {
   .d-emoji {
+    height: 1em;
+
     .d-icon {
       inset-block-start: calc(50% - 1px);
     }

--- a/packages/dialtone-css/lib/build/less/components/emoji-text-wrapper.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji-text-wrapper.less
@@ -1,9 +1,7 @@
 .d-emoji-text-wrapper {
   .d-emoji {
-    height: 1em;
-
     .d-icon {
-      top: calc(50% - 1px);
+      inset-block-start: calc(50% - 1px);
     }
   }
 }

--- a/packages/dialtone-css/lib/build/less/components/emoji-text-wrapper.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji-text-wrapper.less
@@ -1,8 +1,9 @@
 .d-emoji-text-wrapper {
-  .d-emoji {
+  // Only inline emojis need this adjustments
+  >.d-emoji {
     height: 1em;
 
-    .d-icon {
+    img.d-icon {
       inset-block-start: calc(50% - 1px);
     }
   }

--- a/packages/dialtone-css/lib/build/less/recipes/emoji_row.less
+++ b/packages/dialtone-css/lib/build/less/recipes/emoji_row.less
@@ -18,6 +18,10 @@
   background-color: var(--dt-color-neutral-white);
   border-radius: var(--dt-size-radius-300);
   margin-block: var(--dt-space-300) var(--dt-space-350);
+
+  .d-emoji {
+    height: var(--icon-size);
+  }
 }
 
 .d-recipe-emoji-row__tooltip-names {

--- a/packages/dialtone-css/lib/build/less/recipes/emoji_row.less
+++ b/packages/dialtone-css/lib/build/less/recipes/emoji_row.less
@@ -30,8 +30,8 @@
 }
 
 .d-recipe-emoji-row__tooltip-label {
-  color: var(--dt-color-foreground-tertiary-inverted);
-  font-weight: var(--dt-font-weight-normal);
+  color: var(--dt-color-foreground-secondary-inverted);
+  font-weight: var(--dt-font-weight-medium);
 }
 
 .d-recipe-emoji-row__reaction {

--- a/packages/dialtone-css/lib/build/less/recipes/emoji_row.less
+++ b/packages/dialtone-css/lib/build/less/recipes/emoji_row.less
@@ -9,7 +9,25 @@
 }
 
 .d-recipe-emoji-row__tooltip-content {
-   max-width: var(--dt-size-975);
+   max-inline-size: var(--dt-size-875);
+}
+
+.d-recipe-emoji-row__tooltip-emoji {
+  display: inline-block;
+  padding: var(--dt-space-300);
+  background-color: var(--dt-color-neutral-white);
+  border-radius: var(--dt-size-radius-300);
+  margin-block: var(--dt-space-300) var(--dt-space-350);
+}
+
+.d-recipe-emoji-row__tooltip-names {
+  display: inline-block;
+  font-weight: var(--dt-font-weight-semi-bold);
+}
+
+.d-recipe-emoji-row__tooltip-label {
+  color: var(--dt-color-foreground-tertiary-inverted);
+  font-weight: var(--dt-font-weight-normal);
 }
 
 .d-recipe-emoji-row__reaction {

--- a/packages/dialtone-css/lib/build/less/recipes/emoji_row.less
+++ b/packages/dialtone-css/lib/build/less/recipes/emoji_row.less
@@ -52,7 +52,7 @@
   }
 
   &:hover {
-    --emoji-item-color-inset-shadow: var(--dt-color-border-subtle);
+    --emoji-item-color-inset-shadow: var(--dt-color-border-moderate);
     --emoji-item-color-foreground: var(--dt-action-color-foreground-muted-hover);
   }
 
@@ -94,6 +94,15 @@
 }
 
 .d-recipe-emoji-row__emoji {
+  --emoji-size: calc(var(--dt-icon-size-200) + .2rem);
+
   display: inline-flex;
-  margin-right: var(--dt-space-300);
+  margin-inline-end: var(--dt-space-300);
+  inline-size: var(--emoji-size);
+  block-size: var(--emoji-size);
+}
+
+.d-recipe-emoji-row__emoji-img {
+  inline-size: var(--emoji-size);
+  block-size: var(--emoji-size);
 }

--- a/packages/dialtone-vue2/common/emoji/index.js
+++ b/packages/dialtone-vue2/common/emoji/index.js
@@ -142,7 +142,9 @@ export function shortcodeToEmojiData (shortcode) {
   return reference;
 }
 
-export function emojiToShortcode (emoji) {
+export function getEmojiShortCode (emoji) {
+  if (emoji.startsWith(':')) return emoji;
+
   const unicode = unicodeToString(emoji);
   return emojiJson[unicode]?.shortname;
 }

--- a/packages/dialtone-vue2/common/emoji/index.js
+++ b/packages/dialtone-vue2/common/emoji/index.js
@@ -121,7 +121,6 @@ export function validateCustomEmojiJson (json) {
 // recursively searches the emoji data object containing data for all emojis
 // and returns the object with the specified shortcode.
 export function shortcodeToEmojiData (shortcode) {
-  // eslint-disable-next-line complexity
   function f (o, key) {
     if (!o || typeof o !== 'object') {
       return;
@@ -141,6 +140,11 @@ export function shortcodeToEmojiData (shortcode) {
   let reference;
   f(getEmojiData(), null);
   return reference;
+}
+
+export function emojiToShortcode (emoji) {
+  const unicode = unicodeToString(emoji);
+  return emojiJson[unicode]?.shortname;
 }
 
 // Takes in an emoji unicode character(s) and converts it to an emoji string in the format the emoji data object expects

--- a/packages/dialtone-vue2/localization/en-US.ftl
+++ b/packages/dialtone-vue2/localization/en-US.ftl
@@ -62,7 +62,7 @@ DIALTONE_EDITOR_ADD_LINK_BUTTON =
   .title = Add Link
   .aria-label = Input field to add link
 
-DIALTONE_EMOJI_ROW_REACTION_LABEL = { $names } reacted with { $reaction }
+DIALTONE_EMOJI_ROW_REACTION_LABEL = reacted with { $reaction }
 
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = Add emoji
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = No results

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.stories.js
@@ -24,12 +24,12 @@ export const sharedEmojiReactionsData = [
   },
   {
     emojiUnicodeOrShortname: '😌',
-    isSelected: true,
+    isSelected: false,
     names: 'Olivia Chen, Benjamin Carter, Sophia Rodriguez, William Kim & Isabella Garcia',
     num: 5,
   },
   {
-    emojiUnicodeOrShortname: '🙃',
+    emojiUnicodeOrShortname: ':blinkingguy:',
     names: 'You & John Doe',
     isSelected: true,
     num: 2,

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.test.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.test.js
@@ -5,6 +5,7 @@ import {
 } from '@/tests/shared_examples/validation.js';
 import DtRecipeEmojiRow from './emoji_row.vue';
 import { DtTooltip } from '@/components/tooltip';
+import { emojiToShortcode } from '@/common/emoji';
 
 // Constants
 const testEmojiObj = {
@@ -13,12 +14,13 @@ const testEmojiObj = {
   isSelected: false,
   num: 2,
 };
+const emojiShortcode = emojiToShortcode(testEmojiObj.emojiUnicodeOrShortname);
 
 // \u2068 and \u2069 are Unicode bidi isolation characters.
 // They are non-printing characters that help text layout engines to ensure that the interpolated strings are handled correctly
 // in the situation where the text direction of the substitution might not match the text direction of the localized text.
 // https://github.com/django-ftl/fluent-compiler/blob/master/docs/usage.rst#formatting-messages
-const MOCK_LOCALIZED_EMOJI_REACTION_ARIA_LABEL = `\u2068${testEmojiObj.names}\u2069 reacted with \u2068${testEmojiObj.emojiUnicodeOrShortname}\u2069`;
+const MOCK_LOCALIZED_EMOJI_REACTION_ARIA_LABEL = `reacted with \u2068${emojiShortcode}\u2069`;
 
 const basePropsData = {
   reactions: [

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.test.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.test.js
@@ -5,7 +5,7 @@ import {
 } from '@/tests/shared_examples/validation.js';
 import DtRecipeEmojiRow from './emoji_row.vue';
 import { DtTooltip } from '@/components/tooltip';
-import { emojiToShortcode } from '@/common/emoji';
+import { getEmojiShortCode } from '@/common/emoji';
 
 // Constants
 const testEmojiObj = {
@@ -14,7 +14,7 @@ const testEmojiObj = {
   isSelected: false,
   num: 2,
 };
-const emojiShortcode = emojiToShortcode(testEmojiObj.emojiUnicodeOrShortname);
+const emojiShortcode = getEmojiShortCode(testEmojiObj.emojiUnicodeOrShortname);
 
 // \u2068 and \u2069 are Unicode bidi isolation characters.
 // They are non-printing characters that help text layout engines to ensure that the interpolated strings are handled correctly

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -40,7 +40,8 @@
           >
             <span class="d-recipe-emoji-row__emoji">
               <dt-emoji
-                size="300"
+                class="d-recipe-emoji-row__emoji"
+                img-class="d-recipe-emoji-row__emoji-img"
                 :code="reaction.emojiUnicodeOrShortname"
               />
             </span>

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -65,7 +65,7 @@ import { DtTooltip } from '@/components/tooltip';
 import { DtEmoji } from '@/components/emoji';
 import { DtEmojiTextWrapper } from '@/components/emoji_text_wrapper';
 import { DialtoneLocalization } from '@/localization';
-import { emojiToShortcode } from '@/common/emoji';
+import { getEmojiShortCode } from '@/common/emoji';
 
 export default {
   name: 'DtRecipeEmojiRow',
@@ -114,7 +114,7 @@ export default {
 
     reactionLabel (reaction) {
       return this.i18n.$t('DIALTONE_EMOJI_ROW_REACTION_LABEL', {
-        reaction: emojiToShortcode(reaction.emojiUnicodeOrShortname),
+        reaction: getEmojiShortCode(reaction.emojiUnicodeOrShortname),
       });
     },
   },

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -7,12 +7,22 @@
       <dt-tooltip
         class="d-recipe-emoji-row__tooltip"
         content-class="d-recipe-emoji-row__tooltip-content"
+        :fallback-placements="['top', 'bottom']"
         sticky="popper"
         @shown="(shown) => emojiHovered(reaction, shown)"
       >
         <span aria-hidden="true">
-          <dt-emoji-text-wrapper size="200">
-            {{ reactionLabel(reaction) }}
+          <dt-emoji-text-wrapper size="800">
+            <p class="d-recipe-emoji-row__tooltip-emoji">
+              {{ reaction.emojiUnicodeOrShortname }}
+            </p>
+            <p class="d-recipe-emoji-row__tooltip-names">
+              {{ reaction.names }}
+              <span
+                class="d-recipe-emoji-row__tooltip-label"
+                v-text="reactionLabel(reaction)"
+              />
+            </p>
           </dt-emoji-text-wrapper>
         </span>
         <template #anchor="{ attrs }">
@@ -30,7 +40,7 @@
           >
             <span class="d-recipe-emoji-row__emoji">
               <dt-emoji
-                size="200"
+                size="300"
                 :code="reaction.emojiUnicodeOrShortname"
               />
             </span>
@@ -54,6 +64,7 @@ import { DtTooltip } from '@/components/tooltip';
 import { DtEmoji } from '@/components/emoji';
 import { DtEmojiTextWrapper } from '@/components/emoji_text_wrapper';
 import { DialtoneLocalization } from '@/localization';
+import { emojiToShortcode } from '@/common/emoji';
 
 export default {
   name: 'DtRecipeEmojiRow',
@@ -102,8 +113,7 @@ export default {
 
     reactionLabel (reaction) {
       return this.i18n.$t('DIALTONE_EMOJI_ROW_REACTION_LABEL', {
-        names: reaction.names,
-        reaction: reaction.emojiUnicodeOrShortname,
+        reaction: emojiToShortcode(reaction.emojiUnicodeOrShortname),
       });
     },
   },

--- a/packages/dialtone-vue3/common/emoji/index.js
+++ b/packages/dialtone-vue3/common/emoji/index.js
@@ -143,7 +143,9 @@ export function shortcodeToEmojiData (shortcode) {
   return reference;
 }
 
-export function emojiToShortcode (emoji) {
+export function getEmojiShortCode (emoji) {
+  if (emoji.startsWith(':')) return emoji;
+
   const unicode = unicodeToString(emoji);
   return emojiJson[unicode]?.shortname;
 }

--- a/packages/dialtone-vue3/common/emoji/index.js
+++ b/packages/dialtone-vue3/common/emoji/index.js
@@ -143,6 +143,11 @@ export function shortcodeToEmojiData (shortcode) {
   return reference;
 }
 
+export function emojiToShortcode (emoji) {
+  const unicode = unicodeToString(emoji);
+  return emojiJson[unicode]?.shortname;
+}
+
 // Takes in an emoji unicode character(s) and converts it to an emoji string in the format the emoji data object expects
 // as a key. There can be multiple unicode characters in an emoji to denote the emoji itself, skin tone, gender
 // and such. Note that this function does NOT return variation selectors (fe0f) or zero width joiners (200d), as these

--- a/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
+++ b/packages/dialtone-vue3/components/emoji_text_wrapper/emoji_text_wrapper.vue
@@ -78,6 +78,7 @@ export default {
      * @returns {VNode|*}
      */
     searchVNodes (VNode) {
+      if (!VNode) return;
       if (typeof VNode === 'string') return this.searchCodes(VNode);
       if (VNode.type === COMMENT_TYPE) return VNode;
       if (typeof VNode.type === 'symbol') return this.searchCodes(VNode.children);

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.stories.js
@@ -24,12 +24,12 @@ export const sharedEmojiReactionsData = [
   },
   {
     emojiUnicodeOrShortname: '😌',
-    isSelected: true,
+    isSelected: false,
     names: 'Olivia Chen, Benjamin Carter, Sophia Rodriguez, William Kim & Isabella Garcia',
     num: 5,
   },
   {
-    emojiUnicodeOrShortname: '🙃',
+    emojiUnicodeOrShortname: ':blinkingguy:',
     names: 'You & John Doe',
     isSelected: true,
     num: 2,

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.test.js
@@ -5,6 +5,7 @@ import {
 } from '@/tests/shared_examples/validation.js';
 import DtRecipeEmojiRow from './emoji_row.vue';
 import { DtTooltip } from '@/components/tooltip';
+import { emojiToShortcode } from '@/common/emoji';
 
 // Constants
 const testEmojiObj = {
@@ -13,12 +14,13 @@ const testEmojiObj = {
   isSelected: false,
   num: 2,
 };
+const emojiShortcode = emojiToShortcode(testEmojiObj.emojiUnicodeOrShortname);
 
 // \u2068 and \u2069 are Unicode bidi isolation characters.
 // They are non-printing characters that help text layout engines to ensure that the interpolated strings are handled correctly
 // in the situation where the text direction of the substitution might not match the text direction of the localized text.
 // https://github.com/django-ftl/fluent-compiler/blob/master/docs/usage.rst#formatting-messages
-const MOCK_LOCALIZED_EMOJI_REACTION_ARIA_LABEL = `\u2068${testEmojiObj.names}\u2069 reacted with \u2068${testEmojiObj.emojiUnicodeOrShortname}\u2069`;
+const MOCK_LOCALIZED_EMOJI_REACTION_ARIA_LABEL = `reacted with \u2068${emojiShortcode}\u2069`;
 
 const basePropsData = {
   reactions: [

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.test.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.test.js
@@ -5,7 +5,7 @@ import {
 } from '@/tests/shared_examples/validation.js';
 import DtRecipeEmojiRow from './emoji_row.vue';
 import { DtTooltip } from '@/components/tooltip';
-import { emojiToShortcode } from '@/common/emoji';
+import { getEmojiShortCode } from '@/common/emoji';
 
 // Constants
 const testEmojiObj = {
@@ -14,7 +14,7 @@ const testEmojiObj = {
   isSelected: false,
   num: 2,
 };
-const emojiShortcode = emojiToShortcode(testEmojiObj.emojiUnicodeOrShortname);
+const emojiShortcode = getEmojiShortCode(testEmojiObj.emojiUnicodeOrShortname);
 
 // \u2068 and \u2069 are Unicode bidi isolation characters.
 // They are non-printing characters that help text layout engines to ensure that the interpolated strings are handled correctly

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -7,12 +7,22 @@
       <dt-tooltip
         class="d-recipe-emoji-row__tooltip"
         content-class="d-recipe-emoji-row__tooltip-content"
+        :fallback-placements="['top', 'bottom']"
         sticky="popper"
         @shown="(shown) => emojiHovered(reaction, shown)"
       >
         <span aria-hidden="true">
-          <dt-emoji-text-wrapper size="200">
-            {{ reactionLabel(reaction) }}
+          <dt-emoji-text-wrapper size="800">
+            <p class="d-recipe-emoji-row__tooltip-emoji">
+              {{ reaction.emojiUnicodeOrShortname }}
+            </p>
+            <p class="d-recipe-emoji-row__tooltip-names">
+              {{ reaction.names }}
+              <span
+                class="d-recipe-emoji-row__tooltip-label"
+                v-text="reactionLabel(reaction)"
+              />
+            </p>
           </dt-emoji-text-wrapper>
         </span>
         <template #anchor="{ attrs }">
@@ -30,7 +40,7 @@
           >
             <span class="d-recipe-emoji-row__emoji">
               <dt-emoji
-                size="200"
+                size="300"
                 :code="reaction.emojiUnicodeOrShortname"
               />
             </span>
@@ -54,6 +64,7 @@ import { DtTooltip } from '@/components/tooltip';
 import { DtEmoji } from '@/components/emoji';
 import { DtEmojiTextWrapper } from '@/components/emoji_text_wrapper';
 import { DialtoneLocalization } from '@/localization';
+import { emojiToShortcode } from '@/common/emoji';
 
 export default {
   compatConfig: { MODE: 3 },
@@ -103,8 +114,7 @@ export default {
 
     reactionLabel (reaction) {
       return this.i18n.$t('DIALTONE_EMOJI_ROW_REACTION_LABEL', {
-        names: reaction.names,
-        reaction: reaction.emojiUnicodeOrShortname,
+        reaction: emojiToShortcode(reaction.emojiUnicodeOrShortname),
       });
     },
   },

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -40,7 +40,8 @@
           >
             <span class="d-recipe-emoji-row__emoji">
               <dt-emoji
-                size="300"
+                class="d-recipe-emoji-row__emoji"
+                img-class="d-recipe-emoji-row__emoji-img"
                 :code="reaction.emojiUnicodeOrShortname"
               />
             </span>

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -65,7 +65,7 @@ import { DtTooltip } from '@/components/tooltip';
 import { DtEmoji } from '@/components/emoji';
 import { DtEmojiTextWrapper } from '@/components/emoji_text_wrapper';
 import { DialtoneLocalization } from '@/localization';
-import { emojiToShortcode } from '@/common/emoji';
+import { getEmojiShortCode } from '@/common/emoji';
 
 export default {
   compatConfig: { MODE: 3 },
@@ -115,7 +115,7 @@ export default {
 
     reactionLabel (reaction) {
       return this.i18n.$t('DIALTONE_EMOJI_ROW_REACTION_LABEL', {
-        reaction: emojiToShortcode(reaction.emojiUnicodeOrShortname),
+        reaction: getEmojiShortCode(reaction.emojiUnicodeOrShortname),
       });
     },
   },


### PR DESCRIPTION
# Display larger emoji and inline shortcode in emoji row tooltip

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3OW55aG54NGhrMTloZGRycnN5MWc4ejk1aWprcWFwdnp4ZDZlOWRucCZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/IorAqDrjKiDcc3QdN3/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2248

## :book: Description

- Display larger emoji on tooltip
- Display inline shortcode
- Increased reaction count emoji size (requested by @TedGoas on https://github.com/dialpad/dialtone/pull/601#issuecomment-2560158954)

## :bulb: Context

This was a prototype made by @francisrupert last year on #601, this is the actual implementation.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.

## :camera: Screenshots / GIFs

<img width="2557" height="1206" alt="image" src="https://github.com/user-attachments/assets/5094abd7-d29a-4e6b-866b-c99c6f37a919" />
<img width="2560" height="1207" alt="Captura de pantalla 2025-08-22 a las 2 31 56 p m" src="https://github.com/user-attachments/assets/029317e7-eb24-48fc-abb8-998dd130ba5f" />
