### PR TITLE
fix(split-button): NO-JIRA fix infinite loop

### DIFF
--- a/packages/dialtone-vue2/components/split_button/split_button-alpha.vue
+++ b/packages/dialtone-vue2/components/split_button/split_button-alpha.vue
@@ -1,6 +1,6 @@
 <template>
   <dt-button
-    v-dt-tooltip="{ message: tooltipText, inverted: kind === 'inverted' }"
+    v-dt-tooltip="tooltipConfig"
     data-qa="dt-split-button-alpha"
     :active="active"
     :aria-label="ariaLabel"
@@ -129,6 +129,15 @@ export default {
     return {
       BUTTON_ICON_SIZES,
     };
+  },
+
+  computed: {
+    tooltipConfig () {
+      return {
+        message: this.tooltipText,
+        inverted: this.kind === 'inverted',
+      };
+    },
   },
 };
 </script>

--- a/packages/dialtone-vue2/directives/tooltip_directive/tooltip.js
+++ b/packages/dialtone-vue2/directives/tooltip_directive/tooltip.js
@@ -1,5 +1,6 @@
 import { DtTooltip, TOOLTIP_DIRECTIONS } from '@/components/tooltip';
 import { getUniqueString } from '@/common/utils';
+import deepEqual from 'deep-equal';
 
 export const DtTooltipDirective = {
   name: 'dt-tooltip-directive',
@@ -68,7 +69,8 @@ export const DtTooltipDirective = {
       },
       update (anchor, binding) {
         // Update tooltip on binding value change
-        if (binding.value !== binding.oldValue) {
+        // Use deep equality check to prevent infinite loops when objects are passed
+        if (!deepEqual(binding.value, binding.oldValue)) {
           setupTooltip(anchor, binding);
         }
       },

--- a/packages/dialtone-vue3/components/split_button/split_button-alpha.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button-alpha.vue
@@ -1,6 +1,6 @@
 <template>
   <dt-button
-    v-dt-tooltip="{ message: tooltipText, inverted: kind === 'inverted' }"
+    v-dt-tooltip="tooltipConfig"
     data-qa="dt-split-button-alpha"
     :active="active"
     :aria-label="ariaLabel"
@@ -130,6 +130,15 @@ export default {
     return {
       BUTTON_ICON_SIZES,
     };
+  },
+
+  computed: {
+    tooltipConfig () {
+      return {
+        message: this.tooltipText,
+        inverted: this.kind === 'inverted',
+      };
+    },
   },
 };
 </script>

--- a/packages/dialtone-vue3/directives/tooltip_directive/tooltip.js
+++ b/packages/dialtone-vue3/directives/tooltip_directive/tooltip.js
@@ -1,6 +1,7 @@
 import { DtTooltip, TOOLTIP_DIRECTIONS } from '@/components/tooltip';
 import { getUniqueString } from '@/common/utils';
 import { createApp, getCurrentInstance, h } from 'vue';
+import deepEqual from 'deep-equal';
 
 export const DtTooltipDirective = {
   name: 'dt-tooltip-directive',
@@ -67,7 +68,8 @@ export const DtTooltipDirective = {
       },
       updated (anchor, binding) {
         // Update tooltip on binding value change
-        if (binding.value !== binding.oldValue) {
+        // Use deep equality check to prevent infinite loops when objects are passed
+        if (!deepEqual(binding.value, binding.oldValue)) {
           setupTooltip(anchor, binding);
         }
       },


### PR DESCRIPTION
# fix(split-button): NO-JIRA fix infinite loop

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExYm10c3Jsdjc1cGRwZW5jcmJ4YXRuMDd0YWdidGRjbnY2Zzk2M2xyMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ZE7PwZ7w2BN3trcox3/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Fix infinite loop issue by moving the object out of the template into computed property.

## :bulb: Context

This was only happening on vue 2, not vue 3. The way it handles objects in templates is different.

Because it was an object in the template, a new object was being created every time, and then the object way being compared by reference instead of value causing an infinite loop

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
