### PR TITLE
chore(claude-command): NO-JIRA update pr-fill command

### DIFF
--- a/.claude/commands/pr-fill.md
+++ b/.claude/commands/pr-fill.md
@@ -1,41 +1,53 @@
-# /pr-fill - Generate Dialtone PR Description
+# /pr-fill - Generate and Update Dialtone PR Description
 
 ## Usage
 
 ```
-/pr-fill
+/pr-fill [PR_NUMBER or PR_URL] [DESCRIPTION]
 ```
 
 ## Description
 
-Generates a filled PR description based on the Dialtone PR template (.github/pull_request_template.md), analyzing git diff and commit messages to auto-populate relevant sections. Section that cannot be completed are left as placeholders for manual completion (e.g. "Screenshots / GIFs" and "Sources"). Sections that are not relevant to the change should be removed, for example if there were no CSS changes, the CSS checklist should be removed.
+Generates a filled PR description based on the Dialtone PR template (.github/pull_request_template.md) and uses the `gh` CLI to update the actual PR. If no PR number is provided, it assumes the current branch has an open PR. If no description is provided, it analyzes git diff and commit messages to auto-populate relevant sections.
+
+Sections that cannot be completed are left as placeholders for manual completion (e.g. "Screenshots / GIFs" and "Sources"). Sections that are not relevant to the change should be removed, for example if there were no CSS changes, the CSS checklist should be removed.
 
 ## Implementation
 
 When this command is used, Claude should:
 
-1. **Analyze the current git state:**
-   - Get current branch name
-   - Get recent commit messages
+1. **Extract PR information:**
+   - If PR URL provided: Extract PR number from URL
+   - If PR number provided: Use it directly
+   - If no argument provided: Find PR for current branch using `gh pr view --json number`
+
+2. **Fetch PR details (if updating existing PR):**
+   - Get PR diff: `gh pr diff <PR_NUMBER>`
+   - Get PR commits: `gh pr view <PR_NUMBER> --json commits`
+   - Get changed files and their contents
+
+3. **Analyze the changes:**
+   - Get commit messages
    - Get list of changed files
    - Get git diff summary
 
-2. **Auto-detect change type from:**
+4. **Auto-detect change type from:**
    - Commit message prefixes (feat:, fix:, docs:, etc.)
    - File patterns (Vue components, CSS, documentation)
    - New vs modified files
 
-3. **Generate template with smart defaults:**
-   - Use oldest commit message as PR title
+5. **Generate template with smart defaults:**
+   - Use oldest commit message as PR title (preserve existing if present)
    - Auto-check appropriate change type boxes
    - Include relevant checklist sections based on file changes
    - Pre-populate sections where possible
    - Extract Jira ticket URL from oldest commit message
    - In the description section, describe the changes in a summarized way, no need to list every file changed
 
-4. **Output format:**
-   - Complete markdown ready to copy/paste into GitHub PR
-   - Follow exact Dialtone PR template structure
+6. **Update the PR:**
+   - Use `gh pr edit <PR_NUMBER> --body "<DESCRIPTION>"` to update
+   - Confirm update: `gh pr view <PR_NUMBER> --json title,body,url`
+   - Display success message with PR URL
 
 ## File Pattern Detection
 


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaGd5dGNhcXd1dGNhcXd1dGNhcXd1dGNhcXd1dGNhcXd1dGNhcXd1/3o7btPCcdNniyf0ArS/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Other (chore)

## :book: Jira Ticket

NO-JIRA

## :book: Description

Updates the `/pr-fill` Claude Code command to use the GitHub CLI (`gh`) to automatically update pull request descriptions, rather than just generating markdown for manual copy-paste. The command now accepts optional PR number/URL arguments and integrates with `gh pr edit` to directly update PRs.

## :bulb: Context

The previous version of `/pr-fill` only generated markdown output that users had to manually copy and paste into GitHub. This enhancement makes the command more powerful by:
- Accepting PR numbers or URLs as arguments
- Fetching PR details directly from GitHub using `gh` CLI
- Automatically updating the PR description via `gh pr edit`
- Providing better error handling and user feedback

This brings the command in line with similar functionality in other tools and improves the developer workflow.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

N/A

## :camera: Screenshots / GIFs

N/A - Documentation change only

## :link: Sources

N/A