### PR TITLE
fix(radio): NO-JIRA remove click from emits

### DIFF
--- a/packages/dialtone-vue3/components/radio/radio.vue
+++ b/packages/dialtone-vue3/components/radio/radio.vue
@@ -127,14 +127,6 @@ export default {
      * @property {FocusEvent}
      */
     'focusout',
-
-    /**
-     * Native click event
-     *
-     * @event click
-     * @type {PointerEvent | KeyboardEvent}
-     */
-    'click',
   ],
 
   data () {


### PR DESCRIPTION
# fix(radio): remove click from emits

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGVsNXQxYXhkdG8wZHVnNmtxb3dyZWFldHFpeW1oN2hqMDd6dTA3biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/euviDNZfscxPOVSkHa/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Description

remove click event from emits array, as this component never emits a click event

## :bulb: Context

See dialpad conversation: https://dialpad.com/app/messages/agxzfnViZXItdm9pY2VyGAsSC1RleHRNZXNzYWdlGIDA4NypzckJDA

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
