### PR TITLE
ci: NO-JIRA set up NPM <-> GHA trusted publishing

### DIFF
--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -128,7 +128,6 @@ jobs:
         if: matrix.registry == 'npm'
         run: |
           pnpm config delete @dialpad:registry;
-          pnpm config set //registry.npmjs.org/:_authToken=${{ secrets.DIALTONE_NPM_TOKEN }}
 
       - name: Delay job to avoid npm rate limits
         if: matrix.package == 'dialtone-vue3'

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -116,6 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
     env:
       RELEASE_TAG: ${{ needs.get-branch-name.outputs.current_branch == 'staging' && 'latest' || needs.get-branch-name.outputs.current_branch }}
       DIALTONE_VUE3_RELEASE_TAG: ${{ needs.get-branch-name.outputs.current_branch == 'staging' && 'vue3' || needs.get-branch-name.outputs.current_branch }}
-      NPM_TOKEN: ${{ secrets.DIALTONE_NPM_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout


### PR DESCRIPTION
# Set up trusted publishing between GHA and NPM

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)
![Obligatory GIF](https://github.com/user-attachments/assets/86f873e3-b828-4f39-bbf8-b7eae7946364)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [x] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

None :(

## :book: Description

NPM [revoked classic token auth](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/) on Dec 9, which is causing publishing to fail.  This PR sets up [trusted publishing via OIDC](https://docs.npmjs.com/trusted-publishers#how-to-configure-maximum-security) which does not involve using a (now revoked) classic token.

The [instructions for setting up trusted publishing](https://docs.npmjs.com/trusted-publishers#how-to-configure-maximum-security) include adding `id-token: write` to the workflows in question.

## :bulb: Context

Publishing is b0rked!

![b0rked](https://lh3.googleusercontent.com/7_067g4IVulXhdJy-2vEZvimCat5YYm4t0TnAAXwNThaLQVNKZklHvCS2u9TXcZTZGsCuq-iGv91msO9NJAeD2WNNI9tCs_cq6x0=s1600)

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

If new component:

<!--- There are lots of things to remember when adding a new component to the system! This is so you don't forget any of them. -->

- I am exporting any new components or constants:
  - [ ] from the index.js in the component directory.
  - [ ] from the index.js in the root (either `packages/dialtone-vue2` or `packages/dialtone-vue3`).
- [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
- [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
- [ ] I have added the new component to `common/components_list.js`
- [ ] I have created a component story in storybook
- [ ] I have created story / stories for any relevant component variants in storybook
- [ ] I have created a docs page for the component in storybook.
- [ ] I have checked that changing all props/slots via the UI in storybook works as expected.

## :crystal_ball: Next Steps

I'm going to follow the [steps here](https://docs.npmjs.com/trusted-publishers#how-to-configure-maximum-security) for setting up trusted publishing between NPM and GHA.  I'll do this for every dialtone-related package being published from the monorepo.

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

[setting up trusted publishing via oidc](https://docs.npmjs.com/trusted-publishers#how-to-configure-maximum-security)
