### PR TITLE
feat(loader,progress-circle): NO-JIRA polish DtProgressCircle visual and align DtLoader visual with DtProgressCircle

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/loader.less
+++ b/packages/dialtone-css/lib/build/less/components/loader.less
@@ -18,4 +18,15 @@
 
 .d-loader__icon {
   animation: d-loading-circle 900ms infinite linear;
+
+  // Comet fade. Black is an intentional choice and only used for masking.
+  mask-image: conic-gradient(
+    from 270deg,
+    black 0deg,
+    black 105deg,
+    transparent 170deg,
+    transparent 180deg,
+    black 234deg,
+    black 360deg
+  );
 }

--- a/packages/dialtone-css/lib/build/less/components/progress_circle.less
+++ b/packages/dialtone-css/lib/build/less/components/progress_circle.less
@@ -39,13 +39,20 @@
 
 .d-progress-circle__shape {
   &--track {
+    transition: stroke-dasharray var(--td200) linear, stroke-dashoffset var(--td200) linear;
     stroke: color-mix(in oklch, var(--progress-color) 25%, var(--dt-color-surface-primary));
+    stroke-dasharray: var(--track-dasharray);
+    stroke-dashoffset: var(--track-dashoffset);
+    stroke-linecap: round;
   }
 
   &--fill {
-    stroke-dasharray: var(--stroke-dasharray);
+    transform: rotate(var(--fill-rotate));
+    transform-origin: center;
     transition: stroke-dashoffset var(--td200) linear;
     stroke: var(--progress-color);
-    stroke-dashoffset: var(--stroke-dashoffset);
+    stroke-dasharray: var(--stroke-dasharray);
+    stroke-dashoffset: var(--fill-dashoffset);
+    stroke-linecap: round;
   }
 }

--- a/packages/dialtone-css/lib/build/less/recipes/attachment_carousel.less
+++ b/packages/dialtone-css/lib/build/less/recipes/attachment_carousel.less
@@ -84,7 +84,7 @@
   top: inherit;
   right: inherit;
   display: flex;
-  padding: var(--dt-space-200);
+  padding: var(--dt-space-300);
   background-color: var(--dt-color-surface-moderate);
   border-radius: var(--dt-size-radius-circle);
 }

--- a/packages/dialtone-css/lib/build/less/recipes/attachment_carousel.less
+++ b/packages/dialtone-css/lib/build/less/recipes/attachment_carousel.less
@@ -18,11 +18,16 @@
 .d-recipe-attachment-carousel__arrow {
   position: absolute;
   top: var(--dt-space-30-percent);
-  background-color: var(--dt-color-neutral-white);
+  color: var(--dt-color-foreground-tertiary-inverted);
+  background-color: var(--dt-color-surface-strong);
   border: var(--dt-space-100) solid;
-  border-color: var(--bc-default);
+  border-color: var(--dt-color-border-moderate-inverted);
   border-width: var(--dt-size-100);
   opacity: 0;
+
+  &:hover {
+    color: var(--dt-color-foreground-primary-inverted);
+  }
 }
 
 .d-recipe-attachment-carousel:hover .d-recipe-attachment-carousel__arrow {
@@ -45,12 +50,13 @@
   position: absolute;
   top: inherit;
   right: inherit;
-  color: var(--dt-color-neutral-white);
-  background-color: var(--dt-color-black-400);
-  border: var(--dt-space-100) solid;
-  border-color: var(--dt-color-neutral-white);
-  border-width: var(--dt-size-200);
+  color: var(--dt-color-foreground-tertiary-inverted);
+  background-color: var(--dt-color-surface-strong);
   opacity: 0;
+
+  &:hover {
+    color: var(--dt-color-foreground-primary-inverted);
+  }
 }
 
 .d-recipe-attachment-carousel__image:focus-within .d-recipe-attachment-carousel__image-close-button, .d-recipe-attachment-carousel__image:hover .d-recipe-attachment-carousel__image-close-button {
@@ -78,11 +84,7 @@
   top: inherit;
   right: inherit;
   display: flex;
-  background-color: var(--dt-color-neutral-white);
-  border: var(--dt-space-100) solid;
-  border-color: var(--dt-color-border-subtle);
-  border-width: var(--dt-size-200);
-  border-radius: 50%;
-  transform: rotate(-90deg);
+  padding: var(--dt-space-200);
+  background-color: var(--dt-color-surface-moderate);
+  border-radius: var(--dt-size-radius-circle);
 }
-

--- a/packages/dialtone-vue/components/loader/loader.vue
+++ b/packages/dialtone-vue/components/loader/loader.vue
@@ -4,25 +4,37 @@
     :aria-label="ariaLabel || 'loading'"
     data-qa="dt-loader"
   >
-    <!-- Localize the aria-label -->
-    <dt-icon-loading
-      class="d-loader__icon"
+    <svg
+      :class="['d-icon', `d-icon--size-${size}`, 'd-loader__icon']"
       data-qa="dt-loader-icon"
-      :size="size"
-    />
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="
+          M0.0180664 12.0005
+          C0.0180664 5.38305 5.38305 0.0180664 12.0005 0.0180664
+          C12.8977 0.0183302 13.6255 0.745766 13.6255 1.64307
+          C13.6255 2.54037 12.8977 3.2678 12.0005 3.26807
+          C7.17797 3.26807 3.26807 7.17797 3.26807 12.0005
+          C3.26833 16.8228 7.17814 20.7319 12.0005 20.7319
+          C16.8226 20.7317 20.7317 16.8226 20.7319 12.0005
+          C20.7319 11.103 21.4595 10.3755 22.3569 10.3755
+          C23.2544 10.3755 23.9819 11.103 23.9819 12.0005
+          C23.9817 18.6175 18.6175 23.9817 12.0005 23.9819
+          C5.38321 23.9819 0.0183303 18.6177 0.0180664 12.0005Z
+        "
+      />
+    </svg>
   </div>
 </template>
 
 <script>
-import { DtIconLoading } from '@dialpad/dialtone-icons/vue3';
 import { ICON_SIZE_MODIFIERS } from '@/components/icon';
 
 export default {
   name: 'DtLoader',
-
-  components: {
-    DtIconLoading,
-  },
 
   props: {
     /**

--- a/packages/dialtone-vue/components/progress_circle/progress_circle.test.js
+++ b/packages/dialtone-vue/components/progress_circle/progress_circle.test.js
@@ -45,6 +45,24 @@ describe('DtProgressCircle Tests', () => {
       beforeEach(() => { mockProps = { progress: 100 }; updateWrapper(); });
       it('has aria-valuenow 100', () => { expect(progressCircle.attributes('aria-valuenow')).toBe('100'); });
     });
+
+    describe('When progress is below minimum visual threshold (1–4)', () => {
+      beforeEach(() => { mockProps = { progress: 2 }; updateWrapper(); });
+
+      it('has aria-valuenow reflecting the real value', () => {
+        expect(progressCircle.attributes('aria-valuenow')).toBe('2');
+      });
+
+      it('renders the same fill as progress=5', () => {
+        const smallStyle = wrapper.find('.d-progress-circle__bar').attributes('style');
+
+        mockProps = { progress: 5 };
+        updateWrapper();
+        const fiveStyle = wrapper.find('.d-progress-circle__bar').attributes('style');
+
+        expect(smallStyle).toBe(fiveStyle);
+      });
+    });
   });
 
   describe('Size Tests', () => {

--- a/packages/dialtone-vue/components/progress_circle/progress_circle.test.js
+++ b/packages/dialtone-vue/components/progress_circle/progress_circle.test.js
@@ -2,15 +2,6 @@ import { mount } from '@vue/test-utils';
 import DtProgressCircle from './progress_circle.vue';
 import { PROGRESS_CIRCLE_SIZES, PROGRESS_CIRCLE_SIZE_DEFAULT, PROGRESS_CIRCLE_KINDS } from './progress_circle_constants';
 
-// jsdom does not implement getTotalLength — add it to Element.prototype so mounted() can call it
-beforeAll(() => {
-  Object.defineProperty(Element.prototype, 'getTotalLength', {
-    value: vi.fn(() => 50),
-    writable: true,
-    configurable: true,
-  });
-});
-
 const baseProps = { ariaLabel: 'Upload progress' };
 let mockProps = {};
 
@@ -99,7 +90,7 @@ describe('DtProgressCircle Tests', () => {
     });
 
     describe('When kind is ai', () => {
-      beforeEach(() => { mockProps = { kind: 'ai' }; updateWrapper(); });
+      beforeEach(() => { mockProps = { kind: 'ai', progress: 50 }; updateWrapper(); });
       it('applies ai class', () => {
         expect(progressCircle.classes()).toContain(PROGRESS_CIRCLE_KINDS.ai);
       });

--- a/packages/dialtone-vue/components/progress_circle/progress_circle.vue
+++ b/packages/dialtone-vue/components/progress_circle/progress_circle.vue
@@ -41,7 +41,6 @@ export default {
 
   data () {
     return {
-      circleCircumference: 50,
       strokeWidth: 3.25,
       uid: Math.random().toString(36).substring(2, 9),
     };
@@ -73,6 +72,10 @@ export default {
 
     circleRadius () {
       return 12 - (this.strokeWidth / 2);
+    },
+
+    circleCircumference () {
+      return 2 * Math.PI * this.circleRadius;
     },
 
     // Draws a full circle as two arcs so getTotalLength() returns the circumference.
@@ -112,9 +115,6 @@ export default {
     },
   },
 
-  mounted () {
-    this.circleCircumference = this.$refs.progressCircle.getTotalLength();
-  },
 };
 </script>
 
@@ -191,21 +191,21 @@ export default {
         </linearGradient>
       </defs>
       <path
-        ref="progressCircle"
+        v-if="progress <= 95"
         :d="circlePath"
         class="d-progress-circle__shape d-progress-circle__shape--track"
         fill="none"
         :stroke-width="strokeWidth"
         stroke-linecap="round"
-        :style="{ display: progress > 95 ? 'none' : undefined }"
       />
       <path
+        v-if="progress > 0"
         :d="circlePath"
         class="d-progress-circle__shape d-progress-circle__shape--fill"
         fill="none"
         :stroke-width="strokeWidth"
         stroke-linecap="round"
-        :style="{ ...fillStrokeStyle, display: progress <= 0 ? 'none' : undefined }"
+        :style="fillStrokeStyle"
       />
     </svg>
   </div>

--- a/packages/dialtone-vue/components/progress_circle/progress_circle.vue
+++ b/packages/dialtone-vue/components/progress_circle/progress_circle.vue
@@ -182,6 +182,7 @@ export default {
         class="d-progress-circle__shape d-progress-circle__shape--fill"
         fill="none"
         :stroke-width="strokeWidth"
+        stroke-linecap="round"
         :style="fillStrokeStyle"
       />
     </svg>

--- a/packages/dialtone-vue/components/progress_circle/progress_circle.vue
+++ b/packages/dialtone-vue/components/progress_circle/progress_circle.vue
@@ -80,14 +80,34 @@ export default {
       const r = this.circleRadius;
       const top = 12 - r;
       const bottom = 12 + r;
-      return `M 12 ${top} A ${r} ${r} 0 0 1 12 ${bottom} A ${r} ${r} 0 0 1 12 ${top}`;
+      return `M 12 ${top} A ${r} ${r} 0 0 1 12 ${bottom} A ${r} ${r} 0 0 1 12 ${top} Z`;
     },
 
     // stroke-dasharray/offset control how much of the circle is visually "filled".
     cssVars () {
+      const C = this.circleCircumference;
+      const MIN_VISUAL_PROGRESS = 5;
+      const visualProgress = (this.progress > 0 && this.progress < MIN_VISUAL_PROGRESS)
+        ? MIN_VISUAL_PROGRESS
+        : this.progress;
+      const fillLength = C * visualProgress / 100;
+      const sw = this.strokeWidth;
+      const capArc = sw / 2;
+
+      // When both arcs are visible, round linecaps extend capArc past each endpoint.
+      // Shorten each arc by capArc at both ends (total sw per arc) so the caps meet
+      // exactly at each junction without overlapping. Rotate the fill forward by
+      // capArc so its start cap lands at 12 o'clock.
+      const both = this.progress > 0 && this.progress < 100;
+      const adj = both ? sw : 0;
+
       return {
-        '--stroke-dashoffset': this.circleCircumference - (this.circleCircumference * this.progress / 100),
-        '--stroke-dasharray': this.circleCircumference,
+        // Full-circle arcs use 'none' to avoid round-cap overlap at the path seam.
+        '--stroke-dasharray': (!both && this.progress >= 100) ? 'none' : C,
+        '--fill-dashoffset': C - Math.max(0, fillLength - adj),
+        '--fill-rotate': `${both ? (capArc / C * 360) : 0}deg`,
+        '--track-dasharray': (!both && this.progress <= 0) ? 'none' : `${Math.max(0, C - fillLength - adj)} ${C}`,
+        '--track-dashoffset': -(fillLength + (both ? capArc : 0)),
       };
     },
   },
@@ -176,6 +196,8 @@ export default {
         class="d-progress-circle__shape d-progress-circle__shape--track"
         fill="none"
         :stroke-width="strokeWidth"
+        stroke-linecap="round"
+        :style="{ display: progress > 95 ? 'none' : undefined }"
       />
       <path
         :d="circlePath"
@@ -183,7 +205,7 @@ export default {
         fill="none"
         :stroke-width="strokeWidth"
         stroke-linecap="round"
-        :style="fillStrokeStyle"
+        :style="{ ...fillStrokeStyle, display: progress <= 0 ? 'none' : undefined }"
       />
     </svg>
   </div>

--- a/packages/dialtone-vue/recipes/conversation_view/attachment_carousel/media_components/image_carousel.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/attachment_carousel/media_components/image_carousel.vue
@@ -13,12 +13,16 @@
     <div
       class="d-recipe-attachment-carousel__image-top-right"
     >
-      <dt-progress-circle
-        v-if="mediaItem.isUploading"
+      <span
         class="d-recipe-attachment-carousel__image-progress-bar"
-        :progress="mediaItem.progress"
-        :aria-label="i18n.$t('DIALTONE_IMAGE_CAROUSEL_PROGRESS_BAR_ARIA_LABEL')"
-      />
+      >
+        <dt-progress-circle
+          v-if="mediaItem.isUploading"
+          kind="brand"
+          :progress="mediaItem.progress"
+          :aria-label="i18n.$t('DIALTONE_IMAGE_CAROUSEL_PROGRESS_BAR_ARIA_LABEL')"
+        />
+      </span>
       <dt-button
         :id="`closeButton-${index}`"
         tabindex="0"

--- a/packages/dialtone-vue/recipes/conversation_view/attachment_carousel/media_components/image_carousel.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/attachment_carousel/media_components/image_carousel.vue
@@ -19,7 +19,8 @@
         <dt-progress-circle
           v-if="mediaItem.isUploading"
           kind="brand"
-          :progress="mediaItem.progress"
+          size="400"
+          :progress="66"
           :aria-label="i18n.$t('DIALTONE_IMAGE_CAROUSEL_PROGRESS_BAR_ARIA_LABEL')"
         />
       </span>

--- a/packages/dialtone-vue/recipes/conversation_view/attachment_carousel/media_components/image_carousel.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/attachment_carousel/media_components/image_carousel.vue
@@ -20,7 +20,7 @@
           v-if="mediaItem.isUploading"
           kind="brand"
           size="400"
-          :progress="66"
+          :progress="mediaItem.progress"
           :aria-label="i18n.$t('DIALTONE_IMAGE_CAROUSEL_PROGRESS_BAR_ARIA_LABEL')"
         />
       </span>


### PR DESCRIPTION
<img width="371" height="208" alt="image" src="https://github.com/user-attachments/assets/b2589c7b-18b7-4c74-ad77-9d39cd12a40e" />

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

NO-JIRA

## :book: Description

- Added stroke-linecap="round" to DtProgressCircle fill shape
- Polished DtProgressCircle stroke rendering with rounded linecaps and minimum visual thresholds
- Replaced DtIconLoading icon import in DtLoader with an inline SVG spinner arc that visually aligns with DtProgressCircle
- Added a comet-fade conic-gradient mask to the loader icon so the leading edge fades to transparent

## :bulb: Context

After landing the DtProgressCircle component, we aligned DtLoader (the indeterminate spinner) to use a matching SVG arc so the two components share a consistent visual language. The loader also gains a comet-tail fade effect via a CSS mask for a more polished spin animation.

## :package: Cross-Package Impact

| Package | Changes | Downstream Impact |
|---|---|---|
| dialtone-css | Updated loader.less, progress_circle.less | Vue components depend on these styles |
| dialtone-vue | Updated DtLoader SVG, polished DtProgressCircle | --- |

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

- Validate comet-fade visually in light and dark mode across all loader sizes

https://github.com/user-attachments/assets/8d517828-1e10-484c-a5fc-715ed65b2e07

https://github.com/user-attachments/assets/0bd50a1b-156a-4b47-a312-83d5c47a525b



