### PR TITLE
fix(popover): DLT-2870 fix initial focus logic

### DIFF
--- a/packages/dialtone-vue/components/popover/popover.vue
+++ b/packages/dialtone-vue/components/popover/popover.vue
@@ -936,8 +936,8 @@ export default {
       } else {
         console.warn('Could not find the element specified in dt-popover prop "initialFocusElement". ' +
           'Defaulting to focusing the dialog.');
+        returnFirstEl(this.$refs.content?.$el)?.focus();
       }
-      result ? result.focus() : returnFirstEl(this.$refs.content?.$el).focus();
     },
 
     onResize () {


### PR DESCRIPTION
# fix(popover): DLT-2870 fix initial focus logic

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExYW5vN204aXF6NmNnMDcybWI3MDE3YWZieWxvZXZja2Nlenk2M3Z3diZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/i0f2SCKCv7AsM/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2870

## :book: Description

Fix logic on popover where it was unnecessarily focusing twice. Should also fix sentry issue https://dialpad.sentry.io/issues/7106147245/?referrer=jira_integration

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
