### PR TITLE
fix(split-button): NO-JIRA fix label padding

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -707,6 +707,7 @@
 
   &__alpha {
     flex-grow: 1;
+    padding-inline-end: calc(var(--button-padding-x) + var(--dt-size-200));
   }
 
   &__omega {
@@ -771,6 +772,12 @@
 
   &__omega:not(.d-btn--outlined) {
     border-inline-start: 0;
+  }
+
+  &__omega:not(.d-btn--outlined, .d-btn--primary) > * {
+    // yes, I'm pushing a half-pixel over just for this variant
+    // to ensure icon is centered
+    transform: translateX(var(--dt-size-50));
   }
 
   &__omega:disabled:not(.d-btn--outlined),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,10 +843,10 @@ importers:
         version: 7.6.20(react@18.3.1)
       '@storybook/vue':
         specifier: 7.6.20
-        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(vue@2.7.16)
+        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(vue@2.7.16)
       '@storybook/vue-vite':
         specifier: 7.6.20
-        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)
+        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)
       '@vue/test-utils':
         specifier: '1.3'
         version: 1.3.6(vue-template-compiler@2.7.16(vue@2.7.16))(vue@2.7.16)
@@ -22360,12 +22360,12 @@ snapshots:
       '@types/express': 4.17.23
       file-system-cache: 2.3.0
 
-  '@storybook/vue-vite@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)':
+  '@storybook/vue-vite@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)':
     dependencies:
       '@storybook/builder-vite': 7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/core-server': 7.6.20(encoding@0.1.13)
-      '@storybook/vue': 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(vue@2.7.16)
+      '@storybook/vue': 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(vue@2.7.16)
       magic-string: 0.30.19
       vite: 7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0)
       vue: 2.7.16
@@ -22418,7 +22418,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/vue@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(vue@2.7.16)':
+  '@storybook/vue@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(vue@2.7.16)':
     dependencies:
       '@babel/core': 7.28.0
       '@storybook/client-logger': 7.6.20
@@ -22427,7 +22427,7 @@ snapshots:
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.6.20
       '@storybook/types': 7.6.20
-      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.13.2))
+      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 2.7.16
@@ -26000,6 +26000,19 @@ snapshots:
       postcss: 8.5.6
 
   css-functions-list@3.2.3: {}
+
+  css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.4.39)
+      postcss: 8.4.39
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.39)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.4.39)
+      postcss-modules-scope: 3.2.1(postcss@8.4.39)
+      postcss-modules-values: 4.0.0(postcss@8.4.39)
+      postcss-value-parser: 4.2.0
+      semver: 7.7.3
+    optionalDependencies:
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
 
   css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)):
     dependencies:
@@ -35507,6 +35520,19 @@ snapshots:
       type-fest: 2.19.0
       unique-string: 3.0.0
 
+  terser-webpack-plugin@5.3.16(@swc/core@1.13.2)(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.44.1
+      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
+    optionalDependencies:
+      '@swc/core': 1.13.2
+      esbuild: 0.18.20
+    optional: true
+
   terser-webpack-plugin@5.3.16(@swc/core@1.13.2)(webpack@5.95.0(@swc/core@1.13.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -37048,6 +37074,37 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20):
+    dependencies:
+      '@types/estree': 1.0.8
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.18.4
+      es-module-lexer: 1.7.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(@swc/core@1.13.2)(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
+      watchpack: 2.5.0
+      webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    optional: true
 
   websocket-driver@0.7.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,10 +843,10 @@ importers:
         version: 7.6.20(react@18.3.1)
       '@storybook/vue':
         specifier: 7.6.20
-        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(vue@2.7.16)
+        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(vue@2.7.16)
       '@storybook/vue-vite':
         specifier: 7.6.20
-        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)
+        version: 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)
       '@vue/test-utils':
         specifier: '1.3'
         version: 1.3.6(vue-template-compiler@2.7.16(vue@2.7.16))(vue@2.7.16)
@@ -22360,12 +22360,12 @@ snapshots:
       '@types/express': 4.17.23
       file-system-cache: 2.3.0
 
-  '@storybook/vue-vite@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)':
+  '@storybook/vue-vite@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))(vue@2.7.16)':
     dependencies:
       '@storybook/builder-vite': 7.6.20(encoding@0.1.13)(typescript@5.8.3)(vite@7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0))
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/core-server': 7.6.20(encoding@0.1.13)
-      '@storybook/vue': 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(vue@2.7.16)
+      '@storybook/vue': 7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(vue@2.7.16)
       magic-string: 0.30.19
       vite: 7.0.7(@types/node@25.0.3)(jiti@1.21.7)(less@4.2.0)(sugarss@5.0.1(postcss@8.4.39))(terser@5.44.1)(tsx@4.19.0)(yaml@2.8.0)
       vue: 2.7.16
@@ -22418,7 +22418,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/vue@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)))(encoding@0.1.13)(vue@2.7.16)':
+  '@storybook/vue@7.6.20(@babel/core@7.28.0)(css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)))(encoding@0.1.13)(vue@2.7.16)':
     dependencies:
       '@babel/core': 7.28.0
       '@storybook/client-logger': 7.6.20
@@ -22427,7 +22427,7 @@ snapshots:
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.6.20
       '@storybook/types': 7.6.20
-      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
+      css-loader: 6.11.0(webpack@5.95.0(@swc/core@1.13.2))
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 2.7.16
@@ -26000,19 +26000,6 @@ snapshots:
       postcss: 8.5.6
 
   css-functions-list@3.2.3: {}
-
-  css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.39)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.4.39)
-      postcss-modules-scope: 3.2.1(postcss@8.4.39)
-      postcss-modules-values: 4.0.0(postcss@8.4.39)
-      postcss-value-parser: 4.2.0
-      semver: 7.7.3
-    optionalDependencies:
-      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
 
   css-loader@6.11.0(webpack@5.95.0(@swc/core@1.13.2)):
     dependencies:
@@ -35520,19 +35507,6 @@ snapshots:
       type-fest: 2.19.0
       unique-string: 3.0.0
 
-  terser-webpack-plugin@5.3.16(@swc/core@1.13.2)(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      terser: 5.44.1
-      webpack: 5.95.0(@swc/core@1.13.2)(esbuild@0.18.20)
-    optionalDependencies:
-      '@swc/core': 1.13.2
-      esbuild: 0.18.20
-    optional: true
-
   terser-webpack-plugin@5.3.16(@swc/core@1.13.2)(webpack@5.95.0(@swc/core@1.13.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -37074,37 +37048,6 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
-
-  webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20):
-    dependencies:
-      '@types/estree': 1.0.8
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-attributes: 1.9.5(acorn@8.15.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.18.4
-      es-module-lexer: 1.7.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(@swc/core@1.13.2)(esbuild@0.18.20)(webpack@5.95.0(@swc/core@1.13.2)(esbuild@0.18.20))
-      watchpack: 2.5.0
-      webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-    optional: true
 
   websocket-driver@0.7.4:
     dependencies:


### PR DESCRIPTION
# Split Button: fix label padding

<img width="321" height="319" alt="image" src="https://github.com/user-attachments/assets/78916a53-8c62-477f-bca8-343242bae6bf" />

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Description

- Padding to the right side of label
- Center icon on omega button (clear/muted)

https://github.com/user-attachments/assets/910c875c-395c-401a-b95f-becef04730de

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.