### PR TITLE
fix(popover): DP-165062 dont reinit the tippy if the anchor el didnt actually change

### DIFF
--- a/packages/dialtone-vue2/components/popover/popover.test.js
+++ b/packages/dialtone-vue2/components/popover/popover.test.js
@@ -342,6 +342,7 @@ describe('DtPopover Tests', () => {
             <template #anchor>
               <div v-if="showAlternateAnchor" class="testanchor" key="anchor1">Anchor 1</div>
               <div v-else class="testanchor" key="anchor2">Anchor 2</div>
+              <div v-if="showExtraneous">will not be the anchor</div>
             </template>
             <template #content>
               <div class="content">Hello</div>
@@ -351,7 +352,7 @@ describe('DtPopover Tests', () => {
         components: {
           DtPopover,
         },
-        props: ['showAlternateAnchor', 'open'],
+        props: ['showAlternateAnchor', 'showExtraneous', 'open'],
       };
       const wrapper = mount(component, {
         propsData: { showAlternateAnchor: false, open: false },
@@ -375,6 +376,12 @@ describe('DtPopover Tests', () => {
       expect(popoverWindow.isVisible()).toBe(true);
       await wrapper.setProps({ open: false});
       expect(popoverWindow.isVisible()).toBe(false);
+
+      await wrapper.setProps({ open: true});
+      const popover = wrapper.findComponent({ ref: 'popover' });
+      vi.spyOn(popover.vm, 'initTippyInstance');
+      await wrapper.setProps({ showExtraneous: true });
+      expect(popover.vm.initTippyInstance).not.toHaveBeenCalled();
 
       wrapper.destroy();
     });

--- a/packages/dialtone-vue2/components/popover/popover.vue
+++ b/packages/dialtone-vue2/components/popover/popover.vue
@@ -692,7 +692,11 @@ export default {
       const externalAnchorEl = this.externalAnchor
         ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
         : null;
-      this.anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
+      const anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
+      if (anchorEl === this.anchorEl) {
+        return;
+      }
+      this.anchorEl = anchorEl;
 
       this.tip?.destroy();
       delete this.tip;

--- a/packages/dialtone-vue3/components/popover/popover.test.js
+++ b/packages/dialtone-vue3/components/popover/popover.test.js
@@ -313,6 +313,7 @@ describe('DtPopover Tests', () => {
             <template #anchor>
               <div v-if="showAlternateAnchor" class="testanchor">Anchor 1</div>
               <div v-else class="testanchor">Anchor 2</div>
+              <div v-if="showExtraneous">will not be the anchor</div>
             </template>
             <template #content>
               <div class="content">Hello</div>
@@ -322,7 +323,7 @@ describe('DtPopover Tests', () => {
         components: {
           DtPopover,
         },
-        props: ['showAlternateAnchor', 'open'],
+        props: ['showAlternateAnchor', 'showExtraneous', 'open'],
       };
       const wrapper = mount(component, {
         props: { showAlternateAnchor: false },
@@ -349,6 +350,12 @@ describe('DtPopover Tests', () => {
       expect(popoverWindow.isVisible()).toBe(true);
       await wrapper.setProps({ open: false});
       expect(popoverWindow.isVisible()).toBe(false);
+
+      await wrapper.setProps({ open: true});
+      const popover = wrapper.findComponent({ ref: 'popover' });
+      vi.spyOn(popover.vm, 'initTippyInstance');
+      await wrapper.setProps({ showExtraneous: true });
+      expect(popover.vm.initTippyInstance).not.toHaveBeenCalled();
 
       wrapper.unmount();
     });

--- a/packages/dialtone-vue3/components/popover/popover.vue
+++ b/packages/dialtone-vue3/components/popover/popover.vue
@@ -721,7 +721,11 @@ export default {
       const externalAnchorEl = this.externalAnchor
         ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
         : null;
-      this.anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
+      const anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
+      if (anchorEl === this.anchorEl) {
+        return;
+      }
+      this.anchorEl = anchorEl;
 
       this.tip?.destroy();
       delete this.tip;


### PR DESCRIPTION
# DP-165062: dont reinit the tippy if the anchor el didnt actually change

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExajdxOWZva2R5Mjhnb21nZ2Mzd2w1Zm03eHpyOGtwMnpkcTg2M2VpcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/vBYvmEXEH99fmJSm2m/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-165062

## :book: Description

Only reinit the tippy instance if the anchor actually changes.

## :bulb: Context

The search bar was adding a second element to the anchor when you started typing. This caused the focused popover to be destroyed and replaced, even tho the 0th child of the anchor slot was not changing.
For this case the changing anchor slot wasn't broken before because the element we actually attached the tippy to did not change.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.
