### PR TITLE
docs: NO-JIRA remove names from public docs

### DIFF
--- a/packages/dialtone-vue2/docs/welcome.mdx
+++ b/packages/dialtone-vue2/docs/welcome.mdx
@@ -28,6 +28,6 @@ Dialpad projects.
 
 ## Contact
 
-This project is built and maintained by [Dialpad](https://dialpad.com/), you may contact the team at <dialtone@dialpad.com>.
+This project is built and maintained by [Dialpad](https://dialpad.com/), you may contact the team at [dialtone@dialpad.com](mailto:dialtone@dialpad.com).
 
 [dt-components]: https://dialtone.dialpad.com/components

--- a/packages/dialtone-vue2/docs/welcome.mdx
+++ b/packages/dialtone-vue2/docs/welcome.mdx
@@ -26,21 +26,8 @@ Dialpad projects.
 3. Thoroughly document and test shared components to make using them fast and reliable.
 4. Bake in accessibility features to ensure all our projects are usable by all users.
 
-## Project Maintainers
+## Contact
 
-### Engineering
-
-- **Jonathan Araquistain** - Engineering Manager
-- **Brad Paugh** - Engineering
-- **Julio Ortega** - Engineering
-- **Ignacio Ropolo** - Engineering
-- **Nina Repetto** - Engineering
-
-### Product Design
-
-- **Francis Rupert** - Manager, Design Systems and Platform
-- **Marshall Norman** - Product Design
-- **Bradley Hawkins** - Product Design
-- **Federico Sarassola** - Product Design
+This project is built and maintained by [Dialpad](https://dialpad.com/), you may contact the team at <dialtone@dialpad.com>.
 
 [dt-components]: https://dialtone.dialpad.com/components

--- a/packages/dialtone-vue3/docs/welcome.mdx
+++ b/packages/dialtone-vue3/docs/welcome.mdx
@@ -28,6 +28,6 @@ Dialpad projects.
 
 ## Contact
 
-This project is built and maintained by [Dialpad](https://dialpad.com/), you may contact the team at <dialtone@dialpad.com>.
+This project is built and maintained by [Dialpad](https://dialpad.com/), you may contact the team at [dialtone@dialpad.com](mailto:dialtone@dialpad.com).
 
 [dt-components]: https://dialtone.dialpad.com/components

--- a/packages/dialtone-vue3/docs/welcome.mdx
+++ b/packages/dialtone-vue3/docs/welcome.mdx
@@ -26,21 +26,8 @@ Dialpad projects.
 3. Thoroughly document and test shared components to make using them fast and reliable.
 4. Bake in accessibility features to ensure all our projects are usable by all users.
 
-## Project Maintainers
+## Contact
 
-### Engineering
-
-- **Jonathan Araquistain** - Engineering Manager
-- **Brad Paugh** - Engineering
-- **Julio Ortega** - Engineering
-- **Ignacio Ropolo** - Engineering
-- **Nina Repetto** - Engineering
-
-### Product Design
-
-- **Francis Rupert** - Manager, Design Systems and Platform
-- **Marshall Norman** - Product Design
-- **Bradley Hawkins** - Product Design
-- **Federico Sarassola** - Product Design
+This project is built and maintained by [Dialpad](https://dialpad.com/), you may contact the team at <dialtone@dialpad.com>.
 
 [dt-components]: https://dialtone.dialpad.com/components


### PR DESCRIPTION
as a followup to @iropolo's https://github.com/dialpad/dialtone/pull/916. Remove the contributor names from storybook docs as it's not really necessary. Just changed to generic contact info.