### PR TITLE
refactor(emoji-picker): DLT-2774 update custom emoji icon

### DIFF
--- a/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue2/components/emoji_picker/modules/emoji_tabset.vue
@@ -40,7 +40,7 @@ import {
   DtIconLightbulb,
   DtIconHeart,
   DtIconFlag,
-  DtIconTiktok,
+  DtIconDialpadStar,
 } from '@dialpad/dialtone-icons/vue2';
 
 export default {
@@ -102,7 +102,7 @@ export default {
         { label: this.tabSetLabels[6], icon: DtIconLightbulb },
         { label: this.tabSetLabels[7], icon: DtIconHeart },
         { label: this.tabSetLabels[8], icon: DtIconFlag },
-        { label: this.tabSetLabels[9], icon: DtIconTiktok },
+        { label: this.tabSetLabels[9], icon: DtIconDialpadStar },
       ],
     };
   },
@@ -173,7 +173,7 @@ export default {
       }
     },
 
-    // eslint-disable-next-line complexity
+     
     handleKeyDown (event, tabId) {
       if (event.key === 'Enter') {
         this.selectTabset(tabId);

--- a/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue3/components/emoji_picker/modules/emoji_tabset.vue
@@ -42,7 +42,7 @@ import {
   DtIconLightbulb,
   DtIconHeart,
   DtIconFlag,
-  DtIconTiktok,
+  DtIconDialpadStar,
 } from '@dialpad/dialtone-icons/vue3';
 
 const props = defineProps({
@@ -109,7 +109,7 @@ const TABS_DATA = [
   { label: props.tabSetLabels[6], icon: DtIconLightbulb },
   { label: props.tabSetLabels[7], icon: DtIconHeart },
   { label: props.tabSetLabels[8], icon: DtIconFlag },
-  { label: props.tabSetLabels[9], icon: DtIconTiktok },
+  { label: props.tabSetLabels[9], icon: DtIconDialpadStar },
 ];
 
 const tabs = computed(() => {


### PR DESCRIPTION
# update custom emoji icon

  ## :hammer_and_wrench: Type Of Change

  These types will increment the version number on release:

  - [ ] Fix
  - [ ] Feature
  - [ ] Performance Improvement
  - [x] Refactor

  These types will not increment the version number, but will still deploy to documentation site on
  release:

  - [ ] Documentation
  - [ ] Build system
  - [ ] CI
  - [ ] Style (code style changes, not css changes)
  - [ ] Test
  - [x] Other (chore)

  ## :book: Jira Ticket

  https://dialpad.atlassian.net/browse/DLT-2774

  ## :book: Description

  Updated custom emoji icon in the emoji picker component for both Vue 2 and Vue 3 versions.


  ## :pencil: Checklist

  For all PRs:

  - [ ] I have ensured no private Dialpad links or info are in the code or pull request description
  (Dialtone is a public repo!).
  - [ ] I have reviewed my changes.
  - [ ] I have added all relevant documentation.
  - [ ] I have considered the performance impact of my change.

  For all Vue changes:

  - [ ] I have added / updated unit tests.
  - [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3
  (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync
   Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
  - [ ] I have validated components with a screen reader.
  - [ ] I have validated components keyboard navigation.


  ## :camera: Screenshots / GIFs


<img width="250" height="295" alt="Screenshot 2025-09-25 at 11 17 29 AM" src="https://github.com/user-attachments/assets/ee73407a-d950-4b04-acad-14b1b920c28c" />


<img width="250" height="295" alt="Screenshot 2025-09-25 at 11 16 51 AM" src="https://github.com/user-attachments/assets/713c5dc3-6134-4384-a9a6-9093a1eb1f9a" />
