### PR TITLE
docs(skeleton, loader): DLT-2558 add docs to compare both components

### DIFF
--- a/apps/dialtone-documentation/docs/components/loader.md
+++ b/apps/dialtone-documentation/docs/components/loader.md
@@ -10,6 +10,24 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-loader--defa
   <dt-loader></dt-loader>
 </code-well-header>
 
+## Loader vs Skeleton
+
+**Use Loader when:**
+
+- You need a simple, generic loading indicator
+- Loading time is short or indeterminate
+- You want to indicate that a process is running without showing layout structure
+- You need a compact loading indicator for buttons, small components, or overlays
+
+**Use [Skeleton](/components/skeleton.html) when:**
+
+- Content takes more than 300ms to load
+- You want to show the approximate layout and structure of content being loaded
+- Loading complex lists, cards, or detailed content where users benefit from seeing the expected layout
+- You need to maintain visual hierarchy during loading states
+
+## Variants
+
 ### Default
 
 The base loader should be the go-to loader for most of your needs. When in doubt, use this style.

--- a/apps/dialtone-documentation/docs/components/loader.md
+++ b/apps/dialtone-documentation/docs/components/loader.md
@@ -21,7 +21,7 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-loader--defa
 
 **Use [Skeleton](/components/skeleton.html) when:**
 
-- Content takes more than 300ms to load
+- Content is expected to take more than a few hundred milliseconds to load on average
 - You want to show the approximate layout and structure of content being loaded
 - Loading complex lists, cards, or detailed content where users benefit from seeing the expected layout
 - You need to maintain visual hierarchy during loading states

--- a/apps/dialtone-documentation/docs/components/skeleton.md
+++ b/apps/dialtone-documentation/docs/components/skeleton.md
@@ -18,7 +18,7 @@ figma: planned
 
 **Use Skeleton when:**
 
-- Content takes more than 300ms to load
+- Content is expected to take more than a few hundred milliseconds to load on average
 - You want to show the approximate layout and structure of content being loaded
 - Loading complex lists, cards, or detailed content where users benefit from seeing the expected layout
 - You need to maintain visual hierarchy during loading states

--- a/apps/dialtone-documentation/docs/components/skeleton.md
+++ b/apps/dialtone-documentation/docs/components/skeleton.md
@@ -14,6 +14,22 @@ figma: planned
   </div>
 </code-well-header>
 
+## Skeleton vs Loader
+
+**Use Skeleton when:**
+
+- Content takes more than 300ms to load
+- You want to show the approximate layout and structure of content being loaded
+- Loading complex lists, cards, or detailed content where users benefit from seeing the expected layout
+- You need to maintain visual hierarchy during loading states
+
+**Use [Loader](/components/loader.html) when:**
+
+- You need a simple, generic loading indicator
+- Loading time is short or indeterminate
+- You want to indicate that a process is running without showing layout structure
+- You need a compact loading indicator for buttons, small components, or overlays
+
 ## Usage
 
 <dialtone-usage>


### PR DESCRIPTION
# docs(skeleton, loader): DLT-2558 add docs to compare both components

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
[DLT-2558]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Adds docs in skeleton component page to refer to the loader component, and viceversa.
<!--- Describe specifically what the changes are -->

<img width="942" height="396" alt="image" src="https://github.com/user-attachments/assets/ad6bfe4f-8cb4-4d77-b3b9-6222941646e1" />

<img width="942" height="396" alt="image" src="https://github.com/user-attachments/assets/e3f9925b-3c1d-4008-974d-992c5236cecc" />



[DLT-2558]: https://dialpad.atlassian.net/browse/DLT-2558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ