### PR TITLE
fix(avatar): NO-JIRA update padding and white-space for multi-digit group count

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -373,8 +373,7 @@
       }
 
       > .d-avatar__count {
-        padding-right: var(--dt-space-0);
-        padding-left: var(--dt-space-0);
+        padding-inline: var(--dt-space-0);
         inline-size: calc(var(--dt-size-500) + var(--dt-size-200));
       }
     }
@@ -403,8 +402,7 @@
       }
 
       > .d-avatar__count {
-        padding-right: var(--dt-space-0);
-        padding-left: var(--dt-space-0);
+        padding-inline: var(--dt-space-0);
         inline-size: calc(var(--dt-size-550) + var(--dt-size-200));
       }
     }

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -372,6 +372,9 @@
       }
 
       > .d-avatar__count {
+        padding-right: 0;
+        padding-left: 0;
+        white-space: nowrap;
         inline-size: calc(var(--dt-size-500) + var(--dt-size-200));
       }
     }
@@ -400,6 +403,9 @@
       }
 
       > .d-avatar__count {
+        padding-right: 0;
+        padding-left: 0;
+        white-space: nowrap;
         inline-size: calc(var(--dt-size-550) + var(--dt-size-200));
       }
     }

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -372,8 +372,8 @@
       }
 
       > .d-avatar__count {
-        padding-right: 0;
-        padding-left: 0;
+        padding-right: var(--dt-space-0);
+        padding-left: var(--dt-space-0);
         white-space: nowrap;
         inline-size: calc(var(--dt-size-500) + var(--dt-size-200));
       }
@@ -403,8 +403,8 @@
       }
 
       > .d-avatar__count {
-        padding-right: 0;
-        padding-left: 0;
+        padding-right: var(--dt-space-0);
+        padding-left: var(--dt-space-0);
         white-space: nowrap;
         inline-size: calc(var(--dt-size-550) + var(--dt-size-200));
       }

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -118,6 +118,7 @@
     font-weight: var(--dt-font-weight-bold);
     font-size: calc(var(--dt-font-size-100) - var(--dt-size-200));
     line-height: var(--dt-font-line-height-100);
+    white-space: nowrap;
     text-align: center;
     background-color: var(--dt-color-surface-strong);
     border-radius: var(--dt-size-radius-pill);
@@ -374,7 +375,6 @@
       > .d-avatar__count {
         padding-right: var(--dt-space-0);
         padding-left: var(--dt-space-0);
-        white-space: nowrap;
         inline-size: calc(var(--dt-size-500) + var(--dt-size-200));
       }
     }
@@ -405,7 +405,6 @@
       > .d-avatar__count {
         padding-right: var(--dt-space-0);
         padding-left: var(--dt-space-0);
-        white-space: nowrap;
         inline-size: calc(var(--dt-size-550) + var(--dt-size-200));
       }
     }


### PR DESCRIPTION
# fix(avatar): NO-JIRA update padding and white-space for multi-digit group count

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHllc3BuNzFuN244azdjMnVlanVmbXlsbDVzamJ2eGJnYXprM2p3NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/VReuqcpTOB46hkSVAW/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->
https://dialpad.atlassian.net/browse/DP-165629 (Related ux papercut)

## :book: Description

<!--- Describe specifically what the changes are -->
Remove horizontal `padding` & add `white-space: nowrap` for multi-digit group counts for more consistent display and to prevent digits from wrapping. The `align-items` and `justify-content` properties already handle the centering so there is no need for horizontal padding, and the `white-space: nowrap` is an added protection since these are not meant to wrap.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

The group counts do not wrap on the documentation site, but I noticed that they do sometimes wrap in the DP app. See the Jira ticket https://dialpad.atlassian.net/browse/DP-165629  for example(s) as this fix will also enable a more full papercut fix involving a flex container.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.


For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->
This will fix will be in tandem with a UX papercut, both will help with spacing and alignment.

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->
Example from docs site showing the expected layout does not change. See Context section for more.

<img width="1072" height="1130" alt="Screenshot 2025-11-19 at 12 26 35 PM" src="https://github.com/user-attachments/assets/0ba1fdbf-63d3-4eca-a1ef-17fa5e323c8e" />

View in storybook:
<img width="330" height="122" alt="Screenshot 2025-11-18 at 2 32 08 PM" src="https://github.com/user-attachments/assets/e0fc3c0b-86b6-4390-a9bd-1a078e86d247" />


## :link: Sources

<!--- Add any links to external reference material -->
