### PR TITLE
fix(checkbox, radio): DLT-2772 add pointer cursor to entire checkbox/radio label region

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/radio-checkbox.less
+++ b/packages/dialtone-css/lib/build/less/components/radio-checkbox.less
@@ -90,15 +90,17 @@
 .d-radio-group {
     display: inline-flex;
     gap: var(--dt-space-400); // 8
+    cursor: pointer;
+}
+//  --  Wrapper Disabled State
+.d-checkbox-group--disabled,
+.d-radio-group--disabled {
+    cursor: not-allowed;
 
-    //  --  Wrapper Disabled State
-    &.d-checkbox-group--disabled,
-    &.d-radio-group--disabled {
-        .d-checkbox__label,
-        .d-radio__label {
-            color: var(--dt-color-foreground-disabled);
-            cursor: not-allowed;
-        }
+    .d-checkbox__label,
+    .d-radio__label {
+        color: var(--dt-color-foreground-disabled);
+        cursor: not-allowed;
     }
 }
 


### PR DESCRIPTION
# DLT-2772 add pointer cursor to entire checkbox/radio label region

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2772

## :book: Description

The gap between radio/checkbox is technically clickable, though the cursor didn't reflect that. 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.