### PR TITLE
feat(rich-text-editor): NO-JIRA add mention click handling

### DIFF
--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionComponent.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionComponent.vue
@@ -5,6 +5,7 @@
   >
     <dt-link
       kind="mention"
+      @click="handleClick"
     >
       {{ text }}
     </dt-link>
@@ -29,6 +30,19 @@ export default {
   computed: {
     text () {
       return '@' + this.$props.node.attrs.name;
+    },
+  },
+
+  methods: {
+    handleClick (event) {
+      event.preventDefault();
+      const mentionData = {
+        name: this.$props.node.attrs.name,
+        id: this.$props.node.attrs.id,
+        avatarSrc: this.$props.node.attrs.avatarSrc,
+        contactKey: this.$props.node.attrs.contactKey,
+      };
+      this.$props.editor.emit('mention-click', mentionData);
     },
   },
 };

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionComponent.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/mentions/MentionComponent.vue
@@ -5,7 +5,7 @@
   >
     <dt-link
       kind="mention"
-      @click="handleClick"
+      @click.prevent="handleClick"
     >
       {{ text }}
     </dt-link>
@@ -34,8 +34,7 @@ export default {
   },
 
   methods: {
-    handleClick (event) {
-      event.preventDefault();
+    handleClick () {
       const mentionData = {
         name: this.$props.node.attrs.name,
         id: this.$props.node.attrs.id,

--- a/packages/dialtone-vue3/components/rich_text_editor/extensions/suggestion/SuggestionList.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/extensions/suggestion/SuggestionList.vue
@@ -125,7 +125,7 @@ export default {
           this.command(item);
           return;
         case 'mention':
-          this.command({ name: item.name, id: item.id, avatarSrc: item.avatarSrc });
+          this.command({ name: item.name, id: item.id, avatarSrc: item.avatarSrc, contactKey: item.contactKey });
           break;
         case 'channel':
           this.command({ name: item.name, id: item.id, locked: item.locked });

--- a/packages/dialtone-vue3/components/rich_text_editor/mention_suggestion.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/mention_suggestion.js
@@ -1,10 +1,11 @@
 import defaultImage from '@/common/assets/avatar2.png';
 
-/* eslint-disable max-len */
+
 const CONTACT_LIST = [
   {
     id: 'test.person',
     name: 'Test Person',
+    contactKey: '123',
     avatarSrc: defaultImage,
     showDetails: true,
     presence: 'active',
@@ -14,6 +15,7 @@ const CONTACT_LIST = [
   {
     id: 'test.person2',
     name: 'Test Person 2',
+    contactKey: '1234',
     avatarSrc: defaultImage,
     showDetails: true,
     presence: 'busy',
@@ -23,6 +25,7 @@ const CONTACT_LIST = [
   {
     id: 'test.person3',
     name: 'Test Person 3',
+    contactKey: '12345',
     avatarSrc: defaultImage,
     showDetails: true,
     presence: 'busy',
@@ -32,6 +35,7 @@ const CONTACT_LIST = [
   {
     id: 'brad.paugh',
     name: 'Brad Paugh',
+    contactKey: '123456',
     avatarSrc: defaultImage,
     showDetails: true,
     presence: 'offline',
@@ -40,6 +44,7 @@ const CONTACT_LIST = [
   {
     id: 'bradley.hawkins',
     name: 'Bradley Hawkins',
+    contactKey: '1234567',
     avatarSrc: defaultImage,
     showDetails: true,
     presence: 'away',
@@ -50,27 +55,32 @@ const CONTACT_LIST = [
   {
     id: 'julio.ortega',
     name: 'Tico Ortega',
+    contactKey: '12345678',
     avatarSrc: defaultImage,
   },
   {
     id: 'ignacio.ropolo',
     name: 'Ignacio Ropolo',
+    contactKey: '123456789',
     avatarSrc: defaultImage,
   },
   {
     id: 'nina.repetto',
     name: 'Nina Repetto',
+    contactKey: '123456789',
     avatarSrc: defaultImage,
   },
   {
     id: 'long.name',
     name: 'LongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongnameLongname',
     avatarSrc: defaultImage,
+    contactKey: '1234567890',
   },
   {
     id: 'long.name.with.spaces',
     name: 'Long Name Long Name Long Name Long NameLong Name Long Name Long Name Long NameLong Name Long Name Long Name Long NameLong Name Long Name Long Name Long NameLong Name Long Name Long Name Long Name ',
     avatarSrc: defaultImage,
+    contactKey: '12345678901',
   },
 ];
 

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.stories.js
@@ -29,6 +29,7 @@ export const argsData = {
   onMarkdownInput: action('markdown-input'),
   onEditLink: action('edit-link'),
   onSelectedCommand: action('selected-command'),
+  onMentionClick: action('mention-click'),
 };
 
 export const argTypesData = {
@@ -119,6 +120,11 @@ export const argTypesData = {
     },
   },
   onSelectedCommand: {
+    table: {
+      disable: true,
+    },
+  },
+  onMentionClick: {
     table: {
       disable: true,
     },

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.test.js
@@ -604,6 +604,34 @@ describe('DtRichTextEditor tests', () => {
   });
 
   describe('Interactivity Tests', () => {
+    describe('Mention click functionality', () => {
+      describe('When a mention is clicked', () => {
+        it('should emit mention-click event with mention data', async () => {
+          const mentionData = {
+            id: 'john.doe',
+            name: 'John Doe',
+            avatarSrc: 'avatar.jpg',
+            contactKey: 'contact-123',
+          };
+
+          await wrapper.setProps({
+            mentionSuggestion: { items: vi.fn(() => [mentionData]) },
+          });
+
+          const editorInstance = wrapper.vm.editor;
+          const mentionNode = editorInstance.schema.nodes.mention.create(mentionData);
+          editorInstance.view.dispatch(editorInstance.state.tr.insert(0, mentionNode));
+          await wrapper.vm.$nextTick();
+
+          const mentionLink = wrapper.find('a.d-link');
+          expect(mentionLink.text()).toBe('@John Doe');
+
+          await mentionLink.trigger('click');
+          expect(wrapper.emitted('mention-click')[0][0]).toEqual(mentionData);
+        });
+      });
+    });
+
     describe('Link keyboard shortcut functionality', () => {
       describe('When Mod+K is pressed and link is enabled', () => {
         it('should emit edit-link event', async () => {

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -494,6 +494,13 @@ export default {
      * @type {String}
      */
     'selected-command',
+
+    /**
+     * Event fired when a mention is clicked
+     * @event mention-click
+     * @type {Object}
+     */
+    'mention-click',
   ],
 
   data () {
@@ -1188,9 +1195,14 @@ export default {
         this.$emit('focus', event);
       });
 
-      // The editor isn’t focused anymore.
+      // The editor isn't focused anymore.
       this.editor.on('blur', ({ event }) => {
         this.$emit('blur', event);
+      });
+
+      // Mention is clicked
+      this.editor.on('mention-click', (mentionData) => {
+        this.$emit('mention-click', mentionData);
       });
     },
 

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor_default.story.vue
@@ -33,6 +33,7 @@
     @text-input="$attrs.onTextInput"
     @markdown-input="$attrs.onMarkdownInput"
     @selected-command="$attrs.onSelectedCommand"
+    @mention-click="$attrs.onMentionClick"
     @focus="$attrs.onFocus"
     @enter="$attrs.onEnter"
   />


### PR DESCRIPTION
# feat(rich-text-editor): add mention click handling

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExdnJhbmxtbXpmY2pyNHZkbWY0cTIzbXE0djVlYWdpaTUxc2U3b2JiaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ZGqQ6b9uVa1uTPn6W5/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

Not a direct ticket but sorta related to https://dialpad.atlassian.net/browse/DP-119898

## :book: Description

- Added custom mention click handling
- Fixed problem with contactKey not outputting correctly

## :bulb: Context

Couple of follow up items the mobile team asked me for on rich text a long time ago. The contactKey was not populating correctly due to some missing code. Clicking the mention was no longer navigating to the contact as it is now handled internally to rich-text-editor, this one isn't related to mobile team but still fixing it here as it was requested.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

update in ubervoice, test with mobile team
