### PR TITLE
fix(tooltip): NO-JIRA fix docsite

### DIFF
--- a/packages/dialtone-vue/directives/tooltip_directive/tooltip.js
+++ b/packages/dialtone-vue/directives/tooltip_directive/tooltip.js
@@ -7,7 +7,7 @@ export const DtTooltipDirective = {
   name: 'dt-tooltip-directive',
   install (app) {
     const DEFAULT_PLACEMENT = 'top';
-    if (!global.__DtTooltipDirectiveAppInstance) {
+    if (!globalThis.__DtTooltipDirectiveAppInstance) {
       const DtTooltipDirectiveApp = createApp({
         name: 'DtTooltipDirectiveApp',
         components: { DtTooltip },
@@ -18,7 +18,7 @@ export const DtTooltipDirective = {
         },
 
         created () {
-          global.__DtTooltipDirectiveAppInstance = getCurrentInstance();
+          globalThis.__DtTooltipDirectiveAppInstance = getCurrentInstance();
         },
 
         methods: {
@@ -61,7 +61,7 @@ export const DtTooltipDirective = {
       DtTooltipDirectiveApp.mount(mountPoint);
     }
 
-    const tooltipInstance = global.__DtTooltipDirectiveAppInstance;
+    const tooltipInstance = globalThis.__DtTooltipDirectiveAppInstance;
 
     app.directive('dt-tooltip', {
       beforeMount (anchor, binding) {


### PR DESCRIPTION
# Fix docsite

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZmMzYWE2Z3U3bDkxbDdnY3Z0bDBieTh6ODduaDhqY2JhZTRybnlpciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/80TEu4wOBdPLG/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Description

use globalThis because not all builds translate global to window

## :bulb: Context

I recently refactored the tooltip directive to use a singleton but used  node's `global` object. This worked for ubervoice static, but broke in the docsite build.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.