### PR TITLE
fix(modal): DP-169147 nested modal style

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/modal.less
+++ b/packages/dialtone-css/lib/build/less/components/modal.less
@@ -83,7 +83,6 @@
   font-size: var(--dt-font-size-200);
   line-height: var(--dt-font-line-height-400);
   background-color: var(--modal-dialog-color-background);
-  background-clip: padding-box;
   border: var(--dt-size-100) solid var(--modal-dialog-color-border);
   border-radius: var(--dt-size-500);
   box-shadow: var(--modal-dialog-shadow);
@@ -92,6 +91,11 @@
   visibility: hidden;
   opacity: 0;
   will-change: visibility, z-index, opacity, transform;
+
+  // unique non-compliant case where a modal is nested within another
+  &:has(.d-modal) {
+    background-clip: padding-box;
+  }
 }
 
 //  $$   MAKE THEM APPEAR

--- a/packages/dialtone-css/lib/build/less/components/modal.less
+++ b/packages/dialtone-css/lib/build/less/components/modal.less
@@ -83,6 +83,7 @@
   font-size: var(--dt-font-size-200);
   line-height: var(--dt-font-line-height-400);
   background-color: var(--modal-dialog-color-background);
+  background-clip: padding-box;
   border: var(--dt-size-100) solid var(--modal-dialog-color-border);
   border-radius: var(--dt-size-500);
   box-shadow: var(--modal-dialog-shadow);


### PR DESCRIPTION
# fix(modal): DP-169147 nested modal style



## Obligatory GIF (super important!)


https://github.com/user-attachments/assets/a06b077f-cb92-49d1-a5fb-0cf42d732406



## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor


## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-169147


## :book: Description


Seems like the removal of `background-clip: padding-box;` bring some unwanted changes.


## :bulb: Context


The issue can be visualized following this instructions:

1. Go to the Office setting
2. Go to Local Presence
3. Click on the purchase bundle
4. Click on the edit

I couldn't reproduce it on that way but you can also see it with the remove custom emoji flow.

1. Go to Preferences
2. Custom Emojis
3. Delete Emoji
(Attached video)


---

This is linked to the recent change. #992 

I see it was also removed on popover but Im not sure if it is needed to be restored too.
@francisrupert please verify this and if restoring on modal and/or popover is the way to go.
Thanks,


