### PR TITLE
docs: DLT-2854 add MCP Server guide to documentation

### DIFF
--- a/apps/dialtone-documentation/docs/_data/site-nav.json
+++ b/apps/dialtone-documentation/docs/_data/site-nav.json
@@ -48,6 +48,10 @@
           "link": "/guides/getting-started/"
         },
         {
+          "text": "Dialtone MCP Server",
+          "link": "/guides/mcp-server/"
+        },
+        {
           "text": "Contributing",
           "link": "/guides/contributing/"
         },
@@ -89,10 +93,6 @@
         {
           "text": "Accessibility",
           "link": "/guides/accessibility/"
-        },
-        {
-          "text": "MCP Server",
-          "link": "/guides/mcp-server/"
         },
         {
           "text": "Brand",

--- a/apps/dialtone-documentation/docs/_data/site-nav.json
+++ b/apps/dialtone-documentation/docs/_data/site-nav.json
@@ -91,6 +91,10 @@
           "link": "/guides/accessibility/"
         },
         {
+          "text": "MCP Server",
+          "link": "/guides/mcp-server/"
+        },
+        {
           "text": "Brand",
           "link": "/guides/brand/",
           "planned": true

--- a/apps/dialtone-documentation/docs/guides/getting-started/index.md
+++ b/apps/dialtone-documentation/docs/guides/getting-started/index.md
@@ -137,6 +137,30 @@ In `Vue`, we apply `border-box` globally at the `VueView` level, ensuring all ch
 
 In `Backbone` we are not using `border-box` by default. Because Dialtone expects this, anytime we wish to use Dialtone styles in Backbone we must ensure to apply the `border-box` style to all affected elements.
 
+## AI-Assisted Development
+
+The [Dialtone MCP Server](/guides/mcp-server/) enables AI assistants like Claude Code, GitHub Copilot, and Cursor to search Dialtone in real-time while you code. Instead of manually searching documentation, your AI assistant can instantly find the right components, utility classes, design tokens, and icons for you.
+
+**Install with npm:**
+
+```bash
+npm install -D @dialpad/dialtone-mcp-server
+```
+
+Create `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "dialtone": {
+      "command": "dialtone-mcp-server"
+    }
+  }
+}
+```
+
+Restart your AI assistant to connect. [Read the full MCP Server guide](/guides/mcp-server/) for installation options, search tools, and platform-specific setup.
+
 ## Build Dialtone Locally
 
 We're excited you want to install Dialtone locally as this most likely means you'll be contributing soon! Before you get to get started though,  **please make sure you've read our [contributing docs](https://github.com/dialpad/dialtone/blob/master/.github/CONTRIBUTING.md)**.

--- a/apps/dialtone-documentation/docs/guides/mcp-server/index.md
+++ b/apps/dialtone-documentation/docs/guides/mcp-server/index.md
@@ -3,8 +3,6 @@ title: Dialtone MCP Server
 description: Search Dialtone's design system with AI assistants using the Model Context Protocol
 ---
 
-Search and discover Dialtone design system components, tokens, utilities, and icons through AI assistants using the [Model Context Protocol (MCP)](https://modelcontextprotocol.io).
-
 ## What It Does
 
 The Dialtone MCP Server provides AI assistants with real-time search access to:
@@ -47,9 +45,11 @@ Create or update `.mcp.json` in your project root:
 
 Commit `.mcp.json` to version control. Restart Claude Code to connect.
 
-::: tip Priority
+<DtNotice kind="info" title="Priority" :hideClose="true">
+
 Project-scoped configuration overrides user-scoped. The `dialtone-mcp-server` command resolves from `node_modules/.bin/` first.
-:::
+
+</DtNotice>
 
 ### User-Scoped (Personal Use)
 
@@ -90,9 +90,11 @@ Remote server deployment for enterprise use.
 claude mcp add dialtone-http --transport http --scope user https://mcp.dialtone.dialpad.com
 ```
 
-::: tip Version Checking
+<DtNotice kind="info" title="Version Checking" :hideClose="true">
+
 When the server starts, you'll see the current version. If outdated, follow the instructions shown to update.
-:::
+
+</DtNotice>
 
 ## Search Tools
 
@@ -356,9 +358,11 @@ Restart Claude Desktop and look for the 🔌 icon to confirm connection.
    cat ~/.claude/mcp.json
    ```
 
-::: warning Important
+<DtNotice kind="warning" title="Important" :hideClose="true">
+
 Project-scoped configuration overrides user-scoped. If you have both, the project-level `.mcp.json` takes precedence.
-:::
+
+</DtNotice>
 
 ### Version Shows Old After Updating
 
@@ -400,6 +404,8 @@ Now that you have the MCP server installed, explore these resources:
 
 ---
 
-::: tip Developer Tip
+<DtNotice kind="info" title="Developer Tip" :hideClose="true">
+
 The MCP server is perfect for discovering Dialtone patterns while coding. Instead of searching documentation manually, simply ask your AI assistant about components, tokens, or utilities, and it will search for you in real-time.
-:::
+
+</DtNotice>

--- a/apps/dialtone-documentation/docs/guides/mcp-server/index.md
+++ b/apps/dialtone-documentation/docs/guides/mcp-server/index.md
@@ -3,8 +3,6 @@ title: Dialtone MCP Server
 description: Search Dialtone's design system with AI assistants using the Model Context Protocol
 ---
 
-# Dialtone MCP Server
-
 Search and discover Dialtone design system components, tokens, utilities, and icons through AI assistants using the [Model Context Protocol (MCP)](https://modelcontextprotocol.io).
 
 ## What It Does

--- a/apps/dialtone-documentation/docs/guides/mcp-server/index.md
+++ b/apps/dialtone-documentation/docs/guides/mcp-server/index.md
@@ -1,0 +1,407 @@
+---
+title: Dialtone MCP Server
+description: Search Dialtone's design system with AI assistants using the Model Context Protocol
+---
+
+# Dialtone MCP Server
+
+Search and discover Dialtone design system components, tokens, utilities, and icons through AI assistants using the [Model Context Protocol (MCP)](https://modelcontextprotocol.io).
+
+## What It Does
+
+The Dialtone MCP Server provides AI assistants with real-time search access to:
+
+- **3,315 CSS utility classes** - Find classes like `d-p8`, `d-d-flex`, `d-w100p`
+- **5,691 design tokens** - Find tokens like `--dt-color-foreground-primary`, `--dt-space-400`
+- **87 Vue components** - Discover `DtButton`, `DtModal` with full API documentation
+- **594 icons** - Find icons like `bell-ring`, `arrow-up`, `calendar-plus`
+
+### Smart Features
+
+- **Filters deprecated items** - Automatically removes outdated classes and components
+- **Recommends alternatives** - Suggests better patterns when discouraged classes are found
+- **AI-optimized results** - Smart scoring provides the most relevant matches first
+- **Design system aware** - Understands Dialtone's conventions and patterns
+
+## Installation
+
+There are three ways to install the Dialtone MCP Server. **Project-scoped installation takes priority** over user-scoped when both exist.
+
+### Project-Scoped (Recommended for Teams)
+
+Best for team collaboration - everyone uses the same version via version control.
+
+```bash
+npm install -D @dialpad/dialtone-mcp-server
+```
+
+Create or update `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "dialtone": {
+      "command": "dialtone-mcp-server"
+    }
+  }
+}
+```
+
+Commit `.mcp.json` to version control. Restart Claude Code to connect.
+
+::: tip Priority
+Project-scoped configuration overrides user-scoped. The `dialtone-mcp-server` command resolves from `node_modules/.bin/` first.
+:::
+
+### User-Scoped (Personal Use)
+
+Available across all your projects. Choose one method:
+
+**Option A: Install in dedicated directory**
+
+```bash
+# Install in a dedicated directory
+mkdir -p ~/.mcp-servers
+cd ~/.mcp-servers
+npm install @dialpad/dialtone-mcp-server
+
+# Add to Claude Code
+claude mcp add dialtone --scope user dialtone-mcp-server
+```
+
+**Option B: Install globally**
+
+```bash
+npm install -g @dialpad/dialtone-mcp-server
+claude mcp add dialtone --scope user dialtone-mcp-server
+```
+
+**Option C: Use npx (no installation)**
+
+```bash
+claude mcp add dialtone --scope user -- npx -y @dialpad/dialtone-mcp-server
+```
+
+This stores configuration in `~/.claude/mcp.json`.
+
+### HTTP Transport (Coming Soon)
+
+Remote server deployment for enterprise use.
+
+```bash
+claude mcp add dialtone-http --transport http --scope user https://mcp.dialtone.dialpad.com
+```
+
+::: tip Version Checking
+When the server starts, you'll see the current version. If outdated, follow the instructions shown to update.
+:::
+
+## Search Tools
+
+### Utility Classes
+
+**Tool:** `search_utility_classes`
+
+Find CSS utility classes to style HTML elements. Use when your query mentions CSS properties (padding, margin, display, flex) or values (8px, 100%, center, auto).
+
+**Example queries:**
+
+```
+"padding 8px"       → d-p8, d-pt8, d-pr8, d-pb8, d-pl8, d-px8, d-py8
+"display flex"      → d-d-flex, d-d-inline-flex
+"width 100%"        → d-w100p
+"margin top auto"   → d-mt-auto
+"text align center" → d-ta-center
+```
+
+**Parameters:**
+- `query` (required): CSS property and/or value
+- `limit` (optional): Maximum results (1-50, default 15)
+
+### Design Tokens
+
+**Tool:** `search_tokens`
+
+Find design tokens (CSS variables) from Dialtone's design system. Use when your query mentions token categories (color, space, font, size) or semantic names (primary, success, foreground, background).
+
+**Example queries:**
+
+```
+"color foreground primary" → --dt-color-foreground-primary
+"space 400"                → --dt-space-400, --dt-space-400-negative
+"font family"              → --dt-font-family-body, --dt-font-family-expressive
+"font weight bold"         → --dt-font-weight-bold
+```
+
+**Parameters:**
+- `query` (required): Token category, name, or value
+- `limit` (optional): Maximum results (1-50, default 15)
+
+### Components
+
+**Tool:** `search_components`
+
+Find Vue components from Dialtone's component library with props, events, and slots. Use when your query mentions UI elements (button, modal, input, dropdown) or component names.
+
+**Example queries:**
+
+```
+"button"   → DtButton, DtButtonGroup, DtBanner (29 results)
+"modal"    → DtModal, DtBanner, DtDropdown (6 results)
+"checkbox" → DtCheckbox, DtCheckboxGroup, DtRadio
+```
+
+**Returns:**
+- Component name
+- Description
+- Props (name, type, default, description)
+- Events (name, description)
+- Slots (name, description)
+- Import path
+
+**Parameters:**
+- `query` (required): Component name or UI element
+- `limit` (optional): Maximum results (1-30, default 10)
+
+### Icons
+
+**Tool:** `search_icons`
+
+Find icons from Dialtone's icon library and learn how to use icon components. Icons are imported from `@dialpad/dialtone-icons/vue3`, not `@dialpad/dialtone-vue`.
+
+**Example queries:**
+
+```
+"notification" → bell, bell-ring, bell-off, bell-plus
+"arrow up"     → arrow-up, arrow-up-down, arrow-up-left
+"profile"      → user
+"calendar"     → calendar, calendar-plus, calendar-event
+```
+
+**Returns:**
+- Icon name
+- Categories
+- Keywords
+- Tree-shakable import path
+- Usage example
+
+**Parameters:**
+- `query` (required): Icon name, category, or keyword
+- `limit` (optional): Maximum results (1-50, default 20)
+
+## Usage Examples
+
+### Finding Styling Classes
+
+When working on a component and need specific styling:
+
+```
+User: "What class adds padding 8px to all sides?"
+Claude: [Uses search_utility_classes tool]
+Result: d-p8 (padding: var(--dt-space-400) which equals 8px)
+```
+
+### Discovering Components
+
+When building UI and unsure what components exist:
+
+```
+User: "What button components are available in Dialtone?"
+Claude: [Uses search_components tool]
+Result: DtButton, DtButtonGroup, DtIconButton with complete
+        prop documentation, events, and usage examples
+```
+
+### Looking Up Tokens
+
+When implementing designs and need exact token values:
+
+```
+User: "What's the primary foreground color token?"
+Claude: [Uses search_tokens tool]
+Result: --dt-color-foreground-primary
+        Value: #1C1C1C (in light theme)
+        Available in: dp-light, dp-dark themes
+```
+
+### Finding Icons
+
+When adding icons to your interface:
+
+```
+User: "Show me all notification-related icons"
+Claude: [Uses search_icons tool]
+Result: bell, bell-ring, bell-off, bell-plus, bell-minus
+        Import: import { IconBell } from '@dialpad/dialtone-icons/vue3'
+```
+
+## Configuration
+
+### Updating the Server
+
+The server checks for updates automatically on startup. If a new version is available, you'll see:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+⚠️  Dialtone MCP Server Update Available
+   Current: v1.2.0
+   Latest:  v1.2.1
+
+   To update:
+   1. npm install -D @dialpad/dialtone-mcp-server@latest
+   2. Restart this conversation
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**To update:**
+
+**Project-scoped:**
+```bash
+npm install -D @dialpad/dialtone-mcp-server@latest
+```
+
+**User-scoped (local directory):**
+```bash
+cd ~/.mcp-servers
+npm update @dialpad/dialtone-mcp-server
+```
+
+**User-scoped (global):**
+```bash
+npm update -g @dialpad/dialtone-mcp-server
+```
+
+**User-scoped (npx):**
+No action needed - npx always uses the latest version.
+
+After updating, restart your Claude Code conversation to load the new version.
+
+### Managing Connections
+
+**List configured servers:**
+```bash
+claude mcp list
+```
+
+**View specific server:**
+```bash
+claude mcp get dialtone
+```
+
+**Remove server:**
+```bash
+claude mcp remove dialtone
+```
+
+## Compatible Platforms
+
+The Dialtone MCP Server works with any MCP-compatible AI assistant:
+
+- ✅ **Claude Code CLI** - Primary integration
+- ✅ **Claude Desktop** - Via configuration file
+- ✅ **VS Code** - With GitHub Copilot
+- ✅ **Cursor** - Native MCP support
+- ✅ **Windsurf** - Native MCP support
+- ✅ **Cline** - MCP integration
+- ✅ **Continue** - MCP support
+- ✅ **Any MCP-compatible client**
+
+### Platform-Specific Setup
+
+**Claude Desktop:**
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%/Claude/claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "dialtone": {
+      "command": "npx",
+      "args": ["-y", "@dialpad/dialtone-mcp-server"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop and look for the 🔌 icon to confirm connection.
+
+## Troubleshooting
+
+### Server Not Connecting
+
+**For project-scoped installation:**
+
+1. Verify `.mcp.json` exists in your project root with correct format
+2. Check package is installed:
+   ```bash
+   npm list @dialpad/dialtone-mcp-server
+   ```
+3. Verify bin command exists:
+   ```bash
+   ls node_modules/.bin/dialtone-mcp-server
+   ```
+4. Restart Claude Code completely
+
+**For user-scoped installation:**
+
+1. List configured servers:
+   ```bash
+   claude mcp list
+   ```
+2. Check if dialtone is listed and enabled
+3. Test the server:
+   ```bash
+   claude mcp get dialtone
+   ```
+4. Check configuration:
+   ```bash
+   cat ~/.claude/mcp.json
+   ```
+
+::: warning Important
+Project-scoped configuration overrides user-scoped. If you have both, the project-level `.mcp.json` takes precedence.
+:::
+
+### Version Shows Old After Updating
+
+The server loads once at conversation start. You must restart your conversation after updating to see the new version.
+
+### No Search Results
+
+- **Use keywords, not questions** - Try "button" instead of "What button components exist?"
+- **Try broader terms first** - Search "padding" before "padding left 16px"
+- **Check example queries** - Review the examples in each tool section above
+- **Verify installation** - Ensure the server is running: `claude mcp list`
+
+### Build Issues
+
+If you're developing or testing locally:
+
+1. Ensure workspace dependencies are built first
+2. Run from monorepo root: `pnpm install`
+3. Build the server: `pnpm nx run dialtone-mcp-server:build`
+4. Check for TypeScript errors in the console
+
+## Resources
+
+- **Dialtone Documentation** - [dialtone.dialpad.com](https://dialtone.dialpad.com)
+- **npm Package** - [@dialpad/dialtone-mcp-server](https://www.npmjs.com/package/@dialpad/dialtone-mcp-server)
+- **GitHub Repository** - [github.com/dialpad/dialtone](https://github.com/dialpad/dialtone)
+- **MCP Protocol** - [modelcontextprotocol.io](https://modelcontextprotocol.io)
+- **Report Issues** - [GitHub Issues](https://github.com/dialpad/dialtone/issues)
+
+## Next Steps
+
+Now that you have the MCP server installed, explore these resources:
+
+- [Getting Started with Dialtone](/guides/getting-started/) - Learn Dialtone basics
+- [Utility Classes](/utilities/) - Browse all utility classes
+- [Design Tokens](/tokens/) - Explore design tokens
+- [Components](/components/) - Discover Vue components
+- [Icons](/design/icons/) - View the icon library
+
+---
+
+::: tip Developer Tip
+The MCP server is perfect for discovering Dialtone patterns while coding. Instead of searching documentation manually, simply ask your AI assistant about components, tokens, or utilities, and it will search for you in real-time.
+:::


### PR DESCRIPTION
## Obligatory GIF (super important!)

  ![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGR6MnVnMmZrNHBuN3Q1dHk5amYybXc0dG9wZWFvdTNpbnE3dzNoNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/0DYipdNqJ5n4GYATKL/giphy.gif)

  ## :hammer_and_wrench: Type Of Change

  These types will not increment the version number, but will still deploy to documentation site on release:

  - [x] Documentation

  ## :book: Jira Ticket

  https://dialpad.atlassian.net/browse/DLT-2854

  ## :book: Description

  - Added comprehensive MCP Server guide page to `/guides/mcp-server/`
  - Added navigation entry in `site-nav.json` under Guides section
  - Follows official MCP documentation patterns from AWS, Microsoft, Stripe, and Sentry

  ## :bulb: Context

  The Dialtone MCP Server (@dialpad/dialtone-mcp-server) has been published to npm but lacks documentation on the Dialtone docs site. Users need guidance on:
  - What the MCP server does
  - How to install it (project-scoped, user-scoped, HTTP transport)
  - How to use the 4 search tools (utility classes, tokens, components, icons)
  - Platform compatibility and troubleshooting

  This guide provides comprehensive documentation following the same structure used by other official MCP servers.

  ## :pencil: Checklist

  For all PRs:

  - [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
  - [x] I have reviewed my changes.
  - [x] I have added all relevant documentation.
  - [x] I have considered the performance impact of my change.

  ## :crystal_ball: Next Steps

  - None - documentation is complete and ready to publish

  ## :camera: Screenshots / GIFs

  The new guide page will be available at: `https://dialtone.dialpad.com/guides/mcp-server/`

  **Preview URL**: Available in deploy preview once PR is created

  ## :link: Sources

  Research and analysis documents created during development:
  - Analyzed official MCP documentation patterns from AWS, Microsoft, Stripe, Sentry, Brave, and Cloudflare
  - Followed VuePress documentation structure conventions
  - Referenced existing Dialtone guide pages for consistency

  **Official MCP Examples**:
  - [Model Context Protocol Examples](https://modelcontextprotocol.io/examples)
  - [AWS Documentation MCP Server](https://awslabs.github.io/mcp/servers/aws-documentation-mcp-server)
  - [Microsoft Learn MCP Server](https://learn.microsoft.com/en-us/training/support/mcp-developer-reference)
  - [Stripe MCP Documentation](https://docs.stripe.com/mcp)
  - [Sentry MCP Server](https://docs.sentry.io/product/sentry-mcp/)
