### PR TITLE
fix(split-button): NO-JIRA fix split button inline size for importance="clear" variants

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -765,6 +765,14 @@
     border-bottom-right-radius: 0;
   }
 
+  &__alpha:not(.d-btn--outlined) {
+    border-inline-end: 0;
+  }
+
+  &__omega:not(.d-btn--outlined) {
+    border-inline-start: 0;
+  }
+
   &__omega:disabled:not(.d-btn--outlined),
   &__omega:disabled:not(.d-btn--primary),
   &__omega.d-btn--primary,


### PR DESCRIPTION
# Fix split button inline size for importance="clear" variants

https://github.com/user-attachments/assets/f2c9e63b-d0a2-4e28-a510-c3f7d1efc7e6

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Description

`importance="clear"` variants had 2 extra pixels. Became apparent when setting up https://github.com/dialpad/design-studio/pull/184 for Scheduling messages. 

https://dialpad.github.io/design-studio/pr-preview/pr-184/#/SplitButtonVariantToggle

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.