### PR TITLE
fix(tokens): NO-JIRA multi-layer box shadows processing

### DIFF
--- a/packages/dialtone-tokens/postcss/dialtone-tokens.cjs
+++ b/packages/dialtone-tokens/postcss/dialtone-tokens.cjs
@@ -52,8 +52,9 @@ function boxShadows (shadowDeclarations, Declaration) {
     .reduce((shadows, shadow) => {
       const [name, index] = shadow
         .split(shadowSegmentsRegex).slice(1, -1);
-      // if not a number that means it's only a single shadow so set to 1.
-      shadows[name] = Number.isNaN(Number.parseInt(index)) ? 1 : Number.parseInt(index);
+      // Track the maximum layer index for multi-layer shadows
+      const layerIndex = Number.isNaN(Number.parseInt(index)) ? 1 : Number.parseInt(index);
+      shadows[name] = Math.max(shadows[name] || 0, layerIndex);
       return shadows;
     }, {});
 


### PR DESCRIPTION
# Multi-layer box shadows processing

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Description

**Basic test to confirm:** tab through page, blue focus state should appear.

Fixes multi-layer shadow composite token generation which broke, presumably after the Node 24 update (commit e8255214f) bumped `@tokens-studio/sd-transforms` and `style-dictionary`. 

The dependency update appears to change the output order of shadow component variables, exposing a bug in the postcss plugin where the shadow layer count was being overwritten rather than tracking the maximum layer index.

This caused multi-layer shadows to generate composite variables referencing non-existent non-numbered component variables. The fix uses `Math.max()` to correctly track the highest layer index regardless of processing order. 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :camera: Screenshots / GIFs

Before
<img width="748" height="98" alt="image" src="https://github.com/user-attachments/assets/2a35e199-e4a1-4cb9-8f97-42ed1a88b48e" />

<img width="670" height="88" alt="image" src="https://github.com/user-attachments/assets/0d681821-4570-4f4b-89f4-2644a497c306" />

After
<img width="641" height="109" alt="image" src="https://github.com/user-attachments/assets/b489cc50-5956-4545-b380-f1c8d5c04b12" />

<img width="608" height="98" alt="image" src="https://github.com/user-attachments/assets/3c189c3d-8476-419e-83d4-df72cb2c267e" />


## :link: Sources

<!--- Add any links to external reference material -->
