### PR TITLE
fix(emoji-row): DP-168152 add default size to skeletons

### DIFF
--- a/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue2/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -42,6 +42,7 @@
             <span class="d-recipe-emoji-row__emoji">
               <dt-emoji
                 class="d-recipe-emoji-row__emoji"
+                size="200"
                 img-class="d-recipe-emoji-row__emoji-img"
                 :code="reaction.emojiUnicodeOrShortname"
               />

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.vue
@@ -42,6 +42,7 @@
             <span class="d-recipe-emoji-row__emoji">
               <dt-emoji
                 class="d-recipe-emoji-row__emoji"
+                size="200"
                 img-class="d-recipe-emoji-row__emoji-img"
                 :code="reaction.emojiUnicodeOrShortname"
               />


### PR DESCRIPTION
# Fix Emoji row, add default size to loader skeletons

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOWM4MHpmbTM4c3ZoazkzNWlhdDdnMWtlbmJtOWJzZm5ob254YzNuYiZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/DR1WJs5BlozM20aKzr/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-158162

## :book: Description

- Added `size="200"` to emoji_row button, this doesn't change the emoji size, only the default skeleton size

## :bulb: Context

- Loader skeleton was too overlapping reaction count

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)

## :crystal_ball: Next Steps

- Release Dialtone, update and test on product

## :camera: Screenshots / GIFs

**Before**
<img width="208" height="55" alt="Captura de pantalla 2025-09-22 a las 12 14 35 p m" src="https://github.com/user-attachments/assets/730149b7-cdf7-4f57-8ab6-b9df3a00889e" />

**After**
<img width="201" height="52" alt="Captura de pantalla 2025-09-22 a las 12 13 17 p m" src="https://github.com/user-attachments/assets/d7380d3c-0f85-486f-bc8a-2e0a2322bb88" />
