### PR TITLE
chore(docs): NO-JIRA use vuepress global to show/hide theme switcher

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/config.js
+++ b/apps/dialtone-documentation/docs/.vuepress/config.js
@@ -37,6 +37,9 @@ export default defineUserConfig({
 
   bundler: viteBundler({
     viteOptions: {
+      define: {
+        __DIALTONE_DEPLOY_PREVIEW__: JSON.stringify(baseURL.includes('deploy-previews')),
+      },
       build: {
         sourcemap: true,
       },

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Navbar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Navbar.vue
@@ -121,7 +121,7 @@
     </a>
     <dt-dropdown
       id="theme-toggle-dropdown"
-      hidden
+      :hidden="!showThemeSwitcher"
       navigation-type="arrow-keys"
       placement="bottom-start"
       class="theme-toggle-dropdown"
@@ -341,6 +341,7 @@ import { useThemeManager } from '../composables/useThemeManager';
 defineEmits(['search']);
 
 const route = useRoute();
+const showThemeSwitcher = __VUEPRESS_DEV__ || __DIALTONE_DEPLOY_PREVIEW__;
 
 // Top-level navigation items
 const navItems = [

--- a/apps/dialtone-documentation/eslint.config.js
+++ b/apps/dialtone-documentation/eslint.config.js
@@ -17,6 +17,8 @@ export default [
         ...globals.node,
         ...globals.browser,
         __VUEPRESS_SSR__: 'readonly',
+        __VUEPRESS_DEV__: 'readonly',
+        __DIALTONE_DEPLOY_PREVIEW__: 'readonly',
       },
     },
     rules: {


### PR DESCRIPTION
# use vuepress global to show/hide theme switcher

## :hammer_and_wrench: Type Of Change

- [x] Other (chore)

## :book: Description

I only want the theme switcher visible in dev mode or deploy previews.

Show locally or in deploy preview via VuePress (`__VUEPRESS_DEV__` and added `__DIALTONE_DEPLOY_PREVIEW__`) derived fromthe existing `VUEPRESS_BASE_URL`.

<img width="271" height="96" alt="image" src="https://github.com/user-attachments/assets/85b34468-b0bd-4b6d-9adb-419d21acf807" />
