### PR TITLE
feat(utilities): DLT-2811 add line-clamp utility class

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -88,8 +88,8 @@ html body {
     padding: 0 var(--docsearch-spacing);
     padding-right: var(--dt-space-450);
     padding-left: var(--dt-space-450);
-    border-radius: var(--dt-size-radius-400);
     border: none;
+    border-radius: var(--dt-size-radius-400);
     box-shadow: var(--docsearch-searchbox-shadow);
   }
 
@@ -391,6 +391,7 @@ a.header-anchor {
 .d-docsite-code {
   color: var(--dt-color-blue-500) !important;
   font-weight: var(--dt-font-weight-normal) !important;
+  user-select: all;
 }
 
 //  ============================================================================

--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-syntax.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-syntax.less
@@ -27,8 +27,8 @@ div[class*="language-"] {
 	}
 
   &::before {
-    font: var(--dt-typography-body-sm);
-    color: var(--dt-color-foreground-primary)
+    color: var(--dt-color-foreground-primary);
+    font: var(--dt-typography-body-sm)
   }
 }
 
@@ -37,6 +37,7 @@ code:not(.d-code--md, .d-code--sm) {
 	color: var(--dt-color-blue-500);
 	background-color: var(--dt-color-surface-info);
 	border-radius: var(--dt-size-100);
+	user-select: all;
 }
 
 code[class*="language-"],

--- a/apps/dialtone-documentation/docs/_data/site-nav.json
+++ b/apps/dialtone-documentation/docs/_data/site-nav.json
@@ -495,6 +495,10 @@
           "link": "/utilities/typography/line-height.html"
         },
         {
+          "text": "Line Clamp",
+          "link": "/utilities/typography/line-clamp.html"
+        },
+        {
           "text": "Lists",
           "link": "/utilities/typography/lists.html"
         },

--- a/apps/dialtone-documentation/docs/_data/type.json
+++ b/apps/dialtone-documentation/docs/_data/type.json
@@ -554,6 +554,19 @@
     "justify",
     "unset"
   ],
+  "lineClamp": [
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "none",
+    "unset"
+  ],
   "overflowWrap": [
     {
       "class": "normal",

--- a/apps/dialtone-documentation/docs/components/stack.md
+++ b/apps/dialtone-documentation/docs/components/stack.md
@@ -262,20 +262,19 @@ vueCode='
 ## Gap
 
 <code-well-header>
-
   <dt-stack class=" d-w100p">
     <h3 class="d-label">Select a gap option</h3>
     <dt-stack
       :direction="{ 'default': 'column', 'md': 'row' }"
       gap="200"
-      class="d-bgc-primary d-p2 d-bar4 d-mb16"
+      class="d-ba d-bc-subtle d-p2 d-bar8 d-mb16"
     >
       <dt-button
         v-for="gap in gaps"
         size="xs"
         kind="muted"
         importance="clear"
-        class="d-fl1"
+        class="d-fl1 d-bar6"
         :key="gap"
         :class="{ 'd-btn--active': gap === selectedGap }"
         @click="setGap(gap)"

--- a/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
@@ -62,7 +62,7 @@ Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
 
 ## Custom
 
-The `d-lc-{n}` utility currently goes up to `9`. Should you need to go beyond, you can do so with the `d-lc-custom` class and locally adjusting the CSS custom property `--lc-lines`.
+The `d-lc-{n}` utility currently goes up to `9`. Should you need to go beyond, use the `d-lc-custom` class and locally adjust the CSS custom property `--lc-lines`.
 
 ```html
 <div class="d-lc-custom" style="--lc-lines: 11">

--- a/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
@@ -5,95 +5,51 @@ description: Utilities for limiting the number of lines displayed for text conte
 
 ## Usage
 
-Use `d-line-clamp-{n}` to truncate text at a specific number of lines with an ellipsis.
+Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
 
-<code-well-header class="d-w100p">
-  <dt-stack class="d-w100p" gap="500">
-    <dt-stack gap="500" direction="row" class="d-ai-baseline">
-      <p class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-3</p>
-      <p class="d-line-clamp-3">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+<code-well-header>
+  <dt-stack gap="500" class="d-w100p d-ai-baseline">
+    <dt-stack gap="400" class="d-fl1 d-jc-space-between">
+      <!-- <code class="d-code--sm d-docsite-code">class="d-lc-<strong>{{ selectedClamp }}</strong>"</code> -->
+      <dt-select-menu
+        :value="selectedClamp"
+        @input="selectedClamp = $event"
+        :options="clampOptions"
+      />
+    </dt-stack>
+    <dt-stack class="" direction="row" gap="400">
+      <p :class="`d-lc-${selectedClamp}`">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+      </p>
+      <dt-stack class="d-as-flex-end d-fc-success">
+        <dt-icon name="arrow-left" size="400" />
+      </dt-stack>
     </dt-stack>
   </dt-stack>
 </code-well-header>
 
 ```html
-<p class="d-line-clamp-3">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+<p class="d-lc-{n}">Lorem ipsum dolor...</p>
 ```
 
 ### Avoiding Conflicts with Display Utilities
 
 <dt-notice kind="warning" class="d-wmx100p d-mb32" :hideClose="true">
   <template #default>
-    <p>The line-clamp utility sets <code>display: -webkit-box</code> which may conflict with other display utilities. If you need to use line-clamp with flex or grid layouts, consider wrapping the clamped text in a separate element:</p>
+    <p>The line-clamp utility sets <code>display: -webkit-box</code> which will conflict with other display utilities. If you need to use line-clamp with flex or grid layouts, consider wrapping the clamped text in a separate element:</p>
   </template>
 </dt-notice>
 
 ```html
 <!-- This won't work because DtStack is flex-based -->
-<dt-stack class="d-line-clamp-2"> ... </dt-stack>
+<dt-stack class="d-lc-2"> ... </dt-stack>
 
 <!-- This will work -->
 <dt-stack>
-  <p class="d-line-clamp-2"> ... </p>
+  <p class="d-lc-2"> ... </p>
 </dt-stack>
 ```
 
-## Examples
-
-<code-well-header class="d-w100p">
-  <dt-stack class="d-w100p" gap="500">
-    <dt-stack gap="500" direction="row" class="d-ai-baseline">
-      <p class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-2</p>
-      <p class="d-line-clamp-2">Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore nulla pariatur.</p>
-    </dt-stack>
-    <dt-stack gap="500" direction="row" class="d-ai-baseline">
-      <p class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-3</p>
-      <p class="d-line-clamp-3">Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore nulla pariatur.</p>
-    </dt-stack>
-    <dt-stack gap="500" direction="row" class="d-ai-baseline">
-      <p class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-4</p>
-      <p class="d-line-clamp-4">Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore nulla pariatur.</p>
-    </dt-stack>
-    <dt-stack gap="500" direction="row" class="d-ai-baseline">
-      <p class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-5</p>
-      <p class="d-line-clamp-5">Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore nulla pariatur.</p>
-    </dt-stack>
-    <dt-stack gap="500" direction="row" class="d-ai-baseline">
-      <p class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-6</p>
-      <p class="d-line-clamp-6">Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore nulla pariatur.</p>
-    </dt-stack>
-  </dt-stack>
-</code-well-header>
-
-```html
-<p class="d-line-clamp-2">Two lines of text lorem ipsum...</p>
-<p class="d-line-clamp-3">Three lines of text lorem ipsum...</p>
-<p class="d-line-clamp-4">Four lines of text lorem ipsum...</p>
-<p class="d-line-clamp-5">Five lines of text lorem ipsum...</p>
-<p class="d-line-clamp-6">Six lines of text lorem ipsum...</p>
-```
-## Interactive Demo
-
-Try adjusting the line clamp value to see how the text truncates at different lengths:
-
-<code-well-header class="d-w100p">
-  <dt-stack gap="500">
-    <div class="d-d-flex d-ai-center d-g16">
-      <dt-select-menu
-        v-model="selectedClamp"
-        label="Select line clamp value"
-        :options="clampOptions"
-        class="d-w264"
-      />
-      <code class="d-code--sm d-docsite-code">{{ selectedClamp === 'none' ? 'No class applied' : '.d-line-clamp-' + selectedClamp }}</code>
-    </div>
-    <div class="d-ba d-bc-default d-bar8 d-p16">
-      <p :class="`${selectedClamp === 'none' ? '' : 'd-line-clamp-' + selectedClamp}`">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
-      </p>
-    </div>
-  </dt-stack>
-</code-well-header>
 
 ## Classes
 
@@ -101,7 +57,7 @@ Try adjusting the line clamp value to see how the text truncates at different le
   <template #content>
     <tbody>
       <tr v-for="i in lineClamp" :key="i">
-        <th class="d-code--sm d-docsite-code">.d-line-clamp-{{ i }}</th>
+        <th class="d-code--sm d-docsite-code">.d-lc-{{ i }}</th>
         <td class="d-code--sm">
           {{ i !== 'none' && i !== 'unset' ? `-webkit-line-clamp: ${i} !important;` : '-webkit-line-clamp: unset !important;' }}
         </td>
@@ -115,12 +71,19 @@ Try adjusting the line clamp value to see how the text truncates at different le
   import { lineClamp } from '@data/type.json';
 
   const selectedClamp = ref('3');
-  
+
   // Create options for the DtSelectMenu component
-  const clampOptions = computed(() => {
-    return ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'none'].map(value => ({
-      value: value,
-      label: value === 'none' ? 'No clamping' : `${value} line${value === '1' ? '' : 's'}`
-    }));
-  });
+  const clampOptions = computed(() => [
+    { value: '1', label: '1 line' },
+    { value: '2', label: '2 lines' },
+    { value: '3', label: '3 lines' },
+    { value: '4', label: '4 lines' },
+    { value: '5', label: '5 lines' },
+    { value: '6', label: '6 lines' },
+    { value: '7', label: '7 lines' },
+    { value: '8', label: '8 lines' },
+    { value: '9', label: '9 lines' },
+    { value: 'none', label: 'None' },
+    { value: 'unset', label: 'Unset' }
+  ]);
 </script>

--- a/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
@@ -1,0 +1,144 @@
+---
+title: Line Clamp
+description: Utilities for limiting the number of lines displayed for text content.
+---
+
+## Usage
+
+Use `d-line-clamp-{n}` to truncate text at a specific number of lines with an ellipsis.
+
+<code-well-header class="d-w100p">
+  <div class="d-w100p d-d-grid d-g16 d-ai-start lg:d-fs-100" style="grid-template-columns: auto 1fr">
+    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-1</div>
+    <div><p class="d-line-clamp-1 d-bgc-moderate">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</p></div>
+    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-2</div>
+    <div><p class="d-line-clamp-2 d-bgc-moderate">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p></div>
+    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-3</div>
+    <div><p class="d-line-clamp-3 d-bgc-moderate">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p></div>
+    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-4</div>
+    <div><p class="d-line-clamp-4 d-bgc-moderate">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p></div>
+    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-none</div>
+    <div><p class="d-line-clamp-none d-bgc-moderate">Lorem ipsum dolor sit amet, consectetur adipiscing elit. This text will not be clamped and will show in its entirety.</p></div>
+  </div>
+</code-well-header>
+
+```html
+<p class="d-line-clamp-1">...</p>
+<p class="d-line-clamp-2">...</p>
+<p class="d-line-clamp-3">...</p>
+<p class="d-line-clamp-4">...</p>
+<p class="d-line-clamp-none">...</p>
+```
+
+## Browser Compatibility
+
+<dt-notice kind="warning" class="d-wmx100p d-mt24" :hideClose="true">
+  <template #default>
+    The line-clamp utility uses the `-webkit-line-clamp` CSS property, which has good browser support but is technically a webkit-prefixed property. It works in all modern browsers including Chrome, Safari, Firefox (68+), and Edge.
+  </template>
+</dt-notice>
+
+## Display Utility Interaction
+
+<dt-notice kind="info" class="d-wmx100p d-mt24" :hideClose="true">
+  <template #default>
+    <p class="d-body--md-compact">The line-clamp utility sets <code>display: -webkit-box</code> which may conflict with other display utilities. If you need to use line-clamp with flex or grid layouts, consider wrapping the clamped text in a separate element:</p>
+  </template>
+</dt-notice>
+
+```html
+<!-- Instead of this -->
+<div class="d-d-flex d-line-clamp-2">...</div>
+
+<!-- Do this -->
+<div class="d-d-flex">
+  <p class="d-line-clamp-2">...</p>
+</div>
+```
+
+## Examples
+
+### Different Line Clamp Values
+
+<code-well-header class="d-w100p">
+  <dt-stack gap="500">
+    <div>
+      <h4 class="d-label--md d-mb4">Single Line (.d-line-clamp-1)</h4>
+      <p class="d-line-clamp-1 d-bgc-moderate d-p8">
+        The quick brown fox jumps over the lazy dog. This sentence is commonly used as a pangram to display all letters of the alphabet.
+      </p>
+    </div>
+    <div>
+      <h4 class="d-label--md d-mb4">Three Lines (.d-line-clamp-3)</h4>
+      <p class="d-line-clamp-3 d-bgc-moderate d-p8">
+        The quick brown fox jumps over the lazy dog. This sentence is commonly used as a pangram to display all letters of the alphabet. It has been used for testing typefaces, keyboards, and other applications involving all letters of the English alphabet. The phrase has been used since at least the late 1800s.
+      </p>
+    </div>
+    <div>
+      <h4 class="d-label--md d-mb4">Five Lines (.d-line-clamp-5)</h4>
+      <p class="d-line-clamp-5 d-bgc-moderate d-p8">
+        The quick brown fox jumps over the lazy dog. This sentence is commonly used as a pangram to display all letters of the alphabet. It has been used for testing typefaces, keyboards, and other applications involving all letters of the English alphabet. The phrase has been used since at least the late 1800s. Variations of the phrase exist, with some versions attempting to use each letter only once, though this is quite challenging to achieve while maintaining readability and coherence in the sentence structure.
+      </p>
+    </div>
+  </dt-stack>
+</code-well-header>
+
+```html
+<p class="d-line-clamp-1">Single line of text...</p>
+<p class="d-line-clamp-3">Three lines of text...</p>
+<p class="d-line-clamp-5">Five lines of text...</p>
+```
+
+### Use Cases
+
+#### Card Descriptions
+
+<code-well-header>
+  <div class="d-d-grid d-gg16" style="grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));">
+    <div class="d-ba d-bc-default d-bar4 d-p16">
+      <h3 class="d-headline--md d-mb8">Product Feature</h3>
+      <p class="d-line-clamp-3 d-fc-secondary">
+        This is a longer description of a product feature that might go on for several lines but we want to keep the cards uniform in height so we'll limit it to just three lines with an ellipsis at the end if it exceeds that limit.
+      </p>
+    </div>
+    <div class="d-ba d-bc-default d-bar4 d-p16">
+      <h3 class="d-headline--md d-mb8">Another Feature</h3>
+      <p class="d-line-clamp-3 d-fc-secondary">
+        Short description that fits within three lines.
+      </p>
+    </div>
+  </div>
+</code-well-header>
+
+```html
+<div class="card">
+  <h3>Product Feature</h3>
+  <p class="d-line-clamp-3">
+    Long description text...
+  </p>
+</div>
+```
+
+## Classes
+
+<utility-class-table>
+  <template #content>
+    <tbody>
+      <tr v-for="i in lineClamp" :key="i">
+        <th class="d-code--sm d-docsite-code">.d-line-clamp-{{ i }}</th>
+        <td class="d-code--sm">
+          <span v-if="i !== 'none' && i !== 'unset'">
+            -webkit-line-clamp: {{ i }} !important;
+          </span>
+          <span v-else>
+            -webkit-line-clamp: unset !important;
+          </span>
+        </td>
+      </tr>
+    </tbody>
+  </template>
+</utility-class-table>
+
+<script setup>
+  import { lineClamp } from '@data/type.json';
+</script>

--- a/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
@@ -8,17 +8,28 @@ description: Utilities for limiting the number of lines displayed for text conte
 Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
 
 <code-well-header>
-  <dt-stack gap="500" class="d-w100p d-ai-baseline">
-    <dt-stack gap="400" class="d-fl1 d-jc-space-between">
-      <!-- <code class="d-code--sm d-docsite-code">class="d-lc-<strong>{{ selectedClamp }}</strong>"</code> -->
-      <dt-select-menu
-        :value="selectedClamp"
-        @input="selectedClamp = $event"
-        :options="clampOptions"
-      />
+  <dt-stack class="d-w100p">
+    <h3 class="d-label">Select variant</h3>
+    <dt-stack
+      :direction="{ 'default': 'column', 'md': 'row' }"
+      gap="200"
+      class="d-ba d-bc-subtle d-p2 d-bar8 d-mb16"
+    >
+      <dt-button
+        v-for="value in clampValues"
+        size="xs"
+        kind="muted"
+        importance="clear"
+        class="d-fl1 d-bar6"
+        :key="value"
+        :class="{ 'd-btn--active': value === selectedClamp }"
+        @click="setClamp(value)"
+      >
+        {{ value === 'none' ? 'None' : value === 'unset' ? 'Unset' : value }}
+      </dt-button>
     </dt-stack>
-    <dt-stack class="" direction="row" gap="400">
-      <p :class="`d-lc-${selectedClamp}`">
+    <dt-stack direction="row" gap="400">
+      <p :class="`d-lc-${selectedClamp}`" class="d-fl1">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
       </p>
       <dt-stack class="d-as-flex-end d-fc-success">
@@ -32,7 +43,7 @@ Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
 <p class="d-lc-{n}">Lorem ipsum dolor...</p>
 ```
 
-### Avoiding Conflicts with Display Utilities
+### Avoiding display conflicts
 
 <dt-notice kind="warning" class="d-wmx100p d-mb32" :hideClose="true">
   <template #default>
@@ -40,16 +51,30 @@ Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
   </template>
 </dt-notice>
 
+#### Flex example
+
 ```html
 <!-- This won't work because DtStack is flex-based -->
-<dt-stack class="d-lc-2"> ... </dt-stack>
+<dt-stack class="d-lc-3"> ... </dt-stack>
 
-<!-- This will work -->
+<!-- This will -->
 <dt-stack>
-  <p class="d-lc-2"> ... </p>
+  <p class="d-lc-3"> ... </p>
 </dt-stack>
+
 ```
 
+#### Grid example
+
+```html
+<!-- This won't work -->
+<div class="d-lc-3 d-d-grid"> ... </div>
+
+<!-- This will -->
+<div class="d-d-grid">
+  <p class="d-lc-3"> ... </p>
+</div>
+```
 
 ## Classes
 
@@ -67,23 +92,14 @@ Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
 </utility-class-table>
 
 <script setup>
-  import { ref, computed } from 'vue';
+  import { ref } from 'vue';
   import { lineClamp } from '@data/type.json';
 
   const selectedClamp = ref('3');
 
-  // Create options for the DtSelectMenu component
-  const clampOptions = computed(() => [
-    { value: '1', label: '1 line' },
-    { value: '2', label: '2 lines' },
-    { value: '3', label: '3 lines' },
-    { value: '4', label: '4 lines' },
-    { value: '5', label: '5 lines' },
-    { value: '6', label: '6 lines' },
-    { value: '7', label: '7 lines' },
-    { value: '8', label: '8 lines' },
-    { value: '9', label: '9 lines' },
-    { value: 'none', label: 'None' },
-    { value: 'unset', label: 'Unset' }
-  ]);
+  const setClamp = (value) => {
+    selectedClamp.value = value;
+  };
+
+  const clampValues = ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'none', 'unset'];
 </script>

--- a/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
@@ -127,12 +127,7 @@ Use `d-line-clamp-{n}` to truncate text at a specific number of lines with an el
       <tr v-for="i in lineClamp" :key="i">
         <th class="d-code--sm d-docsite-code">.d-line-clamp-{{ i }}</th>
         <td class="d-code--sm">
-          <span v-if="i !== 'none' && i !== 'unset'">
-            -webkit-line-clamp: {{ i }} !important;
-          </span>
-          <span v-else>
-            -webkit-line-clamp: unset !important;
-          </span>
+          {{ i !== 'none' && i !== 'unset' ? `-webkit-line-clamp: ${i} !important;` : '-webkit-line-clamp: unset !important;' }}
         </td>
       </tr>
     </tbody>

--- a/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
@@ -77,22 +77,22 @@ Use `d-line-clamp-{n}` to truncate text at a specific number of lines with an el
 Try adjusting the line clamp value to see how the text truncates at different lengths:
 
 <code-well-header class="d-w100p">
-  <div>
-    <label>
-      Select line clamp value:
+  <dt-stack gap="500">
+    <div class="d-d-flex d-ai-center d-g16">
+      <dt-select-menu
+        v-model="selectedClamp"
+        label="Select line clamp value"
+        :options="clampOptions"
+        class="d-w264"
+      />
       <code class="d-code--sm d-docsite-code">{{ selectedClamp === 'none' ? 'No class applied' : '.d-line-clamp-' + selectedClamp }}</code>
-    </label>
-    <select v-model="selectedClamp">
-      <option v-for="value in ['2', '3', '4', '5', '6', '7', '8', '9', 'none']" :key="value" :value="value">
-        {{ value === 'none' ? 'No clamping' : value + ' line' + (value === '1' ? '' : 's') }}
-      </option>
-    </select>
-  </div>
-  <div class="d-ba d-bc-default d-bar8 d-p16">
-    <p :class="`${selectedClamp === 'none' ? '' : 'd-line-clamp-' + selectedClamp}`">
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
-    </p>
-  </div>
+    </div>
+    <div class="d-ba d-bc-default d-bar8 d-p16">
+      <p :class="`${selectedClamp === 'none' ? '' : 'd-line-clamp-' + selectedClamp}`">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+      </p>
+    </div>
+  </dt-stack>
 </code-well-header>
 
 ## Classes
@@ -111,8 +111,16 @@ Try adjusting the line clamp value to see how the text truncates at different le
 </utility-class-table>
 
 <script setup>
-  import { ref } from 'vue';
+  import { ref, computed } from 'vue';
   import { lineClamp } from '@data/type.json';
 
   const selectedClamp = ref('3');
+  
+  // Create options for the DtSelectMenu component
+  const clampOptions = computed(() => {
+    return ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'none'].map(value => ({
+      value: value,
+      label: value === 'none' ? 'No clamping' : `${value} line${value === '1' ? '' : 's'}`
+    }));
+  });
 </script>

--- a/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
@@ -119,6 +119,134 @@ Use `d-line-clamp-{n}` to truncate text at a specific number of lines with an el
 </div>
 ```
 
+### Complex Examples
+
+#### Mixed Typography Styles
+
+Line clamping works with different text styles and maintains the typography hierarchy:
+
+<code-well-header class="d-w100p">
+  <dt-stack gap="500">
+    <div class="d-ba d-bc-default d-bar4 d-p16">
+      <h2 class="d-headline--lg d-line-clamp-1 d-mb8">This is a Very Long Headline That Will Be Clamped to a Single Line No Matter How Much Content</h2>
+      <p class="d-body--md d-line-clamp-2 d-mb8">This is the body text that provides more detail about the headline above. It uses a different font size and weight but line clamping still works perfectly, maintaining readability while limiting the vertical space used.</p>
+      <p class="d-body--sm d-line-clamp-1 d-fc-tertiary">Author: Jane Doe • Published: October 24, 2025 • Category: Design Systems</p>
+    </div>
+  </dt-stack>
+</code-well-header>
+
+```html
+<h2 class="d-headline--lg d-line-clamp-1">Long headline...</h2>
+<p class="d-body--md d-line-clamp-2">Body text...</p>
+<p class="d-body--sm d-line-clamp-1 d-fc-tertiary">Meta info...</p>
+```
+
+#### Responsive Grid Layout
+
+Combine line clamping with responsive grid layouts for consistent card heights:
+
+<code-well-header class="d-w100p">
+  <div class="d-d-grid d-gg24" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));">
+    <div class="d-ba d-bc-default d-bar4 d-p12">
+      <div class="d-w100p d-h64 d-bgc-moderate d-bar4 d-mb12"></div>
+      <h4 class="d-headline--sm d-line-clamp-2 d-mb4">Product Design Fundamentals and Best Practices</h4>
+      <p class="d-body--sm d-line-clamp-3 d-fc-secondary d-mb8">Learn the essential principles of product design, including user research, prototyping, and iterative design processes that lead to successful digital products.</p>
+      <span class="d-label--sm d-fc-tertiary">12 lessons • 3hrs</span>
+    </div>
+    <div class="d-ba d-bc-default d-bar4 d-p12">
+      <div class="d-w100p d-h64 d-bgc-moderate d-bar4 d-mb12"></div>
+      <h4 class="d-headline--sm d-line-clamp-2 d-mb4">Advanced CSS</h4>
+      <p class="d-body--sm d-line-clamp-3 d-fc-secondary d-mb8">Master modern CSS techniques including Grid, Flexbox, and animations.</p>
+      <span class="d-label--sm d-fc-tertiary">8 lessons • 2hrs</span>
+    </div>
+    <div class="d-ba d-bc-default d-bar4 d-p12">
+      <div class="d-w100p d-h64 d-bgc-moderate d-bar4 d-mb12"></div>
+      <h4 class="d-headline--sm d-line-clamp-2 d-mb4">JavaScript ES6+ Features You Need to Know</h4>
+      <p class="d-body--sm d-line-clamp-3 d-fc-secondary d-mb8">Explore the latest JavaScript features including destructuring, async/await, modules, and more. This comprehensive course covers everything from basic to advanced concepts with practical examples.</p>
+      <span class="d-label--sm d-fc-tertiary">15 lessons • 4hrs</span>
+    </div>
+  </div>
+</code-well-header>
+
+#### Article Preview List
+
+<code-well-header class="d-w100p">
+  <dt-stack gap="400">
+    <article class="d-p16 d-ba d-bc-subtle d-bar4">
+      <div class="d-d-flex d-ai-start d-g16">
+        <div class="d-fl-grow1">
+          <h3 class="d-headline--md d-line-clamp-1 d-mb4">Understanding the Fundamentals of Design Systems in Modern Web Development</h3>
+          <p class="d-body--md d-line-clamp-2 d-fc-secondary d-mb8">Design systems have revolutionized how teams build and maintain digital products. This comprehensive guide explores the core concepts, implementation strategies, and best practices for creating scalable design systems that enhance collaboration between designers and developers.</p>
+          <div class="d-d-flex d-ai-center d-g8">
+            <span class="d-badge">Design</span>
+            <span class="d-badge">Development</span>
+            <span class="d-fc-tertiary d-body--sm">• 5 min read</span>
+          </div>
+        </div>
+        <div class="d-w96 d-h96 d-bgc-moderate d-bar4 d-fl-shrink0"></div>
+      </div>
+    </article>
+    <article class="d-p16 d-ba d-bc-subtle d-bar4">
+      <div class="d-d-flex d-ai-start d-g16">
+        <div class="d-fl-grow1">
+          <h3 class="d-headline--md d-line-clamp-1 d-mb4">CSS Grid vs Flexbox: When to Use Each</h3>
+          <p class="d-body--md d-line-clamp-2 d-fc-secondary d-mb8">Both CSS Grid and Flexbox are powerful layout tools, but knowing when to use each can significantly improve your CSS architecture. Let's explore the strengths of each approach.</p>
+          <div class="d-d-flex d-ai-center d-g8">
+            <span class="d-badge">CSS</span>
+            <span class="d-badge">Tutorial</span>
+            <span class="d-fc-tertiary d-body--sm">• 3 min read</span>
+          </div>
+        </div>
+        <div class="d-w96 d-h96 d-bgc-moderate d-bar4 d-fl-shrink0"></div>
+      </div>
+    </article>
+  </dt-stack>
+</code-well-header>
+
+## Interactive Demo
+
+### Dynamic Line Clamping
+
+Try adjusting the line clamp value to see how the text truncates at different lengths:
+
+<code-well-header class="d-w100p">
+  <div class="d-p16">
+    <div class="d-mb16">
+      <label class="d-label--md d-mb8 d-db">Select line clamp value:</label>
+      <select v-model="selectedClamp" class="d-select">
+        <option v-for="value in ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'none']" :key="value" :value="value">
+          {{ value === 'none' ? 'No clamping' : value + ' line' + (value === '1' ? '' : 's') }}
+        </option>
+      </select>
+    </div>
+    <div class="d-ba d-bc-default d-bar8 d-p16">
+      <h3 class="d-headline--md d-mb8">Sample Article</h3>
+      <p :class="`d-body--md d-fc-secondary ${selectedClamp === 'none' ? '' : 'd-line-clamp-' + selectedClamp}`">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+      </p>
+    </div>
+    <div class="d-mt16 d-p12 d-bgc-secondary d-bar4">
+      <code class="d-code--sm">{{ selectedClamp === 'none' ? 'No class applied' : '.d-line-clamp-' + selectedClamp }}</code>
+    </div>
+  </div>
+</code-well-header>
+
+### Comparison View
+
+See how the same content looks with different line clamp values:
+
+<code-well-header class="d-w100p">
+  <div class="d-d-grid d-gg16" style="grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));">
+    <div v-for="lines in ['1', '2', '3', 'none']" :key="lines" class="d-ba d-bc-default d-bar4 d-p12">
+      <h4 class="d-label--md d-mb8">{{ lines === 'none' ? 'No Clamping' : lines + ' Line' + (lines === '1' ? '' : 's') }}</h4>
+      <p :class="`d-body--sm ${lines === 'none' ? '' : 'd-line-clamp-' + lines}`">
+        The quick brown fox jumps over the lazy dog. This pangram contains every letter of the alphabet at least once, making it useful for testing fonts and demonstrating text layouts. It has been used since the late 1800s by typesetters to display font samples.
+      </p>
+      <code class="d-code--xs d-fc-tertiary d-mt8">{{ lines === 'none' ? 'No class' : '.d-line-clamp-' + lines }}</code>
+    </div>
+  </div>
+</code-well-header>
+
 ## Classes
 
 <utility-class-table>
@@ -135,5 +263,8 @@ Use `d-line-clamp-{n}` to truncate text at a specific number of lines with an el
 </utility-class-table>
 
 <script setup>
+  import { ref } from 'vue';
   import { lineClamp } from '@data/type.json';
+  
+  const selectedClamp = ref('3');
 </script>

--- a/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
@@ -62,19 +62,18 @@ Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
 
 ## Custom
 
-The `d-lc-{n}` utility currently goes up to `9`. Should you need to go beyond, you can do so with the `d-lc-custom` class and locally adjusting the CSS custom property `--dt-line-clamp`.
+The `d-lc-{n}` utility currently goes up to `9`. Should you need to go beyond, you can do so with the `d-lc-custom` class and locally adjusting the CSS custom property `--lc-lines`.
 
 ```html
-<div class="d-lc-custom" style="--dt-line-clamp: 11">
+<div class="d-lc-custom" style="--lc-lines: 11">
   ...
 </div>
 ```
 <code-well-header>
-  <div class="d-lc-custom" style="--dt-line-clamp: 11">
+  <div class="d-lc-custom" style="--lc-lines: 11">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusa qui officia deserunt mollit anim id est laborum. Sed ut per sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.ent, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natumod tempor incididunt ut labore et docat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis t perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natumod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.ent, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natumod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis t perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.
   </div>
 </code-well-header>
-
 
 ## Classes
 

--- a/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
@@ -60,6 +60,22 @@ Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
 </div>
 ```
 
+## Custom
+
+The `d-lc-{n}` utility currently goes up to `9`. Should you need to go beyond, you can do so with the `d-lc-custom` class and locally adjusting the CSS custom property `--dt-line-clamp`.
+
+```html
+<div class="d-lc-custom" style="--dt-line-clamp: 11">
+  ...
+</div>
+```
+<code-well-header>
+  <div class="d-lc-custom" style="--dt-line-clamp: 11">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusa qui officia deserunt mollit anim id est laborum. Sed ut per sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.ent, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natumod tempor incididunt ut labore et docat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis t perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natumod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.ent, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natumod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis t perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.
+  </div>
+</code-well-header>
+
+
 ## Classes
 
 <utility-class-table>

--- a/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
@@ -8,242 +8,90 @@ description: Utilities for limiting the number of lines displayed for text conte
 Use `d-line-clamp-{n}` to truncate text at a specific number of lines with an ellipsis.
 
 <code-well-header class="d-w100p">
-  <div class="d-w100p d-d-grid d-g16 d-ai-start lg:d-fs-100" style="grid-template-columns: auto 1fr">
-    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-1</div>
-    <div><p class="d-line-clamp-1 d-bgc-moderate">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</p></div>
-    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-2</div>
-    <div><p class="d-line-clamp-2 d-bgc-moderate">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p></div>
-    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-3</div>
-    <div><p class="d-line-clamp-3 d-bgc-moderate">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p></div>
-    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-4</div>
-    <div><p class="d-line-clamp-4 d-bgc-moderate">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p></div>
-    <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-none</div>
-    <div><p class="d-line-clamp-none d-bgc-moderate">Lorem ipsum dolor sit amet, consectetur adipiscing elit. This text will not be clamped and will show in its entirety.</p></div>
-  </div>
+  <dt-stack class="d-w100p" gap="500">
+    <dt-stack gap="500" direction="row" class="d-ai-baseline">
+      <p class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-3</p>
+      <p class="d-line-clamp-3">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+    </dt-stack>
+  </dt-stack>
 </code-well-header>
 
 ```html
-<p class="d-line-clamp-1">...</p>
-<p class="d-line-clamp-2">...</p>
-<p class="d-line-clamp-3">...</p>
-<p class="d-line-clamp-4">...</p>
-<p class="d-line-clamp-none">...</p>
+<p class="d-line-clamp-3">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
 ```
 
-## Browser Compatibility
+### Avoiding Conflicts with Display Utilities
 
-<dt-notice kind="warning" class="d-wmx100p d-mt24" :hideClose="true">
+<dt-notice kind="warning" class="d-wmx100p d-mb32" :hideClose="true">
   <template #default>
-    The line-clamp utility uses the `-webkit-line-clamp` CSS property, which has good browser support but is technically a webkit-prefixed property. It works in all modern browsers including Chrome, Safari, Firefox (68+), and Edge.
-  </template>
-</dt-notice>
-
-## Display Utility Interaction
-
-<dt-notice kind="info" class="d-wmx100p d-mt24" :hideClose="true">
-  <template #default>
-    <p class="d-body--md-compact">The line-clamp utility sets <code>display: -webkit-box</code> which may conflict with other display utilities. If you need to use line-clamp with flex or grid layouts, consider wrapping the clamped text in a separate element:</p>
+    <p>The line-clamp utility sets <code>display: -webkit-box</code> which may conflict with other display utilities. If you need to use line-clamp with flex or grid layouts, consider wrapping the clamped text in a separate element:</p>
   </template>
 </dt-notice>
 
 ```html
-<!-- Instead of this -->
-<div class="d-d-flex d-line-clamp-2">...</div>
+<!-- This won't work because DtStack is flex-based -->
+<dt-stack class="d-line-clamp-2"> ... </dt-stack>
 
-<!-- Do this -->
-<div class="d-d-flex">
-  <p class="d-line-clamp-2">...</p>
-</div>
+<!-- This will work -->
+<dt-stack>
+  <p class="d-line-clamp-2"> ... </p>
+</dt-stack>
 ```
 
 ## Examples
 
-### Different Line Clamp Values
-
 <code-well-header class="d-w100p">
-  <dt-stack gap="500">
-    <div>
-      <h4 class="d-label--md d-mb4">Single Line (.d-line-clamp-1)</h4>
-      <p class="d-line-clamp-1 d-bgc-moderate d-p8">
-        The quick brown fox jumps over the lazy dog. This sentence is commonly used as a pangram to display all letters of the alphabet.
-      </p>
-    </div>
-    <div>
-      <h4 class="d-label--md d-mb4">Three Lines (.d-line-clamp-3)</h4>
-      <p class="d-line-clamp-3 d-bgc-moderate d-p8">
-        The quick brown fox jumps over the lazy dog. This sentence is commonly used as a pangram to display all letters of the alphabet. It has been used for testing typefaces, keyboards, and other applications involving all letters of the English alphabet. The phrase has been used since at least the late 1800s.
-      </p>
-    </div>
-    <div>
-      <h4 class="d-label--md d-mb4">Five Lines (.d-line-clamp-5)</h4>
-      <p class="d-line-clamp-5 d-bgc-moderate d-p8">
-        The quick brown fox jumps over the lazy dog. This sentence is commonly used as a pangram to display all letters of the alphabet. It has been used for testing typefaces, keyboards, and other applications involving all letters of the English alphabet. The phrase has been used since at least the late 1800s. Variations of the phrase exist, with some versions attempting to use each letter only once, though this is quite challenging to achieve while maintaining readability and coherence in the sentence structure.
-      </p>
-    </div>
+  <dt-stack class="d-w100p" gap="500">
+    <dt-stack gap="500" direction="row" class="d-ai-baseline">
+      <p class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-2</p>
+      <p class="d-line-clamp-2">Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore nulla pariatur.</p>
+    </dt-stack>
+    <dt-stack gap="500" direction="row" class="d-ai-baseline">
+      <p class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-3</p>
+      <p class="d-line-clamp-3">Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore nulla pariatur.</p>
+    </dt-stack>
+    <dt-stack gap="500" direction="row" class="d-ai-baseline">
+      <p class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-4</p>
+      <p class="d-line-clamp-4">Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore nulla pariatur.</p>
+    </dt-stack>
+    <dt-stack gap="500" direction="row" class="d-ai-baseline">
+      <p class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-5</p>
+      <p class="d-line-clamp-5">Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore nulla pariatur.</p>
+    </dt-stack>
+    <dt-stack gap="500" direction="row" class="d-ai-baseline">
+      <p class="d-code--sm d-docsite-code d-ws-nowrap">.d-line-clamp-6</p>
+      <p class="d-line-clamp-6">Lorem ipsum dolor sit amet consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore nulla pariatur.</p>
+    </dt-stack>
   </dt-stack>
 </code-well-header>
 
 ```html
-<p class="d-line-clamp-1">Single line of text...</p>
-<p class="d-line-clamp-3">Three lines of text...</p>
-<p class="d-line-clamp-5">Five lines of text...</p>
+<p class="d-line-clamp-2">Two lines of text lorem ipsum...</p>
+<p class="d-line-clamp-3">Three lines of text lorem ipsum...</p>
+<p class="d-line-clamp-4">Four lines of text lorem ipsum...</p>
+<p class="d-line-clamp-5">Five lines of text lorem ipsum...</p>
+<p class="d-line-clamp-6">Six lines of text lorem ipsum...</p>
 ```
-
-### Use Cases
-
-#### Card Descriptions
-
-<code-well-header>
-  <div class="d-d-grid d-gg16" style="grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));">
-    <div class="d-ba d-bc-default d-bar4 d-p16">
-      <h3 class="d-headline--md d-mb8">Product Feature</h3>
-      <p class="d-line-clamp-3 d-fc-secondary">
-        This is a longer description of a product feature that might go on for several lines but we want to keep the cards uniform in height so we'll limit it to just three lines with an ellipsis at the end if it exceeds that limit.
-      </p>
-    </div>
-    <div class="d-ba d-bc-default d-bar4 d-p16">
-      <h3 class="d-headline--md d-mb8">Another Feature</h3>
-      <p class="d-line-clamp-3 d-fc-secondary">
-        Short description that fits within three lines.
-      </p>
-    </div>
-  </div>
-</code-well-header>
-
-```html
-<div class="card">
-  <h3>Product Feature</h3>
-  <p class="d-line-clamp-3">
-    Long description text...
-  </p>
-</div>
-```
-
-### Complex Examples
-
-#### Mixed Typography Styles
-
-Line clamping works with different text styles and maintains the typography hierarchy:
-
-<code-well-header class="d-w100p">
-  <dt-stack gap="500">
-    <div class="d-ba d-bc-default d-bar4 d-p16">
-      <h2 class="d-headline--lg d-line-clamp-1 d-mb8">This is a Very Long Headline That Will Be Clamped to a Single Line No Matter How Much Content</h2>
-      <p class="d-body--md d-line-clamp-2 d-mb8">This is the body text that provides more detail about the headline above. It uses a different font size and weight but line clamping still works perfectly, maintaining readability while limiting the vertical space used.</p>
-      <p class="d-body--sm d-line-clamp-1 d-fc-tertiary">Author: Jane Doe • Published: October 24, 2025 • Category: Design Systems</p>
-    </div>
-  </dt-stack>
-</code-well-header>
-
-```html
-<h2 class="d-headline--lg d-line-clamp-1">Long headline...</h2>
-<p class="d-body--md d-line-clamp-2">Body text...</p>
-<p class="d-body--sm d-line-clamp-1 d-fc-tertiary">Meta info...</p>
-```
-
-#### Responsive Grid Layout
-
-Combine line clamping with responsive grid layouts for consistent card heights:
-
-<code-well-header class="d-w100p">
-  <div class="d-d-grid d-gg24" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));">
-    <div class="d-ba d-bc-default d-bar4 d-p12">
-      <div class="d-w100p d-h64 d-bgc-moderate d-bar4 d-mb12"></div>
-      <h4 class="d-headline--sm d-line-clamp-2 d-mb4">Product Design Fundamentals and Best Practices</h4>
-      <p class="d-body--sm d-line-clamp-3 d-fc-secondary d-mb8">Learn the essential principles of product design, including user research, prototyping, and iterative design processes that lead to successful digital products.</p>
-      <span class="d-label--sm d-fc-tertiary">12 lessons • 3hrs</span>
-    </div>
-    <div class="d-ba d-bc-default d-bar4 d-p12">
-      <div class="d-w100p d-h64 d-bgc-moderate d-bar4 d-mb12"></div>
-      <h4 class="d-headline--sm d-line-clamp-2 d-mb4">Advanced CSS</h4>
-      <p class="d-body--sm d-line-clamp-3 d-fc-secondary d-mb8">Master modern CSS techniques including Grid, Flexbox, and animations.</p>
-      <span class="d-label--sm d-fc-tertiary">8 lessons • 2hrs</span>
-    </div>
-    <div class="d-ba d-bc-default d-bar4 d-p12">
-      <div class="d-w100p d-h64 d-bgc-moderate d-bar4 d-mb12"></div>
-      <h4 class="d-headline--sm d-line-clamp-2 d-mb4">JavaScript ES6+ Features You Need to Know</h4>
-      <p class="d-body--sm d-line-clamp-3 d-fc-secondary d-mb8">Explore the latest JavaScript features including destructuring, async/await, modules, and more. This comprehensive course covers everything from basic to advanced concepts with practical examples.</p>
-      <span class="d-label--sm d-fc-tertiary">15 lessons • 4hrs</span>
-    </div>
-  </div>
-</code-well-header>
-
-#### Article Preview List
-
-<code-well-header class="d-w100p">
-  <dt-stack gap="400">
-    <article class="d-p16 d-ba d-bc-subtle d-bar4">
-      <div class="d-d-flex d-ai-start d-g16">
-        <div class="d-fl-grow1">
-          <h3 class="d-headline--md d-line-clamp-1 d-mb4">Understanding the Fundamentals of Design Systems in Modern Web Development</h3>
-          <p class="d-body--md d-line-clamp-2 d-fc-secondary d-mb8">Design systems have revolutionized how teams build and maintain digital products. This comprehensive guide explores the core concepts, implementation strategies, and best practices for creating scalable design systems that enhance collaboration between designers and developers.</p>
-          <div class="d-d-flex d-ai-center d-g8">
-            <span class="d-badge">Design</span>
-            <span class="d-badge">Development</span>
-            <span class="d-fc-tertiary d-body--sm">• 5 min read</span>
-          </div>
-        </div>
-        <div class="d-w96 d-h96 d-bgc-moderate d-bar4 d-fl-shrink0"></div>
-      </div>
-    </article>
-    <article class="d-p16 d-ba d-bc-subtle d-bar4">
-      <div class="d-d-flex d-ai-start d-g16">
-        <div class="d-fl-grow1">
-          <h3 class="d-headline--md d-line-clamp-1 d-mb4">CSS Grid vs Flexbox: When to Use Each</h3>
-          <p class="d-body--md d-line-clamp-2 d-fc-secondary d-mb8">Both CSS Grid and Flexbox are powerful layout tools, but knowing when to use each can significantly improve your CSS architecture. Let's explore the strengths of each approach.</p>
-          <div class="d-d-flex d-ai-center d-g8">
-            <span class="d-badge">CSS</span>
-            <span class="d-badge">Tutorial</span>
-            <span class="d-fc-tertiary d-body--sm">• 3 min read</span>
-          </div>
-        </div>
-        <div class="d-w96 d-h96 d-bgc-moderate d-bar4 d-fl-shrink0"></div>
-      </div>
-    </article>
-  </dt-stack>
-</code-well-header>
-
 ## Interactive Demo
-
-### Dynamic Line Clamping
 
 Try adjusting the line clamp value to see how the text truncates at different lengths:
 
 <code-well-header class="d-w100p">
-  <div class="d-p16">
-    <div class="d-mb16">
-      <label class="d-label--md d-mb8 d-db">Select line clamp value:</label>
-      <select v-model="selectedClamp" class="d-select">
-        <option v-for="value in ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'none']" :key="value" :value="value">
-          {{ value === 'none' ? 'No clamping' : value + ' line' + (value === '1' ? '' : 's') }}
-        </option>
-      </select>
-    </div>
-    <div class="d-ba d-bc-default d-bar8 d-p16">
-      <h3 class="d-headline--md d-mb8">Sample Article</h3>
-      <p :class="`d-body--md d-fc-secondary ${selectedClamp === 'none' ? '' : 'd-line-clamp-' + selectedClamp}`">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
-      </p>
-    </div>
-    <div class="d-mt16 d-p12 d-bgc-secondary d-bar4">
-      <code class="d-code--sm">{{ selectedClamp === 'none' ? 'No class applied' : '.d-line-clamp-' + selectedClamp }}</code>
-    </div>
+  <div>
+    <label>
+      Select line clamp value:
+      <code class="d-code--sm d-docsite-code">{{ selectedClamp === 'none' ? 'No class applied' : '.d-line-clamp-' + selectedClamp }}</code>
+    </label>
+    <select v-model="selectedClamp">
+      <option v-for="value in ['2', '3', '4', '5', '6', '7', '8', '9', 'none']" :key="value" :value="value">
+        {{ value === 'none' ? 'No clamping' : value + ' line' + (value === '1' ? '' : 's') }}
+      </option>
+    </select>
   </div>
-</code-well-header>
-
-### Comparison View
-
-See how the same content looks with different line clamp values:
-
-<code-well-header class="d-w100p">
-  <div class="d-d-grid d-gg16" style="grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));">
-    <div v-for="lines in ['1', '2', '3', 'none']" :key="lines" class="d-ba d-bc-default d-bar4 d-p12">
-      <h4 class="d-label--md d-mb8">{{ lines === 'none' ? 'No Clamping' : lines + ' Line' + (lines === '1' ? '' : 's') }}</h4>
-      <p :class="`d-body--sm ${lines === 'none' ? '' : 'd-line-clamp-' + lines}`">
-        The quick brown fox jumps over the lazy dog. This pangram contains every letter of the alphabet at least once, making it useful for testing fonts and demonstrating text layouts. It has been used since the late 1800s by typesetters to display font samples.
-      </p>
-      <code class="d-code--xs d-fc-tertiary d-mt8">{{ lines === 'none' ? 'No class' : '.d-line-clamp-' + lines }}</code>
-    </div>
+  <div class="d-ba d-bc-default d-bar8 d-p16">
+    <p :class="`${selectedClamp === 'none' ? '' : 'd-line-clamp-' + selectedClamp}`">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+    </p>
   </div>
 </code-well-header>
 
@@ -265,6 +113,6 @@ See how the same content looks with different line clamp values:
 <script setup>
   import { ref } from 'vue';
   import { lineClamp } from '@data/type.json';
-  
+
   const selectedClamp = ref('3');
 </script>

--- a/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
@@ -30,13 +30,11 @@ Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
 
 ### Avoiding display conflicts
 
-<dt-notice kind="warning" class="d-wmx100p d-mb16" :hideClose="true">
+<dt-notice kind="error" class="d-wmx100p d-mb16" :hideClose="true">
   <template #default>
-    Avoid applying line-clamp to elements with flex or grid <code>display</code> styles. Consider wrapping the clamped text in a separate element within the flex or grid container.
+    Avoid applying line-clamp to elements with flex or grid <code>display</code> styles. The clamped text should be considered a child element of the flex or grid container.
   </template>
 </dt-notice>
-
-
 
 #### Flex example
 
@@ -48,7 +46,6 @@ Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
 <dt-stack>
   <p class="d-lc-3"> ... </p>
 </dt-stack>
-
 ```
 
 #### Grid example

--- a/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-clamp.md
@@ -1,6 +1,6 @@
 ---
 title: Line Clamp
-description: Utilities for limiting the number of lines displayed for text content.
+description: Limiting the number of lines displayed for text content.
 ---
 
 ## Usage
@@ -8,34 +8,19 @@ description: Utilities for limiting the number of lines displayed for text conte
 Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
 
 <code-well-header>
-  <dt-stack class="d-w100p">
-    <h3 class="d-label">Select variant</h3>
-    <dt-stack
-      :direction="{ 'default': 'column', 'md': 'row' }"
-      gap="200"
-      class="d-ba d-bc-subtle d-p2 d-bar8 d-mb16"
-    >
-      <dt-button
-        v-for="value in clampValues"
-        size="xs"
-        kind="muted"
-        importance="clear"
-        class="d-fl1 d-bar6"
-        :key="value"
-        :class="{ 'd-btn--active': value === selectedClamp }"
-        @click="setClamp(value)"
-      >
-        {{ value === 'none' ? 'None' : value === 'unset' ? 'Unset' : value }}
-      </dt-button>
-    </dt-stack>
-    <dt-stack direction="row" gap="400">
-      <p :class="`d-lc-${selectedClamp}`" class="d-fl1">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
-      </p>
-      <dt-stack class="d-as-flex-end d-fc-success">
-        <dt-icon name="arrow-left" size="400" />
-      </dt-stack>
-    </dt-stack>
+  <dt-stack direction="row" gap="500" class="d-w100p d-ai-flex-start">
+    <div>
+      <code class="d-code--sm d-docsite-code">d-lc-2</code>
+      <p class="d-lc-2">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p>
+    </div>
+    <div>
+      <code class="d-code--sm d-docsite-code">d-lc-3</code>
+      <p class="d-lc-3">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p>
+    </div>
+    <div>
+      <code class="d-code--sm d-docsite-code">d-lc-4</code>
+      <p class="d-lc-4">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p>
+    </div>
   </dt-stack>
 </code-well-header>
 
@@ -45,11 +30,13 @@ Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
 
 ### Avoiding display conflicts
 
-<dt-notice kind="warning" class="d-wmx100p d-mb32" :hideClose="true">
+<dt-notice kind="warning" class="d-wmx100p d-mb16" :hideClose="true">
   <template #default>
-    <p>The line-clamp utility sets <code>display: -webkit-box</code> which will conflict with other display utilities. If you need to use line-clamp with flex or grid layouts, consider wrapping the clamped text in a separate element:</p>
+    Avoid applying line-clamp to elements with flex or grid <code>display</code> styles. Consider wrapping the clamped text in a separate element within the flex or grid container.
   </template>
 </dt-notice>
+
+
 
 #### Flex example
 
@@ -92,14 +79,5 @@ Use `d-lc-{n}` to truncate text at a specific number of lines with an ellipsis.
 </utility-class-table>
 
 <script setup>
-  import { ref } from 'vue';
   import { lineClamp } from '@data/type.json';
-
-  const selectedClamp = ref('3');
-
-  const setClamp = (value) => {
-    selectedClamp.value = value;
-  };
-
-  const clampValues = ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'none', 'unset'];
 </script>

--- a/packages/dialtone-css/lib/build/less/utilities/typography.less
+++ b/packages/dialtone-css/lib/build/less/utilities/typography.less
@@ -376,6 +376,42 @@ ul {
 .d-to-clip { text-overflow: clip !important; }
 .d-to-unset { text-overflow: unset !important; }
 
+
+//  ============================================================================
+//  $$  LINE CLAMP
+//  ----------------------------------------------------------------------------
+//  Base styles for all line-clamp classes
+[class*="d-line-clamp-"] {
+  --dt-line-clamp: initial;
+  
+  overflow: hidden !important;
+  display: -webkit-box !important;
+  -webkit-box-orient: vertical !important;
+  -webkit-line-clamp: var(--dt-line-clamp) !important;
+}
+
+//  Individual line-clamp values
+.d-line-clamp {
+  &-1 { --dt-line-clamp: 1; }
+  &-2 { --dt-line-clamp: 2; }
+  &-3 { --dt-line-clamp: 3; }
+  &-4 { --dt-line-clamp: 4; }
+  &-5 { --dt-line-clamp: 5; }
+  &-6 { --dt-line-clamp: 6; }
+  &-7 { --dt-line-clamp: 7; }
+  &-8 { --dt-line-clamp: 8; }
+  &-9 { --dt-line-clamp: 9; }
+  
+  //  Reset classes
+  &-none,
+  &-unset {
+    overflow: visible !important;
+    display: block !important;
+    -webkit-box-orient: horizontal !important;
+    -webkit-line-clamp: unset !important;
+  }
+}
+
 //  $$  OVERFLOW WRAP
 //  ----------------------------------------------------------------------------
 .d-ow-normal { overflow-wrap: normal !important; }

--- a/packages/dialtone-css/lib/build/less/utilities/typography.less
+++ b/packages/dialtone-css/lib/build/less/utilities/typography.less
@@ -381,17 +381,17 @@ ul {
 //  $$  LINE CLAMP
 //  ----------------------------------------------------------------------------
 //  Base styles for all line-clamp classes
-[class*="d-line-clamp-"] {
+[class*="d-lc-"] {
   --dt-line-clamp: initial;
-  
-  overflow: hidden !important;
+
   display: -webkit-box !important;
+  overflow: hidden !important;
   -webkit-box-orient: vertical !important;
   -webkit-line-clamp: var(--dt-line-clamp) !important;
 }
 
 //  Individual line-clamp values
-.d-line-clamp {
+.d-lc {
   &-1 { --dt-line-clamp: 1; }
   &-2 { --dt-line-clamp: 2; }
   &-3 { --dt-line-clamp: 3; }
@@ -401,14 +401,14 @@ ul {
   &-7 { --dt-line-clamp: 7; }
   &-8 { --dt-line-clamp: 8; }
   &-9 { --dt-line-clamp: 9; }
-  
+
   //  Reset classes
   &-none,
   &-unset {
-    overflow: visible !important;
-    display: block !important;
-    -webkit-box-orient: horizontal !important;
-    -webkit-line-clamp: unset !important;
+    display: initial !important;
+    overflow: initial !important;
+    -webkit-box-orient: initial !important;
+    -webkit-line-clamp: initial !important;
   }
 }
 

--- a/packages/dialtone-css/lib/build/less/utilities/typography.less
+++ b/packages/dialtone-css/lib/build/less/utilities/typography.less
@@ -382,25 +382,25 @@ ul {
 //  ----------------------------------------------------------------------------
 //  Base styles for all line-clamp classes
 [class*="d-lc-"] {
-  --dt-line-clamp: initial;
+  --lc-lines: initial;
 
   display: -webkit-box !important;
   overflow: hidden !important;
   -webkit-box-orient: vertical !important;
-  -webkit-line-clamp: var(--dt-line-clamp) !important;
+  -webkit-line-clamp: var(--lc-lines) !important;
 }
 
 //  Individual line-clamp values
 .d-lc {
-  &-1 { --dt-line-clamp: 1; }
-  &-2 { --dt-line-clamp: 2; }
-  &-3 { --dt-line-clamp: 3; }
-  &-4 { --dt-line-clamp: 4; }
-  &-5 { --dt-line-clamp: 5; }
-  &-6 { --dt-line-clamp: 6; }
-  &-7 { --dt-line-clamp: 7; }
-  &-8 { --dt-line-clamp: 8; }
-  &-9 { --dt-line-clamp: 9; }
+  &-1 { --lc-lines: 1; }
+  &-2 { --lc-lines: 2; }
+  &-3 { --lc-lines: 3; }
+  &-4 { --lc-lines: 4; }
+  &-5 { --lc-lines: 5; }
+  &-6 { --lc-lines: 6; }
+  &-7 { --lc-lines: 7; }
+  &-8 { --lc-lines: 8; }
+  &-9 { --lc-lines: 9; }
 
   //  Reset classes
   &-none,


### PR DESCRIPTION
# Add line-clamp utility

![E5gKG2R](https://github.com/user-attachments/assets/fddcbddd-8b9e-4178-9bd9-d7cf02770489)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2811

## :book: Description

CSS Utility for truncating multi-line text.

## :bulb: Context

because.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :camera: Screenshots / GIFs

<img width="750" height="228" alt="image" src="https://github.com/user-attachments/assets/536309d2-a972-48e7-abeb-f7ed5bb615b0" />