### PR TITLE
fix(input): DP-173960 handle composition events

### DIFF
--- a/packages/dialtone-vue/components/input/input.test.js
+++ b/packages/dialtone-vue/components/input/input.test.js
@@ -586,6 +586,77 @@ describe('DtInput tests', () => {
     });
   });
 
+  describe('IME Composition Tests', () => {
+    describe('When type is not a textarea', () => {
+      it('should not emit input or update:modelValue while composing', async () => {
+        await nativeInput.trigger('compositionstart');
+        await nativeInput.trigger('input');
+
+        expect(wrapper.emitted().input).toBeUndefined();
+        expect(wrapper.emitted()['update:modelValue']).toBeUndefined();
+      });
+
+      it('should emit input and update:modelValue after composition ends', async () => {
+        await nativeInput.trigger('compositionstart');
+        await nativeInput.trigger('input');
+
+        nativeInput.element.value = 'か';
+        await nativeInput.trigger('compositionend');
+        await nativeInput.trigger('input');
+
+        expect(wrapper.emitted().input[0][0]).toBe('か');
+        expect(wrapper.emitted()['update:modelValue'][0][0]).toBe('か');
+      });
+
+      it('should resume normal emission after composition ends', async () => {
+        await nativeInput.trigger('compositionstart');
+        await nativeInput.trigger('input');
+        await nativeInput.trigger('compositionend');
+
+        nativeInput.element.value = 'hello';
+        await nativeInput.trigger('input');
+
+        expect(wrapper.emitted().input[0][0]).toBe('hello');
+      });
+    });
+
+    describe('When type is a textarea', () => {
+      beforeEach(() => {
+        mockProps = { type: 'textarea' };
+        updateWrapper();
+      });
+
+      it('should not emit input or update:modelValue while composing', async () => {
+        await nativeTextarea.trigger('compositionstart');
+        await nativeTextarea.trigger('input');
+
+        expect(wrapper.emitted().input).toBeUndefined();
+        expect(wrapper.emitted()['update:modelValue']).toBeUndefined();
+      });
+
+      it('should emit input and update:modelValue after composition ends', async () => {
+        await nativeTextarea.trigger('compositionstart');
+        await nativeTextarea.trigger('input');
+
+        nativeTextarea.element.value = 'か';
+        await nativeTextarea.trigger('compositionend');
+        await nativeTextarea.trigger('input');
+
+        expect(wrapper.emitted().input[0][0]).toBe('か');
+        expect(wrapper.emitted()['update:modelValue'][0][0]).toBe('か');
+      });
+
+      it('should not override textarea value via modelValue watcher while composing', async () => {
+        nativeTextarea.element.value = 'composing...';
+        await nativeTextarea.trigger('compositionstart');
+
+        await wrapper.setProps({ modelValue: 'external update' });
+
+        expect(nativeTextarea.element.value).toBe('composing...');
+      });
+    });
+  });
+
   describe('Extendability Tests', () => {
     it('should handle pass through props/attrs', async () => {
       expect(nativeInput.attributes()).toMatchObject(baseAttrs);

--- a/packages/dialtone-vue/components/input/input.vue
+++ b/packages/dialtone-vue/components/input/input.vue
@@ -373,6 +373,7 @@ export default {
       isInvalid: false,
       defaultLength: 0,
       hasSlotContent,
+      isComposing: false,
     };
   },
 
@@ -408,7 +409,16 @@ export default {
 
     inputListeners () {
       return {
+        compositionstart: () => {
+          this.isComposing = true;
+        },
+
+        compositionend: () => {
+          this.isComposing = false;
+        },
+
         input: async event => {
+          if (this.isComposing) return;
           let val = event.target.value;
           if (this.type === INPUT_TYPES.FILE) {
             const files = Array.from(event.target.files);
@@ -534,7 +544,8 @@ export default {
         }
 
         // Set textarea value programmatically to avoid attribute binding
-        if (this.isTextarea && this.$refs.input && this.$refs.input.value !== newValue) {
+        // Skip during IME composition to avoid interrupting in-progress input
+        if (this.isTextarea && this.$refs.input && this.$refs.input.value !== newValue && !this.isComposing) {
           this.$refs.input.value = newValue;
         }
       },


### PR DESCRIPTION
# fix(input): DP-173960 handle composition events

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExZzUxZmo4bWltczMwb2JoODBidms2OGVwdTNoNzk3dnNrYjdwN3c4eiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/jX3XmgJ0wocdG/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-173960

## :book: Description

Add composition events to DtInput and do not trigger input events if composition is "in progress"

## :bulb: Context

issues specific to Japanese text in https://dialpad.atlassian.net/browse/DP-173960

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
