### PR TITLE
fix(lint): NO-JIRA fix typo in recommend-typography-style message

### DIFF
--- a/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
@@ -27,7 +27,7 @@ module.exports = {
     schema: [], // Add a schema if the rule has options
     messages: {
       recommendTypographyStyle: `Combining multiple typography utility categories (Font family, Font weight, Font size, Line height) is
-      discouraged in favor of composed typography utilities. Checkout the available classes here:
+      discouraged in favor of composed typography utilities. Check out the available classes here:
       https://dialtone.dialpad.com/design/typography/#api. There can be cases where using these utilities is intentional and valid,
       in which case you can ignore this lint warning.`,
       conflictingTypographyUtilities: `Conflicting typography utilities detected: multiple {{category}} classes found ({{classes}}).


### PR DESCRIPTION
## :bookmark_tabs: Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## :ticket: Jira

NO-JIRA

## :book: Description

Fixes a typo ("Checkout" → "Check out") in the `recommend-typography-style` lint rule message.

This also triggers a patch release for `@dialpad/eslint-plugin-dialtone` to publish unreleased changes that were committed as `chore` (including the rule behavior update from #1042 that changed the rule to only flag multiple typography categories).

## :bulb: Context

The previous commits that changed runtime lint behavior (`db174abfc`, `27e8ea657`) were typed as `chore`, which doesn't trigger a semantic-release version bump. Consumers on `1.11.0` are not getting those changes. This `fix` commit unblocks the release pipeline.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## :crystal_ball: Next Steps

Consider updating team guidelines to ensure commits that change runtime behavior use `fix`/`feat`/`refactor` rather than `chore`, so releases aren't accidentally skipped.