### PR TITLE
chore(lint): NO-JIRA update recommend-typography-style to only flag multiple 

### DIFF
--- a/packages/eslint-plugin-dialtone/docs/rules/recommend-typography-style.md
+++ b/packages/eslint-plugin-dialtone/docs/rules/recommend-typography-style.md
@@ -4,9 +4,13 @@ Before combining multiple typography utilities from different categories, first 
 
 ## Rule Details
 
-This rule flags when **two or more different categories** of typography utilities are combined in the same class attribute. Single typography utilities are acceptable for overrides.
+This rule flags two issues:
+
+1. **Multiple categories**: When two or more different categories of typography utilities are combined in the same class attribute. Single typography utilities are acceptable for overrides.
+2. **Conflicting utilities**: When multiple utilities from the same category are used together (e.g., `d-fw-bold d-fw-medium`), which likely indicates a mistake since only one will be applied.
 
 The typography categories are:
+
 - **font-weight**: `d-fw-normal`, `d-fw-medium`, `d-fw-semibold`, `d-fw-bold`
 - **font-size**: `d-fs-*` (e.g., `d-fs-200`, `d-fs-300`)
 - **line-height**: `d-lh-*` (e.g., `d-lh-300`, `d-lh-400`)
@@ -23,6 +27,12 @@ Examples of **incorrect** code for this rule:
 
 <!-- Combining font-family + font-weight (2 categories) -->
 <span class="d-ff-mono d-fw-semibold">
+
+<!-- Conflicting utilities: multiple font-weights -->
+<span class="d-fw-bold d-fw-medium">
+
+<!-- Conflicting utilities: multiple font-sizes -->
+<span class="d-fs-100 d-fs-200">
 ```
 
 Examples of **correct** code for this rule:
@@ -33,9 +43,6 @@ Examples of **correct** code for this rule:
 
 <!-- Single typography utility (acceptable for overrides) -->
 <span class="d-fw-bold">
-
-<!-- Single category (same category multiple times is fine) -->
-<span class="d-fw-bold d-fw-medium">
 
 <!-- Single typography utility mixed with non-typography utilities -->
 <span class="d-fw-bold d-mt-4 d-p-8">

--- a/packages/eslint-plugin-dialtone/docs/rules/recommend-typography-style.md
+++ b/packages/eslint-plugin-dialtone/docs/rules/recommend-typography-style.md
@@ -1,21 +1,44 @@
-# Utilities to set Font family, Font weight, Font size, and Line height separately are discouraged in favor of composed typography utilities (`recommend-typography-style`)
+# Combining multiple typography utility categories is discouraged in favor of composed typography utilities (`recommend-typography-style`)
 
-Before applying a typography utility, first consider using Dialtone's text styles that bundles Font family, Font weight, Font size, and Line height together.
+Before combining multiple typography utilities from different categories, first consider using Dialtone's composed text styles that bundle Font family, Font weight, Font size, and Line height together.
 
 ## Rule Details
 
-This rule aims to improve consistency and readability for typography styles by recommending the use of composed typography utilities over setting Font family, Font weight, Font size, and Line height separately.
+This rule flags when **two or more different categories** of typography utilities are combined in the same class attribute. Single typography utilities are acceptable for overrides.
+
+The typography categories are:
+- **font-weight**: `d-fw-normal`, `d-fw-medium`, `d-fw-semibold`, `d-fw-bold`
+- **font-size**: `d-fs-*` (e.g., `d-fs-200`, `d-fs-300`)
+- **line-height**: `d-lh-*` (e.g., `d-lh-300`, `d-lh-400`)
+- **font-family**: `d-ff-custom`, `d-ff-sans`, `d-ff-mono`, `d-ff-marketing`, `d-ff-unset`
 
 Examples of **incorrect** code for this rule:
 
 ```html
+<!-- Combining font-weight + font-size + line-height (3 categories) -->
 <span class="d-fw-bold d-fs-200 d-lh-400">
+
+<!-- Combining font-weight + font-size (2 categories) -->
+<span class="d-fw-bold d-fs-200">
+
+<!-- Combining font-family + font-weight (2 categories) -->
+<span class="d-ff-mono d-fw-semibold">
 ```
 
 Examples of **correct** code for this rule:
 
 ```html
+<!-- Composed typography utility -->
 <span class="d-headline--md">
+
+<!-- Single typography utility (acceptable for overrides) -->
+<span class="d-fw-bold">
+
+<!-- Single category (same category multiple times is fine) -->
+<span class="d-fw-bold d-fw-medium">
+
+<!-- Single typography utility mixed with non-typography utilities -->
+<span class="d-fw-bold d-mt-4 d-p-8">
 ```
 
 ## Further Reading

--- a/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
@@ -30,6 +30,8 @@ module.exports = {
       discouraged in favor of composed typography utilities. Checkout the available classes here:
       https://dialtone.dialpad.com/design/typography/#api. There can be cases where using these utilities is intentional and valid,
       in which case you can ignore this lint warning.`,
+      conflictingTypographyUtilities: `Conflicting typography utilities detected: multiple {{category}} classes found ({{classes}}).
+      Only one will be applied. Remove the conflicting classes.`,
     }, // Add messageId and message
   },
 
@@ -41,22 +43,41 @@ module.exports = {
         if (node.key.name === 'class') {
           const classes = node.value.value.split(' ');
 
-          // For each class, determine which category it belongs to
-          const categoriesFound = new Set();
+          // For each class, determine which category it belongs to and track all matches
+          const categoryCounts = {};
           classes.forEach((className) => {
             for (const [category, patterns] of Object.entries(typographyCategories)) {
               if (patterns.some((pattern) => className.startsWith(pattern))) {
-                categoriesFound.add(category);
+                if (!categoryCounts[category]) {
+                  categoryCounts[category] = [];
+                }
+                categoryCounts[category].push(className);
               }
             }
           });
 
-          // Only report if 2+ different categories are present
-          if (categoriesFound.size >= 2) {
+          const categoriesFound = Object.keys(categoryCounts);
+
+          // Report if 2+ different categories are present
+          if (categoriesFound.length >= 2) {
             context.report({
               node,
               messageId: 'recommendTypographyStyle',
             });
+          }
+
+          // Report conflicting utilities within the same category
+          for (const [category, matchedClasses] of Object.entries(categoryCounts)) {
+            if (matchedClasses.length >= 2) {
+              context.report({
+                node,
+                messageId: 'conflictingTypographyUtilities',
+                data: {
+                  category,
+                  classes: matchedClasses.join(', '),
+                },
+              });
+            }
           }
         }
       },

--- a/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Utilities to set Font family, Font weight, Font size, and Line height separately are discouraged in favor of composed typography utilities
+ * @fileoverview Combining multiple typography utility categories is discouraged in favor of composed typography utilities
  * @author Nina Repetto
  */
 'use strict';
@@ -8,18 +8,25 @@
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const typographyCategories = {
+  'font-weight': ['d-fw-normal', 'd-fw-medium', 'd-fw-semibold', 'd-fw-bold'],
+  'font-size': ['d-fs'], // prefix match
+  'line-height': ['d-lh'], // prefix match
+  'font-family': ['d-ff-custom', 'd-ff-sans', 'd-ff-mono', 'd-ff-marketing', 'd-ff-unset'],
+};
+
 module.exports = {
   meta: {
     type: 'suggestion', // `problem`, `suggestion`, or `layout`
     docs: {
-      description: 'Utilities to set Font family, Font weight, Font size, and Line height separately are discouraged in favor of composed typography utilities',
+      description: 'Combining multiple typography utility categories is discouraged in favor of composed typography utilities',
       recommended: false,
       url: 'https://github.com/dialpad/dialtone/blob/staging/packages/eslint-plugin-dialtone/docs/rules/recommend-typography-style.md', // URL to the documentation page for this rule
     },
     fixable: null, // Or `code` or `whitespace`
     schema: [], // Add a schema if the rule has options
     messages: {
-      recommendTypographyStyle: `Utilities to set Font family, Font weight, Font size, and Line height separately are
+      recommendTypographyStyle: `Combining multiple typography utility categories (Font family, Font weight, Font size, Line height) is
       discouraged in favor of composed typography utilities. Checkout the available classes here:
       https://dialtone.dialpad.com/design/typography/#api. There can be cases where using these utilities is intentional and valid,
       in which case you can ignore this lint warning.`,
@@ -33,23 +40,19 @@ module.exports = {
       VAttribute (node) {
         if (node.key.name === 'class') {
           const classes = node.value.value.split(' ');
-          const typographyClasses = [
-            'd-fs',
-            'd-fw-normal',
-            'd-fw-medium',
-            'd-fw-semibold',
-            'd-fw-bold',
-            'd-lh',
-            'd-ff-custom',
-            'd-ff-sans',
-            'd-ff-mono',
-            'd-ff-marketing',
-            'd-ff-unset',
-          ];
-          const typographyClassesFound = classes.filter((className) =>
-            typographyClasses.some((typographyClass) => className.includes(typographyClass)),
-          );
-          if (typographyClassesFound.length > 0) {
+
+          // For each class, determine which category it belongs to
+          const categoriesFound = new Set();
+          classes.forEach((className) => {
+            for (const [category, patterns] of Object.entries(typographyCategories)) {
+              if (patterns.some((pattern) => className.startsWith(pattern))) {
+                categoriesFound.add(category);
+              }
+            }
+          });
+
+          // Only report if 2+ different categories are present
+          if (categoriesFound.size >= 2) {
             context.report({
               node,
               messageId: 'recommendTypographyStyle',

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/recommend-typography-style.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/recommend-typography-style.js
@@ -41,13 +41,6 @@ ruleTester.run("recommend-typography-style", rule, {
     {
       code: "<template><div class=\"d-ff-mono\" /></template>",
     },
-    // Same category combinations are valid
-    {
-      code: "<template><div class=\"d-fw-bold d-fw-medium\" /></template>",
-    },
-    {
-      code: "<template><div class=\"d-fs-100 d-fs-200\" /></template>",
-    },
     // Mixed with non-typography classes is valid (single category)
     {
       code: "<template><div class=\"d-fw-bold d-mt-4 d-p-8\" /></template>",
@@ -84,6 +77,34 @@ ruleTester.run("recommend-typography-style", rule, {
     {
       code: "<template><div class=\"d-fw-bold d-fs-200 d-mt-4\" /></template>",
       errors: [{ messageId: 'recommendTypographyStyle' }],
+    },
+    // Conflicting utilities within same category: font-weight
+    {
+      code: "<template><div class=\"d-fw-bold d-fw-medium\" /></template>",
+      errors: [{ messageId: 'conflictingTypographyUtilities' }],
+    },
+    // Conflicting utilities within same category: font-size
+    {
+      code: "<template><div class=\"d-fs-100 d-fs-200\" /></template>",
+      errors: [{ messageId: 'conflictingTypographyUtilities' }],
+    },
+    // Conflicting utilities within same category: line-height
+    {
+      code: "<template><div class=\"d-lh-300 d-lh-400\" /></template>",
+      errors: [{ messageId: 'conflictingTypographyUtilities' }],
+    },
+    // Conflicting utilities within same category: font-family
+    {
+      code: "<template><div class=\"d-ff-mono d-ff-sans\" /></template>",
+      errors: [{ messageId: 'conflictingTypographyUtilities' }],
+    },
+    // Both errors: 2+ categories AND conflicting within a category
+    {
+      code: "<template><div class=\"d-fw-bold d-fw-medium d-fs-200\" /></template>",
+      errors: [
+        { messageId: 'recommendTypographyStyle' },
+        { messageId: 'conflictingTypographyUtilities' },
+      ],
     },
   ],
 });

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/recommend-typography-style.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/recommend-typography-style.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Utilities to set Font family, Font weight, Font size, and Line height separately are discouraged in favor of composed typography utilities
+ * @fileoverview Combining multiple typography utility categories is discouraged in favor of composed typography utilities
  * @author Nina Repetto
  */
 "use strict";
@@ -24,26 +24,65 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("recommend-typography-style", rule, {
   valid: [
+    // Composed typography utilities are valid
     {
       code: "<template><div class=\"d-label--md-plain\" /></template>",
+    },
+    // Single typography utilities are valid (acceptable for overrides)
+    {
+      code: "<template><div class=\"d-fw-medium\" /></template>",
+    },
+    {
+      code: "<template><div class=\"d-fs-200\" /></template>",
+    },
+    {
+      code: "<template><div class=\"d-lh-300\" /></template>",
+    },
+    {
+      code: "<template><div class=\"d-ff-mono\" /></template>",
+    },
+    // Same category combinations are valid
+    {
+      code: "<template><div class=\"d-fw-bold d-fw-medium\" /></template>",
+    },
+    {
+      code: "<template><div class=\"d-fs-100 d-fs-200\" /></template>",
+    },
+    // Mixed with non-typography classes is valid (single category)
+    {
+      code: "<template><div class=\"d-fw-bold d-mt-4 d-p-8\" /></template>",
     },
   ],
 
   invalid: [
+    // 2 different categories: font-weight + font-size
     {
-      code: "<template><div class=\"d-fw-medium\" /></template>",
+      code: "<template><div class=\"d-fw-bold d-fs-200\" /></template>",
       errors: [{ messageId: 'recommendTypographyStyle' }],
     },
+    // 2 different categories: font-size + line-height
     {
-      code: "<template><div class=\"d-fs-200\" /></template>",
+      code: "<template><div class=\"d-fs-200 d-lh-300\" /></template>",
       errors: [{ messageId: 'recommendTypographyStyle' }],
     },
+    // 2 different categories: font-family + font-weight
     {
-      code: "<template><div class=\"d-lh-300\" /></template>",
+      code: "<template><div class=\"d-ff-mono d-fw-bold\" /></template>",
       errors: [{ messageId: 'recommendTypographyStyle' }],
     },
+    // 3 different categories: font-family + font-weight + font-size
     {
-      code: "<template><div class=\"d-ff-mono\" /></template>",
+      code: "<template><div class=\"d-ff-mono d-fw-bold d-fs-200\" /></template>",
+      errors: [{ messageId: 'recommendTypographyStyle' }],
+    },
+    // 4 different categories: all of them
+    {
+      code: "<template><div class=\"d-ff-sans d-fw-semibold d-fs-300 d-lh-400\" /></template>",
+      errors: [{ messageId: 'recommendTypographyStyle' }],
+    },
+    // Mixed with non-typography classes but still has 2+ categories
+    {
+      code: "<template><div class=\"d-fw-bold d-fs-200 d-mt-4\" /></template>",
       errors: [{ messageId: 'recommendTypographyStyle' }],
     },
   ],


### PR DESCRIPTION
# Update recommend-typography-style to only flag multiple 

<img alt="lint" src="https://github.com/user-attachments/assets/4fc970df-1e6f-42a2-a35e-ef55e9adee3a" />

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Description

Updates the `recommend-typography-style` ESLint rule to only report violations when **two or more different typography categories** are combined in the same class attribute. Previously, the rule flagged **any** single typography utility (like `d-fw-bold` alone).

Changes:                                                                                                                 

- Rule now only reports when 2+ different typography categories are present in the same class (e.g `d-fw*` + d-fs-*), but won't flag single typography utilities (e.g `d-fw-bold`)
- Rule documentation with clearer examples      
- Updated tests

## :bulb: Context

https://dialpad.com/app/messages/agxzfnViZXItdm9pY2VyGAsSC1RleHRNZXNzYWdlGIDAsOq8wN0JDA

Single typography utilities are often used intentionally for overrides (e.g., making text bold without changing other typography properties). The previous behavior flagged these valid use cases, making the rule too **noisy** to be useful.

This change makes the rule smarter by only flagging combinations instead of using the composed `d-headline--*`, `d-body--*`, or `d-label--*` utilities which already combine typography style properties.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.