### PR TITLE
fix(tooltip): DP-162944 defensively check for a null anchorWrapper

### DIFF
--- a/packages/dialtone-vue2/components/popover/tippy_utils.js
+++ b/packages/dialtone-vue2/components/popover/tippy_utils.js
@@ -66,7 +66,10 @@ const createAnchor = (anchorWrapper) => {
 };
 
 export const getAnchor = (anchorWrapper) => {
-  const anchor = anchorWrapper?.children[0];
+  if (!anchorWrapper) {
+    return;
+  }
+  const anchor = anchorWrapper.children[0];
   if (!anchor) return createAnchor(anchorWrapper);
   return anchor;
 };

--- a/packages/dialtone-vue3/components/popover/tippy_utils.js
+++ b/packages/dialtone-vue3/components/popover/tippy_utils.js
@@ -66,7 +66,10 @@ const createAnchor = (anchorWrapper) => {
 };
 
 export const getAnchor = (anchorWrapper) => {
-  const anchor = anchorWrapper?.children[0];
+  if (!anchorWrapper) {
+    return;
+  }
+  const anchor = anchorWrapper.children[0];
   if (!anchor) return createAnchor(anchorWrapper);
   return anchor;
 };


### PR DESCRIPTION
before trying to create a suitable anchor inside it

## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2oycnB5MjhoMzF5NW11a2VtcWYwd3pkYnhvdndodjF4YXZ2ZXA2eiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3ohze1LSWrEGCML02Y/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-162944

## :book: Description

It seems like sometimes we unmount a tooltip before it has updated to render the wrapper around the anchor slot. When we try to get a reference to the anchor, we incorrectly identify the null wrapper as containing only text and try to wrap the text in a span to act as the anchor.

This change just returns a null anchor if you pass in a null wrapper. The rest of the code already had null checks for other reasons.

## :bulb: Context

Was happening intermittently in vue3-migration branch, possibly a change to how updates were scheduled made this possible?

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

