### PR TITLE
fix(emoji-row): DP-157752 make emoji always appear on top 

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -16,6 +16,7 @@
             <p class="d-recipe-emoji-row__tooltip-emoji">
               {{ reaction.emojiUnicodeOrShortname }}
             </p>
+            <br>
             <p class="d-recipe-emoji-row__tooltip-names">
               {{ reaction.names }}
               <span

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -16,6 +16,7 @@
             <p class="d-recipe-emoji-row__tooltip-emoji">
               {{ reaction.emojiUnicodeOrShortname }}
             </p>
+            <br>
             <p class="d-recipe-emoji-row__tooltip-names">
               {{ reaction.names }}
               <span


### PR DESCRIPTION
# Fix emoji row, make emoji always appear on top

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3NndlN2lqNjRqMHE0bmJxYms4NWNqcWxyOWxwNmZraWd1bGR0ejdjcSZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/CFobS6TYF4ro2y4EWR/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-157752

## :book: Description

Add `<br />` to make sure the emoji is always above the text

## :bulb: Context

Issues reported on beta: https://dialpad.atlassian.net/browse/DP-157752

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

Release and update in product.

## :camera: Screenshots / GIFs

- Before
<img width="258" height="141" alt="Captura de pantalla 2025-09-17 a las 10 49 43 a m" src="https://github.com/user-attachments/assets/12baaf19-f776-42de-b55e-0e5f62fe2049" />

- After
<img width="270" height="159" alt="Captura de pantalla 2025-09-17 a las 10 50 17 a m" src="https://github.com/user-attachments/assets/921699e9-bb7a-4315-a1f0-588b385febdd" />
