### PR TITLE
fix(dropdown): DP-154779 emit close event properly

### DIFF
--- a/packages/dialtone-vue3/components/dropdown/dropdown.test.js
+++ b/packages/dialtone-vue3/components/dropdown/dropdown.test.js
@@ -1,8 +1,10 @@
 import { config, mount } from '@vue/test-utils';
 import DtDropdown from './dropdown.vue';
 import SrOnlyCloseButton from '@/common/sr_only_close_button.vue';
+import { DtPopover } from '@/components/popover';
 
 const MOCK_HIGHLIGHT_STUB = vi.fn();
+const MOCK_UPDATE_OPEN_STUB = vi.fn();
 
 const baseProps = {
   open: true,
@@ -137,6 +139,15 @@ describe('DtDropdown Tests', () => {
       it('should emit highlight event', () => {
         expect(wrapper.emitted().highlight.length).toBe(1);
       });
+    });
+
+    it('should pass listeners to the popover', async () => {
+      mockAttrs = { 'onUpdate:open': MOCK_UPDATE_OPEN_STUB };
+      updateWrapper();
+
+      await wrapper.findComponent(DtPopover).vm.$emit('update:open', false);
+
+      expect(MOCK_UPDATE_OPEN_STUB).toHaveBeenCalledWith(false);
     });
 
     describe('When mouseleave is detected on the list wrapper', () => {

--- a/packages/dialtone-vue3/components/dropdown/dropdown.test.js
+++ b/packages/dialtone-vue3/components/dropdown/dropdown.test.js
@@ -122,7 +122,7 @@ describe('DtDropdown Tests', () => {
 
   describe('Interactivity Tests', () => {
     beforeEach(() => {
-      mockAttrs = { onHighlight: MOCK_HIGHLIGHT_STUB };
+      mockAttrs = { onHighlight: MOCK_HIGHLIGHT_STUB, 'onUpdate:open': MOCK_UPDATE_OPEN_STUB };
 
       updateWrapper();
     });
@@ -142,9 +142,6 @@ describe('DtDropdown Tests', () => {
     });
 
     it('should pass listeners to the popover', async () => {
-      mockAttrs = { 'onUpdate:open': MOCK_UPDATE_OPEN_STUB };
-      updateWrapper();
-
       await wrapper.findComponent(DtPopover).vm.$emit('update:open', false);
 
       expect(MOCK_UPDATE_OPEN_STUB).toHaveBeenCalledWith(false);

--- a/packages/dialtone-vue3/components/dropdown/dropdown.vue
+++ b/packages/dialtone-vue3/components/dropdown/dropdown.vue
@@ -63,7 +63,6 @@ import { LIST_ITEM_NAVIGATION_TYPES } from '@/components/list_item';
 import { DROPDOWN_PADDING_CLASSES } from './dropdown_constants';
 import { getUniqueString } from '@/common/utils';
 import { EVENT_KEYNAMES } from '@/common/constants';
-import { extractVueListeners } from "@/common/utils";
 
 export default {
   compatConfig: { MODE: 3 },
@@ -305,7 +304,6 @@ export default {
      * Event fired to sync the open prop with the parent component
      * @event update:open
      */
-    'update:open',
   ],
 
   data () {
@@ -320,14 +318,13 @@ export default {
 
   computed: {
 
-    popoverListeners () {
-      return extractVueListeners(this.$attrs);
-    },
 
     dropdownListeners () {
       return {
 
-        ...this.popoverListeners,
+        'update:open': value => {
+          this.$emit('update:open', value);
+        },
 
         opened: isPopoverOpen => {
           this.updateInitialHighlightIndex(isPopoverOpen);

--- a/packages/dialtone-vue3/components/dropdown/dropdown.vue
+++ b/packages/dialtone-vue3/components/dropdown/dropdown.vue
@@ -299,11 +299,6 @@ export default {
      * @type {Boolean | Array}
      */
     'opened',
-
-    /**
-     * Event fired to sync the open prop with the parent component
-     * @event update:open
-     */
   ],
 
   data () {

--- a/packages/dialtone-vue3/components/dropdown/dropdown.vue
+++ b/packages/dialtone-vue3/components/dropdown/dropdown.vue
@@ -317,8 +317,6 @@ export default {
   },
 
   computed: {
-
-
     dropdownListeners () {
       return {
 

--- a/packages/dialtone-vue3/components/dropdown/dropdown.vue
+++ b/packages/dialtone-vue3/components/dropdown/dropdown.vue
@@ -63,6 +63,7 @@ import { LIST_ITEM_NAVIGATION_TYPES } from '@/components/list_item';
 import { DROPDOWN_PADDING_CLASSES } from './dropdown_constants';
 import { getUniqueString } from '@/common/utils';
 import { EVENT_KEYNAMES } from '@/common/constants';
+import { extractVueListeners } from "@/common/utils";
 
 export default {
   compatConfig: { MODE: 3 },
@@ -318,8 +319,16 @@ export default {
   },
 
   computed: {
+
+    popoverListeners () {
+      return extractVueListeners(this.$attrs);
+    },
+
     dropdownListeners () {
       return {
+
+        ...this.popoverListeners,
+
         opened: isPopoverOpen => {
           this.updateInitialHighlightIndex(isPopoverOpen);
         },


### PR DESCRIPTION
# Emit close event properly for vue3 dropdown 

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2xnZzE0d3RseDQ5N3ppaGx5eXVuODEyZzFzcWJ2ajgwNHhobm1vayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/oosqY3FwE0aVcehzi8/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

[<!--- Enter the URL of the Jira ticket associated with this PR -->](https://dialpad.atlassian.net/browse/DP-154779)

## :book: Description

Using the util to extract listeners from attr so that we emit the `update:open` event properly. 
 
## :bulb: Context

In Vue2, we were using this.$listeners, which no longer works in Vue3 because listeners are part of attrs and need to be extracted.

This causes issues where the opened prop remains `true` even when the popover is closed. 

> [!NOTE]
>  I wanted to use `extractVueListeners`, like in https://github.com/dialpad/dialtone/pull/883 but since we have the `update:open` as part of our emitted events. Vue removes it from the `attrs` object and thus it returns empty. So I needed to explicitly add the `update:open` listener instead


## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [X] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [X] I have reviewed my changes.
- [] I have added all relevant documentation.
- [X] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

