### PR TITLE
fix(rich-text-editor): DLT-2770 spacing issue on copy

### DIFF
--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -1047,25 +1047,23 @@ export default {
     },
 
     insertPlainTextWithHardBreaks (view, textData) {
-     // Remove trailing newlines to avoid inserting empty lines at the end
-      const trimmedData = textData.replace(/[\r\n]+$/, '');
+      // If we convert both newlines into hardBreak, we create a blank line.
+      // Collapsing avoids the extra hardBreak while preserving single line breaks.
+      const normalizedData = this.pasteRichText
+        ? textData
+        : textData.replace(/\r\n/g, '\n').replace(/\n\n/g, '\n');
 
-      // Split text by line breaks
+      // Remove trailing newlines to avoid inserting empty lines at the end
+      const trimmedData = normalizedData.replace(/[\r\n]+$/, '');
+
       const lines = trimmedData.split(/\r?\n/);
 
-      // Build content array with text nodes and hard breaks
       const content = [];
       for (let i = 0; i < lines.length; i++) {
-        if (i > 0) {
-          // Add hard break between lines
-          content.push({ type: 'hardBreak' });
-        }
-        if (lines[i]) {
-          content.push({ type: 'text', text: lines[i] });
-        }
+        if (i > 0) content.push({ type: 'hardBreak' });
+        if (lines[i]) content.push({ type: 'text', text: lines[i] });
       }
 
-      // Use the editor's insertContent command which handles selection replacement correctly
       this.editor.chain().focus().insertContent(content).run();
     },
 

--- a/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue3/components/rich_text_editor/rich_text_editor.vue
@@ -1047,28 +1047,26 @@ export default {
     },
 
     insertPlainTextWithHardBreaks (view, textData) {
-      const { tr } = view.state;
-      const { from, to } = view.state.selection;
+     // Remove trailing newlines to avoid inserting empty lines at the end
+      const trimmedData = textData.replace(/[\r\n]+$/, '');
 
-      // Delete selected content
-      tr.deleteRange(from, to);
+      // Split text by line breaks
+      const lines = trimmedData.split(/\r?\n/);
 
-      // Split text by line breaks and insert with hard breaks
-      const lines = textData.split(/\r?\n/);
-      let pos = from;
-
+      // Build content array with text nodes and hard breaks
+      const content = [];
       for (let i = 0; i < lines.length; i++) {
         if (i > 0) {
-          // Insert hard break for line breaks (except before first line)
-          tr.insert(pos, view.state.schema.nodes.hardBreak.create());
-          pos++;
+          // Add hard break between lines
+          content.push({ type: 'hardBreak' });
         }
-        // Insert text content (including empty strings for blank lines)
-        tr.insertText(lines[i], pos);
-        pos += lines[i].length;
+        if (lines[i]) {
+          content.push({ type: 'text', text: lines[i] });
+        }
       }
 
-      view.dispatch(tr);
+      // Use the editor's insertContent command which handles selection replacement correctly
+      this.editor.chain().focus().insertContent(content).run();
     },
 
     shouldPreserveLineBreaks (textData, htmlData) {


### PR DESCRIPTION
# fix(rich-text-editor): DLT-2770 spacing issue on copy

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->

https://dialpad.atlassian.net/browse/DLT-2770

## :book: Description

This code line in `shouldPreserveLineBreaks` function:

```
if (!this.pasteRichText) {
        return !!textData;
      }
```

Is what forces our message to go trough `insertPlainTextWithHardBreaks` in the `without extensions` story.
Because `pasteRichText` is  `false`.

As I can see this is why produces extra blank lines, we are forcing “plain text” and then translating paragraph separators (\n\n) into two hardBreaks.
Im just combine into one if there is two, if there is one, no problemo!


Some tecnical explanation. I just simplified it (I believe) , seems like previously we had two issues, you can see on the video,
first is trailing newlines: when splitting `"test\n"` by newlines, we get `["test", ""]` and the code was inserting a hard break before the empty string, creating an extra blank line.

secondly is some kind of position desync? not sure but the manual tracking pos have some issue. So I just replaced it with an `content` array to push the lines there.




## :camera: Screenshots / GIFs

Before:

https://github.com/user-attachments/assets/2ee23460-a9e9-476a-99fc-484af3c361e8




After:

https://github.com/user-attachments/assets/914f3b3e-cf11-450b-9ec0-b3b991ff36d4

