### PR TITLE
fix(motion-text): DLT-2885 fix gradient-in character animation

### DIFF
--- a/packages/dialtone-css/lib/build/less/recipes/motion_text.less
+++ b/packages/dialtone-css/lib/build/less/recipes/motion_text.less
@@ -10,6 +10,7 @@
 //  • TRANSITION CLASSES - GRADIENT IN
 //  • TRANSITION CLASSES - FADE IN
 //  • TRANSITION CLASSES - SLIDE IN
+//  • GRADIENT IN
 //  • GRADIENT SWEEP & SHIMMER
 //  • MODIFIERS
 //  • ACCESSIBILITY
@@ -97,6 +98,16 @@
 
   to {
     opacity: 1;
+  }
+}
+
+@keyframes dt-recipe-motion-text-gradient-in-char-reveal {
+  from {
+    color: var(--dt-color-neutral-transparent);
+  }
+
+  to {
+    color: inherit;
   }
 }
 
@@ -211,6 +222,14 @@
 
 .dt-recipe-motion-text-word-slide-in-leave-active {
   animation: dt-recipe-motion-text-slide-in-word-appear calc(var(--dt-recipe-motion-text-word-duration) * 0.5) var(--ttf-out-quint) reverse;
+}
+
+//  ============================================================================
+//  $   GRADIENT IN
+//  ----------------------------------------------------------------------------
+//  Delay reveal of character text color to prevent a flash on the first letter
+.dt-recipe-motion-text--gradient-in .dt-recipe-motion-text__char {
+  animation: dt-recipe-motion-text-gradient-in-char-reveal var(--dt-recipe-motion-text-char-duration) var(--ttf-in-out);
 }
 
 //  ============================================================================


### PR DESCRIPTION
# fix(motion-text): DLT-2885 fix gradient-in character animation

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExM21oaG9nb3Z3MG01M3hvMHI4eThtNjBnYWxjaGZzMXZzbmlrc3EycSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/9u514UZd57mRhnBCEk/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->
https://dialpad.atlassian.net/browse/DLT-2885

## :book: Description

<!--- Describe specifically what the changes are -->
Adjust gradient-in character animation to delay the reveal of the character's inherited text color. This prevents a flash of color on the first letter of each word, as well as a very slight highlight when the animation exits.

A new CSS animation was added to handle this because adding the transparent -> inherit style only to the existing charaacter animation does not fully fix both issues.

Direct link to the storybook page for the recipe: https://dialtone.dialpad.com/vue/deploy-previews/pr-1030/?path=/docs/recipes-motion-motion-text--docs

https://github.com/user-attachments/assets/8ba3c159-85ab-4b4f-85a9-42c8a87d4676


## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

Currently the first letter of the gradient-in variant seems to display the first letter differently than the rest of the word, resulting in a less smooth animation.

<img width="1024" height="579" alt="c3320220-4e36-4b0a-8ec2-8553673a2c33 (1)" src="https://github.com/user-attachments/assets/cc099f76-f172-4407-a935-b6e4bfd8c78f" />

In the video below, take a look at how the first letter seems to flash to white before the gradient animates in on the word...

https://github.com/user-attachments/assets/1d223157-817f-424d-9ce1-db0ddc092d39

https://github.com/user-attachments/assets/0447cbd2-d535-4c9d-a4ae-f94fecc72c43


## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->
This recipe could use audited for token usage. There are several instances of using color names and percentages that could be converted. We could also work on the gradient-in flow timing even more, but this iteration has at least smoothed out the flashing.

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

https://github.com/user-attachments/assets/7a57fb67-fac4-41f8-a422-5024ab23e0bb


https://github.com/user-attachments/assets/3d8f80ba-9f81-4008-ac83-76d2d4547b4e


https://github.com/user-attachments/assets/1dfebe05-c520-4a14-b030-fcfd95bc0b20


## :link: Sources

<!--- Add any links to external reference material -->
