### PR TITLE
feat(rich-text-editor): DP-175404 add hover event for mentions

### DIFF
--- a/packages/dialtone-vue/components/rich_text_editor/extensions/mentions/MentionComponent.vue
+++ b/packages/dialtone-vue/components/rich_text_editor/extensions/mentions/MentionComponent.vue
@@ -6,6 +6,10 @@
     <dt-link
       kind="mention"
       @click.prevent="handleClick"
+      @mouseenter="handleMouseEnter"
+      @mouseleave="handleMouseLeave"
+      @focusin="handleMouseEnter"
+      @focusout="handleMouseLeave"
     >
       {{ text }}
     </dt-link>
@@ -34,14 +38,25 @@ export default {
   },
 
   methods: {
-    handleClick () {
-      const mentionData = {
+    getMentionData () {
+      return {
         name: this.$props.node.attrs.name,
         id: this.$props.node.attrs.id,
         avatarSrc: this.$props.node.attrs.avatarSrc,
         contactKey: this.$props.node.attrs.contactKey,
       };
-      this.$props.editor.emit('mention-click', mentionData);
+    },
+
+    handleClick () {
+      this.$props.editor.emit('mention-click', this.getMentionData());
+    },
+
+    handleMouseEnter (event) {
+      this.$props.editor.emit('mention-hover', { ...this.getMentionData(), event });
+    },
+
+    handleMouseLeave (event) {
+      this.$props.editor.emit('mention-leave', { ...this.getMentionData(), event });
     },
   },
 };

--- a/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.stories.js
+++ b/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.stories.js
@@ -30,6 +30,8 @@ export const argsData = {
   onEditLink: action('edit-link'),
   onSelectedCommand: action('selected-command'),
   onMentionClick: action('mention-click'),
+  onMentionHover: action('mention-hover'),
+  onMentionLeave: action('mention-leave'),
   onChannelClick: action('channel-click'),
 };
 

--- a/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.test.js
@@ -711,6 +711,50 @@ describe('DtRichTextEditor tests', () => {
       });
     });
 
+    describe('Mention hover functionality', () => {
+      const mentionData = {
+        id: 'john.doe',
+        name: 'John Doe',
+        avatarSrc: 'avatar.jpg',
+        contactKey: 'contact-123',
+      };
+
+      beforeEach(async () => {
+        await wrapper.setProps({
+          mentionSuggestion: { items: vi.fn(() => [mentionData]) },
+        });
+
+        const editorInstance = wrapper.vm.editor;
+        const mentionNode = editorInstance.schema.nodes.mention.create(mentionData);
+        editorInstance.view.dispatch(editorInstance.state.tr.insert(0, mentionNode));
+        await wrapper.vm.$nextTick();
+      });
+
+      describe('When the cursor enters a mention', () => {
+        it('should emit mention-hover event with mention data and mouse event', async () => {
+          const mentionLink = wrapper.find('a.d-link');
+          await mentionLink.trigger('mouseenter');
+
+          const emitted = wrapper.emitted('mention-hover');
+          expect(emitted).toBeTruthy();
+          expect(emitted[0][0]).toMatchObject(mentionData);
+          expect(emitted[0][0].event).toBeInstanceOf(MouseEvent);
+        });
+      });
+
+      describe('When the cursor leaves a mention', () => {
+        it('should emit mention-leave event with mention data and mouse event', async () => {
+          const mentionLink = wrapper.find('a.d-link');
+          await mentionLink.trigger('mouseleave');
+
+          const emitted = wrapper.emitted('mention-leave');
+          expect(emitted).toBeTruthy();
+          expect(emitted[0][0]).toMatchObject(mentionData);
+          expect(emitted[0][0].event).toBeInstanceOf(MouseEvent);
+        });
+      });
+    });
+
     describe('Channel click functionality', () => {
       describe('When a channel is clicked', () => {
         it('should emit channel-click event with channel data', async () => {

--- a/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.vue
@@ -526,6 +526,24 @@ export default {
     'mention-click',
 
     /**
+     * Event fired when the cursor enters a mention. The payload includes the
+     * mention data (name, id, avatarSrc, contactKey) plus the native MouseEvent
+     * as `event`, which can be used for positioning a hovercard.
+     * @event mention-hover
+     * @type {Object}
+     */
+    'mention-hover',
+
+    /**
+     * Event fired when the cursor leaves a mention. The payload includes the
+     * mention data (name, id, avatarSrc, contactKey) plus the native MouseEvent
+     * as `event`.
+     * @event mention-leave
+     * @type {Object}
+     */
+    'mention-leave',
+
+    /**
      * Event fired when a channel is clicked
      * @event channel-click
      * @type {Object}
@@ -1245,6 +1263,16 @@ export default {
       // Mention is clicked
       this.editor.on('mention-click', (mentionData) => {
         this.$emit('mention-click', mentionData);
+      });
+
+      // Cursor enters a mention
+      this.editor.on('mention-hover', (mentionData) => {
+        this.$emit('mention-hover', mentionData);
+      });
+
+      // Cursor leaves a mention
+      this.editor.on('mention-leave', (mentionData) => {
+        this.$emit('mention-leave', mentionData);
       });
 
       // Channel is clicked

--- a/packages/dialtone-vue/components/rich_text_editor/rich_text_editor_default.story.vue
+++ b/packages/dialtone-vue/components/rich_text_editor/rich_text_editor_default.story.vue
@@ -35,6 +35,8 @@
     @markdown-input="$attrs.onMarkdownInput"
     @selected-command="$attrs.onSelectedCommand"
     @mention-click="$attrs.onMentionClick"
+    @mention-hover="$attrs.onMentionHover"
+    @mention-leave="$attrs.onMentionLeave"
     @channel-click="$attrs.onChannelClick"
     @focus="$attrs.onFocus"
     @enter="$attrs.onEnter"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15157,8 +15157,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.2.4:
-    resolution: {integrity: sha512-05lR16HeZDcDpB23ku5b5f1fBOoHqFnMiKRr2CiEvbG5Ux4Yi0McmQBOET0dR0nxDXosxyVqv67q6CzS3AK8rw==}
+  vue-component-type-helpers@3.2.5:
+    resolution: {integrity: sha512-tkvNr+bU8+xD/onAThIe7CHFvOJ/BO6XCOrxMzeytJq40nTfpGDJuVjyCM8ccGZKfAbGk2YfuZyDMXM56qheZQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -19391,7 +19391,7 @@ snapshots:
       storybook: 10.2.6(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       type-fest: 2.19.0
       vue: 3.5.27(typescript@5.9.3)
-      vue-component-type-helpers: 3.2.4
+      vue-component-type-helpers: 3.2.5
 
   '@swc/core-darwin-arm64@1.15.11':
     optional: true
@@ -32831,7 +32831,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.2.4: {}
+  vue-component-type-helpers@3.2.5: {}
 
   vue-demi@0.14.10(vue@3.5.27(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
# feat(rich-text-editor): DP-175404 add hover event for mentions

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExOXh0cWJpNHBvZDJzM2U1N2dzd3h2cXIzN2F2ZW9zdWt6NG5ramJnMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/QBd2kLB5qDmysEXre9/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-175404

## :book: Description

Adds hover and leave events to mentions in rich-text-editor

## :bulb: Context

Since implementing the rich text component we were no longer getting the hovercard on mentions because there was no event triggering from rich-text-editor.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.

## :crystal_ball: Next Steps

Make changes product side to implement this.
