### PR TITLE
docs(json-docs): DLT-2798 add metadata to dialtone JSON documentation files

### DIFF
--- a/packages/dialtone-css/postcss/dialtone-docs.cjs
+++ b/packages/dialtone-css/postcss/dialtone-docs.cjs
@@ -50,6 +50,76 @@ const documentation = {};
 const CSSVarRegex = /var\(([^),]+)\)/g;
 
 /**
+ * Metadata rules for utility classes
+ * Maps patterns to metadata that should be added to the documentation
+ * Based on eslint-plugin-dialtone rules
+ */
+const metadataRules = [
+  // Typography utilities (discouraged per recommend-typography-style.js eslint rule)
+  {
+    pattern: /^d-(fw-|ff-|fs-|lh-)/,
+    metadata: {
+      deprecated: false,
+      discouraged: true,
+      category: 'typography',
+      reason: 'Individual typography utilities are discouraged in favor of composed typography classes',
+      alternatives: ['d-headline-*', 'd-body-*', 'd-label-*', 'd-code-*'],
+      docs: 'https://dialtone.dialpad.com/design/typography/#api',
+    },
+  },
+  // Base colors (deprecated per deprecated-base-color-classes.js eslint rule)
+  {
+    pattern: /^d-(bgc|fc|bc|divide)-\w+-\d{2,4}$/,
+    metadata: {
+      deprecated: true,
+      discouraged: true,
+      category: 'color',
+      reason: 'Base color utilities are deprecated and will be removed in the future',
+      alternatives: [],
+      docs: 'https://dialtone.dialpad.com/utilities/backgrounds/color.html',
+    },
+  },
+  // Flex gap (deprecated per deprecated-flex-gap-classes.js eslint rule)
+  {
+    pattern: /^d-flg\d{1,2}$/,
+    metadata: {
+      deprecated: true,
+      discouraged: true,
+      category: 'flex',
+      reason: 'Flex gap utilities are deprecated and will be removed in the future',
+      alternatives: [],
+      docs: 'https://dialtone.dialpad.com/utilities/flex/gap.html',
+    },
+  },
+  // Grid gap (deprecated per deprecated-grid-gap-classes.js eslint rule)
+  {
+    pattern: /^d-(gg|grg|gcg)\d{1,2}$/,
+    metadata: {
+      deprecated: true,
+      discouraged: true,
+      category: 'grid',
+      reason: 'Grid gap utilities are deprecated and will be removed in the future',
+      alternatives: [],
+      docs: 'https://dialtone.dialpad.com/utilities/grid/gap.html',
+    },
+  },
+];
+
+/**
+ * Get metadata for a utility class based on pattern matching
+ * @param {string} className - The utility class name to check
+ * @returns {object|null} Metadata object if a rule matches, null otherwise
+ */
+function getMetadataForClass (className) {
+  for (const rule of metadataRules) {
+    if (rule.pattern.test(className)) {
+      return rule.metadata;
+    }
+  }
+  return null;
+}
+
+/**
  * Generate dialtone-docs.json
  * @param docs
  * @param {import('postcss').Rule} rule
@@ -75,7 +145,58 @@ function generateUtilityClassDocumentation (docs, rule) {
     return result;
   });
 
-  documentation[className] = { values };
+  const metadata = getMetadataForClass(className);
+
+  documentation[className] = {
+    values,
+    ...(metadata && { metadata }),
+  };
+}
+
+/**
+ * Check if a token should have metadata added
+ * @param {string} tokenName - The token name to check
+ * @returns {object|null} Metadata object if token matches a rule, null otherwise
+ */
+function getMetadataForToken (tokenName) {
+  // Base primitive tokens (--base--*) - not meant for direct use
+  if (tokenName.startsWith('--base--')) {
+    return {
+      deprecated: false,
+      discouraged: true,
+      category: 'internal',
+      reason: 'Base tokens are internal primitive values. Use semantic design tokens or CSS utility classes instead',
+      alternatives: [],
+      docs: 'https://dialtone.dialpad.com/design/tokens/',
+    };
+  }
+
+  // Tokens with -base- in the name (like --dt-action-color-background-base-active)
+  // These are component-level base states, also internal
+  if (tokenName.includes('-base-')) {
+    return {
+      deprecated: false,
+      discouraged: true,
+      category: 'internal',
+      reason: 'Base state tokens are internal values. Use semantic design tokens or CSS utility classes instead',
+      alternatives: [],
+      docs: 'https://dialtone.dialpad.com/design/tokens/',
+    };
+  }
+
+  // Theme tokens (--dt-theme-*) are deprecated in favor of shell tokens
+  if (tokenName.startsWith('--dt-theme-')) {
+    return {
+      deprecated: true,
+      discouraged: true,
+      category: 'deprecated',
+      reason: 'Theme tokens have been replaced by shell tokens',
+      alternatives: ['--dt-shell-*'],
+      docs: 'https://dialtone.dialpad.com/design/tokens/',
+    };
+  }
+
+  return null;
 }
 
 function generateTokensDocumentation (documentation) {
@@ -174,14 +295,19 @@ module.exports = () => {
     async OnceExit () {
       // Iterate over tokens documentation to replace reference variables with primitive values
       const docs = Object.keys(tokensDocs).reduce((tokens, token) => {
-        tokens[token] = Object.keys(tokensDocs[token]).reduce((themes, theme) => {
-          const originalValue = tokensDocs[token][theme].value;
-          themes[theme] = {
-            ...tokensDocs[token][theme],
-            value: replaceVariableValue(tokensDocs, originalValue, theme),
-          };
-          return themes;
-        }, {});
+        const metadata = getMetadataForToken(token);
+
+        tokens[token] = {
+          ...Object.keys(tokensDocs[token]).reduce((themes, theme) => {
+            const originalValue = tokensDocs[token][theme].value;
+            themes[theme] = {
+              ...tokensDocs[token][theme],
+              value: replaceVariableValue(tokensDocs, originalValue, theme),
+            };
+            return themes;
+          }, {}),
+          ...(metadata && { metadata }),
+        };
         return tokens;
       }, {});
 

--- a/packages/dialtone-css/postcss/dialtone-docs.cjs
+++ b/packages/dialtone-css/postcss/dialtone-docs.cjs
@@ -57,7 +57,7 @@ const CSSVarRegex = /var\(([^),]+)\)/g;
 const metadataRules = [
   // Typography utilities (discouraged per recommend-typography-style.js eslint rule)
   {
-    pattern: /^d-(fw-|ff-|fs-|lh-|helper-)/,
+    pattern: /^d-(fw-|ff-|fs-|lh-)/,
     metadata: {
       deprecated: false,
       discouraged: true,

--- a/packages/dialtone-css/postcss/dialtone-docs.cjs
+++ b/packages/dialtone-css/postcss/dialtone-docs.cjs
@@ -57,13 +57,13 @@ const CSSVarRegex = /var\(([^),]+)\)/g;
 const metadataRules = [
   // Typography utilities (discouraged per recommend-typography-style.js eslint rule)
   {
-    pattern: /^d-(fw-|ff-|fs-|lh-)/,
+    pattern: /^d-(fw-|ff-|fs-|lh-|helper-)/,
     metadata: {
       deprecated: false,
       discouraged: true,
       category: 'typography',
       reason: 'Individual typography utilities are discouraged in favor of composed typography classes',
-      alternatives: ['d-headline-*', 'd-body-*', 'd-label-*', 'd-code-*'],
+      alternatives: ['d-headline-*', 'd-body-*', 'd-label-*', 'd-code-*', 'd-helper-*'],
       docs: 'https://dialtone.dialpad.com/design/typography/#api',
     },
   },
@@ -75,7 +75,7 @@ const metadataRules = [
       discouraged: true,
       category: 'color',
       reason: 'Base color utilities are deprecated and will be removed in the future',
-      alternatives: [],
+      alternatives: ['d-fc-primary', 'd-fc-secondary', 'd-fc-tertiary', 'd-bgc-critical', 'd-bgc-success', 'd-bc-default'],
       docs: 'https://dialtone.dialpad.com/utilities/backgrounds/color.html',
     },
   },
@@ -87,7 +87,7 @@ const metadataRules = [
       discouraged: true,
       category: 'flex',
       reason: 'Flex gap utilities are deprecated and will be removed in the future',
-      alternatives: [],
+      alternatives: ['d-g8', 'd-rg8', 'd-cg8'],
       docs: 'https://dialtone.dialpad.com/utilities/flex/gap.html',
     },
   },
@@ -99,7 +99,7 @@ const metadataRules = [
       discouraged: true,
       category: 'grid',
       reason: 'Grid gap utilities are deprecated and will be removed in the future',
-      alternatives: [],
+      alternatives: ['d-g8', 'd-rg8', 'd-cg8'],
       docs: 'https://dialtone.dialpad.com/utilities/grid/gap.html',
     },
   },
@@ -171,14 +171,14 @@ function getMetadataForToken (tokenName) {
     };
   }
 
-  // Tokens with -base- in the name (like --dt-action-color-background-base-active)
-  // These are component-level base states, also internal
-  if (tokenName.includes('-base-')) {
+  // Tokens ending with -base or -root (internal primitive values)
+  // These are not meant for direct use
+  if (tokenName.endsWith('-base') || tokenName.endsWith('-root')) {
     return {
       deprecated: false,
       discouraged: true,
       category: 'internal',
-      reason: 'Base state tokens are internal values. Use semantic design tokens or CSS utility classes instead',
+      reason: 'Base and root tokens are internal primitive values. Use semantic design tokens or CSS utility classes instead',
       alternatives: [],
       docs: 'https://dialtone.dialpad.com/design/tokens/',
     };

--- a/scripts/build-dialtone-vue-docs.mjs
+++ b/scripts/build-dialtone-vue-docs.mjs
@@ -8,6 +8,33 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const version = process.argv[2];
 
+/**
+ * Deprecated components metadata
+ * Based on eslint-plugin-dialtone/lib/rules/deprecated-component.js
+ */
+const deprecatedComponents = {
+  'SelectMenu': {
+    replacement: 'DtComboboxWithPopover',
+    docs: 'https://dialtone.dialpad.com/vue/?path=/story/recipes-comboboxes-combobox-with-popover--default',
+  },
+  'DropdownMenu': {
+    replacement: 'DtSelectMenu',
+    docs: 'https://dialtone.dialpad.com/vue/?path=/story/components-select-menu--default',
+  },
+  'BaseToggle': {
+    replacement: 'DtToggle',
+    docs: 'https://dialtone.dialpad.com/vue/?path=/story/components-toggle--default',
+  },
+  'BaseDatePicker': {
+    replacement: 'DtDatepicker',
+    docs: 'https://dialtone.dialpad.com/vue/?path=/story/components-datepicker--default',
+  },
+  'Checkbox': {
+    replacement: 'DtCheckbox',
+    docs: 'https://dialtone.dialpad.com/vue/?path=/story/components-checkbox--default',
+  },
+};
+
 if (!version) {
   console.info(`Usage: build-dialtone-vue-docs.mjs 2 or build-dialtone-vue-docs.mjs 3`);
   process.exit(-1);
@@ -45,8 +72,24 @@ async function parseDocumentation (fileList) {
   });
 
   try {
-    return Promise.all(parsedDocumentationPromises);
-  } catch (err) {
+    const docs = await Promise.all(parsedDocumentationPromises);
+
+    // Add metadata to deprecated components
+    return docs.map(doc => {
+      const componentName = doc.displayName;
+      if (deprecatedComponents[componentName]) {
+        return {
+          ...doc,
+          metadata: {
+            deprecated: true,
+            reason: 'Replaced by Dialtone Vue component',
+            ...deprecatedComponents[componentName],
+          },
+        };
+      }
+      return doc;
+    });
+  } catch {
     throw new Error('Parsing documentation');
   }
 }


### PR DESCRIPTION
## Obligatory GIF (super important!)

  ![Obligatory GIF](https://media.tenor.com/U5VRXe1WnocAAAAM/i-want-to-break-free-i-want-to-break-free-music-video.gif)

  ## :hammer_and_wrench: Type Of Change

  These types will increment the version number on release:

  - [x] Feature

  ## :book: Jira Ticket

  DLT-2798

  ## :book: Description

  Adds optional `metadata` field to JSON documentation files (`dialtone-docs.json`, `tokens-docs.json`,
  `component-documentation.json`) to flag deprecated and discouraged usage patterns.

  **Utility Classes:** Flagged classes with alternatives
  - Typography utilities (d-fw-, d-ff-, d-fs-, d-lh-, d-helper-*) - discouraged per eslint rule
    - Alternatives: d-headline-*, d-body-*, d-label-*, d-code-*, d-helper-*
  - Base color classes (d-bgc-purple-400, etc.) - deprecated
    - Alternatives: d-fc-primary, d-fc-secondary, d-fc-tertiary, d-bgc-critical, d-bgc-success, d-bc-default
  - Flex gap (d-flg*) - deprecated
    - Alternatives: d-g8, d-rg8, d-cg8
  - Grid gap (d-gg*, d-grg*, d-gcg*) - deprecated
    - Alternatives: d-g8, d-rg8, d-cg8

  **Design Tokens:** Flagged tokens
  - Base primitives (--base--*) - discouraged (internal use)
  - Base/root state tokens (tokens ending with -base or -root) - discouraged (internal use)
  - Deprecated theme tokens (--dt-theme-*) - deprecated (use --dt-shell-* instead)

  **Components:** Infrastructure added for deprecated components

  ## :bulb: Context

  The MCP Server and other AI tools need to know which utilities/tokens are deprecated or discouraged to provide better
  recommendations. Without this metadata, AI assistants recommend deprecated patterns.

  This aligns with existing eslint-plugin-dialtone rules and documentation site exclusions.

  ## :pencil: Checklist

  For all PRs:

  - [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public
  repo!).
  - [x] I have reviewed my changes.
  - [x] I have added all relevant documentation.
  - [x] I have considered the performance impact of my change.

  For all CSS changes:

  - [x] I have used design tokens whenever possible.

  ## :crystal_ball: Next Steps

  After merge, the MCP server (DLT-2787) will be updated to use this metadata to deprioritize deprecated/discouraged options
   in AI recommendations.

  ## :camera: Screenshots / GIFs

  N/A - JSON metadata changes only

  ## :link: Sources

  - eslint-plugin-dialtone rules
  - Documentation site token exclusion logic 
  (`apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/utilities.js`)

  Files Modified:
  1. packages/dialtone-css/postcss/dialtone-docs.cjs - Added metadata logic for utilities and tokens
  2. scripts/build-dialtone-vue-docs.mjs - Added component metadata logic
  
  ## :speech_balloon: Review Feedback Addressed
  
  - Added d-helper-* to typography pattern
  - Added concrete semantic alternatives for all deprecated utilities
  - Fixed base token pattern to only match tokens ending with -base or -root (not containing -base-)
