### PR TITLE
fix(tokens): DLT-2766 sunflower dark and correct shell base references

### DIFF
--- a/packages/dialtone-tokens/tokens/$themes.json
+++ b/packages/dialtone-tokens/tokens/$themes.json
@@ -4187,7 +4187,9 @@
       "theme/dp/default": "enabled",
       "theme/dp/dark": "enabled",
       "theme/sunflower/default": "enabled",
-      "theme/sunflower/dark": "enabled"
+      "theme/sunflower/dark": "enabled",
+      "base/dark": "source",
+      "components/presence/dark": "enabled"
     },
     "$figmaVariableReferences": {},
     "group": "sunflower"

--- a/packages/dialtone-tokens/tokens/base/dark.json
+++ b/packages/dialtone-tokens/tokens/base/dark.json
@@ -710,7 +710,7 @@
           "y": "{size.200}",
           "blur": "{size.400}",
           "spread": "{size.0}",
-          "color": "#0000008c",
+          "color": "#0000008C",
           "type": "dropShadow"
         },
         {
@@ -755,7 +755,7 @@
           "y": "{size.200}",
           "blur": "{size.500}",
           "spread": "{size.0}",
-          "color": "#0000008c",
+          "color": "#0000008C",
           "type": "dropShadow"
         },
         {
@@ -800,7 +800,7 @@
           "y": "{size.200}",
           "blur": "{size.600}",
           "spread": "{size.0}",
-          "color": "#0000008c",
+          "color": "#0000008C",
           "type": "dropShadow"
         },
         {

--- a/packages/dialtone-tokens/tokens/base/default.json
+++ b/packages/dialtone-tokens/tokens/base/default.json
@@ -2,7 +2,7 @@
   "color": {
     "neutral": {
       "white": {
-        "value": "#ffffff",
+        "value": "#FFFFFF",
         "type": "color",
         "description": "White color independent of any theme."
       },
@@ -19,7 +19,7 @@
     },
     "black": {
       "50": {
-        "value": "#ffffff",
+        "value": "#FFFFFF",
         "type": "color"
       },
       "100": {
@@ -69,7 +69,7 @@
     },
     "purple": {
       "50": {
-        "value": "#f9f6ff",
+        "value": "#F9F6FF",
         "type": "color"
       },
       "100": {
@@ -119,7 +119,7 @@
     },
     "blue": {
       "50": {
-        "value": "#f5f9fd",
+        "value": "#F5F9FD",
         "type": "color"
       },
       "100": {
@@ -219,7 +219,7 @@
     },
     "gold": {
       "50": {
-        "value": "#fffae5",
+        "value": "#FFFAE5",
         "type": "color"
       },
       "100": {
@@ -269,7 +269,7 @@
     },
     "green": {
       "50": {
-        "value": "#f6fcf5",
+        "value": "#F6FCF5",
         "type": "color"
       },
       "100": {
@@ -691,7 +691,7 @@
         "description": "Typically used as an accent color."
       },
       "red": {
-        "value": "#ff1356",
+        "value": "#FF1356",
         "type": "color",
         "description": "Typically used as an accent color."
       },
@@ -899,7 +899,7 @@
           "y": "{size.200}",
           "blur": "{size.500}",
           "spread": "{size.0}",
-          "color": "#0000004d",
+          "color": "#0000004D",
           "type": "dropShadow"
         }
       ],
@@ -912,7 +912,7 @@
           "y": "{size.200}",
           "blur": "{size.600}",
           "spread": "{size.0}",
-          "color": "#0000004d",
+          "color": "#0000004D",
           "type": "dropShadow"
         }
       ],
@@ -933,7 +933,7 @@
           "y": "{size.200}",
           "blur": "{size.300}",
           "spread": "{size.0}",
-          "color": "#0000000a",
+          "color": "#0000000A",
           "type": "dropShadow"
         },
         {

--- a/packages/dialtone-tokens/tokens/components/avatar/default.json
+++ b/packages/dialtone-tokens/tokens/components/avatar/default.json
@@ -7,79 +7,79 @@
       },
       "background": {
         "100": {
-          "value": "#1aa340",
+          "value": "#1AA340",
           "type": "color"
         },
         "200": {
-          "value": "#aaff83",
+          "value": "#AAFF83",
           "type": "color"
         },
         "300": {
-          "value": "#adea88",
+          "value": "#ADEA88",
           "type": "color"
         },
         "400": {
-          "value": "#77eca6",
+          "value": "#77ECA6",
           "type": "color"
         },
         "500": {
-          "value": "#7aedbd",
+          "value": "#7AEDBD",
           "type": "color"
         },
         "600": {
-          "value": "#77deec",
+          "value": "#77DEEC",
           "type": "color"
         },
         "700": {
-          "value": "#5ed8ff",
+          "value": "#5ED8FF",
           "type": "color"
         },
         "800": {
-          "value": "#99e7ff",
+          "value": "#99E7FF",
           "type": "color"
         },
         "900": {
-          "value": "#51a0fe",
+          "value": "#51A0FE",
           "type": "color"
         },
         "1000": {
-          "value": "#b6cfff",
+          "value": "#B6CFFF",
           "type": "color"
         },
         "1100": {
-          "value": "#f1b7e8",
+          "value": "#F1B7E8",
           "type": "color"
         },
         "1200": {
-          "value": "#ec77bd",
+          "value": "#EC77BD",
           "type": "color"
         },
         "1300": {
-          "value": "#ff67be",
+          "value": "#FF67BE",
           "type": "color"
         },
         "1400": {
-          "value": "#f87e7e",
+          "value": "#F87E7E",
           "type": "color"
         },
         "1500": {
-          "value": "#eca877",
+          "value": "#ECA877",
           "type": "color"
         },
         "1600": {
-          "value": "#ffbe41",
+          "value": "#FFBE41",
           "type": "color"
         },
         "1700": {
-          "value": "#ffd646",
+          "value": "#FFD646",
           "type": "color"
         },
         "1800": {
-          "value": "#f1dab7",
+          "value": "#F1DAB7",
           "type": "color"
         },
         "000": {
-          "value": "#e0e0e0",
+          "value": "#E0E0E0",
           "type": "color"
         }
       }

--- a/packages/dialtone-tokens/tokens/theme/aegean/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/aegean/dark.json
@@ -3,11 +3,11 @@
     "base": {
       "color": {
         "surface": {
-          "value": "{color.teal.100}",
+          "value": "{color.indigo.100}",
           "type": "color"
         },
         "accent": {
-          "value": "{color.indigo.700}",
+          "value": "{color.teal.700}",
           "type": "color"
         }
       }

--- a/packages/dialtone-tokens/tokens/theme/aegean/default.json
+++ b/packages/dialtone-tokens/tokens/theme/aegean/default.json
@@ -17,24 +17,10 @@
         "accent": {
           "value": "{color.teal.800}",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "{color.coral.900}",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "{color.coral.900}",
-              "type": "color"
-            },
-            "muted": {
-              "value": "{color.coral.900}",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "{color.coral.900}",
+          "type": "color"
         }
       }
     }

--- a/packages/dialtone-tokens/tokens/theme/botany/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/botany/dark.json
@@ -13,24 +13,10 @@
         "accent": {
           "value": "{color.purple.550}",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "#ffdfbf",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "#ffdfbf",
-              "type": "color"
-            },
-            "muted": {
-              "value": "#ffdfbf",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "#ffdfbf",
+          "type": "color"
         }
       }
     },

--- a/packages/dialtone-tokens/tokens/theme/botany/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/botany/dark.json
@@ -7,7 +7,7 @@
           "type": "color"
         },
         "border": {
-          "value": "#c6e4ff",
+          "value": "#C6E4FF",
           "type": "color"
         },
         "accent": {
@@ -15,7 +15,7 @@
           "type": "color"
         },
         "action": {
-          "value": "#ffdfbf",
+          "value": "#FFDFBF",
           "type": "color"
         }
       }

--- a/packages/dialtone-tokens/tokens/theme/botany/default.json
+++ b/packages/dialtone-tokens/tokens/theme/botany/default.json
@@ -3,7 +3,7 @@
     "base": {
       "color": {
         "surface": {
-          "value": "#e9eede",
+          "value": "#E9EEDE",
           "type": "color"
         },
         "border": {

--- a/packages/dialtone-tokens/tokens/theme/botany/default.json
+++ b/packages/dialtone-tokens/tokens/theme/botany/default.json
@@ -3,7 +3,7 @@
     "base": {
       "color": {
         "surface": {
-          "value": "#E6EBDB",
+          "value": "#e9eede",
           "type": "color"
         },
         "border": {
@@ -13,24 +13,10 @@
         "accent": {
           "value": "#6633BB",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "#0d6d4c",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "#0d6d4c",
-              "type": "color"
-            },
-            "muted": {
-              "value": "#0d6d4c",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "#396752",
+          "type": "color"
         }
       }
     }

--- a/packages/dialtone-tokens/tokens/theme/buttercream/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/buttercream/dark.json
@@ -3,7 +3,7 @@
     "base": {
       "color": {
         "surface": {
-          "value": "#231f15",
+          "value": "#231F15",
           "type": "color"
         },
         "foreground": {
@@ -11,15 +11,15 @@
           "type": "color"
         },
         "border": {
-          "value": "#d2edff",
+          "value": "#D2EDFF",
           "type": "color"
         },
         "accent": {
-          "value": "#f4cd0b",
+          "value": "#F4CD0B",
           "type": "color"
         },
         "action": {
-          "value": "#fff5d3",
+          "value": "#FFF5D3",
           "type": "color"
         }
       }
@@ -28,7 +28,7 @@
       "color": {
         "foreground": {
           "primary": {
-            "value": "#090f14",
+            "value": "#090F14",
             "type": "color"
           }
         }

--- a/packages/dialtone-tokens/tokens/theme/buttercream/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/buttercream/dark.json
@@ -3,7 +3,7 @@
     "base": {
       "color": {
         "surface": {
-          "value": "#282317",
+          "value": "#231f15",
           "type": "color"
         },
         "foreground": {
@@ -17,24 +17,10 @@
         "accent": {
           "value": "#f4cd0b",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "#fff5d3",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "#fff5d3",
-              "type": "color"
-            },
-            "muted": {
-              "value": "#fff5d3",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "#fff5d3",
+          "type": "color"
         }
       }
     },

--- a/packages/dialtone-tokens/tokens/theme/buttercream/default.json
+++ b/packages/dialtone-tokens/tokens/theme/buttercream/default.json
@@ -11,15 +11,15 @@
           "type": "color"
         },
         "border": {
-          "value": "#15242e",
+          "value": "#15242E",
           "type": "color"
         },
         "accent": {
-          "value": "#f4cd0b",
+          "value": "#F4CD0B",
           "type": "color"
         },
         "action": {
-          "value": "#2b4b5f",
+          "value": "#2B4B5F",
           "type": "color"
         }
       }
@@ -28,7 +28,7 @@
       "color": {
         "foreground": {
           "primary": {
-            "value": "#090f14",
+            "value": "#090F14",
             "type": "color"
           }
         }

--- a/packages/dialtone-tokens/tokens/theme/buttercream/default.json
+++ b/packages/dialtone-tokens/tokens/theme/buttercream/default.json
@@ -3,7 +3,7 @@
     "base": {
       "color": {
         "surface": {
-          "value": "#fff8e8",
+          "value": "#FFF8E8",
           "type": "color"
         },
         "foreground": {

--- a/packages/dialtone-tokens/tokens/theme/buttercream/default.json
+++ b/packages/dialtone-tokens/tokens/theme/buttercream/default.json
@@ -15,26 +15,12 @@
           "type": "color"
         },
         "accent": {
-          "value": "#F4CD0B",
+          "value": "#f4cd0b",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "#2b4b5f",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "#2b4b5f",
-              "type": "color"
-            },
-            "muted": {
-              "value": "#2b4b5f",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "#2b4b5f",
+          "type": "color"
         }
       }
     },

--- a/packages/dialtone-tokens/tokens/theme/ceruleo/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/ceruleo/dark.json
@@ -18,6 +18,10 @@
           "value": "{color.red.600}",
           "type": "color"
         },
+        "action": {
+          "value": "{color.blue.475}",
+          "type": "color"
+        },
         "status-positive": {
           "value": "{color.green.425}",
           "type": "color"
@@ -29,24 +33,6 @@
         "status-warning": {
           "value": "{color.gold.600}",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "{color.blue.475}",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "{color.blue.475}",
-              "type": "color"
-            },
-            "muted": {
-              "value": "{color.blue.475}",
-              "type": "color"
-            }
-          }
         }
       }
     }

--- a/packages/dialtone-tokens/tokens/theme/ceruleo/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/ceruleo/dark.json
@@ -23,7 +23,7 @@
           "type": "color"
         },
         "status-positive": {
-          "value": "{color.green.425}",
+          "value": "{color.green.475}",
           "type": "color"
         },
         "status-critical": {

--- a/packages/dialtone-tokens/tokens/theme/ceruleo/default.json
+++ b/packages/dialtone-tokens/tokens/theme/ceruleo/default.json
@@ -39,11 +39,11 @@
     "logo": {
       "color": {
         "wordmark": {
-          "value": "#ffffff",
+          "value": "#FFFFFF",
           "type": "color"
         },
         "star": {
-          "value": "#ffffff",
+          "value": "#FFFFFF",
           "type": "color"
         }
       }

--- a/packages/dialtone-tokens/tokens/theme/ceruleo/default.json
+++ b/packages/dialtone-tokens/tokens/theme/ceruleo/default.json
@@ -18,8 +18,12 @@
           "value": "{color.red.400}",
           "type": "color"
         },
+        "action": {
+          "value": "{color.blue.300}",
+          "type": "color"
+        },
         "status-positive": {
-          "value": "{color.green.350}",
+          "value": "{color.green.300}",
           "type": "color"
         },
         "status-critical": {
@@ -30,23 +34,17 @@
           "value": "{color.gold.300}",
           "type": "color"
         }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "{color.blue.300}",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "{color.blue.300}",
-              "type": "color"
-            },
-            "muted": {
-              "value": "{color.blue.300}",
-              "type": "color"
-            }
-          }
+      }
+    },
+    "logo": {
+      "color": {
+        "wordmark": {
+          "value": "#ffffff",
+          "type": "color"
+        },
+        "star": {
+          "value": "#ffffff",
+          "type": "color"
         }
       }
     }

--- a/packages/dialtone-tokens/tokens/theme/dp/default.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/default.json
@@ -4019,6 +4019,10 @@
           "value": "{badge.color.background.bulletin}",
           "type": "color"
         },
+        "action": {
+          "value": "{color.black.800}",
+          "type": "color"
+        },
         "status-positive": {
           "value": "{color.green.425}",
           "type": "color"
@@ -4040,15 +4044,15 @@
         "color": {
           "background": {
             "primary": {
-              "value": "{color.black.800}",
+              "value": "{shell.base.color.action}",
               "type": "color"
             },
             "secondary": {
-              "value": "{color.black.800}",
+              "value": "{shell.base.color.action}",
               "type": "color"
             },
             "muted": {
-              "value": "{color.black.800}",
+              "value": "{shell.base.color.action}",
               "type": "color"
             }
           }

--- a/packages/dialtone-tokens/tokens/theme/high-desert/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/high-desert/dark.json
@@ -3,11 +3,11 @@
     "base": {
       "color": {
         "surface": {
-          "value": "{color.tan.400}",
+          "value": "{color.tan.300}",
           "type": "color"
         },
         "foreground": {
-          "value": "{color.olive.900}",
+          "value": "{color.olive.1000}",
           "type": "color"
         },
         "border": {
@@ -17,24 +17,10 @@
         "accent": {
           "value": "{color.coral.800}",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "{color.olive.700}",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "{color.olive.800}",
-              "type": "color"
-            },
-            "muted": {
-              "value": "{color.olive.700}",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "{color.olive.700}",
+          "type": "color"
         }
       }
     }

--- a/packages/dialtone-tokens/tokens/theme/high-desert/default.json
+++ b/packages/dialtone-tokens/tokens/theme/high-desert/default.json
@@ -3,7 +3,7 @@
     "base": {
       "color": {
         "surface": {
-          "value": "#f5ebd7",
+          "value": "#F5EBD7",
           "type": "color"
         },
         "foreground": {
@@ -11,7 +11,7 @@
           "type": "color"
         },
         "border": {
-          "value": "#141f00",
+          "value": "#141F00",
           "type": "color"
         },
         "accent": {

--- a/packages/dialtone-tokens/tokens/theme/high-desert/default.json
+++ b/packages/dialtone-tokens/tokens/theme/high-desert/default.json
@@ -3,7 +3,7 @@
     "base": {
       "color": {
         "surface": {
-          "value": "#ECE2CE",
+          "value": "#f5ebd7",
           "type": "color"
         },
         "foreground": {
@@ -17,24 +17,10 @@
         "accent": {
           "value": "#E45C10",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "#7A5608",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "#7A5608",
-              "type": "color"
-            },
-            "muted": {
-              "value": "#7A5608",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "#7A5608",
+          "type": "color"
         }
       }
     }

--- a/packages/dialtone-tokens/tokens/theme/melon/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/melon/dark.json
@@ -9,24 +9,10 @@
         "accent": {
           "value": "{color.magenta.600}",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "{color.berry.950}",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "{color.berry.950}",
-              "type": "color"
-            },
-            "muted": {
-              "value": "{color.berry.950}",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "{color.berry.950}",
+          "type": "color"
         }
       }
     }

--- a/packages/dialtone-tokens/tokens/theme/melon/default.json
+++ b/packages/dialtone-tokens/tokens/theme/melon/default.json
@@ -3,7 +3,7 @@
     "base": {
       "color": {
         "surface": {
-          "value": "{color.berry.100}",
+          "value": "{color.berry.50}",
           "type": "color"
         },
         "foreground": {
@@ -17,24 +17,10 @@
         "accent": {
           "value": "{color.magenta.500}",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "{color.berry.900}",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "{color.berry.900}",
-              "type": "color"
-            },
-            "muted": {
-              "value": "{color.berry.900}",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "{color.berry.900}",
+          "type": "color"
         }
       }
     }

--- a/packages/dialtone-tokens/tokens/theme/plum/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/plum/dark.json
@@ -6,31 +6,21 @@
           "value": "{color.purple.50}",
           "type": "color"
         },
+        "foreground": {
+          "value": "#efecf9",
+          "type": "color"
+        },
         "border": {
-          "value": "#0a0029",
+          "value": "#efecf9",
           "type": "color"
         },
         "accent": {
           "value": "#e2aae5",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "#65318E",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "#65318E",
-              "type": "color"
-            },
-            "muted": {
-              "value": "#65318E",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "{color.coral.950}",
+          "type": "color"
         }
       }
     }

--- a/packages/dialtone-tokens/tokens/theme/plum/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/plum/dark.json
@@ -7,15 +7,15 @@
           "type": "color"
         },
         "foreground": {
-          "value": "#efecf9",
+          "value": "#EFECF9",
           "type": "color"
         },
         "border": {
-          "value": "#efecf9",
+          "value": "#EFECF9",
           "type": "color"
         },
         "accent": {
-          "value": "#e2aae5",
+          "value": "#E2AAE5",
           "type": "color"
         },
         "action": {

--- a/packages/dialtone-tokens/tokens/theme/plum/default.json
+++ b/packages/dialtone-tokens/tokens/theme/plum/default.json
@@ -6,6 +6,10 @@
           "value": "{color.purple.50}",
           "type": "color"
         },
+        "foreground": {
+          "value": "#0a0029",
+          "type": "color"
+        },
         "border": {
           "value": "#0a0029",
           "type": "color"
@@ -13,24 +17,10 @@
         "accent": {
           "value": "#DE0276",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "#65318E",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "#65318E",
-              "type": "color"
-            },
-            "muted": {
-              "value": "#65318E",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "#65318E",
+          "type": "color"
         }
       }
     }

--- a/packages/dialtone-tokens/tokens/theme/plum/default.json
+++ b/packages/dialtone-tokens/tokens/theme/plum/default.json
@@ -7,11 +7,11 @@
           "type": "color"
         },
         "foreground": {
-          "value": "#0a0029",
+          "value": "#0A0029",
           "type": "color"
         },
         "border": {
-          "value": "#0a0029",
+          "value": "#0A0029",
           "type": "color"
         },
         "accent": {

--- a/packages/dialtone-tokens/tokens/theme/sunflower/default.json
+++ b/packages/dialtone-tokens/tokens/theme/sunflower/default.json
@@ -7,7 +7,7 @@
           "type": "color"
         },
         "foreground": {
-          "value": "{color.red.900}",
+          "value": "{color.red.1000}",
           "type": "color"
         },
         "border": {
@@ -17,24 +17,10 @@
         "accent": {
           "value": "{color.red.600}",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "{color.olive.800}",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "{color.olive.800}",
-              "type": "color"
-            },
-            "muted": {
-              "value": "{color.olive.800}",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "{color.olive.800}",
+          "type": "color"
         }
       }
     }

--- a/packages/dialtone-tokens/tokens/theme/verdant-haze/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/verdant-haze/dark.json
@@ -17,24 +17,10 @@
         "accent": {
           "value": "#3F5F01",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "#C0CAAE",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "#C0CAAE",
-              "type": "color"
-            },
-            "muted": {
-              "value": "#C0CAAE",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "#C0CAAE",
+          "type": "color"
         }
       }
     },

--- a/packages/dialtone-tokens/tokens/theme/verdant-haze/default.json
+++ b/packages/dialtone-tokens/tokens/theme/verdant-haze/default.json
@@ -17,24 +17,10 @@
         "accent": {
           "value": "#C0CAAE",
           "type": "color"
-        }
-      },
-      "action": {
-        "color": {
-          "background": {
-            "primary": {
-              "value": "#3F5F01",
-              "type": "color"
-            },
-            "secondary": {
-              "value": "#3F5F01",
-              "type": "color"
-            },
-            "muted": {
-              "value": "#3F5F01",
-              "type": "color"
-            }
-          }
+        },
+        "action": {
+          "value": "#3F5F01",
+          "type": "color"
         }
       }
     },


### PR DESCRIPTION
# Fix sunflower dark and correct shell base references

<img width="3334" height="1114" alt="image" src="https://github.com/user-attachments/assets/ab14cb83-0dea-4cec-83ef-4c3d4ef38ab5" />


## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2766

## :book: Description

* Simplified `shell.base.action` as reference.
* Correct broken token set selections for Sunflower dark. See screenshot below.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

1. Release
2. Merge it to `next`
3. Release `next`
4. Integrate with Beacon prototype

## :camera: Screenshots / GIFs

<img width="1279" height="1097" alt="image" src="https://github.com/user-attachments/assets/a5ac67ee-e5ef-4ff5-a662-d1facca17596" />

## :link: Sources

<!--- Add any links to external reference material -->
