### PR TITLE
fix(tokens): NO-JIRA make root-to-host postcss plugin safer

### DIFF
--- a/packages/dialtone-tokens/postcss/root-to-host.js
+++ b/packages/dialtone-tokens/postcss/root-to-host.js
@@ -5,10 +5,16 @@ const creator = () => {
   return {
     postcssPlugin: 'postcss-dialtone-root-to-host',
     Once (root) {
-      const re = /.*?\/css\/tokens-.*?/;
-      if (!re.test(root.source.input.file)) return;
-      const rootRule = root.last;
-      rootRule.selector = ':host';
+      // Only process dialtone token files
+      if (!root.source?.input?.file || !/tokens-.*?\.css/.test(root.source.input.file)) {
+          return;
+      }
+
+      const lastRule = root.last;
+      // Only modify if it's a rule with a selector
+      if (lastRule && lastRule.type === 'rule' && lastRule.selector === ':root') {
+          lastRule.selector = ':host';
+      }
     },
   };
 };


### PR DESCRIPTION
# fix(tokens): NO-JIRA make root-to-host postcss plugin safer

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3cnR4cW93YmgwZzJjYmRkd3F5dnFmcHdvaTZpNTF4dnlsbjNvYTRnZiZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/9wG8hpQRkHMoDbCqzu/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Description

Add some additional guards to the root to host plugin. Before this was causing an issue in unit tests on agent-assist-widget

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

update in agent-assist-widget to confirm fixed
