### PR TITLE
fix(loader): DLT-2754 loader container size and alignment

### DIFF
--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -380,100 +380,6 @@ vueCode='
 '
 showHtmlWarning />
 
-## Loading
-
-Loading buttons are useful for communicating a delay between the button interaction and its action taking place. Every button style can accept the loading button class, though we only provide a few possible examples.
-
-<code-well-header>
-  <dt-stack
-    gap="600"
-    :direction="{ 'default': 'column', 'md': 'row' }"
-  >
-    <dt-stack direction="row" gap="400">
-      <dt-button loading> Place Call </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" loading>
-        <template #icon>
-          <dt-icon
-            name="phone"
-            size="300"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" circle loading>
-        <template #icon>
-          <dt-icon
-            name="phone"
-            size="300"
-          />
-        </template>
-      </dt-button>
-    </dt-stack>
-    <dt-stack direction="row" gap="400">
-      <dt-button kind="muted" importance="outlined" loading> Place Call </dt-button>
-      <dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" loading>
-        <template #icon>
-          <dt-icon
-            name="phone"
-            size="300"
-          />
-        </template>
-      </dt-button>
-      <dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" circle loading>
-        <template #icon>
-          <dt-icon
-            name="phone"
-            size="300"
-          />
-        </template>
-      </dt-button>
-    </dt-stack>
-  </dt-stack>
-</code-well-header>
-
-<code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--loading d-btn--primary" type="button"><span class="d-btn__label">Place Call</span></button>
-<button class="d-btn d-btn--loading d-btn--outlined" type="button"><span class="d-btn__label">Place Call</span></button>
-<button class="d-btn d-btn--danger d-btn--loading" type="button"><span class="d-btn__label">Place Call</span></button>
-'
-vueCode='
-<dt-button loading> Place Call </dt-button>
-<dt-button v-dt-tooltip="`Tooltip`" loading>
-  <template #icon>
-    <dt-icon
-      name="phone"
-      size="300"
-    />
-  </template>
-</dt-button>
-<dt-button v-dt-tooltip="`Tooltip`" circle loading>
-  <template #icon>
-    <dt-icon
-      name="phone"
-      size="300"
-    />
-  </template>
-</dt-button>
-<dt-button kind="muted" importance="outlined" loading> Place Call </dt-button>
-<dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" loading>
-  <template #icon>
-    <dt-icon
-      name="phone"
-      size="300"
-    />
-  </template>
-</dt-button>
-<dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" circle loading>
-  <template #icon>
-    <dt-icon
-      name="phone"
-      size="300"
-    />
-  </template>
-</dt-button>
-'
-showHtmlWarning />
-
 ## Icon Support
 
 ### Icon and Label
@@ -1043,6 +949,183 @@ vueCode='
       name="phone"
       size="300"
     />
+  </template>
+</dt-button>
+'
+showHtmlWarning />
+
+## Loading
+
+Loading buttons are useful for communicating a delay between the button interaction and its action taking place. Every button style can accept the loading button class, though we only provide a few possible examples.
+
+### Replace button label
+
+The width of the button remains determined by the length of the label, which is visually hidden in this state.
+
+<code-well-header>
+  <dt-stack
+    gap="600"
+    :direction="{ 'default': 'column', 'md': 'row' }"
+  >
+    <dt-stack direction="row" gap="400">
+      <dt-button loading> Place Call </dt-button>
+      <dt-button v-dt-tooltip="`Tooltip`" loading>
+        <template #icon>
+          <dt-icon
+            name="phone"
+            size="300"
+          />
+        </template>
+      </dt-button>
+      <dt-button v-dt-tooltip="`Tooltip`" circle loading>
+        <template #icon>
+          <dt-icon
+            name="phone"
+            size="300"
+          />
+        </template>
+      </dt-button>
+    </dt-stack>
+    <dt-stack direction="row" gap="400">
+      <dt-button kind="muted" importance="outlined" loading> Place Call </dt-button>
+      <dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" loading>
+        <template #icon>
+          <dt-icon
+            name="phone"
+            size="300"
+          />
+        </template>
+      </dt-button>
+      <dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" circle loading>
+        <template #icon>
+          <dt-icon
+            name="phone"
+            size="300"
+          />
+        </template>
+      </dt-button>
+    </dt-stack>
+  </dt-stack>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<button class="d-btn d-btn--loading d-btn--primary" type="button"><span class="d-btn__label">Place Call</span></button>
+<button class="d-btn d-btn--loading d-btn--outlined" type="button"><span class="d-btn__label">Place Call</span></button>
+<button class="d-btn d-btn--danger d-btn--loading" type="button"><span class="d-btn__label">Place Call</span></button>
+'
+vueCode='
+<dt-button loading> Place Call </dt-button>
+<dt-button v-dt-tooltip="`Tooltip`" loading>
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+    />
+  </template>
+</dt-button>
+<dt-button v-dt-tooltip="`Tooltip`" circle loading>
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+    />
+  </template>
+</dt-button>
+<dt-button kind="muted" importance="outlined" loading> Place Call </dt-button>
+<dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" loading>
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+    />
+  </template>
+</dt-button>
+<dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" circle loading>
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="300"
+    />
+  </template>
+</dt-button>
+'
+showHtmlWarning />
+
+### With label
+
+<code-well-header>
+  <dt-stack
+    gap="400"
+    direction="row"
+  >
+  <dt-button
+    icon-position="right"
+    size="xs"
+  >
+    Validating
+    <template #icon="{ iconSize }">
+      <dt-loader
+        :size="iconSize"
+      />
+    </template>
+  </dt-button>
+  <dt-button
+    icon-position="right"
+    size="sm"
+  >
+    Validating
+    <template #icon="{ iconSize }">
+      <dt-loader
+        :size="iconSize"
+      />
+    </template>
+  </dt-button>
+  <dt-button
+    icon-position="right"
+    size="md"
+  >
+    Validating
+    <template #icon="{ iconSize }">
+      <dt-loader
+        :size="iconSize"
+      />
+    </template>
+  </dt-button>
+  <dt-button
+    icon-position="right"
+    size="lg"
+  >
+    Validating
+    <template #icon="{ iconSize }">
+      <dt-loader
+        :size="iconSize"
+      />
+    </template>
+  </dt-button>
+</dt-stack>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<button class="d-btn d-btn--primary d-btn--sm" type="button">
+  <span class="d-btn__icon d-btn__icon--right">
+    <div class="d-loader" aria-label="loading">
+      <svg class="d-icon--size-200 d-icon d-icon--loading d-loader__icon" ...>
+        ...
+      </svg>
+    </div>
+  </span>
+  <span class="d-btn__label">
+    Validating
+  </span>
+</button>
+'
+vueCode='
+<dt-button icon-position="right">
+  Validating
+  <template #icon="{ iconSize }">
+    <dt-loader :size="iconSize" />
   </template>
 </dt-button>
 '

--- a/apps/dialtone-documentation/docs/components/loader.md
+++ b/apps/dialtone-documentation/docs/components/loader.md
@@ -21,7 +21,7 @@ The base loader should be the go-to loader for most of your needs. When in doubt
 <code-example-tabs
 htmlCode='
 <div aria-label="loading" class="d-loader" size="500">
-  <svg class="d-icon d-icon--loading d-loader-icon d-icon--size-500">...</svg>
+  <svg class="d-icon d-loader__icon d-icon--size-500">...</svg>
 </div>
 '
 vueCode='
@@ -52,28 +52,28 @@ The base loader size is 24px and should be used in most cases.
 <code-example-tabs
 htmlCode='
 <div aria-label="loading" class="d-loader" size="100">
-  <svg class="d-icon d-icon--loading d-loader-icon d-icon--size-100">...</svg>
+  <svg class="d-icon d-loader__icon d-icon--size-100">...</svg>
 </div>
 <div aria-label="loading" class="d-loader" size="200">
-  <svg class="d-icon d-icon--loading d-loader-icon d-icon--size-200">...</svg>
+  <svg class="d-icon d-loader__icon d-icon--size-200">...</svg>
 </div>
 <div aria-label="loading" class="d-loader" size="300">
-  <svg class="d-icon d-icon--loading d-loader-icon d-icon--size-300">...</svg>
+  <svg class="d-icon d-loader__icon d-icon--size-300">...</svg>
 </div>
 <div aria-label="loading" class="d-loader" size="400">
-  <svg class="d-icon d-icon--loading d-loader-icon d-icon--size-400">...</svg>
+  <svg class="d-icon d-loader__icon d-icon--size-400">...</svg>
 </div>
 <div aria-label="loading" class="d-loader" size="500">
-  <svg class="d-icon d-icon--loading d-loader-icon d-icon--size-500">...</svg>
+  <svg class="d-icon d-loader__icon d-icon--size-500">...</svg>
 </div>
 <div aria-label="loading" class="d-loader" size="600">
-  <svg class="d-icon d-icon--loading d-loader-icon d-icon--size-600">...</svg>
+  <svg class="d-icon d-loader__icon d-icon--size-600">...</svg>
 </div>
 <div aria-label="loading" class="d-loader" size="700">
-  <svg class="d-icon d-icon--loading d-loader-icon d-icon--size-700">...</svg>
+  <svg class="d-icon d-loader__icon d-icon--size-700">...</svg>
 </div>
 <div aria-label="loading" class="d-loader" size="800">
-  <svg class="d-icon d-icon--loading d-loader-icon d-icon--size-800">...</svg>
+  <svg class="d-icon d-loader__icon d-icon--size-800">...</svg>
 </div>
 '
 vueCode='

--- a/packages/dialtone-css/lib/build/less/components/loader.less
+++ b/packages/dialtone-css/lib/build/less/components/loader.less
@@ -12,6 +12,10 @@
 //  ============================================================================
 //  $   DEFAULT LOADER
 //  ----------------------------------------------------------------------------
-.d-loader-icon {
+.d-loader {
+  display: inline-flex;
+}
+
+.d-loader__icon {
   animation: d-loading-circle 900ms infinite linear;
 }

--- a/packages/dialtone-vue2/components/loader/loader.vue
+++ b/packages/dialtone-vue2/components/loader/loader.vue
@@ -5,7 +5,7 @@
     data-qa="dt-loader"
   >
     <dt-icon-loading
-      class="d-loader-icon"
+      class="d-loader__icon"
       data-qa="dt-loader-icon"
       :size="size"
     />

--- a/packages/dialtone-vue3/components/loader/loader.vue
+++ b/packages/dialtone-vue3/components/loader/loader.vue
@@ -6,7 +6,7 @@
   >
     <!-- Localize the aria-label -->
     <dt-icon-loading
-      class="d-loader-icon"
+      class="d-loader__icon"
       data-qa="dt-loader-icon"
       :size="size"
     />


### PR DESCRIPTION
# DLT-2754 loader container size and alignment

![aligned](https://github.com/user-attachments/assets/5d9ef20c-70d3-4ec2-a5cc-8cc3ea049f18)

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2754

## :book: Description

Parent container of loader component needs to shrink to the size of the loader icon. 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.


## :camera: Screenshots / GIFs


https://github.com/user-attachments/assets/7e78c1e7-081f-4a0d-acb6-786f95e31f08

