### PR TITLE
feat(style): DLT-2976 update underline thickness and offset

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/link.less
+++ b/packages/dialtone-css/lib/build/less/components/link.less
@@ -31,8 +31,8 @@
     color: var(--link-color-default);
     font: inherit;
     text-decoration: var(--link-text-decoration);
-    text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100));
-    text-decoration-thickness: var(--dt-size-border-50);
+    text-underline-offset: var(--dt-size-200);
+    text-decoration-thickness: var(--dt-size-border-100);
     background-color: var(--link-background-color);
     border: 0;
     transition-timing-function: var(--ttf-out-quint);
@@ -40,9 +40,7 @@
     transition-property: background-color, border, box-shadow;
 
     //  Reset button appearance
-    -webkit-appearance: none;
-       -moz-appearance: none;
-            appearance: none;
+    appearance: none;
     fill: currentColor;
 
     &:hover {
@@ -188,8 +186,8 @@
             --link-text-decoration: underline;
             --link-background-color: hsl(var(--dt-color-surface-brand-strong-hsl) / 0.25);
 
-            text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100));
-            text-decoration-thickness: var(--dt-size-border-50);
+            text-underline-offset: var(--dt-size-200);
+            text-decoration-thickness: var(--dt-size-border-100);
         }
 
         &:active {

--- a/packages/dialtone-css/lib/build/less/dialtone-reset.less
+++ b/packages/dialtone-css/lib/build/less/dialtone-reset.less
@@ -80,14 +80,14 @@ pre {
 
 a {
   background-color: transparent;
-  text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100));
-  text-decoration-thickness: var(--dt-size-border-50);
+  text-underline-offset: var(--dt-size-200);
+  text-decoration-thickness: var(--dt-size-border-100);
 }
 
 ins,
 u {
-  text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100));
-  text-decoration-thickness: var(--dt-size-border-50);
+  text-underline-offset: var(--dt-size-200);
+  text-decoration-thickness: var(--dt-size-border-100);
 }
 
 /**
@@ -99,7 +99,7 @@ abbr[title] {
   text-decoration: underline; /* 2 */
   text-decoration: underline dotted; /* 2 */
   border-block-end: none; /* 1 */
-  text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100));
+  text-underline-offset: var(--dt-size-200);
   text-decoration-thickness: var(--dt-size-border-100);
 }
 

--- a/packages/dialtone-css/lib/build/less/utilities/typography.less
+++ b/packages/dialtone-css/lib/build/less/utilities/typography.less
@@ -357,13 +357,13 @@ ul {
 
 .d-td-underline {
     text-decoration: underline !important;
-    text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100)) !important;
-    text-decoration-thickness: var(--dt-size-border-50) !important;
+    text-underline-offset: var(--dt-size-200) !important;
+    text-decoration-thickness: var(--dt-size-border-100) !important;
 }
 
 .d-td-dotted {
     text-decoration: underline dotted !important;
-    text-underline-offset: calc(var(--dt-size-border-300) - var(--dt-size-border-100)) !important;
+    text-underline-offset: var(--dt-size-200) !important;
     text-decoration-thickness: var(--dt-size-border-100) !important;
 }
 


### PR DESCRIPTION
# Update underline thickness and offset

> [!NOTE]
> Targets `next` 

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2976

## :book: Description

Updated text decoration line thickness and offset. Applies to all underlined treatments, e.g. `DtLink`, `d-td*`, `<ins>`, `<u>`.

<img width="622" height="476" alt="image" src="https://github.com/user-attachments/assets/adf40db5-c454-4ee5-ad10-a6a0d3326fe6" />

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.