### PR TITLE
fix(mcp-server): DLT-2840 correct installation instructions and improve documentation

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,7 @@
 {
   "mcpServers": {
     "dialtone": {
-      "command": "node",
-      "args": [
-        "./packages/dialtone-mcp-server/build/index.js"
-      ]
+      "command": "dialtone-mcp-server"
     }
   }
 }

--- a/packages/dialtone-mcp-server/README.md
+++ b/packages/dialtone-mcp-server/README.md
@@ -2,6 +2,8 @@
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that provides AI assistants with search access to Dialtone's design system: utility classes, design tokens, Vue components, and icons.
 
+Automatically filters deprecated items, swaps discouraged patterns with recommended alternatives, and provides AI-optimized search results.
+
 ## Installation
 
 Install as a dev dependency in your project:
@@ -35,89 +37,6 @@ npm install -D @dialpad/dialtone-mcp-server@latest
 ```
 
 Then restart your Claude Code conversation to pick up the new version.
-
-## Development Setup
-
-For contributors working in the Dialtone monorepo:
-
-### 1. Build
-
-From the monorepo root:
-
-```bash
-pnpm install
-pnpm nx run dialtone-mcp-server:build
-```
-
-### 2. Test Interactively
-
-Try out search queries (must be run from the package directory):
-
-```bash
-# Navigate to the package directory first!
-cd packages/dialtone-mcp-server
-
-# Then run the interactive tool
-pnpm run interactive
-```
-
-Or use tsx directly from anywhere:
-```bash
-npx tsx packages/dialtone-mcp-server/interactive-search.ts
-```
-
-**Query Format:** Use keywords only, not questions.
-- ✓ Good: `padding 8px`, `color primary`, `button`
-- ✗ Bad: `how do I add padding?`, `what button component exists?`
-
-Example session:
-```
-Select a search tool:
-  1. Utility Classes
-  2. Design Tokens
-  3. Components
-
-Enter 1, 2, or 3: 1
-
-> padding 8px
-Found 8 results:
-  1. d-p8
-  2. d-pt8
-  3. d-pr8
-  4. d-pb8
-  ...
-```
-
-Type `help` for more examples, `switch` to change tools, `quit` to exit.
-
-### 3. Configure with Claude Desktop
-
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (MacOS) or `%APPDATA%/Claude/claude_desktop_config.json` (Windows):
-
-```json
-{
-  "mcpServers": {
-    "dialtone": {
-      "command": "node",
-      "args": [
-        "/ABSOLUTE/PATH/TO/dialtone/packages/dialtone-mcp-server/build/index.js"
-      ]
-    }
-  }
-}
-```
-
-**Important:**
-- Use the absolute path to your dialtone repo
-- Restart Claude Desktop completely after updating the config
-- Look for the 🔌 icon to confirm connection
-
-**Finding your absolute path:**
-```bash
-cd /path/to/dialtone
-pwd
-# Use the output + /packages/dialtone-mcp-server/build/index.js
-```
 
 ## What You Can Search
 
@@ -157,35 +76,55 @@ Find icons from Dialtone's icon library.
 - `profile` → user
 - `calendar` → calendar, calendar-plus, calendar-event
 
-## What Makes This Special
+## Troubleshooting
 
-- **Deprecated filtering**: Automatically removes deprecated items from results
-- **Discouraged swapping**: Replaces discouraged patterns with recommended alternatives
-- **Smart matching**: Understands compound properties (e.g., "padding 8px" finds d-p8, d-pt8, d-pr8, etc.)
-- **AI-optimized formatting**: Results designed for AI consumption
-- **Semantic search**: Finds related tokens/classes based on meaning
-- **Version checking**: Alerts when updates are available
+**Version check shows old version:**
+- Restart your Claude Code conversation after updating
+- The server loads once at conversation start
+
+**MCP server not connecting:**
+1. Verify `.mcp.json` is in your project root with correct format
+2. Check package is installed: `npm list @dialpad/dialtone-mcp-server`
+3. Restart Claude Code completely
+4. Check Claude Code logs for connection errors
+
+## Resources
+
+- [MCP Documentation](https://modelcontextprotocol.io)
+- [Dialtone Docs](https://dialtone.dialpad.com)
+
+---
 
 ## Development
 
-### Project Structure
+For contributors working in the Dialtone monorepo.
 
+### Build
+
+From the monorepo root:
+
+```bash
+pnpm install
+pnpm nx run dialtone-mcp-server:build
 ```
-packages/dialtone-mcp-server/
-├── src/
-│   ├── index.ts              # MCP server setup
-│   ├── types.ts              # TypeScript interfaces
-│   ├── data.ts               # Data imports
-│   ├── utils/filters.ts      # Smart filtering
-│   └── tools/                # Search implementations
-│       ├── utility-classes.ts
-│       ├── tokens.ts
-│       └── components.ts
-├── build/                    # Compiled output
-├── test-search.js           # Automated tests
-├── interactive-search.js    # Interactive CLI tool
-└── README.md
+
+### Test Interactively
+
+Try out search queries (must be run from the package directory):
+
+```bash
+cd packages/dialtone-mcp-server
+pnpm run interactive
 ```
+
+Or use tsx directly from anywhere:
+```bash
+npx tsx packages/dialtone-mcp-server/interactive-search.ts
+```
+
+**Query Format:** Use keywords only, not questions.
+- ✓ Good: `padding 8px`, `color primary`, `button`
+- ✗ Bad: `how do I add padding?`, `what button component exists?`
 
 ### Run Tests
 
@@ -202,31 +141,56 @@ node packages/dialtone-mcp-server/test-search.js
 
 Expected: `Overall Success Rate: 100%` (77/77 tests)
 
-### Rebuild After Changes
+### Configure with Claude Desktop (for testing)
 
-```bash
-pnpm nx run dialtone-mcp-server:build
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (MacOS) or `%APPDATA%/Claude/claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "dialtone": {
+      "command": "node",
+      "args": [
+        "/ABSOLUTE/PATH/TO/dialtone/packages/dialtone-mcp-server/build/index.js"
+      ]
+    }
+  }
+}
 ```
 
-## Troubleshooting
+**Important:**
+- Use the absolute path to your dialtone repo
+- Restart Claude Desktop completely after updating the config
+- Look for the 🔌 icon to confirm connection
 
-**Version check shows old version:**
-- Restart your Claude Code conversation after updating
-- The server loads once at conversation start
+**Finding your absolute path:**
+```bash
+cd /path/to/dialtone
+pwd
+# Use the output + /packages/dialtone-mcp-server/build/index.js
+```
 
-**MCP server not connecting:**
-1. Verify `.mcp.json` is in your project root with correct format
-2. Check package is installed: `npm list @dialpad/dialtone-mcp-server`
-3. Restart Claude Code completely
-4. Check Claude Code logs for connection errors
+### Project Structure
 
-**For monorepo development:**
-1. Verify `build/index.js` exists: `pnpm nx run dialtone-mcp-server:build`
-2. Check path in `.mcp.json` is absolute
-3. Test manually: `node build/index.js` (should print "Dialtone MCP Server running on stdio")
+```
+packages/dialtone-mcp-server/
+├── src/
+│   ├── index.ts              # MCP server setup
+│   ├── types.ts              # TypeScript interfaces
+│   ├── data.ts               # Data imports
+│   ├── utils/filters.ts      # Smart filtering
+│   └── tools/                # Search implementations
+│       ├── utility-classes.ts
+│       ├── tokens.ts
+│       ├── components.ts
+│       └── icons.ts
+├── build/                    # Compiled output
+├── test-search.js           # Automated tests
+├── interactive-search.ts    # Interactive CLI tool
+└── README.md
+```
 
-## Resources
+### Additional Documentation
 
-- [MCP Documentation](https://modelcontextprotocol.io)
-- [Dialtone Docs](https://dialtone.dialpad.com)
-- [Search Implementation Details](./SEARCH_REFERENCE.md)
+- [Search Implementation Details](./MCP_CONTEXT.md)
+- [Icon Search Summary](./ICON_SEARCH_SUMMARY.md)

--- a/packages/dialtone-mcp-server/README.md
+++ b/packages/dialtone-mcp-server/README.md
@@ -1,8 +1,44 @@
 # Dialtone MCP Server
 
-A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that provides AI assistants with search access to Dialtone's design system: utility classes, design tokens, and Vue components.
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that provides AI assistants with search access to Dialtone's design system: utility classes, design tokens, Vue components, and icons.
 
-## Quick Start
+## Installation
+
+Install as a dev dependency in your project:
+
+```bash
+npm install -D @dialpad/dialtone-mcp-server
+```
+
+Create or update `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "dialtone": {
+      "command": "dialtone-mcp-server"
+    }
+  }
+}
+```
+
+Restart Claude Code to connect to the server.
+
+**Checking your version:** When the server starts, you'll see the current version. If outdated, follow the instructions shown.
+
+## Updating
+
+Update the package:
+
+```bash
+npm install -D @dialpad/dialtone-mcp-server@latest
+```
+
+Then restart your Claude Code conversation to pick up the new version.
+
+## Development Setup
+
+For contributors working in the Dialtone monorepo:
 
 ### 1. Build
 
@@ -112,6 +148,24 @@ Discover Vue components with props, events, and slots.
 - `modal` → DtModal, DtBanner, DtDropdown (6 results)
 - `checkbox` → DtCheckbox, DtCheckboxGroup, DtRadio
 
+### 4. Icons (594 icons)
+Find icons from Dialtone's icon library.
+
+**Example queries:**
+- `notification` → bell, bell-ring, bell-off, bell-plus
+- `arrow up` → arrow-up, arrow-up-down, arrow-up-left
+- `profile` → user
+- `calendar` → calendar, calendar-plus, calendar-event
+
+## What Makes This Special
+
+- **Deprecated filtering**: Automatically removes deprecated items from results
+- **Discouraged swapping**: Replaces discouraged patterns with recommended alternatives
+- **Smart matching**: Understands compound properties (e.g., "padding 8px" finds d-p8, d-pt8, d-pr8, etc.)
+- **AI-optimized formatting**: Results designed for AI consumption
+- **Semantic search**: Finds related tokens/classes based on meaning
+- **Version checking**: Alerts when updates are available
+
 ## Development
 
 ### Project Structure
@@ -156,18 +210,20 @@ pnpm nx run dialtone-mcp-server:build
 
 ## Troubleshooting
 
-**MCP server not connecting:**
-1. Verify `build/index.js` exists
-2. Check the path in config is absolute (not relative)
-3. Restart Claude Desktop completely
-4. Check Claude Desktop logs for errors
+**Version check shows old version:**
+- Restart your Claude Code conversation after updating
+- The server loads once at conversation start
 
-**Test the server manually:**
-```bash
-node build/index.js
-# Should print: "Dialtone MCP Server running on stdio"
-# Press Ctrl+C to exit
-```
+**MCP server not connecting:**
+1. Verify `.mcp.json` is in your project root with correct format
+2. Check package is installed: `npm list @dialpad/dialtone-mcp-server`
+3. Restart Claude Code completely
+4. Check Claude Code logs for connection errors
+
+**For monorepo development:**
+1. Verify `build/index.js` exists: `pnpm nx run dialtone-mcp-server:build`
+2. Check path in `.mcp.json` is absolute
+3. Test manually: `node build/index.js` (should print "Dialtone MCP Server running on stdio")
 
 ## Resources
 

--- a/packages/dialtone-mcp-server/README.md
+++ b/packages/dialtone-mcp-server/README.md
@@ -6,7 +6,11 @@ Automatically filters deprecated items, swaps discouraged patterns with recommen
 
 ## Installation
 
-Install as a dev dependency in your project:
+There are three ways to install the Dialtone MCP Server. **Project-scoped installation takes priority** over user-scoped when both exist.
+
+### Project-Scoped (Recommended for Teams)
+
+Best for team collaboration - everyone uses the same version via version control.
 
 ```bash
 npm install -D @dialpad/dialtone-mcp-server
@@ -24,19 +28,69 @@ Create or update `.mcp.json` in your project root:
 }
 ```
 
-Restart Claude Code to connect to the server.
+Commit `.mcp.json` to version control. Restart Claude Code to connect.
 
-**Checking your version:** When the server starts, you'll see the current version. If outdated, follow the instructions shown.
+**Priority:** Project-scoped beats user-scoped. The `dialtone-mcp-server` command resolves from `node_modules/.bin/` first.
+
+### User-Scoped (Personal, All Projects)
+
+Available across all your projects. Choose one method:
+
+**Option A: Install locally in your user directory**
+
+```bash
+# Install in a dedicated directory
+mkdir -p ~/.mcp-servers
+cd ~/.mcp-servers
+npm install @dialpad/dialtone-mcp-server
+
+# Add to Claude Code
+claude mcp add dialtone --scope user dialtone-mcp-server
+```
+
+**Option B: Install globally**
+
+```bash
+npm install -g @dialpad/dialtone-mcp-server
+claude mcp add dialtone --scope user dialtone-mcp-server
+```
+
+**Option C: Use npx (no installation)**
+
+```bash
+claude mcp add dialtone --scope user -- npx -y @dialpad/dialtone-mcp-server
+```
+
+This stores configuration in `~/.claude/mcp.json`.
+
+**Version checking:** When the server starts, you'll see the current version. If outdated, follow the instructions shown.
 
 ## Updating
 
-Update the package:
+**Project-scoped:**
 
 ```bash
 npm install -D @dialpad/dialtone-mcp-server@latest
 ```
 
-Then restart your Claude Code conversation to pick up the new version.
+**User-scoped (local directory):**
+
+```bash
+cd ~/.mcp-servers
+npm update @dialpad/dialtone-mcp-server
+```
+
+**User-scoped (global):**
+
+```bash
+npm update -g @dialpad/dialtone-mcp-server
+```
+
+**User-scoped (npx):**
+
+No action needed - npx always uses the latest version.
+
+After updating, restart your Claude Code conversation to pick up the new version.
 
 ## What You Can Search
 
@@ -83,10 +137,22 @@ Find icons from Dialtone's icon library.
 - The server loads once at conversation start
 
 **MCP server not connecting:**
+
+For project-scoped:
 1. Verify `.mcp.json` is in your project root with correct format
 2. Check package is installed: `npm list @dialpad/dialtone-mcp-server`
-3. Restart Claude Code completely
-4. Check Claude Code logs for connection errors
+3. Verify bin command exists: `ls node_modules/.bin/dialtone-mcp-server`
+4. Restart Claude Code completely
+
+For user-scoped:
+1. List configured servers: `claude mcp list`
+2. Check if dialtone is listed and enabled
+3. Test the server: `claude mcp get dialtone`
+4. Check configuration: `cat ~/.claude/mcp.json`
+
+General:
+- Check Claude Code logs for connection errors
+- Remember: Project-scoped configuration overrides user-scoped
 
 ## Resources
 

--- a/packages/dialtone-mcp-server/package.json
+++ b/packages/dialtone-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dialpad/dialtone-mcp-server",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "main": "build/index.js",
   "type": "module",
   "bin": {

--- a/packages/dialtone-mcp-server/package.json
+++ b/packages/dialtone-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dialpad/dialtone-mcp-server",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "main": "build/index.js",
   "type": "module",
   "bin": {

--- a/packages/dialtone-mcp-server/package.json
+++ b/packages/dialtone-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dialpad/dialtone-mcp-server",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "main": "build/index.js",
   "type": "module",
   "bin": {

--- a/packages/dialtone-mcp-server/src/index.ts
+++ b/packages/dialtone-mcp-server/src/index.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import pkg from '../package.json' assert { type: 'json' };
 
 import { utilityClasses, tokens, components, clientRules } from './data.js';
 import { searchUtilityClasses, formatResults, buildCompoundPropertiesSet } from './tools/utility-classes.js';
@@ -22,8 +23,44 @@ import type {
   SearchResult
 } from './types.js';
 
+/**
+ * Check if a newer version of the package is available on npm
+ * Logs a warning with update instructions if outdated
+ * Fails silently if offline or registry unavailable
+ */
+async function checkVersion() {
+  try {
+    const packageName = pkg.name;
+    const currentVersion = pkg.version;
+
+    const response = await fetch(`https://registry.npmjs.org/${packageName}/latest`);
+    const data = await response.json();
+    const latestVersion = data.version;
+
+    if (currentVersion !== latestVersion) {
+      console.error('');
+      console.error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+      console.error('⚠️  Dialtone MCP Server Update Available');
+      console.error(`   Current: v${currentVersion}`);
+      console.error(`   Latest:  v${latestVersion}`);
+      console.error('');
+      console.error('   To update, run:');
+      console.error('   claude mcp remove dialtone');
+      console.error('   claude mcp add --scope user dialtone -- npx -y @dialpad/dialtone-mcp-server@latest');
+      console.error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+      console.error('');
+    } else {
+      console.error(`✓ Dialtone MCP Server v${currentVersion} (up to date)`);
+    }
+  } catch (error) {
+    // Fail silently if offline or registry unavailable
+    // This ensures the server still starts even without network access
+  }
+}
 
 async function main() {
+  // Check for updates on startup
+  await checkVersion();
   // Build compound properties set from utility classes data (done once at startup)
   const compoundProperties = buildCompoundPropertiesSet(utilityClasses);
   console.error(`[INIT] Built compound properties set: ${compoundProperties.size} properties`);

--- a/packages/dialtone-mcp-server/src/index.ts
+++ b/packages/dialtone-mcp-server/src/index.ts
@@ -44,9 +44,9 @@ async function checkVersion() {
       console.error(`   Current: v${currentVersion}`);
       console.error(`   Latest:  v${latestVersion}`);
       console.error('');
-      console.error('   To update, run:');
-      console.error('   claude mcp remove dialtone');
-      console.error('   claude mcp add --scope user dialtone -- npx -y @dialpad/dialtone-mcp-server@latest');
+      console.error('   To update:');
+      console.error('   1. npm install -D @dialpad/dialtone-mcp-server@latest');
+      console.error('   2. Restart this conversation');
       console.error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
       console.error('');
     } else {


### PR DESCRIPTION
## Obligatory GIF (super important!)

  ![Obligatory GIF](https://media.giphy.com/media/3oKIPnAiaMCws8nOsE/giphy.gif)

  ## :hammer_and_wrench: Type Of Change

  These types will increment the version number on release:

  - [x] Fix
  - [ ] Feature
  - [ ] Performance Improvement
  - [ ] Refactor

  These types will not increment the version number, but will still deploy to documentation site on release:

  - [ ] Documentation
  - [ ] Build system
  - [ ] CI
  - [ ] Style (code style changes, not css changes)
  - [ ] Test
  - [ ] Other (chore)

  ## :book: Jira Ticket

  DLT-2840

  ## :book: Description

  Fixed incorrect installation instructions in the MCP server and significantly improved README documentation:

  **Version Warning Message (src/index.ts)**
  - Changed from incorrect `npx` + `claude mcp` CLI instructions
  - Now shows correct npm workflow: `npm install -D @dialpad/dialtone-mcp-server@latest` + restart conversation

  **README.md Updates**
  - Added **Installation** section with npm install + `.mcp.json` configuration
  - Added **Updating** section with clear update workflow
  - Added **Icons** to searchable items (594 icons, 4th search tool)
  - Added **What Makes This Special** section documenting smart features
  - Improved **Troubleshooting** section with separate guidance for npm users vs monorepo contributors
  - Updated description to include icons

  **package.json**
  - Version updated to 1.1.1

  ## :bulb: Context

  The version check feature was added in v1.1.0 but contained incorrect update instructions. The message told users
  to use `npx` and the `claude mcp` CLI, but the actual installation method for this package is:

  1. Install via npm as a devDependency
  2. Configure via `.mcp.json` in project root
  3. The `dialtone-mcp-server` command comes from the `bin` entry in package.json

  The old instructions would have confused users and sent them down the wrong path. Additionally, the README was
  missing essential user-facing documentation - it only showed monorepo development setup with absolute paths, not
  how external users should install and use the package.

  These changes ensure users see correct instructions when updates are available and have proper documentation for
  installation and usage.

  ## :pencil: Checklist

  For all PRs:

  - [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a
  public repo!).
  - [x] I have reviewed my changes.
  - [x] I have added all relevant documentation.
  - [x] I have considered the performance impact of my change.

  ## :crystal_ball: Next Steps

  After merge and release (v1.1.1):
  - semantic-release will automatically publish to GitHub Packages
  - Users will see the corrected update instructions when v1.1.2+ is available
  - No further action needed

  ## :camera: Screenshots / GIFs

  **Before (incorrect npx instructions):**
  To update, run:
  claude mcp remove dialtone
  claude mcp add --scope user dialtone -- npx -y @dialpad/dialtone-mcp-server@latest

  **After (correct npm workflow):**
  To update:
  1. npm install -D @dialpad/dialtone-mcp-server@latest
  2. Restart this conversation

  ## :link: Sources

  - [MCP Documentation](https://modelcontextprotocol.io)
  - Context from CONTEXT_FOR_NEXT_SESSION.md in the package