### PR TITLE
fix(tooltip): DP-162950 avoid manipulate on null parent

### DIFF
--- a/packages/dialtone-vue2/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue2/components/tooltip/tooltip.vue
@@ -337,7 +337,7 @@ export default {
     },
 
     internalShow (value) {
-      if (!this.tip) return;
+      if (!this.tip || !this.anchor) return;
 
       if (value) {
         this.setProps();
@@ -463,6 +463,8 @@ export default {
     },
 
     setProps () {
+      if (!this.tip || !this.tip.setProps || !this.anchor) return;
+
       if (this.tip && this.tip.setProps) {
         this.tip.setProps({
           ...this.tippyProps,

--- a/packages/dialtone-vue3/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue3/components/tooltip/tooltip.vue
@@ -337,7 +337,7 @@ export default {
     },
 
     internalShow (value) {
-      if (!this.tip) return;
+      if (!this.tip || !this.anchor) return;
 
       if (value) {
         this.setProps();
@@ -464,6 +464,8 @@ export default {
     },
 
     setProps () {
+      if (!this.tip || !this.tip.setProps || !this.anchor) return;
+
       if (this.tip && this.tip.setProps) {
         this.tip.setProps({
           ...this.tippyProps,


### PR DESCRIPTION
# fix(tooltip): DP-162950 avoid manipulate on null parent

Jira: https://dialpad.atlassian.net/browse/DP-162950

In addition to https://github.com/dialpad/dialtone/pull/957

Im not completely sure this will fix the error but lets give it a try.

Since Sentry blame DtTooltip issue I found on `packages/dialtone-vue3/node_modules/tippy.js/dist/tippy.esm.js` a `insertBefore` call on the create call.

I suspect the `this.tip.show` creates it but maybe the anchor is gone so it cannot `insertBefore`.

Same with `.setProp`, maybe it want to manipulate it but it can't because it gone.
