### PR TITLE
docs: NO-JIRA fix links

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/index.js
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/index.js
@@ -51,7 +51,7 @@ function _extractFrontmatter (app, path, options, exceptions = []) {
       const fileName = page.frontmatter.title.toLowerCase().replaceAll(' ', '-');
       return {
         fileName,
-        link: page.frontmatter.shortTitle || fileName,
+        link: page.path,
         ...page.frontmatter,
       };
     })

--- a/apps/dialtone-documentation/docs/.vuepress/theme/index.js
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/index.js
@@ -52,10 +52,11 @@ function _extractFrontmatter (app, path, options, exceptions = []) {
       return {
         fileName,
         link: page.path,
+        name: page.frontmatter.shortTitle || fileName,
         ...page.frontmatter,
       };
     })
-    .sort((a, b) => sortingArr.indexOf(a.link) - sortingArr.indexOf(b.link));
+    .sort((a, b) => sortingArr.indexOf(a.name) - sortingArr.indexOf(b.name));
 }
 
 function _extractComponentStatus (app) {

--- a/apps/dialtone-documentation/docs/.vuepress/views/Overview.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/views/Overview.vue
@@ -3,7 +3,7 @@
     <template v-for="page in pages" :key="page.title">
       <component
         :is="cardElType(page)"
-        :to="`/${basePath}/${page.link}/`"
+        :to="page.link"
         class="dialtone-wall__item"
       >
         <div v-if="page.thumb" class="dialtone-wall__image">
@@ -31,14 +31,11 @@
 
 <script setup>
 import SvgLoader from '../baseComponents/SvgLoader.vue';
+
 defineProps({
   pages: {
     type: Object,
     default: () => {},
-  },
-  basePath: {
-    type: String,
-    default: '/',
   },
 });
 

--- a/apps/dialtone-documentation/docs/components/index.md
+++ b/apps/dialtone-documentation/docs/components/index.md
@@ -4,4 +4,4 @@ description: Reusable components solving common UI needs, designed and built to 
 no_preview: true
 ---
 
-<overview :pages="$page.enhancedFrontmatter" base-path="components" />
+<overview :pages="$page.enhancedFrontmatter" />

--- a/apps/dialtone-documentation/docs/design/colors/index.md
+++ b/apps/dialtone-documentation/docs/design/colors/index.md
@@ -4,4 +4,4 @@ description: A systematic and accessible color palette that supports both functi
 no_preview: true
 ---
 
-<overview :pages="$page.enhancedFrontmatter" base-path="design/colors" />
+<overview :pages="$page.enhancedFrontmatter" />

--- a/apps/dialtone-documentation/docs/design/index.md
+++ b/apps/dialtone-documentation/docs/design/index.md
@@ -3,4 +3,4 @@ title: Design Language
 description: The visual foundation that supports and unites Dialpad products.
 ---
 
-<overview :pages="$page.enhancedFrontmatter" base-path="design" />
+<overview :pages="$page.enhancedFrontmatter" />

--- a/apps/dialtone-documentation/docs/guides/content/index.md
+++ b/apps/dialtone-documentation/docs/guides/content/index.md
@@ -5,4 +5,4 @@ next: { link: "/guides/content/action-language/", text: "Action language" }
 description: Guidelines to unify the way we communicate with our users.
 ---
 
-<overview :pages="$page.enhancedFrontmatter" base-path="guides/content" />
+<overview :pages="$page.enhancedFrontmatter" />

--- a/apps/dialtone-documentation/docs/guides/index.md
+++ b/apps/dialtone-documentation/docs/guides/index.md
@@ -4,4 +4,4 @@ description: In-depth guidance to support consistent, high-quality product desig
 no_preview: true
 ---
 
-<overview :pages="$page.enhancedFrontmatter" base-path="guides" />
+<overview :pages="$page.enhancedFrontmatter" />


### PR DESCRIPTION
# Fix documentation site links

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3Z2NrZDhpODY2MHB1bHF5MHdqdzR4cmh5aWUyajM4eGZtZmlnZ2J5MiZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/9kXmK3Gp9KDApAXqtU/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Description

- Updated the way we extract links on the docsite.
- Updated the `overview` component and usages accordingly.

## :bulb: Context

- We were using the file name to generate the link to the child pages but it wasn't reliable, changed to use the actual path which is more reliable. 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.
