### PR TITLE
fix(combobox-multi-select): DP-162879 fix event listeners

### DIFF
--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.stories.js
@@ -24,6 +24,7 @@ export const argsData = {
   onRemove: action('remove'),
   onMaxSelected: action('maxSelected'),
   onComboboxHighlight: action('comboboxHighlight'),
+  onFocus: action('focus'),
 };
 
 export const argTypesData = {

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select.vue
@@ -60,7 +60,7 @@
           :show-messages="showInputMessages"
           :messages="inputMessages"
           :size="size"
-          v-on="inputListeners"
+          v-bind="inputListeners"
           @input="onInput"
         />
 
@@ -120,7 +120,7 @@ import DtInput from '@/components/input/input.vue';
 import DtChip from '@/components/chip/chip.vue';
 import DtValidationMessages from '@/components/validation_messages/validation_messages.vue';
 import { validationMessageValidator } from '@/common/validators';
-import { hasSlotContent, returnFirstEl } from '@/common/utils';
+import { extractVueListeners, hasSlotContent, returnFirstEl } from '@/common/utils';
 import {
   POPOVER_APPEND_TO_VALUES,
 } from '@/components/popover/popover_constants';
@@ -450,22 +450,23 @@ export default {
 
     inputListeners () {
       return {
-        input: event => {
+        ...extractVueListeners(this.$attrs),
+        onInput: event => {
           this.$emit('input', event);
           if (this.hasSuggestionList) {
             this.showComboboxList();
           }
         },
 
-        keydown: event => {
+        onKeydown: event => {
           this.onInputKeyDown(event);
         },
 
-        keyup: event => {
+        onKeyup: event => {
           this.$emit('keyup', event);
         },
 
-        click: () => {
+        onClick: () => {
           if (this.hasSuggestionList) {
             this.showComboboxList();
           }

--- a/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
+++ b/packages/dialtone-vue3/recipes/comboboxes/combobox_multi_select/combobox_multi_select_default.story.vue
@@ -29,6 +29,7 @@
     @remove="onComboboxRemove"
     @max-selected="$attrs.onMaxSelected"
     @combobox-highlight="$attrs.onComboboxHighlight"
+    @focus="$attrs.onFocus"
   >
     <template
       v-if="$attrs.header"


### PR DESCRIPTION
# fix(combobox-multi-select): DP-162879 fix event listeners

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExc2ZrZWo4OXI2NjI3cWk4cmg3ODlrbWV0Z2wwazdrM2c4cmN4Znc3MSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Nx85vtTY70T3W/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-162879

## :book: Description

Updated Vue 3 multiselect component to have all "listeners" pass down to the input as it did in Vue 2.

## :bulb: Context

Justin investigated in https://github.com/dialpad/firespotter/pull/67203 and found that listeners were not going to the same element that they were in vue 2. Seems `$listeners` was just removed from the component instead of being migrated to the vue 3 equivalent via `extractVueAttrs()`. Fixed and added the focus event to the storybook so we can confirm it works as expected.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

update dialtone in vue 3 branch and verify
