### PR TITLE
fix(emoji-row): NO-JIRA reaction label localization

### DIFF
--- a/packages/dialtone-vue2/localization/en-US.ftl
+++ b/packages/dialtone-vue2/localization/en-US.ftl
@@ -64,8 +64,14 @@ DIALTONE_EDITOR_ADD_LINK_BUTTON =
 
 DIALTONE_EMOJI_ROW_REACTION_LABEL =
   { $personCount ->
-    *[other] reacted with { $reaction }
-    [one] reacted with { $reaction }
+    *[other] { $youIncluded ->
+      *[true] reacted with { $reaction }
+      [false] reacted with { $reaction }
+    }
+    [one] { $youIncluded ->
+      *[true] reacted with { $reaction }
+      [false] reacted with { $reaction }
+    }
   }
 
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = Add emoji

--- a/packages/dialtone-vue2/localization/en-US.ftl
+++ b/packages/dialtone-vue2/localization/en-US.ftl
@@ -62,7 +62,11 @@ DIALTONE_EDITOR_ADD_LINK_BUTTON =
   .title = Add Link
   .aria-label = Input field to add link
 
-DIALTONE_EMOJI_ROW_REACTION_LABEL = reacted with { $reaction }
+DIALTONE_EMOJI_ROW_REACTION_LABEL =
+  { $personCount ->
+    *[other] reacted with { $reaction }
+    [one] reacted with { $reaction }
+  }
 
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = Add emoji
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = No results
@@ -171,3 +175,6 @@ STORYBOOK_LANGUAGE_PORTUGUESE = Portuguese
 STORYBOOK_LANGUAGE_RUSSIAN = Russian
 STORYBOOK_LANGUAGE_SPANISH = Spanish
 STORYBOOK_SET_LANGUAGE = Set language
+STORYBOOK_YOU = You
+STORYBOOK_REACTION_NAMES_2 = Olivia Chen, Benjamin Carter, Sophia Rodriguez, William Kim & Isabella Garcia
+STORYBOOK_REACTION_NAMES_3 = Olivia Chen & { STORYBOOK_YOU }

--- a/packages/dialtone-vue2/localization/es-LA.ftl
+++ b/packages/dialtone-vue2/localization/es-LA.ftl
@@ -55,7 +55,11 @@ DIALTONE_EDITOR_LINK_BUTTON_LABEL = Enlace
 DIALTONE_EDITOR_ADD_LINK_BUTTON =
     .title = Agregar enlace
     .aria-label = Campo de entrada para agregar enlace
-DIALTONE_EMOJI_ROW_REACTION_LABEL = { $names } reaccionó con { $reaction }
+DIALTONE_EMOJI_ROW_REACTION_LABEL =
+  { $personCount ->
+    *[other] reaccionaron con { $reaction }
+    [one] reaccionó con { $reaction }
+  }
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = Agregar emoji
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = No hay resultados
 DIALTONE_EMOJI_PICKER_SEARCH_RESULTS_LABEL = resultados de búsqueda
@@ -153,3 +157,6 @@ STORYBOOK_LANGUAGE_PORTUGUESE = Portugués
 STORYBOOK_LANGUAGE_RUSSIAN = Ruso
 STORYBOOK_LANGUAGE_SPANISH = Español
 STORYBOOK_SET_LANGUAGE = Establecer idioma
+STORYBOOK_YOU = Usted
+STORYBOOK_REACTION_NAMES_2 = Olivia Chen, Benjamin Carter, Sophia Rodriguez, William Kim e Isabella Garcia
+STORYBOOK_REACTION_NAMES_3 = Olivia Chen y { STORYBOOK_YOU }

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.stories.js
@@ -2,6 +2,8 @@ import { action } from '@storybook/addon-actions';
 import { createRenderConfig } from '@/common/storybook_utils';
 import DtRecipeEmojiRow from './emoji_row.vue';
 import DtRecipeEmojiRowDefaultTemplate from './emoji_row_default.story.vue';
+import { DialtoneLocalization } from '@/localization/index.js';
+const i18n = new DialtoneLocalization();
 
 // Default Prop Values
 export const argsData = {
@@ -13,7 +15,7 @@ export const sharedEmojiReactionsData = [
   {
     emojiUnicodeOrShortname: '😀',
     isSelected: true,
-    names: 'You',
+    names: i18n.$t('STORYBOOK_YOU'),
     num: 1,
   },
   {
@@ -25,12 +27,12 @@ export const sharedEmojiReactionsData = [
   {
     emojiUnicodeOrShortname: '😌',
     isSelected: false,
-    names: 'Olivia Chen, Benjamin Carter, Sophia Rodriguez, William Kim & Isabella Garcia',
+    names: i18n.$t('STORYBOOK_REACTION_NAMES_2'),
     num: 5,
   },
   {
     emojiUnicodeOrShortname: ':blinkingguy:',
-    names: 'You & John Doe',
+    names: i18n.$t('STORYBOOK_REACTION_NAMES_3'),
     isSelected: true,
     num: 2,
   },

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -115,6 +115,7 @@ export default {
     reactionLabel (reaction) {
       return this.i18n.$t('DIALTONE_EMOJI_ROW_REACTION_LABEL', {
         reaction: getEmojiShortCode(reaction.emojiUnicodeOrShortname),
+        personCount: reaction.num,
       });
     },
   },

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -116,6 +116,7 @@ export default {
       return this.i18n.$t('DIALTONE_EMOJI_ROW_REACTION_LABEL', {
         reaction: getEmojiShortCode(reaction.emojiUnicodeOrShortname),
         personCount: reaction.num,
+        youIncluded: reaction.isSelected,
       });
     },
   },

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.stories.js
@@ -2,6 +2,8 @@ import { action } from '@storybook/addon-actions';
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import DtRecipeEmojiRow from './emoji_row.vue';
 import DtRecipeEmojiRowDefaultTemplate from './emoji_row_default.story.vue';
+import { DialtoneLocalization } from '@/localization/index.js';
+const i18n = new DialtoneLocalization();
 
 // Default Prop Values
 export const argsData = {
@@ -13,7 +15,7 @@ export const sharedEmojiReactionsData = [
   {
     emojiUnicodeOrShortname: '😀',
     isSelected: true,
-    names: 'You',
+    names: i18n.$t('STORYBOOK_YOU'),
     num: 1,
   },
   {
@@ -25,12 +27,12 @@ export const sharedEmojiReactionsData = [
   {
     emojiUnicodeOrShortname: '😌',
     isSelected: false,
-    names: 'Olivia Chen, Benjamin Carter, Sophia Rodriguez, William Kim & Isabella Garcia',
+    names: i18n.$t('STORYBOOK_REACTION_NAMES_2'),
     num: 5,
   },
   {
     emojiUnicodeOrShortname: ':blinkingguy:',
-    names: 'You & John Doe',
+    names: i18n.$t('STORYBOOK_REACTION_NAMES_3'),
     isSelected: true,
     num: 2,
   },

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -117,6 +117,7 @@ export default {
       return this.i18n.$t('DIALTONE_EMOJI_ROW_REACTION_LABEL', {
         reaction: getEmojiShortCode(reaction.emojiUnicodeOrShortname),
         personCount: reaction.num,
+        youIncluded: reaction.isSelected,
       });
     },
   },

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -116,6 +116,7 @@ export default {
     reactionLabel (reaction) {
       return this.i18n.$t('DIALTONE_EMOJI_ROW_REACTION_LABEL', {
         reaction: getEmojiShortCode(reaction.emojiUnicodeOrShortname),
+        personCount: reaction.num,
       });
     },
   },


### PR DESCRIPTION
# Fix reaction label

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMTE3dnNwa3VmYzVrZGc5czV3YjB3Z2RtNnM3Yzh6Nmdqc3Y1dWt2bSZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/3o6Ztr9s7vPAS8XtK0/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Description

Added `personCount` and `youIncluded` to DIALTONE_EMOJI_ROW_REACTION_LABEL string to be able to handle the translation of one or many people reacting correctly.

## :bulb: Context

Issues reported on Smartling related to emoji_row string localization, it was not possible to translate correctly because it depends on the number of reactions (1 or many)

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.