### PR TITLE
feat(link): DLT-3010 add router-link rendering support

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/BlogPostPreview.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/BlogPostPreview.vue
@@ -1,29 +1,23 @@
 <template>
-  <router-link
-    v-slot="{ navigate }"
+  <dt-link
     :to="`/about/whats-new/posts/${format(posted, 'y-M-d')}`"
-    custom
+    class="d-fc-unset d-d-block d-bar8 d-td-none"
   >
-    <dt-link
-      class="d-fc-unset d-d-block d-bar8 d-td-none"
-      @click="(e) => { navigate(e); }"
+    <dt-card
+      class="d-mt16 d-bgc-primary d-bs-none h:d-bs-sm d-ba d-bar8 d-bbw1 d-bc-default"
     >
-      <dt-card
-        class="d-mt16 d-bgc-primary d-bs-none h:d-bs-sm d-ba d-bar8 d-bbw1 d-bc-default"
-      >
-        <template #content>
-          <blog-post
-            :author="author"
-            :heading="heading"
-            :posted="posted"
-            :is-preview="true"
-          >
-            <slot />
-          </blog-post>
-        </template>
-      </dt-card>
-    </dt-link>
-  </router-link>
+      <template #content>
+        <blog-post
+          :author="author"
+          :heading="heading"
+          :posted="posted"
+          :is-preview="true"
+        >
+          <slot />
+        </blog-post>
+      </template>
+    </dt-card>
+  </dt-link>
 </template>
 
 <script setup>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/FlexStackNotice.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/FlexStackNotice.vue
@@ -6,13 +6,13 @@
     title="Use DtStack in favor of Flex CSS Utilities"
   >
     Use the
-    <router-link class="d-link d-link--muted" to="/components/stack">
+    <dt-link to="/components/stack" kind="muted">
       DtStack
-    </router-link>
+    </dt-link>
     component for most Flex-based layout implementations. View
-    <router-link class="d-link d-link--muted" to="/about/whats-new/posts/2025-12-2">
+    <dt-link to="/about/whats-new/posts/2025-12-2" kind="muted">
       Migrating from Flex CSS Utilities to DtStack
-    </router-link>
+    </dt-link>
     for more details.
   </dt-notice>
 </template>

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Home.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Home.vue
@@ -78,9 +78,9 @@
           Foundational color, iconography, and spacing guidelines
         </p>
         <dt-stack gap="300">
-          <router-link class="d-link" to="/design/">
+          <dt-link to="/design/">
             Browse Design Guidelines
-          </router-link>
+          </dt-link>
         </dt-stack>
       </dt-stack>
       <dt-stack gap="400" class="link d-body--md d-gc3 d-px32 d-ta-center">
@@ -96,12 +96,12 @@
           Presentational UI components offered in CSS and Vue
         </p>
         <dt-stack gap="300">
-          <router-link class="d-link" to="/components/">
+          <dt-link to="/components/">
             Browse CSS Components
-          </router-link>
-          <a class="d-link" href="https://dialtone.dialpad.com/vue/index.html?path=/docs/welcome--docs" target="_blank" rel="noopener noreferrer">
+          </dt-link>
+          <dt-link href="https://dialtone.dialpad.com/vue/index.html?path=/docs/welcome--docs" target="_blank" rel="noopener noreferrer">
             Browse Vue Components
-          </a>
+          </dt-link>
         </dt-stack>
       </dt-stack>
       <dt-stack gap="400" class="link d-body--md d-gc3 d-px32 d-ta-center">
@@ -117,9 +117,9 @@
           A utility-first CSS framework for building user interfaces.
         </p>
         <dt-stack gap="300">
-          <router-link class="d-link" to="/utilities/">
+          <dt-link to="/utilities/">
             Browse Utility Classes
-          </router-link>
+          </dt-link>
         </dt-stack>
       </dt-stack>
       <dt-stack gap="400" class="link d-body--md d-gc3 d-px32 d-ta-center">
@@ -135,15 +135,15 @@
           Reference guidelines for Accessibility, Writing, and more
         </p>
         <dt-stack gap="300">
-          <router-link class="d-link" to="/guides/getting-started/">
+          <dt-link to="/guides/getting-started/">
             Getting Started
-          </router-link>
-          <router-link class="d-link" to="/guides/content/">
+          </dt-link>
+          <dt-link to="/guides/content/">
             Writing Guidelines
-          </router-link>
-          <router-link class="d-link" to="/guides/accessibility/">
+          </dt-link>
+          <dt-link to="/guides/accessibility/">
             Accessibility
-          </router-link>
+          </dt-link>
         </dt-stack>
       </dt-stack>
     </div>

--- a/apps/dialtone-documentation/docs/components/link.md
+++ b/apps/dialtone-documentation/docs/components/link.md
@@ -105,6 +105,45 @@ vueCode='
 '
 showHtmlWarning />
 
+## Navigation
+
+DtLink supports both external links and internal SPA navigation via Vue Router.
+
+### href
+
+Use `href` for standard anchor links — external URLs, hash links, etc.
+
+<code-example-tabs
+vueCode='
+<dt-link href="https://github.com/dialpad/dialtone" target="_blank" rel="noopener noreferrer">
+  GitHub
+</dt-link>
+<dt-link href="#section">Jump to section</dt-link>
+'
+showHtmlWarning />
+
+### to
+
+Use `to` for Vue Router navigation. DtLink renders as a `<router-link>` when `to` is provided.
+
+<code-example-tabs
+vueCode='
+<dt-link to="/components/">Browse Components</dt-link>
+<dt-link to="/components/button">Button docs</dt-link>
+<dt-link :to="{ name: &apos;component&apos;, params: { id: &apos;button&apos; } }">Button docs</dt-link>
+'
+showHtmlWarning />
+
+### Replace history
+
+Use the `replace` prop to replace the current history entry instead of pushing a new one. Only applies when `to` is provided.
+
+<code-example-tabs
+vueCode='
+<dt-link to="/components/" replace>Browse Components</dt-link>
+'
+showHtmlWarning />
+
 ## Vue API
 
 <component-vue-api component-name="link" />

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/color.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/color.md
@@ -4,7 +4,7 @@ description: Utilities for setting the background color.
 ---
 
 <dt-notice kind="warning" class="d-wmx100p d-mt24" hideClose>
-  Before using background color utilities, first consider <router-link class="d-link d-link--muted" to="/design/colors/palette/#surface">semantic surface colors</router-link>.
+  Before using background color utilities, first consider <dt-link to="/design/colors/palette/#surface" kind="muted">semantic surface colors</dt-link>.
 </dt-notice>
 
 ## Usage

--- a/apps/dialtone-documentation/docs/utilities/borders/color.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/color.md
@@ -4,7 +4,7 @@ description: Utilities for controlling an element's border color.
 ---
 
 <dt-notice kind="warning" class="d-wmx100p d-mt24" hideClose>
-  Before using border color utilities, first consider <router-link class="d-link d-link--muted" to="/design/colors/palette/#borders">semantic border colors</router-link>.
+  Before using border color utilities, first consider <dt-link to="/design/colors/palette/#borders" kind="muted">semantic border colors</dt-link>.
 </dt-notice>
 
 ## Usage

--- a/apps/dialtone-documentation/docs/utilities/layout/overflow.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/overflow.md
@@ -4,7 +4,7 @@ description: Utilities for controlling how an element handles content that is to
 ---
 
 <dt-notice kind="info" class="d-wmx100p d-mt24" hideClose>
-Consider using the custom scrollbar first with the <router-link class="d-link d-link--muted" to="/components/scrollbar">Scrollbar Directive</router-link>.
+Consider using the custom scrollbar first with the <dt-link to="/components/scrollbar" kind="muted">Scrollbar Directive</dt-link>.
 </dt-notice>
 
 ## Examples

--- a/apps/dialtone-documentation/docs/utilities/spacing/auto-spacing.md
+++ b/apps/dialtone-documentation/docs/utilities/spacing/auto-spacing.md
@@ -5,7 +5,7 @@ description: Utilities for controlling the space between child elements.
 
 <dt-notice kind="error" class="d-wmx100p d-mt24" hideClose>
 
-`d-stack` and `d-flow` utilities are deprecated. Please use the <router-link class="d-link d-link--muted" to="/components/stack">Stack</router-link> component instead.
+`d-stack` and `d-flow` utilities are deprecated. Please use the <dt-link to="/components/stack" kind="muted">Stack</dt-link> component instead.
 
 </dt-notice>
 

--- a/apps/dialtone-documentation/docs/utilities/spacing/margin.md
+++ b/apps/dialtone-documentation/docs/utilities/spacing/margin.md
@@ -4,7 +4,7 @@ description: Utilities to adjust an element's exterior spacing between other obj
 ---
 
 <dt-notice kind="warning" class="d-wmx100p d-mt24" hideClose>
-  Avoid applying margins directly. Lean toward using layout components like <router-link class="d-link d-link--muted" to="/components/stack/">Stack</router-link> for consistent and maintainable spacing <strong>between</strong> elements.
+  Avoid applying margins directly. Lean toward using layout components like <dt-link to="/components/stack/" kind="muted">Stack</dt-link> for consistent and maintainable spacing <strong>between</strong> elements.
 </dt-notice>
 
 ## Add Margin to All Sides

--- a/apps/dialtone-documentation/docs/utilities/spacing/padding.md
+++ b/apps/dialtone-documentation/docs/utilities/spacing/padding.md
@@ -4,7 +4,7 @@ description: Utilities for setting an element's interior spacing between child e
 ---
 
 <dt-notice kind="info" class="d-wmx100p d-mt24" hideClose>
-  Padding CSS Utilities are most appropriate for padding on the <strong>sides</strong> of an element. Avoiding using it to create spacing <strong>between</strong> elements. Instead, favor the <router-link class="d-link d-link--muted" to="/components/stack/">Stack</router-link> component and its <code>gap</code> property for spacing between. It can still be combined with flex utilities to create more complex layouts.
+  Padding CSS Utilities are most appropriate for padding on the <strong>sides</strong> of an element. Avoiding using it to create spacing <strong>between</strong> elements. Instead, favor the <dt-link to="/components/stack/" kind="muted">Stack</dt-link> component and its <code>gap</code> property for spacing between. It can still be combined with flex utilities to create more complex layouts.
 </dt-notice>
 
 ## Add Padding to All Sides

--- a/apps/dialtone-documentation/docs/utilities/typography/font-color.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-color.md
@@ -9,7 +9,7 @@ The contrast ratio value is noted with the colors below.
 Please use **only** these colors or variations of these colors which pass WCAG 2.1 Level AA contrast ratio requirements.
 
 <dt-notice kind="warning" class="d-wmx100p d-mt24" hideClose>
-  Before using a Color utility, consider <router-link class="d-link d-link--muted" to="/design/colors/palette/#foreground">semantic colors</router-link>.
+  Before using a Color utility, consider <dt-link to="/design/colors/palette/#foreground" kind="muted">semantic colors</dt-link>.
 </dt-notice>
 
 ## Usage

--- a/apps/dialtone-documentation/docs/utilities/typography/font-family.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-family.md
@@ -9,7 +9,7 @@ description: Utilities to change an element's font-family.
   class="d-wmx100p"
 >
   <template #default>
-    <p class="d-body--md-compact">Before applying a typography utility, first consider using <router-link class="d-fw-semibold d-link d-link--muted" to="/design/typography/">Dialtone's text styles</router-link> that bundles Font family, Font weight, Font size, and Line height together.</p>
+    <p class="d-body--md-compact">Before applying a typography utility, first consider using <dt-link to="/design/typography/" kind="muted" class="d-fw-semibold">Dialtone's text styles</dt-link> that bundles Font family, Font weight, Font size, and Line height together.</p>
   </template>
 </dt-notice>
 

--- a/apps/dialtone-documentation/docs/utilities/typography/font-size.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-size.md
@@ -9,7 +9,7 @@ description: Utilities to change an element's font-size.
   class="d-wmx100p"
 >
   <template #default>
-    <p class="d-body--md-compact">Before applying a typography utility, first consider using <router-link class="d-fw-bold d-link d-link--muted" to="/design/typography/">Dialtone's text styles</router-link> that bundles Font family, Font weight, Font size, and Line height together.</p>
+    <p class="d-body--md-compact">Before applying a typography utility, first consider using <dt-link to="/design/typography/" kind="muted" class="d-fw-bold">Dialtone's text styles</dt-link> that bundles Font family, Font weight, Font size, and Line height together.</p>
   </template>
 </dt-notice>
 

--- a/apps/dialtone-documentation/docs/utilities/typography/font-weight.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-weight.md
@@ -9,7 +9,7 @@ description: Utilities to change an element's font-weight.
   class="d-wmx100p"
 >
   <template #default>
-    <p class="d-body--md-compact">Before applying a typography utility, first consider using <router-link class="d-fw-semibold d-link d-link--muted" to="/design/typography/">Dialtone's text styles</router-link> that bundles Font family, Font weight, Font size, and Line height together.</p>
+    <p class="d-body--md-compact">Before applying a typography utility, first consider using <dt-link to="/design/typography/" kind="muted" class="d-fw-semibold">Dialtone's text styles</dt-link> that bundles Font family, Font weight, Font size, and Line height together.</p>
   </template>
 </dt-notice>
 

--- a/apps/dialtone-documentation/docs/utilities/typography/line-height.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/line-height.md
@@ -9,7 +9,7 @@ description: Utilities to change an element's line-height.
   class="d-wmx100p"
 >
   <template #default>
-    <p class="d-body--md-compact">Before applying a typography utility, first consider using <router-link class="d-fw-bold d-link d-link--muted" to="/design/typography/">Dialtone's text styles</router-link> that bundles Font family, Font weight, Font size, and Line height together.</p>
+    <p class="d-body--md-compact">Before applying a typography utility, first consider using <dt-link to="/design/typography/" kind="muted" class="d-fw-bold">Dialtone's text styles</dt-link> that bundles Font family, Font weight, Font size, and Line height together.</p>
   </template>
 </dt-notice>
 

--- a/apps/dialtone-documentation/docs/utilities/typography/styles.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/styles.md
@@ -13,6 +13,6 @@ For example, instead of `class="d-fs-200 d-lh-100"` you would declare `class="d-
   class="d-wmx100p d-mt24"
 >
   <template #default>
-    <p class="d-body--md-compact"> Typography Styles have been moved to <router-link class="d-fw-semibold d-link d-link--muted" to="/design/typography/">Design Language > Typography</router-link>.</p>
+    <p class="d-body--md-compact"> Typography Styles have been moved to <dt-link to="/design/typography/" kind="muted" class="d-fw-semibold">Design Language > Typography</dt-link>.</p>
   </template>
 </dt-notice>

--- a/packages/dialtone-vue/components/link/link.stories.js
+++ b/packages/dialtone-vue/components/link/link.stories.js
@@ -10,6 +10,8 @@ import { LINK_VARIANTS } from './link_constants';
 export const argsData = {
   default: 'Default link',
   href: '#',
+  to: null,
+  replace: false,
   inverted: false,
   kind: '',
   rel: undefined,
@@ -40,21 +42,39 @@ export const argTypesData = {
   inverted: {
     control: 'boolean',
   },
+  href: {
+    description: 'URL for anchor link navigation. Renders as a native <a> element.',
+    type: {
+      summary: 'string',
+    },
+    control: 'text',
+  },
+  to: {
+    description: 'Vue Router destination. Renders as a <router-link>. Takes precedence over href.',
+    type: {
+      summary: 'string | object',
+    },
+    control: 'text',
+  },
+  replace: {
+    description: 'When true, navigation replaces the current history entry. Only applies when `to` is provided.',
+    control: 'boolean',
+  },
 
   // HTML attributes
-  href: {
-    description: 'HTML a href attribute',
+  target: {
+    description: 'HTML a target attribute. Where to display the linked URL.',
     type: {
       summary: 'string',
     },
     table: {
       category: 'html attributes',
     },
-    control: 'text',
+    control: 'select',
+    options: ['_self', '_blank', '_parent', '_top'],
   },
   rel: {
-    description: `HTML a rel attribute. Relationship between the location in the document containing the hyperlink
-        and the destination resource.`,
+    description: `HTML a rel attribute. Relationship between the location in the document containing the hyperlink and the destination resource.`,
     type: {
       summary: 'string',
     },

--- a/packages/dialtone-vue/components/link/link.test.js
+++ b/packages/dialtone-vue/components/link/link.test.js
@@ -18,6 +18,8 @@ const baseSlots = {
 
 let mockProps = {};
 let mockSlots = {};
+let mockAttrs = {};
+let mockGlobal = {};
 
 describe('DtLink tests', () => {
   let wrapper;
@@ -27,6 +29,8 @@ describe('DtLink tests', () => {
     wrapper = mount(DtLink, {
       props: { ...baseProps, ...mockProps },
       slots: { ...baseSlots, ...mockSlots },
+      attrs: { ...mockAttrs },
+      global: { ...mockGlobal },
     });
 
     nativeLink = wrapper.find('[data-qa="dt-link"]');
@@ -39,6 +43,8 @@ describe('DtLink tests', () => {
   afterEach(() => {
     mockProps = {};
     mockSlots = {};
+    mockAttrs = {};
+    mockGlobal = {};
   });
 
   describe('Presentation Tests', () => {
@@ -143,6 +149,131 @@ describe('DtLink tests', () => {
         updateWrapper();
 
         expect(nativeLink.classes(getLinkKindModifier(MUTED, true))).toBe(true);
+      });
+    });
+  });
+
+  describe('Navigation Tests', () => {
+    describe('When href is provided', () => {
+      it('should render an anchor element', () => {
+        mockProps = { href: 'https://example.com' };
+
+        updateWrapper();
+
+        expect(nativeLink.element.tagName).toBe('A');
+        expect(nativeLink.attributes('href')).toBe('https://example.com');
+      });
+    });
+
+    describe('When neither href nor to is provided', () => {
+      it('should render an anchor with javascript:void(0) fallback', () => {
+        mockProps = { href: null };
+
+        updateWrapper();
+
+        expect(nativeLink.element.tagName).toBe('A');
+        expect(nativeLink.attributes('href')).toBe('javascript:void(0)');
+      });
+    });
+
+    describe('When to is provided', () => {
+      const RouterLinkStub = {
+        name: 'RouterLink',
+        template: '<a data-qa="dt-link" :href="to"><slot /></a>',
+        props: ['to', 'replace'],
+      };
+
+      it('should render a router-link', () => {
+        mockProps = { to: '/components/' };
+        mockGlobal = {
+          stubs: { RouterLink: RouterLinkStub },
+        };
+
+        updateWrapper();
+
+        const routerLink = wrapper.findComponent(RouterLinkStub);
+        expect(routerLink.exists()).toBe(true);
+        expect(routerLink.props('to')).toBe('/components/');
+      });
+
+      it('should pass replace prop to router-link', () => {
+        mockProps = { to: '/components/', replace: true };
+        mockGlobal = {
+          stubs: { RouterLink: RouterLinkStub },
+        };
+
+        updateWrapper();
+
+        const routerLink = wrapper.findComponent(RouterLinkStub);
+        expect(routerLink.props('replace')).toBe(true);
+      });
+
+      it('should default replace to false', () => {
+        mockProps = { to: '/components/' };
+        mockGlobal = {
+          stubs: { RouterLink: RouterLinkStub },
+        };
+
+        updateWrapper();
+
+        const routerLink = wrapper.findComponent(RouterLinkStub);
+        expect(routerLink.props('replace')).toBe(false);
+      });
+
+      it('should support object routes', () => {
+        const route = { name: 'components', params: { id: 1 } };
+        mockProps = { to: route };
+        mockGlobal = {
+          stubs: { RouterLink: RouterLinkStub },
+        };
+
+        updateWrapper();
+
+        const routerLink = wrapper.findComponent(RouterLinkStub);
+        expect(routerLink.props('to')).toEqual(route);
+      });
+    });
+
+    describe('When both to and href are provided', () => {
+      const RouterLinkStub = {
+        name: 'RouterLink',
+        template: '<a data-qa="dt-link"><slot /></a>',
+        props: ['to', 'replace'],
+      };
+
+      it('should render router-link (to takes precedence)', () => {
+        mockProps = { to: '/components/', href: 'https://example.com' };
+        mockGlobal = {
+          stubs: { RouterLink: RouterLinkStub },
+        };
+
+        updateWrapper();
+
+        const routerLink = wrapper.findComponent(RouterLinkStub);
+        expect(routerLink.exists()).toBe(true);
+        expect(routerLink.props('to')).toBe('/components/');
+      });
+    });
+
+    describe('When to is provided with kind', () => {
+      const RouterLinkStub = {
+        name: 'RouterLink',
+        template: '<a data-qa="dt-link" :class="$attrs.class"><slot /></a>',
+        props: ['to', 'replace'],
+      };
+
+      it('should apply link classes to the router-link', () => {
+        mockProps = { to: '/components/', kind: MUTED };
+        mockGlobal = {
+          stubs: { RouterLink: RouterLinkStub },
+        };
+
+        updateWrapper();
+
+        const routerLink = wrapper.findComponent(RouterLinkStub);
+        expect(routerLink.exists()).toBe(true);
+        expect(wrapper.find('[data-qa="dt-link"]').classes()).toContain('d-link');
+        expect(wrapper.find('[data-qa="dt-link"]').classes()).toContain(LINK_KIND_MODIFIERS[MUTED]);
       });
     });
   });

--- a/packages/dialtone-vue/components/link/link.vue
+++ b/packages/dialtone-vue/components/link/link.vue
@@ -1,20 +1,21 @@
 <template>
-  <a
+  <component
+    :is="computedTag"
     :class="getLinkClasses()"
     data-qa="dt-link"
-    :href="'href' in $attrs ? $attrs.href : 'javascript:void(0)'"
+    v-bind="computedAttrs"
   >
     <!-- @slot Slot for main content -->
     <slot />
-  </a>
+  </component>
 </template>
 
 <script>
+import { resolveComponent } from 'vue';
 import { LINK_VARIANTS, LINK_KIND_MODIFIERS, getLinkKindModifier } from './link_constants';
 
 /**
  * A link is a navigational element that can be found on its own, within other text, or directly following content.
- * @property {String} href attribute
  * @property {String} rel attribute
  * @see https://dialtone.dialpad.com/components/link.html
  */
@@ -44,12 +45,61 @@ export default {
       type: Boolean,
       default: false,
     },
+
+    /**
+     * URL for anchor link navigation. Renders as a native <a> element.
+     */
+    href: {
+      type: String,
+      default: null,
+    },
+
+    /**
+     * Vue Router destination. Renders as a <router-link>.
+     * Takes precedence over href when both are provided.
+     * @see https://router.vuejs.org/api/interfaces/RouterLinkProps.html#to
+     */
+    to: {
+      type: [String, Object],
+      default: null,
+    },
+
+    /**
+     * When true, navigation replaces the current history entry instead of pushing.
+     * Only applies when `to` is provided.
+     * @values true, false
+     */
+    replace: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data () {
     return {
       LINK_KIND_MODIFIERS,
     };
+  },
+
+  computed: {
+    computedTag () {
+      if (this.to) {
+        return resolveComponent('RouterLink');
+      }
+      return 'a';
+    },
+
+    computedAttrs () {
+      if (this.to) {
+        return {
+          to: this.to,
+          replace: this.replace,
+        };
+      }
+      return {
+        href: this.href || 'javascript:void(0)',
+      };
+    },
   },
 
   methods: {

--- a/packages/dialtone-vue/components/link/link_default.story.vue
+++ b/packages/dialtone-vue/components/link/link_default.story.vue
@@ -2,6 +2,8 @@
   <div>
     <dt-link
       :href="$attrs.href"
+      :to="$attrs.to"
+      :replace="$attrs.replace"
       :kind="$attrs.kind"
       :inverted="$attrs.inverted"
       :rel="$attrs.rel"

--- a/packages/dialtone-vue/components/link/link_variants.story.vue
+++ b/packages/dialtone-vue/components/link/link_variants.story.vue
@@ -1,36 +1,47 @@
 <template>
   <div>
-    <dt-link
-      v-for="kind in LINK_VARIANTS"
-      :key="kind"
-      href="#"
-      :kind="kind"
-      class="d-tt-capitalize d-mr8"
+    <dt-stack
+      gap="400"
+      direction="row"
+      class="d-p8"
     >
-      {{ kind }} link
-    </dt-link>
-    <div class="d-bgc-purple-600">
       <dt-link
         v-for="kind in LINK_VARIANTS"
         :key="kind"
-        inverted
         href="#"
         :kind="kind"
-        class="d-tt-capitalize d-mr8"
       >
-        Inverted {{ kind }} link
+        {{ kind }} link
       </dt-link>
+    </dt-stack>
+    <div class="d-bgc-contrast">
+      <dt-stack
+        gap="400"
+        direction="row"
+        class="d-p8"
+      >
+        <dt-link
+          v-for="kind in LINK_VARIANTS"
+          :key="kind"
+          inverted
+          href="#"
+          :kind="kind"
+        >
+          {{ kind }} inverted
+        </dt-link>
+      </dt-stack>
     </div>
   </div>
 </template>
 
 <script>
 import DtLink from './link.vue';
+import DtStack from '../stack/stack.vue';
 import { LINK_VARIANTS } from './link_constants';
 
 export default {
   name: 'DtLinkVariants',
-  components: { DtLink },
+  components: { DtLink, DtStack },
   data () {
     return {
       LINK_VARIANTS,


### PR DESCRIPTION
# Add router-link rendering support to DtLink

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3010

## :book: Description

### TLDR

Add `to` and `href` props to DtLink that control the rendered root element:

| Prop | Renders | Use case |
|------|---------|----------|
| `to` | `<router-link>` | Internal SPA navigation |
| `href` | `<a>` | External links, hash links |
| neither | `<a>` | Fallback (unchanged default) |

### Context

DtLink hardcodes `<a>` as its root element. Consuming products use raw `<router-link class="d-link">` workarounds for with link styling. 

This follows the same `resolveComponent('RouterLink')` pattern used by https://github.com/dialpad/dialtone/pull/1055, and aligns with how Bootstrap Vue and Vuetify handle navigation in their link/button components.

> [!TIP]
> **Non-breaking, purely additive change.** All new props default to
`null`/`false` — existing DtLink usage renders identically.

### Component changes (`link.vue`)

- New props: `to`, `href`, `replace`
- `href` promoted from `$attrs` fallthrough to a declared prop
- Template switches from `<a>` to `<component :is="computedTag">` with conditional attributes
- Lazy-resolves `RouterLink` via `resolveComponent` — falls back to `<a>` when vue-router isn't available
- `javascript:void(0)` fallback preserved when neither `to` nor `href` is provided

### Doc site migrations

Converted all `<router-link class="d-link">` workarounds across the doc site, e.g.

- `<router-link class="d-link">` to `<dt-link to="...">`
- `<a class="d-link">` → `<dt-link href="...">`
- `<router-link class="d-link d-link--muted">` to `<dt-link to="..." kind="muted">`

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull
request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :link: Sources

- [Vue Router extending
RouterLink](https://router.vuejs.org/guide/advanced/extending-router-link)
- [DtButton anchor support PR (same
pattern)](../active/dt-button-anchor-support.md)