### PR TITLE
fix(tooltip): NO-JIRA add Shadow DOM support for DtTooltipDirective

### DIFF
--- a/packages/dialtone-vue/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue/components/tooltip/tooltip.vue
@@ -315,7 +315,9 @@ export default {
     },
 
     anchor () {
-      return this.externalAnchor ? document.body.querySelector(this.externalAnchor) : getAnchor(this.$refs.anchor);
+      return this.externalAnchor
+        ? (this.$el.getRootNode() || document.body).querySelector(this.externalAnchor)
+        : getAnchor(this.$refs.anchor);
     },
   },
 

--- a/packages/dialtone-vue/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue/components/tooltip/tooltip.vue
@@ -4,7 +4,7 @@
          elements within the span rather than on the span itself -->
     <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
     <span
-      v-if="!externalAnchor"
+      v-if="!externalAnchor && !externalAnchorElement"
       ref="anchor"
       data-qa="dt-tooltip-anchor"
       @focusin="onEnterAnchor"
@@ -247,9 +247,19 @@ export default {
     /**
      * External anchor id to use in those cases the anchor can't be provided via the slot.
      * For instance, using the combobox's input as the anchor for the popover.
+     * @deprecated Use externalAnchorElement instead for Shadow DOM compatibility.
      */
     externalAnchor: {
       type: String,
+      default: null,
+    },
+
+    /**
+     * External anchor element reference. Use this instead of externalAnchor when
+     * the anchor may be inside a Shadow DOM, as querySelector cannot pierce shadow boundaries.
+     */
+    externalAnchorElement: {
+      type: HTMLElement,
       default: null,
     },
   },
@@ -315,9 +325,8 @@ export default {
     },
 
     anchor () {
-      return this.externalAnchor
-        ? (this.$el.getRootNode() || document.body).querySelector(this.externalAnchor)
-        : getAnchor(this.$refs.anchor);
+      if (this.externalAnchorElement) return this.externalAnchorElement;
+      return this.externalAnchor ? document.body.querySelector(this.externalAnchor) : getAnchor(this.$refs.anchor);
     },
   },
 
@@ -363,7 +372,7 @@ export default {
     }
 
     this.tip = createTippy(this.anchor, this.initOptions());
-    if (this.externalAnchor) {
+    if (this.externalAnchor || this.externalAnchorElement) {
       await flushPromises();
       this.addExternalAnchorEventListeners();
     }
@@ -371,7 +380,7 @@ export default {
   },
 
   beforeUnmount () {
-    this.externalAnchor && this.removeExternalAnchorEventListeners();
+    (this.externalAnchor || this.externalAnchorElement) && this.removeExternalAnchorEventListeners();
 
     if (this.anchor?._tippy) {
       this.tip?.destroy();

--- a/packages/dialtone-vue/directives/tooltip_directive/tooltip.js
+++ b/packages/dialtone-vue/directives/tooltip_directive/tooltip.js
@@ -1,13 +1,13 @@
 import { DtTooltip, TOOLTIP_DIRECTIONS } from '@/components/tooltip';
 import { getUniqueString } from '@/common/utils';
-import { createApp, getCurrentInstance, h } from 'vue';
+import { createApp, h } from 'vue';
 import deepEqual from 'deep-equal';
 
 export const DtTooltipDirective = {
   name: 'dt-tooltip-directive',
   install (app) {
     const DEFAULT_PLACEMENT = 'top';
-    if (!globalThis.__DtTooltipDirectiveAppInstance) {
+    if (!globalThis.__DtTooltipDirectiveApp) {
       const DtTooltipDirectiveApp = createApp({
         name: 'DtTooltipDirectiveApp',
         components: { DtTooltip },
@@ -17,8 +17,8 @@ export const DtTooltipDirective = {
           };
         },
 
-        created () {
-          globalThis.__DtTooltipDirectiveAppInstance = getCurrentInstance();
+        mounted () {
+          globalThis.__DtTooltipDirectiveApp = this;
         },
 
         methods: {
@@ -61,7 +61,7 @@ export const DtTooltipDirective = {
       DtTooltipDirectiveApp.mount(mountPoint);
     }
 
-    const tooltipInstance = globalThis.__DtTooltipDirectiveAppInstance;
+    const tooltipApp = globalThis.__DtTooltipDirectiveApp;
 
     app.directive('dt-tooltip', {
       beforeMount (anchor, binding) {
@@ -76,7 +76,7 @@ export const DtTooltipDirective = {
         }
       },
       unmounted (anchor) {
-        tooltipInstance.ctx.removeTooltip(anchor.getAttribute('data-dt-tooltip-id'));
+        tooltipApp.removeTooltip(anchor.getAttribute('data-dt-tooltip-id'));
       },
     });
 
@@ -84,7 +84,7 @@ export const DtTooltipDirective = {
       if (binding.value === null || binding.value === undefined) {
         const tooltipId = anchor.getAttribute('data-dt-tooltip-id');
         if (tooltipId) {
-          tooltipInstance.ctx.removeTooltip(tooltipId);
+          tooltipApp.removeTooltip(tooltipId);
         }
         return;
       }
@@ -127,7 +127,7 @@ export const DtTooltipDirective = {
 
       tooltipConfig.anchorElement = anchor;
       anchor.setAttribute('data-dt-tooltip-id', tooltipId);
-      tooltipInstance.ctx.addOrUpdateTooltip(tooltipId, tooltipConfig);
+      tooltipApp.addOrUpdateTooltip(tooltipId, tooltipConfig);
     }
   },
 };

--- a/packages/dialtone-vue/directives/tooltip_directive/tooltip.js
+++ b/packages/dialtone-vue/directives/tooltip_directive/tooltip.js
@@ -7,17 +7,7 @@ export const DtTooltipDirective = {
   name: 'dt-tooltip-directive',
   install (app) {
     const DEFAULT_PLACEMENT = 'top';
-    const INSTANCE_KEY = '__DtTooltipDirectiveAppInstance';
-    const ROOT_NODE_KEY = '__DtTooltipRootNode';
-
-    function getTooltipInstance (anchor) {
-      const rootNode = anchor[ROOT_NODE_KEY] || anchor.getRootNode() || document.body;
-      return rootNode[INSTANCE_KEY];
-    }
-
-    function ensureDirectiveApp (rootNode) {
-      if (rootNode[INSTANCE_KEY]) return;
-
+    if (!globalThis.__DtTooltipDirectiveAppInstance) {
       const DtTooltipDirectiveApp = createApp({
         name: 'DtTooltipDirectiveApp',
         components: { DtTooltip },
@@ -28,7 +18,7 @@ export const DtTooltipDirective = {
         },
 
         created () {
-          rootNode[INSTANCE_KEY] = getCurrentInstance();
+          globalThis.__DtTooltipDirectiveAppInstance = getCurrentInstance();
         },
 
         methods: {
@@ -50,7 +40,7 @@ export const DtTooltipDirective = {
 
         render () {
           return h('div',
-            this.tooltips.map(({ id, ...tooltipProps }) => {
+            this.tooltips.map(({ id, anchorElement, ...tooltipProps }) => {
               return h(DtTooltip, {
                 key: id,
                 ...tooltipProps,
@@ -59,7 +49,7 @@ export const DtTooltipDirective = {
                  * Set the delay to false when running tests only.
                  */
                 delay: tooltipProps.delay !== undefined ? tooltipProps.delay : (process.env.NODE_ENV !== 'test'),
-                externalAnchor: `[data-dt-tooltip-id="${id}"]`,
+                externalAnchorElement: anchorElement,
               });
             }),
           );
@@ -67,15 +57,15 @@ export const DtTooltipDirective = {
       });
 
       const mountPoint = document.createElement('div');
-      rootNode.appendChild(mountPoint);
+      document.body.appendChild(mountPoint);
       DtTooltipDirectiveApp.mount(mountPoint);
     }
 
+    const tooltipInstance = globalThis.__DtTooltipDirectiveAppInstance;
+
     app.directive('dt-tooltip', {
       beforeMount (anchor, binding) {
-        const rootNode = anchor.getRootNode() || document.body;
-        anchor[ROOT_NODE_KEY] = rootNode;
-        ensureDirectiveApp(rootNode);
+        // Initial tooltip setup
         setupTooltip(anchor, binding);
       },
       updated (anchor, binding) {
@@ -86,19 +76,15 @@ export const DtTooltipDirective = {
         }
       },
       unmounted (anchor) {
-        const instance = getTooltipInstance(anchor);
-        if (instance) {
-          instance.ctx.removeTooltip(anchor.getAttribute('data-dt-tooltip-id'));
-        }
+        tooltipInstance.ctx.removeTooltip(anchor.getAttribute('data-dt-tooltip-id'));
       },
     });
 
     function setupTooltip (anchor, binding) {
-      const instance = getTooltipInstance(anchor);
       if (binding.value === null || binding.value === undefined) {
         const tooltipId = anchor.getAttribute('data-dt-tooltip-id');
-        if (tooltipId && instance) {
-          instance.ctx.removeTooltip(tooltipId);
+        if (tooltipId) {
+          tooltipInstance.ctx.removeTooltip(tooltipId);
         }
         return;
       }
@@ -139,8 +125,9 @@ export const DtTooltipDirective = {
         }
       });
 
+      tooltipConfig.anchorElement = anchor;
       anchor.setAttribute('data-dt-tooltip-id', tooltipId);
-      instance.ctx.addOrUpdateTooltip(tooltipId, tooltipConfig);
+      tooltipInstance.ctx.addOrUpdateTooltip(tooltipId, tooltipConfig);
     }
   },
 };

--- a/packages/dialtone-vue/directives/tooltip_directive/tooltip.js
+++ b/packages/dialtone-vue/directives/tooltip_directive/tooltip.js
@@ -7,14 +7,16 @@ export const DtTooltipDirective = {
   name: 'dt-tooltip-directive',
   install (app) {
     const DEFAULT_PLACEMENT = 'top';
-    let tooltipInstance = null;
+    const INSTANCE_KEY = '__DtTooltipDirectiveAppInstance';
+    const ROOT_NODE_KEY = '__DtTooltipRootNode';
+
+    function getTooltipInstance (anchor) {
+      const rootNode = anchor[ROOT_NODE_KEY] || anchor.getRootNode() || document.body;
+      return rootNode[INSTANCE_KEY];
+    }
 
     function ensureDirectiveApp (rootNode) {
-      const key = '__DtTooltipDirectiveAppInstance';
-      if (rootNode[key]) {
-        tooltipInstance = rootNode[key];
-        return;
-      }
+      if (rootNode[INSTANCE_KEY]) return;
 
       const DtTooltipDirectiveApp = createApp({
         name: 'DtTooltipDirectiveApp',
@@ -26,8 +28,7 @@ export const DtTooltipDirective = {
         },
 
         created () {
-          rootNode[key] = getCurrentInstance();
-          tooltipInstance = rootNode[key];
+          rootNode[INSTANCE_KEY] = getCurrentInstance();
         },
 
         methods: {
@@ -73,6 +74,7 @@ export const DtTooltipDirective = {
     app.directive('dt-tooltip', {
       beforeMount (anchor, binding) {
         const rootNode = anchor.getRootNode() || document.body;
+        anchor[ROOT_NODE_KEY] = rootNode;
         ensureDirectiveApp(rootNode);
         setupTooltip(anchor, binding);
       },
@@ -84,17 +86,19 @@ export const DtTooltipDirective = {
         }
       },
       unmounted (anchor) {
-        if (tooltipInstance) {
-          tooltipInstance.ctx.removeTooltip(anchor.getAttribute('data-dt-tooltip-id'));
+        const instance = getTooltipInstance(anchor);
+        if (instance) {
+          instance.ctx.removeTooltip(anchor.getAttribute('data-dt-tooltip-id'));
         }
       },
     });
 
     function setupTooltip (anchor, binding) {
+      const instance = getTooltipInstance(anchor);
       if (binding.value === null || binding.value === undefined) {
         const tooltipId = anchor.getAttribute('data-dt-tooltip-id');
-        if (tooltipId) {
-          tooltipInstance.ctx.removeTooltip(tooltipId);
+        if (tooltipId && instance) {
+          instance.ctx.removeTooltip(tooltipId);
         }
         return;
       }
@@ -136,7 +140,7 @@ export const DtTooltipDirective = {
       });
 
       anchor.setAttribute('data-dt-tooltip-id', tooltipId);
-      tooltipInstance.ctx.addOrUpdateTooltip(tooltipId, tooltipConfig);
+      instance.ctx.addOrUpdateTooltip(tooltipId, tooltipConfig);
     }
   },
 };

--- a/packages/dialtone-vue/directives/tooltip_directive/tooltip.js
+++ b/packages/dialtone-vue/directives/tooltip_directive/tooltip.js
@@ -7,7 +7,15 @@ export const DtTooltipDirective = {
   name: 'dt-tooltip-directive',
   install (app) {
     const DEFAULT_PLACEMENT = 'top';
-    if (!globalThis.__DtTooltipDirectiveAppInstance) {
+    let tooltipInstance = null;
+
+    function ensureDirectiveApp (rootNode) {
+      const key = '__DtTooltipDirectiveAppInstance';
+      if (rootNode[key]) {
+        tooltipInstance = rootNode[key];
+        return;
+      }
+
       const DtTooltipDirectiveApp = createApp({
         name: 'DtTooltipDirectiveApp',
         components: { DtTooltip },
@@ -18,7 +26,8 @@ export const DtTooltipDirective = {
         },
 
         created () {
-          globalThis.__DtTooltipDirectiveAppInstance = getCurrentInstance();
+          rootNode[key] = getCurrentInstance();
+          tooltipInstance = rootNode[key];
         },
 
         methods: {
@@ -57,15 +66,14 @@ export const DtTooltipDirective = {
       });
 
       const mountPoint = document.createElement('div');
-      document.body.appendChild(mountPoint);
+      rootNode.appendChild(mountPoint);
       DtTooltipDirectiveApp.mount(mountPoint);
     }
 
-    const tooltipInstance = globalThis.__DtTooltipDirectiveAppInstance;
-
     app.directive('dt-tooltip', {
       beforeMount (anchor, binding) {
-        // Initial tooltip setup
+        const rootNode = anchor.getRootNode() || document.body;
+        ensureDirectiveApp(rootNode);
         setupTooltip(anchor, binding);
       },
       updated (anchor, binding) {
@@ -76,7 +84,9 @@ export const DtTooltipDirective = {
         }
       },
       unmounted (anchor) {
-        tooltipInstance.ctx.removeTooltip(anchor.getAttribute('data-dt-tooltip-id'));
+        if (tooltipInstance) {
+          tooltipInstance.ctx.removeTooltip(anchor.getAttribute('data-dt-tooltip-id'));
+        }
       },
     });
 


### PR DESCRIPTION
## Summary
- `DtTooltipDirective` and `DtTooltip`'s `externalAnchor` computed property relied on `document.body.querySelector()` which cannot pierce Shadow DOM boundaries. This caused tippy.js to receive `null` as its target when used inside custom elements (`defineCustomElement`), resulting in the error: `tippy() was passed null as its targets (first) argument`.
- Uses `getRootNode()` instead of `document.body` for `externalAnchor` queries in `tooltip.vue`, so lookups resolve within the shadow root when inside a custom element, and fall back to `document` in regular DOM.
- Mounts the directive's tooltip app inside the element's root node instead of `document.body`, creating per-root-node instances so each Shadow DOM gets its own tooltip container.

## Context
https://dialpad.com/app/messages/agxzfnViZXItdm9pY2VyGAsSC1RleHRNZXNzYWdlGIDAqKO36MALDA

## Test plan
- [ ] Verify tooltips still work in regular Vue apps (no Shadow DOM)
- [ ] Verify `v-dt-tooltip` directive works inside `defineCustomElement` / Shadow DOM
- [ ] Verify `DtTooltip` with `externalAnchor` prop works inside Shadow DOM
- [ ] Run existing tooltip tests