### PR TITLE
fix(tokens): DLT-3053 preserve root font size variable as reference

### DIFF
--- a/packages/dialtone-tokens/postcss/dialtone-tokens.cjs
+++ b/packages/dialtone-tokens/postcss/dialtone-tokens.cjs
@@ -112,9 +112,10 @@ function boxShadows (shadowDeclarations, Declaration) {
  */
 function wrapInCalc (declaration) {
   if ([' * ', ' + '].some(str => declaration.value.includes(str)) && !declaration.value.startsWith('calc')) {
-    if (declaration.value.includes('var(--dt-font-size-root)')) {
-      // replace referenced root font size with 1 rem so they output as rem instead of px.
-      declaration.value = declaration.value.replace('var(--dt-font-size-root)', '1rem');
+    // Simplify "var(--dt-font-size-root) * 1" to just the variable reference
+    if (declaration.value === 'var(--dt-font-size-root) * 1') {
+      declaration.value = 'var(--dt-font-size-root)';
+      return;
     }
     declaration.value = `calc(${declaration.value})`;
   }


### PR DESCRIPTION
> [!NOTE]
> Targets `next` 

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3053

## :book: Description

Updated PostCSS to retain `--dt-font-size-root` as reference in font size css variables.

### Before

```css
--dt-font-size-500: 3.2rem;
--dt-font-size-400: 2.8rem;
--dt-font-size-350: 2.4rem;
--dt-font-size-300: 2rem;
--dt-font-size-250: 1.8rem;
--dt-font-size-200: 1.6rem;
--dt-font-size-150: 1.4rem;
--dt-font-size-125: 1.3rem;
--dt-font-size-100: 1.2rem;
--dt-font-size-75: 1.1rem;
--dt-font-size-50: 1rem;
```

### After

```css
--dt-font-size-500: calc(var(--dt-font-size-root) * 3.2);
--dt-font-size-400: calc(var(--dt-font-size-root) * 2.8);
--dt-font-size-350: calc(var(--dt-font-size-root) * 2.4);
--dt-font-size-300: calc(var(--dt-font-size-root) * 2);
--dt-font-size-250: calc(var(--dt-font-size-root) * 1.8);
--dt-font-size-200: calc(var(--dt-font-size-root) * 1.6);
--dt-font-size-150: calc(var(--dt-font-size-root) * 1.4);
--dt-font-size-125: calc(var(--dt-font-size-root) * 1.3);
--dt-font-size-100: calc(var(--dt-font-size-root) * 1.2);
--dt-font-size-75:  calc(var(--dt-font-size-root) * 1.1);
--dt-font-size-50:  var(--dt-font-size-root);
```

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request desxcription (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.