### PR TITLE
fix(message-input): DLT-3000 incorrect syntax on emoji picker open

### DIFF
--- a/packages/dialtone-tokens/project.json
+++ b/packages/dialtone-tokens/project.json
@@ -27,6 +27,7 @@
         "cwd": "{projectRoot}",
         "commands": [
           "rm -rf dist",
+          "git clean -fx themes/",
           "node ./build.js",
           "pnpm exec vite build"
         ],

--- a/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.vue
@@ -124,7 +124,7 @@
           />
           <dt-popover
             v-if="showEmojiPicker"
-            open.sync="emojiPickerOpened"
+            v-model:open="emojiPickerOpened"
             data-qa="dt-recipe-message-input-emoji-picker-popover"
             initial-focus-element="#searchInput"
             padding="none"


### PR DESCRIPTION
# fix(message-input): DLT-3000 incorrect syntax on emoji picker open

https://dialpad.atlassian.net/browse/DLT-3000

Small fix for the emoji picker within the message input, it was still using vue 2 syntax.

I will copy this to uikits as well.