### PR TITLE
fix(feed-item-row): DLT-2810 avoid rendering attanchment if slot is empty

### DIFF
--- a/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
+++ b/packages/dialtone-vue3/recipes/conversation_view/feed_item_row/feed_item_row.vue
@@ -75,7 +75,7 @@
         <slot />
       </span>
       <div
-        v-if="$slots.attachment"
+        v-if="hasAttachmentContent"
         data-qa="dt-recipe-feed-item-row--attachment"
         class="d-recipe-feed-item-row__attachment"
       >
@@ -130,6 +130,7 @@ import { DtListItem } from '@/components/list_item';
 import { DtBadge } from '@/components/badge';
 import Modal from '@/common/mixins/modal';
 import { DtIconUser } from '@dialpad/dialtone-icons/vue3';
+import { hasSlotContent } from '@/common/utils';
 
 export default {
   compatConfig: { MODE: 3 },
@@ -292,6 +293,10 @@ export default {
         FEED_ROW_STATE_BACKGROUND_COLOR[this.state],
 
       ];
+    },
+
+    hasAttachmentContent () {
+      return hasSlotContent(this.$slots.attachment);
     },
   },
 


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZnN4enJkdnB6bGY4ZnN4enJkdnB6bGY4/l0HlBO7eyXzSZkJri/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

[DLT-2810](https://dialpad.atlassian.net/browse/DLT-2810)

## :book: Description

Fixes extra spacing in feed item rows caused by empty attachment slot containers being rendered. The Vue3 feed item row component now properly checks if the attachment slot has actual content before rendering the container div.

## :bulb: Context

In Vue3, the spacing/padding around individual posts in the conversation feed was increased compared to Vue2. The issue was caused by an empty `d-recipe-feed-item-row__attachment` container being rendered even when no attachment content was provided.

The Vue2 instance was correctly suppressing the empty container, but Vue3's slot checking behaves differently - `v-if="$slots.attachment"` only checks if the slot exists, not if it has content. When slots are forwarded (like `<template #attachment><slot name="attachment" /></template>`), the slot exists but may be empty.

The fix uses the existing `hasSlotContent` utility function to properly detect whether the attachment slot contains actual content (filtering out comments, whitespace, and empty arrays). This ensures the attachment container (which has CSS padding) only renders when there's real content to display.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

[DLT-2810]: https://dialpad.atlassian.net/browse/DLT-2810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ