### PR TITLE
fix(modal, popover): NO-JIRA remove bg clip

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -63,11 +63,10 @@ html body {
   --docsearch-footer-height: var(--dt-size-650);
   --docsearch-footer-background: var(--dt-color-surface-primary);
   /* stylelint-disable-next-line meowtec/no-px */
-  --docsearch-footer-shadow: 0 -1px 0 0 var(--dt-color-border-subtle),0 -1px 3px 0 rgba(0,0,0,.2);
+  --docsearch-footer-shadow: 0 -1px 0 0 var(--dt-color-border-subtle),0 -1px 3px 0 rgb(0,0,0,.2);
 
   .DocSearch-Modal {
     margin-top: 15vh;
-    background-clip: padding-box;
     border: var(--dt-size-100) solid var(--dt-color-border-subtle);
     border-radius: var(--dt-size-radius-500);
     box-shadow: var(--dt-shadow-large);
@@ -657,12 +656,12 @@ a.header-anchor {
 
 .dialtone-wall {
   display: grid;
-  grid-gap: var(--dt-space-500);
+  gap: var(--dt-space-500);
   margin-top: var(--dt-space-500);
 
   @media screen and (min-width: 640px) {
-    grid-gap: var(--dt-space-600);
     grid-template-columns: [full-start] repeat(2, [col-start] var(--col-width, minmax(0, 1fr)) [col-end]) [full-end] !important;
+    gap: var(--dt-space-600);
   }
 
   @media screen and (min-width: 768px) {

--- a/packages/dialtone-css/lib/build/less/components/modal.less
+++ b/packages/dialtone-css/lib/build/less/components/modal.less
@@ -83,7 +83,6 @@
   font-size: var(--dt-font-size-200);
   line-height: var(--dt-font-line-height-400);
   background-color: var(--modal-dialog-color-background);
-  background-clip: padding-box;
   border: var(--dt-size-100) solid var(--modal-dialog-color-border);
   border-radius: var(--dt-size-500);
   box-shadow: var(--modal-dialog-shadow);
@@ -171,7 +170,6 @@
   font-size: var(--dt-font-size-200);
   line-height: var(--dt-font-line-height-300);
   background-color: var(--modal-banner-color-background);
-  background-clip: padding-box;
   border: var(--dt-size-100) solid var(--modal-dialog-color-border);
   border-bottom-width: 0;
   border-radius: var(--dt-size-500) var(--dt-size-500) 0 0;

--- a/packages/dialtone-css/lib/build/less/components/popover.less
+++ b/packages/dialtone-css/lib/build/less/components/popover.less
@@ -45,7 +45,6 @@
     overflow: auto;
     color: var(--dt-color-foreground-primary);
     background-color: var(--popover-color-background);
-    background-clip: padding-box;
     border: var(--popover-border-width) solid var(--popover-color-border);
     border-radius: var(--popover-border-radius);
     box-shadow: var(--popover-shadow);


### PR DESCRIPTION
# Remove background-clip from Modal and Popover

<img width="4288" height="4042" alt="image" src="https://github.com/user-attachments/assets/0bc98955-f000-4e73-8428-7ebf2532f534" />

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Description

More pronounced in Dark Mode, but applies to both. Content beneath the translucent border was awkwardly leaking through. Zoom in on attached screenshot to see before/after.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.