### PR TITLE
chore: NO-JIRA fix documentation watch command

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/config.js
+++ b/apps/dialtone-documentation/docs/.vuepress/config.js
@@ -51,6 +51,17 @@ export default defineUserConfig({
       css: {
         devSourcemap: true,
       },
+      server: {
+        watch: {
+          ignored: [
+            '**/packages/dialtone-icons/dist/**',
+            '**/packages/dialtone-vue3/dist/**',
+            '**/packages/dialtone-css/dist/**',
+            '**/packages/dialtone-tokens/dist/**',
+            '**/node_modules/**',
+          ],
+        },
+      },
     },
     vuePluginOptions: {
       template: {

--- a/apps/dialtone-documentation/docs/.vuepress/config.js
+++ b/apps/dialtone-documentation/docs/.vuepress/config.js
@@ -51,17 +51,6 @@ export default defineUserConfig({
       css: {
         devSourcemap: true,
       },
-      server: {
-        watch: {
-          ignored: [
-            '**/packages/dialtone-icons/dist/**',
-            '**/packages/dialtone-vue3/dist/**',
-            '**/packages/dialtone-css/dist/**',
-            '**/packages/dialtone-tokens/dist/**',
-            '**/node_modules/**',
-          ],
-        },
-      },
     },
     vuePluginOptions: {
       template: {

--- a/apps/dialtone-documentation/project.json
+++ b/apps/dialtone-documentation/project.json
@@ -40,7 +40,7 @@
         "cwd": "{projectRoot}",
         "commands": [
           {
-            "command": "nx watch --projects=dialtone-css,dialtone-icons,dialtone-tokens,dialtone-vue3 --includeDependentProjects -- nx run \\$NX_PROJECT_NAME:build"
+            "command": "nx watch --projects=dialtone-css,dialtone-tokens,dialtone-vue3 -- nx run \\$NX_PROJECT_NAME:build"
           },
           {
             "command": "vuepress dev docs"


### PR DESCRIPTION
# chore: NO-JIRA fix documentation watch command

Fix to avoid infinite loop when running `nx run dialtone-documentation:start` and making changes in `dialtone-vue3`.

Previously, when making any change in `dialtone-vue3` the build for `dialtone-icons` would enter an infinite loop.
I removed `dialtone-icons` build from the watch command. The caveat of doing this is that when making a change in `dialtone-icons` the web server would have to be restarted to see the changes.