### PR TITLE
feat(split-button): DLT-2869 add alpha and omega disabled attributes

### DIFF
--- a/apps/dialtone-documentation/docs/components/split-button.md
+++ b/apps/dialtone-documentation/docs/components/split-button.md
@@ -260,12 +260,13 @@ showHtmlWarning />
 
 ### Disabled
 
+Use the `disabled` prop to disable both buttons, or use `alpha-disabled` and `omega-disabled` to disable each button independently.
+
 <code-well-header>
   <dt-stack direction="row" gap="400">
-      <dt-split-button disabled omega-tooltip-text="More calling options"> Place Call (disable attribute)</dt-split-button>
-      <span class="d-c-not-allowed">
-        <dt-split-button class="d-btn--disabled" omega-tooltip-text="More calling options"> Place Call (disabled class) </dt-split-button>
-      </span>
+      <dt-split-button disabled omega-tooltip-text="More calling options"> Both disabled </dt-split-button>
+      <dt-split-button alpha-disabled omega-tooltip-text="More calling options"> Alpha disabled </dt-split-button>
+      <dt-split-button omega-disabled omega-tooltip-text="More calling options"> Omega disabled </dt-split-button>
   </dt-stack>
 </code-well-header>
 
@@ -273,26 +274,33 @@ showHtmlWarning />
 htmlCode='
 <span class="d-split-btn">
   <button class="base-button__button d-btn d-btn--primary d-split-btn__alpha d-split-btn__alpha--md" type="button" disabled>
-    <span class="d-btn__label base-button__label"> Place Call </span>
+    <span class="d-btn__label base-button__label"> Both disabled </span>
   </button>
   <button class="base-button__button d-btn d-btn--primary d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button" disabled>
     <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
   </button>
 </span>
 <span class="d-split-btn">
-  <button class="base-button__button d-btn d-btn--primary d-split-btn__alpha d-split-btn__alpha--md d-btn--disabled" type="button">
-    <span class="d-btn__label base-button__label"> Place Call </span>
+  <button class="base-button__button d-btn d-btn--primary d-split-btn__alpha d-split-btn__alpha--md" type="button" disabled>
+    <span class="d-btn__label base-button__label"> Alpha disabled </span>
   </button>
-  <button class="base-button__button d-btn d-btn--primary d-btn--icon-only d-split-btn__omega d-split-btn__omega--md d-btn--disabled" type="button">
+  <button class="base-button__button d-btn d-btn--primary d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button">
+    <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
+  </button>
+</span>
+<span class="d-split-btn">
+  <button class="base-button__button d-btn d-btn--primary d-split-btn__alpha d-split-btn__alpha--md" type="button">
+    <span class="d-btn__label base-button__label"> Omega disabled </span>
+  </button>
+  <button class="base-button__button d-btn d-btn--primary d-btn--icon-only d-split-btn__omega d-split-btn__omega--md" type="button" disabled>
     <span class="base-button__icon d-btn__icon d-btn__icon--left">...</span>
   </button>
 </span>
 '
 vueCode='
-<dt-split-button disabled> Place Call (disable attribute)</dt-split-button>
-<span class="d-c-not-allowed">
-  <dt-split-button class="d-btn--disabled"> Place Call (disabled class) </dt-split-button>
-</span>
+<dt-split-button disabled omega-tooltip-text="More calling options"> Both disabled </dt-split-button>
+<dt-split-button alpha-disabled omega-tooltip-text="More calling options"> Alpha disabled </dt-split-button>
+<dt-split-button omega-disabled omega-tooltip-text="More calling options"> Omega disabled </dt-split-button>
 '
 showHtmlWarning />
 

--- a/packages/dialtone-vue3/components/split_button/split_button.stories.js
+++ b/packages/dialtone-vue3/components/split_button/split_button.stories.js
@@ -99,6 +99,10 @@ export const argTypesData = {
     control: 'boolean',
   },
 
+  alphaDisabled: {
+    control: 'boolean',
+  },
+
   alphaIconPosition: {
     control: 'select',
     options: Object.keys(ICON_POSITION_MODIFIERS),
@@ -109,6 +113,10 @@ export const argTypesData = {
   },
 
   omegaActive: {
+    control: 'boolean',
+  },
+
+  omegaDisabled: {
     control: 'boolean',
   },
 

--- a/packages/dialtone-vue3/components/split_button/split_button.test.js
+++ b/packages/dialtone-vue3/components/split_button/split_button.test.js
@@ -127,6 +127,39 @@ describe('DtSplitButton Tests', function () {
       });
     });
 
+    describe('When alpha-disabled is set to true', () => {
+      it('Should disable only the alpha button', async () => {
+        mockProps = { alphaDisabled: true };
+
+        updateWrapper();
+
+        expect(alphaButton.attributes('disabled')).toBeDefined();
+        expect(omegaButton.attributes('disabled')).toBeUndefined();
+      });
+    });
+
+    describe('When omega-disabled is set to true', () => {
+      it('Should disable only the omega button', async () => {
+        mockProps = { omegaDisabled: true };
+
+        updateWrapper();
+
+        expect(alphaButton.attributes('disabled')).toBeUndefined();
+        expect(omegaButton.attributes('disabled')).toBeDefined();
+      });
+    });
+
+    describe('When disabled is set to true', () => {
+      it('Should disable both buttons', async () => {
+        mockProps = { disabled: true };
+
+        updateWrapper();
+
+        expect(alphaButton.attributes('disabled')).toBeDefined();
+        expect(omegaButton.attributes('disabled')).toBeDefined();
+      });
+    });
+
     describe('When alpha-active is set to true', () => {
       it('Should have active class', async () => {
         mockProps = { alphaActive: true };

--- a/packages/dialtone-vue3/components/split_button/split_button.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button.vue
@@ -129,6 +129,18 @@ export default {
     },
 
     /**
+     * HTML button disabled attribute for alpha button only
+     * <a class="d-link" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled" target="_blank">
+     *  (Reference)
+     * </a>
+     * @values true, false
+     */
+    alphaDisabled: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
      * Whether the alpha button should display a loading animation or not.
      * @values true, false
      */
@@ -158,7 +170,8 @@ export default {
     },
 
     /**
-     * HTML button disabled attribute
+     * HTML button disabled attribute for both buttons.
+     * Use alphaDisabled or omegaDisabled to disable buttons individually.
      * <a class="d-link" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled" target="_blank">
      *  (Reference)
      * </a>
@@ -213,6 +226,18 @@ export default {
     omegaAriaLabel: {
       type: String,
       default: null,
+    },
+
+    /**
+     * HTML button disabled attribute for omega button only
+     * <a class="d-link" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled" target="_blank">
+     *  (Reference)
+     * </a>
+     * @values true, false
+     */
+    omegaDisabled: {
+      type: Boolean,
+      default: false,
     },
 
     /**
@@ -296,7 +321,7 @@ export default {
         active: this.alphaActive,
         ariaLabel: this.alphaAriaLabel,
         assertiveOnFocus: this.assertiveOnFocus,
-        disabled: this.disabled,
+        disabled: this.disabled || this.alphaDisabled,
         iconPosition: this.alphaIconPosition,
         labelClass: this.alphaLabelClass,
         loading: this.alphaLoading,
@@ -314,7 +339,7 @@ export default {
         id: this.omegaId,
         active: this.omegaActive,
         ariaLabel: this.omegaAriaLabel,
-        disabled: this.disabled,
+        disabled: this.disabled || this.omegaDisabled,
         importance: this.importance,
         kind: this.kind,
         size: this.size,

--- a/packages/dialtone-vue3/components/split_button/split_button_variants.story.vue
+++ b/packages/dialtone-vue3/components/split_button/split_button_variants.story.vue
@@ -208,6 +208,39 @@
           />
         </dt-stack>
       </dt-stack>
+      <!-- Disabled  -->
+      <dt-stack
+        gap="500"
+        class="d-br d-bc-default d-pr16"
+      >
+        <h2>Disabled</h2>
+        <dt-stack gap="500">
+          <dt-split-button
+            size="xs"
+            :alpha-disabled="true"
+            :omega-tooltip-text="omegaTooltipText"
+            :omega-aria-label="omegaAriaLabel"
+          >
+            Alpha disabled
+          </dt-split-button>
+          <dt-split-button
+            size="xs"
+            :omega-disabled="true"
+            :omega-tooltip-text="omegaTooltipText"
+            :omega-aria-label="omegaAriaLabel"
+          >
+            Omega disabled
+          </dt-split-button>
+          <dt-split-button
+            size="xs"
+            :disabled="true"
+            :omega-tooltip-text="omegaTooltipText"
+            :omega-aria-label="omegaAriaLabel"
+          >
+            Both disabled
+          </dt-split-button>
+        </dt-stack>
+      </dt-stack>
       <!-- With tooltip -->
       <dt-stack
         gap="500"
@@ -299,7 +332,6 @@
 </template>
 
 <script>
-/* eslint-disable max-lines */
 import { DtSplitButton } from './';
 import { DtStack } from '@/components/stack';
 import { DtIcon } from '@/components/icon';


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExM25xOTF1M3dzZ3d0bDRqdDhiaGc1dnEzdDI1Ym4zNWJmNXUxNnNlbSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/8cErRl4M1KIiXpW3Fp/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-2869](https://dialpad.atlassian.net/browse/DLT-2869)

## :book: Description

Adds the ability to disable each button independently in a split button component. Previously, the `disabled` prop would disable both the alpha and omega buttons together. This change introduces two new props:

- `alphaDisabled`: Disables only the alpha (primary action) button
- `omegaDisabled`: Disables only the omega (secondary/dropdown) button

The existing `disabled` prop continues to work as before, disabling both buttons when set to true. The individual disabled props can be used alongside the global `disabled` prop.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs
<img width="160" height="195" alt="image" src="https://github.com/user-attachments/assets/20e0c026-9a4a-41da-b3fc-82fadf1b0d0a" />

<img width="969" height="206" alt="image" src="https://github.com/user-attachments/assets/b28eefb8-4cd0-40d9-8c43-8c39467bbf03" />



[DLT-2869]: https://dialpad.atlassian.net/browse/DLT-2869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ