### PR TITLE
fix(toast): DP-154396 fix toast class and listeners vue3

### DIFF
--- a/packages/dialtone-vue3/components/toast/layouts/toast_layout_alternate.vue
+++ b/packages/dialtone-vue3/components/toast/layouts/toast_layout_alternate.vue
@@ -3,6 +3,7 @@
     v-if="isShown"
     :class="[
       'd-toast-alternate',
+      $attrs.class,
       kindClass,
     ]"
     data-qa="dt-toast"
@@ -14,7 +15,7 @@
           v-if="!hideIcon"
           :kind="kind"
           size="200"
-          v-bind="$attrs"
+          v-bind="toastListeners"
         >
           <slot name="icon" />
         </dt-toast-layout-alternate-icon>
@@ -23,7 +24,7 @@
           :content-id="contentId"
           :title="title"
           :role="role"
-          v-bind="$attrs"
+          v-bind="toastListeners"
         >
           <template #titleOverride>
             <slot name="titleOverride" />
@@ -35,7 +36,7 @@
           :hide-action="true"
           :hide-close="hideClose"
           button-size="xs"
-          v-bind="$attrs"
+          v-bind="toastListeners"
           @close="$emit('close')"
         />
       </div>
@@ -54,6 +55,8 @@ import utils from '@/common/utils';
 import DtToastLayoutAlternateIcon from './toast_layout_alternate_icon.vue';
 import { DtNoticeAction, DtNoticeContent } from '@/components/notice';
 import { TOAST_ROLES, TOAST_ALTERNATE_KINDS } from '../toast_constants.js';
+import { extractVueListeners } from "@/common/utils/index.js";
+
 export default {
   name: 'ToastLayoutAlternate',
 
@@ -160,6 +163,10 @@ export default {
       };
 
       return kindClasses[this.kind];
+    },
+
+    toastListeners () {
+      return extractVueListeners(this.$attrs);
     },
   },
 };

--- a/packages/dialtone-vue3/components/toast/layouts/toast_layout_default.vue
+++ b/packages/dialtone-vue3/components/toast/layouts/toast_layout_default.vue
@@ -4,6 +4,7 @@
     :class="[
       'd-toast',
       kindClass,
+      $attrs.class,
       { 'd-toast--important': important },
     ]"
     data-qa="dt-toast"
@@ -13,7 +14,7 @@
       <dt-notice-icon
         v-if="!hideIcon"
         :kind="kind"
-        v-bind="$attrs"
+        v-bind="toastListeners"
       >
         <!-- @slot Slot for custom icon -->
         <slot name="icon" />
@@ -23,7 +24,7 @@
         :content-id="contentId"
         :title="title"
         :role="role"
-        v-bind="$attrs"
+        v-bind="toastListeners"
       >
         <template #titleOverride>
           <!-- @slot Allows you to override the title, only use this if you need to override
@@ -38,7 +39,7 @@
       <dt-notice-action
         :hide-action="hideAction"
         :hide-close="hideClose"
-        v-bind="$attrs"
+        v-bind="toastListeners"
         @close="$emit('close')"
       >
         <!-- @slot Enter a possible action for the user to take, such as a link to another page -->
@@ -52,6 +53,8 @@
 import utils from '@/common/utils';
 import { DtNoticeIcon, DtNoticeContent, DtNoticeAction, NOTICE_KINDS } from '@/components/notice';
 import { TOAST_ROLES } from '../toast_constants.js';
+import { extractVueListeners } from "@/common/utils/index.js";
+
 export default {
   name: 'ToastLayoutDefault',
 
@@ -178,6 +181,10 @@ export default {
       };
 
       return kindClasses[this.kind];
+    },
+
+    toastListeners () {
+      return extractVueListeners(this.$attrs);
     },
   },
 };


### PR DESCRIPTION
# fix(toast): DP-154396 fix toast class and listeners vue3

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->

https://dialpad.atlassian.net/browse/DP-154396

## :book: Description

This fix the implementation of Toast component in vue3.
Previously class from the parent were not being passed correctly to our children component.
We wrap the listeners with our util `extractVueListeners` and add `$attrs.class` to the children class attribute.


With: 
<img width="248" height="58" alt="image" src="https://github.com/user-attachments/assets/1da88931-d8b9-42fd-8e25-a7f4ae59c6df" />


Before: 
<img width="418" height="176" alt="Screenshot 2025-08-26 at 4 18 49 PM" src="https://github.com/user-attachments/assets/b903eff9-9e5d-4ca8-b445-473301f7fd34" />


After:
<img width="418" height="176" alt="Screenshot 2025-08-26 at 4 18 04 PM" src="https://github.com/user-attachments/assets/3e5e5061-b2cd-4700-9e79-61557b6cbd68" />


## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

This comes from bug fixes on the effort to migrate vue2 to vue3.


## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

Deploy!