### PR TITLE
fix(pagination): DLT-2765 active page and change page buttons

### DIFF
--- a/packages/dialtone-vue2/components/pagination/pagination.stories.js
+++ b/packages/dialtone-vue2/components/pagination/pagination.stories.js
@@ -7,6 +7,7 @@ import DtPaginationVariantsTemplate from './pagination_variants.story.vue';
 
 // Default Prop Values
 export const argsData = {
+  ariaLabel: 'pagination',
   totalPages: 5,
   activePage: 1,
   maxVisible: 5,

--- a/packages/dialtone-vue2/components/pagination/pagination.vue
+++ b/packages/dialtone-vue2/components/pagination/pagination.vue
@@ -1,5 +1,6 @@
 <template>
   <nav
+    v-show="totalPages > 0"
     :aria-label="ariaLabel"
     class="d-pagination"
   >
@@ -228,6 +229,12 @@ export default {
   watch: {
     activePage () {
       this.currentPage = this.activePage;
+    },
+
+    totalPages (pages) {
+      if (this.currentPage > pages || this.currentPage <= 0){
+        this.currentPage = pages;
+      }
     },
   },
 

--- a/packages/dialtone-vue3/components/pagination/pagination.stories.js
+++ b/packages/dialtone-vue3/components/pagination/pagination.stories.js
@@ -7,6 +7,7 @@ import DtPaginationVariantsTemplate from './pagination_variants.story.vue';
 
 // Default Prop Values
 export const argsData = {
+  ariaLabel: 'pagination',
   totalPages: 5,
   activePage: 1,
   maxVisible: 5,

--- a/packages/dialtone-vue3/components/pagination/pagination.vue
+++ b/packages/dialtone-vue3/components/pagination/pagination.vue
@@ -1,5 +1,6 @@
 <template>
   <nav
+    v-show="totalPages > 0"
     :aria-label="ariaLabel"
     class="d-pagination"
   >
@@ -229,6 +230,12 @@ export default {
   watch: {
     activePage () {
       this.currentPage = this.activePage;
+    },
+
+    totalPages (pages) {
+      if (this.currentPage > pages || this.currentPage <= 0){
+        this.currentPage = pages;
+      }
     },
   },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17129,8 +17129,8 @@ packages:
   vue-component-type-helpers@1.8.24:
     resolution: {integrity: sha512-lqWs/7fdRXoSBAlbouHBX+LNuaY6gI9xWW34m/ZIz9zVPYHEyw0b2/zaCBwlKx0NtKTeF/6pOpvrxVkh7nhIYg==}
 
-  vue-component-type-helpers@3.0.7:
-    resolution: {integrity: sha512-TvyUcFXmjZcXUvU+r1MOyn4/vv4iF+tPwg5Ig33l/FJ3myZkxeQpzzQMLMFWcQAjr6Xs7BRwVy/TwbmNZUA/4w==}
+  vue-component-type-helpers@3.0.8:
+    resolution: {integrity: sha512-WyR30Eq15Y/+odrUUMax6FmPbZwAp/HnC7qgR1r3lVFAcqwQ4wUoV79Mbh4SxDy3NiqDa+G4TOKD5xXSgBHo5A==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -23405,7 +23405,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.15(typescript@5.8.3)
-      vue-component-type-helpers: 3.0.7
+      vue-component-type-helpers: 3.0.8
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -38157,7 +38157,7 @@ snapshots:
 
   vue-component-type-helpers@1.8.24: {}
 
-  vue-component-type-helpers@3.0.7: {}
+  vue-component-type-helpers@3.0.8: {}
 
   vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16):
     dependencies:


### PR DESCRIPTION
# (Pagination) Fix active page and change page buttons

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3ODE3OXQyYjlqMmZycmxkbms3M2U4aDVxd2J3dDJ1Ynlib2RrZWhzOSZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/sy2y0F3AcztxC/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2765

## :book: Description

- Added a watcher on `totalPages` so whenever it changes, updates the `currentPage` to be within the limits.
- Hide the pagination when `totalPages` is 0 or lower.

## :bulb: Context

Issues reported on product: https://dialpad.atlassian.net/browse/DP-155834

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

https://github.com/user-attachments/assets/a4204d96-d21d-4515-b347-f58ae224421f

https://github.com/user-attachments/assets/9dacf13d-ce18-440c-a372-84c831bdc6cc