### PR TITLE
feat(datepicker): DLT-3015 add weekStartsOn prop for locale-aware week start

### DIFF
--- a/packages/dialtone-vue/components/datepicker/composables/useCalendar.js
+++ b/packages/dialtone-vue/components/datepicker/composables/useCalendar.js
@@ -1,6 +1,6 @@
 import { computed, ref, watch, nextTick } from 'vue';
 import { getWeekDayNames, calculateNextFocusDate, calculatePrevFocusDate, formatDate } from '../utils.js';
-import { INTL_MONTH_FORMAT, WEEK_START } from '../datepicker_constants.js';
+import { INTL_MONTH_FORMAT } from '../datepicker_constants.js';
 import { returnFirstEl } from '@/common/utils';
 import { DialtoneLocalization } from '@/localization';
 
@@ -11,7 +11,7 @@ export function useCalendar (props, emits) {
   const i18n = new DialtoneLocalization();
 
   const weekDays = computed(() => {
-    return getWeekDayNames(props.locale, WEEK_START);
+    return getWeekDayNames(props.locale, props.weekStartsOn);
   });
 
   watch(() => props.calendarDays, () => {

--- a/packages/dialtone-vue/components/datepicker/composables/useMonthYearPicker.js
+++ b/packages/dialtone-vue/components/datepicker/composables/useMonthYearPicker.js
@@ -14,7 +14,10 @@ export function useMonthYearPicker (props, emits) {
   const i18n = new DialtoneLocalization();
 
   const calendarDays = computed(() => {
-    return getCalendarDays(selectMonth.value, selectYear.value, highlightedDay.value, props.minDate, props.maxDate);
+    return getCalendarDays(
+      selectMonth.value, selectYear.value, highlightedDay.value,
+      props.minDate, props.maxDate, props.weekStartsOn,
+    );
   });
 
   const isPrevMonthDisabled = computed(() => {

--- a/packages/dialtone-vue/components/datepicker/datepicker.stories.js
+++ b/packages/dialtone-vue/components/datepicker/datepicker.stories.js
@@ -13,6 +13,7 @@ export const argsData = {
   opened: false,
   minDate: null,
   maxDate: null,
+  weekStartsOn: 0,
 };
 
 export const argTypesData = {
@@ -38,6 +39,12 @@ export const argTypesData = {
     table: {
       type: { summary: 'event' },
     },
+  },
+  weekStartsOn: {
+    control: { type: 'select' },
+    options: [0, 1, 2, 3, 4, 5, 6],
+    description: 'Day the week starts on. 0 = Sunday, 1 = Monday, … 6 = Saturday.',
+    table: { defaultValue: { summary: 0 } },
   },
 };
 

--- a/packages/dialtone-vue/components/datepicker/datepicker.test.js
+++ b/packages/dialtone-vue/components/datepicker/datepicker.test.js
@@ -343,6 +343,48 @@ describe('DtDatepicker Tests', () => {
     });
   });
 
+  describe('weekStartsOn prop', () => {
+    it('defaults to Sunday (0) — first weekday header is "Su"', async () => {
+      const weekDays = wrapper.findAll('.d-datepicker__weekday');
+
+      expect(weekDays.at(0).text()).toBe('Su');
+    });
+
+    it('weekStartsOn=1 — first weekday header is "Mo"', async () => {
+      mockProps = { weekStartsOn: 1 };
+      await updateWrapper();
+
+      const weekDays = wrapper.findAll('.d-datepicker__weekday');
+
+      expect(weekDays.at(0).text()).toBe('Mo');
+      expect(weekDays.at(6).text()).toBe('Su');
+    });
+
+    it('calendar grid starts on Monday when weekStartsOn=1', async () => {
+      // Jan 2023: Jan 1 is a Sunday
+      mockProps = {
+        selectedDate: new Date(2023, 0, 15),
+        weekStartsOn: 1,
+      };
+      await updateWrapper();
+
+      const days = wrapper.findAll('.d-datepicker__calendar button');
+
+      // With Monday start, the first row starts on Mon Dec 26.
+      // Jan 1 (Sunday) should be in the 7th cell (index 6) of the first week row.
+      expect(days.at(6).text()).toBe('1');
+    });
+
+    it('weekStartsOn=6 — first weekday header is "Sa"', async () => {
+      mockProps = { weekStartsOn: 6 };
+      await updateWrapper();
+
+      const weekDays = wrapper.findAll('.d-datepicker__weekday');
+
+      expect(weekDays.at(0).text()).toBe('Sa');
+    });
+  });
+
   describe('Min/Max Date Tests', () => {
     const MIN_DATE = new Date(MOCK_YEAR, MOCK_MONTH, 10);
     const MAX_DATE = new Date(MOCK_YEAR, MOCK_MONTH, 20);

--- a/packages/dialtone-vue/components/datepicker/datepicker.vue
+++ b/packages/dialtone-vue/components/datepicker/datepicker.vue
@@ -10,6 +10,7 @@
         :selected-date="selectedDate"
         :min-date="minDate"
         :max-date="maxDate"
+        :week-starts-on="weekStartsOn"
         @calendar-days="updateCalendarDays"
         @focus-first-day="$refs.calendar.focusFirstDay()"
         @focus-last-day="$refs.calendar.focusLastDay()"
@@ -20,6 +21,7 @@
       <calendar
         ref="calendar"
         :calendar-days="calendarDays"
+        :week-starts-on="weekStartsOn"
         @select-date="$emit('selected-date', $event)"
         @focus-month-year-picker="$refs.monthYearPicker.focusMonthYearPicker()"
         @close-datepicker="$emit('close-datepicker')"
@@ -75,6 +77,17 @@ defineProps({
       }
       return true;
     },
+  },
+
+  /**
+     * Day the week starts on. 0 = Sunday, 1 = Monday, ... 6 = Saturday.
+     *
+     * @values 0, 1, 2, 3, 4, 5, 6
+     */
+  weekStartsOn: {
+    type: Number,
+    default: 0,
+    validator: (v) => Number.isInteger(v) && v >= 0 && v <= 6,
   },
 });
 

--- a/packages/dialtone-vue/components/datepicker/datepicker_default.story.vue
+++ b/packages/dialtone-vue/components/datepicker/datepicker_default.story.vue
@@ -45,6 +45,7 @@
       :selected-date="currentSelectedDate"
       :min-date="$attrs.minDate"
       :max-date="$attrs.maxDate"
+      :week-starts-on="$attrs.weekStartsOn"
       @selected-date="currentSelectedDate = $event; $attrs.onSelectedDate($event)"
       @close-datepicker="$attrs.onCloseDatepicker"
     />

--- a/packages/dialtone-vue/components/datepicker/modules/calendar.vue
+++ b/packages/dialtone-vue/components/datepicker/modules/calendar.vue
@@ -67,6 +67,12 @@ const props = defineProps({
     type: Array,
     required: true,
   },
+
+  weekStartsOn: {
+    type: Number,
+    default: 0,
+    validator: (v) => Number.isInteger(v) && v >= 0 && v <= 6,
+  },
 });
 
 const emits = defineEmits([

--- a/packages/dialtone-vue/components/datepicker/modules/month-year-picker.vue
+++ b/packages/dialtone-vue/components/datepicker/modules/month-year-picker.vue
@@ -162,6 +162,12 @@ const props = defineProps({
     type: Date,
     default: null,
   },
+
+  weekStartsOn: {
+    type: Number,
+    default: 0,
+    validator: (v) => Number.isInteger(v) && v >= 0 && v <= 6,
+  },
 });
 
 const emits = defineEmits([

--- a/packages/dialtone-vue/components/datepicker/utils.js
+++ b/packages/dialtone-vue/components/datepicker/utils.js
@@ -44,12 +44,12 @@ const isDateEqual = (date, dateToCompare) => {
 /**
  * Get days for the calendar to be displayed in a table grouped by weeks
  */
-export const getCalendarDays = (month, year, selectedDay, minDate = null, maxDate = null) => {
+export const getCalendarDays = (month, year, selectedDay, minDate = null, maxDate = null, weekStart = WEEK_START) => {
   const weeks = [];
   const firstDate = _parsedGetDate(new Date(year, month));
   const lastDate = _parsedGetDate(new Date(year, month + 1, 0));
 
-  const weekStartsOn = WEEK_START;
+  const weekStartsOn = weekStart;
 
   const firstDateInCalendar = startOfWeek(firstDate, { weekStartsOn });
 


### PR DESCRIPTION
## Problem

The Dialtone DatePicker hardcodes Sunday as the first day of the week. This breaks for European and global users where weeks start on Monday (or other days). Shannon Ashley (WFM) flagged this — WFM already ships a Mon-Sun toggle in their own component, but Dialtone's datepicker didn't support it. Shannon reported this a couple of weeks ago on our design-product channel: 
<img width="464" height="534" alt="Screenshot 2026-02-21 at 23 28 48" src="https://github.com/user-attachments/assets/610d21f8-28f4-48e4-9108-2f2d619516a7" />


## What this PR adds

A `weekStartsOn` prop (0 = Sunday … 6 = Saturday) on `DtDatepicker`. Defaults to `0` — fully backward compatible, zero breaking changes.

## How I approached it

### Step 0 — Read before writing

Before touching any code, I read every file in the datepicker folder. Key discovery: **most of the plumbing already existed**.

- `getWeekDayNames(locale, weekStart)` in `utils.js` already accepts a `weekStart` param and reorders day headers correctly.
- `getCalendarDays(...)` in `utils.js` hardcodes `WEEK_START = 0` internally — just needed to accept it as a parameter.
- `date-fns` `startOfWeek({ weekStartsOn })` already handles 0–6.

So the problem wasn't "build week-start logic" — it was **"pipe a value through the component tree instead of hardcoding it."**

### Step 1 — Trace the data flow

```
datepicker.vue  (parent — user-facing)
  ├── month-year-picker.vue  (generates calendar grid)
  │     └── useMonthYearPicker.js
  │           └── getCalendarDays()  ← WEEK_START hardcoded here
  └── calendar.vue  (renders grid + day headers)
        └── useCalendar.js
              └── getWeekDayNames()  ← WEEK_START hardcoded here
```

Two places where `WEEK_START` was hardcoded. Both needed to read from a prop instead.

### Step 2 — Work bottom-up

**Layer 1 — Utility** (`utils.js`): Made `getCalendarDays` accept an optional `weekStart` param, defaulting to the existing `WEEK_START` constant.

**Layer 2 — Composables**: `useMonthYearPicker.js` and `useCalendar.js` now pass `props.weekStartsOn` instead of the hardcoded constant.

**Layer 3 — Components**: Added the `weekStartsOn` prop (with validator: integer 0–6) to `datepicker.vue`, `month-year-picker.vue`, and `calendar.vue`. Parent passes it down to both children.

### Step 3 — Tests (4 new, 56 existing all pass)

1. Default is Sunday — first header is "Su"
2. `weekStartsOn=1` — first header is "Mo", last is "Su"
3. Grid shifts correctly — Jan 1, 2023 (a Sunday) lands in the last column with Monday start
4. `weekStartsOn=6` — first header is "Sa"

### Step 4 — Storybook

Added a `weekStartsOn` select control (0–6). Toggle it in the Datepicker story to see headers and grid update live.

## The key insight

The entire change is one concept repeated at each layer:

> Replace a hardcoded constant with a prop that defaults to that same constant.

That's why it's backward compatible — if you don't pass `weekStartsOn`, nothing changes.

## How products would use this

Dialtone provides the knob. Products decide the value based on user locale:

```vue
<dt-datepicker :week-starts-on="userPrefersMonday ? 1 : 0" />
```

US users see Sun–Sat. EU users see Mon–Sun. Same component, different config.

## Test plan

- [x] All 60 tests pass (56 existing + 4 new)
- [ ] Storybook: open Datepicker story → toggle `weekStartsOn` 0 → 1 → headers shift from "Su Mo Tu…" to "Mo Tu We…"
- [ ] Default (`weekStartsOn` not set) behaves identically to before