### PR TITLE
feat(message-input): DLT-3051 add slot for message polish

### DIFF
--- a/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.stories.js
+++ b/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.stories.js
@@ -90,6 +90,14 @@ export const argTypesData = {
       type: 'text',
     },
   },
+  messagePolish: {
+    table: {
+      type: { summary: 'VNode' },
+    },
+    control: {
+      type: 'text',
+    },
+  },
   smsCount: {
     table: {
       type: { summary: 'VNode' },
@@ -228,6 +236,7 @@ export const argsData = {
   customActionIcons: '',
   sendButton: '',
   scheduleMessage: '',
+  messagePolish: '',
   smsCount: '',
   placeholder: 'New message',
   inputAriaLabel: 'Input text field',

--- a/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.vue
@@ -171,6 +171,8 @@
           <slot name="emojiGiphyPicker" />
           <!-- @slot Slot to add extra action icons next to default ones -->
           <slot name="customActionIcons" />
+          <!-- @slot Slot for message polish -->
+          <slot name="messagePolish" />
         </dt-stack>
       </div>
       <!-- Right content -->

--- a/packages/dialtone-vue/recipes/conversation_view/message_input/message_input_default.story.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/message_input/message_input_default.story.vue
@@ -104,6 +104,12 @@
         <span v-html="$attrs.scheduleMessage" />
       </template>
       <template
+        v-if="$attrs.messagePolish"
+        #messagePolish
+      >
+        <span v-html="$attrs.messagePolish" />
+      </template>
+      <template
         v-if="$attrs.smsCount"
         #smsCount
       >


### PR DESCRIPTION
 # feat(message-input): DLT-3051 add slot for message polish

  ## Obligatory GIF (super important!)

  ![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3dDBqZTY3dGVtajZlNjVqNzVsZTF6NTgxN3Jid2Mzam9ycDA2M2xlYSZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/GRPy8MKag9U1U88hzY/giphy.gif)

  ## :hammer_and_wrench: Type Of Change

  These types will increment the version number on release:

  - [ ] Fix
  - [x] Feature
  - [ ] Performance Improvement
  - [ ] Refactor


  ## :book: Jira Ticket

  https://dialpad.atlassian.net/browse/DLT-3051

  ## :book: Description

  Added `messagePolish` slot to the Message Input component to allow consuming applications to inject custom message polishing UI (e.g., AI-powered message enhancement buttons).

  **Changes:**
  - Added `messagePolish` named slot to `message_input.vue` (positioned after `customActionIcons`)
  - Updated storybook configuration in `message_input.stories.js` with `messagePolish` in argTypesData and argsData
  - Added template slot passthrough in `message_input_default.story.vue`

  ## :bulb: Context

  This follows the same pattern as DLT-2743 (schedule message slot). Dialpad is implementing an AI Message Polish feature (DP-173639) that allows users to enhance their messages before sending. Rather than building this feature directly into Dialtone
  (which would couple the design system to Dialpad-specific business logic), we're providing a slot-based extension point.

  This maintains separation of concerns:
  - **Dialtone** provides the UI extension point (slot)
  - **Dialpad** owns the business logic (AI polish, experiments, API integration)

  ## :pencil: Checklist

  For all PRs:

  - [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
  - [x] I have reviewed my changes.
  - [x] I have added all relevant documentation.
  - [x] I have considered the performance impact of my change.

  For all Vue changes:

  - [x] I have added / updated unit tests. _(N/A - simple pass-through slot, no logic to test)_
  - [x] I have validated components with a screen reader. _(N/A - slot content provided by consumer)_
  - [x] I have validated components keyboard navigation. _(N/A - slot content provided by consumer)_

  For all CSS changes:

  - [x] I have used design tokens whenever possible. _(N/A - no CSS changes)_
  - [x] I have considered how this change will behave on different screen sizes. _(Slot inherits layout from parent dt-stack)_
  - [x] I have visually validated my change in light and dark mode. _(N/A - slot renders only when content provided)_
  - [x] I have used gap or flexbox properties for layout instead of margin whenever possible. _(Existing dt-stack handles layout)_

  ## :crystal_ball: Next Steps

  Once merged and released, Dialpad can implement the frontend UI for AI Message Polish (DP-178123) using this slot.

  ## :camera: Screenshots / GIFs

  Deploy preview will show the new slot in the message input component stories.

  ## :link: Sources

  - **Pattern reference:** DLT-2743 - Schedule message slot
  - **Reference commit:** `5df518d904be39034719ffd1bfda3aeeba5a8e1b`
  - **Dialpad epic:** DP-173639 - AI Message Polish (internal only)