### PR TITLE
fix(docs): DLT-2797 fix broken links

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/MarkdownRender.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/MarkdownRender.vue
@@ -22,9 +22,32 @@ const props = defineProps({
 });
 
 const markdownToHtml = computed(() => {
-  // eslint-disable-next-line new-cap
+  /**
+   * Fix multi-line HTML tags from JSDoc comments.
+   *
+   * Problem: JSDoc comments can have HTML tags split across multiple lines like:
+   *   <a
+   *     class="d-link"
+   *     href="..."
+   *   >
+   *
+   * Solution: Collapse all whitespace (including newlines) within HTML tags into single spaces.
+   * This transforms the above into: <a class="d-link" href="...">
+   */
+  const normalizedMarkdown = props.markdown.replace(
+    /<(\w+)([^>]*)>/gs,
+    (match, tagName, attributes) => {
+      // Replace all whitespace (spaces, tabs, newlines) with a single space
+      const cleanAttributes = attributes.replace(/\s+/g, ' ').trim();
+
+      // Reconstruct the tag: <tagName attributes> or <tagName> if no attributes
+      return cleanAttributes ? `<${tagName} ${cleanAttributes}>` : `<${tagName}>`;
+    },
+  );
+
+  // Convert markdown to HTML (with HTML tags enabled)
   const md = new markdownIt({ html: true });
-  let renderedMarkdown = md.render(props.markdown);
+  let renderedMarkdown = md.render(normalizedMarkdown);
 
   // Add 'd-link' class to all <a> tags
   renderedMarkdown = renderedMarkdown.replace(/<a /g, '<a class="d-link" ');


### PR DESCRIPTION
# fix(docs): DLT-2797 fix broken links

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->


These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2797

## :book: Description

I don't know what was the cause of this issue or since when we have it , I spend some time trying to find it.

Seems like some break line or whitespace are interfering on how we get the markdown to render it well.

With this fix we are cleaning it all.


## :camera: Screenshots / GIFs

Before:

<img width="929" height="539" alt="image" src="https://github.com/user-attachments/assets/ae46bae6-994d-44c6-92ba-3f22089586cc" />


After:

<img width="929" height="539" alt="image" src="https://github.com/user-attachments/assets/4b256bd9-d464-433f-acb4-e2d6ba3af77d" />



