### PR TITLE
fix(motion-text): DLT-2804 motion-text recipe letter-spacing fixes

### DIFF
--- a/packages/dialtone-css/lib/build/less/recipes/motion_text.less
+++ b/packages/dialtone-css/lib/build/less/recipes/motion_text.less
@@ -81,7 +81,7 @@
 
 .dt-recipe-motion-text__word {
   position: relative;
-  display: inline;
+  display: inline-block;
   white-space: nowrap;
 }
 
@@ -248,10 +248,6 @@
 //  ============================================================================
 //  $   MODIFIERS
 //  ----------------------------------------------------------------------------
-.dt-recipe-motion-text--slide-in .dt-recipe-motion-text__word {
-  display: inline-block;
-}
-
 .dt-recipe-motion-text--none .dt-recipe-motion-text__word,
 .dt-recipe-motion-text--none .dt-recipe-motion-text__char {
   transform: none;

--- a/packages/dialtone-css/lib/build/less/recipes/motion_text.less
+++ b/packages/dialtone-css/lib/build/less/recipes/motion_text.less
@@ -75,7 +75,7 @@
 }
 
 .dt-recipe-motion-text__char {
-  display: inline-block;
+  display: inline;
   white-space: pre;
 }
 
@@ -248,6 +248,10 @@
 //  ============================================================================
 //  $   MODIFIERS
 //  ----------------------------------------------------------------------------
+.dt-recipe-motion-text--slide-in .dt-recipe-motion-text__word {
+  display: inline-block;
+}
+
 .dt-recipe-motion-text--none .dt-recipe-motion-text__word,
 .dt-recipe-motion-text--none .dt-recipe-motion-text__char {
   transform: none;

--- a/packages/dialtone-vue2/recipes/motion/motion_text/motion_text.mdx
+++ b/packages/dialtone-vue2/recipes/motion/motion_text/motion_text.mdx
@@ -25,7 +25,7 @@ The component supports six different animation modes, each with its own unique v
 
 - **gradient-in**: Characters appear with a colorful gradient highlight reveal
 - **fade-in**: Smooth opacity-based character reveal
-- **slide-in**: Characters slide up from below
+- **slide-in**: Words slide up from below
 - **gradient-sweep**: Static text with an animated gradient sweep (loops automatically)
 - **shimmer**: Static text with an animated shimmer effect (loops automatically)
 - **none**: Instant text display without animation
@@ -167,6 +167,7 @@ Provide alternative text for screen readers:
 ### ARIA Attributes
 
 The component automatically includes proper ARIA attributes:
+
 - `aria-live="polite"` during animation
 - `aria-label` when screen reader text is provided
 - `aria-hidden` for animated content while animating

--- a/packages/dialtone-vue2/recipes/motion/motion_text/motion_text_modes.story.vue
+++ b/packages/dialtone-vue2/recipes/motion/motion_text/motion_text_modes.story.vue
@@ -93,7 +93,7 @@ export default {
       const descriptions = {
         'gradient-in': 'Characters appear one by one with a gradient highlight reveal effect',
         'fade-in': 'Characters fade in smoothly with opacity transitions',
-        'slide-in': 'Characters slide up from below with smooth vertical movement',
+        'slide-in': 'Words slide up from below with smooth vertical movement',
         'gradient-sweep': 'Text is static while a gradient sweeps across continuously',
         'shimmer': 'Text is static while a black and white gradient pulses continuously',
         'none': 'All text appears instantly without animation',

--- a/packages/dialtone-vue3/recipes/motion/motion_text/motion_text.mdx
+++ b/packages/dialtone-vue3/recipes/motion/motion_text/motion_text.mdx
@@ -25,7 +25,7 @@ The component supports six different animation modes, each with its own unique v
 
 - **gradient-in**: Characters appear with a colorful gradient highlight reveal
 - **fade-in**: Smooth opacity-based character reveal
-- **slide-in**: Characters slide up from below
+- **slide-in**: Words slide up from below
 - **gradient-sweep**: Static text with an animated gradient sweep (loops automatically)
 - **shimmer**: Static text with an animated shimmer effect (loops automatically)
 - **none**: Instant text display without animation
@@ -167,6 +167,7 @@ Provide alternative text for screen readers:
 ### ARIA Attributes
 
 The component automatically includes proper ARIA attributes:
+
 - `aria-live="polite"` during animation
 - `aria-label` when screen reader text is provided
 - `aria-hidden` for animated content while animating

--- a/packages/dialtone-vue3/recipes/motion/motion_text/motion_text_modes.story.vue
+++ b/packages/dialtone-vue3/recipes/motion/motion_text/motion_text_modes.story.vue
@@ -93,7 +93,7 @@ export default {
       const descriptions = {
         'gradient-in': 'Characters appear one by one with a gradient highlight reveal effect',
         'fade-in': 'Characters fade in smoothly with opacity transitions',
-        'slide-in': 'Characters slide up from below with smooth vertical movement',
+        'slide-in': 'Words slide up from below with smooth vertical movement',
         'gradient-sweep': 'Text is static while a gradient sweeps across continuously',
         'shimmer': 'Text is static while a black and white gradient pulses continuously',
         'none': 'All text appears instantly without animation',


### PR DESCRIPTION
# fix(motion-text): DLT-2804 fix motion-text recipe letter-spacing 

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExMmplYXVkaHBweXEwNjhxa3hwYjc0MnR6M2pzaGg1ZGdkejk3NWFzMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/TvVck7lO4LDJS/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->
https://dialpad.atlassian.net/browse/DLT-2806

## :book: Description

<!--- Describe specifically what the changes are -->
Adjusting how the `.dt-recipe-motion-text__char` and `.dt-recipe-motion-text__word` classes are styled in the motion-text recipe to enable normal letter-spacing while keeping the motion effects in place. 

`.dt-recipe-motion-text__char` now uses `display:inline`, which retains the normal letter-spacing. This aligns with the `::before` pseudo-element that is used for the `gradient-in` effect with the text and also prevents unexpected letter alignment within words.

<img width="1184" height="556" alt="527141075-e33611b0-b271-4c6b-a9e5-173abc893efe" src="https://github.com/user-attachments/assets/45466655-d25c-4a56-9086-31ee80276373" />

https://github.com/user-attachments/assets/7a0bb3b0-3bad-4fd5-9d07-7979747af715

https://github.com/user-attachments/assets/c73ad097-bf6a-4ae5-bef2-42dfc0b879e8

---

Setting the characters to display inline had a side effect of disabling the `slide-in` variant's vertical movement and also preventing some lines from wrapping, so `.dt-recipe-motion-text__word` is now set to `display:inline-block` to re-enable the position transforms and wrapping.


https://github.com/user-attachments/assets/135b05aa-d7b7-4f9a-8f17-730b37172ef4

Note: It does shift the `slide-in` variant from a "character-by-character" animation to be closer to "word-by-word", which I think is actually more in line with the brand animations I've seen previously.



## :bulb: Context

Original request was to "remove the ghosting effect of the layered text in the Motion Text Component". With some initial testing, we found that the ghosting effect was being caused by letter-spacing differences in the pseudo-element and the actual text characters, caused by using display:inline-block on the characters.

Examples of the ghosting effect:

https://github.com/user-attachments/assets/30d69b8e-3976-42a2-9ec6-31a8c0f1d4fb

Keep an eye on the last word here compared to the example in the description section above:

https://github.com/user-attachments/assets/5b642d5b-7fc3-4696-b4f6-b7eba8e0a3e1

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->
I noticed another item while working on the letter spacing. It involves the first letter of each word appearing separately from the rest of the word animation. I originally had attempted to combine the fixes for these items, but have decided to address that in a separate PR. In the screenshots below you can see how the first letter appears to contrast starkly from the remainder of the word:

<img width="401" height="96" alt="Screenshot 2026-01-07 at 4 33 03 PM" src="https://github.com/user-attachments/assets/be6de2b0-67cc-4641-8ae9-dd4738c5cb15" />

<img width="261" height="100" alt="Screenshot 2026-01-07 at 4 32 44 PM" src="https://github.com/user-attachments/assets/b8d04fcf-fa93-4e39-96a9-59b1ad817ce8" />

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

Longer text block examples for other animation types to show that words wrap appropriately:

`fade-in`

https://github.com/user-attachments/assets/3caa7889-2b40-44b6-8e96-f7d3ff0767da

`slide-in`

https://github.com/user-attachments/assets/bc37ad64-fc52-4298-98b8-ffcd380cff52

`gradient-sweep`

https://github.com/user-attachments/assets/ce00c13b-a9c9-4668-a012-ca4436979ffd

`shimmer`

https://github.com/user-attachments/assets/680b8fe7-c20a-4beb-b18e-cdb3de132c00

`none`

<img width="803" height="156" alt="Screenshot 2026-01-07 at 5 21 55 PM" src="https://github.com/user-attachments/assets/ffe95ef0-6e8e-4d09-add4-7123cb827e2f" />

## :link: Sources

<!--- Add any links to external reference material -->
