### PR TITLE
fix(tokens): NO-JIRA output line-height as unitless instead of percentages

### DIFF
--- a/packages/dialtone-tokens/build-sd-transforms-layered.js
+++ b/packages/dialtone-tokens/build-sd-transforms-layered.js
@@ -120,7 +120,7 @@ StyleDictionary.registerAction({
 
 StyleDictionary.registerTransformGroup({
   name: 'custom/css/tokens-studio',
-  transforms: [...getTransforms({ platform: 'css' }), 'name/kebab', 'dt/size/pxToRem', 'dt/space/pxToRem']
+  transforms: [...getTransforms({ platform: 'css' }), 'name/kebab', 'dt/size/pxToRem', 'dt/space/pxToRem', 'dt/lineHeight/percentToDecimal']
     .filter(transform => !['name/camel', 'ts/size/px', 'ts/typography/css/fontFamily'].includes(transform)),
 });
 

--- a/packages/dialtone-tokens/build-sd-transforms.js
+++ b/packages/dialtone-tokens/build-sd-transforms.js
@@ -28,7 +28,7 @@ StyleDictionary.registerAction({
 
 StyleDictionary.registerTransformGroup({
   name: 'custom/css/tokens-studio',
-  transforms: [...getTransforms({ platform: 'css' }), 'name/kebab', 'dt/size/pxToRem', 'dt/space/pxToRem'].filter(transform => !['name/camel', 'ts/size/px', 'ts/typography/css/fontFamily'].includes(transform)),
+  transforms: [...getTransforms({ platform: 'css' }), 'name/kebab', 'dt/size/pxToRem', 'dt/space/pxToRem', 'dt/lineHeight/percentToDecimal'].filter(transform => !['name/camel', 'ts/size/px', 'ts/typography/css/fontFamily'].includes(transform)),
 });
 
 export async function run () {

--- a/packages/dialtone-tokens/dialtone-transforms.js
+++ b/packages/dialtone-tokens/dialtone-transforms.js
@@ -74,7 +74,7 @@ export function registerDialtoneTransforms (styleDictionary) {
     transform: (token) => {
       // replace unmathable characters with empty string
       const mathString = token.value.replace(/dp|sp|em|px|%/g, '');
-      // eslint-disable-next-line no-eval
+       
       const result = eval(mathString).toFixed(2);
       return `${result}dp`;
     },
@@ -167,6 +167,8 @@ export function registerDialtoneTransforms (styleDictionary) {
     type: 'value',
     transitive: true,
     filter: function (token) {
+      // Exclude lineHeight dimension tokens - they're handled by lineHeight transform
+      if (token.type === 'dimension' && token.path?.includes('lineHeight')) return false;
       return [...SPACING_IDENTIFIERS, ...SIZE_IDENTIFIERS].includes(token.type) &&
         // The fontSize token in typography tokens is a 'dimension' type for some reason,
         // so have this special case to exclude it from this transform.
@@ -219,7 +221,7 @@ export function registerDialtoneTransforms (styleDictionary) {
       if (token.value.includes('.sp')) unit = 'sp';
       if (token.value.includes('.em')) unit = 'em';
       const mathString = token.value.replace(/\.dp|\.sp|\.em|px|%/g, '');
-      // eslint-disable-next-line no-eval
+       
       const result = eval(mathString);
       return `${result}.${unit}`;
     },
@@ -229,7 +231,9 @@ export function registerDialtoneTransforms (styleDictionary) {
     name: 'dt/android/compose/lineHeight/percentToDecimal',
     type: 'value',
     filter: function (token) {
-      return LINE_HEIGHT_IDENTIFIERS.includes(token.type);
+      // Match by type (legacy tokens) or path (DTCG-compliant tokens with type: dimension)
+      return LINE_HEIGHT_IDENTIFIERS.includes(token.type) ||
+        (token.type === 'dimension' && token.path?.includes('lineHeight'));
     },
     transform: (token) => {
       const floatVal = parseFloat(token.value);
@@ -313,6 +317,8 @@ export function registerDialtoneTransforms (styleDictionary) {
     name: 'dt/ios/size/pxToCGFloat',
     type: 'value',
     filter: function (token) {
+      // Exclude lineHeight dimension tokens - they're handled by dt/ios/lineHeight/percentToDecimal
+      if (token.type === 'dimension' && token.path?.includes('lineHeight')) return false;
       return [...SPACING_IDENTIFIERS, ...SIZE_IDENTIFIERS].includes(token.type);
     },
     transform: (token) => {
@@ -330,7 +336,11 @@ export function registerDialtoneTransforms (styleDictionary) {
     name: 'dt/ios/lineHeight/percentToDecimal',
     type: 'value',
     filter: function (token) {
-      return ['opacity', ...LINE_HEIGHT_IDENTIFIERS].includes(token.type);
+      // Skip if already transformed to CGFloat
+      if (typeof token.value === 'string' && token.value.includes('CGFloat')) return false;
+      // Match by type (legacy tokens) or path (DTCG-compliant tokens with type: dimension)
+      return ['opacity', ...LINE_HEIGHT_IDENTIFIERS].includes(token.type) ||
+        (token.type === 'dimension' && token.path?.includes('lineHeight'));
     },
     transform: (token) => {
       const floatVal = parseFloat(token.value);
@@ -347,7 +357,9 @@ export function registerDialtoneTransforms (styleDictionary) {
     name: 'dt/lineHeight/percentToDecimal',
     type: 'value',
     filter: function (token) {
-      return LINE_HEIGHT_IDENTIFIERS.includes(token.type);
+      // Match by type (legacy tokens) or path (DTCG-compliant tokens with type: dimension)
+      return LINE_HEIGHT_IDENTIFIERS.includes(token.type) ||
+        (token.type === 'dimension' && token.path?.includes('lineHeight'));
     },
     transform: (token) => {
       const floatVal = parseFloat(token.value);
@@ -380,24 +392,4 @@ export function registerDialtoneTransforms (styleDictionary) {
     },
   });
 
-  styleDictionary.registerTransform({
-    name: 'dt/lineHeight/percentToDecimal',
-    type: 'value',
-    filter: function (token) {
-      return LINE_HEIGHT_IDENTIFIERS.includes(token.type);
-    },
-    transform: (token) => {
-      const floatVal = parseFloat(token.value);
-
-      if (isNaN(floatVal)) {
-        throwSizeError(token.path, token.value, '%');
-      }
-
-      if (floatVal === 0) {
-        return '0';
-      }
-
-      return `${floatVal / 100}`;
-    },
-  });
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Targets `next` 

# Output line-height as unitless instead of percentages

![friday](https://github.com/user-attachments/assets/2c93bc09-d5be-4bf9-bbfc-99c77b01c581)

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Description

- Update transform filters to use path-based detection for lineHeight tokens with DTCG-compliant `type: dimension`                        
- Exclude lineHeight dimension tokens from generic size transforms (`pxToDp`, `pxToCGFloat`) so they use the correct lineHeight transforms                                                                                                                                
- Add `dt/lineHeight/percentToDecimal` to CSS transform group                                                                             
- Remove duplicate transform registration  

**Verified outputs after fix:**                                                                                                           
                                                                                                                                          
CSS (unitless decimals):                                                                                                                  
```css                                                                                                                                    
--dt-font-line-height-600: 2; // not 200%
--dt-font-line-height-500: 1.8; // not 180%
--dt-font-line-height-100: 1; // not 100%
```                                                                                                                                       
                                                                                                                                          
Android Compose (.em suffix):                                                                                                             
```kotlin                                                                                                                                 
val dtFontLineHeight100 = 1.em                                                                                                            
val dtFontLineHeight200 = 1.2.em                                                                                                          
val dtFontLineHeight300 = 1.4.em                                                                                                          
```                                                                                                                                       
                                                                                                                                          
iOS Swift (CGFloat with percentage values):                                                                                               
```swift                                                                                                                                  
public static let dtFontLineHeight100 = CGFloat(100.00)                                                                                   
public static let dtFontLineHeight200 = CGFloat(120.00)                                                                                   
public static let dtFontLineHeight300 = CGFloat(140.00)                                                                                   
```  

## :bulb: Context

Line-height values were being output as percentages (`140%`) instead of unitless values (`1.4`), which causes CSS inheritance issues, as realized in Beacon https://github.com/dialpad/beacon-app/pull/399#issuecomment-3825994577
                                                                                                                                          
The root cause was commit `5160cae34` ("update types to match DTCG specification") which changed lineHeight token types from              
`"lineHeights"` to `"dimension"`, breaking the transform filters that relied on type-based detection.
                                                                                                                                          
This fix updates the transforms to use path-based detection in addition to type-based detection, ensuring lineHeight tokens are correctly identified regardless of their DTCG type.  

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :camera: Screenshots / GIFs

<img width="1918" height="768" alt="image" src="https://github.com/user-attachments/assets/c2ed7741-acf0-4d90-914f-9fd84be9e4ba" />