### PR TITLE
fix(popover): DLT-2795 add aria-hidden attribute on popover

### DIFF
--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -4,6 +4,7 @@
     <portal v-if="modal && isOpen">
       <div
         class="d-modal--transparent"
+        aria-hidden="false"
         @click.prevent.stop
       />
     </portal>

--- a/packages/dialtone-vue3/components/popover/popover.vue
+++ b/packages/dialtone-vue3/components/popover/popover.vue
@@ -7,6 +7,7 @@
     >
       <div
         class="d-modal--transparent"
+        aria-hidden="false"
         @click.prevent.stop
       />
     </Teleport>


### PR DESCRIPTION
# Add aria-hidden attribute on popover

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor


## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2795

## :book: Description

CSS styles need to have aria-hidden false attribute set to being applied.
We are adding this attribute to the HTML.

## :bulb: Context

This attribute is necessary to apply the correct CSS styles.
In this specific case we want to avoid interaction with elements below it, with an invisible overlay.

## :camera: Screenshots / GIFs

Previously without fix:

https://github.com/user-attachments/assets/5763e572-f828-4dc7-914a-1136989585da





With this fix:


https://github.com/user-attachments/assets/169b3937-7914-4084-8e0c-1e13d9ec9a59




