### PR TITLE
fix(tooltip): NO-JIRA console warn on null anchorWrapper

### DIFF
--- a/packages/dialtone-vue2/components/popover/tippy_utils.js
+++ b/packages/dialtone-vue2/components/popover/tippy_utils.js
@@ -67,6 +67,7 @@ const createAnchor = (anchorWrapper) => {
 
 export const getAnchor = (anchorWrapper) => {
   if (!anchorWrapper) {
+    console.warn('No anchor wrapper provided. This may cause issues with the popover.');
     return;
   }
   const anchor = anchorWrapper.children[0];

--- a/packages/dialtone-vue3/components/popover/tippy_utils.js
+++ b/packages/dialtone-vue3/components/popover/tippy_utils.js
@@ -67,6 +67,7 @@ const createAnchor = (anchorWrapper) => {
 
 export const getAnchor = (anchorWrapper) => {
   if (!anchorWrapper) {
+    console.warn('No anchor wrapper provided. This may cause issues with the popover.');
     return;
   }
   const anchor = anchorWrapper.children[0];


### PR DESCRIPTION
# fix(tooltip): NO-JIRA console warn on null anchorWrapper

In addition to https://github.com/dialpad/dialtone/pull/957
