### PR TITLE
refactor(emoji-picker): DLT-2776 new prop showAddEmojiButton

### DIFF
--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.stories.js
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.stories.js
@@ -65,6 +65,7 @@ export const argsData = {
   customEmojis,
   skinTone: 'Default',
   showPopover: false,
+  showAddEmojiButton: true,
 };
 
 export const argTypesData = {
@@ -76,6 +77,9 @@ export const argTypesData = {
     control: 'text',
   },
   showSearch: {
+    control: 'boolean',
+  },
+  showAddEmojiButton: {
     control: 'boolean',
   },
   onSkinTone: {

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.test.js
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.test.js
@@ -178,6 +178,10 @@ describe('DtEmojiPicker Tests', () => {
     });
 
     it('Should render add emoji button', () => {
+      mockProps = { showAddEmojiButton: true };
+
+      updateWrapper();
+
       const addEmojiButton = wrapper.find('.d-emoji-picker__add-emoji');
 
       expect(addEmojiButton.exists()).toBe(true);
@@ -243,6 +247,21 @@ describe('DtEmojiPicker Tests', () => {
   });
 
   describe('Interactivity Tests', () => {
+    it('Should emit add-emoji event when add emoji button is clicked', async () => {
+      mockProps = { showAddEmojiButton: true };
+
+      updateWrapper();
+
+      const addEmojiButton = wrapper.find('.d-emoji-picker__add-emoji');
+
+      expect(addEmojiButton.exists()).toBe(true);
+
+      await addEmojiButton.trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted('add-emoji')).toBeTruthy();
+    });
+
     it('Should emit selected-emoji event when emoji is clicked', async () => {
       const emoji = wrapper.find('.d-emoji-picker__selector .d-emoji-picker__tab button');
 

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker.vue
@@ -51,7 +51,7 @@
     </div>
     <div class="d-emoji-picker--footer">
       <dt-button
-        v-if="showCustomEmojisTab && !highlightedEmoji"
+        v-if="showAddEmojiButton && !highlightedEmoji"
         importance="outlined"
         :aria-label="addEmojiLabel"
         class="d-emoji-picker__add-emoji"
@@ -157,6 +157,17 @@ export default {
       type: Boolean,
       default: true,
     },
+
+    /**
+     * Shows the add emoji button in the footer when no emoji is highlighted
+     * @type {Boolean}
+     * @example
+     * <dt-emoji-picker :show-add-emoji-button="true" />
+     */
+    showAddEmojiButton: {
+      type: Boolean,
+      default: false,
+    }
   },
 
   data () {

--- a/packages/dialtone-vue2/components/emoji_picker/emoji_picker_default.story.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/emoji_picker_default.story.vue
@@ -5,6 +5,7 @@
     :custom-emojis="$attrs.customEmojis"
     :search-query="$attrs.searchQuery"
     :show-search="$attrs.showSearch"
+    :show-add-emoji-button="$attrs.showAddEmojiButton"
     @skin-tone="isSkinTone = $event; $attrs.onSkinTone($event)"
     @close="$attrs.onClose($event)"
     @selected-emoji="$attrs.onSelectedEmoji($event)"

--- a/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue2/recipes/conversation_view/message_input/message_input.stories.js
@@ -318,6 +318,7 @@ export const WithCustomEmoji = {
     emojiPickerProps: {
       skinTone: 'Default',
       customEmojis: customEmojiJson,
+      showAddEmojiButton: true,
     },
   },
 };

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.stories.js
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.stories.js
@@ -65,6 +65,7 @@ export const argsData = {
   customEmojis,
   skinTone: 'Default',
   showPopover: false,
+  showAddEmojiButton: true,
 };
 
 export const argTypesData = {
@@ -76,6 +77,9 @@ export const argTypesData = {
     control: 'text',
   },
   showSearch: {
+    control: 'boolean',
+  },
+  showAddEmojiButton: {
     control: 'boolean',
   },
   onSkinTone: {

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.test.js
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.test.js
@@ -180,6 +180,10 @@ describe('DtEmojiPicker Tests', () => {
     });
 
     it('Should render add emoji button', () => {
+      mockProps = { showAddEmojiButton: true };
+
+      updateWrapper();
+
       const addEmojiButton = wrapper.find('.d-emoji-picker__add-emoji');
 
       expect(addEmojiButton.exists()).toBe(true);
@@ -278,6 +282,10 @@ describe('DtEmojiPicker Tests', () => {
 
   describe('Interactivity Tests', () => {
     it('Should emit add-emoji event when add emoji button is clicked', async () => {
+      mockProps = { showAddEmojiButton: true };
+
+      updateWrapper();
+
       const addEmojiButton = wrapper.find('.d-emoji-picker__add-emoji');
 
       expect(addEmojiButton.exists()).toBe(true);

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker.vue
@@ -50,7 +50,7 @@
     </div>
     <div class="d-emoji-picker--footer">
       <dt-button
-        v-if="showCustomEmojisTab && !highlightedEmoji"
+        v-if="showAddEmojiButton && !highlightedEmoji"
         importance="outlined"
         :aria-label="addEmojiLabel"
         class="d-emoji-picker__add-emoji"
@@ -146,6 +146,17 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+
+  /**
+     * Shows the add emoji button in the footer when no emoji is highlighted
+     * @type {Boolean}
+     * @example
+     * <dt-emoji-picker :show-add-emoji-button="true" />
+     */
+    showAddEmojiButton: {
+      type: Boolean,
+      default: false,
+    }
 });
 
 const emits = defineEmits(

--- a/packages/dialtone-vue3/components/emoji_picker/emoji_picker_default.story.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/emoji_picker_default.story.vue
@@ -5,6 +5,7 @@
     :custom-emojis="$attrs.customEmojis"
     :search-query="$attrs.searchQuery"
     :show-search="$attrs.showSearch"
+    :show-add-emoji-button="$attrs.showAddEmojiButton"
     @skin-tone="skinTone = $event"
     @selected-emoji="$attrs.selectedEmoji"
     @scroll-bottom-reached="$attrs.scrollBottomReached"

--- a/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/message_input/message_input.stories.js
@@ -326,6 +326,7 @@ export const WithCustomEmoji = {
     emojiPickerProps: {
       skinTone: 'Default',
       customEmojis: customEmojiJson,
+      showAddEmojiButton: true,
     },
   },
 };


### PR DESCRIPTION
# DLT-2776 new prop showAddEmojiButton

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [x] Refactor


## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2776

## :book: Description

We update add-emoji button logic with a new prop `showAddEmojiButton`. Product can use this prop with the experiment `hasCustomEmojiExperiment` to still handle this behavior.

## :bulb: Context

Previously we show this button if there is some custom emoji to show.
But if there is no custom emoji, how the user will add one? 🤪

This was probably some old flag that we use to hide this feature.
But now we need to update it!


