### PR TITLE
fix(tooltip): DP-162955 call removeTooltip on root component instance

### DIFF
--- a/packages/dialtone-vue2/directives/tooltip_directive/tooltip.test.js
+++ b/packages/dialtone-vue2/directives/tooltip_directive/tooltip.test.js
@@ -15,7 +15,8 @@ const WrapperComponent = {
   template: `
     <div>
       <button :key="id" data-qa="dt-tooltip-placement" v-dt-tooltip:[placement]="MOCK_TOOLTIP_TEXT">{{MOCK_ANCHOR_TEXT}}</button>
-      <button :key="id + '-object'" data-qa="dt-tooltip-object" v-dt-tooltip="MOCK_TOOLTIP_PROPS">{{MOCK_ANCHOR_TEXT}}</button>
+      <button :key="id + 'object'" data-qa="dt-tooltip-object" v-dt-tooltip="MOCK_TOOLTIP_PROPS">{{MOCK_ANCHOR_TEXT}}</button>
+      <button :key="id + 'changing'" data-qa="dt-tooltip-changing" v-dt-tooltip:[placement]="tooltipText">{{MOCK_ANCHOR_TEXT}}</button>
     </div>
   `,
 
@@ -32,6 +33,7 @@ const WrapperComponent = {
       MOCK_ANCHOR_TEXT,
       MOCK_TOOLTIP_TEXT,
       MOCK_TOOLTIP_PROPS,
+      tooltipText: 'foo',
     };
   },
 };
@@ -46,6 +48,7 @@ describe('DtTooltipDirective Tests', () => {
   let wrapper;
   let anchorButtonPlacement;
   let anchorButtonObject;
+  let anchorButtonChanging;
 
   const updateWrapper = () => {
     wrapper = mount(WrapperComponent, {
@@ -56,6 +59,7 @@ describe('DtTooltipDirective Tests', () => {
 
     anchorButtonPlacement = wrapper.find('[data-qa="dt-tooltip-placement"]');
     anchorButtonObject = wrapper.find('[data-qa="dt-tooltip-object"]');
+    anchorButtonChanging = wrapper.find('[data-qa="dt-tooltip-changing"]')
   };
 
   afterEach(() => {
@@ -124,6 +128,26 @@ describe('DtTooltipDirective Tests', () => {
 
       it('should render the message', () => {
         expect(document.body.querySelector('[data-qa="dt-tooltip"]').textContent.trim()).toBe(MOCK_TOOLTIP_TEXT);
+      });
+    });
+
+    describe('when tooltip with dynamic argument is open', () => {
+      beforeEach(async () => {
+        await updateWrapper();
+        await flushPromises();
+        await anchorButtonChanging.trigger('mouseenter');
+      });
+
+      it('should update the message when the argument updates', async () => {
+        expect(document.body.querySelector('[data-qa="dt-tooltip"]').textContent.trim()).toBe('foo');
+        await wrapper.setData({ tooltipText: 'bar' });
+        expect(document.body.querySelector('[data-qa="dt-tooltip"]').textContent.trim()).toBe('bar');
+      });
+
+      it('should remove the tooltip when the argument becomes nullish', async () => {
+        expect(document.body.querySelector('[data-qa="dt-tooltip"]').textContent.trim()).toBe('foo');
+        await wrapper.setData({ tooltipText: null });
+        expect(document.body.querySelector('[data-qa="dt-tooltip"]')).toBeNull();
       });
     });
   });

--- a/packages/dialtone-vue3/directives/tooltip_directive/tooltip.js
+++ b/packages/dialtone-vue3/directives/tooltip_directive/tooltip.js
@@ -82,7 +82,7 @@ export const DtTooltipDirective = {
       if (binding.value === null || binding.value === undefined) {
         const tooltipId = anchor.getAttribute('data-dt-tooltip-id');
         if (tooltipId) {
-          DtTooltipDirectiveApp.removeTooltip(tooltipId);
+          tooltipInstance.ctx.removeTooltip(tooltipId);
         }
         return;
       }

--- a/packages/dialtone-vue3/directives/tooltip_directive/tooltip.test.js
+++ b/packages/dialtone-vue3/directives/tooltip_directive/tooltip.test.js
@@ -16,6 +16,7 @@ const WrapperComponent = {
     <div>
       <button :key="id" data-qa="dt-tooltip-placement" v-dt-tooltip:[placement]="MOCK_TOOLTIP_TEXT">{{MOCK_ANCHOR_TEXT}}</button>
       <button :key="id" data-qa="dt-tooltip-object" v-dt-tooltip="MOCK_TOOLTIP_PROPS">{{MOCK_ANCHOR_TEXT}}</button>
+      <button :key="id" data-qa="dt-tooltip-changing" v-dt-tooltip:[placement]="tooltipText">{{MOCK_ANCHOR_TEXT}}</button>
     </div>
   `,
 
@@ -32,6 +33,7 @@ const WrapperComponent = {
       MOCK_ANCHOR_TEXT,
       MOCK_TOOLTIP_TEXT,
       MOCK_TOOLTIP_PROPS,
+      tooltipText: 'foo',
     };
   },
 };
@@ -44,6 +46,7 @@ describe('DtTooltipDirective Tests', () => {
   let wrapper;
   let anchorButtonPlacement;
   let anchorButtonObject;
+  let anchorButtonChanging;
 
   const updateWrapper = () => {
     wrapper = mount(WrapperComponent, {
@@ -59,6 +62,7 @@ describe('DtTooltipDirective Tests', () => {
 
     anchorButtonPlacement = wrapper.find('[data-qa="dt-tooltip-placement"]');
     anchorButtonObject = wrapper.find('[data-qa="dt-tooltip-object"]');
+    anchorButtonChanging = wrapper.find('[data-qa="dt-tooltip-changing"]')
   };
 
   afterEach(() => {
@@ -125,6 +129,26 @@ describe('DtTooltipDirective Tests', () => {
 
       it('should render the message', () => {
         expect(document.body.querySelector('[data-qa="dt-tooltip"]').textContent.trim()).toBe(MOCK_TOOLTIP_TEXT);
+      });
+    });
+
+    describe('when tooltip with dynamic argument is open', () => {
+      beforeEach(async () => {
+        await updateWrapper();
+        await flushPromises();
+        await anchorButtonChanging.trigger('mouseenter');
+      });
+
+      it('should update the message when the argument updates', async () => {
+        expect(document.body.querySelector('[data-qa="dt-tooltip"]').textContent.trim()).toBe('foo');
+        await wrapper.setData({ tooltipText: 'bar' });
+        expect(document.body.querySelector('[data-qa="dt-tooltip"]').textContent.trim()).toBe('bar');
+      });
+
+      it('should remove the tooltip when the argument becomes nullish', async () => {
+        expect(document.body.querySelector('[data-qa="dt-tooltip"]').textContent.trim()).toBe('foo');
+        await wrapper.setData({ tooltipText: null });
+        expect(document.body.querySelector('[data-qa="dt-tooltip"]')).toBeNull();
       });
     });
   });


### PR DESCRIPTION
In vue3 apps are not just the root component instance and you can't call the methods on the app.

## Obligatory GIF (super important!)

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExamo3cHlpNWkwem9vb3JoMHVkdG5seWl3MTBvYmViamYwZXpqbW55MiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tLRifcvQNJIic/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-162955

## :book: Description

call removeTooltip on root component instance

## :bulb: Context

In vue2 we had direct access to root component methods on the app instance we created, but in vue3 the app is a distinct object from the mounted root component. Methods need to be called on the component instance we extract.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have made my changes in Vue 2 and Vue 3. Note: you may sync your changes from Vue 2 to Vue 3 (or vice versa) using the `./scripts/dialtone-vue-sync.sh` script. Read docs here: [Dialtone Vue Sync Script](../packages/dialtone-vue3/.github/CONTRIBUTING.md#dialtone-vue-sync-script)
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.
