### PR TITLE
ci: NO-JIRA fix public npm package deploy

### DIFF
--- a/.github/workflows/a11y_tests.yml
+++ b/.github/workflows/a11y_tests.yml
@@ -59,22 +59,8 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v4
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "dialpad"
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
-
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
@@ -92,22 +78,8 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v4
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "dialpad"
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
-
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -16,22 +16,8 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v4
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "dialpad"
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
-
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
       - name: Lint pull request title
         run: |

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -76,22 +76,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "dialpad"
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
-
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -31,22 +31,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "dialpad"
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
-
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
       - name: Build swift
         run: pnpm nx run dialtone-tokens:build:ios

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -124,10 +124,10 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
 
-      - name: Remove GitHub registry if publishing to npm
-        if: matrix.registry == 'npm'
-        run: |
-          pnpm config delete @dialpad:registry;
+      - name: Setup registry authentication
+        uses: actions/setup-node@v4
+        with:
+          registry-url: 'https:${{ matrix.registry_url }}'
 
       - name: Delay job to avoid npm rate limits
         if: matrix.package == 'dialtone-vue3'

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -124,7 +124,8 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
 
-      - name: Setup registry authentication
+      - name: Set npm registry URL
+        if: matrix.registry == 'npm'
         uses: actions/setup-node@v4
         with:
           registry-url: 'https:${{ matrix.registry_url }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,22 +72,8 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.DIALTONE_CI_TOKEN }}
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "dialpad"
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
-
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
       # Release to GitHub
       - name: Release Dialtone Combinator ${{ env.RELEASE_TAG }}

--- a/.github/workflows/sync-figma-to-tokens.yml
+++ b/.github/workflows/sync-figma-to-tokens.yml
@@ -18,22 +18,8 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v4
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "dialpad"
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
-
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
       - name: Sync variables in Figma file to tokens
         run: pnpm nx run --verbose dialtone-tokens:sync:figma-to-tokens -- --output tokens

--- a/.github/workflows/sync-tokens-to-figma.yml
+++ b/.github/workflows/sync-tokens-to-figma.yml
@@ -15,22 +15,8 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v4
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "dialpad"
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
-
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
       - name: Sync tokens to Figma file
         run: pnpm nx run --verbose dialtone-tokens:sync:tokens-to-figma

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -28,22 +28,8 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v4
 
-      - name: Use pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "dialpad"
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
-
-      - name: Install dependencies
-        shell: bash
-        run: pnpm install --frozen-lockfile
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
       - name: Run dialtone-vue2 tests with coverage
         run: pnpm nx run dialtone-vue2:test:coverage


### PR DESCRIPTION
# ci: fix public npm package deploy

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

- [x] CI

## :book: Description

- set npm registry URL
- make all workflows use the `./.github/actions/setup-environment` action for better maintenance

## :bulb: Context

Justin implemented OIDC authentication with npm in this PR: https://github.com/dialpad/dialtone/pull/997/changes, however instead of removing just the token he removed the setting of the registry URL entirely. This fixes that problem and also makes all workflows use the common `./.github/actions/setup-environment` for consistency and better maintenance.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :link: Sources

https://docs.npmjs.com/trusted-publishers#how-to-configure-maximum-security
