### PR TITLE
fix(leftbar-row): DP-157563 call button wrong color on hover

### DIFF
--- a/packages/dialtone-css/lib/build/less/recipes/leftbar_row.less
+++ b/packages/dialtone-css/lib/build/less/recipes/leftbar_row.less
@@ -196,11 +196,11 @@
   }
 
   .d-btn--inverted.d-btn--primary:hover:not([disabled]) {
-    --button-color-background: color-mix(in srgb, var(--dt-shell-mention-color-surface-primary) 10%, white 100%);
+    --button-color-background: color-mix(in srgb, var(--dt-shell-mention-color-surface-primary) 10%, var(--dt-color-surface-primary) 100%);
   }
 
   .d-btn--inverted.d-btn--primary:active:not([disabled]) {
-    --button-color-background: color-mix(in srgb, var(--dt-shell-mention-color-surface-primary) 30%, white 100%);
+    --button-color-background: color-mix(in srgb, var(--dt-shell-mention-color-surface-primary) 30%, var(--dt-color-surface-primary) 100%);
   }
 
   .d-fc-success {


### PR DESCRIPTION
# fix(leftbar-row): DP-157563 call button wrong color on hover
Fix leftbar row call button on dark theme

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DP-157563]


## :camera: Screenshots / GIFs

**Previous**
<img width="301" height="118" alt="image" src="https://github.com/user-attachments/assets/bebe6cce-a1fb-4861-be7e-99e5cc04063a" />

**Now**
<img width="319" height="123" alt="image" src="https://github.com/user-attachments/assets/cb78b303-b32c-4e27-8d6e-e46c7d027f9e" />



[DP-157563]: https://dialpad.atlassian.net/browse/DP-157563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ