### PR TITLE
revert: NO-JIRA revert progress circle polish commits for re-PR

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/loader.less
+++ b/packages/dialtone-css/lib/build/less/components/loader.less
@@ -18,15 +18,4 @@
 
 .d-loader__icon {
   animation: d-loading-circle 900ms infinite linear;
-
-  // Comet fade. Black is an intentional choice and only used for masking.
-  mask-image: conic-gradient(
-    from 270deg,
-    black 0deg,
-    black 105deg,
-    transparent 170deg,
-    transparent 180deg,
-    black 234deg,
-    black 360deg
-  );
 }

--- a/packages/dialtone-css/lib/build/less/components/progress_circle.less
+++ b/packages/dialtone-css/lib/build/less/components/progress_circle.less
@@ -39,20 +39,13 @@
 
 .d-progress-circle__shape {
   &--track {
-    transition: stroke-dasharray var(--td200) linear, stroke-dashoffset var(--td200) linear;
     stroke: color-mix(in oklch, var(--progress-color) 25%, var(--dt-color-surface-primary));
-    stroke-dasharray: var(--track-dasharray);
-    stroke-dashoffset: var(--track-dashoffset);
-    stroke-linecap: round;
   }
 
   &--fill {
-    transform: rotate(var(--fill-rotate));
-    transform-origin: center;
+    stroke-dasharray: var(--stroke-dasharray);
     transition: stroke-dashoffset var(--td200) linear;
     stroke: var(--progress-color);
-    stroke-dasharray: var(--stroke-dasharray);
-    stroke-dashoffset: var(--fill-dashoffset);
-    stroke-linecap: round;
+    stroke-dashoffset: var(--stroke-dashoffset);
   }
 }

--- a/packages/dialtone-vue/components/loader/loader.vue
+++ b/packages/dialtone-vue/components/loader/loader.vue
@@ -4,37 +4,25 @@
     :aria-label="ariaLabel || 'loading'"
     data-qa="dt-loader"
   >
-    <svg
-      :class="['d-icon', `d-icon--size-${size}`, 'd-loader__icon']"
+    <!-- Localize the aria-label -->
+    <dt-icon-loading
+      class="d-loader__icon"
       data-qa="dt-loader-icon"
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="
-          M0.0180664 12.0005
-          C0.0180664 5.38305 5.38305 0.0180664 12.0005 0.0180664
-          C12.8977 0.0183302 13.6255 0.745766 13.6255 1.64307
-          C13.6255 2.54037 12.8977 3.2678 12.0005 3.26807
-          C7.17797 3.26807 3.26807 7.17797 3.26807 12.0005
-          C3.26833 16.8228 7.17814 20.7319 12.0005 20.7319
-          C16.8226 20.7317 20.7317 16.8226 20.7319 12.0005
-          C20.7319 11.103 21.4595 10.3755 22.3569 10.3755
-          C23.2544 10.3755 23.9819 11.103 23.9819 12.0005
-          C23.9817 18.6175 18.6175 23.9817 12.0005 23.9819
-          C5.38321 23.9819 0.0183303 18.6177 0.0180664 12.0005Z
-        "
-      />
-    </svg>
+      :size="size"
+    />
   </div>
 </template>
 
 <script>
+import { DtIconLoading } from '@dialpad/dialtone-icons/vue3';
 import { ICON_SIZE_MODIFIERS } from '@/components/icon';
 
 export default {
   name: 'DtLoader',
+
+  components: {
+    DtIconLoading,
+  },
 
   props: {
     /**

--- a/packages/dialtone-vue/components/progress_circle/progress_circle.test.js
+++ b/packages/dialtone-vue/components/progress_circle/progress_circle.test.js
@@ -45,24 +45,6 @@ describe('DtProgressCircle Tests', () => {
       beforeEach(() => { mockProps = { progress: 100 }; updateWrapper(); });
       it('has aria-valuenow 100', () => { expect(progressCircle.attributes('aria-valuenow')).toBe('100'); });
     });
-
-    describe('When progress is below minimum visual threshold (1–4)', () => {
-      beforeEach(() => { mockProps = { progress: 2 }; updateWrapper(); });
-
-      it('has aria-valuenow reflecting the real value', () => {
-        expect(progressCircle.attributes('aria-valuenow')).toBe('2');
-      });
-
-      it('renders the same fill as progress=5', () => {
-        const smallStyle = wrapper.find('.d-progress-circle__bar').attributes('style');
-
-        mockProps = { progress: 5 };
-        updateWrapper();
-        const fiveStyle = wrapper.find('.d-progress-circle__bar').attributes('style');
-
-        expect(smallStyle).toBe(fiveStyle);
-      });
-    });
   });
 
   describe('Size Tests', () => {

--- a/packages/dialtone-vue/components/progress_circle/progress_circle.vue
+++ b/packages/dialtone-vue/components/progress_circle/progress_circle.vue
@@ -80,34 +80,14 @@ export default {
       const r = this.circleRadius;
       const top = 12 - r;
       const bottom = 12 + r;
-      return `M 12 ${top} A ${r} ${r} 0 0 1 12 ${bottom} A ${r} ${r} 0 0 1 12 ${top} Z`;
+      return `M 12 ${top} A ${r} ${r} 0 0 1 12 ${bottom} A ${r} ${r} 0 0 1 12 ${top}`;
     },
 
     // stroke-dasharray/offset control how much of the circle is visually "filled".
     cssVars () {
-      const C = this.circleCircumference;
-      const MIN_VISUAL_PROGRESS = 5;
-      const visualProgress = (this.progress > 0 && this.progress < MIN_VISUAL_PROGRESS)
-        ? MIN_VISUAL_PROGRESS
-        : this.progress;
-      const fillLength = C * visualProgress / 100;
-      const sw = this.strokeWidth;
-      const capArc = sw / 2;
-
-      // When both arcs are visible, round linecaps extend capArc past each endpoint.
-      // Shorten each arc by capArc at both ends (total sw per arc) so the caps meet
-      // exactly at each junction without overlapping. Rotate the fill forward by
-      // capArc so its start cap lands at 12 o'clock.
-      const both = this.progress > 0 && this.progress < 100;
-      const adj = both ? sw : 0;
-
       return {
-        // Full-circle arcs use 'none' to avoid round-cap overlap at the path seam.
-        '--stroke-dasharray': (!both && this.progress >= 100) ? 'none' : C,
-        '--fill-dashoffset': C - Math.max(0, fillLength - adj),
-        '--fill-rotate': `${both ? (capArc / C * 360) : 0}deg`,
-        '--track-dasharray': (!both && this.progress <= 0) ? 'none' : `${Math.max(0, C - fillLength - adj)} ${C}`,
-        '--track-dashoffset': -(fillLength + (both ? capArc : 0)),
+        '--stroke-dashoffset': this.circleCircumference - (this.circleCircumference * this.progress / 100),
+        '--stroke-dasharray': this.circleCircumference,
       };
     },
   },
@@ -196,8 +176,6 @@ export default {
         class="d-progress-circle__shape d-progress-circle__shape--track"
         fill="none"
         :stroke-width="strokeWidth"
-        stroke-linecap="round"
-        :style="{ display: progress > 95 ? 'none' : undefined }"
       />
       <path
         :d="circlePath"
@@ -205,7 +183,7 @@ export default {
         fill="none"
         :stroke-width="strokeWidth"
         stroke-linecap="round"
-        :style="{ ...fillStrokeStyle, display: progress <= 0 ? 'none' : undefined }"
+        :style="fillStrokeStyle"
       />
     </svg>
   </div>

--- a/packages/dialtone-vue/components/progress_circle/progress_circle.vue
+++ b/packages/dialtone-vue/components/progress_circle/progress_circle.vue
@@ -182,7 +182,6 @@ export default {
         class="d-progress-circle__shape d-progress-circle__shape--fill"
         fill="none"
         :stroke-width="strokeWidth"
-        stroke-linecap="round"
         :style="fillStrokeStyle"
       />
     </svg>


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Other (chore)

## :book: Jira Ticket

NO-JIRA

## :book: Description

Reverts 4 commits that were pushed directly to staging so they can be re-submitted as a proper PR:

- adbeeee03 add stroke-linecap="round" to progress circle fill shape
- 6eb6b460a polish stroke rendering with rounded linecaps and visual thresholds
- e535c800a replace DtIconLoading with inline SVG spinner icon
- 40794a516 comet fade effect to loader icon

## :bulb: Context

These commits were accidentally pushed to staging. This revert clears them so the changes can be re-introduced via a reviewed PR on the improve-progress-circle-visuals branch.
