### PR TITLE
fix(avatar): DLT-2693 sanitize full name before extracting initials

### DIFF
--- a/packages/dialtone-vue2/components/avatar/avatar.test.js
+++ b/packages/dialtone-vue2/components/avatar/avatar.test.js
@@ -358,10 +358,11 @@ describe('DtAvatar Tests', () => {
     describe('When provided with names containing special characters', () => {
       it('should remove special characters and extract initials', () => {
         expect(extractInitialsFromName('John Doe (General Manager)')).toBe('JM');
+        expect(extractInitialsFromName('John Doe [Contractor]')).toBe('JC');
       });
 
       it('should handle names with numbers', () => {
-        expect(extractInitialsFromName('John Doe [Contractor]')).toBe('JC');
+        expect(extractInitialsFromName('John Doe 123')).toBe('J1');
       });
     });
 

--- a/packages/dialtone-vue2/components/avatar/avatar.test.js
+++ b/packages/dialtone-vue2/components/avatar/avatar.test.js
@@ -2,6 +2,7 @@ import { createLocalVue, mount } from '@vue/test-utils';
 import { DtIconUser } from '@dialpad/dialtone-icons/vue2';
 import DtAvatar from './avatar.vue';
 import { AVATAR_KIND_MODIFIERS, AVATAR_SIZE_MODIFIERS } from './avatar_constants';
+import { extractInitialsFromName } from './utils';
 
 const MOCK_AVATAR_STUB = vi.fn();
 const MOCK_IMAGE_SOURCE = 'image.png';
@@ -339,6 +340,40 @@ describe('DtAvatar Tests', () => {
         MOCK_ELEMENT = wrapper.find('[data-qa="dt-avatar"]');
 
         expect(wrapper.find('.my-custom-class').html()).toBe(MOCK_ELEMENT.html());
+      });
+    });
+  });
+
+  describe('extractInitialsFromName Utility Tests', () => {
+    describe('When provided with valid names', () => {
+      it('should extract initials from first and last name', () => {
+        expect(extractInitialsFromName('John Doe')).toBe('JD');
+      });
+
+      it('should extract initials from multiple names (first and last only)', () => {
+        expect(extractInitialsFromName('John Michael Doe')).toBe('JD');
+      });
+    });
+
+    describe('When provided with names containing special characters', () => {
+      it('should remove special characters and extract initials', () => {
+        expect(extractInitialsFromName('John Doe (General Manager)')).toBe('JM');
+      });
+
+      it('should handle names with numbers', () => {
+        expect(extractInitialsFromName('John Doe [Contractor]')).toBe('JC');
+      });
+    });
+
+    describe('When provided with international names', () => {
+      it('should handle Japanese kanji characters', () => {
+        expect(extractInitialsFromName('田中太郎')).toBe('田中');
+      });
+    });
+
+    describe('When provided with emojis', () => {
+      it('should remove emojis from names', () => {
+        expect(extractInitialsFromName('John Doe 😀')).toBe('JD');
       });
     });
   });

--- a/packages/dialtone-vue2/components/avatar/utils.js
+++ b/packages/dialtone-vue2/components/avatar/utils.js
@@ -1,6 +1,9 @@
 export const extractInitialsFromName = (fullName) => {
   if (typeof fullName !== 'string' || !fullName.trim()) return '';
 
+  // sanitize fullName by leaving only letters, numbers and spaces
+  fullName = fullName.replace(/[^\p{L}\p{N}\s]/gu, '');
+
   const names = fullName.trim().split(/\s+/g);
 
   return names.length === 1

--- a/packages/dialtone-vue3/components/avatar/avatar.test.js
+++ b/packages/dialtone-vue3/components/avatar/avatar.test.js
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils';
 import { DtIconUser } from '@dialpad/dialtone-icons/vue3';
 import DtAvatar from './avatar.vue';
 import { AVATAR_KIND_MODIFIERS, AVATAR_SIZE_MODIFIERS } from './avatar_constants';
+import { extractInitialsFromName } from './utils';
 
 const MOCK_AVATAR_STUB = vi.fn();
 const MOCK_IMAGE_SOURCE = 'image.png';
@@ -336,6 +337,40 @@ describe('DtAvatar Tests', () => {
         MOCK_ELEMENT = wrapper.find('[data-qa="dt-avatar"]');
 
         expect(wrapper.find('.my-custom-class').html()).toBe(MOCK_ELEMENT.html());
+      });
+    });
+  });
+
+  describe('extractInitialsFromName Utility Tests', () => {
+    describe('When provided with valid names', () => {
+      it('should extract initials from first and last name', () => {
+        expect(extractInitialsFromName('John Doe')).toBe('JD');
+      });
+
+      it('should extract initials from multiple names (first and last only)', () => {
+        expect(extractInitialsFromName('John Michael Doe')).toBe('JD');
+      });
+    });
+
+    describe('When provided with names containing special characters', () => {
+      it('should remove special characters and extract initials', () => {
+        expect(extractInitialsFromName('John Doe (General Manager)')).toBe('JM');
+      });
+
+      it('should handle names with numbers', () => {
+        expect(extractInitialsFromName('John Doe [Contractor]')).toBe('JC');
+      });
+    });
+
+    describe('When provided with international names', () => {
+      it('should handle Japanese kanji characters', () => {
+        expect(extractInitialsFromName('田中太郎')).toBe('田中');
+      });
+    });
+
+    describe('When provided with emojis', () => {
+      it('should remove emojis from names', () => {
+        expect(extractInitialsFromName('John Doe 😀')).toBe('JD');
       });
     });
   });

--- a/packages/dialtone-vue3/components/avatar/utils.js
+++ b/packages/dialtone-vue3/components/avatar/utils.js
@@ -1,6 +1,9 @@
 export const extractInitialsFromName = (fullName) => {
   if (typeof fullName !== 'string' || !fullName.trim()) return '';
 
+  // sanitize fullName by leaving only letters, numbers and spaces
+  fullName = fullName.replace(/[^\p{L}\p{N}\s]/gu, '');
+
   const names = fullName.trim().split(/\s+/g);
 
   return names.length === 1


### PR DESCRIPTION
# Avatar: sanitize full name before extracting initials

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3R6emEzNHhrZTRhOWN2bThzcm5kZTFycHZrMXdpdDYyemQ4NTRwbiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/NVUuyo5DYmBZLKMAvI/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
[DLT-2693]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Even though `fullName` is not supposed to have special characters, we want to prevent the avatar from showing them in the initials, to avoid cases like this one:
<img width="222" height="101" alt="image" src="https://github.com/user-attachments/assets/9a84e665-9670-4dac-88ee-98bb5d48faf7" />

The regex used will leave only letters (from any language) and numbers. 
<!--- Describe specifically what the changes are -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.



[DLT-2693]: https://dialpad.atlassian.net/browse/DLT-2693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ