### PR TITLE
fix(modal): DLT-2628 improve close button positioning

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/modal.less
+++ b/packages/dialtone-css/lib/build/less/components/modal.less
@@ -148,8 +148,8 @@
 //  ----------------------------------------------------------------------------
 .d-modal__close {
   position: absolute;
-  top: var(--dt-space-500); // 16
-  right: var(--dt-space-500); // 16
+  inset-block-start: var(--dt-space-400);
+  inset-inline-end: var(--dt-space-400);
   margin: 0 !important;
 }
 

--- a/packages/dialtone-vue2/components/modal/modal.vue
+++ b/packages/dialtone-vue2/components/modal/modal.vue
@@ -95,16 +95,16 @@
           v-else
           class="d-modal__close"
           data-qa="dt-modal-close-button"
-          circle
-          size="lg"
+          size="md"
+          kind="muted"
           importance="clear"
           :aria-label="closeButtonTitle"
           :title="closeButtonTitle"
           @click="close"
         >
-          <template #icon>
+          <template #icon="{ iconSize }">
             <dt-icon-close
-              size="400"
+              :size="iconSize"
             />
           </template>
         </dt-button>

--- a/packages/dialtone-vue3/components/modal/modal.vue
+++ b/packages/dialtone-vue3/components/modal/modal.vue
@@ -95,16 +95,16 @@
           v-else
           class="d-modal__close"
           data-qa="dt-modal-close-button"
-          circle
-          size="lg"
+          size="md"
+          kind="muted"
           importance="clear"
           :aria-label="closeButtonTitle"
           :title="closeButtonTitle"
           @click="close"
         >
-          <template #icon>
+          <template #icon="{ iconSize }">
             <dt-icon-close
-              size="400"
+              :size="iconSize"
             />
           </template>
         </dt-button>


### PR DESCRIPTION
# Improve close button positioning

https://github.com/user-attachments/assets/2bbe107e-689c-4733-9594-4f86cc71834f

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2628

## :book: Description

* Position closer to upper-right corner, reducing risk of collisions with varying modal contents.
* Changed button size from `lg` to `md`
* Changed button from `circle` type, as we're already incrementally reducing Circle Buttons throughout.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.