### PR TITLE
fix: DP-161959 modelValue selects the default option correctly

### DIFF
--- a/packages/dialtone-vue3/components/select_menu/select_menu.test.js
+++ b/packages/dialtone-vue3/components/select_menu/select_menu.test.js
@@ -262,6 +262,31 @@ describe('DtSelectMenu Tests', () => {
         expect(wrapper.emitted('change')[0][0]).toBe(MOCK_SELECTED_VALUE.toString());
       });
     });
+
+    describe('When modelValue prop is set', () => {
+      it('should set the select element value', () => {
+        const MOCK_MODEL_VALUE = MOCK_OPTIONS[1].value;
+        mockProps = { modelValue: MOCK_MODEL_VALUE };
+
+        updateWrapper();
+
+        expect(select.element.value).toBe(MOCK_MODEL_VALUE.toString());
+      });
+
+      it('should update when modelValue prop changes', async () => {
+        const INITIAL_VALUE = MOCK_OPTIONS[0].value;
+        const UPDATED_VALUE = MOCK_OPTIONS[2].value;
+
+        mockProps = { modelValue: INITIAL_VALUE };
+        updateWrapper();
+
+        expect(select.element.value).toBe(INITIAL_VALUE.toString());
+
+        await wrapper.setProps({ modelValue: UPDATED_VALUE });
+
+        expect(select.element.value).toBe(UPDATED_VALUE.toString());
+      });
+    });
   });
 
   describe('Validation Tests', () => {

--- a/packages/dialtone-vue3/components/select_menu/select_menu.vue
+++ b/packages/dialtone-vue3/components/select_menu/select_menu.vue
@@ -50,6 +50,7 @@
           v-bind="removeClassStyleAttrs($attrs)"
           data-qa="dt-select"
           :disabled="disabled"
+          :value="modelValue"
           v-on="selectListeners"
         >
           <!-- @slot Slot for select menu options, defaults to options prop -->
@@ -227,6 +228,14 @@ export default {
      */
     rootClass: {
       type: [String, Object, Array],
+      default: '',
+    },
+
+    /**
+     * The value of the select menu
+     */
+    modelValue: {
+      type: [String, Number],
       default: '',
     },
   },


### PR DESCRIPTION
# fix: DP-161959 modelValue selects the default option correctly

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExejd5NmlwODVuZmJhNWR3YWI4ZGxjNjY5N25qNDB3Znc4YWp0a204aiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/nbQiWoHJFaJtcl3qT6/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-161959

## :book: Description

Added modelValue prop and set the correct property. This is a Vue 3 specific change only. In Vue 2 it works fine.

## :bulb: Context

modelValue was not implemented correctly in select_menu for vue 3. It was just doing nothing.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
