### PR TITLE
fix(split-button): DLT-2746 dropdown not working

### DIFF
--- a/packages/dialtone-vue2/components/split_button/split_button.vue
+++ b/packages/dialtone-vue2/components/split_button/split_button.vue
@@ -22,7 +22,7 @@
     <!-- @slot Omega (right) content slot, overrides omega button styling and functionality completely -->
     <slot name="omega">
       <dt-dropdown
-        v-if="$slots.dropdownList"
+        v-if="dropdownSlotIsSet"
         :placement="dropdownPlacement"
         @click="isDropdownOpen = true"
         @opened="open => isDropdownOpen = open"
@@ -50,7 +50,6 @@
           />
         </template>
       </dt-dropdown>
-
       <split-button-omega
         v-else
         v-bind="omegaButtonProps"
@@ -317,6 +316,10 @@ export default {
 
     omegaSlotIsSet () {
       return this.$scopedSlots.omega && this.$scopedSlots.omega();
+    },
+
+    dropdownSlotIsSet () {
+      return this.$scopedSlots.dropdownList && this.$scopedSlots.dropdownList();
     },
   },
 


### PR DESCRIPTION
# Fix split button omega button dropdown (Vue 2 only)

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3czlrenlsMmN3NWNoemU2bTY5dGQwN2E2YjYzcWV4bjk0ZTBheXNtdCZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/1QffP8E6nk4gKYZO5S/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2746

## :book: Description

- Added `scopedSlots` validation instead of just `slots`

## :bulb: Context

- In Vue 2 there are two different objects: `slots` and `scopedSlots` which have different content depending on the kind of slot.
- It is working correctly on vue 3.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :link: Sources

https://v3-migration.vuejs.org/breaking-changes/slots-unification