### PR TITLE
feat(modal): DLT-2789 add appendTo prop

### DIFF
--- a/packages/dialtone-vue2/components/modal/modal.stories.js
+++ b/packages/dialtone-vue2/components/modal/modal.stories.js
@@ -106,6 +106,12 @@ export const argTypesData = {
       type: 'boolean',
     },
   },
+  appendTo: {
+    options: [undefined, 'body', 'html'],
+    control: {
+      type: 'select',
+    },
+  },
 
   // Events
   'update:show': {

--- a/packages/dialtone-vue2/components/modal/modal.vue
+++ b/packages/dialtone-vue2/components/modal/modal.vue
@@ -1,116 +1,122 @@
 <template>
-  <dt-lazy-show
-    transition="d-zoom"
-    :show="show"
-    :class="[
-      'd-modal',
-      MODAL_KIND_MODIFIERS[kind],
-      MODAL_SIZE_MODIFIERS[size],
-      modalClass,
-    ]"
-    data-qa="dt-modal"
-    :aria-hidden="open"
-    v-on="modalListeners"
+  <portal
+    :disabled="!appendTo"
+    :selector="appendTo"
   >
-    <div
-      v-if="show && ($slots.banner || bannerTitle)"
-      data-qa="dt-modal-banner"
+    <dt-lazy-show
+      ref="modalRoot"
+      transition="d-zoom"
+      :show="show"
       :class="[
-        'd-modal__banner',
-        bannerClass,
-        bannerKindClass,
+        'd-modal',
+        MODAL_KIND_MODIFIERS[kind],
+        MODAL_SIZE_MODIFIERS[size],
+        modalClass,
       ]"
-    >
-      <!-- @slot Slot for the banner, defaults to bannerTitle prop -->
-      <slot name="banner">
-        {{ bannerTitle }}
-      </slot>
-    </div>
-    <transition
-      appear
-      name="d-modal__dialog"
+      data-qa="dt-modal"
+      :aria-hidden="open"
+      v-on="modalListeners"
     >
       <div
-        v-show="show"
+        v-if="show && ($slots.banner || bannerTitle)"
+        data-qa="dt-modal-banner"
         :class="[
-          'd-modal__dialog',
-          { 'd-modal__dialog--scrollable': fixedHeaderFooter },
-          dialogClass,
+          'd-modal__banner',
+          bannerClass,
+          bannerKindClass,
         ]"
-        role="dialog"
-        aria-modal="true"
-        :aria-describedby="describedById"
-        :aria-labelledby="labelledById"
+      >
+        <!-- @slot Slot for the banner, defaults to bannerTitle prop -->
+        <slot name="banner">
+          {{ bannerTitle }}
+        </slot>
+      </div>
+      <transition
+        appear
+        name="d-modal__dialog"
       >
         <div
-          v-if="$slots.header"
-          :id="labelledById"
-          class="d-modal__header"
-          data-qa="dt-modal-title"
-        >
-          <!-- @slot Slot for dialog header section, taking the place of any "title" text prop -->
-          <slot name="header" />
-        </div>
-        <h2
-          v-else
-          :id="labelledById"
-          class="d-modal__header"
-          data-qa="dt-modal-title"
-        >
-          {{ title }}
-        </h2>
-        <div
-          v-if="$slots.default"
+          v-show="show"
           :class="[
-            'd-modal__content',
-            contentClass,
+            'd-modal__dialog',
+            { 'd-modal__dialog--scrollable': fixedHeaderFooter },
+            dialogClass,
           ]"
-          data-qa="dt-modal-copy"
+          role="dialog"
+          aria-modal="true"
+          :aria-describedby="describedById"
+          :aria-labelledby="labelledById"
         >
-          <!-- @slot Default slot for dialog body section, taking the place of any "copy" text prop -->
-          <slot />
+          <div
+            v-if="$slots.header"
+            :id="labelledById"
+            class="d-modal__header"
+            data-qa="dt-modal-title"
+          >
+            <!-- @slot Slot for dialog header section, taking the place of any "title" text prop -->
+            <slot name="header" />
+          </div>
+          <h2
+            v-else
+            :id="labelledById"
+            class="d-modal__header"
+            data-qa="dt-modal-title"
+          >
+            {{ title }}
+          </h2>
+          <div
+            v-if="$slots.default"
+            :class="[
+              'd-modal__content',
+              contentClass,
+            ]"
+            data-qa="dt-modal-copy"
+          >
+            <!-- @slot Default slot for dialog body section, taking the place of any "copy" text prop -->
+            <slot />
+          </div>
+          <p
+            v-else
+            :class="[
+              'd-modal__content',
+              contentClass,
+            ]"
+            data-qa="dt-modal-copy"
+          >
+            {{ copy }}
+          </p>
+          <footer
+            v-if="hasFooterSlot"
+            class="d-modal__footer"
+          >
+            <!-- @slot Slot for dialog footer content, often containing cancel and confirm buttons. -->
+            <slot name="footer" />
+          </footer>
+          <sr-only-close-button
+            v-if="hideClose"
+            @close="close"
+          />
+          <dt-button
+            v-else
+            class="d-modal__close"
+            data-qa="dt-modal-close-button"
+            size="md"
+            kind="muted"
+            importance="clear"
+            :aria-label="closeButtonTitle"
+            :title="closeButtonTitle"
+            @click="close"
+          >
+            <template #icon="{ iconSize }">
+              <dt-icon-close
+                :size="iconSize"
+              />
+            </template>
+          </dt-button>
         </div>
-        <p
-          v-else
-          :class="[
-            'd-modal__content',
-            contentClass,
-          ]"
-          data-qa="dt-modal-copy"
-        >
-          {{ copy }}
-        </p>
-        <footer
-          v-if="hasFooterSlot"
-          class="d-modal__footer"
-        >
-          <!-- @slot Slot for dialog footer content, often containing cancel and confirm buttons. -->
-          <slot name="footer" />
-        </footer>
-        <sr-only-close-button
-          v-if="hideClose"
-          @close="close"
-        />
-        <dt-button
-          v-else
-          class="d-modal__close"
-          data-qa="dt-modal-close-button"
-          size="md"
-          kind="muted"
-          importance="clear"
-          :aria-label="closeButtonTitle"
-          :title="closeButtonTitle"
-          @click="close"
-        >
-          <template #icon="{ iconSize }">
-            <dt-icon-close
-              :size="iconSize"
-            />
-          </template>
-        </dt-button>
-      </div>
-    </transition>
-  </dt-lazy-show>
+      </transition>
+    </dt-lazy-show>
+  </portal>
 </template>
 
 <script>
@@ -129,6 +135,7 @@ import { EVENT_KEYNAMES } from '@/common/constants';
 import SrOnlyCloseButton from '@/common/sr_only_close_button.vue';
 import { NOTICE_KINDS } from '@/components/notice';
 import { DialtoneLocalization } from '@/localization';
+import { Portal } from '@linusborg/vue-simple-portal';
 
 /**
  * Modals focus the user’s attention exclusively on one task or piece of information
@@ -143,6 +150,7 @@ export default {
     DtButton,
     DtIconClose,
     SrOnlyCloseButton,
+    Portal,
   },
 
   mixins: [Modal],
@@ -315,6 +323,14 @@ export default {
           initialFocusElement.startsWith('#');
       },
     },
+
+    /**
+     * A CSS selector string for the element to portal the modal to. If not provided, the modal will be rendered in its default location.
+     */
+    appendTo: {
+      type: String,
+      default: undefined,
+    },
   },
 
   emits: [
@@ -398,9 +414,11 @@ export default {
         if (isShowing) {
           // Set a reference to the previously-active element, to which we'll return focus on modal close.
           this.previousActiveElement = document.activeElement;
-          disableRootScrolling(this.$el.getRootNode().host);
+          const modalEl = this.$refs.modalRoot?.$el || this.$el;
+          disableRootScrolling(modalEl.getRootNode().host);
         } else {
-          enableRootScrolling(this.$el.getRootNode().host);
+          const modalEl = this.$refs.modalRoot?.$el || this.$el;
+          enableRootScrolling(modalEl.getRootNode().host);
           // Modal is being hidden, so return focus to the previously active element before clearing the reference.
           this.previousActiveElement?.focus();
           this.previousActiveElement = null;
@@ -415,8 +433,9 @@ export default {
     },
 
     async setFocusAfterTransition () {
+      const modalEl = this.$refs.modalRoot?.$el || this.$el;
       if (this.initialFocusElement === 'first') {
-        await this.focusFirstElement();
+        await this.focusFirstElement(modalEl);
       } else if (this.initialFocusElement.startsWith('#')) {
         await this.focusElementById(this.initialFocusElement);
       } else if (this.initialFocusElement instanceof HTMLElement) {
@@ -426,20 +445,22 @@ export default {
 
     trapFocus (e) {
       if (this.show) {
-        this.focusTrappedTabPress(e);
+        const modalEl = this.$refs.modalRoot?.$el || this.$el;
+        this.focusTrappedTabPress(e, modalEl);
       }
     },
 
     handleModalClick (event) {
       // Ensure focus stays within modal when clicking inside it
       const clickedElement = event.target;
-      const focusableElements = this._getFocusableElements();
+      const modalEl = this.$refs.modalRoot?.$el || this.$el;
+      const focusableElements = this._getFocusableElements(modalEl);
 
       // If the clicked element is not focusable, ensure focus stays in modal
       if (focusableElements.length && !focusableElements.includes(clickedElement)) {
         // Check if current active element is still within the modal
         if (!focusableElements.includes(document.activeElement)) {
-          this.focusFirstElement();
+          this.focusFirstElement(modalEl);
         }
       }
     },

--- a/packages/dialtone-vue2/components/modal/modal_default.story.vue
+++ b/packages/dialtone-vue2/components/modal/modal_default.story.vue
@@ -17,6 +17,7 @@
       :fixed-header-footer="$attrs.fixedHeaderFooter"
       :close-on-click="$attrs.closeOnClick"
       :initial-focus-element="$attrs.initialFocusElement"
+      :append-to="$attrs.appendTo"
       @update:show="updateShow"
     >
       <template

--- a/packages/dialtone-vue3/components/modal/modal.stories.js
+++ b/packages/dialtone-vue3/components/modal/modal.stories.js
@@ -106,6 +106,12 @@ export const argTypesData = {
       type: 'boolean',
     },
   },
+  appendTo: {
+    options: [undefined, 'body', 'html'],
+    control: {
+      type: 'select',
+    },
+  },
 
   // Events
   'update:show': {

--- a/packages/dialtone-vue3/components/modal/modal.vue
+++ b/packages/dialtone-vue3/components/modal/modal.vue
@@ -1,116 +1,122 @@
 <template>
-  <dt-lazy-show
-    transition="d-zoom"
-    :show="show"
-    :class="[
-      'd-modal',
-      MODAL_KIND_MODIFIERS[kind],
-      MODAL_SIZE_MODIFIERS[size],
-      modalClass,
-    ]"
-    data-qa="dt-modal"
-    :aria-hidden="open"
-    v-on="modalListeners"
+  <teleport
+    :disabled="!appendTo"
+    :to="appendTo"
   >
-    <div
-      v-if="show && (hasSlotContent($slots.banner) || bannerTitle)"
-      data-qa="dt-modal-banner"
+    <dt-lazy-show
+      ref="modalRoot"
+      transition="d-zoom"
+      :show="show"
       :class="[
-        'd-modal__banner',
-        bannerClass,
-        bannerKindClass,
+        'd-modal',
+        MODAL_KIND_MODIFIERS[kind],
+        MODAL_SIZE_MODIFIERS[size],
+        modalClass,
       ]"
-    >
-      <!-- @slot Slot for the banner, defaults to bannerTitle prop -->
-      <slot name="banner">
-        {{ bannerTitle }}
-      </slot>
-    </div>
-    <transition
-      appear
-      name="d-modal__dialog"
+      data-qa="dt-modal"
+      :aria-hidden="open"
+      v-on="modalListeners"
     >
       <div
-        v-show="show"
+        v-if="show && (hasSlotContent($slots.banner) || bannerTitle)"
+        data-qa="dt-modal-banner"
         :class="[
-          'd-modal__dialog',
-          { 'd-modal__dialog--scrollable': fixedHeaderFooter },
-          dialogClass,
+          'd-modal__banner',
+          bannerClass,
+          bannerKindClass,
         ]"
-        role="dialog"
-        aria-modal="true"
-        :aria-describedby="describedById"
-        :aria-labelledby="labelledById"
+      >
+        <!-- @slot Slot for the banner, defaults to bannerTitle prop -->
+        <slot name="banner">
+          {{ bannerTitle }}
+        </slot>
+      </div>
+      <transition
+        appear
+        name="d-modal__dialog"
       >
         <div
-          v-if="hasSlotContent($slots.header)"
-          :id="labelledById"
-          class="d-modal__header"
-          data-qa="dt-modal-title"
-        >
-          <!-- @slot Slot for dialog header section, taking the place of any "title" text prop -->
-          <slot name="header" />
-        </div>
-        <h2
-          v-else
-          :id="labelledById"
-          class="d-modal__header"
-          data-qa="dt-modal-title"
-        >
-          {{ title }}
-        </h2>
-        <div
-          v-if="hasSlotContent($slots.default)"
+          v-show="show"
           :class="[
-            'd-modal__content',
-            contentClass,
+            'd-modal__dialog',
+            { 'd-modal__dialog--scrollable': fixedHeaderFooter },
+            dialogClass,
           ]"
-          data-qa="dt-modal-copy"
+          role="dialog"
+          aria-modal="true"
+          :aria-describedby="describedById"
+          :aria-labelledby="labelledById"
         >
-          <!-- @slot Default slot for dialog body section, taking the place of any "copy" text prop -->
-          <slot />
+          <div
+            v-if="hasSlotContent($slots.header)"
+            :id="labelledById"
+            class="d-modal__header"
+            data-qa="dt-modal-title"
+          >
+            <!-- @slot Slot for dialog header section, taking the place of any "title" text prop -->
+            <slot name="header" />
+          </div>
+          <h2
+            v-else
+            :id="labelledById"
+            class="d-modal__header"
+            data-qa="dt-modal-title"
+          >
+            {{ title }}
+          </h2>
+          <div
+            v-if="hasSlotContent($slots.default)"
+            :class="[
+              'd-modal__content',
+              contentClass,
+            ]"
+            data-qa="dt-modal-copy"
+          >
+            <!-- @slot Default slot for dialog body section, taking the place of any "copy" text prop -->
+            <slot />
+          </div>
+          <p
+            v-else
+            :class="[
+              'd-modal__content',
+              contentClass,
+            ]"
+            data-qa="dt-modal-copy"
+          >
+            {{ copy }}
+          </p>
+          <footer
+            v-if="hasFooterSlot"
+            class="d-modal__footer"
+          >
+            <!-- @slot Slot for dialog footer content, often containing cancel and confirm buttons. -->
+            <slot name="footer" />
+          </footer>
+          <sr-only-close-button
+            v-if="hideClose"
+            @close="close"
+          />
+          <dt-button
+            v-else
+            class="d-modal__close"
+            data-qa="dt-modal-close-button"
+            size="md"
+            kind="muted"
+            importance="clear"
+            :aria-label="closeButtonTitle"
+            :title="closeButtonTitle"
+            @click="close"
+          >
+            <template #icon="{ iconSize }">
+              <dt-icon-close
+                :size="iconSize"
+              />
+            </template>
+          </dt-button>
         </div>
-        <p
-          v-else
-          :class="[
-            'd-modal__content',
-            contentClass,
-          ]"
-          data-qa="dt-modal-copy"
-        >
-          {{ copy }}
-        </p>
-        <footer
-          v-if="hasFooterSlot"
-          class="d-modal__footer"
-        >
-          <!-- @slot Slot for dialog footer content, often containing cancel and confirm buttons. -->
-          <slot name="footer" />
-        </footer>
-        <sr-only-close-button
-          v-if="hideClose"
-          @close="close"
-        />
-        <dt-button
-          v-else
-          class="d-modal__close"
-          data-qa="dt-modal-close-button"
-          size="md"
-          kind="muted"
-          importance="clear"
-          :aria-label="closeButtonTitle"
-          :title="closeButtonTitle"
-          @click="close"
-        >
-          <template #icon="{ iconSize }">
-            <dt-icon-close
-              :size="iconSize"
-            />
-          </template>
-        </dt-button>
-      </div>
-    </transition>
-  </dt-lazy-show>
+      </transition>
+    </dt-lazy-show>
+  </teleport>
 </template>
 
 <script>
@@ -316,6 +322,14 @@ export default {
           initialFocusElement.startsWith('#');
       },
     },
+
+    /**
+     * A CSS selector string for the element to portal the modal to. If not provided, the modal will be rendered in its default location.
+     */
+    appendTo: {
+      type: String,
+      default: undefined,
+    },
   },
 
   emits: [
@@ -391,9 +405,10 @@ export default {
 
         focusin: event => {
           // Ensure focus stays within modal
-          if (this.show && !this.$el.contains(event.target)) {
+          const modalEl = this.$refs.modalRoot?.$el || this.$el;
+          if (this.show && modalEl && !modalEl.contains(event.target)) {
             event.preventDefault();
-            this.focusFirstElement();
+            this.focusFirstElement(modalEl);
           }
         },
       };
@@ -422,9 +437,11 @@ export default {
         if (isShowing) {
           // Set a reference to the previously-active element, to which we'll return focus on modal close.
           this.previousActiveElement = document.activeElement;
-          disableRootScrolling(returnFirstEl(this.$el).getRootNode().host);
+          const modalEl = this.$refs.modalRoot?.$el || this.$el;
+          disableRootScrolling(returnFirstEl(modalEl).getRootNode().host);
         } else {
-          enableRootScrolling(returnFirstEl(this.$el).getRootNode().host);
+          const modalEl = this.$refs.modalRoot?.$el || this.$el;
+          enableRootScrolling(returnFirstEl(modalEl).getRootNode().host);
           // Modal is being hidden, so return focus to the previously active element before clearing the reference.
           this.previousActiveElement?.focus();
           this.previousActiveElement = null;
@@ -439,8 +456,9 @@ export default {
     },
 
     async setFocusAfterTransition () {
+      const modalEl = this.$refs.modalRoot?.$el || this.$el;
       if (this.initialFocusElement === 'first') {
-        await this.focusFirstElement();
+        await this.focusFirstElement(modalEl);
       } else if (this.initialFocusElement.startsWith('#')) {
         await this.focusElementById(this.initialFocusElement);
       } else if (this.initialFocusElement instanceof HTMLElement) {
@@ -450,20 +468,22 @@ export default {
 
     trapFocus (e) {
       if (this.show) {
-        this.focusTrappedTabPress(e);
+        const modalEl = this.$refs.modalRoot?.$el || this.$el;
+        this.focusTrappedTabPress(e, modalEl);
       }
     },
 
     handleModalClick (event) {
       // Ensure focus stays within modal when clicking inside it
       const clickedElement = event.target;
-      const focusableElements = this._getFocusableElements();
+      const modalEl = this.$refs.modalRoot?.$el || this.$el;
+      const focusableElements = this._getFocusableElements(modalEl);
 
       // If the clicked element is not focusable, ensure focus stays in modal
       if (focusableElements.length && !focusableElements.includes(clickedElement)) {
         // Check if current active element is still within the modal
         if (!focusableElements.includes(document.activeElement)) {
-          this.focusFirstElement();
+          this.focusFirstElement(modalEl);
         }
       }
     },

--- a/packages/dialtone-vue3/components/modal/modal_default.story.vue
+++ b/packages/dialtone-vue3/components/modal/modal_default.story.vue
@@ -16,6 +16,7 @@
       :labelled-by-id="$attrs.labelledById"
       :fixed-header-footer="$attrs.fixedHeaderFooter"
       :close-on-click="$attrs.closeOnClick"
+      :append-to="$attrs.appendTo"
       @update:show="close"
     >
       <template
@@ -110,7 +111,7 @@ export default {
 
   methods: {
     close (event) {
-      this.isOpen = !this.isOpen;
+      this.isOpen = event;
       this.$attrs.onClose(event);
     },
   },


### PR DESCRIPTION
# feat(modal): DLT-2789 add appendTo prop

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExamZzbXE0dWo0N3RubzVtOG9taGhrMGdycjMwaHQzbnFqdDJuaWx3dSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/djjERWETDoAHS/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2789

## :book: Description

Added support for appendTo to modal

## :bulb: Context

Up to this point all our modals have been rendering inline, not great. Had a request for this from @AlexLamDialpad who was having some strange behaviour when triggering a modal in a table.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :link: Sources

vue-simple-portal is needed for vue 2. In vue 3 it is built in with `<Teleport>`
https://github.com/LinusBorg/vue-simple-portal