### PR TITLE
fix(i18n): NO-JIRA initialization tweaks

### DIFF
--- a/packages/dialtone-vue2/localization/index.js
+++ b/packages/dialtone-vue2/localization/index.js
@@ -70,7 +70,6 @@ export class DialtoneLocalization {
       namespaces: [dialtoneNamespace],
     });
 
-    //localeManager.install(dialtoneNamespace);
     this.i18n = localeManager.useI18N(dialtoneNamespace);
 
     DialtoneLocalization.instance = this;
@@ -123,7 +122,6 @@ export class DialtoneLocalization {
    * https://github.com/dialpad/goblin-client-tools/tree/main/packages/i18n#t
    */
   $t (...args) {
-    //return useI18N(dialtoneNamespace).$t(...args);
     return this.i18n.$t(...args);
   }
 
@@ -134,7 +132,6 @@ export class DialtoneLocalization {
    * https://github.com/dialpad/goblin-client-tools/tree/main/packages/i18n#ta
    */
   $ta (...args) {
-    //return useI18N(dialtoneNamespace).$ta(...args);
     return this.i18n.$ta(...args);
   }
 

--- a/packages/dialtone-vue2/localization/index.js
+++ b/packages/dialtone-vue2/localization/index.js
@@ -1,4 +1,4 @@
-import { LocaleManager, RawBundleSource, useI18N } from '@dialpad/i18n-vue2';
+import { LocaleManager, RawBundleSource } from '@dialpad/i18n-vue2';
 
 import enUS from './en-US.ftl?raw';
 import zhCN from './zh-CN.ftl?raw';
@@ -36,6 +36,10 @@ const localeManagerStorageKey = 'user-locale';
  * https://github.com/dialpad/goblin-client-tools/tree/main/packages/i18n#i18n-vue-3-compatible
  */
 export class DialtoneLocalization {
+  /**
+   * @prop {import('@dialpad/i18n').UseI18N} i18n
+   * @private
+   */
   constructor (locale = null) {
     if (typeof DialtoneLocalization.instance === 'object') {
       return DialtoneLocalization.instance;
@@ -66,7 +70,8 @@ export class DialtoneLocalization {
       namespaces: [dialtoneNamespace],
     });
 
-    localeManager.install(dialtoneNamespace);
+    //localeManager.install(dialtoneNamespace);
+    this.i18n = localeManager.useI18N(dialtoneNamespace);
 
     DialtoneLocalization.instance = this;
 
@@ -118,7 +123,8 @@ export class DialtoneLocalization {
    * https://github.com/dialpad/goblin-client-tools/tree/main/packages/i18n#t
    */
   $t (...args) {
-    return useI18N(dialtoneNamespace).$t(...args);
+    //return useI18N(dialtoneNamespace).$t(...args);
+    return this.i18n.$t(...args);
   }
 
   /**
@@ -128,7 +134,8 @@ export class DialtoneLocalization {
    * https://github.com/dialpad/goblin-client-tools/tree/main/packages/i18n#ta
    */
   $ta (...args) {
-    return useI18N(dialtoneNamespace).$ta(...args);
+    //return useI18N(dialtoneNamespace).$ta(...args);
+    return this.i18n.$ta(...args);
   }
 
   get currentLocale () {
@@ -142,6 +149,6 @@ export class DialtoneLocalization {
     }
 
     this._locale = newLocale;
-    useI18N(dialtoneNamespace).setI18N({ preferredLocale: newLocale }, dialtoneNamespace);
+    this.i18n.setI18N({ preferredLocale: newLocale }, dialtoneNamespace);
   }
 }

--- a/packages/dialtone-vue2/package.json
+++ b/packages/dialtone-vue2/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@dialpad/dialtone-emojis": "workspace:*",
     "@dialpad/dialtone-icons": "workspace:*",
-    "@dialpad/i18n-vue2": "1.7.0",
+    "@dialpad/i18n-vue2": "1.7.1",
     "@linusborg/vue-simple-portal": "0.1.5",
     "@tiptap/core": "2.12.0",
     "@tiptap/extension-blockquote": "2.12.0",

--- a/packages/dialtone-vue2/package.json
+++ b/packages/dialtone-vue2/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@dialpad/dialtone-emojis": "workspace:*",
     "@dialpad/dialtone-icons": "workspace:*",
-    "@dialpad/i18n-vue2": "1.2.0",
+    "@dialpad/i18n-vue2": "1.7.0",
     "@linusborg/vue-simple-portal": "0.1.5",
     "@tiptap/core": "2.12.0",
     "@tiptap/extension-blockquote": "2.12.0",

--- a/packages/dialtone-vue3/localization/index.js
+++ b/packages/dialtone-vue3/localization/index.js
@@ -1,5 +1,4 @@
-import { LocaleManager, RawBundleSource, } from '@dialpad/i18n';
-import { getCurrentInstance } from 'vue';
+import { LocaleManager, RawBundleSource } from '@dialpad/i18n';
 
 import enUS from './en-US.ftl?raw';
 import zhCN from './zh-CN.ftl?raw';
@@ -46,8 +45,6 @@ export class DialtoneLocalization {
       return DialtoneLocalization.instance;
     }
 
-    // no good
-    //const app = getCurrentInstance().appContext.app;
     this._locale = locale || DialtoneLocalization.getPreferredLocale();
 
     const bundleSource = new RawBundleSource({

--- a/packages/dialtone-vue3/localization/index.js
+++ b/packages/dialtone-vue3/localization/index.js
@@ -1,4 +1,4 @@
-import { LocaleManager, RawBundleSource, useI18N } from '@dialpad/i18n';
+import { LocaleManager, RawBundleSource, } from '@dialpad/i18n';
 import { getCurrentInstance } from 'vue';
 
 import enUS from './en-US.ftl?raw';
@@ -37,12 +37,17 @@ const localeManagerStorageKey = 'user-locale';
  * https://github.com/dialpad/goblin-client-tools/tree/main/packages/i18n#i18n-vue-3-compatible
  */
 export class DialtoneLocalization {
+  /**
+   * @prop {import('@dialpad/i18n').UseI18N} i18n
+   * @private
+   */
   constructor (locale = null) {
     if (typeof DialtoneLocalization.instance === 'object') {
       return DialtoneLocalization.instance;
     }
 
-    const app = getCurrentInstance().appContext.app;
+    // no good
+    //const app = getCurrentInstance().appContext.app;
     this._locale = locale || DialtoneLocalization.getPreferredLocale();
 
     const bundleSource = new RawBundleSource({
@@ -60,6 +65,10 @@ export class DialtoneLocalization {
       ]),
     });
 
+    // ehhh im pretty sure we want there to be one of these already?? so rather
+    // than instatiate it directly, there should be a createLocaleManager(),
+    // which uses the global version (while also adding necessary options!) or
+    // creates a new one like this:
     const localeManager = new LocaleManager({
       bundleSource,
       allowedLocales: Object.values(allowedLocales),
@@ -68,9 +77,8 @@ export class DialtoneLocalization {
       namespaces: [dialtoneNamespace],
     });
 
-    localeManager.install(app, dialtoneNamespace);
-
     DialtoneLocalization.instance = this;
+    this.i18n = localeManager.useI18N(dialtoneNamespace);
 
     if (typeof window !== 'undefined') {
       /**
@@ -120,7 +128,8 @@ export class DialtoneLocalization {
    * https://github.com/dialpad/goblin-client-tools/tree/main/packages/i18n#t
    */
   $t (...args) {
-    return useI18N(dialtoneNamespace).$t(...args);
+    //return useI18N(dialtoneNamespace).$t(...args);
+    return this.i18n.$t(...args);
   }
 
   /**
@@ -130,7 +139,8 @@ export class DialtoneLocalization {
    * https://github.com/dialpad/goblin-client-tools/tree/main/packages/i18n#ta
    */
   $ta (...args) {
-    return useI18N(dialtoneNamespace).$ta(...args);
+    //return useI18N(dialtoneNamespace).$ta(...args);
+    return this.i18n.$ta(...args);
   }
 
   get currentLocale () {
@@ -144,6 +154,6 @@ export class DialtoneLocalization {
     }
 
     this._locale = newLocale;
-    useI18N(dialtoneNamespace).setI18N({ preferredLocale: newLocale }, dialtoneNamespace);
+    this.i18n.setI18N({ preferredLocale: newLocale }, dialtoneNamespace);
   }
 }

--- a/packages/dialtone-vue3/localization/index.js
+++ b/packages/dialtone-vue3/localization/index.js
@@ -62,10 +62,6 @@ export class DialtoneLocalization {
       ]),
     });
 
-    // ehhh im pretty sure we want there to be one of these already?? so rather
-    // than instatiate it directly, there should be a createLocaleManager(),
-    // which uses the global version (while also adding necessary options!) or
-    // creates a new one like this:
     const localeManager = new LocaleManager({
       bundleSource,
       allowedLocales: Object.values(allowedLocales),
@@ -125,7 +121,6 @@ export class DialtoneLocalization {
    * https://github.com/dialpad/goblin-client-tools/tree/main/packages/i18n#t
    */
   $t (...args) {
-    //return useI18N(dialtoneNamespace).$t(...args);
     return this.i18n.$t(...args);
   }
 
@@ -136,7 +131,6 @@ export class DialtoneLocalization {
    * https://github.com/dialpad/goblin-client-tools/tree/main/packages/i18n#ta
    */
   $ta (...args) {
-    //return useI18N(dialtoneNamespace).$ta(...args);
     return this.i18n.$ta(...args);
   }
 

--- a/packages/dialtone-vue3/localization/localization.mdx
+++ b/packages/dialtone-vue3/localization/localization.mdx
@@ -133,6 +133,10 @@ You can pass in a locale to the constructor. The default is your browser locale 
 
 `dialtonei18n.currentLocale = 'en-US';`
 
+another todo - interacting with the current locale this way is only a workaround
+for dialtone users that aren't already using @dialpad/i18n; those who are should
+use set it there
+
 #### Get the current locale
 
 `dialtonei18n.currentLocale`

--- a/packages/dialtone-vue3/package.json
+++ b/packages/dialtone-vue3/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@dialpad/dialtone-emojis": "workspace:*",
     "@dialpad/dialtone-icons": "workspace:*",
-    "@dialpad/i18n": "1.20.1",
+    "@dialpad/i18n": "1.22.0",
     "@tiptap/core": "2.12.0",
     "@tiptap/extension-blockquote": "2.12.0",
     "@tiptap/extension-bold": "2.12.0",

--- a/packages/dialtone-vue3/package.json
+++ b/packages/dialtone-vue3/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@dialpad/dialtone-emojis": "workspace:*",
     "@dialpad/dialtone-icons": "workspace:*",
-    "@dialpad/i18n": "1.22.0",
+    "@dialpad/i18n": "1.22.1",
     "@tiptap/core": "2.12.0",
     "@tiptap/extension-blockquote": "2.12.0",
     "@tiptap/extension-bold": "2.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -707,8 +707,8 @@ importers:
         specifier: workspace:*
         version: link:../dialtone-icons
       '@dialpad/i18n-vue2':
-        specifier: 1.7.0
-        version: 1.7.0(@fluent/bundle@0.17.1)(vue@2.7.16)
+        specifier: 1.7.1
+        version: 1.7.1(@fluent/bundle@0.17.1)(vue@2.7.16)
       '@linusborg/vue-simple-portal':
         specifier: 0.1.5
         version: 0.1.5(vue@2.7.16)
@@ -867,8 +867,8 @@ importers:
         specifier: workspace:*
         version: link:../dialtone-icons
       '@dialpad/i18n':
-        specifier: 1.22.0
-        version: 1.22.0(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
+        specifier: 1.22.1
+        version: 1.22.1(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
       '@tiptap/core':
         specifier: 2.12.0
         version: 2.12.0(@tiptap/pm@2.12.0)
@@ -1904,11 +1904,7 @@ packages:
     resolution: {integrity: sha512-NzGie5sIbfW/AyJwtIRZOumhAiXP6329VNBOrVerXgGrXqbTacTAuXPPVSgprFol5kWdbV34QtAlKN5OY11WEw==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-services/1.11.0/20198484967555617ab62da6ad3c276265ee232d}
     hasBin: true
     peerDependencies:
-      '@vue/composition-api': '*'
       vue: ^2.0.0 || >=3.0.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
 
   '@dialpad/i18n-services@1.5.0':
     resolution: {integrity: sha512-roHr0G1+C/3VeDureM5NRqK1rgt2xdF/MK1bT8khEYWW8KwQ3BuPpbvS3sz/V0kOqzQKzPaGX0ePYXpNnddzmw==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-services/1.5.0/410424f9243242ab8ebfe80116c2ddc3df54ddb6}
@@ -1927,8 +1923,8 @@ packages:
       '@vue/composition-api':
         optional: true
 
-  '@dialpad/i18n-vue2@1.7.0':
-    resolution: {integrity: sha512-wADj7VcQEPkiuHGPANPFu3GwPXu839Qz5OUUw/FcVUsoErfuqp0Er4mE8onBjBMBM0wlPt6Be//pXjpXN+gEhA==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-vue2/1.7.0/793f0da9ed6f0f3a1f5977cb391f1417911e07ab}
+  '@dialpad/i18n-vue2@1.7.1':
+    resolution: {integrity: sha512-lIhj8ShVWU/PNqFFmZBE6MsgS/27epP0j07U7sQyuVPDiX0fu6knx2O2ZrbmS0xkMktDDm2OjTnyK6kCEZp6xg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-vue2/1.7.1/57aeee1e47bd569d02725ad464fbed89c4cc2542}
     peerDependencies:
       vue: 2.6.14
 
@@ -1937,8 +1933,8 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@dialpad/i18n@1.22.0':
-    resolution: {integrity: sha512-GPhp6I6sKPfXkwKghkjuFZvZrvpYNM14hK0YD8O0ZNF+LAm6CeeNe6v8O6Fpv0rKMIEAjz7aeMKXVvHHrJZI8Q==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n/1.22.0/607c7720cc3a3c3f9e558780f333ed6fd9c08597}
+  '@dialpad/i18n@1.22.1':
+    resolution: {integrity: sha512-QxloGSVSg0KgmZTtfeHj6/omi/M3aBruYZ+U24vTvfNg0CrYxWBvTAkvFe6rIEiEydu1TwP0pYfnSIwy2XNaoA==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n/1.22.1/e4244bd56b3642daebe0cc953f933a9223364d71}
     peerDependencies:
       vue: ^3.0.0
 
@@ -18317,8 +18313,8 @@ snapshots:
       fluent-vue: 3.7.2(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
       vue: 2.7.16
       vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
-    optionalDependencies:
-      '@vue/composition-api': 1.7.2(vue@2.7.16)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   '@dialpad/i18n-services@1.11.0(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))':
     dependencies:
@@ -18328,8 +18324,8 @@ snapshots:
       fluent-vue: 3.7.2(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
       vue: 3.4.15(typescript@5.8.3)
       vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
-    optionalDependencies:
-      '@vue/composition-api': 1.7.2(vue@3.4.15(typescript@5.8.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   '@dialpad/i18n-services@1.5.0(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3))':
     dependencies:
@@ -18352,7 +18348,7 @@ snapshots:
     optionalDependencies:
       '@vue/composition-api': 1.7.2(vue@3.5.21(typescript@5.8.3))
 
-  '@dialpad/i18n-vue2@1.7.0(@fluent/bundle@0.17.1)(vue@2.7.16)':
+  '@dialpad/i18n-vue2@1.7.1(@fluent/bundle@0.17.1)(vue@2.7.16)':
     dependencies:
       '@dialpad/i18n-services': 1.11.0(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
       '@vue/composition-api': 1.7.2(vue@2.7.16)
@@ -18368,7 +18364,7 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  '@dialpad/i18n@1.22.0(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))':
+  '@dialpad/i18n@1.22.1(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))':
     dependencies:
       '@dialpad/i18n-services': 1.11.0(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
       vue: 3.4.15(typescript@5.8.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,7 +149,7 @@ importers:
         version: 6.3.7
       vue:
         specifier: ^2 || ^3
-        version: 3.5.18(typescript@5.8.3)
+        version: 3.5.21(typescript@5.8.3)
     devDependencies:
       '@commitlint/cli':
         specifier: ^18.4.3
@@ -162,7 +162,7 @@ importers:
         version: 1.1.1
       '@dialpad/i18n-services':
         specifier: 1.5.0
-        version: 1.5.0(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3))
+        version: 1.5.0(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
       '@dialpad/semantic-release-changelog-json':
         specifier: ^1.0.0
         version: 1.0.0(semantic-release@21.1.2(typescript@5.8.3))
@@ -216,13 +216,13 @@ importers:
         version: 20.19.9
       '@vitejs/plugin-vue':
         specifier: ^5.2.3
-        version: 5.2.4(vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1))(vue@3.5.18(typescript@5.8.3))
+        version: 5.2.4(vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1))(vue@3.5.21(typescript@5.8.3))
       '@vitejs/plugin-vue2':
         specifier: ^2.3.3
-        version: 2.3.3(vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1))(vue@3.5.18(typescript@5.8.3))
+        version: 2.3.3(vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1))(vue@3.5.21(typescript@5.8.3))
       '@vitest/coverage-v8':
         specifier: ^1.0.0
-        version: 1.6.1(vitest@1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1))
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1))
       '@vue/tsconfig':
         specifier: ^0.4.0
         version: 0.4.0
@@ -261,7 +261,7 @@ importers:
         version: 0.12.0(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3)
       eslint-plugin-vitest:
         specifier: ^0.5.4
-        version: 0.5.4(@typescript-eslint/eslint-plugin@8.44.1(@typescript-eslint/parser@8.44.1(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3)(vitest@1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1))
+        version: 0.5.4(@typescript-eslint/eslint-plugin@8.44.1(@typescript-eslint/parser@8.44.1(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3)(vitest@1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1))
       eslint-plugin-vue:
         specifier: ^10.4.0
         version: 10.4.0(@typescript-eslint/parser@8.44.1(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.33.0(jiti@1.21.7))(vue-eslint-parser@10.2.0(eslint@9.33.0(jiti@1.21.7)))
@@ -357,22 +357,22 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^5.4.2
-        version: 5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)
+        version: 5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)
       vite-bundle-visualizer:
         specifier: ^1.2.1
         version: 1.2.1(rollup@4.45.1)
       vite-plugin-dts:
         specifier: ^4.0.3
-        version: 4.5.4(@types/node@20.19.9)(rollup@4.45.1)(typescript@5.8.3)(vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1))
+        version: 4.5.4(@types/node@20.19.9)(rollup@4.45.1)(typescript@5.8.3)(vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1))
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)
+        version: 1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)
       vue-docgen-api:
         specifier: ^4.75.0
-        version: 4.79.2(vue@3.5.18(typescript@5.8.3))
+        version: 4.79.2(vue@3.5.21(typescript@5.8.3))
       vue-template-compiler:
         specifier: ^2.7.16
-        version: 2.7.16(vue@3.5.18(typescript@5.8.3))
+        version: 2.7.16(vue@3.5.21(typescript@5.8.3))
       wait-on:
         specifier: ^7.2.0
         version: 7.2.0
@@ -417,22 +417,22 @@ importers:
         version: 1.2.4
       '@vuepress/bundler-vite':
         specifier: 2.0.0-rc.24
-        version: 2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0)
+        version: 2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0)
       '@vuepress/plugin-active-header-links':
         specifier: 2.0.0-rc.112
-        version: 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
+        version: 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
       '@vuepress/plugin-back-to-top':
         specifier: 2.0.0-rc.112
-        version: 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
+        version: 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
       '@vuepress/plugin-git':
         specifier: 2.0.0-rc.112
-        version: 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
+        version: 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
       '@vuepress/plugin-prismjs':
         specifier: 2.0.0-rc.112
-        version: 2.0.0-rc.112(@vueuse/core@13.9.0(vue@3.5.21(typescript@5.8.3)))(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
+        version: 2.0.0-rc.112(@vueuse/core@13.9.0(vue@3.5.21(typescript@5.8.3)))(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
       '@vuepress/plugin-theme-data':
         specifier: 2.0.0-rc.112
-        version: 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
+        version: 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -462,10 +462,10 @@ importers:
         version: 4.5.1(vue@3.5.21(typescript@5.8.3))
       vuepress:
         specifier: 2.0.0-rc.24
-        version: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
+        version: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
       vuepress-plugin-sitemap2:
         specifier: 2.0.0-rc.16
-        version: 2.0.0-rc.16(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
+        version: 2.0.0-rc.16(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
 
   generator-dialtone:
     dependencies:
@@ -514,7 +514,7 @@ importers:
         version: link:../postcss-responsive-variations
       '@vue/cli-plugin-unit-mocha':
         specifier: ^5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3))(encoding@0.1.13)(webpack@5.95.0(@swc/core@1.13.2))
+        version: 5.0.8(@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3))(encoding@0.1.13)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
       chai:
         specifier: ^4.3.6
         version: 4.3.10
@@ -566,7 +566,7 @@ importers:
         version: 5.0.0
       gulp-postcss:
         specifier: ^9.0.1
-        version: 9.0.1(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.2)(@types/node@24.3.1)(typescript@5.8.3))
+        version: 9.0.1(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.2)(@types/node@25.0.3)(typescript@5.8.3))
       gulp-rename:
         specifier: ^2.0.0
         version: 2.0.0
@@ -844,7 +844,7 @@ importers:
         version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(vue@2.7.16)
       '@storybook/vue-vite':
         specifier: 7.6.20
-        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)
+        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)
       '@vue/test-utils':
         specifier: '1.3'
         version: 1.3.6(vue-template-compiler@2.7.16(vue@2.7.16))(vue@2.7.16)
@@ -1001,7 +1001,7 @@ importers:
         version: 7.6.20(encoding@0.1.13)(vue@3.4.15(typescript@5.8.3))
       '@storybook/vue3-vite':
         specifier: 7.6.20
-        version: 7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))(vue@3.4.15(typescript@5.8.3))
+        version: 7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@3.4.15(typescript@5.8.3))
       '@vue/test-utils':
         specifier: ^2.4.0
         version: 2.4.2(@vue/server-renderer@3.5.21(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
@@ -1104,6 +1104,10 @@ importers:
         version: 10.2.0(eslint@9.33.0(jiti@1.21.7))
 
 packages:
+
+  '@achrinza/node-ipc@9.2.10':
+    resolution: {integrity: sha512-rCkw57K82y1XA9KwBmuMrupFQr9VOS4Rn77vW2UD2j0+HjlP/npSON9COkUIfocd95B4wv5EpfWMr6lGD4lN3A==}
+    engines: {node: 8 || 9 || 10 || 11 || 12 || 13 || 14 || 15 || 16 || 17 || 18 || 19 || 20 || 21 || 22 || 23 || 24 || 25}
 
   '@achrinza/node-ipc@9.2.8':
     resolution: {integrity: sha512-DSzEEkbMYbAUVlhy7fg+BzccoRuSQzqHbIPGxGv19OJ2WKwS3/9ChAnQcII4g+GujcHhyJ8BUuOVAx/S5uAfQg==}
@@ -1917,14 +1921,10 @@ packages:
     resolution: {integrity: sha512-g+sEZBG1IMPoAFHswBCxcNPr4mt8KFHptAkKUaG2w0JP8ffz4qbz4GuyEQIm1pJqbucpR3eH2CnAYENCgA3k7g==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-services/1.9.0/106aff474118a9919972f8c6e02b257e005d14bb}
     hasBin: true
     peerDependencies:
-      '@vue/composition-api': '*'
       vue: ^2.0.0 || >=3.0.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
 
   '@dialpad/i18n-vue2@1.7.1':
-    resolution: {integrity: sha512-lIhj8ShVWU/PNqFFmZBE6MsgS/27epP0j07U7sQyuVPDiX0fu6knx2O2ZrbmS0xkMktDDm2OjTnyK6kCEZp6xg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-vue2/1.7.1/57aeee1e47bd569d02725ad464fbed89c4cc2542}
+    resolution: {integrity: sha512-OW6Qh4QvW/zONrERcDUBog3eU10j0uVXi+Kgjkh2GAkqWICjZ+M02FFJ9AS7cdmxqGHqZ0AnnWgOFXIByHELWg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-vue2/1.7.1/ff2bf370c2cf46e57eaf6f8603df11a05bb40eb8}
     peerDependencies:
       vue: 2.6.14
 
@@ -1934,7 +1934,7 @@ packages:
       vue: ^3.0.0
 
   '@dialpad/i18n@1.22.1':
-    resolution: {integrity: sha512-QxloGSVSg0KgmZTtfeHj6/omi/M3aBruYZ+U24vTvfNg0CrYxWBvTAkvFe6rIEiEydu1TwP0pYfnSIwy2XNaoA==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n/1.22.1/e4244bd56b3642daebe0cc953f933a9223364d71}
+    resolution: {integrity: sha512-OMu86aeVtKU3ipoRw5ui0VPv4XHM+MCN/3W2DEopJMylnlAmYKKg+JL7pwcMyWF/rnccpCKY1rAQFGXucL92Tw==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n/1.22.1/5e0d08b533b68069caab8a89fa1bbb1bbb955e69}
     peerDependencies:
       vue: ^3.0.0
 
@@ -3102,12 +3102,15 @@ packages:
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/source-map@0.3.10':
-    resolution: {integrity: sha512-0pPkgz9dY+bijgistcTTJ5mR+ocqRXLuhXHYdzoMmmoJ2C9S46RCm2GMUbatPEUK9Yjy26IrAy8D/M00lLkv+Q==}
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
@@ -3120,6 +3123,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -5401,11 +5407,17 @@ packages:
   '@types/express-serve-static-core@4.19.6':
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
 
-  '@types/express-serve-static-core@5.0.7':
-    resolution: {integrity: sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==}
+  '@types/express-serve-static-core@4.19.7':
+    resolution: {integrity: sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==}
+
+  '@types/express-serve-static-core@5.1.0':
+    resolution: {integrity: sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==}
 
   '@types/express@4.17.23':
     resolution: {integrity: sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==}
+
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
   '@types/find-cache-dir@3.2.1':
     resolution: {integrity: sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==}
@@ -5434,8 +5446,8 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
-  '@types/http-proxy@1.17.16':
-    resolution: {integrity: sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==}
+  '@types/http-proxy@1.17.17':
+    resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
 
   '@types/inquirer@9.0.8':
     resolution: {integrity: sha512-CgPD5kFGWsb8HJ5K7rfWlifao87m4ph8uioU7OTncJevmE/VLIqAAjfQtko578JZg7/f69K4FgqYym3gNr7DeA==}
@@ -5507,8 +5519,8 @@ packages:
   '@types/node-fetch@2.6.12':
     resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
 
-  '@types/node-forge@1.3.13':
-    resolution: {integrity: sha512-zePQJSW5QkwSHKRApqWCVKeKoSOt4xvEnLENZPjyvm9Ezdf/EyDeJM7jqLzOwjVICQQzvLZ63T55MKdJB5H6ww==}
+  '@types/node-forge@1.3.14':
+    resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
 
   '@types/node@16.18.126':
     resolution: {integrity: sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==}
@@ -5522,6 +5534,9 @@ packages:
   '@types/node@18.19.120':
     resolution: {integrity: sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==}
 
+  '@types/node@20.19.27':
+    resolution: {integrity: sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==}
+
   '@types/node@20.19.9':
     resolution: {integrity: sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==}
 
@@ -5530,6 +5545,9 @@ packages:
 
   '@types/node@24.3.1':
     resolution: {integrity: sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==}
+
+  '@types/node@25.0.3':
+    resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -5552,8 +5570,8 @@ packages:
   '@types/react-dom@17.0.25':
     resolution: {integrity: sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==}
 
-  '@types/react@17.0.87':
-    resolution: {integrity: sha512-wpg9AbtJ6agjA+BKYmhG6dRWEU/2DHYwMzCaBzsz137ft6IyuqZ5fI4ic1DWL4DrI03Zy78IyVE6ucrXl0mu4g==}
+  '@types/react@17.0.90':
+    resolution: {integrity: sha512-P9beVR/x06U9rCJzSxtENnOr4BrbJ6VrsrDTc+73TtHv9XHhryXKbjGRB+6oooB2r0G/pQkD/S4dHo/7jUfwFw==}
 
   '@types/react@18.2.37':
     resolution: {integrity: sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==}
@@ -5585,8 +5603,17 @@ packages:
   '@types/send@0.17.5':
     resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
 
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
   '@types/serve-index@1.9.4':
     resolution: {integrity: sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
   '@types/serve-static@1.15.8':
     resolution: {integrity: sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==}
@@ -5783,11 +5810,11 @@ packages:
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
 
-  '@vue/cli-overlay@5.0.8':
-    resolution: {integrity: sha512-KmtievE/B4kcXp6SuM2gzsnSd8WebkQpg3XaB6GmFh1BJGRqa1UiW9up7L/Q67uOdTigHxr5Ar2lZms4RcDjwQ==}
+  '@vue/cli-overlay@5.0.9':
+    resolution: {integrity: sha512-aBdZWrYKxLuFz1FDsk/muFD7GycrsW73Gi11yRc7R2W7Bm8mDRc9HKAI790gdg4NV+chkDFmfkegjg5iMDEpAA==}
 
-  '@vue/cli-plugin-router@5.0.8':
-    resolution: {integrity: sha512-Gmv4dsGdAsWPqVijz3Ux2OS2HkMrWi1ENj2cYL75nUeL+Xj5HEstSqdtfZ0b1q9NCce+BFB6QnHfTBXc/fCvMg==}
+  '@vue/cli-plugin-router@5.0.9':
+    resolution: {integrity: sha512-kopbO/8kIl5CAffwgptXEwV509i+M0FfwW4sSkgQ2RzpxOYBjQZvp+096mjZfFcWKSmryNP/ri/Mnu78vmhlhw==}
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0 || ^5.0.0-0
 
@@ -5796,8 +5823,8 @@ packages:
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0 || ^5.0.0-0
 
-  '@vue/cli-plugin-vuex@5.0.8':
-    resolution: {integrity: sha512-HSYWPqrunRE5ZZs8kVwiY6oWcn95qf/OQabwLfprhdpFWAGtLStShjsGED2aDpSSeGAskQETrtR/5h7VqgIlBA==}
+  '@vue/cli-plugin-vuex@5.0.9':
+    resolution: {integrity: sha512-AQhgGNFVd4Pu2crvS0a+hRckgrJv07gzOASdbLd3I72wkT43dd01MLRp8IBRRsu92t3MXenW86AZUCbQBz3//A==}
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0 || ^5.0.0-0
 
@@ -5834,6 +5861,9 @@ packages:
 
   '@vue/cli-shared-utils@5.0.8':
     resolution: {integrity: sha512-uK2YB7bBVuQhjOJF+O52P9yFMXeJVj7ozqJkwYE9PlMHL1LMHjtCYm4cSdOebuPzyP+/9p0BimM/OqxsevIopQ==}
+
+  '@vue/cli-shared-utils@5.0.9':
+    resolution: {integrity: sha512-lf4KykiG8j9KwvNVi7fKtASmHuLsxCcCsflVU2b2CHMRuR4weOIV3zuuCrjWKjk0APn/MHJhgCjJGzHMbTtd5w==}
 
   '@vue/compiler-core@3.4.15':
     resolution: {integrity: sha512-XcJQVOaxTKCnth1vCxEChteGuwG6wqnUHxAm1DO3gCz0+uXKaJNx8/digSz4dLALCy8n2lKq24jSUs8segoqIw==}
@@ -5908,26 +5938,17 @@ packages:
   '@vue/reactivity@3.4.15':
     resolution: {integrity: sha512-55yJh2bsff20K5O84MxSvXKPHHt17I2EomHznvFiJCAZpJTNW8IuLj1xZWMLELRhBK3kkFV/1ErZGHJfah7i7w==}
 
-  '@vue/reactivity@3.5.18':
-    resolution: {integrity: sha512-x0vPO5Imw+3sChLM5Y+B6G1zPjwdOri9e8V21NnTnlEvkxatHEH5B5KEAJcjuzQ7BsjGrKtfzuQ5eQwXh8HXBg==}
-
   '@vue/reactivity@3.5.21':
     resolution: {integrity: sha512-3ah7sa+Cwr9iiYEERt9JfZKPw4A2UlbY8RbbnH2mGCE8NwHkhmlZt2VsH0oDA3P08X3jJd29ohBDtX+TbD9AsA==}
 
   '@vue/runtime-core@3.4.15':
     resolution: {integrity: sha512-6E3by5m6v1AkW0McCeAyhHTw+3y17YCOKG0U0HDKDscV4Hs0kgNT5G+GCHak16jKgcCDHpI9xe5NKb8sdLCLdw==}
 
-  '@vue/runtime-core@3.5.18':
-    resolution: {integrity: sha512-DUpHa1HpeOQEt6+3nheUfqVXRog2kivkXHUhoqJiKR33SO4x+a5uNOMkV487WPerQkL0vUuRvq/7JhRgLW3S+w==}
-
   '@vue/runtime-core@3.5.21':
     resolution: {integrity: sha512-+DplQlRS4MXfIf9gfD1BOJpk5RSyGgGXD/R+cumhe8jdjUcq/qlxDawQlSI8hCKupBlvM+3eS1se5xW+SuNAwA==}
 
   '@vue/runtime-dom@3.4.15':
     resolution: {integrity: sha512-EVW8D6vfFVq3V/yDKNPBFkZKGMFSvZrUQmx196o/v2tHKdwWdiZjYUBS+0Ez3+ohRyF8Njwy/6FH5gYJ75liUw==}
-
-  '@vue/runtime-dom@3.5.18':
-    resolution: {integrity: sha512-YwDj71iV05j4RnzZnZtGaXwPoUWeRsqinblgVJwR8XTXYZ9D5PbahHQgsbmzUvCWNF6x7siQ89HgnX5eWkr3mw==}
 
   '@vue/runtime-dom@3.5.21':
     resolution: {integrity: sha512-3M2DZsOFwM5qI15wrMmNF5RJe1+ARijt2HM3TbzBbPSuBHOQpoidE+Pa+XEaVN+czbHf81ETRoG1ltztP2em8w==}
@@ -5936,11 +5957,6 @@ packages:
     resolution: {integrity: sha512-3HYzaidu9cHjrT+qGUuDhFYvF/j643bHC6uUN9BgM11DVy+pM6ATsG6uPBLnkwOgs7BpJABReLmpL3ZPAsUaqw==}
     peerDependencies:
       vue: 3.4.15
-
-  '@vue/server-renderer@3.5.18':
-    resolution: {integrity: sha512-PvIHLUoWgSbDG7zLHqSqaCoZvHi6NNmfVFOqO+OnwvqMz/tqQr3FuGWS8ufluNddk7ZLBJYMrjcw1c6XzR12mA==}
-    peerDependencies:
-      vue: 3.5.18
 
   '@vue/server-renderer@3.5.21':
     resolution: {integrity: sha512-qr8AqgD3DJPJcGvLcJKQo2tAc8OnXRcfxhOJCPF+fcfn5bBGz7VCcO7t+qETOPxpWK1mgysXvVT/j+xWaHeMWA==}
@@ -6655,6 +6671,13 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  autoprefixer@10.4.23:
+    resolution: {integrity: sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -6785,6 +6808,10 @@ packages:
     resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==}
     engines: {node: '>=0.10.0'}
 
+  baseline-browser-mapping@2.9.11:
+    resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
+    hasBin: true
+
   basic-auth@2.0.1:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
@@ -6865,6 +6892,10 @@ packages:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  body-parser@1.20.4:
+    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
     engines: {node: '>=18'}
@@ -6922,6 +6953,11 @@ packages:
 
   browserslist@4.25.1:
     resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  browserslist@4.28.1:
+    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -7066,6 +7102,9 @@ packages:
 
   caniuse-lite@1.0.30001727:
     resolution: {integrity: sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==}
+
+  caniuse-lite@1.0.30001762:
+    resolution: {integrity: sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==}
 
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
@@ -7789,12 +7828,19 @@ packages:
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
 
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
+    engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   copy-anything@2.0.6:
@@ -8034,6 +8080,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   csv-parse@5.5.6:
     resolution: {integrity: sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A==}
@@ -8570,6 +8619,9 @@ packages:
   electron-to-chromium@1.5.190:
     resolution: {integrity: sha512-k4McmnB2091YIsdCgkS0fMVMPOJgxl93ltFzaryXqwip1AaxeDqKCGLxkXODDA5Ab/D+tV5EL5+aTx76RvLRxw==}
 
+  electron-to-chromium@1.5.267:
+    resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
+
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
@@ -8615,6 +8667,10 @@ packages:
 
   enhanced-resolve@5.18.2:
     resolution: {integrity: sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.18.4:
+    resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.3.6:
@@ -9195,6 +9251,7 @@ packages:
 
   expect-playwright@0.8.0:
     resolution: {integrity: sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg==}
+    deprecated: ⚠️ The 'expect-playwright' package is deprecated. The Playwright core assertions (via @playwright/test) now cover the same functionality. Please migrate to built-in expect. See https://playwright.dev/docs/test-assertions for migration.
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -9217,6 +9274,10 @@ packages:
 
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
+    engines: {node: '>= 0.10.0'}
+
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
   express@5.1.0:
@@ -9368,6 +9429,10 @@ packages:
 
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
+    engines: {node: '>= 0.8'}
+
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
   finalhandler@2.1.0:
@@ -9540,6 +9605,9 @@ packages:
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   fragment-cache@0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
@@ -10177,8 +10245,8 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
-  html-webpack-plugin@5.6.3:
-    resolution: {integrity: sha512-QSf1yjtSAsmf7rYBV7XX86uua4W/vkhIt0xNXKbsi2foEeW7vjJQz4bhnpL3xH+l1ryl1680uNv968Z+X6jSYg==}
+  html-webpack-plugin@5.6.5:
+    resolution: {integrity: sha512-4xynFbKNNk+WlzXeQQ+6YYsH2g7mpfPszQZUi3ovKlj+pDmngQ7vRXjrrmGROabmKwyQkcgcX5hqfOwHbFmK5g==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -10216,6 +10284,10 @@ packages:
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
   http-parser-js@0.5.10:
@@ -10456,8 +10528,8 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
-  ipaddr.js@2.2.0:
-    resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
 
   is-absolute-url@3.0.3:
@@ -11060,6 +11132,7 @@ packages:
 
   jest-playwright-preset@4.0.0:
     resolution: {integrity: sha512-+dGZ1X2KqtwXaabVjTGxy0a3VzYfvYsWaRcuO8vMhyclHSOpGSI1+5cmlqzzCwQ3+fv0EjkTc7I5aV9lo08dYw==}
+    deprecated: ⚠️ The 'jest-playwright-preset' package is deprecated. Please migrate to Playwright's built-in test runner (@playwright/test) which now includes full Jest-style features and parallel testing. See https://playwright.dev/docs/intro for details.
     peerDependencies:
       jest: ^29.3.1
       jest-circus: ^29.3.1
@@ -11077,6 +11150,7 @@ packages:
 
   jest-process-manager@0.4.0:
     resolution: {integrity: sha512-80Y6snDyb0p8GG83pDxGI/kQzwVTkCxc7ep5FPe/F6JYdvRDhwr6RzRmPSP7SEwuLhxo80lBS/NqOdUIbHIfhw==}
+    deprecated: ⚠️ The 'jest-process-manager' package is deprecated. Please migrate to Playwright's built-in test runner (@playwright/test) which now includes full Jest-style features and parallel testing. See https://playwright.dev/docs/intro for details.
 
   jest-regex-util@29.6.3:
     resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
@@ -11393,11 +11467,11 @@ packages:
     resolution: {integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==}
     engines: {node: '>=8'}
 
-  launch-editor-middleware@2.10.0:
-    resolution: {integrity: sha512-RzZu7MeVlE3p1H6Sadc2BhuDGAj7bkeDCBpNq/zSENP4ohJGhso00k5+iYaRwKshIpiOAhMmimce+5D389xmSg==}
+  launch-editor-middleware@2.12.0:
+    resolution: {integrity: sha512-SgU5QWoR+Grq1sQedvS/RlfoyO6bdvrztpP+2RRg8UzE7Jz2Yup5J4jiFfm2J9dYBCQYD26AbJVbjnvgwdL6Pw==}
 
-  launch-editor@2.10.0:
-    resolution: {integrity: sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==}
+  launch-editor@2.12.0:
+    resolution: {integrity: sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==}
 
   launch-editor@2.6.1:
     resolution: {integrity: sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==}
@@ -11489,8 +11563,8 @@ packages:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
 
-  loader-runner@4.3.0:
-    resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
+  loader-runner@4.3.1:
+    resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
     engines: {node: '>=6.11.5'}
 
   loader-utils@1.4.2:
@@ -12131,8 +12205,8 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  mini-css-extract-plugin@2.9.2:
-    resolution: {integrity: sha512-GJuACcS//jtq4kCtd5ii/M0SZf7OZRH+BxdqXZHaJfb8TJiVl+NgQRPwiYt2EuqeSkNydn/7vP+bcE27C5mb9w==}
+  mini-css-extract-plugin@2.9.4:
+    resolution: {integrity: sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
@@ -12408,8 +12482,8 @@ packages:
       encoding:
         optional: true
 
-  node-forge@1.3.1:
-    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
+  node-forge@1.3.3:
+    resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
     engines: {node: '>= 6.13.0'}
 
   node-gyp@10.3.1:
@@ -12437,6 +12511,9 @@ packages:
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  node-releases@2.0.27:
+    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
   nodent-runtime@3.2.1:
     resolution: {integrity: sha512-7Ws63oC+215smeKJQCxzrK21VFVlCFBkwl0MOObt0HOpVQXs3u483sAmtkF33nNqZ5rSOQjB76fgyPBmAUrtCA==}
@@ -13470,6 +13547,10 @@ packages:
     resolution: {integrity: sha512-yuGIEjDAYnnOex9ddMnKZEMFE0CcGo6zbfzDklkmT1m5z734ss6JMzN9rNB3+RR7iS+F10D4/BVIaXOyh8PQKw==}
     engines: {node: '>= 10.12'}
 
+  portfinder@1.0.38:
+    resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
+    engines: {node: '>= 10.12'}
+
   posix-character-classes@0.1.1:
     resolution: {integrity: sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==}
     engines: {node: '>=0.10.0'}
@@ -13893,6 +13974,10 @@ packages:
     resolution: {integrity: sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==}
     engines: {node: '>=4'}
 
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+    engines: {node: '>=4'}
+
   postcss-sorting@4.1.0:
     resolution: {integrity: sha512-r4T2oQd1giURJdHQ/RMb72dKZCuLOdWx2B/XhXN1Y1ZdnwXsKH896Qz6vD4tFy9xSjpKNYhlZoJmWyhH/7JUQw==}
     engines: {node: '>=6.14.3'}
@@ -14220,6 +14305,10 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.10:
     resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
 
@@ -14263,6 +14352,10 @@ packages:
 
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
   raw-body@3.0.1:
@@ -14808,8 +14901,8 @@ packages:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
     engines: {node: '>= 10.13.0'}
 
-  schema-utils@4.3.2:
-    resolution: {integrity: sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==}
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
 
   section-matter@1.0.0:
@@ -14882,8 +14975,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
+    engines: {node: '>= 0.8.0'}
+
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
   send@1.2.0:
@@ -14915,6 +15017,10 @@ packages:
 
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
 
   serve-static@2.2.0:
@@ -15249,6 +15355,10 @@ packages:
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   std-env@3.9.0:
@@ -15610,6 +15720,10 @@ packages:
     resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
     engines: {node: '>=6'}
 
+  tapable@2.3.0:
+    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
   tar-fs@3.1.1:
     resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
 
@@ -15654,8 +15768,8 @@ packages:
     resolution: {integrity: sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==}
     engines: {node: '>=14.16'}
 
-  terser-webpack-plugin@5.3.14:
-    resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
+  terser-webpack-plugin@5.3.16:
+    resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -15670,8 +15784,8 @@ packages:
       uglify-js:
         optional: true
 
-  terser@5.43.1:
-    resolution: {integrity: sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==}
+  terser@5.44.1:
+    resolution: {integrity: sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -16137,6 +16251,9 @@ packages:
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
   undici@6.20.1:
     resolution: {integrity: sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==}
     engines: {node: '>=18.17'}
@@ -16282,6 +16399,12 @@ packages:
 
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -16728,14 +16851,6 @@ packages:
       typescript:
         optional: true
 
-  vue@3.5.18:
-    resolution: {integrity: sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   vue@3.5.21:
     resolution: {integrity: sha512-xxf9rum9KtOdwdRkiApWL+9hZEMWE90FHh8yS1+KJAiWYh+iGWV1FquPjoO9VUHQ+VIhsCXNNyZ5Sf4++RVZBA==}
     peerDependencies:
@@ -16807,6 +16922,10 @@ packages:
 
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
+    engines: {node: '>=10.13.0'}
+
+  watchpack@2.5.0:
+    resolution: {integrity: sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==}
     engines: {node: '>=10.13.0'}
 
   wbuf@1.7.3:
@@ -16889,10 +17008,12 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -17070,6 +17191,18 @@ packages:
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -17281,6 +17414,12 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@achrinza/node-ipc@9.2.10':
+    dependencies:
+      '@node-ipc/js-queue': 2.0.3
+      event-pubsub: 4.3.0
+      js-message: 1.0.7
 
   '@achrinza/node-ipc@9.2.8':
     dependencies:
@@ -18327,15 +18466,15 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  '@dialpad/i18n-services@1.5.0(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3))':
+  '@dialpad/i18n-services@1.5.0(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))':
     dependencies:
       '@fluent/bundle': 0.17.1
       '@fluent/syntax': 0.19.0
-      '@vue/composition-api': 1.7.2(vue@3.5.18(typescript@5.8.3))
+      '@vue/composition-api': 1.7.2(vue@3.5.21(typescript@5.8.3))
       csv-parse: 5.5.6
-      fluent-vue: 3.6.0(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3))
-      vue: 3.5.18(typescript@5.8.3)
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3))
+      fluent-vue: 3.6.0(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
+      vue: 3.5.21(typescript@5.8.3)
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
 
   '@dialpad/i18n-services@1.9.0(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))':
     dependencies:
@@ -18345,8 +18484,8 @@ snapshots:
       fluent-vue: 3.7.2(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
       vue: 3.5.21(typescript@5.8.3)
       vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
-    optionalDependencies:
-      '@vue/composition-api': 1.7.2(vue@3.5.21(typescript@5.8.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   '@dialpad/i18n-vue2@1.7.1(@fluent/bundle@0.17.1)(vue@2.7.16)':
     dependencies:
@@ -19366,12 +19505,17 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.4
       '@jridgewell/trace-mapping': 0.3.29
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/source-map@0.3.10':
+  '@jridgewell/source-map@0.3.11':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
@@ -19383,6 +19527,11 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -21577,13 +21726,13 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.95.0(@swc/core@1.13.2))':
+  '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))':
     dependencies:
       chalk: 3.0.0
       error-stack-parser: 2.1.4
       string-width: 4.2.3
       strip-ansi: 6.0.1
-      webpack: 5.95.0(@swc/core@1.13.2)
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
 
   '@soda/get-current-script@1.0.2': {}
 
@@ -21765,7 +21914,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-vite@7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))':
+  '@storybook/builder-vite@7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))':
     dependencies:
       '@storybook/channels': 7.6.20
       '@storybook/client-logger': 7.6.20
@@ -21783,32 +21932,7 @@ snapshots:
       fs-extra: 11.3.0
       magic-string: 0.30.19
       rollup: 3.29.5
-      vite: 7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  '@storybook/builder-vite@7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))':
-    dependencies:
-      '@storybook/channels': 7.6.20
-      '@storybook/client-logger': 7.6.20
-      '@storybook/core-common': 7.6.20(encoding@0.1.13)
-      '@storybook/csf-plugin': 7.6.20
-      '@storybook/node-logger': 7.6.20
-      '@storybook/preview': 7.6.20
-      '@storybook/preview-api': 7.6.20
-      '@storybook/types': 7.6.20
-      '@types/find-cache-dir': 3.2.1
-      browser-assert: 1.2.1
-      es-module-lexer: 0.9.3
-      express: 4.21.2
-      find-cache-dir: 3.3.2
-      fs-extra: 11.3.0
-      magic-string: 0.30.19
-      rollup: 3.29.5
-      vite: 7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0)
+      vite: 7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0)
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22246,14 +22370,14 @@ snapshots:
       '@types/express': 4.17.23
       file-system-cache: 2.3.0
 
-  '@storybook/vue-vite@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)':
+  '@storybook/vue-vite@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)':
     dependencies:
-      '@storybook/builder-vite': 7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))
+      '@storybook/builder-vite': 7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/core-server': 7.6.20(encoding@0.1.13)
       '@storybook/vue': 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(vue@2.7.16)
       magic-string: 0.30.19
-      vite: 7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0)
+      vite: 7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0)
       vue: 2.7.16
       vue-docgen-api: 4.79.2(vue@2.7.16)
     transitivePeerDependencies:
@@ -22268,14 +22392,14 @@ snapshots:
       - utf-8-validate
       - vite-plugin-glimmerx
 
-  '@storybook/vue3-vite@7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))(vue@3.4.15(typescript@5.8.3))':
+  '@storybook/vue3-vite@7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@3.4.15(typescript@5.8.3))':
     dependencies:
-      '@storybook/builder-vite': 7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))
+      '@storybook/builder-vite': 7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))
       '@storybook/core-server': 7.6.20(encoding@0.1.13)
       '@storybook/vue3': 7.6.20(encoding@0.1.13)(vue@3.4.15(typescript@5.8.3))
-      '@vitejs/plugin-vue': 4.6.2(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))(vue@3.4.15(typescript@5.8.3))
+      '@vitejs/plugin-vue': 4.6.2(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@3.4.15(typescript@5.8.3))
       magic-string: 0.30.11
-      vite: 7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0)
+      vite: 7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0)
       vue-docgen-api: 4.79.2(vue@3.4.15(typescript@5.8.3))
     transitivePeerDependencies:
       - '@preact/preset-vite'
@@ -22626,7 +22750,7 @@ snapshots:
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 25.0.3
 
   '@types/cacheable-request@6.0.3':
     dependencies:
@@ -22637,8 +22761,8 @@ snapshots:
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
-      '@types/express-serve-static-core': 5.0.7
-      '@types/node': 22.8.4
+      '@types/express-serve-static-core': 5.1.0
+      '@types/node': 25.0.3
 
   '@types/connect@3.4.38':
     dependencies:
@@ -22671,12 +22795,19 @@ snapshots:
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
 
-  '@types/express-serve-static-core@5.0.7':
+  '@types/express-serve-static-core@4.19.7':
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 25.0.3
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
-      '@types/send': 0.17.5
+      '@types/send': 1.2.1
+
+  '@types/express-serve-static-core@5.1.0':
+    dependencies:
+      '@types/node': 25.0.3
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
 
   '@types/express@4.17.23':
     dependencies:
@@ -22684,6 +22815,13 @@ snapshots:
       '@types/express-serve-static-core': 4.19.6
       '@types/qs': 6.14.0
       '@types/serve-static': 1.15.8
+
+  '@types/express@4.17.25':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 4.19.7
+      '@types/qs': 6.14.0
+      '@types/serve-static': 1.15.10
 
   '@types/find-cache-dir@3.2.1': {}
 
@@ -22713,9 +22851,9 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
-  '@types/http-proxy@1.17.16':
+  '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 25.0.3
 
   '@types/inquirer@9.0.8':
     dependencies:
@@ -22786,9 +22924,9 @@ snapshots:
       '@types/node': 22.8.4
       form-data: 4.0.4
 
-  '@types/node-forge@1.3.13':
+  '@types/node-forge@1.3.14':
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 25.0.3
 
   '@types/node@16.18.126': {}
 
@@ -22799,6 +22937,10 @@ snapshots:
   '@types/node@18.19.120':
     dependencies:
       undici-types: 5.26.5
+
+  '@types/node@20.19.27':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@20.19.9':
     dependencies:
@@ -22811,6 +22953,10 @@ snapshots:
   '@types/node@24.3.1':
     dependencies:
       undici-types: 7.10.0
+
+  '@types/node@25.0.3':
+    dependencies:
+      undici-types: 7.16.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -22827,21 +22973,21 @@ snapshots:
 
   '@types/react-dom@17.0.25':
     dependencies:
-      '@types/react': 17.0.87
+      '@types/react': 17.0.90
     optional: true
 
-  '@types/react@17.0.87':
+  '@types/react@17.0.90':
     dependencies:
       '@types/prop-types': 15.7.15
       '@types/scheduler': 0.16.8
-      csstype: 3.1.3
+      csstype: 3.2.3
     optional: true
 
   '@types/react@18.2.37':
     dependencies:
       '@types/prop-types': 15.7.15
       '@types/scheduler': 0.26.0
-      csstype: 3.1.3
+      csstype: 3.2.3
     optional: true
 
   '@types/react@19.1.8':
@@ -22873,9 +23019,24 @@ snapshots:
       '@types/mime': 1.3.5
       '@types/node': 22.8.4
 
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 25.0.3
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 25.0.3
+
   '@types/serve-index@1.9.4':
     dependencies:
-      '@types/express': 4.17.23
+      '@types/express': 4.17.25
+
+  '@types/serve-static@1.15.10':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.0.3
+      '@types/send': 0.17.6
 
   '@types/serve-static@1.15.8':
     dependencies:
@@ -22885,7 +23046,7 @@ snapshots:
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 25.0.3
 
   '@types/stack-utils@2.0.3': {}
 
@@ -22916,7 +23077,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 25.0.3
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -23083,28 +23244,28 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue2@2.3.3(vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1))(vue@3.5.18(typescript@5.8.3))':
+  '@vitejs/plugin-vue2@2.3.3(vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1))(vue@3.5.21(typescript@5.8.3))':
     dependencies:
-      vite: 5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)
-      vue: 3.5.18(typescript@5.8.3)
-
-  '@vitejs/plugin-vue@4.6.2(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))(vue@3.4.15(typescript@5.8.3))':
-    dependencies:
-      vite: 7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0)
-      vue: 3.4.15(typescript@5.8.3)
-
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1))(vue@3.5.18(typescript@5.8.3))':
-    dependencies:
-      vite: 5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)
-      vue: 3.5.18(typescript@5.8.3)
-
-  '@vitejs/plugin-vue@6.0.1(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))(vue@3.5.21(typescript@5.8.3))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0)
+      vite: 5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)
       vue: 3.5.21(typescript@5.8.3)
 
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1))':
+  '@vitejs/plugin-vue@4.6.2(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@3.4.15(typescript@5.8.3))':
+    dependencies:
+      vite: 7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0)
+      vue: 3.4.15(typescript@5.8.3)
+
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1))(vue@3.5.21(typescript@5.8.3))':
+    dependencies:
+      vite: 5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)
+      vue: 3.5.21(typescript@5.8.3)
+
+  '@vitejs/plugin-vue@6.0.1(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@3.5.21(typescript@5.8.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.29
+      vite: 7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0)
+      vue: 3.5.21(typescript@5.8.3)
+
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -23119,7 +23280,7 @@ snapshots:
       std-env: 3.9.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)
+      vitest: 1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23204,23 +23365,23 @@ snapshots:
 
   '@vscode/l10n@0.0.18': {}
 
-  '@vue/cli-overlay@5.0.8': {}
+  '@vue/cli-overlay@5.0.9': {}
 
-  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3))(encoding@0.1.13)':
+  '@vue/cli-plugin-router@5.0.9(@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3))(encoding@0.1.13)':
     dependencies:
-      '@vue/cli-service': 5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3)
-      '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
+      '@vue/cli-service': 5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3)
+      '@vue/cli-shared-utils': 5.0.9(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
-  '@vue/cli-plugin-unit-mocha@5.0.8(@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3))(encoding@0.1.13)(webpack@5.95.0(@swc/core@1.13.2))':
+  '@vue/cli-plugin-unit-mocha@5.0.8(@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3))(encoding@0.1.13)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3)
+      '@vue/cli-service': 5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       jsdom: 18.1.1
       jsdom-global: 3.0.2(jsdom@18.1.1)
       mocha: 8.4.0
-      mochapack: 2.1.4(mocha@8.4.0)(webpack@5.95.0(@swc/core@1.13.2))
+      mochapack: 2.1.4(mocha@8.4.0)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -23229,36 +23390,36 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3))':
+  '@vue/cli-plugin-vuex@5.0.9(@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3)
+      '@vue/cli-service': 5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3)
 
-  '@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3)':
+  '@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3)':
     dependencies:
       '@babel/helper-compilation-targets': 7.27.2
-      '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.95.0(@swc/core@1.13.2))
+      '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
       '@soda/get-current-script': 1.0.2
       '@types/minimist': 1.2.5
-      '@vue/cli-overlay': 5.0.8
-      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3))(encoding@0.1.13)
-      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3))
-      '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
+      '@vue/cli-overlay': 5.0.9
+      '@vue/cli-plugin-router': 5.0.9(@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3))(encoding@0.1.13)
+      '@vue/cli-plugin-vuex': 5.0.9(@vue/cli-service@5.0.8(@swc/core@1.13.2)(@vue/compiler-sfc@3.5.21)(ejs@3.1.10)(encoding@0.1.13)(esbuild@0.18.20)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))(webpack-sources@3.3.3))
+      '@vue/cli-shared-utils': 5.0.9(encoding@0.1.13)
       '@vue/component-compiler-utils': 3.3.0(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)
-      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.5.21)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(webpack@5.95.0(@swc/core@1.13.2))
+      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.5.21)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
       '@vue/web-component-wrapper': 1.3.0
       acorn: 8.15.0
       acorn-walk: 8.3.4
       address: 1.2.2
-      autoprefixer: 10.4.21(postcss@8.4.39)
-      browserslist: 4.25.1
+      autoprefixer: 10.4.23(postcss@8.5.6)
+      browserslist: 4.28.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cli-highlight: 2.1.11
       clipboardy: 2.3.0
       cliui: 7.0.4
-      copy-webpack-plugin: 9.1.0(webpack@5.95.0(@swc/core@1.13.2))
-      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.13.2))
-      css-minimizer-webpack-plugin: 3.4.1(webpack@5.95.0(@swc/core@1.13.2))
-      cssnano: 5.1.15(postcss@8.4.39)
+      copy-webpack-plugin: 9.1.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
+      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
+      css-minimizer-webpack-plugin: 3.4.1(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
+      cssnano: 5.1.15(postcss@8.5.6)
       debug: 4.4.3
       default-gateway: 6.0.3
       dotenv: 10.0.0
@@ -23266,27 +23427,27 @@ snapshots:
       fs-extra: 9.1.0
       globby: 11.1.0
       hash-sum: 2.0.0
-      html-webpack-plugin: 5.6.3(webpack@5.95.0(@swc/core@1.13.2))
+      html-webpack-plugin: 5.6.5(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
       is-file-esm: 1.0.0
-      launch-editor-middleware: 2.10.0
+      launch-editor-middleware: 2.12.0
       lodash.defaultsdeep: 4.6.1
       lodash.mapvalues: 4.6.0
-      mini-css-extract-plugin: 2.9.2(webpack@5.95.0(@swc/core@1.13.2))
+      mini-css-extract-plugin: 2.9.4(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
       minimist: 1.2.8
       module-alias: 2.2.3
-      portfinder: 1.0.37
-      postcss: 8.4.39
-      postcss-loader: 6.2.1(postcss@8.4.39)(webpack@5.95.0(@swc/core@1.13.2))
-      progress-webpack-plugin: 1.0.16(webpack@5.95.0(@swc/core@1.13.2))
+      portfinder: 1.0.38
+      postcss: 8.5.6
+      postcss-loader: 6.2.1(postcss@8.5.6)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
+      progress-webpack-plugin: 1.0.16(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
       ssri: 8.0.1
-      terser-webpack-plugin: 5.3.14(@swc/core@1.13.2)(webpack@5.95.0(@swc/core@1.13.2))
-      thread-loader: 3.0.4(webpack@5.95.0(@swc/core@1.13.2))
-      vue-loader: 17.4.2(@vue/compiler-sfc@3.5.21)(vue@3.4.15(typescript@5.8.3))(webpack@5.95.0(@swc/core@1.13.2))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.13.2)(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
+      thread-loader: 3.0.4(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
+      vue-loader: 17.4.2(@vue/compiler-sfc@3.5.21)(vue@3.4.15(typescript@5.8.3))(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
       vue-style-loader: 4.1.3
-      webpack: 5.95.0(@swc/core@1.13.2)
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
       webpack-bundle-analyzer: 4.10.2
       webpack-chain: 6.5.1
-      webpack-dev-server: 4.15.2(debug@4.4.3)(webpack@5.95.0(@swc/core@1.13.2))
+      webpack-dev-server: 4.15.2(debug@4.4.3)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
       webpack-merge: 5.10.0
       webpack-virtual-modules: 0.4.6
       whatwg-fetch: 3.6.20
@@ -23376,6 +23537,23 @@ snapshots:
       ora: 5.4.1
       read-pkg: 5.2.0
       semver: 7.7.2
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - encoding
+
+  '@vue/cli-shared-utils@5.0.9(encoding@0.1.13)':
+    dependencies:
+      '@achrinza/node-ipc': 9.2.10
+      chalk: 4.1.2
+      execa: 1.0.0
+      joi: 17.13.3
+      launch-editor: 2.12.0
+      lru-cache: 6.0.0
+      node-fetch: 2.7.0(encoding@0.1.13)
+      open: 8.4.2
+      ora: 5.4.1
+      read-pkg: 5.2.0
+      semver: 7.7.3
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - encoding
@@ -23559,14 +23737,9 @@ snapshots:
       vue: 3.4.15(typescript@5.8.3)
     optional: true
 
-  '@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3))':
-    dependencies:
-      vue: 3.5.18(typescript@5.8.3)
-
   '@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3))':
     dependencies:
       vue: 3.5.21(typescript@5.8.3)
-    optional: true
 
   '@vue/devtools-api@6.6.4': {}
 
@@ -23605,10 +23778,6 @@ snapshots:
     dependencies:
       '@vue/shared': 3.4.15
 
-  '@vue/reactivity@3.5.18':
-    dependencies:
-      '@vue/shared': 3.5.18
-
   '@vue/reactivity@3.5.21':
     dependencies:
       '@vue/shared': 3.5.21
@@ -23617,11 +23786,6 @@ snapshots:
     dependencies:
       '@vue/reactivity': 3.4.15
       '@vue/shared': 3.4.15
-
-  '@vue/runtime-core@3.5.18':
-    dependencies:
-      '@vue/reactivity': 3.5.18
-      '@vue/shared': 3.5.18
 
   '@vue/runtime-core@3.5.21':
     dependencies:
@@ -23632,13 +23796,6 @@ snapshots:
     dependencies:
       '@vue/runtime-core': 3.4.15
       '@vue/shared': 3.4.15
-      csstype: 3.1.3
-
-  '@vue/runtime-dom@3.5.18':
-    dependencies:
-      '@vue/reactivity': 3.5.18
-      '@vue/runtime-core': 3.5.18
-      '@vue/shared': 3.5.18
       csstype: 3.1.3
 
   '@vue/runtime-dom@3.5.21':
@@ -23653,12 +23810,6 @@ snapshots:
       '@vue/compiler-ssr': 3.4.15
       '@vue/shared': 3.4.15
       vue: 3.4.15(typescript@5.8.3)
-
-  '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@5.8.3))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.18
-      '@vue/shared': 3.5.18
-      vue: 3.5.18(typescript@5.8.3)
 
   '@vue/server-renderer@3.5.21(vue@3.4.15(typescript@5.8.3))':
     dependencies:
@@ -23699,9 +23850,9 @@ snapshots:
 
   '@vue/web-component-wrapper@1.3.0': {}
 
-  '@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0)':
+  '@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0)':
     dependencies:
-      '@vitejs/plugin-vue': 6.0.1(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))(vue@3.5.21(typescript@5.8.3))
+      '@vitejs/plugin-vue': 6.0.1(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@3.5.21(typescript@5.8.3))
       '@vuepress/bundlerutils': 2.0.0-rc.24(typescript@5.8.3)
       '@vuepress/client': 2.0.0-rc.24(typescript@5.8.3)
       '@vuepress/core': 2.0.0-rc.24(typescript@5.8.3)
@@ -23712,7 +23863,7 @@ snapshots:
       postcss: 8.5.6
       postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.19.0)(yaml@2.8.0)
       rollup: 4.45.1
-      vite: 7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0)
+      vite: 7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0)
       vue: 3.5.21(typescript@5.8.3)
       vue-router: 4.5.1(vue@3.5.21(typescript@5.8.3))
     transitivePeerDependencies:
@@ -23776,7 +23927,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vuepress/helper@2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
+  '@vuepress/helper@2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
     dependencies:
       '@vue/shared': 3.5.18
       '@vueuse/core': 13.9.0(vue@3.5.21(typescript@5.8.3))
@@ -23784,13 +23935,13 @@ snapshots:
       fflate: 0.8.2
       gray-matter: 4.0.3
       vue: 3.5.21(typescript@5.8.3)
-      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
+      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
     transitivePeerDependencies:
       - typescript
 
-  '@vuepress/highlighter-helper@2.0.0-rc.112(@vueuse/core@13.9.0(vue@3.5.21(typescript@5.8.3)))(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
+  '@vuepress/highlighter-helper@2.0.0-rc.112(@vueuse/core@13.9.0(vue@3.5.21(typescript@5.8.3)))(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
     dependencies:
-      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
+      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
     optionalDependencies:
       '@vueuse/core': 13.9.0(vue@3.5.21(typescript@5.8.3))
 
@@ -23815,51 +23966,51 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vuepress/plugin-active-header-links@2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
+  '@vuepress/plugin-active-header-links@2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
     dependencies:
       '@vueuse/core': 13.9.0(vue@3.5.21(typescript@5.8.3))
       vue: 3.5.21(typescript@5.8.3)
-      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
+      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
     transitivePeerDependencies:
       - typescript
 
-  '@vuepress/plugin-back-to-top@2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
+  '@vuepress/plugin-back-to-top@2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
+      '@vuepress/helper': 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
       '@vueuse/core': 13.9.0(vue@3.5.21(typescript@5.8.3))
       vue: 3.5.21(typescript@5.8.3)
-      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
+      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
     transitivePeerDependencies:
       - typescript
 
-  '@vuepress/plugin-git@2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
+  '@vuepress/plugin-git@2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
+      '@vuepress/helper': 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
       '@vueuse/core': 13.9.0(vue@3.5.21(typescript@5.8.3))
       rehype-parse: 9.0.1
       rehype-sanitize: 6.0.0
       rehype-stringify: 10.0.1
       unified: 11.0.5
       vue: 3.5.21(typescript@5.8.3)
-      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
+      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
     transitivePeerDependencies:
       - typescript
 
-  '@vuepress/plugin-prismjs@2.0.0-rc.112(@vueuse/core@13.9.0(vue@3.5.21(typescript@5.8.3)))(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
+  '@vuepress/plugin-prismjs@2.0.0-rc.112(@vueuse/core@13.9.0(vue@3.5.21(typescript@5.8.3)))(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
-      '@vuepress/highlighter-helper': 2.0.0-rc.112(@vueuse/core@13.9.0(vue@3.5.21(typescript@5.8.3)))(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
+      '@vuepress/helper': 2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
+      '@vuepress/highlighter-helper': 2.0.0-rc.112(@vueuse/core@13.9.0(vue@3.5.21(typescript@5.8.3)))(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
       prismjs: 1.30.0
-      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
+      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
     transitivePeerDependencies:
       - '@vueuse/core'
       - typescript
 
-  '@vuepress/plugin-theme-data@2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
+  '@vuepress/plugin-theme-data@2.0.0-rc.112(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))':
     dependencies:
       '@vue/devtools-api': 7.7.7
       vue: 3.5.21(typescript@5.8.3)
-      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
+      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
     transitivePeerDependencies:
       - typescript
 
@@ -24453,22 +24604,21 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  autoprefixer@10.4.21(postcss@8.4.39):
-    dependencies:
-      browserslist: 4.25.1
-      caniuse-lite: 1.0.30001727
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
-      picocolors: 1.1.1
-      postcss: 8.4.39
-      postcss-value-parser: 4.2.0
-
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.25.1
       caniuse-lite: 1.0.30001727
       fraction.js: 4.3.7
       normalize-range: 0.1.2
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
+  autoprefixer@10.4.23(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.28.1
+      caniuse-lite: 1.0.30001762
+      fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
@@ -24657,6 +24807,8 @@ snapshots:
       mixin-deep: 1.3.2
       pascalcase: 0.1.1
 
+  baseline-browser-mapping@2.9.11: {}
+
   basic-auth@2.0.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -24736,6 +24888,23 @@ snapshots:
       on-finished: 2.4.1
       qs: 6.13.0
       raw-body: 2.5.2
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@1.20.4:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.14.1
+      raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
     transitivePeerDependencies:
@@ -24821,6 +24990,14 @@ snapshots:
       electron-to-chromium: 1.5.190
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
+
+  browserslist@4.28.1:
+    dependencies:
+      baseline-browser-mapping: 2.9.11
+      caniuse-lite: 1.0.30001762
+      electron-to-chromium: 1.5.267
+      node-releases: 2.0.27
+      update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   bser@2.1.1:
     dependencies:
@@ -25034,6 +25211,8 @@ snapshots:
   caniuse-lite@1.0.30001561: {}
 
   caniuse-lite@1.0.30001727: {}
+
+  caniuse-lite@1.0.30001762: {}
 
   capital-case@1.0.4:
     dependencies:
@@ -25704,9 +25883,13 @@ snapshots:
 
   cookie-signature@1.0.6: {}
 
+  cookie-signature@1.0.7: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.1: {}
+
+  cookie@0.7.2: {}
 
   copy-anything@2.0.6:
     dependencies:
@@ -25723,7 +25906,7 @@ snapshots:
       each-props: 1.3.2
       is-plain-object: 5.0.0
 
-  copy-webpack-plugin@9.1.0(webpack@5.95.0(@swc/core@1.13.2)):
+  copy-webpack-plugin@9.1.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -25731,7 +25914,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.95.0(@swc/core@1.13.2)
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
 
   core-js-compat@3.44.0:
     dependencies:
@@ -25818,10 +26001,6 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
-  css-declaration-sorter@6.4.1(postcss@8.4.39):
-    dependencies:
-      postcss: 8.4.39
-
   css-declaration-sorter@6.4.1(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -25830,39 +26009,28 @@ snapshots:
 
   css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.39)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.4.39)
-      postcss-modules-scope: 3.2.1(postcss@8.4.39)
-      postcss-modules-values: 4.0.0(postcss@8.4.39)
+      icss-utils: 5.1.0(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
+      postcss-modules-scope: 3.2.1(postcss@8.5.6)
+      postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
-      semver: 7.7.2
+      semver: 7.7.3
     optionalDependencies:
       webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
 
-  css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)):
+  css-minimizer-webpack-plugin@3.4.1(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.39)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.4.39)
-      postcss-modules-scope: 3.2.1(postcss@8.4.39)
-      postcss-modules-values: 4.0.0(postcss@8.4.39)
-      postcss-value-parser: 4.2.0
-      semver: 7.7.2
-    optionalDependencies:
-      webpack: 5.95.0(@swc/core@1.13.2)
-
-  css-minimizer-webpack-plugin@3.4.1(webpack@5.95.0(@swc/core@1.13.2)):
-    dependencies:
-      cssnano: 5.1.15(postcss@8.4.39)
+      cssnano: 5.1.15(postcss@8.5.6)
       jest-worker: 27.5.1
-      postcss: 8.4.39
-      schema-utils: 4.3.2
+      postcss: 8.5.6
+      schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       source-map: 0.6.1
-      webpack: 5.95.0(@swc/core@1.13.2)
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
+    optionalDependencies:
+      esbuild: 0.18.20
 
   css-select@4.3.0:
     dependencies:
@@ -25912,38 +26080,38 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-default@5.2.14(postcss@8.4.39):
+  cssnano-preset-default@5.2.14(postcss@8.5.6):
     dependencies:
-      css-declaration-sorter: 6.4.1(postcss@8.4.39)
-      cssnano-utils: 3.1.0(postcss@8.4.39)
-      postcss: 8.4.39
-      postcss-calc: 8.2.4(postcss@8.4.39)
-      postcss-colormin: 5.3.1(postcss@8.4.39)
-      postcss-convert-values: 5.1.3(postcss@8.4.39)
-      postcss-discard-comments: 5.1.2(postcss@8.4.39)
-      postcss-discard-duplicates: 5.1.0(postcss@8.4.39)
-      postcss-discard-empty: 5.1.1(postcss@8.4.39)
-      postcss-discard-overridden: 5.1.0(postcss@8.4.39)
-      postcss-merge-longhand: 5.1.7(postcss@8.4.39)
-      postcss-merge-rules: 5.1.4(postcss@8.4.39)
-      postcss-minify-font-values: 5.1.0(postcss@8.4.39)
-      postcss-minify-gradients: 5.1.1(postcss@8.4.39)
-      postcss-minify-params: 5.1.4(postcss@8.4.39)
-      postcss-minify-selectors: 5.2.1(postcss@8.4.39)
-      postcss-normalize-charset: 5.1.0(postcss@8.4.39)
-      postcss-normalize-display-values: 5.1.0(postcss@8.4.39)
-      postcss-normalize-positions: 5.1.1(postcss@8.4.39)
-      postcss-normalize-repeat-style: 5.1.1(postcss@8.4.39)
-      postcss-normalize-string: 5.1.0(postcss@8.4.39)
-      postcss-normalize-timing-functions: 5.1.0(postcss@8.4.39)
-      postcss-normalize-unicode: 5.1.1(postcss@8.4.39)
-      postcss-normalize-url: 5.1.0(postcss@8.4.39)
-      postcss-normalize-whitespace: 5.1.1(postcss@8.4.39)
-      postcss-ordered-values: 5.1.3(postcss@8.4.39)
-      postcss-reduce-initial: 5.1.2(postcss@8.4.39)
-      postcss-reduce-transforms: 5.1.0(postcss@8.4.39)
-      postcss-svgo: 5.1.0(postcss@8.4.39)
-      postcss-unique-selectors: 5.1.1(postcss@8.4.39)
+      css-declaration-sorter: 6.4.1(postcss@8.5.6)
+      cssnano-utils: 3.1.0(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-calc: 8.2.4(postcss@8.5.6)
+      postcss-colormin: 5.3.1(postcss@8.5.6)
+      postcss-convert-values: 5.1.3(postcss@8.5.6)
+      postcss-discard-comments: 5.1.2(postcss@8.5.6)
+      postcss-discard-duplicates: 5.1.0(postcss@8.5.6)
+      postcss-discard-empty: 5.1.1(postcss@8.5.6)
+      postcss-discard-overridden: 5.1.0(postcss@8.5.6)
+      postcss-merge-longhand: 5.1.7(postcss@8.5.6)
+      postcss-merge-rules: 5.1.4(postcss@8.5.6)
+      postcss-minify-font-values: 5.1.0(postcss@8.5.6)
+      postcss-minify-gradients: 5.1.1(postcss@8.5.6)
+      postcss-minify-params: 5.1.4(postcss@8.5.6)
+      postcss-minify-selectors: 5.2.1(postcss@8.5.6)
+      postcss-normalize-charset: 5.1.0(postcss@8.5.6)
+      postcss-normalize-display-values: 5.1.0(postcss@8.5.6)
+      postcss-normalize-positions: 5.1.1(postcss@8.5.6)
+      postcss-normalize-repeat-style: 5.1.1(postcss@8.5.6)
+      postcss-normalize-string: 5.1.0(postcss@8.5.6)
+      postcss-normalize-timing-functions: 5.1.0(postcss@8.5.6)
+      postcss-normalize-unicode: 5.1.1(postcss@8.5.6)
+      postcss-normalize-url: 5.1.0(postcss@8.5.6)
+      postcss-normalize-whitespace: 5.1.1(postcss@8.5.6)
+      postcss-ordered-values: 5.1.3(postcss@8.5.6)
+      postcss-reduce-initial: 5.1.2(postcss@8.5.6)
+      postcss-reduce-transforms: 5.1.0(postcss@8.5.6)
+      postcss-svgo: 5.1.0(postcss@8.5.6)
+      postcss-unique-selectors: 5.1.1(postcss@8.5.6)
 
   cssnano-preset-default@6.0.1(postcss@8.5.6):
     dependencies:
@@ -25978,19 +26146,19 @@ snapshots:
       postcss-svgo: 6.0.0(postcss@8.5.6)
       postcss-unique-selectors: 6.0.0(postcss@8.5.6)
 
-  cssnano-utils@3.1.0(postcss@8.4.39):
+  cssnano-utils@3.1.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
 
   cssnano-utils@4.0.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  cssnano@5.1.15(postcss@8.4.39):
+  cssnano@5.1.15(postcss@8.5.6):
     dependencies:
-      cssnano-preset-default: 5.2.14(postcss@8.4.39)
+      cssnano-preset-default: 5.2.14(postcss@8.5.6)
       lilconfig: 2.1.0
-      postcss: 8.4.39
+      postcss: 8.5.6
       yaml: 1.10.2
 
   cssnano@6.0.1(postcss@8.5.6):
@@ -26021,6 +26189,9 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.1.3: {}
+
+  csstype@3.2.3:
+    optional: true
 
   csv-parse@5.5.6: {}
 
@@ -26512,6 +26683,8 @@ snapshots:
 
   electron-to-chromium@1.5.190: {}
 
+  electron-to-chromium@1.5.267: {}
+
   emittery@0.13.1: {}
 
   emoji-regex@10.4.0: {}
@@ -26553,6 +26726,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.2
+
+  enhanced-resolve@5.18.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.0
 
   enquirer@2.3.6:
     dependencies:
@@ -27063,13 +27241,13 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.44.1(@typescript-eslint/parser@8.44.1(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3)(vitest@1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)):
+  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.44.1(@typescript-eslint/parser@8.44.1(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3)(vitest@1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)):
     dependencies:
       '@typescript-eslint/utils': 8.44.1(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3)
       eslint: 9.33.0(jiti@1.21.7)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.44.1(@typescript-eslint/parser@8.44.1(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.33.0(jiti@1.21.7))(typescript@5.8.3)
-      vitest: 1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)
+      vitest: 1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -27406,6 +27584,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.4
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.14.1
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.1.0:
     dependencies:
       accepts: 2.0.0
@@ -27622,6 +27836,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   finalhandler@2.1.0:
     dependencies:
       debug: 4.4.1
@@ -27751,15 +27977,15 @@ snapshots:
 
   flow-parser@0.277.1: {}
 
-  fluent-vue@3.6.0(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3)):
+  fluent-vue@3.6.0(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3)):
     dependencies:
       '@fluent/bundle': 0.17.1
       '@fluent/sequence': 0.8.0(@fluent/bundle@0.17.1)
       cached-iterable: 0.3.0
-      vue: 3.5.18(typescript@5.8.3)
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3))
+      vue: 3.5.21(typescript@5.8.3)
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
     optionalDependencies:
-      '@vue/composition-api': 1.7.2(vue@3.5.18(typescript@5.8.3))
+      '@vue/composition-api': 1.7.2(vue@3.5.21(typescript@5.8.3))
 
   fluent-vue@3.7.2(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16):
     dependencies:
@@ -27846,6 +28072,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fraction.js@4.3.7: {}
+
+  fraction.js@5.3.4: {}
 
   fragment-cache@0.2.1:
     dependencies:
@@ -28430,12 +28658,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gulp-postcss@9.0.1(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.2)(@types/node@24.3.1)(typescript@5.8.3)):
+  gulp-postcss@9.0.1(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.2)(@types/node@25.0.3)(typescript@5.8.3)):
     dependencies:
       fancy-log: 1.3.3
       plugin-error: 1.0.1
       postcss: 8.5.6
-      postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.2)(@types/node@24.3.1)(typescript@5.8.3))
+      postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.2)(@types/node@25.0.3)(typescript@5.8.3))
       vinyl-sourcemaps-apply: 0.2.1
     transitivePeerDependencies:
       - ts-node
@@ -28697,21 +28925,21 @@ snapshots:
       he: 1.2.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.43.1
+      terser: 5.44.1
 
   html-tags@3.3.1: {}
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.95.0(@swc/core@1.13.2)):
+  html-webpack-plugin@5.6.5(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
-      tapable: 2.2.2
+      tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.95.0(@swc/core@1.13.2)
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
 
   htmlparser2@10.0.0:
     dependencies:
@@ -28769,6 +28997,14 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   http-parser-js@0.5.10: {}
 
   http-proxy-agent@5.0.0:
@@ -28786,15 +29022,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.23)(debug@4.4.3):
+  http-proxy-middleware@2.0.9(@types/express@4.17.25)(debug@4.4.3):
     dependencies:
-      '@types/http-proxy': 1.17.16
+      '@types/http-proxy': 1.17.17
       http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
     optionalDependencies:
-      '@types/express': 4.17.23
+      '@types/express': 4.17.25
     transitivePeerDependencies:
       - debug
 
@@ -28881,9 +29117,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.4.39):
+  icss-utils@5.1.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
 
   ieee754@1.2.1: {}
 
@@ -29057,7 +29293,7 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  ipaddr.js@2.2.0: {}
+  ipaddr.js@2.3.0: {}
 
   is-absolute-url@3.0.3: {}
 
@@ -29906,7 +30142,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 25.0.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -30214,11 +30450,11 @@ snapshots:
     dependencies:
       package-json: 6.5.0
 
-  launch-editor-middleware@2.10.0:
+  launch-editor-middleware@2.12.0:
     dependencies:
-      launch-editor: 2.10.0
+      launch-editor: 2.12.0
 
-  launch-editor@2.10.0:
+  launch-editor@2.12.0:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.3
@@ -30358,7 +30594,7 @@ snapshots:
       pify: 3.0.0
       strip-bom: 3.0.0
 
-  loader-runner@4.3.0: {}
+  loader-runner@4.3.1: {}
 
   loader-utils@1.4.2:
     dependencies:
@@ -30853,7 +31089,7 @@ snapshots:
 
   mem-fs@4.0.0:
     dependencies:
-      '@types/node': 20.19.9
+      '@types/node': 20.19.27
       '@types/vinyl': 2.0.12
       vinyl: 3.0.1
       vinyl-file: 5.0.0
@@ -31180,11 +31416,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.2(webpack@5.95.0(@swc/core@1.13.2)):
+  mini-css-extract-plugin@2.9.4(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
-      schema-utils: 4.3.2
-      tapable: 2.2.2
-      webpack: 5.95.0(@swc/core@1.13.2)
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
 
   minimalistic-assert@1.0.1: {}
 
@@ -31373,7 +31609,7 @@ snapshots:
       yargs-parser: 20.2.4
       yargs-unparser: 2.0.0
 
-  mochapack@2.1.4(mocha@8.4.0)(webpack@5.95.0(@swc/core@1.13.2)):
+  mochapack@2.1.4(mocha@8.4.0)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
       '@babel/runtime-corejs2': 7.26.0
       chalk: 2.4.2
@@ -31392,7 +31628,7 @@ snapshots:
       progress: 2.0.3
       source-map-support: 0.5.21
       toposort: 2.0.2
-      webpack: 5.95.0(@swc/core@1.13.2)
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
       yargs: 14.0.0
 
   modify-values@1.0.1: {}
@@ -31519,7 +31755,7 @@ snapshots:
     optionalDependencies:
       encoding: 0.1.13
 
-  node-forge@1.3.1: {}
+  node-forge@1.3.3: {}
 
   node-gyp@10.3.1:
     dependencies:
@@ -31564,6 +31800,8 @@ snapshots:
   node-releases@2.0.13: {}
 
   node-releases@2.0.19: {}
+
+  node-releases@2.0.27: {}
 
   nodent-runtime@3.2.1: {}
 
@@ -32607,6 +32845,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  portfinder@1.0.38:
+    dependencies:
+      async: 3.2.6
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   posix-character-classes@0.1.1: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -32615,9 +32860,9 @@ snapshots:
     dependencies:
       postcss-value-parser: 3.3.1
 
-  postcss-calc@8.2.4(postcss@8.4.39):
+  postcss-calc@8.2.4(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
@@ -32646,12 +32891,12 @@ snapshots:
       - jiti
       - tsx
 
-  postcss-colormin@5.3.1(postcss@8.4.39):
+  postcss-colormin@5.3.1(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.1
+      browserslist: 4.28.1
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-colormin@6.0.0(postcss@8.5.6):
@@ -32662,10 +32907,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@5.1.3(postcss@8.4.39):
+  postcss-convert-values@5.1.3(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.1
-      postcss: 8.4.39
+      browserslist: 4.28.1
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-convert-values@6.0.0(postcss@8.5.6):
@@ -32674,33 +32919,33 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-discard-comments@5.1.2(postcss@8.4.39):
+  postcss-discard-comments@5.1.2(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
 
   postcss-discard-comments@6.0.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-discard-duplicates@5.1.0(postcss@8.4.39):
+  postcss-discard-duplicates@5.1.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
 
   postcss-discard-duplicates@6.0.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-discard-empty@5.1.1(postcss@8.4.39):
+  postcss-discard-empty@5.1.1(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
 
   postcss-discard-empty@6.0.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-discard-overridden@5.1.0(postcss@8.4.39):
+  postcss-discard-overridden@5.1.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
 
   postcss-discard-overridden@6.0.0(postcss@8.5.6):
     dependencies:
@@ -32710,13 +32955,13 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.2)(@types/node@24.3.1)(typescript@5.8.3)):
+  postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.13.2)(@types/node@25.0.3)(typescript@5.8.3)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.5.6
-      ts-node: 10.9.2(@swc/core@1.13.2)(@types/node@24.3.1)(typescript@5.8.3)
+      ts-node: 10.9.2(@swc/core@1.13.2)(@types/node@25.0.3)(typescript@5.8.3)
 
   postcss-load-config@5.1.0(jiti@1.21.7)(postcss@8.4.39)(tsx@4.19.0):
     dependencies:
@@ -32736,19 +32981,19 @@ snapshots:
       tsx: 4.19.0
       yaml: 2.8.0
 
-  postcss-loader@6.2.1(postcss@8.4.39)(webpack@5.95.0(@swc/core@1.13.2)):
+  postcss-loader@6.2.1(postcss@8.5.6)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
-      postcss: 8.4.39
-      semver: 7.7.2
-      webpack: 5.95.0(@swc/core@1.13.2)
+      postcss: 8.5.6
+      semver: 7.7.3
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
 
-  postcss-merge-longhand@5.1.7(postcss@8.4.39):
+  postcss-merge-longhand@5.1.7(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
-      stylehacks: 5.1.1(postcss@8.4.39)
+      stylehacks: 5.1.1(postcss@8.5.6)
 
   postcss-merge-longhand@6.0.0(postcss@8.5.6):
     dependencies:
@@ -32756,12 +33001,12 @@ snapshots:
       postcss-value-parser: 4.2.0
       stylehacks: 6.0.0(postcss@8.5.6)
 
-  postcss-merge-rules@5.1.4(postcss@8.4.39):
+  postcss-merge-rules@5.1.4(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.1
+      browserslist: 4.28.1
       caniuse-api: 3.0.0
-      cssnano-utils: 3.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      cssnano-utils: 3.1.0(postcss@8.5.6)
+      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
   postcss-merge-rules@6.0.1(postcss@8.5.6):
@@ -32772,9 +33017,9 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  postcss-minify-font-values@5.1.0(postcss@8.4.39):
+  postcss-minify-font-values@5.1.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-minify-font-values@6.0.0(postcss@8.5.6):
@@ -32782,11 +33027,11 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@5.1.1(postcss@8.4.39):
+  postcss-minify-gradients@5.1.1(postcss@8.5.6):
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 3.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      cssnano-utils: 3.1.0(postcss@8.5.6)
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-minify-gradients@6.0.0(postcss@8.5.6):
@@ -32796,11 +33041,11 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@5.1.4(postcss@8.4.39):
+  postcss-minify-params@5.1.4(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.1
-      cssnano-utils: 3.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      browserslist: 4.28.1
+      cssnano-utils: 3.1.0(postcss@8.5.6)
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-minify-params@6.0.0(postcss@8.5.6):
@@ -32810,9 +33055,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@5.2.1(postcss@8.4.39):
+  postcss-minify-selectors@5.2.1(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
   postcss-minify-selectors@6.0.0(postcss@8.5.6):
@@ -32820,38 +33065,38 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.4.39):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.4.39):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.6):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
-      postcss-selector-parser: 7.1.0
+      icss-utils: 5.1.0(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.4.39):
+  postcss-modules-scope@3.2.1(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 7.1.0
+      postcss: 8.5.6
+      postcss-selector-parser: 7.1.1
 
-  postcss-modules-values@4.0.0(postcss@8.4.39):
+  postcss-modules-values@4.0.0(postcss@8.5.6):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      icss-utils: 5.1.0(postcss@8.5.6)
+      postcss: 8.5.6
 
-  postcss-normalize-charset@5.1.0(postcss@8.4.39):
+  postcss-normalize-charset@5.1.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
 
   postcss-normalize-charset@6.0.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
-  postcss-normalize-display-values@5.1.0(postcss@8.4.39):
+  postcss-normalize-display-values@5.1.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-display-values@6.0.0(postcss@8.5.6):
@@ -32859,9 +33104,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@5.1.1(postcss@8.4.39):
+  postcss-normalize-positions@5.1.1(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-positions@6.0.0(postcss@8.5.6):
@@ -32869,9 +33114,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@5.1.1(postcss@8.4.39):
+  postcss-normalize-repeat-style@5.1.1(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-repeat-style@6.0.0(postcss@8.5.6):
@@ -32879,9 +33124,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@5.1.0(postcss@8.4.39):
+  postcss-normalize-string@5.1.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-string@6.0.0(postcss@8.5.6):
@@ -32889,9 +33134,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@5.1.0(postcss@8.4.39):
+  postcss-normalize-timing-functions@5.1.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-timing-functions@6.0.0(postcss@8.5.6):
@@ -32899,10 +33144,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@5.1.1(postcss@8.4.39):
+  postcss-normalize-unicode@5.1.1(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.1
-      postcss: 8.4.39
+      browserslist: 4.28.1
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@6.0.0(postcss@8.5.6):
@@ -32911,10 +33156,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@5.1.0(postcss@8.4.39):
+  postcss-normalize-url@5.1.0(postcss@8.5.6):
     dependencies:
       normalize-url: 6.1.0
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-url@6.0.0(postcss@8.5.6):
@@ -32922,9 +33167,9 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@5.1.1(postcss@8.4.39):
+  postcss-normalize-whitespace@5.1.1(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-whitespace@6.0.0(postcss@8.5.6):
@@ -32932,10 +33177,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-ordered-values@5.1.3(postcss@8.4.39):
+  postcss-ordered-values@5.1.3(postcss@8.5.6):
     dependencies:
-      cssnano-utils: 3.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      cssnano-utils: 3.1.0(postcss@8.5.6)
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-ordered-values@6.0.0(postcss@8.5.6):
@@ -32944,11 +33189,11 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-initial@5.1.2(postcss@8.4.39):
+  postcss-reduce-initial@5.1.2(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.1
+      browserslist: 4.28.1
       caniuse-api: 3.0.0
-      postcss: 8.4.39
+      postcss: 8.5.6
 
   postcss-reduce-initial@6.0.0(postcss@8.5.6):
     dependencies:
@@ -32956,9 +33201,9 @@ snapshots:
       caniuse-api: 3.0.0
       postcss: 8.5.6
 
-  postcss-reduce-transforms@5.1.0(postcss@8.4.39):
+  postcss-reduce-transforms@5.1.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-reduce-transforms@6.0.0(postcss@8.5.6):
@@ -32988,14 +33233,19 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
+  postcss-selector-parser@7.1.1:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss-sorting@4.1.0:
     dependencies:
       lodash: 4.17.21
       postcss: 7.0.39
 
-  postcss-svgo@5.1.0(postcss@8.4.39):
+  postcss-svgo@5.1.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
       svgo: 2.8.0
 
@@ -33005,9 +33255,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 3.0.2
 
-  postcss-unique-selectors@5.1.1(postcss@8.4.39):
+  postcss-unique-selectors@5.1.1(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
   postcss-unique-selectors@6.0.0(postcss@8.5.6):
@@ -33100,12 +33350,12 @@ snapshots:
 
   proggy@2.0.0: {}
 
-  progress-webpack-plugin@1.0.16(webpack@5.95.0(@swc/core@1.13.2)):
+  progress-webpack-plugin@1.0.16(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
       chalk: 2.4.2
       figures: 2.0.0
       log-update: 2.3.0
-      webpack: 5.95.0(@swc/core@1.13.2)
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
 
   progress@2.0.3: {}
 
@@ -33389,6 +33639,10 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.14.1:
+    dependencies:
+      side-channel: 1.1.0
+
   quansync@0.2.10: {}
 
   querystringify@2.2.0: {}
@@ -33421,6 +33675,13 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
@@ -34081,7 +34342,7 @@ snapshots:
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
 
-  schema-utils@4.3.2:
+  schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
       ajv: 8.17.1
@@ -34099,8 +34360,8 @@ snapshots:
 
   selfsigned@2.4.1:
     dependencies:
-      '@types/node-forge': 1.3.13
-      node-forge: 1.3.1
+      '@types/node-forge': 1.3.14
+      node-forge: 1.3.3
 
   semantic-release-plus@20.0.0(encoding@0.1.13)(semantic-release@21.1.2(typescript@5.8.3)):
     dependencies:
@@ -34205,6 +34466,8 @@ snapshots:
 
   semver@7.7.2: {}
 
+  semver@7.7.3: {}
+
   send@0.19.0:
     dependencies:
       debug: 2.6.9
@@ -34220,6 +34483,24 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -34289,6 +34570,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -34696,6 +34986,8 @@ snapshots:
 
   statuses@2.0.1: {}
 
+  statuses@2.0.2: {}
+
   std-env@3.9.0: {}
 
   stdin-discarder@0.2.2: {}
@@ -34931,10 +35223,10 @@ snapshots:
       path-unified: 0.1.0
       tinycolor2: 1.6.0
 
-  stylehacks@5.1.1(postcss@8.4.39):
+  stylehacks@5.1.1(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.1
-      postcss: 8.4.39
+      browserslist: 4.28.1
+      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
   stylehacks@6.0.0(postcss@8.5.6):
@@ -35046,11 +35338,6 @@ snapshots:
       is-docker: 1.1.0
       is-root: 1.0.0
 
-  sugarss@5.0.1(postcss@8.4.39):
-    dependencies:
-      postcss: 8.4.39
-    optional: true
-
   sugarss@5.0.1(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -35150,6 +35437,8 @@ snapshots:
 
   tapable@2.2.2: {}
 
+  tapable@2.3.0: {}
+
   tar-fs@3.1.1:
     dependencies:
       pump: 3.0.3
@@ -35223,33 +35512,21 @@ snapshots:
       type-fest: 2.19.0
       unique-string: 3.0.0
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.13.2)(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
+  terser-webpack-plugin@5.3.16(@swc/core@1.13.2)(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
-      schema-utils: 4.3.2
+      schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      terser: 5.43.1
+      terser: 5.44.1
       webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
     optionalDependencies:
       '@swc/core': 1.13.2
       esbuild: 0.18.20
-    optional: true
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.13.2)(webpack@5.95.0(@swc/core@1.13.2)):
+  terser@5.44.1:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
-      jest-worker: 27.5.1
-      schema-utils: 4.3.2
-      serialize-javascript: 6.0.2
-      terser: 5.43.1
-      webpack: 5.95.0(@swc/core@1.13.2)
-    optionalDependencies:
-      '@swc/core': 1.13.2
-
-  terser@5.43.1:
-    dependencies:
-      '@jridgewell/source-map': 0.3.10
+      '@jridgewell/source-map': 0.3.11
       acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
@@ -35292,14 +35569,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  thread-loader@3.0.4(webpack@5.95.0(@swc/core@1.13.2)):
+  thread-loader@3.0.4(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
       json-parse-better-errors: 1.0.2
-      loader-runner: 4.3.0
+      loader-runner: 4.3.1
       loader-utils: 2.0.4
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      webpack: 5.95.0(@swc/core@1.13.2)
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
 
   through2-filter@3.0.0:
     dependencies:
@@ -35501,6 +35778,27 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.13.2
+
+  ts-node@10.9.2(@swc/core@1.13.2)(@types/node@25.0.3)(typescript@5.8.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.0.3
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.13.2
+    optional: true
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -35706,6 +36004,8 @@ snapshots:
 
   undici-types@7.10.0: {}
 
+  undici-types@7.16.0: {}
+
   undici@6.20.1: {}
 
   undici@7.16.0: {}
@@ -35848,6 +36148,12 @@ snapshots:
   update-browserslist-db@1.1.3(browserslist@4.25.1):
     dependencies:
       browserslist: 4.25.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  update-browserslist-db@1.2.3(browserslist@4.28.1):
+    dependencies:
+      browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -36086,13 +36392,13 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-node@1.6.1(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1):
+  vite-node@1.6.1(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -36104,7 +36410,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@4.5.4(@types/node@20.19.9)(rollup@4.45.1)(typescript@5.8.3)(vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)):
+  vite-plugin-dts@4.5.4(@types/node@20.19.9)(rollup@4.45.1)(typescript@5.8.3)(vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)):
     dependencies:
       '@microsoft/api-extractor': 7.52.9(@types/node@20.19.9)
       '@rollup/pluginutils': 5.2.0(rollup@4.45.1)
@@ -36117,7 +36423,7 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.8.3
     optionalDependencies:
-      vite: 5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -36128,7 +36434,7 @@ snapshots:
       svgo: 3.0.2
       vue: 3.5.21(typescript@5.8.3)
 
-  vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1):
+  vite@5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -36138,9 +36444,9 @@ snapshots:
       fsevents: 2.3.3
       less: 4.2.0
       sugarss: 5.0.1(postcss@8.5.6)
-      terser: 5.43.1
+      terser: 5.44.1
 
-  vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0):
+  vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -36149,34 +36455,16 @@ snapshots:
       rollup: 4.45.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 24.3.1
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      less: 4.2.0
-      sugarss: 5.0.1(postcss@8.4.39)
-      terser: 5.43.1
-      tsx: 4.19.0
-      yaml: 2.8.0
-
-  vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0):
-    dependencies:
-      esbuild: 0.25.10
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.45.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.3.1
+      '@types/node': 25.0.3
       fsevents: 2.3.3
       jiti: 1.21.7
       less: 4.2.0
       sugarss: 5.0.1(postcss@8.5.6)
-      terser: 5.43.1
+      terser: 5.44.1
       tsx: 4.19.0
       yaml: 2.8.0
 
-  vitest@1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1):
+  vitest@1.6.1(@types/node@20.19.9)(jsdom@24.1.3)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -36195,8 +36483,8 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)
-      vite-node: 1.6.1(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)
+      vite-node: 1.6.1(@types/node@20.19.9)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.9
@@ -36296,12 +36584,6 @@ snapshots:
     optionalDependencies:
       '@vue/composition-api': 1.7.2(vue@3.4.15(typescript@5.8.3))
 
-  vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3)):
-    dependencies:
-      vue: 3.5.18(typescript@5.8.3)
-    optionalDependencies:
-      '@vue/composition-api': 1.7.2(vue@3.5.18(typescript@5.8.3))
-
   vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3)):
     dependencies:
       vue: 3.5.21(typescript@5.8.3)
@@ -36340,7 +36622,7 @@ snapshots:
       vue: 3.4.15(typescript@5.8.3)
       vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.4.15(typescript@5.8.3))
 
-  vue-docgen-api@4.79.2(vue@3.5.18(typescript@5.8.3)):
+  vue-docgen-api@4.79.2(vue@3.5.21(typescript@5.8.3)):
     dependencies:
       '@babel/parser': 7.28.0
       '@babel/types': 7.28.2
@@ -36353,8 +36635,8 @@ snapshots:
       pug: 3.0.3
       recast: 0.23.11
       ts-map: 1.0.3
-      vue: 3.5.18(typescript@5.8.3)
-      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.18(typescript@5.8.3))
+      vue: 3.5.21(typescript@5.8.3)
+      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.21(typescript@5.8.3))
 
   vue-eslint-parser@10.2.0(eslint@9.33.0(jiti@1.21.7)):
     dependencies:
@@ -36391,19 +36673,19 @@ snapshots:
     dependencies:
       vue: 3.4.15(typescript@5.8.3)
 
-  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.5.18(typescript@5.8.3)):
+  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.5.21(typescript@5.8.3)):
     dependencies:
-      vue: 3.5.18(typescript@5.8.3)
+      vue: 3.5.21(typescript@5.8.3)
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.5.21)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(webpack@5.95.0(@swc/core@1.13.2)):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.5.21)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(prettier@3.3.2)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)(vue-template-compiler@2.7.16(vue@3.4.15(typescript@5.8.3)))(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(nunjucks@3.2.4(chokidar@3.6.0))(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(twig@1.17.1)(underscore@1.13.7)
-      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.13.2))
+      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4
       vue-style-loader: 4.1.3
-      webpack: 5.95.0(@swc/core@1.13.2)
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.21
       prettier: 3.3.2
@@ -36463,12 +36745,12 @@ snapshots:
       - walrus
       - whiskers
 
-  vue-loader@17.4.2(@vue/compiler-sfc@3.5.21)(vue@3.4.15(typescript@5.8.3))(webpack@5.95.0(@swc/core@1.13.2)):
+  vue-loader@17.4.2(@vue/compiler-sfc@3.5.21)(vue@3.4.15(typescript@5.8.3))(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
-      watchpack: 2.4.4
-      webpack: 5.95.0(@swc/core@1.13.2)
+      watchpack: 2.5.0
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.21
       vue: 3.4.15(typescript@5.8.3)
@@ -36496,11 +36778,11 @@ snapshots:
       vue: 3.4.15(typescript@5.8.3)
     optional: true
 
-  vue-template-compiler@2.7.16(vue@3.5.18(typescript@5.8.3)):
+  vue-template-compiler@2.7.16(vue@3.5.21(typescript@5.8.3)):
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
-      vue: 3.5.18(typescript@5.8.3)
+      vue: 3.5.21(typescript@5.8.3)
 
   vue-template-es2015-compiler@1.9.1: {}
 
@@ -36523,16 +36805,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  vue@3.5.18(typescript@5.8.3):
-    dependencies:
-      '@vue/compiler-dom': 3.5.18
-      '@vue/compiler-sfc': 3.5.18
-      '@vue/runtime-dom': 3.5.18
-      '@vue/server-renderer': 3.5.18(vue@3.5.18(typescript@5.8.3))
-      '@vue/shared': 3.5.18
-    optionalDependencies:
-      typescript: 5.8.3
-
   vue@3.5.21(typescript@5.8.3):
     dependencies:
       '@vue/compiler-dom': 3.5.21
@@ -36543,16 +36815,16 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  vuepress-plugin-sitemap2@2.0.0-rc.16(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))):
+  vuepress-plugin-sitemap2@2.0.0-rc.16(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))):
     dependencies:
       sitemap: 7.1.1
-      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
-      vuepress-shared: 2.0.0-rc.16(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
+      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
+      vuepress-shared: 2.0.0-rc.16(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
 
-  vuepress-shared@2.0.0-rc.16(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))):
+  vuepress-shared@2.0.0-rc.16(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(typescript@5.8.3)(vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))):
     dependencies:
       '@vueuse/core': 10.11.1(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
       cheerio: 1.0.0-rc.12
@@ -36564,12 +36836,12 @@ snapshots:
       striptags: 3.2.0
       vue: 3.5.21(typescript@5.8.3)
       vue-router: 4.5.1(vue@3.5.21(typescript@5.8.3))
-      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
+      vuepress: 2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
 
-  vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)):
+  vuepress@2.0.0-rc.24(@vuepress/bundler-vite@2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0))(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)):
     dependencies:
       '@vuepress/cli': 2.0.0-rc.24(typescript@5.8.3)
       '@vuepress/client': 2.0.0-rc.24(typescript@5.8.3)
@@ -36579,7 +36851,7 @@ snapshots:
       '@vuepress/utils': 2.0.0-rc.24
       vue: 3.5.21(typescript@5.8.3)
     optionalDependencies:
-      '@vuepress/bundler-vite': 2.0.0-rc.24(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.43.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0)
+      '@vuepress/bundler-vite': 2.0.0-rc.24(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.1)(tsx@4.19.0)(typescript@5.8.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -36631,6 +36903,11 @@ snapshots:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
+  watchpack@2.5.0:
+    dependencies:
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+
   wbuf@1.7.3:
     dependencies:
       minimalistic-assert: 1.0.1
@@ -36668,22 +36945,22 @@ snapshots:
       deepmerge: 1.5.2
       javascript-stringify: 2.1.0
 
-  webpack-dev-middleware@5.3.4(webpack@5.95.0(@swc/core@1.13.2)):
+  webpack-dev-middleware@5.3.4(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
-      schema-utils: 4.3.2
-      webpack: 5.95.0(@swc/core@1.13.2)
+      schema-utils: 4.3.3
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
 
-  webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.95.0(@swc/core@1.13.2)):
+  webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.23
+      '@types/express': 4.17.25
       '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.8
+      '@types/serve-static': 1.15.10
       '@types/sockjs': 0.3.36
       '@types/ws': 8.18.1
       ansi-html-community: 0.0.8
@@ -36693,24 +36970,24 @@ snapshots:
       compression: 1.8.1
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.21.2
+      express: 4.22.1
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.23)(debug@4.4.3)
-      ipaddr.js: 2.2.0
-      launch-editor: 2.10.0
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3)
+      ipaddr.js: 2.3.0
+      launch-editor: 2.12.0
       open: 8.4.2
       p-retry: 4.6.2
       rimraf: 3.0.2
-      schema-utils: 4.3.2
+      schema-utils: 4.3.3
       selfsigned: 2.4.1
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.95.0(@swc/core@1.13.2))
-      ws: 8.18.3
+      webpack-dev-middleware: 5.3.4(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
+      ws: 8.19.0
     optionalDependencies:
-      webpack: 5.95.0(@swc/core@1.13.2)
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -36729,36 +37006,6 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.95.0(@swc/core@1.13.2):
-    dependencies:
-      '@types/estree': 1.0.8
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-attributes: 1.9.5(acorn@8.15.0)
-      browserslist: 4.25.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.18.2
-      es-module-lexer: 1.7.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(@swc/core@1.13.2)(webpack@5.95.0(@swc/core@1.13.2))
-      watchpack: 2.4.4
-      webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
   webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20):
     dependencies:
       '@types/estree': 1.0.8
@@ -36767,28 +37014,27 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
-      browserslist: 4.25.1
+      browserslist: 4.28.1
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.18.2
+      enhanced-resolve: 5.18.4
       es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
+      loader-runner: 4.3.1
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(@swc/core@1.13.2)(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
-      watchpack: 2.4.4
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(@swc/core@1.13.2)(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
+      watchpack: 2.5.0
       webpack-sources: 3.3.3
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
       - uglify-js
-    optional: true
 
   websocket-driver@0.7.4:
     dependencies:
@@ -37005,6 +37251,8 @@ snapshots:
   ws@7.5.10: {}
 
   ws@8.18.3: {}
+
+  ws@8.19.0: {}
 
   wsl-utils@0.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -707,8 +707,8 @@ importers:
         specifier: workspace:*
         version: link:../dialtone-icons
       '@dialpad/i18n-vue2':
-        specifier: 1.2.0
-        version: 1.2.0(vue@2.7.16)
+        specifier: 1.7.0
+        version: 1.7.0(@fluent/bundle@0.17.1)(vue@2.7.16)
       '@linusborg/vue-simple-portal':
         specifier: 0.1.5
         version: 0.1.5(vue@2.7.16)
@@ -841,10 +841,10 @@ importers:
         version: 7.6.20(react@18.3.1)
       '@storybook/vue':
         specifier: 7.6.20
-        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(vue@2.7.16)
+        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(vue@2.7.16)
       '@storybook/vue-vite':
         specifier: 7.6.20
-        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)
+        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)
       '@vue/test-utils':
         specifier: '1.3'
         version: 1.3.6(vue-template-compiler@2.7.16(vue@2.7.16))(vue@2.7.16)
@@ -867,8 +867,8 @@ importers:
         specifier: workspace:*
         version: link:../dialtone-icons
       '@dialpad/i18n':
-        specifier: 1.20.1
-        version: 1.20.1(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
+        specifier: 1.22.0
+        version: 1.22.0(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
       '@tiptap/core':
         specifier: 2.12.0
         version: 2.12.0(@tiptap/pm@2.12.0)
@@ -1900,6 +1900,16 @@ packages:
     resolution: {integrity: sha512-TLsyNwTUmGK6TtvdoC4SE/13Ae501pdzhSIyOV9V3HOVf8YrVTOgLUJ/l97kZSxcTOeRbFeRjbWfH7W3ixn36g==, tarball: https://npm.pkg.github.com/download/@dialpad/conventional-changelog-angular/1.1.1/1c54240f941b2d02d73e4ca2d4e53420d128bbf6}
     engines: {node: '>=10'}
 
+  '@dialpad/i18n-services@1.11.0':
+    resolution: {integrity: sha512-NzGie5sIbfW/AyJwtIRZOumhAiXP6329VNBOrVerXgGrXqbTacTAuXPPVSgprFol5kWdbV34QtAlKN5OY11WEw==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-services/1.11.0/20198484967555617ab62da6ad3c276265ee232d}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': '*'
+      vue: ^2.0.0 || >=3.0.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
   '@dialpad/i18n-services@1.5.0':
     resolution: {integrity: sha512-roHr0G1+C/3VeDureM5NRqK1rgt2xdF/MK1bT8khEYWW8KwQ3BuPpbvS3sz/V0kOqzQKzPaGX0ePYXpNnddzmw==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-services/1.5.0/410424f9243242ab8ebfe80116c2ddc3df54ddb6}
     hasBin: true
@@ -1917,13 +1927,18 @@ packages:
       '@vue/composition-api':
         optional: true
 
-  '@dialpad/i18n-vue2@1.2.0':
-    resolution: {integrity: sha512-VwETc0b8IYGWuOnYq5Y+w3LjQkc1rpcXODykQuYc4YRv9CRfm/BdD3NL+JA5DKXUX0i27yUw5+XQWwixS6wkIQ==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-vue2/1.2.0/e5c047c76d946359be73eabb30578324f91e7318}
+  '@dialpad/i18n-vue2@1.7.0':
+    resolution: {integrity: sha512-wADj7VcQEPkiuHGPANPFu3GwPXu839Qz5OUUw/FcVUsoErfuqp0Er4mE8onBjBMBM0wlPt6Be//pXjpXN+gEhA==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-vue2/1.7.0/793f0da9ed6f0f3a1f5977cb391f1417911e07ab}
     peerDependencies:
       vue: 2.6.14
 
   '@dialpad/i18n@1.20.1':
     resolution: {integrity: sha512-QBA3hEDvnurtKEG0BvVxpnjKNdfuZVfSBeta0+9MFgQSglGs0FVt/7MMrIXo7Znzj3HPgWwpcrGtvgLhhh95dw==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n/1.20.1/6a1d5416005078640950525452ff7d147044019d}
+    peerDependencies:
+      vue: ^3.0.0
+
+  '@dialpad/i18n@1.22.0':
+    resolution: {integrity: sha512-GPhp6I6sKPfXkwKghkjuFZvZrvpYNM14hK0YD8O0ZNF+LAm6CeeNe6v8O6Fpv0rKMIEAjz7aeMKXVvHHrJZI8Q==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n/1.22.0/607c7720cc3a3c3f9e558780f333ed6fd9c08597}
     peerDependencies:
       vue: ^3.0.0
 
@@ -16614,8 +16629,8 @@ packages:
   vue-component-type-helpers@1.8.24:
     resolution: {integrity: sha512-lqWs/7fdRXoSBAlbouHBX+LNuaY6gI9xWW34m/ZIz9zVPYHEyw0b2/zaCBwlKx0NtKTeF/6pOpvrxVkh7nhIYg==}
 
-  vue-component-type-helpers@3.1.5:
-    resolution: {integrity: sha512-7V3yJuNWW7/1jxCcI1CswnpDsvs02Qcx/N43LkV+ZqhLj2PKj50slUflHAroNkN4UWiYfzMUUUXiNuv9khmSpQ==}
+  vue-component-type-helpers@3.2.2:
+    resolution: {integrity: sha512-x8C2nx5XlUNM0WirgfTkHjJGO/ABBxlANZDtHw2HclHtQnn+RFPTnbjMJn8jHZW4TlUam0asHcA14lf1C6Jb+A==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -18294,15 +18309,27 @@ snapshots:
       compare-func: 2.0.0
       q: 1.5.1
 
-  '@dialpad/i18n-services@1.5.0(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)':
+  '@dialpad/i18n-services@1.11.0(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)':
     dependencies:
       '@fluent/bundle': 0.17.1
       '@fluent/syntax': 0.19.0
-      '@vue/composition-api': 1.7.2(vue@2.7.16)
       csv-parse: 5.5.6
-      fluent-vue: 3.6.0(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
+      fluent-vue: 3.7.2(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
       vue: 2.7.16
       vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
+    optionalDependencies:
+      '@vue/composition-api': 1.7.2(vue@2.7.16)
+
+  '@dialpad/i18n-services@1.11.0(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))':
+    dependencies:
+      '@fluent/bundle': 0.17.1
+      '@fluent/syntax': 0.19.0
+      csv-parse: 5.5.6
+      fluent-vue: 3.7.2(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
+      vue: 3.4.15(typescript@5.8.3)
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
+    optionalDependencies:
+      '@vue/composition-api': 1.7.2(vue@3.4.15(typescript@5.8.3))
 
   '@dialpad/i18n-services@1.5.0(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3))':
     dependencies:
@@ -18313,17 +18340,6 @@ snapshots:
       fluent-vue: 3.6.0(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3))
       vue: 3.5.18(typescript@5.8.3)
       vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3))
-
-  '@dialpad/i18n-services@1.9.0(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))':
-    dependencies:
-      '@fluent/bundle': 0.17.1
-      '@fluent/syntax': 0.19.0
-      csv-parse: 5.5.6
-      fluent-vue: 3.7.2(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
-      vue: 3.4.15(typescript@5.8.3)
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
-    optionalDependencies:
-      '@vue/composition-api': 1.7.2(vue@3.4.15(typescript@5.8.3))
 
   '@dialpad/i18n-services@1.9.0(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))':
     dependencies:
@@ -18336,23 +18352,26 @@ snapshots:
     optionalDependencies:
       '@vue/composition-api': 1.7.2(vue@3.5.21(typescript@5.8.3))
 
-  '@dialpad/i18n-vue2@1.2.0(vue@2.7.16)':
+  '@dialpad/i18n-vue2@1.7.0(@fluent/bundle@0.17.1)(vue@2.7.16)':
     dependencies:
-      '@dialpad/i18n-services': 1.5.0(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
+      '@dialpad/i18n-services': 1.11.0(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
       '@vue/composition-api': 1.7.2(vue@2.7.16)
+      fluent-vue: 3.7.2(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
       vue: 2.7.16
-
-  '@dialpad/i18n@1.20.1(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))':
-    dependencies:
-      '@dialpad/i18n-services': 1.9.0(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
-      vue: 3.4.15(typescript@5.8.3)
     transitivePeerDependencies:
-      - '@vue/composition-api'
+      - '@fluent/bundle'
 
   '@dialpad/i18n@1.20.1(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))':
     dependencies:
       '@dialpad/i18n-services': 1.9.0(@vue/composition-api@1.7.2(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
       vue: 3.5.21(typescript@5.8.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+
+  '@dialpad/i18n@1.22.0(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))':
+    dependencies:
+      '@dialpad/i18n-services': 1.11.0(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3))
+      vue: 3.4.15(typescript@5.8.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -22231,12 +22250,12 @@ snapshots:
       '@types/express': 4.17.23
       file-system-cache: 2.3.0
 
-  '@storybook/vue-vite@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)':
+  '@storybook/vue-vite@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)':
     dependencies:
       '@storybook/builder-vite': 7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0))
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/core-server': 7.6.20(encoding@0.1.13)
-      '@storybook/vue': 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(vue@2.7.16)
+      '@storybook/vue': 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(vue@2.7.16)
       magic-string: 0.30.19
       vite: 7.0.7(@types/node@24.3.1)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.43.1)(tsx@4.19.0)(yaml@2.8.0)
       vue: 2.7.16
@@ -22284,12 +22303,12 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.15(typescript@5.8.3)
-      vue-component-type-helpers: 3.1.5
+      vue-component-type-helpers: 3.2.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@storybook/vue@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(vue@2.7.16)':
+  '@storybook/vue@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(vue@2.7.16)':
     dependencies:
       '@babel/core': 7.28.0
       '@storybook/client-logger': 7.6.20
@@ -22298,7 +22317,7 @@ snapshots:
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.6.20
       '@storybook/types': 7.6.20
-      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.13.2))
+      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 2.7.16
@@ -25813,6 +25832,19 @@ snapshots:
 
   css-functions-list@3.2.3: {}
 
+  css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.4.39)
+      postcss: 8.4.39
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.39)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.4.39)
+      postcss-modules-scope: 3.2.1(postcss@8.4.39)
+      postcss-modules-values: 4.0.0(postcss@8.4.39)
+      postcss-value-parser: 4.2.0
+      semver: 7.7.2
+    optionalDependencies:
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
+
   css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.39)
@@ -27723,16 +27755,6 @@ snapshots:
 
   flow-parser@0.277.1: {}
 
-  fluent-vue@3.6.0(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16):
-    dependencies:
-      '@fluent/bundle': 0.17.1
-      '@fluent/sequence': 0.8.0(@fluent/bundle@0.17.1)
-      cached-iterable: 0.3.0
-      vue: 2.7.16
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
-    optionalDependencies:
-      '@vue/composition-api': 1.7.2(vue@2.7.16)
-
   fluent-vue@3.6.0(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3)):
     dependencies:
       '@fluent/bundle': 0.17.1
@@ -27742,6 +27764,17 @@ snapshots:
       vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3))
     optionalDependencies:
       '@vue/composition-api': 1.7.2(vue@3.5.18(typescript@5.8.3))
+
+  fluent-vue@3.7.2(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16):
+    dependencies:
+      '@fluent/bundle': 0.17.1
+      '@fluent/sequence': 0.8.0(@fluent/bundle@0.17.1)
+      '@vue/devtools-api': 7.7.7
+      cached-iterable: 0.3.0
+      vue: 2.7.16
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16)
+    optionalDependencies:
+      '@vue/composition-api': 1.7.2(vue@2.7.16)
 
   fluent-vue@3.7.2(@fluent/bundle@0.17.1)(@vue/composition-api@1.7.2(vue@3.4.15(typescript@5.8.3)))(vue@3.4.15(typescript@5.8.3)):
     dependencies:
@@ -35194,6 +35227,19 @@ snapshots:
       type-fest: 2.19.0
       unique-string: 3.0.0
 
+  terser-webpack-plugin@5.3.14(@swc/core@1.13.2)(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.29
+      jest-worker: 27.5.1
+      schema-utils: 4.3.2
+      serialize-javascript: 6.0.2
+      terser: 5.43.1
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
+    optionalDependencies:
+      '@swc/core': 1.13.2
+      esbuild: 0.18.20
+    optional: true
+
   terser-webpack-plugin@5.3.14(@swc/core@1.13.2)(webpack@5.95.0(@swc/core@1.13.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
@@ -36240,7 +36286,7 @@ snapshots:
 
   vue-component-type-helpers@1.8.24: {}
 
-  vue-component-type-helpers@3.1.5: {}
+  vue-component-type-helpers@3.2.2: {}
 
   vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@2.7.16))(vue@2.7.16):
     dependencies:
@@ -36716,6 +36762,37 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20):
+    dependencies:
+      '@types/estree': 1.0.8
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      browserslist: 4.25.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.18.2
+      es-module-lexer: 1.7.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.2
+      terser-webpack-plugin: 5.3.14(@swc/core@1.13.2)(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
+      watchpack: 2.4.4
+      webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    optional: true
 
   websocket-driver@0.7.4:
     dependencies:


### PR DESCRIPTION
- refactor DialtoneLocalization to allow i18n usage without needing to interact directly with app
- don't call useI18n outside of component init/setup, use a cached object for `.$t` et al. rather than calling `useI18N` for every access (useI18N should not be called in the render function)

corresponding changes on WCF side: https://github.com/dialpad/goblin-client-tools/pull/54