### PR TITLE
fix(tooltip): DLT-3029 render tooltip-directive with a singleton app

### DIFF
--- a/packages/dialtone-vue/directives/tooltip_directive/tooltip.js
+++ b/packages/dialtone-vue/directives/tooltip_directive/tooltip.js
@@ -6,60 +6,62 @@ import deepEqual from 'deep-equal';
 export const DtTooltipDirective = {
   name: 'dt-tooltip-directive',
   install (app) {
-    let tooltipInstance;
-    const mountPoint = document.createElement('div');
-    document.body.appendChild(mountPoint);
-
     const DEFAULT_PLACEMENT = 'top';
-    const DtTooltipDirectiveApp = createApp({
-      name: 'DtTooltipDirectiveApp',
-      components: { DtTooltip },
-      data () {
-        return {
-          tooltips: [],
-        };
-      },
-
-      created () {
-        tooltipInstance = getCurrentInstance();
-      },
-
-      methods: {
-        addOrUpdateTooltip (id, tooltipConfig) {
-          const index = this.tooltips.findIndex(tooltip => tooltip.id === id);
-          if (index !== -1) {
-            // Update existing tooltip
-            this.tooltips.splice(index, 1, { id, ...tooltipConfig });
-          } else {
-            // Add new tooltip
-            this.tooltips.push({ id, ...tooltipConfig });
-          }
+    if (!global.__DtTooltipDirectiveAppInstance) {
+      const DtTooltipDirectiveApp = createApp({
+        name: 'DtTooltipDirectiveApp',
+        components: { DtTooltip },
+        data () {
+          return {
+            tooltips: [],
+          };
         },
 
-        removeTooltip (id) {
-          this.tooltips = this.tooltips.filter(tooltip => tooltip.id !== id);
+        created () {
+          global.__DtTooltipDirectiveAppInstance = getCurrentInstance();
         },
-      },
 
-      render () {
-        return h('div',
-          this.tooltips.map(({ id, ...tooltipProps }) => {
-            return h(DtTooltip, {
-              key: id,
-              ...tooltipProps,
-              sticky: tooltipProps.sticky !== undefined ? tooltipProps.sticky : true,
-              /**
-               * Set the delay to false when running tests only.
-               */
-              delay: tooltipProps.delay !== undefined ? tooltipProps.delay : (process.env.NODE_ENV !== 'test'),
-              externalAnchor: `[data-dt-tooltip-id="${id}"]`,
-            });
-          }),
-        );
-      },
-    });
+        methods: {
+          addOrUpdateTooltip (id, tooltipConfig) {
+            const index = this.tooltips.findIndex(tooltip => tooltip.id === id);
+            if (index !== -1) {
+              // Update existing tooltip
+              this.tooltips.splice(index, 1, { id, ...tooltipConfig });
+            } else {
+              // Add new tooltip
+              this.tooltips.push({ id, ...tooltipConfig });
+            }
+          },
 
-    DtTooltipDirectiveApp.mount(mountPoint);
+          removeTooltip (id) {
+            this.tooltips = this.tooltips.filter(tooltip => tooltip.id !== id);
+          },
+        },
+
+        render () {
+          return h('div',
+            this.tooltips.map(({ id, ...tooltipProps }) => {
+              return h(DtTooltip, {
+                key: id,
+                ...tooltipProps,
+                sticky: tooltipProps.sticky !== undefined ? tooltipProps.sticky : true,
+                /**
+                 * Set the delay to false when running tests only.
+                 */
+                delay: tooltipProps.delay !== undefined ? tooltipProps.delay : (process.env.NODE_ENV !== 'test'),
+                externalAnchor: `[data-dt-tooltip-id="${id}"]`,
+              });
+            }),
+          );
+        },
+      });
+
+      const mountPoint = document.createElement('div');
+      document.body.appendChild(mountPoint);
+      DtTooltipDirectiveApp.mount(mountPoint);
+    }
+
+    const tooltipInstance = global.__DtTooltipDirectiveAppInstance;
 
     app.directive('dt-tooltip', {
       beforeMount (anchor, binding) {


### PR DESCRIPTION

# DLT-3029 render tooltip-directive with a singleton app

## Obligatory GIF (super important!)

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjhjcGdqaTZjd2xpeXE4dXN5anlyMnJtc3QyOG9sMnpoOHZqZDEwcyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/RmEfRFT6kU3Uw25Fnu/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-3029

## :book: Description
 render tooltip-directive with a singleton app

## :bulb: Context
Previously we created a sidecar app for each vue app the plugin was initalized for. These apps were never being cleaned up.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.