### PR TITLE
fix(presence): DLT-2755 correct offline's border / background colors

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExamplePresence.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExamplePresence.vue
@@ -1,18 +1,14 @@
 <template>
-  <div class="d-recipe-leftbar-row d-recipe-leftbar-row__primary">
+  <div class="d-presence">
     <div
-      class="d-presence"
-    >
-      <div
-        class="d-presence__inner"
-        :class="{
-          'd-presence__inner--active': presence === 'active',
-          'd-presence__inner--away': presence === 'away',
-          'd-presence__inner--busy': presence === 'busy',
-          'd-presence__inner--offline': presence === 'offline',
-        }"
-      />
-    </div>
+      class="d-presence__inner"
+      :class="{
+        'd-presence__inner--active': presence === 'active',
+        'd-presence__inner--away': presence === 'away',
+        'd-presence__inner--busy': presence === 'busy',
+        'd-presence__inner--offline': presence === 'offline',
+      }"
+    />
   </div>
 </template>
 

--- a/apps/dialtone-documentation/docs/components/presence.md
+++ b/apps/dialtone-documentation/docs/components/presence.md
@@ -8,7 +8,12 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-presence--de
 figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Library--Rebrand-2025-?node-id=9628-58458
 ---
 <code-well-header>
-  <example-presence presence="active"/>
+  <dt-stack direction="row" gap="500">
+    <example-presence presence="active"/>
+    <example-presence presence="away"/>
+    <example-presence presence="busy"/>
+    <example-presence presence="offline"/>
+  </dt-stack>
 </code-well-header>
 
 ## Usage
@@ -21,19 +26,13 @@ Located at the bottom right of an avatar, the `presence` indicator displays a us
 
 When a user is available.
 <code-well-header>
-  <example-presence presence="active"/>
+  <example-presence presence="active" ref="activeExample"/>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<div class="d-presence">
-  <div class="d-presence__inner d-presence__inner--active"></div>
-</div>
-'
+:htmlCode='() => $refs.activeExample'
 vueCode='
-<dt-presence
-  presence="active"
-/>
+<dt-presence presence="active"  />
 '
 showHtmlWarning />
 
@@ -41,19 +40,13 @@ showHtmlWarning />
 
 When a user is unavailable, either due to being **'On a call'**, **'In a meeting'**, or set to **'DND (Do Not Disturb)'**. Additionally, a text label indicating their specific status will appear under the user's name.
 <code-well-header>
-  <example-presence presence="busy"/>
+  <example-presence presence="busy" ref="busyExample"/>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<div class="d-presence">
-  <div class="d-presence__inner d-presence__inner--busy"></div>
-</div>
-'
+:htmlCode='() => $refs.busyExample'
 vueCode='
-<dt-presence
-  presence="busy"
-/>
+<dt-presence presence="busy" />
 '
 showHtmlWarning />
 
@@ -61,19 +54,13 @@ showHtmlWarning />
 
 When a user has a scheduled meeting on their synced calendar (Google G Suite or Microsoft Office 365) and is not actively participating in it through the app. Additionally, **'In a meeting'** will appear under the user's name.
 <code-well-header>
-  <example-presence presence="away"/>
+  <example-presence presence="away" ref="awayExample"/>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<div class="d-presence">
-  <div class="d-presence__inner d-presence__inner--away"></div>
-</div>
-'
+:htmlCode='() => $refs.awayExample'
 vueCode='
-<dt-presence
-  presence="away"
-/>
+<dt-presence presence="away" />
 '
 showHtmlWarning />
 
@@ -81,19 +68,13 @@ showHtmlWarning />
 
 When a user has not logged in for their first time.
 <code-well-header>
-  <example-presence presence="offline"/>
+  <example-presence presence="offline" ref="offlineExample"/>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<div class="d-presence">
-  <div class="d-presence__inner d-presence__inner--offline"></div>
-</div>
-'
+:htmlCode='() => $refs.offlineExample'
 vueCode='
-<dt-presence
-  presence="offline"
-/>
+<dt-presence presence="offline" />
 '
 showHtmlWarning />
 

--- a/packages/dialtone-css/lib/build/less/components/presence.less
+++ b/packages/dialtone-css/lib/build/less/components/presence.less
@@ -7,13 +7,13 @@
 //  visit https://dialtone.dialpad.com/components/presence
 
 .d-presence {
-  --presence-color-border-base: var(--dt-shell-color-surface-default);
-  --presence-color-border-offline: var(--dt-color-border-bold);
-  --presence-color-background-active: var(--dt-shell-presence-color-available);
-  --presence-color-background-busy: var(--dt-shell-presence-color-unavailable);
-  --presence-color-background-away: var(--dt-shell-presence-color-busy);
-  --presence-color-background-offline: var(--dt-shell-presence-color-offline);
-  --presence-border-size: var(--dt-size-200);
+  --presence-color-border-base: var(--dt-color-surface-secondary); // Probably won't be necessary after @jeverhart-dialpad's DLT-2665 PR
+  --presence-color-border-offline: var(--dt-presence-color-offline);
+  --presence-color-background-active: var(--dt-presence-color-available);
+  --presence-color-background-busy: var(--dt-presence-color-unavailable);
+  --presence-color-background-away: var(--dt-presence-color-busy);
+  --presence-color-background-offline: var(--dt-color-surface-primary);
+  --presence-border-size: var(--dt-size-border-200);
   --presence-size: var(--dt-size-400);
 
   display: inline-block;
@@ -24,7 +24,7 @@
   border-radius: var(--dt-size-radius-circle);
 
   .d-recipe-leftbar-row--selected & {
-    --presence-color-border-base: var(--dt-shell-color-surface-default);
+    --presence-color-border-base: var(--dt-color-surface-secondary);
   }
 
   .d-recipe-leftbar-row__primary:hover & {
@@ -33,8 +33,8 @@
 
   &__inner {
     box-sizing: border-box;
-    width: var(--presence-size);
-    height: var(--presence-size);
+    inline-size: var(--presence-size);
+    block-size: var(--presence-size);
     border: none;
     border-radius: 50%;
 
@@ -54,7 +54,7 @@
       background-color: var(--presence-color-background-offline);
       border-color: var(--presence-color-border-offline);
       border-style: solid;
-      border-width: var(--dt-size-200);
+      border-width: var(--dt-size-border-200);
     }
   }
 }

--- a/packages/dialtone-css/lib/build/less/recipes/leftbar_row.less
+++ b/packages/dialtone-css/lib/build/less/recipes/leftbar_row.less
@@ -23,6 +23,14 @@
   --leftbar-row-action-width: var(--dt-size-550);
   --leftbar-row-action-height: var(--leftbar-row-action-width);
 
+  .d-presence {
+    // Presence colors in shell have specific tokens
+    --presence-color-border-offline: var(--dt-shell-presence-color-offline);
+    --presence-color-background-active: var(--dt-shell-presence-color-available);
+    --presence-color-background-busy: var(--dt-shell-presence-color-unavailable);
+    --presence-color-background-away: var(--dt-shell-presence-color-busy);
+  }
+
   //  ============================================================================
   //  $   BASE STYLE
   //  ----------------------------------------------------------------------------
@@ -62,10 +70,12 @@
     --leftbar-row-color-background: var(--dt-shell-action-color-background-primary-hover);
 
     .d-presence {
+      // TODO: Remove this once @jeverhart-dialpad's DLT-2665 PR
       --presence-color-border-base: var(--dt-color-black-200);
     }
 
     .d-avatar__count {
+      // TODO: Remove this once @jeverhart-dialpad's DLT-2665 PR
       --avatar-count-color-shadow: var(--dt-shell-action-color-background-primary-selected);
     }
   }
@@ -180,7 +190,7 @@
   // </div>
   //
 
-    // Style overrides for leftbar button icon and background, using the shell tokens for theming
+  // Style overrides for leftbar button icon and background, using the shell tokens for theming
   .d-btn--inverted.d-btn--primary {
     --button-color-text: var(--dt-shell-mention-color-surface-primary);
   }
@@ -255,8 +265,6 @@
     flex: 0 1;
     min-width: 0;
   }
-
-
 
   &__omega {
     position: absolute;


### PR DESCRIPTION
# DLT-2755 correct offline's border / background colors

![the-shell-knows-all-theshellknowsall](https://github.com/user-attachments/assets/ab2df86e-f1f9-4931-9e6e-c1534438d8b6)

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2755

## :book: Description

* Correct Presence design tokens for `offline` variant
* Correct presence design tokens between its default and when in the shell (app wrapper).

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

## Screenshot

<img width="1142" height="580" alt="image" src="https://github.com/user-attachments/assets/03d65c18-1ad3-4f7e-9bc1-9a8615f54c27" />
