### PR TITLE
fix: DLT-2878 stories using emoji row

### DIFF
--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/composables/useMockReactions.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/composables/useMockReactions.js
@@ -1,0 +1,41 @@
+import { ref } from 'vue';
+import { DialtoneLocalization } from '@/localization/index.js';
+
+/**
+ * Composable that provides mock reaction data for Storybook stories
+ * @returns {Object} Object containing mockReactions ref
+ */
+export function useMockReactions() {
+  const i18n = new DialtoneLocalization();
+
+  const mockReactions = ref([
+    {
+      emojiUnicodeOrShortname: '😀',
+      isSelected: true,
+      names: i18n.$t('STORYBOOK_YOU'),
+      num: 1,
+    },
+    {
+      emojiUnicodeOrShortname: '😒',
+      isSelected: false,
+      names: 'John Doe',
+      num: 1,
+    },
+    {
+      emojiUnicodeOrShortname: '😌',
+      isSelected: false,
+      names: i18n.$t('STORYBOOK_REACTION_NAMES_2'),
+      num: 5,
+    },
+    {
+      emojiUnicodeOrShortname: ':blinkingguy:',
+      names: i18n.$t('STORYBOOK_REACTION_NAMES_3'),
+      isSelected: true,
+      num: 2,
+    },
+  ]);
+
+  return {
+    mockReactions,
+  };
+}

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.stories.js
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row.stories.js
@@ -2,41 +2,12 @@ import { action } from '@storybook/addon-actions';
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import DtRecipeEmojiRow from './emoji_row.vue';
 import DtRecipeEmojiRowDefaultTemplate from './emoji_row_default.story.vue';
-import { DialtoneLocalization } from '@/localization/index.js';
-const i18n = new DialtoneLocalization();
 
 // Default Prop Values
 export const argsData = {
   onEmojiClicked: action('emoji-clicked'),
   onEmojiHovered: action('emoji-hovered'),
 };
-
-export const sharedEmojiReactionsData = [
-  {
-    emojiUnicodeOrShortname: '😀',
-    isSelected: true,
-    names: i18n.$t('STORYBOOK_YOU'),
-    num: 1,
-  },
-  {
-    emojiUnicodeOrShortname: '😒',
-    isSelected: false,
-    names: 'John Doe',
-    num: 1,
-  },
-  {
-    emojiUnicodeOrShortname: '😌',
-    isSelected: false,
-    names: i18n.$t('STORYBOOK_REACTION_NAMES_2'),
-    num: 5,
-  },
-  {
-    emojiUnicodeOrShortname: ':blinkingguy:',
-    names: i18n.$t('STORYBOOK_REACTION_NAMES_3'),
-    isSelected: true,
-    num: 2,
-  },
-];
 
 export const argTypesData = {
   // Props
@@ -96,7 +67,5 @@ const DefaultTemplate = (args, { argTypes }) => createTemplateFromVueFile(
 export const Default = {
   render: DefaultTemplate,
 
-  args: {
-    reactions: sharedEmojiReactionsData,
-  },
+  args: {},
 };

--- a/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/emoji_row/emoji_row_default.story.vue
@@ -1,16 +1,14 @@
 <template>
   <dt-recipe-emoji-row
-    :reactions="$attrs.reactions"
+    :reactions="emojiReactionsData"
     @emoji-clicked="$attrs.onEmojiClicked"
     @emoji-hovered="$attrs.onEmojiHovered"
   />
 </template>
 
-<script>
+<script setup>
 import DtRecipeEmojiRow from './emoji_row.vue';
+import { useMockReactions } from '@/recipes/conversation_view/emoji_row/composables/useMockReactions.js';
 
-export default {
-  name: 'DtRecipeEmojiRowDefault',
-  components: { DtRecipeEmojiRow },
-};
+const { mockReactions: emojiReactionsData } = useMockReactions();
 </script>

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_default.story.vue
@@ -131,7 +131,7 @@
   </dt-recipe-feed-item-row>
 </template>
 
-<script>
+<script setup>
 import DtRecipeFeedItemRow from './feed_item_row.vue';
 import { DtRecipeEmojiRow } from '../emoji_row';
 import { DtEmojiTextWrapper } from '@/components/emoji_text_wrapper';
@@ -139,28 +139,11 @@ import { DtAvatar } from '@/components/avatar';
 import { DtIcon } from '@/components/icon';
 import { DtButton } from '@/components/button';
 import { DtStack } from '@/components/stack';
-import { sharedEmojiReactionsData } from '@/recipes/conversation_view/emoji_row/emoji_row.stories.js';
+import { useMockReactions } from '@/recipes/conversation_view/emoji_row/composables/useMockReactions.js';
 
-export default {
-  name: 'DtRecipeFeedItemRowDefault',
-  components: {
-    DtAvatar,
-    DtRecipeFeedItemRow,
-    DtRecipeEmojiRow,
-    DtEmojiTextWrapper,
-    DtIcon,
-    DtButton,
-    DtStack,
-  },
+const hoverButtons = ['bell', 'living-thing', 'map-pin'];
 
-  data () {
-    return {
-      mockReactions: sharedEmojiReactionsData,
+const persons = ['Jim Halpert', 'Michael Scott', 'Pam'];
 
-      hoverButtons: ['bell', 'living-thing', 'map-pin'],
-
-      persons: ['Jim Halpert', 'Michael Scott', 'Pam'],
-    };
-  },
-};
+const { mockReactions } = useMockReactions();
 </script>

--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -285,7 +285,7 @@
   </dt-stack>
 </template>
 
-<script>
+<script setup>
 import DtRecipeFeedItemRow from './feed_item_row.vue';
 
 import { DtRecipeEmojiRow } from '../emoji_row';
@@ -296,36 +296,13 @@ import { DtAvatar } from '@/components/avatar';
 import { DtIcon } from '@/components/icon';
 import { DtImageViewer } from '@/components/image_viewer';
 import { DtButton } from '@/components/button';
-import { sharedEmojiReactionsData } from '@/recipes/conversation_view/emoji_row/emoji_row.stories.js';
-
+import { useMockReactions } from '@/recipes/conversation_view/emoji_row/composables/useMockReactions.js';
 import fryImage from '@/common/assets/fry.gif';
 
-export default {
-  name: 'DtRecipeFeedItemRowVariants',
-
-  components: {
-    DtEmojiTextWrapper,
-    DtRecipeEmojiRow,
-    DtRecipeFeedItemRow,
-    DtRecipeFeedItemPill,
-    DtStack,
-    DtAvatar,
-    DtIcon,
-    DtImageViewer,
-    DtButton,
-  },
-
-  data () {
-    return {
-      fadeState: 'SEARCHED',
-      mockReactions: sharedEmojiReactionsData,
-
-      hoverButtons: ['bell', 'living-thing', 'map-pin'],
-      persons: ['Jim Halpert', 'Michael Scott', 'Pam'],
-      fryImage,
-    };
-  },
-};
+const fadeState = 'SEARCHED';
+const hoverButtons = ['bell', 'living-thing', 'map-pin'];
+const persons = ['Jim Halpert', 'Michael Scott', 'Pam'];
+const { mockReactions } = useMockReactions();
 </script>
 
 <style lang="less" scoped>


### PR DESCRIPTION
# fix: DLT-2878 stories using emoji row

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
[DLT-2878]
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
The problem was that `getCurrentInstance()` when initializing localization was being called outside of a Vue context. Created a composable so that the storybook components can get the mocked data with the translated names from there, instead of calling directly the constructor for `DialtoneLocalization` in the storybook module.
<!--- Describe specifically what the changes are -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->
<img width="343" height="212" alt="image" src="https://github.com/user-attachments/assets/e5b93774-5484-4999-ba5b-cd7951560b63" />

<!--- Add any links to external reference material -->


[DLT-2878]: https://dialpad.atlassian.net/browse/DLT-2878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ