### PR TITLE
feat(link,button): DLT-3012 add underline prop

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/config.js
+++ b/apps/dialtone-documentation/docs/.vuepress/config.js
@@ -47,9 +47,11 @@ export default defineUserConfig({
         devSourcemap: true,
       },
       server: {
+        // hmr: {
+        //   overlay: false,
+        // },
         watch: {
-          // Ignore packages directory to prevent rebuild loops
-          ignored: ['**/packages/**', '**/node_modules/**'],
+          ignored: ['**/node_modules/**'],
         },
       },
     },

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -1087,7 +1087,6 @@ We provide the following branded buttons for log-in and sign-up workflows.
   <dt-stack
     gap="400"
     :direction="{ 'default': 'column', 'md': 'row' }"
-    ref="brandedExample"
   >
     <span><button class="d-btn d-btn--brand d-btn--google d-w100p" type="button"><span class="d-btn__icon"><dt-icon name="google-glyph" /></span><span class="d-btn__label">Log in with Google</span></button></span>
     <span><button class="d-btn d-btn--brand d-btn--o365 d-w100p" type="button"><span class="d-btn__icon"><dt-icon name="office-365" /></span><span class="d-btn__label">Log in with Office365</span></button></span>

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -303,6 +303,29 @@ vueCode='
 '
 showHtmlWarning />
 
+### Link no underline
+
+This inverts the underline behavior. With `underline="false"`, the link will not have an underline by default, but will show one on hover.
+
+<code-well-header>
+  <dt-stack
+    gap="400"
+    :direction="{ 'default': 'column', 'md': 'row' }"
+    ref="linkNoUnderlineExample"
+  >
+    <dt-button link :underline="false">Place Call</dt-button>
+    <dt-button link linkKind="danger" :underline="false">Place Call</dt-button>
+  </dt-stack>
+</code-well-header>
+
+<code-example-tabs
+:htmlCode='() => $refs.linkNoUnderlineExample'
+vueCode='
+<dt-button link :underline="false">Place Call</dt-button>
+<dt-button link linkKind="danger" :underline="false">Place Call</dt-button>
+'
+showHtmlWarning />
+
 ### Unstyled
 
 The unstyled button removes all default Dialtone styling while preserving the semantic HTML `<button>` element and maintaining proper button behavior and accessibility.

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -70,19 +70,15 @@ Dialtone provides five options for `kind`, with three levels of `importance`.
 The base button should be the go-to button for most of your needs. When in doubt, use this style. To help provide clarity to users, it is generally recommended to use only one primary button style within a section or page.
 
 <code-well-header>
-  <dt-stack direction="row" gap="400">
-      <button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">Place Call</span></button>
-      <button class="d-btn d-btn--outlined" type="button"><span class="d-btn__label">Place Call</span></button>
-      <button class="d-btn" type="button"><span class="d-btn__label">Place Call</span></button>
+  <dt-stack direction="row" gap="400" ref="defaultExample">
+      <dt-button> Place Call </dt-button>
+      <dt-button importance="outlined"> Place Call </dt-button>
+      <dt-button importance="clear"> Place Call </dt-button>
   </dt-stack>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn" type="button"><span class="d-btn__label">...</span></button>
-'
+:htmlCode='() => $refs.defaultExample'
 vueCode='
 <dt-button> Place Call </dt-button>
 <dt-button importance="outlined"> Place Call </dt-button>
@@ -95,19 +91,15 @@ showHtmlWarning />
 The danger button style is used to communicate critical or destructive actions such as deleting content, accounts, or canceling services.
 
 <code-well-header>
-  <dt-stack direction="row" gap="400">
-    <button class="d-btn d-btn--danger d-btn--primary" type="button"><span class="d-btn__label">Place Call</span></button>
-    <button class="d-btn d-btn--danger d-btn--outlined" type="button"><span class="d-btn__label">Place Call</span></button>
-    <button class="d-btn d-btn--danger" type="button"><span class="d-btn__label">Place Call</span></button>
+  <dt-stack direction="row" gap="400" ref="dangerExample">
+    <dt-button kind="danger"> Place Call </dt-button>
+    <dt-button kind="danger" importance="outlined"> Place Call </dt-button>
+    <dt-button kind="danger" importance="clear"> Place Call </dt-button>
   </dt-stack>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--danger d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--danger d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--danger" type="button"><span class="d-btn__label">...</span></button>
-'
+:htmlCode='() => $refs.dangerExample'
 vueCode='
 <dt-button kind="danger"> Place Call </dt-button>
 <dt-button kind="danger" importance="outlined"> Place Call </dt-button>
@@ -120,7 +112,7 @@ showHtmlWarning />
 The positive button style is used to communicate positive actions.
 
 <code-well-header>
-  <dt-stack direction="row" gap="400">
+  <dt-stack direction="row" gap="400" ref="positiveExample">
     <dt-button kind="positive">Place Call</dt-button>
     <dt-button kind="positive" importance="outlined">Place Call</dt-button>
     <dt-button kind="positive" importance="clear">Place Call</dt-button>
@@ -128,11 +120,7 @@ The positive button style is used to communicate positive actions.
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--positive d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--positive d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--positive" type="button"><span class="d-btn__label">...</span></button>
-'
+:htmlCode='() => $refs.positiveExample'
 vueCode='
 <dt-button kind="positive"> Place Call </dt-button>
 <dt-button kind="positive" importance="outlined"> Place Call </dt-button>
@@ -145,19 +133,15 @@ showHtmlWarning />
 The inverted button style is used to visually separate buttons set on darker backgrounds.
 
 <code-well-header bgclass="d-bgc-contrast">
-  <dt-stack direction="row" gap="400">
-    <button class="d-btn d-btn--inverted d-btn--primary" type="button"><span class="d-btn__label">Place Call</span></button>
-    <button class="d-btn d-btn--inverted d-btn--outlined" type="button"><span class="d-btn__label">Place Call</span></button>
-    <button class="d-btn d-btn--inverted" type="button"><span class="d-btn__label">Place Call</span></button>
+  <dt-stack direction="row" gap="400" ref="invertedExample">
+    <dt-button kind="inverted"> Place Call </dt-button>
+    <dt-button kind="inverted" importance="outlined"> Place Call </dt-button>
+    <dt-button kind="inverted" importance="clear"> Place Call </dt-button>
   </dt-stack>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--inverted d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--inverted d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--inverted" type="button"><span class="d-btn__label">...</span></button>
-'
+:htmlCode='() => $refs.invertedExample'
 vueCode='
 <dt-button kind="inverted"> Place Call </dt-button>
 <dt-button kind="inverted" importance="outlined"> Place Call </dt-button>
@@ -172,17 +156,14 @@ The muted button style is used to communicate non-primary actions for contexts i
 This style’s use should be rare. When in doubt, use the [default button style](#default).
 
 <code-well-header>
-  <dt-stack direction="row" gap="400">
-    <button class="d-btn d-btn--muted" type="button"><span class="d-btn__label">Place Call</span></button>
-    <button class="d-btn d-btn--muted d-btn--outlined" type="button"><span class="d-btn__label">Place Call</span></button>
+  <dt-stack direction="row" gap="400" ref="mutedExample">
+    <dt-button kind="muted" importance="clear"> Place Call </dt-button>
+    <dt-button kind="muted" importance="outlined"> Place Call </dt-button>
   </dt-stack>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--muted" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--muted d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
-'
+:htmlCode='() => $refs.mutedExample'
 vueCode='
 <dt-button kind="muted" importance="clear"> Place Call </dt-button>
 <dt-button kind="muted" importance="outlined"> Place Call </dt-button>
@@ -198,6 +179,7 @@ All button styles and variations appear the same when disabled.
   <dt-stack
     gap="400"
     :direction="{ 'default': 'column', 'md': 'row' }"
+    ref="disabledExample"
   >
     <span>
       <dt-button disabled>Place Call (disabled attribute)</dt-button>
@@ -211,14 +193,7 @@ All button styles and variations appear the same when disabled.
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<!-- disabled attribute -->
-<button class="d-btn" type="button" disabled><span class="d-btn__label">...</span></button>
-<!-- disabled class -->
-<span class="d-c-not-allowed">
-  <button type="button" class="base-button__button d-btn d-btn--primary d-btn--disabled"><span class="d-btn__label base-button__label">...</span></button>
-</span>
-'
+:htmlCode='() => $refs.disabledExample'
 vueCode='
 <!-- disabled attribute -->
 <dt-button disabled>Place Call</dt-button>
@@ -237,6 +212,7 @@ Buttons can be set to active state using the `active` prop or `.d-btn--active` D
   <dt-stack
     gap="400"
     :direction="{ 'default': 'column', 'md': 'row' }"
+    ref="activeExample"
   >
     <dt-button importance="clear" active>Place Call</dt-button>
     <dt-button active>Place Call</dt-button>
@@ -248,14 +224,7 @@ Buttons can be set to active state using the `active` prop or `.d-btn--active` D
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--active" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--primary d-btn--active" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--danger d-btn--active" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--positive d-btn--active" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--inverted d-btn--primary d-btn--active" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--primary d-btn--muted d-btn--active" type="button"><span class="d-btn__label">...</span></button>
-'
+:htmlCode='() => $refs.activeExample'
 vueCode='
 <dt-button importance="clear" active>Place Call</dt-button>
 <dt-button active>Place Call</dt-button>
@@ -274,6 +243,7 @@ Buttons can be styled as a [Link](link.md) in situations for which you need the 
   <dt-stack
     gap="400"
     :direction="{ 'default': 'column', 'md': 'row' }"
+    ref="linkExample"
   >
     <dt-button link>Place Call</dt-button>
     <dt-button link linkKind="warning">Place Call</dt-button>
@@ -285,14 +255,7 @@ Buttons can be styled as a [Link](link.md) in situations for which you need the 
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-link" type="button"> <span class="d-btn__label">Place Call</span></button>
-<button class="d-link d-link--warning" type="button"> <span class="d-btn__label">Place Call</span></button>
-<button class="d-link d-link--danger" type="button"> <span class="d-btn__label">Place Call</span></button>
-<button class="d-link d-link--success" type="button"> <span class="d-btn__label">Place Call</span></button>
-<button class="d-link d-link--muted" type="button"> <span class="d-btn__label">Place Call</span></button>
-<button class="d-link" type="button" disabled=""> <span class="d-btn__label">Place Call</span></button>
-'
+:htmlCode='() => $refs.linkExample'
 vueCode='
 <dt-button link>Place Call</dt-button>
 <dt-button link linkKind="warning">Place Call</dt-button>
@@ -331,13 +294,11 @@ showHtmlWarning />
 The unstyled button removes all default Dialtone styling while preserving the semantic HTML `<button>` element and maintaining proper button behavior and accessibility.
 
 <code-well-header>
-    <dt-button kind="unstyled">Place Call</dt-button>
+    <dt-button kind="unstyled" ref="unstyledExample">Place Call</dt-button>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn--unstyled" type="button">Place Call</button>
-'
+:htmlCode='() => $refs.unstyledExample'
 vueCode='
 <dt-button kind="unstyled">Place Call</dt-button>
 '
@@ -368,6 +329,7 @@ The default button size is `md`, but does not need to be explicitly specified.
   <dt-stack
     gap="400"
     :direction="{ 'default': 'column', 'md': 'row' }"
+    ref="sizesExample"
   >
     <span>
       <dt-button size="xs"> Place Call </dt-button>
@@ -388,13 +350,7 @@ The default button size is `md`, but does not need to be explicitly specified.
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--primary d-btn--xs" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--primary d-btn--sm" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--primary d-btn--lg" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--primary d-btn--xl" type="button"><span class="d-btn__label">...</span></button>
-'
+:htmlCode='() => $refs.sizesExample'
 vueCode='
 <dt-button size="xs"> Place Call </dt-button>
 <dt-button size="sm"> Place Call </dt-button>
@@ -414,6 +370,7 @@ Button labels can include an icon next to the text. Every button style can accep
   <dt-stack
     gap="400"
     :direction="{ 'default': 'column', 'md': 'row' }"
+    ref="iconLabelExample"
   >
     <span>
       <dt-button importance="outlined">
@@ -463,20 +420,7 @@ Button labels can include an icon next to the text. Every button style can accep
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--outlined" type="button">
-  <span class="d-btn__icon d-btn__icon--left">...</span>
-  <span class="d-btn__label">...</span>
-</button>
-<button class="d-btn d-btn--vertical d-btn--outlined" type="button">
-  <span class="d-btn__icon d-btn__icon--top">...</span>
-  <span class="d-btn__label">...</span>
-</button>
-<button class="d-btn d-btn--outlined" type="button">
-  <span class="d-btn__icon d-btn__icon--right">...</span>
-  <span class="d-btn__label">...</span>
-</button>
-'
+:htmlCode='() => $refs.iconLabelExample'
 vueCode='
 <dt-button importance="outlined">
   <template #icon>
@@ -525,6 +469,7 @@ Icon-only buttons are commonly used for toggling actions, navigation, or closing
   <dt-stack
     gap="600"
     :direction="{ 'default': 'column', 'md': 'row' }"
+    ref="iconOnlyExample"
   >
     <dt-stack direction="row" gap="400">
       <dt-button v-dt-tooltip="`Tooltip`" kind="muted" importance="clear">
@@ -652,10 +597,7 @@ Icon-only buttons are commonly used for toggling actions, navigation, or closing
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--icon-only" type="button">...</button>
-<button class="d-btn d-btn--icon-only d-btn--outlined" type="button">...</button>
-'
+:htmlCode='() => $refs.iconOnlyExample'
 vueCode='
 <dt-button v-dt-tooltip="`Tooltip`" kind="muted" importance="clear">
   <template #icon>
@@ -780,6 +722,7 @@ The following styles are available as a circle shape.
   <dt-stack
     gap="600"
     :direction="{ 'default': 'column', 'md': 'row' }"
+    ref="circleExample"
   >
     <dt-stack direction="row" gap="400">
       <dt-button v-dt-tooltip="`Tooltip`" circle kind="muted" importance="clear">
@@ -881,11 +824,7 @@ The following styles are available as a circle shape.
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--circle btn--inverted" type="button">...</button>
-<button class="d-btn d-btn--circle btn--inverted d-btn--outlined" type="button">...</button>
-<button class="d-btn d-btn--circle btn--inverted d-btn--primary" type="button">...</button>
-'
+:htmlCode='() => $refs.circleExample'
 vueCode='
 <dt-button v-dt-tooltip="`Tooltip`" circle kind="muted" importance="clear">
   <template #icon>
@@ -990,6 +929,7 @@ The width of the button remains determined by the length of the label, which is 
   <dt-stack
     gap="600"
     :direction="{ 'default': 'column', 'md': 'row' }"
+    ref="loadingExample"
   >
     <dt-stack direction="row" gap="400">
       <dt-button loading> Place Call </dt-button>
@@ -1033,11 +973,7 @@ The width of the button remains determined by the length of the label, which is 
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--loading d-btn--primary" type="button"><span class="d-btn__label">Place Call</span></button>
-<button class="d-btn d-btn--loading d-btn--outlined" type="button"><span class="d-btn__label">Place Call</span></button>
-<button class="d-btn d-btn--danger d-btn--loading" type="button"><span class="d-btn__label">Place Call</span></button>
-'
+:htmlCode='() => $refs.loadingExample'
 vueCode='
 <dt-button loading> Place Call </dt-button>
 <dt-button v-dt-tooltip="`Tooltip`" loading>
@@ -1082,6 +1018,7 @@ showHtmlWarning />
   <dt-stack
     gap="400"
     direction="row"
+    ref="loadingLabelExample"
   >
   <dt-button
     icon-position="right"
@@ -1131,20 +1068,7 @@ showHtmlWarning />
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button class="d-btn d-btn--primary d-btn--sm" type="button">
-  <span class="d-btn__icon d-btn__icon--right">
-    <div class="d-loader" aria-label="loading">
-      <svg class="d-icon--size-200 d-icon d-icon--loading d-loader__icon" ...>
-        ...
-      </svg>
-    </div>
-  </span>
-  <span class="d-btn__label">
-    Validating
-  </span>
-</button>
-'
+:htmlCode='() => $refs.loadingLabelExample'
 vueCode='
 <dt-button icon-position="right">
   Validating
@@ -1163,6 +1087,7 @@ We provide the following branded buttons for log-in and sign-up workflows.
   <dt-stack
     gap="400"
     :direction="{ 'default': 'column', 'md': 'row' }"
+    ref="brandedExample"
   >
     <span><button class="d-btn d-btn--brand d-btn--google d-w100p" type="button"><span class="d-btn__icon"><dt-icon name="google-glyph" /></span><span class="d-btn__label">Log in with Google</span></button></span>
     <span><button class="d-btn d-btn--brand d-btn--o365 d-w100p" type="button"><span class="d-btn__icon"><dt-icon name="office-365" /></span><span class="d-btn__label">Log in with Office365</span></button></span>

--- a/apps/dialtone-documentation/docs/components/link.md
+++ b/apps/dialtone-documentation/docs/components/link.md
@@ -10,7 +10,7 @@ keywords: ["anchor", "hyperlink", "url", "d-link", "DtLink", "dt-link", "text li
 ---
 
 <code-well-header>
-  <dt-link href="#link" class="d-link">Base link</dt-link>
+  <dt-link href="#link">Base link</dt-link>
 </code-well-header>
 
 <!-- <component-combinator component-name="DtLink" /> -->
@@ -93,6 +93,23 @@ vueCode='
 <dt-link :href="#link" kind="warning" inverted>Inverted warning link</dt-link>
 <dt-link :href="#link" kind="muted" inverted>Inverted muted link</dt-link>
 <dt-link :href="#link" kind="mention" inverted>Inverted mention link</dt-link>
+'
+showHtmlWarning />
+
+### No underline
+
+This inverts the underline behavior. With `underline="false"`, the link will not have an underline by default, but will show one on hover.
+
+<code-well-header>
+  <dt-link href="#link" :underline="false">No underline link</dt-link>
+</code-well-header>
+
+<code-example-tabs
+htmlCode='
+<a href="#link" class="d-link d-link--no-underline">No underline link</a>
+'
+vueCode='
+<dt-link href="#link" :underline="false">No underline link</dt-link>
 '
 showHtmlWarning />
 

--- a/apps/dialtone-documentation/docs/components/link.md
+++ b/apps/dialtone-documentation/docs/components/link.md
@@ -10,7 +10,7 @@ keywords: ["anchor", "hyperlink", "url", "d-link", "DtLink", "dt-link", "text li
 ---
 
 <code-well-header>
-  <a href="#link" class="d-link">Base link</a>
+  <dt-link href="#link" class="d-link">Base link</dt-link>
 </code-well-header>
 
 <!-- <component-combinator component-name="DtLink" /> -->
@@ -49,23 +49,18 @@ keywords: ["anchor", "hyperlink", "url", "d-link", "DtLink", "dt-link", "text li
 ### Default
 
 <code-well-header>
-  <a href="#link" class="d-link">Base link</a>
-  <a href="#link" class="d-link d-link--danger">Danger link</a>
-  <a href="#link" class="d-link d-link--muted">Muted link</a>
-  <a href="#link" class="d-link d-link--success">Success link</a>
-  <a href="#link" class="d-link d-link--warning">Warning link</a>
-  <a href="#link" class="d-link d-link--mention">Mention link</a>
+  <DtStack gap="400" ref="linkExample1">
+    <dt-link href="#link">Base link</dt-link>
+    <dt-link href="#link" kind="danger">Danger link</dt-link>
+    <dt-link href="#link" kind="muted">Muted link</dt-link>
+    <dt-link href="#link" kind="success">Success link</dt-link>
+    <dt-link href="#link" kind="warning">Warning link</dt-link>
+    <dt-link href="#link" kind="mention">Mention link</dt-link>
+  </DtStack>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<a href="#link" class="d-link">Link</a>
-<a href="#link" class="d-link d-link--danger">Danger link</a>
-<a href="#link" class="d-link d-link--muted">Muted link</a>
-<a href="#link" class="d-link d-link--success">Success link</a>
-<a href="#link" class="d-link d-link--warning">Warning link</a>
-<a href="#link" class="d-link d-link--mention">Mention link</a>
-'
+:htmlCode='() => $refs.linkExample1'
 vueCode='
 <dt-link :href="#link">Link</dt-link>
 <dt-link :href="#link" kind="danger">Danger link</dt-link>
@@ -79,23 +74,18 @@ showHtmlWarning />
 ### Inverted
 
 <code-well-header bgclass="d-bgc-contrast">
-  <a href="#link" class="d-link d-link--inverted">Inverted base link</a>
-  <a href="#link" class="d-link d-link--inverted-danger">Inverted danger link</a>
-  <a href="#link" class="d-link d-link--inverted-success">Inverted success link</a>
-  <a href="#link" class="d-link d-link--inverted-warning">Inverted warning link</a>
-  <a href="#link" class="d-link d-link--inverted-muted">Inverted muted link</a>
-  <a href="#link" class="d-link d-link--inverted-mention">Inverted mention link</a>
+  <DtStack gap="400" ref="linkExample2">
+    <dt-link href="#link" inverted>Inverted base link</dt-link>
+    <dt-link href="#link" kind="danger" inverted>Inverted danger link</dt-link>
+    <dt-link href="#link" kind="success" inverted>Inverted success link</dt-link>
+    <dt-link href="#link" kind="warning" inverted>Inverted warning link</dt-link>
+    <dt-link href="#link" kind="muted" inverted>Inverted muted link</dt-link>
+    <dt-link href="#link" kind="mention" inverted>Inverted mention link</dt-link>
+  </DtStack>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<a href="#link" class="d-link d-link--inverted">Inverted link</a>
-<a href="#link" class="d-link d-link--inverted-danger">Inverted danger link</a>
-<a href="#link" class="d-link d-link--inverted-success">Inverted success link</a>
-<a href="#link" class="d-link d-link--inverted-warning">Inverted warning link</a>
-<a href="#link" class="d-link d-link--inverted-muted">Inverted muted link</a>
-<a href="#link" class="d-link d-link--inverted-mention">Inverted muted link</a>
-'
+:htmlCode='() => $refs.linkExample2'
 vueCode='
 <dt-link :href="#link" inverted>Inverted link</dt-link>
 <dt-link :href="#link" kind="danger" inverted>Inverted danger link</dt-link>

--- a/packages/dialtone-css/lib/build/less/components/link.less
+++ b/packages/dialtone-css/lib/build/less/components/link.less
@@ -69,6 +69,16 @@
     //  ============================================================================
     //  $$  WARNING
     //  ----------------------------------------------------------------------------
+    &--no-underline {
+        --link-text-decoration: none;
+
+        &:hover {
+            --link-text-decoration: underline;
+        }
+    }
+
+    //  $$  WARNING
+    //  ----------------------------------------------------------------------------
     &--warning {
         --link-color-default: var(--dt-color-link-warning);
         --link-color-default-hover: var(--dt-color-link-warning-hover);

--- a/packages/dialtone-vue/components/button/button.test.js
+++ b/packages/dialtone-vue/components/button/button.test.js
@@ -271,6 +271,20 @@ describe('DtButton Tests', () => {
             expect(button.classes().includes('d-link--danger')).toBe(true);
           });
         });
+
+        describe('When underline is false', () => {
+          it('should have no-underline class', async () => {
+            await wrapper.setProps({ underline: false });
+
+            expect(button.classes().includes('d-link--no-underline')).toBe(true);
+          });
+        });
+
+        describe('When underline is true (default)', () => {
+          it('should not have no-underline class', () => {
+            expect(button.classes().includes('d-link--no-underline')).toBe(false);
+          });
+        });
       });
 
       describe('When button has kind set to unstyled', () => {

--- a/packages/dialtone-vue/components/button/button.test.js
+++ b/packages/dialtone-vue/components/button/button.test.js
@@ -287,6 +287,14 @@ describe('DtButton Tests', () => {
         });
       });
 
+      describe('When underline is false and link is not set', () => {
+        it('should not have no-underline class', async () => {
+          await wrapper.setProps({ underline: false });
+
+          expect(button.classes().includes('d-link--no-underline')).toBe(false);
+        });
+      });
+
       describe('When button has kind set to unstyled', () => {
         it('Should have unstyled class', async () => {
           await wrapper.setProps({

--- a/packages/dialtone-vue/components/button/button.vue
+++ b/packages/dialtone-vue/components/button/button.vue
@@ -134,6 +134,16 @@ export default {
     },
 
     /**
+     * Determines whether the link-styled button should display an underline.
+     * Only applies when the link prop is true.
+     * @values true, false
+     */
+    underline: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
      * HTML button disabled attribute
      * <a class="d-link" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#disabled" target="_blank"> (Reference) </a>
      * @values true, false
@@ -307,6 +317,7 @@ export default {
           'd-link',
           getLinkKindModifier(this.linkKind, this.linkInverted),
           BUTTON_SIZE_MODIFIERS[this.size],
+          { 'd-link--no-underline': !this.underline },
         ];
       }
       if (this.kind === 'unstyled') {

--- a/packages/dialtone-vue/components/link/link.test.js
+++ b/packages/dialtone-vue/components/link/link.test.js
@@ -145,5 +145,21 @@ describe('DtLink tests', () => {
         expect(nativeLink.classes(getLinkKindModifier(MUTED, true))).toBe(true);
       });
     });
+
+    describe('When underline is false', () => {
+      it('should have no-underline class', async () => {
+        mockProps = { underline: false };
+
+        updateWrapper();
+
+        expect(nativeLink.classes('d-link--no-underline')).toBe(true);
+      });
+    });
+
+    describe('When underline is true (default)', () => {
+      it('should not have no-underline class', () => {
+        expect(nativeLink.classes('d-link--no-underline')).toBe(false);
+      });
+    });
   });
 });

--- a/packages/dialtone-vue/components/link/link.vue
+++ b/packages/dialtone-vue/components/link/link.vue
@@ -44,6 +44,15 @@ export default {
       type: Boolean,
       default: false,
     },
+
+    /**
+     * Determines whether the link should display an underline.
+     * @values true, false
+     */
+    underline: {
+      type: Boolean,
+      default: true,
+    },
   },
 
   data () {
@@ -57,6 +66,7 @@ export default {
       return [
         'd-link',
         getLinkKindModifier(this.kind, this.inverted),
+        { 'd-link--no-underline': !this.underline },
       ];
     },
   },


### PR DESCRIPTION
# Add underline prop

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3012

## :book: Description

1. Add `underline` prop to `DtLink`
1. Add `underline` prop to `DtButton`, available when `link` prop in use. 
1. Also converts docs code examples from hardcoded `htmlCode` strings to the `ref` + `:htmlCode` pattern.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :camera: Screenshots / GIFs

### DtLink

<img width="711" height="307" alt="image" src="https://github.com/user-attachments/assets/2919756a-0dde-45b7-a2b2-58892bb6c55a" />

### DtButton** with `link` prop

<img width="705" height="330" alt="image" src="https://github.com/user-attachments/assets/a0713dd9-9f24-4c7e-b38e-b1a7fd7541f5" />
