### PR TITLE
docs: NO-JIRA fix focus left-nav items on keypress down up

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/SidebarItem.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/SidebarItem.vue
@@ -123,6 +123,7 @@
               importance="clear"
               kind="muted"
               label-class="d-jc-flex-start"
+              :data-sidebar-link="subItem.link"
               :class="[
                 'd-w100p d-fw-normal',
                 { 'd-pl48': depth === 0 },


### PR DESCRIPTION
# Fix ability to focus each left-nav item on keypress while filtering left nav

## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :book: Description

This functionality was broken at some point recently, likely as a result of a `staging` to `next` merge.