### PR TITLE
fix(popover): DP-162957 reinitialize the tippy when the anchor element changes

### DIFF
--- a/packages/dialtone-vue2/components/popover/popover.test.js
+++ b/packages/dialtone-vue2/components/popover/popover.test.js
@@ -1,7 +1,6 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import { DtPopover } from '@/components/popover';
 import SrOnlyCloseButtonComponent from '@/common/sr_only_close_button.vue';
-import { nextTick } from 'vue';
 
 const MOCK_TRANSITION_STUB = () => ({
   render: function () {
@@ -363,23 +362,18 @@ describe('DtPopover Tests', () => {
 
       let popoverWindow = wrapper.findComponent({ ref: 'popover' }).findComponent({ ref: 'content' });
       expect(popoverWindow.isVisible()).toBe(false);
-      wrapper.setProps({ open: true});
-      await nextTick();
+      await wrapper.setProps({ open: true});
       expect(popoverWindow.isVisible()).toBe(true);
-      wrapper.setProps({ open: false});
-      await nextTick();
+      await wrapper.setProps({ open: false});
       expect(popoverWindow.isVisible()).toBe(false);
 
-      wrapper.setProps({ showAlternateAnchor: true});
-      await nextTick();
+      await wrapper.setProps({ showAlternateAnchor: true});
       popoverWindow = wrapper.findComponent({ ref: 'popover' }).findComponent({ ref: 'content' });
 
       expect(popoverWindow.isVisible()).toBe(false);
-      wrapper.setProps({ open: true});
-      await nextTick();
+      await wrapper.setProps({ open: true});
       expect(popoverWindow.isVisible()).toBe(true);
-      wrapper.setProps({ open: false});
-      await nextTick();
+      await wrapper.setProps({ open: false});
       expect(popoverWindow.isVisible()).toBe(false);
 
       wrapper.destroy();

--- a/packages/dialtone-vue2/components/popover/popover.test.js
+++ b/packages/dialtone-vue2/components/popover/popover.test.js
@@ -1,6 +1,7 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import { DtPopover } from '@/components/popover';
 import SrOnlyCloseButtonComponent from '@/common/sr_only_close_button.vue';
+import { nextTick } from 'vue';
 
 const MOCK_TRANSITION_STUB = () => ({
   render: function () {
@@ -331,6 +332,57 @@ describe('DtPopover Tests', () => {
       it('should have correct aria attributes on the content window', async () => {
         expect(popoverWindow.attributes('aria-hidden')).toBe('true');
       });
+    });
+  });
+
+  describe('When anchor slot content changes', () => {
+    it('should attach the tippy instance to the new DOM node', async () => {
+      const component = {
+        template: `
+          <dt-popover ref="popover" :open="open">
+            <template #anchor>
+              <div v-if="showAlternateAnchor" class="testanchor">Anchor 1</div>
+              <div v-else class="testanchor">Anchor 2</div>
+            </template>
+            <template #content>
+              <div class="content">Hello</div>
+            </template>
+          </dt-popover>
+        `,
+        components: {
+          DtPopover,
+        },
+        props: ['showAlternateAnchor', 'open'],
+      };
+      const wrapper = mount(component, {
+        propsData: { showAlternateAnchor: false, open: false },
+        stubs: baseStubs,
+        localVue: testContext.localVue,
+        attachTo: document.body,
+      })
+
+      let popoverWindow = wrapper.findComponent({ ref: 'popover' }).findComponent({ ref: 'content' });
+      expect(popoverWindow.isVisible()).toBe(false);
+      wrapper.setProps({ open: true});
+      await nextTick();
+      expect(popoverWindow.isVisible()).toBe(true);
+      wrapper.setProps({ open: false});
+      await nextTick();
+      expect(popoverWindow.isVisible()).toBe(false);
+
+      wrapper.setProps({ showAlternateAnchor: true});
+      await nextTick();
+      popoverWindow = wrapper.findComponent({ ref: 'popover' }).findComponent({ ref: 'content' });
+
+      expect(popoverWindow.isVisible()).toBe(false);
+      wrapper.setProps({ open: true});
+      await nextTick();
+      expect(popoverWindow.isVisible()).toBe(true);
+      wrapper.setProps({ open: false});
+      await nextTick();
+      expect(popoverWindow.isVisible()).toBe(false);
+
+      wrapper.destroy();
     });
   });
 });

--- a/packages/dialtone-vue2/components/popover/popover.test.js
+++ b/packages/dialtone-vue2/components/popover/popover.test.js
@@ -341,8 +341,8 @@ describe('DtPopover Tests', () => {
         template: `
           <dt-popover ref="popover" :open="open">
             <template #anchor>
-              <div v-if="showAlternateAnchor" class="testanchor">Anchor 1</div>
-              <div v-else class="testanchor">Anchor 2</div>
+              <div v-if="showAlternateAnchor" class="testanchor" key="anchor1">Anchor 1</div>
+              <div v-else class="testanchor" key="anchor2">Anchor 2</div>
             </template>
             <template #content>
               <div class="content">Hello</div>

--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -544,6 +544,7 @@ export default {
       POPOVER_PADDING_CLASSES,
       POPOVER_HEADER_FOOTER_PADDING_CLASSES,
       intersectionObserver: null,
+      mutationObserver: null,
       isOutsideViewport: false,
       isOpen: false,
       anchorEl: null,
@@ -654,16 +655,11 @@ export default {
   mounted () {
     warnIfUnmounted(this.$el, this.$options.name);
 
-    const externalAnchorEl = this.externalAnchor
-      ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
-      : null;
-    this.anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
     this.popoverContentEl = this.$refs.content?.$el;
+    this.updateAnchorEl();
 
-    if (this.isOpen) {
-      this.initTippyInstance();
-      this.tip?.show();
-    }
+    this.mutationObserver = new MutationObserver(this.updateAnchorEl);
+    this.mutationObserver.observe(this.$refs.anchor, {childList: true});
 
     // rootMargin here must be greater than the margin of the height we are setting in calculatedMaxHeight which
     // currently is var(--dt-space-300) (4px). If not the intersectionObserver will continually trigger in an infinite
@@ -676,6 +672,7 @@ export default {
   beforeDestroy () {
     this.tip?.destroy();
     this.intersectionObserver?.disconnect();
+    this.mutationObserver?.disconnect();
     this.removeReferences();
     this.removeEventListeners();
   },
@@ -689,6 +686,26 @@ export default {
       if (!dialog) return;
       const isOut = isOutOfViewPort(dialog);
       this.isOutsideViewport = isOut.bottom || isOut.top;
+    },
+
+    updateAnchorEl () {
+      const externalAnchorEl = this.externalAnchor
+        ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
+        : null;
+      this.anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
+
+      this.tip?.destroy();
+      delete this.tip;
+
+      if (!this.anchorEl) {
+        console.warn('No anchor found for popover');
+        return;
+      }
+
+      if (this.isOpen) {
+        this.initTippyInstance();
+        this.tip?.show();
+      }
     },
 
     popperOptions () {
@@ -976,6 +993,8 @@ export default {
           internalAppendTo = this.appendTo;
           break;
       }
+
+      this.tip?.destroy();
 
       this.tip = createTippyPopover(this.anchorEl, {
         popperOptions: this.popperOptions(),

--- a/packages/dialtone-vue2/components/popover/popover_variants.story.vue
+++ b/packages/dialtone-vue2/components/popover/popover_variants.story.vue
@@ -438,6 +438,30 @@
       </template>
     </dt-popover>
 
+    <dt-popover>
+      <template
+        #anchor="{ attrs }"
+      >
+        <dt-button
+          v-if="switchAnchor"
+          v-bind="attrs"
+        >
+          Changing anchor 1
+        </dt-button>
+        <dt-button
+          v-else
+          v-bind="attrs"
+        >
+          Changing anchor 2
+        </dt-button>
+      </template>
+      <template #content>
+        <dt-button @click="switchAnchor = !switchAnchor">
+          switch anchor
+        </dt-button>
+      </template>
+    </dt-popover>
+
     <iframe
       title="iframe popover example"
       :src="withURLprefix('?args=&id=components-popover--iframe-test&viewMode=story')"
@@ -478,6 +502,8 @@ export default {
             maiores mollitia reprehenderit sunt tempore veritatis.
             Aliquam delectus earum ex, expedita ipsam nobis
             obcaecati quibusdam repudiandae.`,
+
+      switchAnchor: true,
     };
   },
 

--- a/packages/dialtone-vue2/components/popover/popover_variants.story.vue
+++ b/packages/dialtone-vue2/components/popover/popover_variants.story.vue
@@ -445,12 +445,14 @@
         <dt-button
           v-if="switchAnchor"
           v-bind="attrs"
+          key="anchor1"
         >
           Changing anchor 1
         </dt-button>
         <dt-button
           v-else
           v-bind="attrs"
+          key="anchor2"
         >
           Changing anchor 2
         </dt-button>

--- a/packages/dialtone-vue3/components/popover/popover.test.js
+++ b/packages/dialtone-vue3/components/popover/popover.test.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { DtPopover } from '@/components/popover';
 import SrOnlyCloseButtonComponent from '@/common/sr_only_close_button.vue';
+import { nextTick } from 'vue';
 
 const MOCK_DEFAULT_SLOT_MESSAGE = 'Message';
 const MOCK_HEADER_CONTENT = 'Popover Title';
@@ -302,6 +303,60 @@ describe('DtPopover Tests', () => {
       it('should have correct aria attributes on the content window', async () => {
         expect(popoverWindow.attributes('aria-hidden')).toBe('true');
       });
+    });
+  });
+
+  describe('When anchor slot content changes', () => {
+    it('should attach the tippy instance to the new DOM node', async () => {
+      const component = {
+        template: `
+          <dt-popover ref="popover" :open="open">
+            <template #anchor>
+              <div v-if="showAlternateAnchor" class="testanchor">Anchor 1</div>
+              <div v-else class="testanchor">Anchor 2</div>
+            </template>
+            <template #content>
+              <div class="content">Hello</div>
+            </template>
+          </dt-popover>
+        `,
+        components: {
+          DtPopover,
+        },
+        props: ['showAlternateAnchor', 'open'],
+      };
+      const wrapper = mount(component, {
+        props: { showAlternateAnchor: false },
+        global: {
+          stubs: {
+            transition: false,
+          },
+        },
+        attachTo: document.body,
+      })
+
+      let popoverWindow = wrapper.findComponent({ ref: 'popover' }).findComponent({ ref: 'content' });
+      expect(popoverWindow.isVisible()).toBe(false);
+      wrapper.setProps({ open: true});
+      await nextTick();
+      expect(popoverWindow.isVisible()).toBe(true);
+      wrapper.setProps({ open: false});
+      await nextTick();
+      expect(popoverWindow.isVisible()).toBe(false);
+
+      wrapper.setProps({ showAlternateAnchor: true});
+      await nextTick();
+      popoverWindow = wrapper.findComponent({ ref: 'popover' }).findComponent({ ref: 'content' });
+
+      expect(popoverWindow.isVisible()).toBe(false);
+      wrapper.setProps({ open: true});
+      await nextTick();
+      expect(popoverWindow.isVisible()).toBe(true);
+      wrapper.setProps({ open: false});
+      await nextTick();
+      expect(popoverWindow.isVisible()).toBe(false);
+
+      wrapper.unmount();
     });
   });
 });

--- a/packages/dialtone-vue3/components/popover/popover.test.js
+++ b/packages/dialtone-vue3/components/popover/popover.test.js
@@ -1,7 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { DtPopover } from '@/components/popover';
 import SrOnlyCloseButtonComponent from '@/common/sr_only_close_button.vue';
-import { nextTick } from 'vue';
 
 const MOCK_DEFAULT_SLOT_MESSAGE = 'Message';
 const MOCK_HEADER_CONTENT = 'Popover Title';
@@ -337,23 +336,18 @@ describe('DtPopover Tests', () => {
 
       let popoverWindow = wrapper.findComponent({ ref: 'popover' }).findComponent({ ref: 'content' });
       expect(popoverWindow.isVisible()).toBe(false);
-      wrapper.setProps({ open: true});
-      await nextTick();
+      await wrapper.setProps({ open: true});
       expect(popoverWindow.isVisible()).toBe(true);
-      wrapper.setProps({ open: false});
-      await nextTick();
+      await wrapper.setProps({ open: false});
       expect(popoverWindow.isVisible()).toBe(false);
 
-      wrapper.setProps({ showAlternateAnchor: true});
-      await nextTick();
+      await wrapper.setProps({ showAlternateAnchor: true});
       popoverWindow = wrapper.findComponent({ ref: 'popover' }).findComponent({ ref: 'content' });
 
       expect(popoverWindow.isVisible()).toBe(false);
-      wrapper.setProps({ open: true});
-      await nextTick();
+      await wrapper.setProps({ open: true});
       expect(popoverWindow.isVisible()).toBe(true);
-      wrapper.setProps({ open: false});
-      await nextTick();
+      await wrapper.setProps({ open: false});
       expect(popoverWindow.isVisible()).toBe(false);
 
       wrapper.unmount();

--- a/packages/dialtone-vue3/components/popover/popover.vue
+++ b/packages/dialtone-vue3/components/popover/popover.vue
@@ -562,6 +562,7 @@ export default {
       POPOVER_PADDING_CLASSES,
       POPOVER_HEADER_FOOTER_PADDING_CLASSES,
       intersectionObserver: null,
+      mutationObserver: null,
       isOutsideViewport: false,
       isOpen: false,
       toAppear: false,
@@ -682,16 +683,11 @@ export default {
   mounted () {
     warnIfUnmounted(returnFirstEl(this.$el), this.$options.name);
 
-    const externalAnchorEl = this.externalAnchor
-      ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
-      : null;
-    this.anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
     this.popoverContentEl = returnFirstEl(this.$refs.content?.$el);
+    this.updateAnchorEl();
 
-    if (this.isOpen) {
-      this.initTippyInstance();
-      this.tip?.show();
-    }
+    this.mutationObserver = new MutationObserver(this.updateAnchorEl);
+    this.mutationObserver.observe(this.$refs.anchor, {childList: true});
 
     // rootMargin here must be greater than the margin of the height we are setting in calculatedMaxHeight which
     // currently is var(--dt-space-300) (4px). If not the intersectionObserver will continually trigger in an infinite
@@ -704,6 +700,7 @@ export default {
   beforeUnmount () {
     this.tip?.destroy();
     this.intersectionObserver?.disconnect();
+    this.mutationObserver?.disconnect();
     this.removeReferences();
     this.removeEventListeners();
   },
@@ -718,6 +715,26 @@ export default {
       if (!dialog) return;
       const isOut = isOutOfViewPort(dialog);
       this.isOutsideViewport = isOut.bottom || isOut.top;
+    },
+
+    updateAnchorEl () {
+      const externalAnchorEl = this.externalAnchor
+        ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
+        : null;
+      this.anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
+
+      this.tip?.destroy();
+      delete this.tip;
+
+      if (!this.anchorEl) {
+        console.warn('No anchor found for popover');
+        return;
+      }
+
+      if (this.isOpen) {
+        this.initTippyInstance();
+        this.tip?.show();
+      }
     },
 
     popperOptions () {
@@ -1014,6 +1031,8 @@ export default {
           internalAppendTo = this.appendTo;
           break;
       }
+
+      this.tip?.destroy();
 
       this.tip = createTippyPopover(this.anchorEl, {
         popperOptions: this.popperOptions(),

--- a/packages/dialtone-vue3/components/popover/popover_variants.story.vue
+++ b/packages/dialtone-vue3/components/popover/popover_variants.story.vue
@@ -415,6 +415,30 @@
       </template>
     </dt-popover>
 
+    <dt-popover>
+      <template
+        #anchor="{ attrs }"
+      >
+        <dt-button
+          v-if="switchAnchor"
+          v-bind="attrs"
+        >
+          Changing anchor 1
+        </dt-button>
+        <dt-button
+          v-else
+          v-bind="attrs"
+        >
+          Changing anchor 2
+        </dt-button>
+      </template>
+      <template #content>
+        <dt-button @click="switchAnchor = !switchAnchor">
+          switch anchor
+        </dt-button>
+      </template>
+    </dt-popover>
+
     <iframe
       title="iframe popover example"
       :src="withURLprefix('?args=&id=components-popover--iframe-test&viewMode=story')"
@@ -455,6 +479,8 @@ export default {
             maiores mollitia reprehenderit sunt tempore veritatis.
             Aliquam delectus earum ex, expedita ipsam nobis
             obcaecati quibusdam repudiandae.`,
+
+      switchAnchor: true,
     };
   },
 


### PR DESCRIPTION
# PR Title
reinitialize the tippy when the anchor element changes

## Obligatory GIF (super important!)

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExYmh3cHAxNnA4bWE2ZnZtbmduY3czdXdrOWRkNmFhNDZsMDlra2dtZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fkLMC52ghhIUU/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-162957

## :book: Description

Use a mutationObserver to notice when the DOM element rendered into the content slot changes. This element is used to anchor the tippy, and if it has become detached from the DOM, tippy will throw an error when trying to find the element's parent.

As a bonus, this also makes sure to call destroy on this.tip before replacing it, this is possibly fixing a memory leak.

## :bulb: Context

In the native app, we wrap DtRecipeSettingsMenuButton in a DtPopover. When an app update becomes available, the root DOM element rendered by DtRecipeSettingsMenuButton changes, this breaks the tippy binding and clicking the menu just throws an error.

This does not seem to happen in vue 2, I suspect vue 2 is more sloppy about when it reuses DOM elments.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

Similar changes should be made in other places we anchor a tippy to slot content, in particular in DtTooltip.
