### PR TITLE
feat(popover,hovercard): DP-175404 support externalAnchorElement

### DIFF
--- a/packages/dialtone-vue/components/hovercard/hovercard.vue
+++ b/packages/dialtone-vue/components/hovercard/hovercard.vue
@@ -16,6 +16,7 @@
     :header-class="headerClass"
     :footer-class="footerClass"
     :append-to="appendTo"
+    :external-anchor-element="externalAnchorElement"
     data-qa="dt-hovercard"
     :enter-delay="enterDelay"
     :leave-delay="leaveDelay"
@@ -202,6 +203,15 @@ const props = defineProps({
   leaveDelay: {
     type: Number,
     default: TOOLTIP_DELAY_MS,
+  },
+
+  /**
+   * External anchor element reference. Use this instead of the anchor slot when
+   * the anchor may be inside a Shadow DOM, as querySelector cannot pierce shadow boundaries.
+   */
+  externalAnchorElement: {
+    type: HTMLElement,
+    default: null,
   },
 });
 

--- a/packages/dialtone-vue/components/popover/popover.vue
+++ b/packages/dialtone-vue/components/popover/popover.vue
@@ -281,10 +281,20 @@ export default {
     /**
      * External anchor id to use in those cases the anchor can't be provided via the slot.
      * For instance, using the combobox's input as the anchor for the popover.
+     * @deprecated Use externalAnchorElement instead for Shadow DOM compatibility.
      */
     externalAnchor: {
       type: String,
       default: '',
+    },
+
+    /**
+     * External anchor element reference. Use this instead of externalAnchor when
+     * the anchor may be inside a Shadow DOM, as querySelector cannot pierce shadow boundaries.
+     */
+    externalAnchorElement: {
+      type: HTMLElement,
+      default: null,
     },
 
     /**
@@ -642,6 +652,10 @@ export default {
       });
     },
 
+    externalAnchorElement () {
+      this.updateAnchorEl();
+    },
+
     placement (placement) {
       this.tip?.setProps({
         placement,
@@ -718,9 +732,10 @@ export default {
     },
 
     updateAnchorEl () {
-      const externalAnchorEl = this.externalAnchor
-        ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
-        : null;
+      const externalAnchorEl = this.externalAnchorElement ||
+        (this.externalAnchor
+          ? this.$refs.anchor.getRootNode().querySelector(`#${this.externalAnchor}`)
+          : null);
       const anchorEl = externalAnchorEl ?? this.$refs.anchor.children[0];
       if (anchorEl === this.anchorEl) {
         return;


### PR DESCRIPTION
# feat(popover,hovercard): DP-175404 support externalAnchorElement

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGxmaTcxZmxwZ2VhZGFueDd5ZmZ0MHl1YXZ6b3JsMjl5a2s0aWZ4dCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Tq2tPTrQANKfK/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-175404

## :book: Description

Added new prop externalAnchorElement to popover and hovercard

## :bulb: Context

Kind of a follow up from PR from earlier today https://github.com/dialpad/dialtone/pull/1100 to support the same behaviour in popover and hovercard that we added to tooltip, this will also help me complete ticket https://dialpad.atlassian.net/browse/DP-175404 avoiding a really hacky product side workaround.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
