### PR TITLE
fix(message-input): DP-174678 protect isSelectionActive

### DIFF
--- a/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.vue
@@ -909,8 +909,11 @@ export default {
 
     // Checks if the node currently selected is active ex/ the bold button is active if the selected text is bold
 
+    // eslint-disable-next-line complexity
     isSelectionActive (type) {
       if (['bulletList', 'orderedList'].includes(type)) {
+        // List extensions are only loaded when richText is true
+        if (!this.richText) return false;
         return this.lastActiveNodes(this.$refs.richTextEditor?.editor?.state, [{ type: 'bulletList' }, { type: 'orderedList' }]).includes(type) && this.isFocused;
       }
       return this.$refs.richTextEditor?.editor?.isActive(type) && this.isFocused;


### PR DESCRIPTION
# fix(message-input): DP-174678 protect isSelectionActive

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZG9rdjh0OW1raW15bGgwNmVhYmo1dDczNjV0ajg4cTNtb2syc3ZxaCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/StoeNoDkYuum8cj8MV/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-174678

## :book: Description

Add early exit protection from isSelectionActive function if richText is false

## :bulb: Context

From sentry error: https://dialpad.sentry.io/issues/7226905243/?project=5269274

This code appears to sometimes be executing even when the richText prop is false, added an extra check here to prevent this as it causes an error

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
