### PR TITLE
fix(toggle): NO-JIRA emit modelValue before change

### DIFF
--- a/packages/dialtone-vue3/components/toggle/toggle.vue
+++ b/packages/dialtone-vue3/components/toggle/toggle.vue
@@ -200,8 +200,8 @@ export default {
   methods: {
     addClassStyleAttrs,
     toggleCheckedValue () {
-      this.$emit('change', !this.internalChecked);
       this.$emit('update:modelValue', !this.internalChecked);
+      this.$emit('change', !this.internalChecked);
 
       if (this.toggleOnClick) {
         this.internalChecked = !this.internalChecked;


### PR DESCRIPTION
# fix(toggle): NO-JIRA emit modelValue before change

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExeDg5bDBlZWRoZjh6MzE2M2piNHB0MHV1N3NxY2dob2F2NjQxYTA2ZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/UTFiHeDL8cOSA/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

Changed the order of emits, so update:model-value goes first. Necessary for Vue 3 only.

## :bulb: Context

Related to issue https://github.com/dialpad/firespotter/pull/67106. The order of emits was causing an edge case issue when using v-model, as described in the linked ticket.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
