### PR TITLE
chore(docs): NO-JIRA add aria-labelledby and remove focusablity when not actionable

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/SidebarItem.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/SidebarItem.vue
@@ -22,7 +22,7 @@
             kind="muted"
             label-class="d-jc-flex-start"
             icon-position="right"
-            :tabindex="!item.link ? -1 : undefined"
+            :tabindex="actionableTabIndex"
             :class="[
               'd-w100p d-fw-normal',
               {
@@ -119,6 +119,10 @@ const subItems = computed(() => {
 });
 const labelId = computed(() => {
   return `sidebar-label-${props.item?.text?.toLowerCase().replace(/\s+/g, '-')}`;
+});
+const actionableTabIndex = computed(() => {
+  // Items without links are not actionable and should be removed from tab order
+  return props.item.link ? undefined : -1;
 });
 const route = useRoute();
 const hash = ref(route.hash);

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/SidebarItem.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/SidebarItem.vue
@@ -16,11 +16,13 @@
           custom
         >
           <dt-button
+            :id="labelId"
             v-bind="attrs"
             importance="clear"
             kind="muted"
             label-class="d-jc-flex-start"
             icon-position="right"
+            :tabindex="!item.link ? -1 : undefined"
             :class="[
               'd-w100p d-fw-normal',
               {
@@ -45,6 +47,7 @@
     <template #content>
       <dt-stack
         as="ul"
+        :aria-labelledby="labelId"
         :class="{ 'd-pl8': nested }"
         gap="200"
       >
@@ -113,6 +116,9 @@ const props = defineProps({
 });
 const subItems = computed(() => {
   return props.item?.children || [];
+});
+const labelId = computed(() => {
+  return `sidebar-label-${props.item?.text?.toLowerCase().replace(/\s+/g, '-')}`;
 });
 const route = useRoute();
 const hash = ref(route.hash);


### PR DESCRIPTION
# Sidebar: add `aria-labelledby` and remove `focusablity` when not actionable

https://github.com/user-attachments/assets/6d6be39e-0836-48cd-9407-ca950ab0f59b

## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :book: Description

Resolving a small nit I had: the sidebar subtitles are focusable and shouldn't be. Ideally they wouldn't be `button` elements, but I don't want to mess with restructuring it to not be a button. It's good enough as is. 

* Add `tabindex="-1"` if it's not actionable.
* Add dynamic `id` and add `aria-labeledby` to its associated `<ul>`.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.