### PR TITLE
fix(localization): DLT-2768  emoji row reaction label warnings

### DIFF
--- a/packages/dialtone-vue2/localization/de-DE.ftl
+++ b/packages/dialtone-vue2/localization/de-DE.ftl
@@ -3,17 +3,17 @@ DIALTONE_CLOSE_BUTTON = Zum Schließen klicken
 DIALTONE_BREADCRUMBS_ARIA_LABEL = Brotkrumen
 DIALTONE_LOADING = Lädt ...
 DIALTONE_UNREAD_MESSAGE_COUNT_TEXT =
-    { $unreadCount ->
-        [0] Keine ungelesenen Nachrichten
-        [1] 1 ungelesene Nachricht
-       *[other] { $unreadCount } ungelesene Nachrichten
-    }
+  { $unreadCount ->
+  [0] Keine ungelesenen Nachrichten
+  [1] 1 ungelesene Nachricht
+  *[other] { $unreadCount } ungelesene Nachrichten
+      }
 DIALTONE_UNREAD_MENTION_COUNT_TEXT =
-    { $unreadCount ->
-        [0] Keine ungelesenen Erwähnungen
-        [1] 1 ungelesene Erwähnung
-       *[other] { $unreadCount } ungelesene Erwähnungen
-    }
+  { $unreadCount ->
+  [0] Keine ungelesenen Erwähnungen
+  [1] 1 ungelesene Erwähnung
+  *[other] { $unreadCount } ungelesene Erwähnungen
+      }
 DIALTONE_TYPING_TEXT = schreibt
 DIALTONE_ATTACHMENT_CAROUSEL_CLICK_TO_OPEN_ARIA_LABEL = Zum Öffnen klicken
 DIALTONE_ATTACHMENT_CAROUSEL_PROGRESS_BAR_ARIA_LABEL = Wird hochgeladen
@@ -29,14 +29,14 @@ DIALTONE_DATEPICKER_NEXT_YEAR = nächstes Jahr
 DIALTONE_DATEPICKER_SELECT_DAY = Tag auswählen
 DIALTONE_DATEPICKER_CHANGE_TO = Wechseln zu
 DIALTONE_EDITOR_CONFIRM_SET_LINK_BUTTON =
-    .title = Bestätigen
-    .aria-label = Gesetzten Link bestätigen
+  .title = Bestätigen
+  .aria-label = Gesetzten Link bestätigen
 DIALTONE_EDITOR_REMOVE_LINK_BUTTON =
-    .title = Entfernen
-    .aria-label = Link entfernen
+  .title = Entfernen
+  .aria-label = Link entfernen
 DIALTONE_EDITOR_CANCEL_SET_LINK_BUTTON =
-    .title = ABBRECHEN
-    .aria-label = Set-Link abbrechen
+  .title = ABBRECHEN
+  .aria-label = Set-Link abbrechen
 DIALTONE_EDITOR_QUICK_REPLY_BUTTON_LABEL = Vorlage
 DIALTONE_EDITOR_BOLD_BUTTON_LABEL = Fett
 DIALTONE_EDITOR_ITALICS_BUTTON_LABEL = Kursiv
@@ -53,21 +53,13 @@ DIALTONE_EDITOR_CODE_BUTTON_LABEL = Code
 DIALTONE_EDITOR_IMAGE_BUTTON_LABEL = Bild
 DIALTONE_EDITOR_LINK_BUTTON_LABEL = Link
 DIALTONE_EDITOR_ADD_LINK_BUTTON =
-    .title = Link hinzufügen
-    .aria-label = Eingabefeld zum Hinzufügen eines Links
+  .title = Link hinzufügen
+  .aria-label = Eingabefeld zum Hinzufügen eines Links
 DIALTONE_EMOJI_ROW_REACTION_LABEL =
-    { $personCount ->
-        [one]
-            { $youIncluded ->
-               *[true] reagierte mit { $reaction }
-                [false] reagierte mit { $reaction }
-            }
-       *[other]
-            { $youIncluded ->
-               *[true] reagierten mit { $reaction }
-                [false] reagierten mit { $reaction }
-            }
-    }
+  { $personCount ->
+  [one] reagierte mit { $reaction }
+  *[other] reagierten mit { $reaction }
+      }
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = Emoji hinzufügen
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = Keine Ergebnisse
 DIALTONE_EMOJI_PICKER_SEARCH_RESULTS_LABEL = Suchergebnisse
@@ -88,10 +80,10 @@ DIALTONE_GENERAL_ROW_ACTIVE_VOICE_CHAT_TEXT = Aktiver Voice-Chat
 DIALTONE_GENERAL_ROW_CALL_BUTTON_TOOLTIP = Anruf
 DIALTONE_GENERAL_ROW_DND_TEXT_TOOLTIP = Bitte nicht stören
 DIALTONE_GROUP_ROW_GROUP_COUNT_TEXT =
-    { $count ->
-        [1] 1 Benutzer
-       *[other] { $count } Benutzer
-    }
+  { $count ->
+  [1] 1 Benutzer
+  *[other] { $count } Benutzer
+      }
 DIALTONE_IVR_NODE_MENU_BUTTON_ARIA_LABEL = Menü öffnen
 DIALTONE_IVR_NODE_PROMPTMENU_ARIA_LABEL = Prompt-Menü-Knoten
 DIALTONE_IVR_NODE_PROMPTCOLLECT_ARIA_LABEL = Prompterfassung-Knoten
@@ -108,32 +100,32 @@ DIALTONE_MESSAGE_INPUT_IMAGE_PICKER_BUTTON_ARIA_LABEL = Bild anhängen
 DIALTONE_MESSAGE_INPUT_EMOJI_PICKER_BUTTON_ARIA_LABEL = Emoji auswählen
 DIALTONE_MESSAGE_INPUT_CANCEL_BUTTON_ARIA_LABEL = ABBRECHEN
 DIALTONE_MESSAGE_INPUT_BOLD_BUTTON_LABEL =
-    .aria-label = Ausgewählten Text auf fett umschalten
-    .tooltip-text = Fett
+  .aria-label = Ausgewählten Text auf fett umschalten
+  .tooltip-text = Fett
 DIALTONE_MESSAGE_INPUT_ITALIC_BUTTON_LABEL =
-    .aria-label = Ausgewählten Text auf kursiv umschalten
-    .tooltip-text = Kursiv
+  .aria-label = Ausgewählten Text auf kursiv umschalten
+  .tooltip-text = Kursiv
 DIALTONE_MESSAGE_INPUT_STRIKETHROUGH_BUTTON_LABEL =
-    .aria-label = Markierten Text durchstreichen
-    .tooltip-text = Durchstreichen
+  .aria-label = Markierten Text durchstreichen
+  .tooltip-text = Durchstreichen
 DIALTONE_MESSAGE_INPUT_BULLET_LIST_BUTTON_LABEL =
-    .aria-label = Erstellen oder Bearbeiten einer Aufzählung für ausgewählten Text
-    .tooltip-text = Aufzählung
+  .aria-label = Erstellen oder Bearbeiten einer Aufzählung für ausgewählten Text
+  .tooltip-text = Aufzählung
 DIALTONE_MESSAGE_INPUT_ORDERED_LIST_BUTTON_LABEL =
-    .aria-label = Erstellen oder Bearbeiten einer geordneten Liste für ausgewählten Text
-    .tooltip-text = Geordnete Liste
+  .aria-label = Erstellen oder Bearbeiten einer geordneten Liste für ausgewählten Text
+  .tooltip-text = Geordnete Liste
 DIALTONE_MESSAGE_INPUT_BLOCK_QUOTE_BUTTON_LABEL =
-    .aria-label = Erstellen oder Bearbeiten von Blockzitaten für ausgewählten Text
-    .tooltip-text = Blockzitat
+  .aria-label = Erstellen oder Bearbeiten von Blockzitaten für ausgewählten Text
+  .tooltip-text = Blockzitat
 DIALTONE_MESSAGE_INPUT_CODE_BUTTON_LABEL =
-    .aria-label = Erstellen oder Bearbeiten von Code für markierten Text
-    .tooltip-text = Code
+  .aria-label = Erstellen oder Bearbeiten von Code für markierten Text
+  .tooltip-text = Code
 DIALTONE_MESSAGE_INPUT_CODE_BLOCK_BUTTON_LABEL =
-    .aria-label = Erstellen oder Bearbeiten eines Codeblocks für ausgewählten Text
-    .tooltip-text = Codeblock
+  .aria-label = Erstellen oder Bearbeiten eines Codeblocks für ausgewählten Text
+  .tooltip-text = Codeblock
 DIALTONE_MESSAGE_INPUT_LINK_BUTTON_LABEL =
-    .aria-label = Erstellen oder Bearbeiten eines Links für ausgewählten Text
-    .tooltip-text = Link
+  .aria-label = Erstellen oder Bearbeiten eines Links für ausgewählten Text
+  .tooltip-text = Link
 DIALTONE_MESSAGE_INPUT_LINK_DIALOG_TITLE = Link hinzufügen
 DIALTONE_MESSAGE_INPUT_LINK_TEXT_LABEL = Anzuzeigender Text (optional)
 DIALTONE_MESSAGE_INPUT_LINK_LINK_LABEL = Link

--- a/packages/dialtone-vue2/localization/en-US.ftl
+++ b/packages/dialtone-vue2/localization/en-US.ftl
@@ -4,16 +4,16 @@ DIALTONE_BREADCRUMBS_ARIA_LABEL = breadcrumbs
 DIALTONE_LOADING = loading
 DIALTONE_UNREAD_MESSAGE_COUNT_TEXT =
   { $unreadCount ->
-    [0] No unread messages
-    [1] 1 unread message
-    *[other] {$unreadCount} unread messages
-  }
+  [0] No unread messages
+  [1] 1 unread message
+  *[other] {$unreadCount} unread messages
+        }
 DIALTONE_UNREAD_MENTION_COUNT_TEXT =
   { $unreadCount ->
-    [0] No unread mentions
-    [1] 1 unread mention
-    *[other] {$unreadCount} unread mentions
-  }
+  [0] No unread mentions
+  [1] 1 unread mention
+  *[other] {$unreadCount} unread mentions
+        }
 DIALTONE_TYPING_TEXT = Typing
 
 DIALTONE_ATTACHMENT_CAROUSEL_CLICK_TO_OPEN_ARIA_LABEL = Click to open
@@ -64,15 +64,9 @@ DIALTONE_EDITOR_ADD_LINK_BUTTON =
 
 DIALTONE_EMOJI_ROW_REACTION_LABEL =
   { $personCount ->
-    *[other] { $youIncluded ->
-      *[true] reacted with { $reaction }
-      [false] reacted with { $reaction }
+  *[other] reacted with { $reaction }
+  [one] reacted with { $reaction }
     }
-    [one] { $youIncluded ->
-      *[true] reacted with { $reaction }
-      [false] reacted with { $reaction }
-    }
-  }
 
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = Add emoji
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = No results
@@ -98,9 +92,9 @@ DIALTONE_GENERAL_ROW_DND_TEXT_TOOLTIP = Do not disturb
 
 DIALTONE_GROUP_ROW_GROUP_COUNT_TEXT =
   { $count ->
-    [1] 1 user
-    *[other] {$count} users
-  }
+  [1] 1 user
+  *[other] {$count} users
+        }
 
 DIALTONE_IVR_NODE_MENU_BUTTON_ARIA_LABEL = Open menu
 DIALTONE_IVR_NODE_PROMPTMENU_ARIA_LABEL = prompt menu node

--- a/packages/dialtone-vue2/localization/es-LA.ftl
+++ b/packages/dialtone-vue2/localization/es-LA.ftl
@@ -3,17 +3,17 @@ DIALTONE_CLOSE_BUTTON = Haga clic para cerrar
 DIALTONE_BREADCRUMBS_ARIA_LABEL = Breadcrumbs
 DIALTONE_LOADING = Cargando
 DIALTONE_UNREAD_MESSAGE_COUNT_TEXT =
-    { $unreadCount ->
-        [0] No hay mensajes sin leer
-        [1] 1 mensaje sin leer
-       *[other] { $unreadCount } mensajes sin leer
-    }
+  { $unreadCount ->
+  [0] No hay mensajes sin leer
+  [1] 1 mensaje sin leer
+  *[other] { $unreadCount } mensajes sin leer
+      }
 DIALTONE_UNREAD_MENTION_COUNT_TEXT =
-    { $unreadCount ->
-        [0] No hay menciones sin leer
-        [1] 1 mención sin leer
-       *[other] { $unreadCount } menciones sin leer
-    }
+  { $unreadCount ->
+  [0] No hay menciones sin leer
+  [1] 1 mención sin leer
+  *[other] { $unreadCount } menciones sin leer
+      }
 DIALTONE_TYPING_TEXT = Está escribiendo
 DIALTONE_ATTACHMENT_CAROUSEL_CLICK_TO_OPEN_ARIA_LABEL = Haga clic para abrir
 DIALTONE_ATTACHMENT_CAROUSEL_PROGRESS_BAR_ARIA_LABEL = Subiendo
@@ -29,14 +29,14 @@ DIALTONE_DATEPICKER_NEXT_YEAR = el próximo año
 DIALTONE_DATEPICKER_SELECT_DAY = Seleccionar día
 DIALTONE_DATEPICKER_CHANGE_TO = Cambiar a
 DIALTONE_EDITOR_CONFIRM_SET_LINK_BUTTON =
-    .title = Confirmar
-    .aria-label = Confirmar enlace establecido
+  .title = Confirmar
+  .aria-label = Confirmar enlace establecido
 DIALTONE_EDITOR_REMOVE_LINK_BUTTON =
-    .title = Eliminar
-    .aria-label = Eliminar enlace
+  .title = Eliminar
+  .aria-label = Eliminar enlace
 DIALTONE_EDITOR_CANCEL_SET_LINK_BUTTON =
-    .title = cancelar
-    .aria-label = Cancelar enlace establecido
+  .title = cancelar
+  .aria-label = Cancelar enlace establecido
 DIALTONE_EDITOR_QUICK_REPLY_BUTTON_LABEL = Plantilla
 DIALTONE_EDITOR_BOLD_BUTTON_LABEL = Negrita
 DIALTONE_EDITOR_ITALICS_BUTTON_LABEL = Cursiva
@@ -53,21 +53,13 @@ DIALTONE_EDITOR_CODE_BUTTON_LABEL = Código
 DIALTONE_EDITOR_IMAGE_BUTTON_LABEL = Imagen
 DIALTONE_EDITOR_LINK_BUTTON_LABEL = Enlace
 DIALTONE_EDITOR_ADD_LINK_BUTTON =
-    .title = Agregar enlace
-    .aria-label = Campo de entrada para agregar enlace
+  .title = Agregar enlace
+  .aria-label = Campo de entrada para agregar enlace
 DIALTONE_EMOJI_ROW_REACTION_LABEL =
-    { $personCount ->
-        [one]
-            { $youIncluded ->
-               *[true] reaccionó con { $reaction }
-                [false] reaccionó con { $reaction }
-            }
-       *[other]
-            { $youIncluded ->
-               *[true] reaccionaron con { $reaction }
-                [false] reaccionaron con { $reaction }
-            }
-    }
+  { $personCount ->
+  [one] reaccionó con { $reaction }
+  *[other] reaccionaron con { $reaction }
+      }
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = Agregar emoji
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = No hay resultados
 DIALTONE_EMOJI_PICKER_SEARCH_RESULTS_LABEL = resultados de búsqueda
@@ -88,10 +80,10 @@ DIALTONE_GENERAL_ROW_ACTIVE_VOICE_CHAT_TEXT = Chat de voz activo
 DIALTONE_GENERAL_ROW_CALL_BUTTON_TOOLTIP = Llamar
 DIALTONE_GENERAL_ROW_DND_TEXT_TOOLTIP = No molestar
 DIALTONE_GROUP_ROW_GROUP_COUNT_TEXT =
-    { $count ->
-        [1] 1 usuario
-       *[other] { $count } usuarios
-    }
+  { $count ->
+  [1] 1 usuario
+  *[other] { $count } usuarios
+      }
 DIALTONE_IVR_NODE_MENU_BUTTON_ARIA_LABEL = Abrir menú
 DIALTONE_IVR_NODE_PROMPTMENU_ARIA_LABEL = nodo de menú de indicación
 DIALTONE_IVR_NODE_PROMPTCOLLECT_ARIA_LABEL = nodo de recopilación rápida
@@ -108,32 +100,32 @@ DIALTONE_MESSAGE_INPUT_IMAGE_PICKER_BUTTON_ARIA_LABEL = Anexar imagen
 DIALTONE_MESSAGE_INPUT_EMOJI_PICKER_BUTTON_ARIA_LABEL = Seleccionar emoji
 DIALTONE_MESSAGE_INPUT_CANCEL_BUTTON_ARIA_LABEL = cancelar
 DIALTONE_MESSAGE_INPUT_BOLD_BUTTON_LABEL =
-    .aria-label = Active la negrita en el texto seleccionado
-    .tooltip-text = Negrita
+  .aria-label = Active la negrita en el texto seleccionado
+  .tooltip-text = Negrita
 DIALTONE_MESSAGE_INPUT_ITALIC_BUTTON_LABEL =
-    .aria-label = Active la cursiva en el texto seleccionado
-    .tooltip-text = Cursiva
+  .aria-label = Active la cursiva en el texto seleccionado
+  .tooltip-text = Cursiva
 DIALTONE_MESSAGE_INPUT_STRIKETHROUGH_BUTTON_LABEL =
-    .aria-label = Active el tachado del texto seleccionado
-    .tooltip-text = Tachado
+  .aria-label = Active el tachado del texto seleccionado
+  .tooltip-text = Tachado
 DIALTONE_MESSAGE_INPUT_BULLET_LIST_BUTTON_LABEL =
-    .aria-label = Cree o edite una lista de viñetas en el texto seleccionado
-    .tooltip-text = Lista de viñetas
+  .aria-label = Cree o edite una lista de viñetas en el texto seleccionado
+  .tooltip-text = Lista de viñetas
 DIALTONE_MESSAGE_INPUT_ORDERED_LIST_BUTTON_LABEL =
-    .aria-label = Cree o edite una lista ordenada en el texto seleccionado
-    .tooltip-text = Lista ordenada
+  .aria-label = Cree o edite una lista ordenada en el texto seleccionado
+  .tooltip-text = Lista ordenada
 DIALTONE_MESSAGE_INPUT_BLOCK_QUOTE_BUTTON_LABEL =
-    .aria-label = Cree o edite una cita en bloque en el texto seleccionado
-    .tooltip-text = Cita en bloque
+  .aria-label = Cree o edite una cita en bloque en el texto seleccionado
+  .tooltip-text = Cita en bloque
 DIALTONE_MESSAGE_INPUT_CODE_BUTTON_LABEL =
-    .aria-label = Cree o edite un código en el texto seleccionado
-    .tooltip-text = Código
+  .aria-label = Cree o edite un código en el texto seleccionado
+  .tooltip-text = Código
 DIALTONE_MESSAGE_INPUT_CODE_BLOCK_BUTTON_LABEL =
-    .aria-label = Cree o edite un bloque de código en el texto seleccionado
-    .tooltip-text = Bloque de código
+  .aria-label = Cree o edite un bloque de código en el texto seleccionado
+  .tooltip-text = Bloque de código
 DIALTONE_MESSAGE_INPUT_LINK_BUTTON_LABEL =
-    .aria-label = Cree o edite un enlace en el texto seleccionado
-    .tooltip-text = Enlace
+  .aria-label = Cree o edite un enlace en el texto seleccionado
+  .tooltip-text = Enlace
 DIALTONE_MESSAGE_INPUT_LINK_DIALOG_TITLE = Agregar un enlace
 DIALTONE_MESSAGE_INPUT_LINK_TEXT_LABEL = Texto para mostrar (opcional)
 DIALTONE_MESSAGE_INPUT_LINK_LINK_LABEL = Enlace

--- a/packages/dialtone-vue2/localization/fr-FR.ftl
+++ b/packages/dialtone-vue2/localization/fr-FR.ftl
@@ -3,17 +3,17 @@ DIALTONE_CLOSE_BUTTON = Cliquez pour fermer
 DIALTONE_BREADCRUMBS_ARIA_LABEL = Breadcrumbs
 DIALTONE_LOADING = En cours de chargement
 DIALTONE_UNREAD_MESSAGE_COUNT_TEXT =
-    { $unreadCount ->
-        [0] Aucun message non lu
-        [1] 1 message non lu
-       *[other] { $unreadCount } messages non lus
-    }
+  { $unreadCount ->
+  [0] Aucun message non lu
+  [1] 1 message non lu
+  *[other] { $unreadCount } messages non lus
+      }
 DIALTONE_UNREAD_MENTION_COUNT_TEXT =
-    { $unreadCount ->
-        [0] Aucune mention non lue
-        [1] 1 mention non lue
-       *[other] { $unreadCount } mentions non lues
-    }
+  { $unreadCount ->
+  [0] Aucune mention non lue
+  [1] 1 mention non lue
+  *[other] { $unreadCount } mentions non lues
+      }
 DIALTONE_TYPING_TEXT = Est en train d’écrire
 DIALTONE_ATTACHMENT_CAROUSEL_CLICK_TO_OPEN_ARIA_LABEL = Cliquez pour ouvrir
 DIALTONE_ATTACHMENT_CAROUSEL_PROGRESS_BAR_ARIA_LABEL = Téléchargement en cours
@@ -29,14 +29,14 @@ DIALTONE_DATEPICKER_NEXT_YEAR = l'année prochaine
 DIALTONE_DATEPICKER_SELECT_DAY = Sélectionnez le jour
 DIALTONE_DATEPICKER_CHANGE_TO = Passez à
 DIALTONE_EDITOR_CONFIRM_SET_LINK_BUTTON =
-    .title = Confirmer
-    .aria-label = Confirmer le lien défini
+  .title = Confirmer
+  .aria-label = Confirmer le lien défini
 DIALTONE_EDITOR_REMOVE_LINK_BUTTON =
-    .title = Supprimer
-    .aria-label = Supprimer le lien
+  .title = Supprimer
+  .aria-label = Supprimer le lien
 DIALTONE_EDITOR_CANCEL_SET_LINK_BUTTON =
-    .title = Annuler
-    .aria-label = Annuler le lien défini
+  .title = Annuler
+  .aria-label = Annuler le lien défini
 DIALTONE_EDITOR_QUICK_REPLY_BUTTON_LABEL = Modèle
 DIALTONE_EDITOR_BOLD_BUTTON_LABEL = Gras
 DIALTONE_EDITOR_ITALICS_BUTTON_LABEL = Italique
@@ -53,21 +53,13 @@ DIALTONE_EDITOR_CODE_BUTTON_LABEL = Code
 DIALTONE_EDITOR_IMAGE_BUTTON_LABEL = Image
 DIALTONE_EDITOR_LINK_BUTTON_LABEL = Lien
 DIALTONE_EDITOR_ADD_LINK_BUTTON =
-    .title = Ajouter un lien
-    .aria-label = Champ de saisie pour ajouter un lien
+  .title = Ajouter un lien
+  .aria-label = Champ de saisie pour ajouter un lien
 DIALTONE_EMOJI_ROW_REACTION_LABEL =
-    { $personCount ->
-        [one]
-            { $youIncluded ->
-               *[true] a réagi avec { $reaction }
-                [false] a réagi avec { $reaction }
-            }
-       *[other]
-            { $youIncluded ->
-               *[true] ont réagi avec { $reaction }
-                [false] ont réagi avec { $reaction }
-            }
-    }
+  { $personCount ->
+  [one] a réagi avec { $reaction }
+  *[other] ont réagi avec { $reaction }
+      }
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = Ajouter un émoji
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = Aucun résultat
 DIALTONE_EMOJI_PICKER_SEARCH_RESULTS_LABEL = résultats de la recherche
@@ -88,10 +80,10 @@ DIALTONE_GENERAL_ROW_ACTIVE_VOICE_CHAT_TEXT = Chat vocal actif
 DIALTONE_GENERAL_ROW_CALL_BUTTON_TOOLTIP = Appel
 DIALTONE_GENERAL_ROW_DND_TEXT_TOOLTIP = Ne pas déranger
 DIALTONE_GROUP_ROW_GROUP_COUNT_TEXT =
-    { $count ->
-        [1] 1 utilisateur
-       *[other] { $count } utilisateurs
-    }
+  { $count ->
+  [1] 1 utilisateur
+  *[other] { $count } utilisateurs
+      }
 DIALTONE_IVR_NODE_MENU_BUTTON_ARIA_LABEL = Ouvrir le menu
 DIALTONE_IVR_NODE_PROMPTMENU_ARIA_LABEL = nœud de menu d'invite
 DIALTONE_IVR_NODE_PROMPTCOLLECT_ARIA_LABEL = nœud de collecte d'invite
@@ -108,32 +100,32 @@ DIALTONE_MESSAGE_INPUT_IMAGE_PICKER_BUTTON_ARIA_LABEL = Joindre une image
 DIALTONE_MESSAGE_INPUT_EMOJI_PICKER_BUTTON_ARIA_LABEL = Sélectionner un emoji
 DIALTONE_MESSAGE_INPUT_CANCEL_BUTTON_ARIA_LABEL = Annuler
 DIALTONE_MESSAGE_INPUT_BOLD_BUTTON_LABEL =
-    .aria-label = Mettre en gras le texte sélectionné
-    .tooltip-text = Gras
+  .aria-label = Mettre en gras le texte sélectionné
+  .tooltip-text = Gras
 DIALTONE_MESSAGE_INPUT_ITALIC_BUTTON_LABEL =
-    .aria-label = Mettre en italique le texte sélectionné
-    .tooltip-text = Italique
+  .aria-label = Mettre en italique le texte sélectionné
+  .tooltip-text = Italique
 DIALTONE_MESSAGE_INPUT_STRIKETHROUGH_BUTTON_LABEL =
-    .aria-label = Barrer le texte sélectionné
-    .tooltip-text = Barré
+  .aria-label = Barrer le texte sélectionné
+  .tooltip-text = Barré
 DIALTONE_MESSAGE_INPUT_BULLET_LIST_BUTTON_LABEL =
-    .aria-label = Créez ou modifiez une liste à puces sur le texte sélectionné
-    .tooltip-text = Liste à puces
+  .aria-label = Créez ou modifiez une liste à puces sur le texte sélectionné
+  .tooltip-text = Liste à puces
 DIALTONE_MESSAGE_INPUT_ORDERED_LIST_BUTTON_LABEL =
-    .aria-label = Créer ou modifier une liste numérotée sur le texte sélectionné
-    .tooltip-text = Liste numérotée
+  .aria-label = Créer ou modifier une liste numérotée sur le texte sélectionné
+  .tooltip-text = Liste numérotée
 DIALTONE_MESSAGE_INPUT_BLOCK_QUOTE_BUTTON_LABEL =
-    .aria-label = Créer ou modifier un bloc de citation sur le texte sélectionné
-    .tooltip-text = Bloc de citation
+  .aria-label = Créer ou modifier un bloc de citation sur le texte sélectionné
+  .tooltip-text = Bloc de citation
 DIALTONE_MESSAGE_INPUT_CODE_BUTTON_LABEL =
-    .aria-label = Créer ou modifier un code sur le texte sélectionné
-    .tooltip-text = Code
+  .aria-label = Créer ou modifier un code sur le texte sélectionné
+  .tooltip-text = Code
 DIALTONE_MESSAGE_INPUT_CODE_BLOCK_BUTTON_LABEL =
-    .aria-label = Créer ou modifier un bloc de code sur le texte sélectionné
-    .tooltip-text = Bloc de code
+  .aria-label = Créer ou modifier un bloc de code sur le texte sélectionné
+  .tooltip-text = Bloc de code
 DIALTONE_MESSAGE_INPUT_LINK_BUTTON_LABEL =
-    .aria-label = Créer ou modifier un lien sur le texte sélectionné
-    .tooltip-text = Lien
+  .aria-label = Créer ou modifier un lien sur le texte sélectionné
+  .tooltip-text = Lien
 DIALTONE_MESSAGE_INPUT_LINK_DIALOG_TITLE = Ajouter un lien
 DIALTONE_MESSAGE_INPUT_LINK_TEXT_LABEL = Texte à afficher (facultatif)
 DIALTONE_MESSAGE_INPUT_LINK_LINK_LABEL = Lien

--- a/packages/dialtone-vue2/localization/it-IT.ftl
+++ b/packages/dialtone-vue2/localization/it-IT.ftl
@@ -3,17 +3,17 @@ DIALTONE_CLOSE_BUTTON = Clicca per chiudere
 DIALTONE_BREADCRUMBS_ARIA_LABEL = Breadcrumb
 DIALTONE_LOADING = Caricamento in corso
 DIALTONE_UNREAD_MESSAGE_COUNT_TEXT =
-    { $unreadCount ->
-        [0] Nessun messaggio non letto
-        [1] 1 messaggio non letto
-       *[other] { $unreadCount } messaggi non letti
-    }
+  { $unreadCount ->
+  [0] Nessun messaggio non letto
+  [1] 1 messaggio non letto
+  *[other] { $unreadCount } messaggi non letti
+      }
 DIALTONE_UNREAD_MENTION_COUNT_TEXT =
-    { $unreadCount ->
-        [0] Nessuna menzione non letta
-        [1] 1 menzione non letta
-       *[other] { $unreadCount } menzioni non lette
-    }
+  { $unreadCount ->
+  [0] Nessuna menzione non letta
+  [1] 1 menzione non letta
+  *[other] { $unreadCount } menzioni non lette
+      }
 DIALTONE_TYPING_TEXT = Digitare
 DIALTONE_ATTACHMENT_CAROUSEL_CLICK_TO_OPEN_ARIA_LABEL = Clicca per aprire
 DIALTONE_ATTACHMENT_CAROUSEL_PROGRESS_BAR_ARIA_LABEL = Caricamento
@@ -29,14 +29,14 @@ DIALTONE_DATEPICKER_NEXT_YEAR = l'anno prossimo
 DIALTONE_DATEPICKER_SELECT_DAY = Seleziona il giorno
 DIALTONE_DATEPICKER_CHANGE_TO = Cambia in
 DIALTONE_EDITOR_CONFIRM_SET_LINK_BUTTON =
-    .title = Conferma
-    .aria-label = Conferma il link impostato
+  .title = Conferma
+  .aria-label = Conferma il link impostato
 DIALTONE_EDITOR_REMOVE_LINK_BUTTON =
-    .title = Rimuovi
-    .aria-label = Rimuovi il link
+  .title = Rimuovi
+  .aria-label = Rimuovi il link
 DIALTONE_EDITOR_CANCEL_SET_LINK_BUTTON =
-    .title = Annulla
-    .aria-label = Annulla il link impostato
+  .title = Annulla
+  .aria-label = Annulla il link impostato
 DIALTONE_EDITOR_QUICK_REPLY_BUTTON_LABEL = Modello
 DIALTONE_EDITOR_BOLD_BUTTON_LABEL = Grassetto
 DIALTONE_EDITOR_ITALICS_BUTTON_LABEL = Corsivo
@@ -53,21 +53,13 @@ DIALTONE_EDITOR_CODE_BUTTON_LABEL = Codice
 DIALTONE_EDITOR_IMAGE_BUTTON_LABEL = Immagine
 DIALTONE_EDITOR_LINK_BUTTON_LABEL = Link
 DIALTONE_EDITOR_ADD_LINK_BUTTON =
-    .title = Aggiungi link
-    .aria-label = Campo di input per aggiungere il link
+  .title = Aggiungi link
+  .aria-label = Campo di input per aggiungere il link
 DIALTONE_EMOJI_ROW_REACTION_LABEL =
-    { $personCount ->
-        [one]
-            { $youIncluded ->
-               *[true] ha reagito con { $reaction }
-                [false] ha reagito con { $reaction }
-            }
-       *[other]
-            { $youIncluded ->
-               *[true] hanno reagito con { $reaction }
-                [false] hanno reagito con { $reaction }
-            }
-    }
+  { $personCount ->
+  [one] ha reagito con { $reaction }
+  *[other] hanno reagito con { $reaction }
+      }
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = Aggiungi emoji
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = Nessun risultato
 DIALTONE_EMOJI_PICKER_SEARCH_RESULTS_LABEL = ricerca risultati
@@ -88,10 +80,10 @@ DIALTONE_GENERAL_ROW_ACTIVE_VOICE_CHAT_TEXT = Chat vocale attiva
 DIALTONE_GENERAL_ROW_CALL_BUTTON_TOOLTIP = Chiamata
 DIALTONE_GENERAL_ROW_DND_TEXT_TOOLTIP = Non disturbare
 DIALTONE_GROUP_ROW_GROUP_COUNT_TEXT =
-    { $count ->
-        [1] 1 utente
-       *[other] { $count } utenti
-    }
+  { $count ->
+  [1] 1 utente
+  *[other] { $count } utenti
+      }
 DIALTONE_IVR_NODE_MENU_BUTTON_ARIA_LABEL = Apri menu
 DIALTONE_IVR_NODE_PROMPTMENU_ARIA_LABEL = nodo del menu di richiesta
 DIALTONE_IVR_NODE_PROMPTCOLLECT_ARIA_LABEL = nodo di raccolta prompt
@@ -108,32 +100,32 @@ DIALTONE_MESSAGE_INPUT_IMAGE_PICKER_BUTTON_ARIA_LABEL = Allega immagine
 DIALTONE_MESSAGE_INPUT_EMOJI_PICKER_BUTTON_ARIA_LABEL = Seleziona emoji
 DIALTONE_MESSAGE_INPUT_CANCEL_BUTTON_ARIA_LABEL = Annulla
 DIALTONE_MESSAGE_INPUT_BOLD_BUTTON_LABEL =
-    .aria-label = Attiva/disattiva il grassetto per il testo selezionato
-    .tooltip-text = Grassetto
+  .aria-label = Attiva/disattiva il grassetto per il testo selezionato
+  .tooltip-text = Grassetto
 DIALTONE_MESSAGE_INPUT_ITALIC_BUTTON_LABEL =
-    .aria-label = Attiva/disattiva il corsivo per il testo selezionato
-    .tooltip-text = Corsivo
+  .aria-label = Attiva/disattiva il corsivo per il testo selezionato
+  .tooltip-text = Corsivo
 DIALTONE_MESSAGE_INPUT_STRIKETHROUGH_BUTTON_LABEL =
-    .aria-label = Attiva/disattiva il barrato per il testo selezionato
-    .tooltip-text = Barrato
+  .aria-label = Attiva/disattiva il barrato per il testo selezionato
+  .tooltip-text = Barrato
 DIALTONE_MESSAGE_INPUT_BULLET_LIST_BUTTON_LABEL =
-    .aria-label = Crea o modifica l'elenco puntato per il testo selezionato
-    .tooltip-text = Elenco puntato
+  .aria-label = Crea o modifica l'elenco puntato per il testo selezionato
+  .tooltip-text = Elenco puntato
 DIALTONE_MESSAGE_INPUT_ORDERED_LIST_BUTTON_LABEL =
-    .aria-label = Crea o modifica un elenco ordinato per il testo selezionato
-    .tooltip-text = Elenco ordinato
+  .aria-label = Crea o modifica un elenco ordinato per il testo selezionato
+  .tooltip-text = Elenco ordinato
 DIALTONE_MESSAGE_INPUT_BLOCK_QUOTE_BUTTON_LABEL =
-    .aria-label = Crea o modifica una citazione in blocco per il testo selezionato
-    .tooltip-text = Citazione in blocco
+  .aria-label = Crea o modifica una citazione in blocco per il testo selezionato
+  .tooltip-text = Citazione in blocco
 DIALTONE_MESSAGE_INPUT_CODE_BUTTON_LABEL =
-    .aria-label = Crea o modifica il codice per il testo selezionato
-    .tooltip-text = Codice
+  .aria-label = Crea o modifica il codice per il testo selezionato
+  .tooltip-text = Codice
 DIALTONE_MESSAGE_INPUT_CODE_BLOCK_BUTTON_LABEL =
-    .aria-label = Crea o modifica un blocco di codice per il testo selezionato
-    .tooltip-text = Blocco di codice
+  .aria-label = Crea o modifica un blocco di codice per il testo selezionato
+  .tooltip-text = Blocco di codice
 DIALTONE_MESSAGE_INPUT_LINK_BUTTON_LABEL =
-    .aria-label = Crea o modifica un collegamento per il testo selezionato
-    .tooltip-text = Link
+  .aria-label = Crea o modifica un collegamento per il testo selezionato
+  .tooltip-text = Link
 DIALTONE_MESSAGE_INPUT_LINK_DIALOG_TITLE = Aggiungi un link
 DIALTONE_MESSAGE_INPUT_LINK_TEXT_LABEL = Testo da visualizzare (facoltativo)
 DIALTONE_MESSAGE_INPUT_LINK_LINK_LABEL = Link

--- a/packages/dialtone-vue2/localization/ja-JP.ftl
+++ b/packages/dialtone-vue2/localization/ja-JP.ftl
@@ -3,17 +3,17 @@ DIALTONE_CLOSE_BUTTON = クリックして閉じる
 DIALTONE_BREADCRUMBS_ARIA_LABEL = ブレッドクラム
 DIALTONE_LOADING = 読み込んでいます
 DIALTONE_UNREAD_MESSAGE_COUNT_TEXT =
-    { $unreadCount ->
-        [0] 未読メッセージはありません
-        [1] 1件の未読メッセージ
-       *[other] { $unreadCount }件の未読メッセージ
-    }
+  { $unreadCount ->
+  [0] 未読メッセージはありません
+  [1] 1件の未読メッセージ
+  *[other] { $unreadCount }件の未読メッセージ
+      }
 DIALTONE_UNREAD_MENTION_COUNT_TEXT =
-    { $unreadCount ->
-        [0] 未読メンションはありません
-        [1] 1件の未読メンション
-       *[other] { $unreadCount }件の未読メンション
-    }
+  { $unreadCount ->
+  [0] 未読メンションはありません
+  [1] 1件の未読メンション
+  *[other] { $unreadCount }件の未読メンション
+      }
 DIALTONE_TYPING_TEXT = 入力中
 DIALTONE_ATTACHMENT_CAROUSEL_CLICK_TO_OPEN_ARIA_LABEL = クリックして開く
 DIALTONE_ATTACHMENT_CAROUSEL_PROGRESS_BAR_ARIA_LABEL = アップロードしています...
@@ -29,14 +29,14 @@ DIALTONE_DATEPICKER_NEXT_YEAR = 来年
 DIALTONE_DATEPICKER_SELECT_DAY = 曜日を選択
 DIALTONE_DATEPICKER_CHANGE_TO = 次に変更 :
 DIALTONE_EDITOR_CONFIRM_SET_LINK_BUTTON =
-    .title = 確認
-    .aria-label = 設定リンクを確定
+  .title = 確認
+  .aria-label = 設定リンクを確定
 DIALTONE_EDITOR_REMOVE_LINK_BUTTON =
-    .title = 削除
-    .aria-label = リンクを削除
+  .title = 削除
+  .aria-label = リンクを削除
 DIALTONE_EDITOR_CANCEL_SET_LINK_BUTTON =
-    .title = キャンセル
-    .aria-label = 設定リンクをキャンセル
+  .title = キャンセル
+  .aria-label = 設定リンクをキャンセル
 DIALTONE_EDITOR_QUICK_REPLY_BUTTON_LABEL = テンプレート
 DIALTONE_EDITOR_BOLD_BUTTON_LABEL = 太字
 DIALTONE_EDITOR_ITALICS_BUTTON_LABEL = 斜体
@@ -53,16 +53,12 @@ DIALTONE_EDITOR_CODE_BUTTON_LABEL = コード
 DIALTONE_EDITOR_IMAGE_BUTTON_LABEL = 画像
 DIALTONE_EDITOR_LINK_BUTTON_LABEL = リンク
 DIALTONE_EDITOR_ADD_LINK_BUTTON =
-    .title = リンクを追加
-    .aria-label = リンクを追加するための入力フィールド
+  .title = リンクを追加
+  .aria-label = リンクを追加するための入力フィールド
 DIALTONE_EMOJI_ROW_REACTION_LABEL =
-    { $personCount ->
-       *[other]
-            { $youIncluded ->
-               *[true] が { $reaction } で反応しました
-                [false] が { $reaction } で反応しました
-            }
-    }
+  { $personCount ->
+  *[other] が { $reaction } で反応しました
+      }
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = 絵文字を追加
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = 見つかりません
 DIALTONE_EMOJI_PICKER_SEARCH_RESULTS_LABEL = 検索結果
@@ -83,10 +79,10 @@ DIALTONE_GENERAL_ROW_ACTIVE_VOICE_CHAT_TEXT = 進行中の音声チャット
 DIALTONE_GENERAL_ROW_CALL_BUTTON_TOOLTIP = 発信
 DIALTONE_GENERAL_ROW_DND_TEXT_TOOLTIP = プライバシーモード
 DIALTONE_GROUP_ROW_GROUP_COUNT_TEXT =
-    { $count ->
-        [1] 1ユーザー
-       *[other] { $count } ユーザー
-    }
+  { $count ->
+  [1] 1ユーザー
+  *[other] { $count } ユーザー
+      }
 DIALTONE_IVR_NODE_MENU_BUTTON_ARIA_LABEL = メニューを開く
 DIALTONE_IVR_NODE_PROMPTMENU_ARIA_LABEL = プロンプトメニューノード
 DIALTONE_IVR_NODE_PROMPTCOLLECT_ARIA_LABEL = プロンプト収集ノード
@@ -103,32 +99,32 @@ DIALTONE_MESSAGE_INPUT_IMAGE_PICKER_BUTTON_ARIA_LABEL = 画像を添付
 DIALTONE_MESSAGE_INPUT_EMOJI_PICKER_BUTTON_ARIA_LABEL = 絵文字を選択
 DIALTONE_MESSAGE_INPUT_CANCEL_BUTTON_ARIA_LABEL = キャンセル
 DIALTONE_MESSAGE_INPUT_BOLD_BUTTON_LABEL =
-    .aria-label = 選択したテキストの太字を切り替え
-    .tooltip-text = 太字
+  .aria-label = 選択したテキストの太字を切り替え
+  .tooltip-text = 太字
 DIALTONE_MESSAGE_INPUT_ITALIC_BUTTON_LABEL =
-    .aria-label = 選択したテキストの斜体を切り替え
-    .tooltip-text = 斜体
+  .aria-label = 選択したテキストの斜体を切り替え
+  .tooltip-text = 斜体
 DIALTONE_MESSAGE_INPUT_STRIKETHROUGH_BUTTON_LABEL =
-    .aria-label = 選択したテキストの取り消し線を切り替え
-    .tooltip-text = 取り消し線
+  .aria-label = 選択したテキストの取り消し線を切り替え
+  .tooltip-text = 取り消し線
 DIALTONE_MESSAGE_INPUT_BULLET_LIST_BUTTON_LABEL =
-    .aria-label = 選択したテキストの箇条書きを作成・編集
-    .tooltip-text = 箇条書きリスト
+  .aria-label = 選択したテキストの箇条書きを作成・編集
+  .tooltip-text = 箇条書きリスト
 DIALTONE_MESSAGE_INPUT_ORDERED_LIST_BUTTON_LABEL =
-    .aria-label = 選択したテキストの番号付きリストを作成・編集
-    .tooltip-text = 番号付きリスト
+  .aria-label = 選択したテキストの番号付きリストを作成・編集
+  .tooltip-text = 番号付きリスト
 DIALTONE_MESSAGE_INPUT_BLOCK_QUOTE_BUTTON_LABEL =
-    .aria-label = 選択したテキストの引用ブロックを作成・編集
-    .tooltip-text = 引用ブロック
+  .aria-label = 選択したテキストの引用ブロックを作成・編集
+  .tooltip-text = 引用ブロック
 DIALTONE_MESSAGE_INPUT_CODE_BUTTON_LABEL =
-    .aria-label = 選択したテキストのコードを作成・編集
-    .tooltip-text = コード
+  .aria-label = 選択したテキストのコードを作成・編集
+  .tooltip-text = コード
 DIALTONE_MESSAGE_INPUT_CODE_BLOCK_BUTTON_LABEL =
-    .aria-label = 選択したテキストのコードブロックを作成・編集
-    .tooltip-text = コードブロック
+  .aria-label = 選択したテキストのコードブロックを作成・編集
+  .tooltip-text = コードブロック
 DIALTONE_MESSAGE_INPUT_LINK_BUTTON_LABEL =
-    .aria-label = 選択したテキストのリンクを作成・編集
-    .tooltip-text = リンク
+  .aria-label = 選択したテキストのリンクを作成・編集
+  .tooltip-text = リンク
 DIALTONE_MESSAGE_INPUT_LINK_DIALOG_TITLE = リンクを追加
 DIALTONE_MESSAGE_INPUT_LINK_TEXT_LABEL = 表示するテキスト (任意)
 DIALTONE_MESSAGE_INPUT_LINK_LINK_LABEL = リンク

--- a/packages/dialtone-vue2/localization/nl-NL.ftl
+++ b/packages/dialtone-vue2/localization/nl-NL.ftl
@@ -3,17 +3,17 @@ DIALTONE_CLOSE_BUTTON = Klik om te sluiten
 DIALTONE_BREADCRUMBS_ARIA_LABEL = Breadcrumbs
 DIALTONE_LOADING = Laden
 DIALTONE_UNREAD_MESSAGE_COUNT_TEXT =
-    { $unreadCount ->
-        [0] Geen ongelezen berichten
-        [1] 1 ongelezen bericht
-       *[other] { $unreadCount } ongelezen berichten
-    }
+  { $unreadCount ->
+  [0] Geen ongelezen berichten
+  [1] 1 ongelezen bericht
+  *[other] { $unreadCount } ongelezen berichten
+      }
 DIALTONE_UNREAD_MENTION_COUNT_TEXT =
-    { $unreadCount ->
-        [0] Geen ongelezen vermeldingen
-        [1] 1 ongelezen vermelding
-       *[other] { $unreadCount } ongelezen vermeldingen
-    }
+  { $unreadCount ->
+  [0] Geen ongelezen vermeldingen
+  [1] 1 ongelezen vermelding
+  *[other] { $unreadCount } ongelezen vermeldingen
+      }
 DIALTONE_TYPING_TEXT = Typen
 DIALTONE_ATTACHMENT_CAROUSEL_CLICK_TO_OPEN_ARIA_LABEL = Klik om te openen
 DIALTONE_ATTACHMENT_CAROUSEL_PROGRESS_BAR_ARIA_LABEL = Uploaden
@@ -29,14 +29,14 @@ DIALTONE_DATEPICKER_NEXT_YEAR = volgend jaar
 DIALTONE_DATEPICKER_SELECT_DAY = Dag selecteren
 DIALTONE_DATEPICKER_CHANGE_TO = Wijzigen in
 DIALTONE_EDITOR_CONFIRM_SET_LINK_BUTTON =
-    .title = Bevestigen
-    .aria-label = Ingestelde link bevestigen
+  .title = Bevestigen
+  .aria-label = Ingestelde link bevestigen
 DIALTONE_EDITOR_REMOVE_LINK_BUTTON =
-    .title = Verwijderen
-    .aria-label = Link verwijderen
+  .title = Verwijderen
+  .aria-label = Link verwijderen
 DIALTONE_EDITOR_CANCEL_SET_LINK_BUTTON =
-    .title = Annuleren
-    .aria-label = Ingestelde link annuleren
+  .title = Annuleren
+  .aria-label = Ingestelde link annuleren
 DIALTONE_EDITOR_QUICK_REPLY_BUTTON_LABEL = Sjabloon
 DIALTONE_EDITOR_BOLD_BUTTON_LABEL = Vet
 DIALTONE_EDITOR_ITALICS_BUTTON_LABEL = Cursief
@@ -53,21 +53,13 @@ DIALTONE_EDITOR_CODE_BUTTON_LABEL = Code
 DIALTONE_EDITOR_IMAGE_BUTTON_LABEL = Afbeelding
 DIALTONE_EDITOR_LINK_BUTTON_LABEL = Link
 DIALTONE_EDITOR_ADD_LINK_BUTTON =
-    .title = Link toevoegen
-    .aria-label = Invoerveld om link toe te voegen
+  .title = Link toevoegen
+  .aria-label = Invoerveld om link toe te voegen
 DIALTONE_EMOJI_ROW_REACTION_LABEL =
-    { $personCount ->
-        [one]
-            { $youIncluded ->
-               *[true] heeft gereageerd met { $reaction }
-                [false] heeft gereageerd met { $reaction }
-            }
-       *[other]
-            { $youIncluded ->
-               *[true] hebben gereageerd met { $reaction }
-                [false] hebben gereageerd met { $reaction }
-            }
-    }
+  { $personCount ->
+  [one] heeft gereageerd met { $reaction }
+  *[other] hebben gereageerd met { $reaction }
+      }
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = Emoji toevoegen
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = Geen resultaten
 DIALTONE_EMOJI_PICKER_SEARCH_RESULTS_LABEL = Zoekresultaten
@@ -88,10 +80,10 @@ DIALTONE_GENERAL_ROW_ACTIVE_VOICE_CHAT_TEXT = Actieve voicechat
 DIALTONE_GENERAL_ROW_CALL_BUTTON_TOOLTIP = Bel
 DIALTONE_GENERAL_ROW_DND_TEXT_TOOLTIP = Niet storen
 DIALTONE_GROUP_ROW_GROUP_COUNT_TEXT =
-    { $count ->
-        [1] 1 gebruiker
-       *[other] { $count } gebruikers
-    }
+  { $count ->
+  [1] 1 gebruiker
+  *[other] { $count } gebruikers
+      }
 DIALTONE_IVR_NODE_MENU_BUTTON_ARIA_LABEL = Menu openen
 DIALTONE_IVR_NODE_PROMPTMENU_ARIA_LABEL = knooppunt promptmenu
 DIALTONE_IVR_NODE_PROMPTCOLLECT_ARIA_LABEL = knooppunt prompt verzamelen
@@ -108,32 +100,32 @@ DIALTONE_MESSAGE_INPUT_IMAGE_PICKER_BUTTON_ARIA_LABEL = Afbeelding bijvoegen
 DIALTONE_MESSAGE_INPUT_EMOJI_PICKER_BUTTON_ARIA_LABEL = Emoji selecteren
 DIALTONE_MESSAGE_INPUT_CANCEL_BUTTON_ARIA_LABEL = Annuleren
 DIALTONE_MESSAGE_INPUT_BOLD_BUTTON_LABEL =
-    .aria-label = Vet in- of uitschakelen voor geselecteerde tekst
-    .tooltip-text = Vet
+  .aria-label = Vet in- of uitschakelen voor geselecteerde tekst
+  .tooltip-text = Vet
 DIALTONE_MESSAGE_INPUT_ITALIC_BUTTON_LABEL =
-    .aria-label = Cursief in- of uitschakelen voor geselecteerde tekst
-    .tooltip-text = Cursief
+  .aria-label = Cursief in- of uitschakelen voor geselecteerde tekst
+  .tooltip-text = Cursief
 DIALTONE_MESSAGE_INPUT_STRIKETHROUGH_BUTTON_LABEL =
-    .aria-label = Doorhalen in- of uitschakelen voor geselecteerde tekst
-    .tooltip-text = Doorhalen
+  .aria-label = Doorhalen in- of uitschakelen voor geselecteerde tekst
+  .tooltip-text = Doorhalen
 DIALTONE_MESSAGE_INPUT_BULLET_LIST_BUTTON_LABEL =
-    .aria-label = Lijst met opsommingstekens maken of bewerken voor geselecteerde tekst
-    .tooltip-text = Lijst met opsommingstekens
+  .aria-label = Lijst met opsommingstekens maken of bewerken voor geselecteerde tekst
+  .tooltip-text = Lijst met opsommingstekens
 DIALTONE_MESSAGE_INPUT_ORDERED_LIST_BUTTON_LABEL =
-    .aria-label = Lijst op volgorde maken of bewerken voor geselecteerde tekst
-    .tooltip-text = Lijst op volgorde
+  .aria-label = Lijst op volgorde maken of bewerken voor geselecteerde tekst
+  .tooltip-text = Lijst op volgorde
 DIALTONE_MESSAGE_INPUT_BLOCK_QUOTE_BUTTON_LABEL =
-    .aria-label = Blokcitaat maken of bewerken voor geselecteerde tekst
-    .tooltip-text = Blokcitaat
+  .aria-label = Blokcitaat maken of bewerken voor geselecteerde tekst
+  .tooltip-text = Blokcitaat
 DIALTONE_MESSAGE_INPUT_CODE_BUTTON_LABEL =
-    .aria-label = Code maken of bewerken voor geselecteerde tekst
-    .tooltip-text = Code
+  .aria-label = Code maken of bewerken voor geselecteerde tekst
+  .tooltip-text = Code
 DIALTONE_MESSAGE_INPUT_CODE_BLOCK_BUTTON_LABEL =
-    .aria-label = Codeblok maken of bewerken voor geselecteerde tekst
-    .tooltip-text = Codeblok
+  .aria-label = Codeblok maken of bewerken voor geselecteerde tekst
+  .tooltip-text = Codeblok
 DIALTONE_MESSAGE_INPUT_LINK_BUTTON_LABEL =
-    .aria-label = Link maken of bewerken voor geselecteerde tekst
-    .tooltip-text = Link
+  .aria-label = Link maken of bewerken voor geselecteerde tekst
+  .tooltip-text = Link
 DIALTONE_MESSAGE_INPUT_LINK_DIALOG_TITLE = Link toevoegen
 DIALTONE_MESSAGE_INPUT_LINK_TEXT_LABEL = Tekst om weer te geven (optioneel)
 DIALTONE_MESSAGE_INPUT_LINK_LINK_LABEL = Link

--- a/packages/dialtone-vue2/localization/pt-BR.ftl
+++ b/packages/dialtone-vue2/localization/pt-BR.ftl
@@ -3,17 +3,17 @@ DIALTONE_CLOSE_BUTTON = Clique para fechar
 DIALTONE_BREADCRUMBS_ARIA_LABEL = Breadcrumbs
 DIALTONE_LOADING = Carregando
 DIALTONE_UNREAD_MESSAGE_COUNT_TEXT =
-    { $unreadCount ->
-        [0] Nenhuma mensagem não lida
-        [1] 1 mensagem não lida
-       *[other] { $unreadCount } mensagens não lidas
-    }
+  { $unreadCount ->
+  [0] Nenhuma mensagem não lida
+  [1] 1 mensagem não lida
+  *[other] { $unreadCount } mensagens não lidas
+      }
 DIALTONE_UNREAD_MENTION_COUNT_TEXT =
-    { $unreadCount ->
-        [0] Sem menções não lidas
-        [1] 1 menção não lida
-       *[other] { $unreadCount } menções não lidas
-    }
+  { $unreadCount ->
+  [0] Sem menções não lidas
+  [1] 1 menção não lida
+  *[other] { $unreadCount } menções não lidas
+      }
 DIALTONE_TYPING_TEXT = Digitando
 DIALTONE_ATTACHMENT_CAROUSEL_CLICK_TO_OPEN_ARIA_LABEL = Clique para abrir
 DIALTONE_ATTACHMENT_CAROUSEL_PROGRESS_BAR_ARIA_LABEL = Carregando
@@ -29,14 +29,14 @@ DIALTONE_DATEPICKER_NEXT_YEAR = próximo ano
 DIALTONE_DATEPICKER_SELECT_DAY = Selecionar dia
 DIALTONE_DATEPICKER_CHANGE_TO = Mudar para
 DIALTONE_EDITOR_CONFIRM_SET_LINK_BUTTON =
-    .title = Confirmar
-    .aria-label = Confirmar link de definição
+  .title = Confirmar
+  .aria-label = Confirmar link de definição
 DIALTONE_EDITOR_REMOVE_LINK_BUTTON =
-    .title = Remover
-    .aria-label = Remover link
+  .title = Remover
+  .aria-label = Remover link
 DIALTONE_EDITOR_CANCEL_SET_LINK_BUTTON =
-    .title = Cancelar
-    .aria-label = Cancelar link de definição
+  .title = Cancelar
+  .aria-label = Cancelar link de definição
 DIALTONE_EDITOR_QUICK_REPLY_BUTTON_LABEL = Modelo
 DIALTONE_EDITOR_BOLD_BUTTON_LABEL = Negrito
 DIALTONE_EDITOR_ITALICS_BUTTON_LABEL = Itálico
@@ -53,21 +53,13 @@ DIALTONE_EDITOR_CODE_BUTTON_LABEL = Código
 DIALTONE_EDITOR_IMAGE_BUTTON_LABEL = Imagem
 DIALTONE_EDITOR_LINK_BUTTON_LABEL = Link
 DIALTONE_EDITOR_ADD_LINK_BUTTON =
-    .title = Adicionar link
-    .aria-label = Campo de entrada para adicionar link
+  .title = Adicionar link
+  .aria-label = Campo de entrada para adicionar link
 DIALTONE_EMOJI_ROW_REACTION_LABEL =
-    { $personCount ->
-        [one]
-            { $youIncluded ->
-               *[true] reagiu com { $reaction }
-                [false] reagiu com { $reaction }
-            }
-       *[other]
-            { $youIncluded ->
-               *[true] reagiram com { $reaction }
-                [false] reagiram com { $reaction }
-            }
-    }
+  { $personCount ->
+  [one] reagiu com { $reaction }
+  *[other] reagiram com { $reaction }
+      }
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = Adicionar emoji
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = Nenhum resultado
 DIALTONE_EMOJI_PICKER_SEARCH_RESULTS_LABEL = resultados da pesquisa
@@ -88,10 +80,10 @@ DIALTONE_GENERAL_ROW_ACTIVE_VOICE_CHAT_TEXT = Chat de voz ativo
 DIALTONE_GENERAL_ROW_CALL_BUTTON_TOOLTIP = Ligar
 DIALTONE_GENERAL_ROW_DND_TEXT_TOOLTIP = Não Perturbe
 DIALTONE_GROUP_ROW_GROUP_COUNT_TEXT =
-    { $count ->
-        [1] 1 usuário
-       *[other] { $count } Usuários
-    }
+  { $count ->
+  [1] 1 usuário
+  *[other] { $count } Usuários
+      }
 DIALTONE_IVR_NODE_MENU_BUTTON_ARIA_LABEL = Abrir menu
 DIALTONE_IVR_NODE_PROMPTMENU_ARIA_LABEL = nó do menu de comandos
 DIALTONE_IVR_NODE_PROMPTCOLLECT_ARIA_LABEL = nó de coleta de comandos
@@ -108,32 +100,32 @@ DIALTONE_MESSAGE_INPUT_IMAGE_PICKER_BUTTON_ARIA_LABEL = Anexar imagem
 DIALTONE_MESSAGE_INPUT_EMOJI_PICKER_BUTTON_ARIA_LABEL = Selecione emoji
 DIALTONE_MESSAGE_INPUT_CANCEL_BUTTON_ARIA_LABEL = Cancelar
 DIALTONE_MESSAGE_INPUT_BOLD_BUTTON_LABEL =
-    .aria-label = Ativar negrito no texto selecionado
-    .tooltip-text = Negrito
+  .aria-label = Ativar negrito no texto selecionado
+  .tooltip-text = Negrito
 DIALTONE_MESSAGE_INPUT_ITALIC_BUTTON_LABEL =
-    .aria-label = Ativar itálico no texto selecionado
-    .tooltip-text = Itálico
+  .aria-label = Ativar itálico no texto selecionado
+  .tooltip-text = Itálico
 DIALTONE_MESSAGE_INPUT_STRIKETHROUGH_BUTTON_LABEL =
-    .aria-label = Ativar o tachado no texto selecionado
-    .tooltip-text = Tachado
+  .aria-label = Ativar o tachado no texto selecionado
+  .tooltip-text = Tachado
 DIALTONE_MESSAGE_INPUT_BULLET_LIST_BUTTON_LABEL =
-    .aria-label = Crie ou edite uma lista de marcadores no texto selecionado
-    .tooltip-text = Lista de marcadores
+  .aria-label = Crie ou edite uma lista de marcadores no texto selecionado
+  .tooltip-text = Lista de marcadores
 DIALTONE_MESSAGE_INPUT_ORDERED_LIST_BUTTON_LABEL =
-    .aria-label = Crie ou edite uma lista ordenada no texto selecionado
-    .tooltip-text = Lista ordenada
+  .aria-label = Crie ou edite uma lista ordenada no texto selecionado
+  .tooltip-text = Lista ordenada
 DIALTONE_MESSAGE_INPUT_BLOCK_QUOTE_BUTTON_LABEL =
-    .aria-label = Crie ou edite a citação em bloco no texto selecionado
-    .tooltip-text = Citação em bloco
+  .aria-label = Crie ou edite a citação em bloco no texto selecionado
+  .tooltip-text = Citação em bloco
 DIALTONE_MESSAGE_INPUT_CODE_BUTTON_LABEL =
-    .aria-label = Crie ou edite código no texto selecionado
-    .tooltip-text = Código
+  .aria-label = Crie ou edite código no texto selecionado
+  .tooltip-text = Código
 DIALTONE_MESSAGE_INPUT_CODE_BLOCK_BUTTON_LABEL =
-    .aria-label = Crie ou edite um bloco de código no texto selecionado
-    .tooltip-text = Bloco de código
+  .aria-label = Crie ou edite um bloco de código no texto selecionado
+  .tooltip-text = Bloco de código
 DIALTONE_MESSAGE_INPUT_LINK_BUTTON_LABEL =
-    .aria-label = Crie ou edite link no texto selecionado
-    .tooltip-text = Link
+  .aria-label = Crie ou edite link no texto selecionado
+  .tooltip-text = Link
 DIALTONE_MESSAGE_INPUT_LINK_DIALOG_TITLE = Adicionar um link
 DIALTONE_MESSAGE_INPUT_LINK_TEXT_LABEL = Texto a ser exibido (opcional)
 DIALTONE_MESSAGE_INPUT_LINK_LINK_LABEL = Link

--- a/packages/dialtone-vue2/localization/ru-RU.ftl
+++ b/packages/dialtone-vue2/localization/ru-RU.ftl
@@ -3,17 +3,17 @@ DIALTONE_CLOSE_BUTTON = Нажмите, чтобы закрыть
 DIALTONE_BREADCRUMBS_ARIA_LABEL = Навигационная цепочка
 DIALTONE_LOADING = Идет загрузка
 DIALTONE_UNREAD_MESSAGE_COUNT_TEXT =
-    { $unreadCount ->
-        [0] Нет непрочитанных сообщений
-        [1] 1 непрочитанное сообщение
-       *[other] Непрочитанных сообщений: { $unreadCount }
-    }
+  { $unreadCount ->
+  [0] Нет непрочитанных сообщений
+  [1] 1 непрочитанное сообщение
+  *[other] Непрочитанных сообщений: { $unreadCount }
+      }
 DIALTONE_UNREAD_MENTION_COUNT_TEXT =
-    { $unreadCount ->
-        [0] Нет непрочитанных упоминаний
-        [1] 1 непрочитанное упоминание
-       *[other] Непрочитанных упоминаний: { $unreadCount }
-    }
+  { $unreadCount ->
+  [0] Нет непрочитанных упоминаний
+  [1] 1 непрочитанное упоминание
+  *[other] Непрочитанных упоминаний: { $unreadCount }
+      }
 DIALTONE_TYPING_TEXT = Пишет
 DIALTONE_ATTACHMENT_CAROUSEL_CLICK_TO_OPEN_ARIA_LABEL = Нажмите, чтобы открыть
 DIALTONE_ATTACHMENT_CAROUSEL_PROGRESS_BAR_ARIA_LABEL = Загрузка
@@ -29,14 +29,14 @@ DIALTONE_DATEPICKER_NEXT_YEAR = в следующем году
 DIALTONE_DATEPICKER_SELECT_DAY = Выберите день
 DIALTONE_DATEPICKER_CHANGE_TO = Изменить на
 DIALTONE_EDITOR_CONFIRM_SET_LINK_BUTTON =
-    .title = Подтвердить
-    .aria-label = Подтвердите заданную ссылку
+  .title = Подтвердить
+  .aria-label = Подтвердите заданную ссылку
 DIALTONE_EDITOR_REMOVE_LINK_BUTTON =
-    .title = Удалить
-    .aria-label = Удалить ссылку
+  .title = Удалить
+  .aria-label = Удалить ссылку
 DIALTONE_EDITOR_CANCEL_SET_LINK_BUTTON =
-    .title = Отмена
-    .aria-label = Отменить заданную ссылку
+  .title = Отмена
+  .aria-label = Отменить заданную ссылку
 DIALTONE_EDITOR_QUICK_REPLY_BUTTON_LABEL = Шаблон
 DIALTONE_EDITOR_BOLD_BUTTON_LABEL = Жирный
 DIALTONE_EDITOR_ITALICS_BUTTON_LABEL = Курсив
@@ -53,31 +53,15 @@ DIALTONE_EDITOR_CODE_BUTTON_LABEL = Код
 DIALTONE_EDITOR_IMAGE_BUTTON_LABEL = Изображение
 DIALTONE_EDITOR_LINK_BUTTON_LABEL = Ссылка
 DIALTONE_EDITOR_ADD_LINK_BUTTON =
-    .title = Добавить ссылку
-    .aria-label = Поле ввода для добавления ссылки
+  .title = Добавить ссылку
+  .aria-label = Поле ввода для добавления ссылки
 DIALTONE_EMOJI_ROW_REACTION_LABEL =
-    { $personCount ->
-        [one]
-            { $youIncluded ->
-               *[true] реагирует с { $reaction }
-                [false] реагирует с { $reaction }
-            }
-        [few]
-            { $youIncluded ->
-               *[true] реагируют с { $reaction }
-                [false] реагируют с { $reaction }
-            }
-        [many]
-            { $youIncluded ->
-               *[true] реагируют с { $reaction }
-                [false] реагируют с { $reaction }
-            }
-       *[other]
-            { $youIncluded ->
-               *[true] реагируют с { $reaction }
-                [false] реагируют с { $reaction }
-            }
-    }
+  { $personCount ->
+  [one] реагирует с { $reaction }
+  [few] реагируют с { $reaction }
+  [many] реагируют с { $reaction }
+  *[other] реагируют с { $reaction }
+      }
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = Добавить смайлик
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = Нет результатов
 DIALTONE_EMOJI_PICKER_SEARCH_RESULTS_LABEL = результаты поиска
@@ -98,10 +82,10 @@ DIALTONE_GENERAL_ROW_ACTIVE_VOICE_CHAT_TEXT = Активный голосово�
 DIALTONE_GENERAL_ROW_CALL_BUTTON_TOOLTIP = Вызов
 DIALTONE_GENERAL_ROW_DND_TEXT_TOOLTIP = Режим «Не беспокоить»
 DIALTONE_GROUP_ROW_GROUP_COUNT_TEXT =
-    { $count ->
-        [1] 1 пользователь
-       *[other] { $count } пользователей
-    }
+  { $count ->
+  [1] 1 пользователь
+  *[other] { $count } пользователей
+      }
 DIALTONE_IVR_NODE_MENU_BUTTON_ARIA_LABEL = Открыть меню
 DIALTONE_IVR_NODE_PROMPTMENU_ARIA_LABEL = узел меню запросов
 DIALTONE_IVR_NODE_PROMPTCOLLECT_ARIA_LABEL = узел сбора запросов
@@ -118,32 +102,32 @@ DIALTONE_MESSAGE_INPUT_IMAGE_PICKER_BUTTON_ARIA_LABEL = Прикрепить и�
 DIALTONE_MESSAGE_INPUT_EMOJI_PICKER_BUTTON_ARIA_LABEL = Выбрать эмодзи
 DIALTONE_MESSAGE_INPUT_CANCEL_BUTTON_ARIA_LABEL = Отмена
 DIALTONE_MESSAGE_INPUT_BOLD_BUTTON_LABEL =
-    .aria-label = Переключить жирный шрифт в выбранном тексте
-    .tooltip-text = Жирный
+  .aria-label = Переключить жирный шрифт в выбранном тексте
+  .tooltip-text = Жирный
 DIALTONE_MESSAGE_INPUT_ITALIC_BUTTON_LABEL =
-    .aria-label = Включить курсив в выбранном тексте
-    .tooltip-text = Курсив
+  .aria-label = Включить курсив в выбранном тексте
+  .tooltip-text = Курсив
 DIALTONE_MESSAGE_INPUT_STRIKETHROUGH_BUTTON_LABEL =
-    .aria-label = Включить зачеркивание выбранного текста
-    .tooltip-text = Зачеркнутый
+  .aria-label = Включить зачеркивание выбранного текста
+  .tooltip-text = Зачеркнутый
 DIALTONE_MESSAGE_INPUT_BULLET_LIST_BUTTON_LABEL =
-    .aria-label = Создать или отредактировать маркированный список в выбранном тексте
-    .tooltip-text = Маркированный список
+  .aria-label = Создать или отредактировать маркированный список в выбранном тексте
+  .tooltip-text = Маркированный список
 DIALTONE_MESSAGE_INPUT_ORDERED_LIST_BUTTON_LABEL =
-    .aria-label = Создать или отредактировать упорядоченный список в выбранном тексте
-    .tooltip-text = Упорядоченный список
+  .aria-label = Создать или отредактировать упорядоченный список в выбранном тексте
+  .tooltip-text = Упорядоченный список
 DIALTONE_MESSAGE_INPUT_BLOCK_QUOTE_BUTTON_LABEL =
-    .aria-label = Создать или отредактировать блочную цитату в выбранном тексте
-    .tooltip-text = Блочная цитата
+  .aria-label = Создать или отредактировать блочную цитату в выбранном тексте
+  .tooltip-text = Блочная цитата
 DIALTONE_MESSAGE_INPUT_CODE_BUTTON_LABEL =
-    .aria-label = Создать или отредактировать код в выбранном тексте
-    .tooltip-text = Код
+  .aria-label = Создать или отредактировать код в выбранном тексте
+  .tooltip-text = Код
 DIALTONE_MESSAGE_INPUT_CODE_BLOCK_BUTTON_LABEL =
-    .aria-label = Создать или отредактировать блок кода в выбранном тексте
-    .tooltip-text = Блок кода
+  .aria-label = Создать или отредактировать блок кода в выбранном тексте
+  .tooltip-text = Блок кода
 DIALTONE_MESSAGE_INPUT_LINK_BUTTON_LABEL =
-    .aria-label = Создать или изменить ссылку в выделенном тексте
-    .tooltip-text = Ссылка
+  .aria-label = Создать или изменить ссылку в выделенном тексте
+  .tooltip-text = Ссылка
 DIALTONE_MESSAGE_INPUT_LINK_DIALOG_TITLE = Добавить ссылку
 DIALTONE_MESSAGE_INPUT_LINK_TEXT_LABEL = Текст для отображения (необязательно)
 DIALTONE_MESSAGE_INPUT_LINK_LINK_LABEL = Ссылка

--- a/packages/dialtone-vue2/localization/zh-CN.ftl
+++ b/packages/dialtone-vue2/localization/zh-CN.ftl
@@ -3,17 +3,17 @@ DIALTONE_CLOSE_BUTTON = 点击关闭
 DIALTONE_BREADCRUMBS_ARIA_LABEL = 面包屑导航
 DIALTONE_LOADING = 正在加载
 DIALTONE_UNREAD_MESSAGE_COUNT_TEXT =
-    { $unreadCount ->
-        [0] 没有未读消息
-        [1] 1 条未读消息
-       *[other] { $unreadCount } 条未读消息
-    }
+  { $unreadCount ->
+  [0] 没有未读消息
+  [1] 1 条未读消息
+  *[other] { $unreadCount } 条未读消息
+      }
 DIALTONE_UNREAD_MENTION_COUNT_TEXT =
-    { $unreadCount ->
-        [0] 没有未读提及
-        [1] 1 条未读提及
-       *[other] { $unreadCount } 条未读提及
-    }
+  { $unreadCount ->
+  [0] 没有未读提及
+  [1] 1 条未读提及
+  *[other] { $unreadCount } 条未读提及
+      }
 DIALTONE_TYPING_TEXT = 正在打字
 DIALTONE_ATTACHMENT_CAROUSEL_CLICK_TO_OPEN_ARIA_LABEL = 点击打开
 DIALTONE_ATTACHMENT_CAROUSEL_PROGRESS_BAR_ARIA_LABEL = 上传
@@ -29,14 +29,14 @@ DIALTONE_DATEPICKER_NEXT_YEAR = 明年
 DIALTONE_DATEPICKER_SELECT_DAY = 选择日期
 DIALTONE_DATEPICKER_CHANGE_TO = 更改为
 DIALTONE_EDITOR_CONFIRM_SET_LINK_BUTTON =
-    .title = 确认
-    .aria-label = 确认设置链接
+  .title = 确认
+  .aria-label = 确认设置链接
 DIALTONE_EDITOR_REMOVE_LINK_BUTTON =
-    .title = 移除
-    .aria-label = 删除链接
+  .title = 移除
+  .aria-label = 删除链接
 DIALTONE_EDITOR_CANCEL_SET_LINK_BUTTON =
-    .title = 取消
-    .aria-label = 取消设置链接
+  .title = 取消
+  .aria-label = 取消设置链接
 DIALTONE_EDITOR_QUICK_REPLY_BUTTON_LABEL = 模板
 DIALTONE_EDITOR_BOLD_BUTTON_LABEL = 粗体
 DIALTONE_EDITOR_ITALICS_BUTTON_LABEL = 斜体
@@ -53,16 +53,12 @@ DIALTONE_EDITOR_CODE_BUTTON_LABEL = 代码
 DIALTONE_EDITOR_IMAGE_BUTTON_LABEL = 图像
 DIALTONE_EDITOR_LINK_BUTTON_LABEL = 链接
 DIALTONE_EDITOR_ADD_LINK_BUTTON =
-    .title = 添加链接
-    .aria-label = 添加链接的输入字段
+  .title = 添加链接
+  .aria-label = 添加链接的输入字段
 DIALTONE_EMOJI_ROW_REACTION_LABEL =
-    { $personCount ->
-       *[other]
-            { $youIncluded ->
-               *[true] 使用了 { $reaction } 作为回复
-                [false] 使用了 { $reaction } 作为回复
-            }
-    }
+  { $personCount ->
+  *[other] 使用了 { $reaction } 作为回复
+      }
 DIALTONE_EMOJI_PICKER_ADD_EMOJI_LABEL = 添加表情符号
 DIALTONE_EMOJI_PICKER_SEARCH_NO_RESULTS_LABEL = 没有结果
 DIALTONE_EMOJI_PICKER_SEARCH_RESULTS_LABEL = 搜索结果
@@ -83,10 +79,10 @@ DIALTONE_GENERAL_ROW_ACTIVE_VOICE_CHAT_TEXT = 进行语音聊天
 DIALTONE_GENERAL_ROW_CALL_BUTTON_TOOLTIP = 呼叫
 DIALTONE_GENERAL_ROW_DND_TEXT_TOOLTIP = 请勿打扰
 DIALTONE_GROUP_ROW_GROUP_COUNT_TEXT =
-    { $count ->
-        [1] 1 位用户
-       *[other] { $count } 用户
-    }
+  { $count ->
+  [1] 1 位用户
+  *[other] { $count } 用户
+      }
 DIALTONE_IVR_NODE_MENU_BUTTON_ARIA_LABEL = 打开菜单
 DIALTONE_IVR_NODE_PROMPTMENU_ARIA_LABEL = 提示菜单节点
 DIALTONE_IVR_NODE_PROMPTCOLLECT_ARIA_LABEL = 提示收集节点
@@ -103,32 +99,32 @@ DIALTONE_MESSAGE_INPUT_IMAGE_PICKER_BUTTON_ARIA_LABEL = 附上图片
 DIALTONE_MESSAGE_INPUT_EMOJI_PICKER_BUTTON_ARIA_LABEL = 选择表情符号
 DIALTONE_MESSAGE_INPUT_CANCEL_BUTTON_ARIA_LABEL = 取消
 DIALTONE_MESSAGE_INPUT_BOLD_BUTTON_LABEL =
-    .aria-label = 切换选定文本的粗体
-    .tooltip-text = 粗体
+  .aria-label = 切换选定文本的粗体
+  .tooltip-text = 粗体
 DIALTONE_MESSAGE_INPUT_ITALIC_BUTTON_LABEL =
-    .aria-label = 切换所选文本的斜体
-    .tooltip-text = 斜体
+  .aria-label = 切换所选文本的斜体
+  .tooltip-text = 斜体
 DIALTONE_MESSAGE_INPUT_STRIKETHROUGH_BUTTON_LABEL =
-    .aria-label = 切换选定文本的删除线
-    .tooltip-text = 删除线
+  .aria-label = 切换选定文本的删除线
+  .tooltip-text = 删除线
 DIALTONE_MESSAGE_INPUT_BULLET_LIST_BUTTON_LABEL =
-    .aria-label = 在选定的文本上创建或编辑项目符号列表
-    .tooltip-text = 项目符号列表
+  .aria-label = 在选定的文本上创建或编辑项目符号列表
+  .tooltip-text = 项目符号列表
 DIALTONE_MESSAGE_INPUT_ORDERED_LIST_BUTTON_LABEL =
-    .aria-label = 创建或编辑选定文本的有序列表
-    .tooltip-text = 有序列表
+  .aria-label = 创建或编辑选定文本的有序列表
+  .tooltip-text = 有序列表
 DIALTONE_MESSAGE_INPUT_BLOCK_QUOTE_BUTTON_LABEL =
-    .aria-label = 在选定的文本上创建或编辑块引用
-    .tooltip-text = 块引用
+  .aria-label = 在选定的文本上创建或编辑块引用
+  .tooltip-text = 块引用
 DIALTONE_MESSAGE_INPUT_CODE_BUTTON_LABEL =
-    .aria-label = 在选定的文本上创建或编辑代码
-    .tooltip-text = 代码
+  .aria-label = 在选定的文本上创建或编辑代码
+  .tooltip-text = 代码
 DIALTONE_MESSAGE_INPUT_CODE_BLOCK_BUTTON_LABEL =
-    .aria-label = 在选定的文本上创建或编辑代码块
-    .tooltip-text = 代码块
+  .aria-label = 在选定的文本上创建或编辑代码块
+  .tooltip-text = 代码块
 DIALTONE_MESSAGE_INPUT_LINK_BUTTON_LABEL =
-    .aria-label = 在选定的文本上创建或编辑链接
-    .tooltip-text = 链接
+  .aria-label = 在选定的文本上创建或编辑链接
+  .tooltip-text = 链接
 DIALTONE_MESSAGE_INPUT_LINK_DIALOG_TITLE = 添加链接
 DIALTONE_MESSAGE_INPUT_LINK_TEXT_LABEL = 显示的文本（可选）
 DIALTONE_MESSAGE_INPUT_LINK_LINK_LABEL = 链接

--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -116,7 +116,6 @@ export default {
       return this.i18n.$t('DIALTONE_EMOJI_ROW_REACTION_LABEL', {
         reaction: getEmojiShortCode(reaction.emojiUnicodeOrShortname),
         personCount: reaction.num,
-        youIncluded: reaction.isSelected,
       });
     },
   },

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -117,7 +117,6 @@ export default {
       return this.i18n.$t('DIALTONE_EMOJI_ROW_REACTION_LABEL', {
         reaction: getEmojiShortCode(reaction.emojiUnicodeOrShortname),
         personCount: reaction.num,
-        youIncluded: reaction.isSelected,
       });
     },
   },


### PR DESCRIPTION
# Fix emoji row reaction label fluent-vue warnings

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3dDFudXV0ZDk0ZTlxZnR6MWk5Mm1nNW93czcxbXJrcWNiM3NzM21ncCZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/pyHTKJ4G9WGQKd12cl/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2768

## :book: Description

- Removed `youIncluded` boolean variable, fluent doesn't allow to use boolean values.
- Updated translations to avoid having to wait for translations to be ready on Smartling

## :bulb: Context

Warnings reported on product and replicated on our documentation site

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

- Update string on smartling
