### PR TITLE
refactor(stack): DLT-2886 update justify prop values

### DIFF
--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2025-12-2.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2025-12-2.md
@@ -63,7 +63,7 @@ The tool is ideal for projects with many flex containers. For small, one-off cha
 **After**
 
 <code-well-header>
-  <dt-stack direction="row" align="center" justify="between" gap="500" class="d-w100p d-bgc-moderate-opaque d-bar8">
+  <dt-stack direction="row" align="center" justify="space-between" gap="500" class="d-w100p d-bgc-moderate-opaque d-bar8">
     <div class="d-bgc-moderate-opaque d-p16 d-bar8">Left</div>
     <div class="d-bgc-moderate-opaque d-p16 d-bar8">Right</div>
   </dt-stack>
@@ -73,7 +73,7 @@ The tool is ideal for projects with many flex containers. For small, one-off cha
 <dt-stack
   direction="row"
   align="center"
-  justify="between"
+  justify="space-between"
   gap="500"
 >
   <div>Left</div>
@@ -526,7 +526,7 @@ If you own the component, refactor its root element to use DtStack.
 ```html
 <dt-stack
   :align="{ default: 'start', md: 'center' }"
-  :justify="{ lg: 'between' }"
+  :justify="{ lg: 'space-between' }"
 >
 ```
 
@@ -630,17 +630,17 @@ If you own the component, refactor its root element to use DtStack.
       <tr>
         <td><code>d-jc-space-between</code></td>
         <td><code>justify</code></td>
-        <td><code>"between"</code></td>
+        <td><code>"space-between"</code></td>
       </tr>
       <tr>
         <td><code>d-jc-space-around</code></td>
         <td><code>justify</code></td>
-        <td><code>"around"</code></td>
+        <td><code>"space-around"</code></td>
       </tr>
       <tr>
         <td><code>d-jc-space-evenly</code></td>
         <td><code>justify</code></td>
-        <td><code>"evenly"</code></td>
+        <td><code>"space-evenly"</code></td>
       </tr>
       <tr>
         <td><code>d-fd-row</code></td>

--- a/apps/dialtone-documentation/docs/components/stack.md
+++ b/apps/dialtone-documentation/docs/components/stack.md
@@ -963,7 +963,7 @@ showHtmlWarning />
 
 The `justify` prop controls how items are distributed along the main axis (the direction of the stack). For row stacks, this controls horizontal distribution. For column stacks, this controls vertical distribution.
 
-Available `justify` values: `start` (default), `center`, `end`, `around`, `between`, `evenly`.
+Available `justify` values: `start` (default), `center`, `end`, `space-around`, `space-between`, `space-evenly`.
 
 ### Start
 
@@ -1104,7 +1104,7 @@ vueCode='
 '
 showHtmlWarning />
 
-### Around
+### Space Around
 
 Distribute items with equal space around each item.
 
@@ -1117,7 +1117,7 @@ Distribute items with equal space around each item.
   >
     <dt-stack
       gap="400"
-      justify="around"
+      justify="space-around"
       class="d-w100p d-h332 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
     >
       <div class="d-bgc-moderate-opaque d-p16 d-bar8">Item 1</div>
@@ -1127,7 +1127,7 @@ Distribute items with equal space around each item.
     <dt-stack
       direction="row"
       gap="400"
-      justify="around"
+      justify="space-around"
       class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
     >
       <div class="d-bgc-moderate-opaque d-p16 d-bar8">Item 1</div>
@@ -1141,7 +1141,7 @@ Distribute items with equal space around each item.
 :htmlCode="() => $refs.justifyAroundExample"
 vueCode='
 <dt-stack
-  justify="around"
+  justify="space-around"
 >
   <div>Item 1</div>
   <div>Item 2</div>
@@ -1150,7 +1150,7 @@ vueCode='
 '
 showHtmlWarning />
 
-### Between
+### Space Between
 
 Distribute items with space between them, edges flush to container.
 
@@ -1163,7 +1163,7 @@ Distribute items with space between them, edges flush to container.
   >
     <dt-stack
       gap="400"
-      justify="between"
+      justify="space-between"
       class="d-w100p d-h332 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
     >
       <div class="d-bgc-moderate-opaque d-p16 d-bar8">Item 1</div>
@@ -1173,7 +1173,7 @@ Distribute items with space between them, edges flush to container.
     <dt-stack
       direction="row"
       gap="400"
-      justify="between"
+      justify="space-between"
       class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
     >
       <div class="d-bgc-moderate-opaque d-p16 d-bar8">Item 1</div>
@@ -1189,7 +1189,7 @@ vueCode='
 <dt-stack
   direction="row"
   gap="400"
-  justify="between"
+  justify="space-between"
   class="d-w100p"
 >
   <div>Item 1</div>
@@ -1199,7 +1199,7 @@ vueCode='
 '
 showHtmlWarning />
 
-### Evenly
+### Space Evenly
 
 Distribute items with equal space between all items, including edges.
 
@@ -1212,7 +1212,7 @@ Distribute items with equal space between all items, including edges.
   >
     <dt-stack
       gap="400"
-      justify="evenly"
+      justify="space-evenly"
       class="d-w100p d-h332 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
     >
       <div class="d-bgc-moderate-opaque d-p16 d-bar8">Item 1</div>
@@ -1222,7 +1222,7 @@ Distribute items with equal space between all items, including edges.
     <dt-stack
       direction="row"
       gap="400"
-      justify="evenly"
+      justify="space-evenly"
       class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
     >
       <div class="d-bgc-moderate-opaque d-p16 d-bar8">Item 1</div>
@@ -1236,7 +1236,7 @@ Distribute items with equal space between all items, including edges.
 :htmlCode="() => $refs.justifyEvenlyExample"
 vueCode='
 <dt-stack
-  justify="evenly"
+  justify="space-evenly"
 >
   <div>Item 1</div>
   <div>Item 2</div>
@@ -1423,7 +1423,7 @@ Resize your browser to see the alignment change at different breakpoints.
   <dt-stack
     direction="row"
     gap="0"
-    :justify="{ default: 'start', md: 'center', lg: 'between' }"
+    :justify="{ default: 'start', md: 'center', lg: 'space-between' }"
     class="d-w100p d-bgc-moderate-opaque d-bar8"
     ref="responsiveJustifyExample"
   >
@@ -1438,7 +1438,7 @@ Resize your browser to see the alignment change at different breakpoints.
 vueCode='
 <dt-stack
   direction="row"
-  :justify="{ default: `start`, md: `center`, lg: `between` }"
+  :justify="{ default: `start`, md: `center`, lg: `space-between` }"
   class="d-w100p"
 >
   <div>Item 1</div>

--- a/packages/dialtone-css/lib/build/less/utilities/flex.less
+++ b/packages/dialtone-css/lib/build/less/utilities/flex.less
@@ -23,8 +23,8 @@
 //     has more than one line.
 //  ----------------------------------------------------------------------------
 .d-ac-center { align-content: center !important; }
-.d-ac-flex-end { align-content: flex-end !important; }
-.d-ac-flex-start { align-content: flex-start !important; }
+.d-ac-flex-end, .d-ac-end { align-content: flex-end !important; }
+.d-ac-flex-start, .d-ac-start { align-content: flex-start !important; }
 .d-ac-space-around { align-content: space-around !important; }
 .d-ac-space-between { align-content: space-between !important; }
 .d-ac-space-evenly { align-content: space-evenly !important; }
@@ -41,8 +41,8 @@
 //     justify-content.
 //  ----------------------------------------------------------------------------
 .d-ai-center { align-items: center !important; }
-.d-ai-flex-end { align-items: flex-end !important; }
-.d-ai-flex-start { align-items: flex-start !important; }
+.d-ai-flex-end, .d-ai-end { align-items: flex-end !important; }
+.d-ai-flex-start, .d-ai-start { align-items: flex-start !important; }
 .d-ai-baseline { align-items: baseline !important; }
 .d-ai-stretch { align-items: stretch !important; }
 .d-ai-normal { align-items: normal !important; }
@@ -55,14 +55,13 @@
 //     of the parent's main axis direction.
 //  ----------------------------------------------------------------------------
 .d-as-center { align-self: center !important; }
-.d-as-flex-end { align-self: flex-end !important; }
-.d-as-flex-start { align-self: flex-start !important; }
+.d-as-flex-end, .d-as-end { align-self: flex-end !important; }
+.d-as-flex-start, .d-as-start { align-self: flex-start !important; }
 .d-as-baseline { align-self: baseline !important; }
 .d-as-stretch { align-self: stretch !important; }
 .d-as-auto { align-self: auto !important; }
 .d-as-normal { align-self: normal !important; }
 .d-as-unset { align-self: unset !important; }
-
 
 //  ============================================================================
 //  $  COLUMNS & LAYOUTS
@@ -185,11 +184,11 @@
 //     Defines the child alignment along the parent's main axis
 //  ----------------------------------------------------------------------------
 .d-jc-center { justify-content: center !important; }
-.d-jc-flex-end { justify-content: flex-end !important; }
-.d-jc-flex-start { justify-content: flex-start !important; }
-.d-jc-space-around { justify-content: space-around !important; }
-.d-jc-space-between { justify-content: space-between !important; }
-.d-jc-space-evenly { justify-content: space-evenly !important; }
+.d-jc-flex-end, .d-jc-end { justify-content: flex-end !important; }
+.d-jc-flex-start, .d-jc-start { justify-content: flex-start !important; }
+.d-jc-space-around, .d-jc-around { justify-content: space-around !important; }
+.d-jc-space-between, .d-jc-between { justify-content: space-between !important; }
+.d-jc-space-evenly, .d-jc-evenly { justify-content: space-evenly !important; }
 .d-jc-baseline { justify-content: baseline !important; }
 .d-jc-normal { justify-content: normal !important; }
 .d-jc-unset { justify-content: unset !important; }

--- a/packages/dialtone-vue2/components/stack/stack.test.js
+++ b/packages/dialtone-vue2/components/stack/stack.test.js
@@ -269,8 +269,8 @@ describe('DtStack Tests', () => {
           justify: {
             sm: 'center',
             md: 'end',
-            lg: 'between',
-            xl: 'around',
+            lg: 'space-between',
+            xl: 'space-around',
           },
         });
 
@@ -284,9 +284,22 @@ describe('DtStack Tests', () => {
 
       describe('When `default` is provided', () => {
         it('should override the default value', async () => {
-          await wrapper.setProps({ justify: { default: 'between' } });
+          await wrapper.setProps({ justify: { default: 'space-between' } });
 
           expect(wrapper.classes('d-stack', 'd-stack--justify-between')).toBe(true);
+        });
+      });
+
+      describe('When legacy alias values are used', () => {
+        it('should support legacy alias values for backwards compatibility', async () => {
+          await wrapper.setProps({ justify: 'between' });
+          expect(wrapper.classes()).toContain('d-stack--justify-between');
+
+          await wrapper.setProps({ justify: 'around' });
+          expect(wrapper.classes()).toContain('d-stack--justify-around');
+
+          await wrapper.setProps({ justify: 'evenly' });
+          expect(wrapper.classes()).toContain('d-stack--justify-evenly');
         });
       });
     });

--- a/packages/dialtone-vue2/components/stack/stack.vue
+++ b/packages/dialtone-vue2/components/stack/stack.vue
@@ -82,7 +82,7 @@ export default {
      * All the undefined breakpoints will have the 'default' value.
      * You can override the default justify with 'default' key.
      * In case of string, it will be applied to all the breakpoints.
-     * Valid values are 'start', 'center', 'end', 'around', 'between', 'evenly'.
+     * Valid values are 'start', 'center', 'end', 'space-around', 'space-between', 'space-evenly'.
      */
     justify: {
       type: [String, Object],

--- a/packages/dialtone-vue2/components/stack/stack_constants.js
+++ b/packages/dialtone-vue2/components/stack/stack_constants.js
@@ -35,9 +35,10 @@ export const DT_STACK_ALIGN = ['start', 'center', 'end', 'stretch', 'baseline'];
 /**
  * Justify values for the stack component (main-axis distribution).
  * Uses array format - simpler structure for newer props.
+ * Primary values align with CSS justify-content values.
  * @type {string[]}
  */
-export const DT_STACK_JUSTIFY = ['start', 'center', 'end', 'around', 'between', 'evenly'];
+export const DT_STACK_JUSTIFY = ['start', 'center', 'end', 'space-around', 'space-between', 'space-evenly', 'around', 'between', 'evenly'];
 
 export default {
   DT_STACK_DIRECTION,

--- a/packages/dialtone-vue2/components/stack/stack_variants.story.vue
+++ b/packages/dialtone-vue2/components/stack/stack_variants.story.vue
@@ -433,13 +433,13 @@
 
           <div>
             <h4 class="d-headline--lg d-mb8">
-              Around
+              space-around
             </h4>
             <div class="d-ba d-bc-default d-p16 d-bar8">
               <dt-stack
                 direction="row"
                 gap="400"
-                justify="around"
+                justify="space-around"
               >
                 <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p8">
                   Stack item 1
@@ -457,13 +457,13 @@
 
           <div>
             <h4 class="d-headline--lg d-mb8">
-              Between
+              space-between
             </h4>
             <div class="d-ba d-bc-default d-p16 d-bar8">
               <dt-stack
                 direction="row"
                 gap="400"
-                justify="between"
+                justify="space-between"
               >
                 <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p8">
                   Stack item 1
@@ -481,13 +481,13 @@
 
           <div>
             <h4 class="d-headline--lg d-mb8">
-              Evenly
+              space-evenly
             </h4>
             <div class="d-ba d-bc-default d-p16 d-bar8">
               <dt-stack
                 direction="row"
                 gap="400"
-                justify="evenly"
+                justify="space-evenly"
               >
                 <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p8">
                   Stack item 1
@@ -586,13 +586,13 @@
 
           <div>
             <h4 class="d-headline--lg d-mb8">
-              Responsive Justify (start → center @md → between @lg)
+              Responsive Justify (start → center @md → space-between @lg)
             </h4>
             <div class="d-ba d-bc-default d-p16 d-bar8">
               <dt-stack
                 direction="row"
                 gap="400"
-                :justify="{ default: 'start', md: 'center', lg: 'between' }"
+                :justify="{ default: 'start', md: 'center', lg: 'space-between' }"
               >
                 <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p8">
                   Stack item 1

--- a/packages/dialtone-vue2/components/stack/utils.js
+++ b/packages/dialtone-vue2/components/stack/utils.js
@@ -73,7 +73,17 @@ function getResponsiveAlignClasses (align) {
 }
 
 function getResponsiveJustifyClasses (justify) {
-  return _getResponsiveClasses(justify, 'justify', DT_STACK_JUSTIFY);
+  if (typeof justify !== 'object' || justify === null) return [];
+
+  return DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
+    const value = justify[breakpoint];
+    if (!value) return null;
+
+    const isValid = DT_STACK_JUSTIFY.includes(value);
+    const normalizedValue = _normalizeJustifyForClass(value);
+
+    return isValid ? `d-stack--${breakpoint}-justify-${normalizedValue}` : null;
+  });
 }
 
 export function getResponsiveClasses (direction, gap, align, justify) {
@@ -95,7 +105,24 @@ export function getDefaultAlignClass (align) {
   return DT_STACK_ALIGN.includes(validAlign) ? `d-stack--align-${validAlign}` : null;
 }
 
+/**
+ * Normalizes justify value to CSS class suffix.
+ * Maps CSS-aligned values (space-around, space-between, space-evenly) to shorthand
+ * (around, between, evenly) for CSS class generation.
+ * @param {string} value - The justify value
+ * @returns {string} The normalized value for CSS class
+ */
+function _normalizeJustifyForClass (value) {
+  const normalizeMap = {
+    'space-around': 'around',
+    'space-between': 'between',
+    'space-evenly': 'evenly',
+  };
+  return normalizeMap[value] || value;
+}
+
 export function getDefaultJustifyClass (justify) {
   const validJustify = _getDefaultValue(justify);
-  return DT_STACK_JUSTIFY.includes(validJustify) ? `d-stack--justify-${validJustify}` : null;
+  const normalizedJustify = _normalizeJustifyForClass(validJustify);
+  return DT_STACK_JUSTIFY.includes(validJustify) ? `d-stack--justify-${normalizedJustify}` : null;
 }

--- a/packages/dialtone-vue3/components/stack/stack.test.js
+++ b/packages/dialtone-vue3/components/stack/stack.test.js
@@ -263,8 +263,8 @@ describe('DtStack Tests', () => {
           justify: {
             sm: 'center',
             md: 'end',
-            lg: 'between',
-            xl: 'around',
+            lg: 'space-between',
+            xl: 'space-around',
           },
         });
 
@@ -278,9 +278,22 @@ describe('DtStack Tests', () => {
 
       describe('When `default` is provided', () => {
         it('should override the default value', async () => {
-          await wrapper.setProps({ justify: { default: 'between' } });
+          await wrapper.setProps({ justify: { default: 'space-between' } });
 
           expect(wrapper.classes('d-stack', 'd-stack--justify-between')).toBe(true);
+        });
+      });
+
+      describe('When legacy alias values are used', () => {
+        it('should support legacy alias values for backwards compatibility', async () => {
+          await wrapper.setProps({ justify: 'between' });
+          expect(wrapper.classes()).toContain('d-stack--justify-between');
+
+          await wrapper.setProps({ justify: 'around' });
+          expect(wrapper.classes()).toContain('d-stack--justify-around');
+
+          await wrapper.setProps({ justify: 'evenly' });
+          expect(wrapper.classes()).toContain('d-stack--justify-evenly');
         });
       });
     });

--- a/packages/dialtone-vue3/components/stack/stack.vue
+++ b/packages/dialtone-vue3/components/stack/stack.vue
@@ -83,7 +83,7 @@ export default {
      * All the undefined breakpoints will have the 'default' value.
      * You can override the default justify with 'default' key.
      * In case of string, it will be applied to all the breakpoints.
-     * Valid values are 'start', 'center', 'end', 'around', 'between', 'evenly'.
+     * Valid values are 'start', 'center', 'end', 'space-around', 'space-between', 'space-evenly'.
      */
     justify: {
       type: [String, Object],

--- a/packages/dialtone-vue3/components/stack/stack_constants.js
+++ b/packages/dialtone-vue3/components/stack/stack_constants.js
@@ -35,9 +35,10 @@ export const DT_STACK_ALIGN = ['start', 'center', 'end', 'stretch', 'baseline'];
 /**
  * Justify values for the stack component (main-axis distribution).
  * Uses array format - simpler structure for newer props.
+ * Primary values align with CSS justify-content values.
  * @type {string[]}
  */
-export const DT_STACK_JUSTIFY = ['start', 'center', 'end', 'around', 'between', 'evenly'];
+export const DT_STACK_JUSTIFY = ['start', 'center', 'end', 'space-around', 'space-between', 'space-evenly', 'around', 'between', 'evenly'];
 
 export default {
   DT_STACK_DIRECTION,

--- a/packages/dialtone-vue3/components/stack/stack_variants.story.vue
+++ b/packages/dialtone-vue3/components/stack/stack_variants.story.vue
@@ -433,13 +433,13 @@
 
           <div>
             <h4 class="d-headline--lg d-mb8">
-              Around
+              space-around
             </h4>
             <div class="d-ba d-bc-default d-p16 d-bar8">
               <dt-stack
                 direction="row"
                 gap="400"
-                justify="around"
+                justify="space-around"
               >
                 <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p8">
                   Stack item 1
@@ -457,13 +457,13 @@
 
           <div>
             <h4 class="d-headline--lg d-mb8">
-              Between
+              space-between
             </h4>
             <div class="d-ba d-bc-default d-p16 d-bar8">
               <dt-stack
                 direction="row"
                 gap="400"
-                justify="between"
+                justify="space-between"
               >
                 <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p8">
                   Stack item 1
@@ -481,13 +481,13 @@
 
           <div>
             <h4 class="d-headline--lg d-mb8">
-              Evenly
+              space-evenly
             </h4>
             <div class="d-ba d-bc-default d-p16 d-bar8">
               <dt-stack
                 direction="row"
                 gap="400"
-                justify="evenly"
+                justify="space-evenly"
               >
                 <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p8">
                   Stack item 1
@@ -586,13 +586,13 @@
 
           <div>
             <h4 class="d-headline--lg d-mb8">
-              Responsive Justify (start → center @md → between @lg)
+              Responsive Justify (start → center @md → space-between @lg)
             </h4>
             <div class="d-ba d-bc-default d-p16 d-bar8">
               <dt-stack
                 direction="row"
                 gap="400"
-                :justify="{ default: 'start', md: 'center', lg: 'between' }"
+                :justify="{ default: 'start', md: 'center', lg: 'space-between' }"
               >
                 <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p8">
                   Stack item 1

--- a/packages/dialtone-vue3/components/stack/utils.js
+++ b/packages/dialtone-vue3/components/stack/utils.js
@@ -73,7 +73,17 @@ function getResponsiveAlignClasses (align) {
 }
 
 function getResponsiveJustifyClasses (justify) {
-  return _getResponsiveClasses(justify, 'justify', DT_STACK_JUSTIFY);
+  if (typeof justify !== 'object' || justify === null) return [];
+
+  return DT_STACK_RESPONSIVE_BREAKPOINTS.map((breakpoint) => {
+    const value = justify[breakpoint];
+    if (!value) return null;
+
+    const isValid = DT_STACK_JUSTIFY.includes(value);
+    const normalizedValue = _normalizeJustifyForClass(value);
+
+    return isValid ? `d-stack--${breakpoint}-justify-${normalizedValue}` : null;
+  });
 }
 
 export function getResponsiveClasses (direction, gap, align, justify) {
@@ -95,7 +105,24 @@ export function getDefaultAlignClass (align) {
   return DT_STACK_ALIGN.includes(validAlign) ? `d-stack--align-${validAlign}` : null;
 }
 
+/**
+ * Normalizes justify value to CSS class suffix.
+ * Maps CSS-aligned values (space-around, space-between, space-evenly) to shorthand
+ * (around, between, evenly) for CSS class generation.
+ * @param {string} value - The justify value
+ * @returns {string} The normalized value for CSS class
+ */
+function _normalizeJustifyForClass (value) {
+  const normalizeMap = {
+    'space-around': 'around',
+    'space-between': 'between',
+    'space-evenly': 'evenly',
+  };
+  return normalizeMap[value] || value;
+}
+
 export function getDefaultJustifyClass (justify) {
   const validJustify = _getDefaultValue(justify);
-  return DT_STACK_JUSTIFY.includes(validJustify) ? `d-stack--justify-${validJustify}` : null;
+  const normalizedJustify = _normalizeJustifyForClass(validJustify);
+  return DT_STACK_JUSTIFY.includes(validJustify) ? `d-stack--justify-${normalizedJustify}` : null;
 }


### PR DESCRIPTION
# Update DtStack justify values to align to css prop name

![justify](https://github.com/user-attachments/assets/bf872b8e-0a40-40c8-b6fd-8928e0dc677f)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2886

## :book: Description

Updates the DtStack component's `justify` prop to accept CSS-aligned values as primary options while maintaining backwards compatibility:

- **New primary values**: `space-around`, `space-between`, `space-evenly`
- **Legacy aliases** still supported: `around`, `between`, `evenly`

## :bulb: Context

Abstracted values weren't intuitive, resulting in some using wrong name and, worse, ai tools always wanted to use e.g. `space-between` instead of abstracted `between`. This will make API more intuitive.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.