### PR TITLE
fix(hovercard): DLT-2827 remain when focused

### DIFF
--- a/packages/dialtone-vue2/components/hovercard/hovercard.stories.js
+++ b/packages/dialtone-vue2/components/hovercard/hovercard.stories.js
@@ -186,7 +186,7 @@ export const Many = {
   args: { ...Default.args, offset: [0, 5] },
 };
 
-export const WithInputDefault = {
+export const WithInput = {
   render: (argsData) => createRenderConfig(DtHovercard, DtHovercardWithInputTemplate, argsData),
   decorators: [() => ({
     template: `<div class="d-d-flex d-jc-center d-ai-center d-h464">

--- a/packages/dialtone-vue2/components/hovercard/hovercard.stories.js
+++ b/packages/dialtone-vue2/components/hovercard/hovercard.stories.js
@@ -3,6 +3,7 @@ import DtHovercard from './hovercard.vue';
 import DtHovercardDefaultTemplate from './hovercard_default.story.vue';
 import DtHovercardManyTemplate from './hovercard_many.story.vue';
 import { createRenderConfig } from '@/common/storybook_utils';
+import DtHovercardWithInputTemplate from './hovercard_with_input.story.vue';
 import { action } from '@storybook/addon-actions';
 import {
   POPOVER_DIRECTIONS,
@@ -183,4 +184,17 @@ export const Many = {
     </div>`,
   })],
   args: { ...Default.args, offset: [0, 5] },
+};
+
+export const WithInputDefault = {
+  render: (argsData) => createRenderConfig(DtHovercard, DtHovercardWithInputTemplate, argsData),
+  decorators: [() => ({
+    template: `<div class="d-d-flex d-jc-center d-ai-center d-h464">
+      <div class="d-w164">
+        <story />
+      </div>
+    </div>`,
+  })],
+
+  args: {},
 };

--- a/packages/dialtone-vue2/components/hovercard/hovercard.test.js
+++ b/packages/dialtone-vue2/components/hovercard/hovercard.test.js
@@ -121,6 +121,32 @@ describe('DtHovercard Tests', () => {
       });
     });
 
+    describe('When content is focused', () => {
+      it('hovercard should remain visible', async () => {
+        vi.useFakeTimers();
+        await anchor.trigger('mouseenter');
+        await vi.runAllTimers();
+
+        content = getHovercardContent();
+        expect(content).not.toBeNull();
+
+        // Focus on the hovercard content wrapper (which has the focusin event handler)
+        const contentWrapper = content.querySelector('div');
+        contentWrapper.tabIndex = -1; // Make it focusable
+        await contentWrapper.focus();
+        await vi.runAllTimers();
+
+        // Leave the hovercard
+        await anchor.trigger('mouseleave');
+        await vi.runAllTimers();
+
+        // Hovercard should still be visible
+        content = getHovercardContent();
+        expect(content).not.toBeNull();
+        expect(content.textContent).toBe(MOCK_DEFAULT_SLOT_MESSAGE);
+      });
+    });
+
     describe('When anchor is removed from DOM', () => {
       it('hovercardOpen is set to false', async () => {
         vi.useFakeTimers();

--- a/packages/dialtone-vue2/components/hovercard/hovercard.vue
+++ b/packages/dialtone-vue2/components/hovercard/hovercard.vue
@@ -268,23 +268,26 @@ export default {
 
   methods: {
     setInTimer () {
-      this.inTimer = setTimeout(() => {
-        this.hovercardOpen = true;
-      }, this.enterDelay);
+      if (this.open === null) {
+        clearTimeout(this.outTimer);
+        this.inTimer = setTimeout(() => {
+          this.hovercardOpen = true;
+        }, this.enterDelay);
+      }
     },
 
     setOutTimer () {
-      this.outTimer = setTimeout(() => {
-        this.hovercardOpen = false;
-      }, this.leaveDelay);
+      if (this.open === null) {
+        clearTimeout(this.inTimer);
+        this.outTimer = setTimeout(() => {
+          this.hovercardOpen = false;
+        }, this.leaveDelay);
+      }
     },
 
     onMouseEnter () {
       this.mouseOverHovercard = true;
-      if (this.open === null) {
-        clearTimeout(this.outTimer);
-        this.setInTimer();
-      }
+      this.setInTimer();
     },
 
     onMouseLeave () {
@@ -300,14 +303,14 @@ export default {
 
     onContentFocusIn () {
       this.contentFocused = true;
+      this.setInTimer();
     },
 
     onContentFocusOut () {
       this.contentFocused = false;
 
       // If mouse is not over the hovercard, close it
-      if (!this.mouseOverHovercard && this.open === null) {
-        clearTimeout(this.inTimer);
+      if (!this.mouseOverHovercard) {
         this.setOutTimer();
       }
     },

--- a/packages/dialtone-vue2/components/hovercard/hovercard.vue
+++ b/packages/dialtone-vue2/components/hovercard/hovercard.vue
@@ -31,7 +31,13 @@
       />
     </template>
     <template #content>
-      <slot name="content" />
+      <div
+        @focusin="onContentFocusIn"
+        @focusout="onContentFocusOut"
+      >
+        <!-- @slot Slot for the content that is displayed in the hovercard. -->
+        <slot name="content" />
+      </div>
     </template>
     <template #headerContent>
       <slot name="headerContent" />
@@ -218,6 +224,8 @@ export default {
       observer: null,
       inTimer: null,
       outTimer: null,
+      contentFocused: false,
+      mouseOverHovercard: false,
     };
   },
 
@@ -272,6 +280,7 @@ export default {
     },
 
     onMouseEnter () {
+      this.mouseOverHovercard = true;
       if (this.open === null) {
         clearTimeout(this.outTimer);
         this.setInTimer();
@@ -279,7 +288,25 @@ export default {
     },
 
     onMouseLeave () {
+      this.mouseOverHovercard = false;
+      if (this.contentFocused) {
+        return;
+      }
       if (this.open === null) {
+        clearTimeout(this.inTimer);
+        this.setOutTimer();
+      }
+    },
+
+    onContentFocusIn () {
+      this.contentFocused = true;
+    },
+
+    onContentFocusOut () {
+      this.contentFocused = false;
+
+      // If mouse is not over the hovercard, close it
+      if (!this.mouseOverHovercard && this.open === null) {
         clearTimeout(this.inTimer);
         this.setOutTimer();
       }

--- a/packages/dialtone-vue2/components/hovercard/hovercard_with_input.story.vue
+++ b/packages/dialtone-vue2/components/hovercard/hovercard_with_input.story.vue
@@ -1,0 +1,133 @@
+<template>
+  <dt-hovercard
+    :id="$attrs.id"
+    :placement="$attrs.placement"
+    :content-class="$attrs.contentClass"
+    :fallback-placements="$attrs.fallbackPlacements"
+    :padding="$attrs.padding"
+    :transition="$attrs.transition"
+    :offset="$attrs.offset"
+    initial-focus-element="none"
+    :header-class="$attrs.headerClass"
+    :footer-class="$attrs.footerClass"
+    :append-to="$attrs.appendTo"
+    :open="$attrs.open"
+    :enter-delay="$attrs.enterDelay"
+    :leave-delay="$attrs.leaveDelay"
+    @opened="$attrs.onOpened"
+  >
+    <template #anchor="slotProps">
+      <dt-recipe-contact-row
+        name="Jaqueline Nackos"
+        avatar-presence="busy"
+        avatar-seed="JN"
+        avatar-alt="Avatar person"
+        :avatar-src="defaultImage"
+        user-status="Working from SF"
+        call-button-tooltip="Call contact"
+        v-bind="slotProps"
+      />
+    </template>
+    <template #content>
+      <dt-stack
+        direction="column"
+        gap="400"
+      >
+        <dt-stack
+          direction="row"
+          gap="300"
+        >
+          <dt-avatar
+            full-name="Jaqueline Nackos"
+            :image-src="defaultImage"
+            image-alt="Person avatar"
+            seed="JN"
+            size="md"
+            presence="busy"
+          />
+          <dt-stack
+            direction="column"
+            gap="0"
+          >
+            <p class="d-headline--md-compact">
+              Jaqueline Nackos
+            </p>
+            <p class="d-body--sm d-fc-tertiary">
+              <span class="d-fc-critical">In a meeting</span> • Working from SF
+            </p>
+          </dt-stack>
+        </dt-stack>
+        <dt-stack
+          direction="column"
+          gap="300"
+          class="d-fc-secondary"
+        >
+          <p>
+            Vice President of Sales Enablement Aerolabs
+          </p>
+          <dt-stack
+            direction="row"
+            gap="300"
+          >
+            <dt-icon
+              name="clock-4"
+              size="200"
+            />
+            <p class="d-body--sm">
+              <b>Local Time:</b> 12:32 PM
+            </p>
+          </dt-stack>
+        </dt-stack>
+        <dt-stack
+          direction="row"
+          gap="400"
+        >
+          <dt-button
+            width="var(--dt-size-100-percent)"
+            importance="outlined"
+            kind="muted"
+          >
+            Call
+          </dt-button>
+          <dt-button
+            width="var(--dt-size-100-percent)"
+            importance="outlined"
+            kind="muted"
+          >
+            Message
+          </dt-button>
+        </dt-stack>
+        <dt-input
+          v-model="inputValue"
+          placeholder="Quick message"
+          size="md"
+          width="var(--dt-size-100-percent)"
+        />
+      </dt-stack>
+    </template>
+    <template
+      v-if="$attrs.headerContent"
+      #headerContent
+    >
+      <span v-html="$attrs.headerContent" />
+    </template>
+    <template
+      v-if="$attrs.footerContent"
+      #footerContent
+    >
+      <span v-html="$attrs.footerContent" />
+    </template>
+  </dt-hovercard>
+</template>
+
+<script setup>
+// eslint-disable-next-line storybook/default-exports
+import DtHovercard from './hovercard.vue';
+import DtRecipeContactRow from '@/recipes/leftbar/contact_row/contact_row.vue';
+import defaultImage from '@/common/assets/avatar2.png';
+import DtStack from '../stack/stack.vue';
+import DtIcon from '../icon/icon.vue';
+import DtButton from '../button/button.vue';
+import DtAvatar from '../avatar/avatar.vue';
+import DtInput from '../input/input.vue';
+</script>

--- a/packages/dialtone-vue2/components/hovercard/hovercard_with_input.story.vue
+++ b/packages/dialtone-vue2/components/hovercard/hovercard_with_input.story.vue
@@ -120,8 +120,7 @@
   </dt-hovercard>
 </template>
 
-<script setup>
-// eslint-disable-next-line storybook/default-exports
+<script>
 import DtHovercard from './hovercard.vue';
 import DtRecipeContactRow from '@/recipes/leftbar/contact_row/contact_row.vue';
 import defaultImage from '@/common/assets/avatar2.png';
@@ -130,4 +129,32 @@ import DtIcon from '../icon/icon.vue';
 import DtButton from '../button/button.vue';
 import DtAvatar from '../avatar/avatar.vue';
 import DtInput from '../input/input.vue';
+
+export default {
+  name: 'WithInput',
+
+  components: {
+    DtHovercard,
+    DtRecipeContactRow,
+    DtStack,
+    DtIcon,
+    DtButton,
+    DtAvatar,
+    DtInput,
+  },
+
+  data () {
+    return {
+      inputValue: '',
+      defaultImage,
+    };
+  },
+
+  watch: {
+    value (val) {
+      this.inputValue = val;
+    },
+  },
+
+}
 </script>

--- a/packages/dialtone-vue3/components/hovercard/hovercard.stories.js
+++ b/packages/dialtone-vue3/components/hovercard/hovercard.stories.js
@@ -2,6 +2,7 @@ import DtHovercard from './hovercard.vue';
 
 import DtHovercardDefaultTemplate from './hovercard_default.story.vue';
 import DtHovercardManyTemplate from './hovercard_many.story.vue';
+import DtHovercardWithInputTemplate from './hovercard_with_input.story.vue';
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import { action } from '@storybook/addon-actions';
 import {
@@ -190,6 +191,23 @@ export const Many = {
   render: ManyTemplate,
   decorators: [() => ({
     template: `<div class="d-wmx464"><story />
+    </div>`,
+  })],
+  args: { ...Default.args, offset: [0, 5] },
+};
+
+const InputTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  DtHovercardWithInputTemplate,
+);
+export const WithInput = {
+  render: InputTemplate,
+  decorators: [() => ({
+    template: `<div class="d-d-flex d-jc-center d-ai-center d-h464">
+      <div class="d-w164">
+        <story />
+      </div>
     </div>`,
   })],
   args: { ...Default.args, offset: [0, 5] },

--- a/packages/dialtone-vue3/components/hovercard/hovercard.test.js
+++ b/packages/dialtone-vue3/components/hovercard/hovercard.test.js
@@ -118,6 +118,32 @@ describe('DtHovercard Tests', () => {
       });
     });
 
+    describe('When content is focused', () => {
+      it('hovercard should remain visible', async () => {
+        vi.useFakeTimers();
+        await anchor.trigger('mouseenter');
+        await vi.runAllTimers();
+
+        content = getHovercardContent();
+        expect(content).not.toBeNull();
+
+        // Focus on the hovercard content wrapper (which has the focusin event handler)
+        const contentWrapper = content.querySelector('div');
+        contentWrapper.tabIndex = -1; // Make it focusable
+        await contentWrapper.focus();
+        await vi.runAllTimers();
+
+        // Leave the hovercard
+        await anchor.trigger('mouseleave');
+        await vi.runAllTimers();
+
+        // Hovercard should still be visible
+        content = getHovercardContent();
+        expect(content).not.toBeNull();
+        expect(content.textContent).toBe(MOCK_DEFAULT_SLOT_MESSAGE);
+      });
+    });
+
     describe('When anchor is removed from DOM', () => {
       it('hovercardOpen is set to false', async () => {
         vi.useFakeTimers();

--- a/packages/dialtone-vue3/components/hovercard/hovercard.vue
+++ b/packages/dialtone-vue3/components/hovercard/hovercard.vue
@@ -253,23 +253,26 @@ watch(() => props.open, (open) => {
 }, { immediate: true });
 
 function setInTimer () {
-  inTimer.value = setTimeout(() => {
-    hovercardOpen.value = true;
-  }, props.enterDelay);
+  if (props.open === null) {
+    clearTimeout(outTimer.value);
+    inTimer.value = setTimeout(() => {
+      hovercardOpen.value = true;
+    }, props.enterDelay);
+  }
 }
 
 function setOutTimer () {
-  outTimer.value = setTimeout(() => {
-    hovercardOpen.value = false;
-  }, props.leaveDelay);
+  if (props.open === null) {
+    clearTimeout(inTimer.value);
+    outTimer.value = setTimeout(() => {
+      hovercardOpen.value = false;
+    }, props.leaveDelay);
+  }
 }
 
 function onMouseEnter () {
   mouseOverHovercard.value = true;
-  if (props.open === null) {
-    clearTimeout(outTimer.value);
-    setInTimer();
-  }
+  setInTimer();
 }
 
 function onMouseLeave () {
@@ -277,22 +280,19 @@ function onMouseLeave () {
   if (contentFocused.value) {
     return;
   }
-  if (props.open === null) {
-    clearTimeout(inTimer.value);
-    setOutTimer();
-  }
+  setOutTimer();
 }
 
 function onContentFocusIn () {
   contentFocused.value = true;
+  setInTimer();
 }
 
 function onContentFocusOut () {
   contentFocused.value = false;
 
   // If mouse is not over the hovercard, close it
-  if (!mouseOverHovercard.value && props.open === null) {
-    clearTimeout(inTimer.value);
+  if (!mouseOverHovercard.value) {
     setOutTimer();
   }
 }

--- a/packages/dialtone-vue3/components/hovercard/hovercard.vue
+++ b/packages/dialtone-vue3/components/hovercard/hovercard.vue
@@ -33,8 +33,13 @@
       />
     </template>
     <template #content>
-      <!-- @slot Slot for the content that is displayed in the hovercard. -->
-      <slot name="content" />
+      <div
+        @focusin="onContentFocusIn"
+        @focusout="onContentFocusOut"
+      >
+        <!-- @slot Slot for the content that is displayed in the hovercard. -->
+        <slot name="content" />
+      </div>
     </template>
     <template #headerContent>
       <!-- @slot Slot for hovercard header content -->
@@ -211,6 +216,8 @@ defineEmits([
 ]);
 
 const hovercardOpen = ref(props.open);
+const contentFocused = ref(false);
+const mouseOverHovercard = ref(false);
 const inTimer = ref(null);
 const outTimer = ref(null);
 const anchorEl = ref(null);
@@ -258,6 +265,7 @@ function setOutTimer () {
 }
 
 function onMouseEnter () {
+  mouseOverHovercard.value = true;
   if (props.open === null) {
     clearTimeout(outTimer.value);
     setInTimer();
@@ -265,7 +273,25 @@ function onMouseEnter () {
 }
 
 function onMouseLeave () {
+  mouseOverHovercard.value = false;
+  if (contentFocused.value) {
+    return;
+  }
   if (props.open === null) {
+    clearTimeout(inTimer.value);
+    setOutTimer();
+  }
+}
+
+function onContentFocusIn () {
+  contentFocused.value = true;
+}
+
+function onContentFocusOut () {
+  contentFocused.value = false;
+
+  // If mouse is not over the hovercard, close it
+  if (!mouseOverHovercard.value && props.open === null) {
     clearTimeout(inTimer.value);
     setOutTimer();
   }

--- a/packages/dialtone-vue3/components/hovercard/hovercard_with_input.story.vue
+++ b/packages/dialtone-vue3/components/hovercard/hovercard_with_input.story.vue
@@ -1,0 +1,132 @@
+<template>
+  <dt-hovercard
+    :id="$attrs.id"
+    :placement="$attrs.placement"
+    :content-class="$attrs.contentClass"
+    :fallback-placements="$attrs.fallbackPlacements"
+    :padding="$attrs.padding"
+    :transition="$attrs.transition"
+    :offset="$attrs.offset"
+    initial-focus-element="none"
+    :header-class="$attrs.headerClass"
+    :footer-class="$attrs.footerClass"
+    :append-to="$attrs.appendTo"
+    :open="$attrs.open"
+    :enter-delay="$attrs.enterDelay"
+    :leave-delay="$attrs.leaveDelay"
+    @opened="$attrs.onOpened"
+  >
+    <template #anchor="slotProps">
+      <dt-recipe-contact-row
+        name="Jaqueline Nackos"
+        avatar-presence="busy"
+        avatar-seed="JN"
+        avatar-alt="Avatar person"
+        :avatar-src="defaultImage"
+        user-status="Working from SF"
+        call-button-tooltip="Call contact"
+        v-bind="slotProps"
+      />
+    </template>
+    <template #content>
+      <dt-stack
+        direction="column"
+        gap="400"
+      >
+        <dt-stack
+          direction="row"
+          gap="300"
+        >
+          <dt-avatar
+            full-name="Jaqueline Nackos"
+            :image-src="defaultImage"
+            image-alt="Person avatar"
+            seed="JN"
+            size="md"
+            presence="busy"
+          />
+          <dt-stack
+            direction="column"
+            gap="0"
+          >
+            <p class="d-headline--md-compact">
+              Jaqueline Nackos
+            </p>
+            <p class="d-body--sm d-fc-tertiary">
+              <span class="d-fc-critical">In a meeting</span> • Working from SF
+            </p>
+          </dt-stack>
+        </dt-stack>
+        <dt-stack
+          direction="column"
+          gap="300"
+          class="d-fc-secondary"
+        >
+          <p>
+            Vice President of Sales Enablement Aerolabs
+          </p>
+          <dt-stack
+            direction="row"
+            gap="300"
+          >
+            <dt-icon
+              name="clock-4"
+              size="200"
+            />
+            <p class="d-body--sm">
+              <b>Local Time:</b> 12:32 PM
+            </p>
+          </dt-stack>
+        </dt-stack>
+        <dt-stack
+          direction="row"
+          gap="400"
+        >
+          <dt-button
+            width="var(--dt-size-100-percent)"
+            importance="outlined"
+            kind="muted"
+          >
+            Call
+          </dt-button>
+          <dt-button
+            width="var(--dt-size-100-percent)"
+            importance="outlined"
+            kind="muted"
+          >
+            Message
+          </dt-button>
+        </dt-stack>
+        <dt-input
+          v-model="inputValue"
+          placeholder="Quick message"
+          size="md"
+          width="var(--dt-size-100-percent)"
+        />
+      </dt-stack>
+    </template>
+    <template
+      v-if="$attrs.headerContent"
+      #headerContent
+    >
+      <span v-html="$attrs.headerContent" />
+    </template>
+    <template
+      v-if="$attrs.footerContent"
+      #footerContent
+    >
+      <span v-html="$attrs.footerContent" />
+    </template>
+  </dt-hovercard>
+</template>
+
+<script setup>
+import DtHovercard from './hovercard.vue';
+import DtRecipeContactRow from '@/recipes/leftbar/contact_row/contact_row.vue';
+import defaultImage from '@/common/assets/avatar2.png';
+import DtStack from '../stack/stack.vue';
+import DtIcon from '../icon/icon.vue';
+import DtButton from '../button/button.vue';
+import DtAvatar from '../avatar/avatar.vue';
+import DtInput from '../input/input.vue';
+</script>


### PR DESCRIPTION
# fix(hovercard): DLT-2827 remain when focused

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExb2VoZnp3Y3o2M24xaXd3NDB6NmRsa3h2YnJvcmNmMzJrYWNwdGIzcyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Rf4WPLXF1seO2oTkTX/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DLT-2827]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
When an element inside the hovercard is focused, it will not close when the mouse leaves the card or the anchor. If it loses focus, it will close unless the mouse is over.
<!--- Describe specifically what the changes are -->

## :bulb: Context
When writing a quick message in the user hovercard it would close if you move the mouse away, see video in the ticket for reference.
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs
![hovercard-focus](https://github.com/user-attachments/assets/daaacafb-d132-4766-a2bc-c55bc5a6f997)

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

<!--- Add any links to external reference material -->


[DLT-2827]: https://dialpad.atlassian.net/browse/DLT-2827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ