### PR TITLE
fix(split-button): NO-JIRA invert tooltip when button inverted

### DIFF
--- a/packages/dialtone-vue2/components/split_button/split_button-alpha.vue
+++ b/packages/dialtone-vue2/components/split_button/split_button-alpha.vue
@@ -1,6 +1,6 @@
 <template>
   <dt-button
-    v-dt-tooltip="tooltipText"
+    v-dt-tooltip="{ message: tooltipText, inverted: kind === 'inverted' }"
     data-qa="dt-split-button-alpha"
     :active="active"
     :aria-label="ariaLabel"

--- a/packages/dialtone-vue2/components/split_button/split_button-omega.vue
+++ b/packages/dialtone-vue2/components/split_button/split_button-omega.vue
@@ -1,7 +1,7 @@
 <template>
   <dt-button
     :id="id"
-    v-dt-tooltip="tooltipText"
+    v-dt-tooltip="{ message: tooltipText, inverted: kind === 'inverted' }"
     data-qa="dt-split-button-omega"
     :active="active"
     :aria-label="ariaLabel"

--- a/packages/dialtone-vue3/components/split_button/split_button-alpha.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button-alpha.vue
@@ -1,6 +1,6 @@
 <template>
   <dt-button
-    v-dt-tooltip="tooltipText"
+    v-dt-tooltip="{ message: tooltipText, inverted: kind === 'inverted' }"
     data-qa="dt-split-button-alpha"
     :active="active"
     :aria-label="ariaLabel"

--- a/packages/dialtone-vue3/components/split_button/split_button-omega.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button-omega.vue
@@ -1,7 +1,7 @@
 <template>
   <dt-button
     :id="id"
-    v-dt-tooltip="tooltipText"
+    v-dt-tooltip="{ message: tooltipText, inverted: kind === 'inverted' }"
     data-qa="dt-split-button-omega"
     :active="active"
     :aria-label="ariaLabel"


### PR DESCRIPTION
# fix(split-button): NO-JIRA invert tooltip when button inverted

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHdlcGIxbmJrbHFkNGRrNnZvYjczZjF6MHNwcWZjdm1hbTlienR6NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/S6qePuiqFNehb16Ivv/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

invert the tooltip when the button itself is inverted

## :bulb: Context

Requested by josh in #dialtone

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
