### PR TITLE
feat(datepicker): DP-175969 add min and max date props

### DIFF
--- a/apps/dialtone-documentation/docs/components/datepicker.md
+++ b/apps/dialtone-documentation/docs/components/datepicker.md
@@ -335,6 +335,35 @@ vueCode='
 '
 />
 
+### With min/max date
+
+Constrain the selectable date range by providing `min-date` and/or `max-date` props. Days outside the range are disabled and navigation buttons are disabled when the target month is fully out of range.
+
+<code-well-header>
+  <dt-datepicker
+    :selected-date="currentSelectedDate"
+    :min-date="minDate"
+    :max-date="maxDate"
+    @selected-date="currentSelectedDate = $event;"
+  />
+</code-well-header>
+
+<code-example-tabs
+vueCode='
+<script setup>
+const today = new Date();
+const minDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 5);
+const maxDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 15);
+</script>
+
+<dt-datepicker
+  :selected-date="new Date()"
+  :min-date="minDate"
+  :max-date="maxDate"
+/>
+'
+showHtmlWarning />
+
 ## Vue API
 
 <component-vue-api component-name="datepicker"></component-vue-api>
@@ -528,6 +557,10 @@ const { formatLong, formatMedium, formatShort, formatNoYear, formatNumerical } =
 
 const currentSelectedDate = ref(new Date());
 const datepickerOpened = ref(false);
+
+const today = new Date();
+const minDate = ref(new Date(today.getFullYear(), today.getMonth(), today.getDate() - 5));
+const maxDate = ref(new Date(today.getFullYear(), today.getMonth(), today.getDate() + 15));
 
 const toggleDatepicker = () => {
   datepickerOpened.value = !datepickerOpened.value;

--- a/packages/dialtone-css/lib/build/less/components/datepicker.less
+++ b/packages/dialtone-css/lib/build/less/components/datepicker.less
@@ -22,7 +22,6 @@
     padding: 0 var(--dt-space-300);
   }
 
-
   &__month-year {
     justify-content: space-between;
     width: 100%;
@@ -40,6 +39,11 @@
   &__nav-btn {
     width: var(--datepicker-button-size);
     height: var(--datepicker-button-size);
+
+    &:disabled {
+      background-color: var(--dt-color-neutral-transparent);
+      opacity: var(--dt-opacity-900);
+    }
   }
 
   &__weekday {
@@ -76,8 +80,8 @@
     }
 
     &--disabled {
-      color: var(--dt-color-foreground-muted);
       background-color: var(--dt-color-neutral-transparent);
+      opacity: var(--dt-opacity-900);
     }
   }
 }

--- a/packages/dialtone-vue/components/datepicker/composables/useCalendar.js
+++ b/packages/dialtone-vue/components/datepicker/composables/useCalendar.js
@@ -25,7 +25,7 @@ export function useCalendar (props, emits) {
   }
 
   function setDayRef (el, day) {
-    if (!daysRef.value.some(day => day.el === el) && day.currentMonth) {
+    if (!daysRef.value.some(day => day.el === el) && !day.disabled) {
       daysRef.value.push({ el, day });
     }
   }
@@ -116,7 +116,7 @@ export function useCalendar (props, emits) {
   }
 
   function selectDay (day) {
-    if (!day.currentMonth) { return; }
+    if (day.disabled) { return; }
 
     // local selectedDay is updated when a day is selected
     selectedDay.value = day.text;

--- a/packages/dialtone-vue/components/datepicker/composables/useMonthYearPicker.js
+++ b/packages/dialtone-vue/components/datepicker/composables/useMonthYearPicker.js
@@ -1,5 +1,5 @@
 import { computed, ref, watch } from 'vue';
-import { addMonths, getDate, getMonth, getYear, set, subMonths } from 'date-fns';
+import { addMonths, endOfMonth, getDate, getMonth, getYear, set, startOfDay, startOfMonth, subMonths } from 'date-fns';
 import { formatMonth, getCalendarDays } from '../utils.js';
 import { INTL_MONTH_FORMAT } from '../datepicker_constants';
 import { returnFirstEl } from '@/common/utils';
@@ -14,7 +14,31 @@ export function useMonthYearPicker (props, emits) {
   const i18n = new DialtoneLocalization();
 
   const calendarDays = computed(() => {
-    return getCalendarDays(selectMonth.value, selectYear.value, highlightedDay.value);
+    return getCalendarDays(selectMonth.value, selectYear.value, highlightedDay.value, props.minDate, props.maxDate);
+  });
+
+  const isPrevMonthDisabled = computed(() => {
+    if (!props.minDate) return false;
+    const prevMonth = subMonths(new Date(selectYear.value, selectMonth.value, 1), 1);
+    return endOfMonth(prevMonth) < startOfDay(props.minDate);
+  });
+
+  const isNextMonthDisabled = computed(() => {
+    if (!props.maxDate) return false;
+    const nextMonth = addMonths(new Date(selectYear.value, selectMonth.value, 1), 1);
+    return startOfMonth(nextMonth) > startOfDay(props.maxDate);
+  });
+
+  const isPrevYearDisabled = computed(() => {
+    if (!props.minDate) return false;
+    const prevYearMonth = new Date(selectYear.value - 1, selectMonth.value, 1);
+    return endOfMonth(prevYearMonth) < startOfDay(props.minDate);
+  });
+
+  const isNextYearDisabled = computed(() => {
+    if (!props.maxDate) return false;
+    const nextYearMonth = new Date(selectYear.value + 1, selectMonth.value, 1);
+    return startOfMonth(nextYearMonth) > startOfDay(props.maxDate);
   });
 
   watch(selectMonth, () => {
@@ -26,6 +50,14 @@ export function useMonthYearPicker (props, emits) {
     highlightDay();
     emits('calendar-days', calendarDays.value);
   }, { immediate: true });
+
+  watch(() => props.minDate, () => {
+    emits('calendar-days', calendarDays.value);
+  });
+
+  watch(() => props.maxDate, () => {
+    emits('calendar-days', calendarDays.value);
+  });
 
   function formattedMonth (month) {
     return formatMonth(month, INTL_MONTH_FORMAT, i18n.currentLocale);
@@ -93,6 +125,9 @@ export function useMonthYearPicker (props, emits) {
   }
 
   function changeMonth (value) {
+    if (value === -1 && isPrevMonthDisabled.value) return;
+    if (value === 1 && isNextMonthDisabled.value) return;
+
     // Adjust year when changing from January to December or vice versa
     if ((selectMonth.value === 0 && value === -1) || (selectMonth.value === 11 && value === 1)) {
       selectYear.value += value;
@@ -107,6 +142,9 @@ export function useMonthYearPicker (props, emits) {
   }
 
   function changeYear (value) {
+    if (value === -1 && isPrevYearDisabled.value) return;
+    if (value === 1 && isNextYearDisabled.value) return;
+
     selectYear.value = selectYear.value + value;
   }
 
@@ -145,6 +183,10 @@ export function useMonthYearPicker (props, emits) {
     changeYear,
     goToNextMonth,
     goToPrevMonth,
+    isPrevMonthDisabled,
+    isNextMonthDisabled,
+    isPrevYearDisabled,
+    isNextYearDisabled,
     previousYearAriaLabel,
     previousMonthAriaLabel,
     nextYearAriaLabel,

--- a/packages/dialtone-vue/components/datepicker/datepicker.stories.js
+++ b/packages/dialtone-vue/components/datepicker/datepicker.stories.js
@@ -11,6 +11,8 @@ export const argsData = {
   onCloseDatepicker: action('close-datepicker'),
   date: new Date(),
   opened: false,
+  minDate: null,
+  maxDate: null,
 };
 
 export const argTypesData = {

--- a/packages/dialtone-vue/components/datepicker/datepicker.test.js
+++ b/packages/dialtone-vue/components/datepicker/datepicker.test.js
@@ -342,4 +342,221 @@ describe('DtDatepicker Tests', () => {
       expect(wrapper.emitted('selected-date')).toBeTruthy();
     });
   });
+
+  describe('Min/Max Date Tests', () => {
+    const MIN_DATE = new Date(MOCK_YEAR, MOCK_MONTH, 10);
+    const MAX_DATE = new Date(MOCK_YEAR, MOCK_MONTH, 20);
+
+    beforeEach(async () => {
+      mockProps = { minDate: MIN_DATE, maxDate: MAX_DATE };
+      await updateWrapper();
+    });
+
+    it('days before minDate should be disabled', () => {
+      const days = wrapper.findAll('.d-datepicker__calendar button');
+      // Day 9 (July 9) is index 14 (6 offset days from June + 9 - 1)
+      const day9 = days.at(14);
+
+      expect(day9.attributes('disabled')).toBeDefined();
+      expect(day9.classes('d-datepicker__day--disabled')).toBe(true);
+    });
+
+    it('days after maxDate should be disabled', () => {
+      const days = wrapper.findAll('.d-datepicker__calendar button');
+      // Day 21 (July 21) is index 26 (6 + 21 - 1)
+      const day21 = days.at(26);
+
+      expect(day21.attributes('disabled')).toBeDefined();
+      expect(day21.classes('d-datepicker__day--disabled')).toBe(true);
+    });
+
+    it('days within range should be enabled', () => {
+      const days = wrapper.findAll('.d-datepicker__calendar button');
+      // Day 15 (July 15) is index 20 (6 + 15 - 1)
+      const day15 = days.at(20);
+
+      expect(day15.attributes('disabled')).toBeUndefined();
+      expect(day15.classes('d-datepicker__day--disabled')).toBe(false);
+    });
+
+    it('clicking a disabled day should not emit selected-date', async () => {
+      const days = wrapper.findAll('.d-datepicker__calendar button');
+      // Day 9 is before minDate
+      const day9 = days.at(14);
+
+      await day9.trigger('click');
+
+      expect(wrapper.emitted('selected-date')).toBeFalsy();
+    });
+
+    it('clicking an enabled day should emit selected-date', async () => {
+      const days = wrapper.findAll('.d-datepicker__calendar button');
+      // Day 15 is within range
+      const day15 = days.at(20);
+
+      await day15.trigger('click');
+
+      expect(wrapper.emitted('selected-date')).toBeTruthy();
+    });
+
+    describe('navigation button constraints', () => {
+      it('previous month button should be disabled when at min bound', () => {
+        expect(prevMonthButton.attributes('disabled')).toBeDefined();
+      });
+
+      it('next month button should be disabled when at max bound', () => {
+        expect(nextMonthButton.attributes('disabled')).toBeDefined();
+      });
+
+      it('should not navigate past minDate month', async () => {
+        await prevMonthButton.trigger('click');
+
+        expect(datepickerValue.text()).toBe(MOCK_HEADER_SELECTED_DATE);
+      });
+
+      it('should not navigate past maxDate month', async () => {
+        await nextMonthButton.trigger('click');
+
+        expect(datepickerValue.text()).toBe(MOCK_HEADER_SELECTED_DATE);
+      });
+    });
+
+    it('boundary minDate day should be enabled', () => {
+      const days = wrapper.findAll('.d-datepicker__calendar button');
+      // Day 10 (July 10) is index 15 (6 + 10 - 1), the minDate itself
+      const day10 = days.at(15);
+
+      expect(day10.attributes('disabled')).toBeUndefined();
+      expect(day10.classes('d-datepicker__day--disabled')).toBe(false);
+    });
+
+    it('boundary maxDate day should be enabled', () => {
+      const days = wrapper.findAll('.d-datepicker__calendar button');
+      // Day 20 (July 20) is index 25 (6 + 20 - 1), the maxDate itself
+      const day20 = days.at(25);
+
+      expect(day20.attributes('disabled')).toBeUndefined();
+      expect(day20.classes('d-datepicker__day--disabled')).toBe(false);
+    });
+
+    it('clicking boundary minDate day should emit selected-date', async () => {
+      const days = wrapper.findAll('.d-datepicker__calendar button');
+      const day10 = days.at(15);
+
+      await day10.trigger('click');
+
+      expect(wrapper.emitted('selected-date')).toBeTruthy();
+    });
+
+    it('clicking boundary maxDate day should emit selected-date', async () => {
+      const days = wrapper.findAll('.d-datepicker__calendar button');
+      const day20 = days.at(25);
+
+      await day20.trigger('click');
+
+      expect(wrapper.emitted('selected-date')).toBeTruthy();
+    });
+
+    describe('reactive prop changes', () => {
+      it('should update disabled days when minDate changes', async () => {
+        const days = wrapper.findAll('.d-datepicker__calendar button');
+        // Day 5 (July 5) is index 10 (6 + 5 - 1), currently disabled
+        const day5 = days.at(10);
+
+        expect(day5.attributes('disabled')).toBeDefined();
+
+        // Change minDate to July 3
+        await wrapper.setProps({ minDate: new Date(MOCK_YEAR, MOCK_MONTH, 3) });
+
+        const updatedDays = wrapper.findAll('.d-datepicker__calendar button');
+        const updatedDay5 = updatedDays.at(10);
+
+        expect(updatedDay5.attributes('disabled')).toBeUndefined();
+      });
+
+      it('should update disabled days when maxDate changes', async () => {
+        const days = wrapper.findAll('.d-datepicker__calendar button');
+        // Day 25 (July 25) is index 30 (6 + 25 - 1), currently disabled
+        const day25 = days.at(30);
+
+        expect(day25.attributes('disabled')).toBeDefined();
+
+        // Change maxDate to July 28
+        await wrapper.setProps({ maxDate: new Date(MOCK_YEAR, MOCK_MONTH, 28) });
+
+        const updatedDays = wrapper.findAll('.d-datepicker__calendar button');
+        const updatedDay25 = updatedDays.at(30);
+
+        expect(updatedDay25.attributes('disabled')).toBeUndefined();
+      });
+    });
+
+    describe('with only minDate', () => {
+      beforeEach(async () => {
+        mockProps = { minDate: MIN_DATE };
+        await updateWrapper();
+      });
+
+      it('days before minDate should be disabled', () => {
+        const days = wrapper.findAll('.d-datepicker__calendar button');
+        const day9 = days.at(14);
+
+        expect(day9.attributes('disabled')).toBeDefined();
+      });
+
+      it('days after minDate should be enabled', () => {
+        const days = wrapper.findAll('.d-datepicker__calendar button');
+        const day15 = days.at(20);
+
+        expect(day15.attributes('disabled')).toBeUndefined();
+      });
+
+      it('next month button should not be disabled', () => {
+        expect(nextMonthButton.attributes('disabled')).toBeUndefined();
+      });
+    });
+
+    describe('with only maxDate', () => {
+      beforeEach(async () => {
+        mockProps = { maxDate: MAX_DATE };
+        await updateWrapper();
+      });
+
+      it('days after maxDate should be disabled', () => {
+        const days = wrapper.findAll('.d-datepicker__calendar button');
+        const day21 = days.at(26);
+
+        expect(day21.attributes('disabled')).toBeDefined();
+      });
+
+      it('days before maxDate should be enabled', () => {
+        const days = wrapper.findAll('.d-datepicker__calendar button');
+        const day15 = days.at(20);
+
+        expect(day15.attributes('disabled')).toBeUndefined();
+      });
+
+      it('previous month button should not be disabled', () => {
+        expect(prevMonthButton.attributes('disabled')).toBeUndefined();
+      });
+    });
+
+    describe('invalid prop combination', () => {
+      it('should warn when maxDate is before minDate', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        mockProps = {
+          minDate: new Date(MOCK_YEAR, MOCK_MONTH, 20),
+          maxDate: new Date(MOCK_YEAR, MOCK_MONTH, 10),
+        };
+        await updateWrapper();
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('maxDate must be after or equal to minDate'),
+        );
+
+        warnSpy.mockRestore();
+      });
+    });
+  });
 });

--- a/packages/dialtone-vue/components/datepicker/datepicker.vue
+++ b/packages/dialtone-vue/components/datepicker/datepicker.vue
@@ -8,6 +8,8 @@
       <month-year-picker
         ref="monthYearPicker"
         :selected-date="selectedDate"
+        :min-date="minDate"
+        :max-date="maxDate"
         @calendar-days="updateCalendarDays"
         @focus-first-day="$refs.calendar.focusFirstDay()"
         @focus-last-day="$refs.calendar.focusLastDay()"
@@ -44,6 +46,35 @@ defineProps({
   selectedDate: {
     type: Date,
     default: () => (new Date()),
+  },
+
+  /**
+     * Minimum selectable date. Days before this date will be disabled.
+     * Must be before or equal to maxDate when both are provided.
+     *
+     * @type {Date}
+     */
+  minDate: {
+    type: Date,
+    default: null,
+  },
+
+  /**
+     * Maximum selectable date. Days after this date will be disabled.
+     * Must be after or equal to minDate when both are provided.
+     *
+     * @type {Date}
+     */
+  maxDate: {
+    type: Date,
+    default: null,
+    validator: (value, props) => {
+      if (value && props.minDate && value < props.minDate) {
+        console.warn('[DtDatepicker]: maxDate must be after or equal to minDate.');
+        return false;
+      }
+      return true;
+    },
   },
 });
 

--- a/packages/dialtone-vue/components/datepicker/datepicker_default.story.vue
+++ b/packages/dialtone-vue/components/datepicker/datepicker_default.story.vue
@@ -43,6 +43,8 @@
     <br>
     <dt-datepicker
       :selected-date="currentSelectedDate"
+      :min-date="$attrs.minDate"
+      :max-date="$attrs.maxDate"
       @selected-date="currentSelectedDate = $event; $attrs.onSelectedDate($event)"
       @close-datepicker="$attrs.onCloseDatepicker"
     />

--- a/packages/dialtone-vue/components/datepicker/modules/calendar.vue
+++ b/packages/dialtone-vue/components/datepicker/modules/calendar.vue
@@ -36,15 +36,15 @@
             :circle="true"
             size="sm"
             importance="clear"
-            :disabled="!day.currentMonth"
+            :disabled="day.disabled"
             :class="{
-              'd-datepicker__day--disabled': !day.currentMonth,
+              'd-datepicker__day--disabled': day.disabled,
               'd-datepicker__day--selected': selectedDay
-                ? ((day.text === selectedDay) && day.currentMonth)
+                ? ((day.text === selectedDay) && !day.disabled)
                 : day.selected,
             }"
             type="button"
-            :aria-selected="!!selectedDay ? ((day.text === selectedDay) && day.currentMonth) : day.selected"
+            :aria-selected="!!selectedDay ? ((day.text === selectedDay) && !day.disabled) : day.selected"
             :aria-label="dayAriaLabel(day)"
             role="option"
             @click="selectDay(day)"

--- a/packages/dialtone-vue/components/datepicker/modules/month-year-picker.vue
+++ b/packages/dialtone-vue/components/datepicker/modules/month-year-picker.vue
@@ -21,6 +21,7 @@
             :ref="el => { if (el) setDayRef(el) }"
             :aria-label="previousYearAriaLabel()"
             :circle="true"
+            :disabled="isPrevYearDisabled"
             class="d-datepicker__nav-btn"
             importance="clear"
             kind="muted"
@@ -46,6 +47,7 @@
             :ref="el => { if (el) setDayRef(el) }"
             :aria-label="previousMonthAriaLabel()"
             :circle="true"
+            :disabled="isPrevMonthDisabled"
             class="d-datepicker__nav-btn"
             importance="clear"
             kind="muted"
@@ -86,6 +88,7 @@
             :ref="el => { if (el) setDayRef(el) }"
             :aria-label="nextMonthAriaLabel()"
             :circle="true"
+            :disabled="isNextMonthDisabled"
             class="d-datepicker__nav-btn"
             importance="clear"
             kind="muted"
@@ -111,6 +114,7 @@
             :ref="el => { if (el) setDayRef(el) }"
             :aria-label="nextYearAriaLabel()"
             :circle="true"
+            :disabled="isNextYearDisabled"
             class="d-datepicker__nav-btn"
             importance="clear"
             kind="muted"
@@ -147,6 +151,16 @@ const props = defineProps({
   selectedDate: {
     type: Date,
     required: true,
+  },
+
+  minDate: {
+    type: Date,
+    default: null,
+  },
+
+  maxDate: {
+    type: Date,
+    default: null,
   },
 });
 
@@ -194,6 +208,10 @@ const {
   changeYear,
   goToNextMonth,
   goToPrevMonth,
+  isPrevMonthDisabled,
+  isNextMonthDisabled,
+  isPrevYearDisabled,
+  isNextYearDisabled,
   previousYearAriaLabel,
   previousMonthAriaLabel,
   nextMonthAriaLabel,

--- a/packages/dialtone-vue/components/datepicker/utils.js
+++ b/packages/dialtone-vue/components/datepicker/utils.js
@@ -1,5 +1,5 @@
 import {
-  startOfWeek, addDays, getMonth, isEqual,
+  startOfWeek, startOfDay, addDays, getMonth, isEqual,
   addMonths, startOfMonth, getDay, getDate,
   subMonths, endOfMonth,
 } from 'date-fns';
@@ -11,19 +11,24 @@ const _parsedGetDate = (value) => (value ? new Date(value) : new Date());
  * Get 7 days from the provided start date, month is used to check
  * whether the date is from the specified month or in the offset
  */
-const getWeekDays = (startDay, month, selectedDay) => {
+const getWeekDays = (startDay, month, selectedDay, minDate = null, maxDate = null) => {
   const startDate = _parsedGetDate(JSON.parse(JSON.stringify(startDay)));
+  const normalizedMin = minDate ? startOfDay(minDate) : null;
+  const normalizedMax = maxDate ? startOfDay(maxDate) : null;
   const dates = [];
   for (let i = 0; i < 7; i++) {
     const next = addDays(startDate, i);
     const isNext = getMonth(next) !== month;
+    const disabled = isNext
+      || (normalizedMin && startOfDay(next) < normalizedMin)
+      || (normalizedMax && startOfDay(next) > normalizedMax);
     dates.push({
       text: next.getDate(),
       value: next,
       currentMonth: !isNext,
+      disabled: !!disabled,
       isFirstDayOfMonth: next.getDate() === 1 && !isNext,
-      // will be selected if the date is the same as the selected day and is from the current month
-      selected: selectedDay ? (next.getDate() === selectedDay && !isNext) : false,
+      selected: selectedDay ? (next.getDate() === selectedDay && !disabled) : false,
     });
   }
   return dates;
@@ -39,7 +44,7 @@ const isDateEqual = (date, dateToCompare) => {
 /**
  * Get days for the calendar to be displayed in a table grouped by weeks
  */
-export const getCalendarDays = (month, year, selectedDay) => {
+export const getCalendarDays = (month, year, selectedDay, minDate = null, maxDate = null) => {
   const weeks = [];
   const firstDate = _parsedGetDate(new Date(year, month));
   const lastDate = _parsedGetDate(new Date(year, month + 1, 0));
@@ -49,7 +54,7 @@ export const getCalendarDays = (month, year, selectedDay) => {
   const firstDateInCalendar = startOfWeek(firstDate, { weekStartsOn });
 
   const addDaysToWeek = (date) => {
-    const days = getWeekDays(date, month, selectedDay);
+    const days = getWeekDays(date, month, selectedDay, minDate, maxDate);
 
     weeks.push({ days });
 


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-175969

## :book: Description

Adds native `minDate` and `maxDate` props to the DtDatepicker component, allowing consumers to constrain selectable dates within a range. Days outside the range are visually disabled and unclickable. Navigation buttons (prev/next month/year) are disabled when they would go beyond the allowed bounds.

## :bulb: Context

The scorecard grading "Share later" flow needs to constrain the date picker to a specific range (tomorrow → 1 month out). Currently this is handled by wrapping v-calendar directly via `base-date-picker`. Adding native min/max support to DtDatepicker enables migration away from the v-calendar wrapper.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

- I need to update https://github.com/dialpad/firespotter/pull/70089 with this Datepicker 

## :camera: Screenshots / GIFs
<img width="309" height="239" alt="image" src="https://github.com/user-attachments/assets/b453ccbc-ba63-4f5b-b46a-bbb344c7318c" />

## Note
Visual tests had 1 change where one pic wouldn't load. It seems unrelated to this, so I approved them. 