### PR TITLE
fix(postcss-responsive-variations): NO-JIRA filter empty atRules

### DIFF
--- a/packages/postcss-responsive-variations/index.js
+++ b/packages/postcss-responsive-variations/index.js
@@ -54,6 +54,7 @@ function _prefixRule (rule, breakpoints, classes) {
     });
   });
 }
+
 function _escapeRegex (string) {
   return string.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
 }
@@ -83,9 +84,13 @@ module.exports = (opts = {}) => {
         _prefixRule(rule, processedBreakpoints, processedClasses);
       });
 
-      if (processedBreakpoints && processedBreakpoints[0].atRule.nodes) {
-        root.append(processedBreakpoints.map(breakpoint => breakpoint.atRule));
-      }
+      const atRules = processedBreakpoints
+        .filter(breakpoint => breakpoint.atRule.nodes?.length)
+        .map(breakpoint => breakpoint.atRule);
+
+      if (!atRules?.length) return;
+
+      root.append(atRules);
     },
   };
 };


### PR DESCRIPTION
# Filter empty atRules

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjJ4emZ5NGxxMmk2NTNwajhpcDc2bnJ6azd5dXI1c21zeDlzaDRkeiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/SIiAAC6dG2PYzvx7gM/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Description

- Added a filter to remove empty atRules and avoid adding them to the final css file.

## :bulb: Context

- Detected warnings related to empty media queries while trying to minify the CSS.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.