### PR TITLE
docs: DLT-2880 remove user facing vue 2 docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -74,7 +74,7 @@ If new component:
 
 - I am exporting any new components or constants:
   - [ ] from the index.js in the component directory.
-  - [ ] from the index.js in the root (either `packages/dialtone-vue2` or `packages/dialtone-vue3`).
+  - [ ] from the index.js in the root (like`packages/dialtone-vue3`).
 - [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
 - [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
 - [ ] I have added the new component to `common/components_list.js`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -74,7 +74,7 @@ If new component:
 
 - I am exporting any new components or constants:
   - [ ] from the index.js in the component directory.
-  - [ ] from the index.js in the root (like`packages/dialtone-vue3`).
+  - [ ] from the index.js in the root (like `packages/dialtone-vue3`).
 - [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
 - [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
 - [ ] I have added the new component to `common/components_list.js`

--- a/.github/workflows/clean-preview.yml
+++ b/.github/workflows/clean-preview.yml
@@ -12,8 +12,7 @@ jobs:
       id-token: 'write'
     env:
       DIALTONE_BUCKET_DIRECTORY: dialtone.dialpad.com/deploy-previews/pr-${{ github.event.pull_request.number }}/
-      DIALTONE_VUE_2_BUCKET_DIRECTORY: dialtone.dialpad.com/vue/deploy-previews/pr-${{ github.event.pull_request.number }}/
-      DIALTONE_VUE_3_BUCKET_DIRECTORY: dialtone.dialpad.com/vue3/deploy-previews/pr-${{ github.event.pull_request.number }}/
+      DIALTONE_VUE_3_BUCKET_DIRECTORY: dialtone.dialpad.com/vue/deploy-previews/pr-${{ github.event.pull_request.number }}/
     steps:
       - uses: actions/checkout@v4
 
@@ -33,11 +32,6 @@ jobs:
           gcloud storage rm --recursive ${{ format('gs://{0}', env.DIALTONE_BUCKET_DIRECTORY) }}
 
       - name: Clean up dialtone-vue preview
-        continue-on-error: true
-        run: |
-          gcloud storage rm --recursive ${{ format('gs://{0}', env.DIALTONE_VUE_2_BUCKET_DIRECTORY) }}
-
-      - name: Clean up dialtone-vue3 preview
         continue-on-error: true
         run: |
           gcloud storage rm --recursive ${{ format('gs://{0}', env.DIALTONE_VUE_3_BUCKET_DIRECTORY) }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,9 @@ on:
       - 'packages/dialtone-tokens/themes/**'
       - 'packages/dialtone-tokens/tokens/**'
       - 'packages/dialtone-tokens/gulpfile.cjs'
-      - 'packages/dialtone-vue*/**/*.vue'
-      - 'packages/dialtone-vue*/**/*.*js'
-      - 'packages/dialtone-vue*/**/*.stories.js'
+      - 'packages/dialtone-vue3/**/*.vue'
+      - 'packages/dialtone-vue3/**/*.*js'
+      - 'packages/dialtone-vue3/**/*.stories.js'
       - '!**/*.test.*js'
   pull_request:
     paths:
@@ -40,17 +40,16 @@ on:
       - 'packages/dialtone-tokens/themes/**'
       - 'packages/dialtone-tokens/tokens/**'
       - 'packages/dialtone-tokens/gulpfile.cjs'
-      - 'packages/dialtone-vue*/**/*.vue'
-      - 'packages/dialtone-vue*/**/*.*js'
-      - 'packages/dialtone-vue*/**/*.stories.js'
+      - 'packages/dialtone-vue3/**/*.vue'
+      - 'packages/dialtone-vue3/**/*.*js'
+      - 'packages/dialtone-vue3/**/*.stories.js'
       - '!**/*.test.*js'
 
 env:
   HUSKY: 0
   BASE_URL: ${{ github.event_name == 'pull_request' && format('deploy-previews/pr-{0}/', github.event.pull_request.number) || (github.ref_name != 'production' && format('{0}/', github.ref_name)) || '' }}
   DIALTONE_BUCKET_DIRECTORY: dialtone.dialpad.com
-  DIALTONE_VUE_2_BUCKET_DIRECTORY: dialtone.dialpad.com/vue
-  DIALTONE_VUE_3_BUCKET_DIRECTORY: dialtone.dialpad.com/vue3
+  DIALTONE_VUE_3_BUCKET_DIRECTORY: dialtone.dialpad.com/vue
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -86,19 +85,6 @@ jobs:
               - 'packages/dialtone-tokens/tokens/**'
               - 'packages/dialtone-tokens/gulpfile.cjs'
               - 'packages/dialtone-vue3/{common,components,directives,localization,recipes}/**/!(*.story.vue|*.test.js|*.stories.js)'
-            dialtone-vue2:
-              - 'packages/dialtone-css/**/*.less'
-              - 'packages/dialtone-css/postcss/*.cjs'
-              - 'packages/dialtone-css/gulpfile.cjs'
-              - 'packages/dialtone-emojis/src/**'
-              - 'packages/dialtone-icons/src/**'
-              - 'packages/dialtone-icons/gulpfile.cjs'
-              - 'packages/dialtone-tokens/*.js'
-              - 'packages/dialtone-tokens/postcss/**'
-              - 'packages/dialtone-tokens/themes/**'
-              - 'packages/dialtone-tokens/tokens/**'
-              - 'packages/dialtone-tokens/gulpfile.cjs'
-              - 'packages/dialtone-vue2/**'
             dialtone-vue3:
               - 'packages/dialtone-css/**/*.less'
               - 'packages/dialtone-css/postcss/*.cjs'
@@ -130,7 +116,7 @@ jobs:
     name: Deploy sites
     if: ${{ needs.filter-actions.outputs.packages != '[]' }}
     env:
-      BUCKET_CLEANUP_EXCLUDE: '/alpha/|/beta/|/deploy-previews/|/staging/|/next/|/vue/|/vue3/'
+      BUCKET_CLEANUP_EXCLUDE: '/alpha/|/beta/|/deploy-previews/|/staging/|/next/|/vue/'
     strategy:
       fail-fast: false
       matrix:
@@ -162,7 +148,6 @@ jobs:
         id: expand
         env:
           DIALTONE_DIST_DIRECTORY: apps/dialtone-documentation/docs/.vuepress/dist
-          DIALTONE_VUE_2_DIST_DIRECTORY: packages/dialtone-vue2/storybook-static
           DIALTONE_VUE_3_DIST_DIRECTORY: packages/dialtone-vue3/storybook-static
         run: |
           if [[ ${{ matrix.package }} == 'dialtone-documentation' ]]; then
@@ -170,10 +155,6 @@ jobs:
             echo "source_directory=$DIALTONE_DIST_DIRECTORY" >> $GITHUB_OUTPUT;
             echo "dest_directory=$DIALTONE_BUCKET_DIRECTORY/$BASE_URL" >> $GITHUB_OUTPUT;
             echo "build_command=dialtone-documentation:build" >> $GITHUB_OUTPUT;
-          elif [[ ${{ matrix.package }} == 'dialtone-vue2' ]]; then
-            echo "source_directory=$DIALTONE_VUE_2_DIST_DIRECTORY" >> $GITHUB_OUTPUT;
-            echo "dest_directory=$DIALTONE_VUE_2_BUCKET_DIRECTORY/$BASE_URL" >> $GITHUB_OUTPUT;
-            echo "build_command=dialtone-vue2:build-storybook" >> $GITHUB_OUTPUT;
           elif [[ ${{ matrix.package }} == 'dialtone-vue3' ]]; then
             echo "source_directory=$DIALTONE_VUE_3_DIST_DIRECTORY" >> $GITHUB_OUTPUT;
             echo "dest_directory=$DIALTONE_VUE_3_BUCKET_DIRECTORY/$BASE_URL" >> $GITHUB_OUTPUT;
@@ -238,7 +219,6 @@ jobs:
           message: |
             ✔️ Deploy previews ready!
             ${{ contains(needs.filter-actions.outputs.packages, 'dialtone-documentation') && format('😎 Dialtone documentation preview: https://{0}/{1}', env.DIALTONE_BUCKET_DIRECTORY, env.BASE_URL) }}
-            ${{ contains(needs.filter-actions.outputs.packages, 'dialtone-vue2') && format('😎 Dialtone-vue 2 preview: https://{0}/{1}', env.DIALTONE_VUE_2_BUCKET_DIRECTORY, env.BASE_URL) || '' }}
-            ${{ contains(needs.filter-actions.outputs.packages, 'dialtone-vue3') && format('😎 Dialtone-vue 3 the preview: https://{0}/{1}', env.DIALTONE_VUE_3_BUCKET_DIRECTORY, env.BASE_URL) || '' }}
+            ${{ contains(needs.filter-actions.outputs.packages, 'dialtone-vue3') && format('😎 Dialtone-vue preview: https://{0}/{1}', env.DIALTONE_VUE_3_BUCKET_DIRECTORY, env.BASE_URL) || '' }}
           message-id: 'deploy-preview-message'
           refresh-message-position: true

--- a/README.md
+++ b/README.md
@@ -12,16 +12,9 @@ The below usage instructions are for the combined package.
 
 ### Install it via NPM:
 
-#### Using Vue@3
-
 ```shell
 npm install @dialpad/dialtone @dialpad/i18n
 ```
-
-#### Using Vue@2
-
-```shell
-npm install @dialpad/dialtone @dialpad/i18n-vue2
 
 ### Import packages:
 
@@ -110,20 +103,6 @@ import "@dialpad/dialtone/tokens/tokens-dp-light.css" // Dialpad light brand
 
 #### Dialtone icons
 
-- Vue 2:
-
-```js
-// Named import
-import { DtIconArrowUp } from '@dialpad/dialtone-icons/vue2';
-import { DtIllustrationBlankSpace } from '@dialpad/dialtone-icons/vue2';
-
-// Default import (Preferred if using webpack as it is tree-shakeable by default)
-import DtIconArrowUp from '@dialpad/dialtone-icons/vue2/arrow-up';
-import DtIllustrationBlankSpace from '@dialpad/dialtone-icons/vue2/blank-space';
-```
-
-- Vue 3:
-
 ```js
 // Named import
 import { DtIconArrowUp } from '@dialpad/dialtone-icons/vue3';
@@ -136,18 +115,6 @@ import DtIllustrationBlankSpace from '@dialpad/dialtone-icons/vue3/blank-space';
 
 #### Dialtone Vue components
 
-- Vue 2
-
-```js
-// Named import
-import { DtButton } from "@dialpad/dialtone/vue2"
-
-// Default import (Preferred if using webpack as it is tree-shakeable by default)
-import { DtButton } from "@dialpad/dialtone/vue2/lib/button"
-```
-
-- Vue 3
-
 ```js
 // Named import
 import { DtButton } from "@dialpad/dialtone/vue3"
@@ -156,7 +123,7 @@ import { DtButton } from "@dialpad/dialtone/vue3"
 import { DtButton } from "@dialpad/dialtone/vue3/lib/button"
 ```
 
-#### Dialtine MCP Server
+#### Dialtone MCP Server
 
 Install the MCP server to use it in your local environment and develop efficiently with Dialtone.
 Follow the instructions in the [MCP Server](https://github.com/dialpad/dialtone/tree/staging/packages/dialtone-mcp-server) folder.

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Home.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Home.vue
@@ -100,10 +100,7 @@
             Browse CSS Components
           </router-link>
           <a class="d-link" href="https://dialtone.dialpad.com/vue/index.html?path=/docs/welcome--docs" target="_blank" rel="noopener noreferrer">
-            Browse Vue 2 Components
-          </a>
-          <a class="d-link" href="https://dialtone.dialpad.com/vue3/index.html?path=/docs/welcome--docs" target="_blank" rel="noopener noreferrer">
-            Browse Vue 3 Components
+            Browse Vue Components
           </a>
         </dt-stack>
       </dt-stack>

--- a/apps/dialtone-documentation/docs/about/dialtone.md
+++ b/apps/dialtone-documentation/docs/about/dialtone.md
@@ -29,7 +29,7 @@ Dialtone provides two options to use the components: CSS and Vue.
 
 ### Vue components (recommended)
 
-Use [Vue components](https://dialtone.dialpad.com/vue3/index.html) in the case your project supports Vue since these components are built conforming to [WCAG AA Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/glance/)
+Use [Vue components](https://dialtone.dialpad.com/vue/index.html) in the case your project supports Vue since these components are built conforming to [WCAG AA Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/glance/)
 and with usability and performance in mind.
 
 ### CSS components

--- a/apps/dialtone-documentation/docs/components/emoji-picker.md
+++ b/apps/dialtone-documentation/docs/components/emoji-picker.md
@@ -4,7 +4,7 @@ thumb: true
 image: assets/images/components/emoji-picker.png
 description: A emoji picker component that allows you to view and select an emoji from a list.
 status: beta
-storybook: https://dialtone.dialpad.com/vue3/?path=/story/components-emoji-picker--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-emoji-picker--default
 ---
 
 <code-well-header>

--- a/apps/dialtone-documentation/docs/components/icon.md
+++ b/apps/dialtone-documentation/docs/components/icon.md
@@ -18,15 +18,7 @@ Check out our complete icon collection in the [icon catalog](/design/icons/index
 
 Here is an example that demonstrates how you can use the icon component in your project:
 
-### Vue 2
-
-```js
-import { DtIconUserPlus } from '@dialpad/dialtone-icons/vue2';
-
-<dt-icon-user-plus size="500" />
-```
-
-### Vue 3
+### With Tree Shaking (Preferred)
 
 ```js
 import { DtIconUserPlus } from '@dialpad/dialtone-icons/vue3';

--- a/apps/dialtone-documentation/docs/components/input-group.md
+++ b/apps/dialtone-documentation/docs/components/input-group.md
@@ -61,7 +61,7 @@ The Vue model is dependant on the child component(s) implementing the provided `
 import {
   DtInputMixin,
   DtGroupableInputMixin,
-} from '@dialpad/dialtone/vue2';
+} from '@dialpad/dialtone/vue3';
 
 export default {
   name: 'MyInputElement',
@@ -279,7 +279,7 @@ If your input(s) require additional logic in order to be grouped then you can ex
 
 ```vue
 <script>
-import { DtInputGroup } from '@dialpad/dialtone/vue2';
+import { DtInputGroup } from '@dialpad/dialtone/vue3';
 
 export default {
   name: "MyComponent",

--- a/apps/dialtone-documentation/docs/components/scrollbar.md
+++ b/apps/dialtone-documentation/docs/components/scrollbar.md
@@ -61,10 +61,6 @@ vueCode='
 Import the directive and styling from dialtone
 
 ```javascript
-// For Vue 2
-import { DtScrollbarDirective } from "@dialpad/dialtone/vue2";
-
-// For Vue 3+
 import { DtScrollbarDirective } from "@dialpad/dialtone/vue3";
 
 // Import styling
@@ -74,10 +70,6 @@ import 'overlayscrollbars/overlayscrollbars.css';
 Install the directive into vue instance
 
 ```javascript
-// For Vue 2
-Vue.use(DtScrollbarDirective);
-
-// For Vue 3+
 app.use(DtScrollbarDirective);
 ```
 

--- a/apps/dialtone-documentation/docs/components/scroller.md
+++ b/apps/dialtone-documentation/docs/components/scroller.md
@@ -4,7 +4,7 @@ description: A scroller component that allows blazing fast scrolling of any amou
 status: beta
 thumb: true
 image: assets/images/components/scroller.png
-storybook: https://dialtone.dialpad.com/vue3/?path=/story/components-scroller--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-scroller--default
 ---
 
 #### Default Scroller

--- a/apps/dialtone-documentation/docs/design/icons/index.md
+++ b/apps/dialtone-documentation/docs/design/icons/index.md
@@ -2,7 +2,7 @@
 title: Icons
 shortTitle: icons
 description: An icon style for visually communicating commands, status, and more.
-storybook: https://vue.dialpad.design/?path=/story/components-icon--default
+storybook: https://dialtone.dialpad.com/vue/?path=/story/components-icon--default
 figma_url: https://www.figma.com/file/zz40wi0uW9MvaJ5RuhcRZR/DT-Core%3A-Icons-7?node-id=1473%3A3757&viewport=-168%2C479%2C1&t=OhX4ilCDvb7Tqkx4-11
 ---
 
@@ -38,15 +38,6 @@ For detailed instructions on using the icons, check the [Icon component](/compon
     <dt-select-menu label="Size" :options="sizeValues" v-model="selectedSize" />
   </div>
 </code-well-header>
-
-#### Vue 2
-
-```js
-import { DtIconCreditCard } from '@dialpad/dialtone-icons/vue2';
-<dt-icon-credit-card size="500" aria-label="Description" />
-```
-
-#### Vue 3
 
 ```js
 import { DtIconCreditCard } from '@dialpad/dialtone-icons/vue3';

--- a/packages/dialtone-vue3/README.md
+++ b/packages/dialtone-vue3/README.md
@@ -2,14 +2,10 @@
 
 Dialtone Vue is a library of Vue components for [Dialtone][dt]. The goal is to simplify and standardize the use of common UI patterns and behaviour across all Dialpad projects.
 
-Dialtone Vue is available in Vue 2 as well as Vue 3:
-
-- **[Component Documentation Site (Vue 2) ↗️][dialtone-vue]**
-- **[Component Documentation Site (Vue 3) ↗️][dialtone-vue3]**
+- **[Component Documentation Site ↗️][dialtone-vue]**
 
 [dt]: https://dialtone.dialpad.com
 [dialtone-vue]: https://dialtone.dialpad.com/vue
-[dialtone-vue3]: https://dialtone.dialpad.com/vue3
 
 ## Installation
 

--- a/packages/dialtone-vue3/docs/storybook/getting_started.mdx
+++ b/packages/dialtone-vue3/docs/storybook/getting_started.mdx
@@ -41,7 +41,7 @@ nx run dialtone-vue3:build-storybook
 
 ### Deploying Storybook
 
-Storybook is deployed automatically from the production branch to [Dialtone Vue 3 documentation](https://dialtone.dialpad.com/vue3).
+Storybook is deployed automatically from the production branch to [Dialtone Vue documentation](https://dialtone.dialpad.com/vue).
 
 ## Modifying Storybook Build Config
 

--- a/packages/dialtone-vue3/package.json
+++ b/packages/dialtone-vue3/package.json
@@ -125,7 +125,7 @@
       "test"
     ]
   },
-  "homepage": "https://dialtone.dialpad.com/vue3",
+  "homepage": "https://dialtone.dialpad.com/vue",
   "keywords": [
     "Dialpad",
     "Dialtone",

--- a/packages/dialtone-vue3/recipes/leftbar/callbox/callbox_variants.story.vue
+++ b/packages/dialtone-vue3/recipes/leftbar/callbox/callbox_variants.story.vue
@@ -406,7 +406,7 @@ import {
   DtIconMic,
   DtIconUsers,
   DtIconWaveform,
-} from '@dialpad/dialtone-icons/vue2';
+} from '@dialpad/dialtone-icons/vue3';
 import DtItemLayout from '@/components/item_layout/item_layout.vue';
 import DtStack from '@/components/stack/stack.vue';
 import chattingPersonImage from '@/common/assets/chatting-person-example.png';


### PR DESCRIPTION
# docs: DLT-2880 remove user facing vue 2 docs

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExYmI4NDJnaXQ4c2c4MHZnM2NuejZrcWpqdHY5NmxiMHB0MTBsamZpOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/oe33xf3B50fsc/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2880

## :book: Description

- Changed web address of `/vue3` to `/vue`.
- Stopped deployment of vue2 docsite.
- Changed any remaining documents that still contained links or references to vue2 vs vue 3.

Note that no changes have yet been made to package deployment.

## :bulb: Context

Vue 2 is no longer used, so might as well remove it from our docsite so it's less confusing for everyone. We will fully remove from the repo, and figure out what we're doing with package management at a later date.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

Fully remove Vue 2
