### PR TITLE
fix(card): DLT-2868 add border

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/card.less
+++ b/packages/dialtone-css/lib/build/less/components/card.less
@@ -22,7 +22,8 @@
   flex-direction: column;
   justify-content: center;
   background: var(--dt-color-surface-primary);
-  border-radius: var(--dt-size-300);
+  border: var(--dt-size-border-100) solid var(--dt-color-border-subtle);
+  border-radius: var(--dt-size-radius-300);
   box-shadow: var(--dt-shadow-card);
 }
 


### PR DESCRIPTION
# Add border to DtCard

<img width="201" height="179" alt="image" src="https://github.com/user-attachments/assets/7eb78d68-9c4a-474b-8de9-02eeb683c6a9" />

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2868

## :book: Description

Card has a shadow, no border – but no bueno in Dark Mode. A better fix is probably more about how we'll update Dialtone's **Elevation** Design Language strategy.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :camera: Screenshots / GIFs

<img width="1406" height="1420" alt="image" src="https://github.com/user-attachments/assets/4b7245b4-583a-45b7-a0bc-69a53e5e3729" />