### PR TITLE
feat(button): DLT-3086 update loading state to use dt-loader component

### DIFF
--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -1078,47 +1078,52 @@ Loading buttons are useful for communicating a delay between the button interact
 The width of the button remains determined by the length of the label, which is visually hidden in this state.
 
 <code-well-header>
-  <dt-stack
-    gap="600"
-    :direction="{ 'default': 'column', 'md': 'row' }"
-  >
-    <dt-stack direction="row" gap="400">
-      <dt-button loading> Place Call </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" loading>
-        <template #icon>
-          <dt-icon
-            name="phone"
-            size="300"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" circle loading>
-        <template #icon>
-          <dt-icon
-            name="phone"
-            size="300"
-          />
-        </template>
-      </dt-button>
-    </dt-stack>
-    <dt-stack direction="row" gap="400">
-      <dt-button kind="muted" importance="outlined" loading> Place Call </dt-button>
-      <dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" loading>
-        <template #icon>
-          <dt-icon
-            name="phone"
-            size="300"
-          />
-        </template>
-      </dt-button>
-      <dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" circle loading>
-        <template #icon>
-          <dt-icon
-            name="phone"
-            size="300"
-          />
-        </template>
-      </dt-button>
+  <dt-stack gap="500" align="center">
+    <dt-toggle size="sm" v-model="loading" wrapperClass="d-g8">
+      Loading
+    </dt-toggle>
+    <dt-stack
+      gap="600"
+      :direction="{ 'default': 'column', 'md': 'row' }"
+    >
+      <dt-stack direction="row" gap="400">
+        <dt-button :loading="loading"> Place Call </dt-button>
+        <dt-button v-dt-tooltip="`Tooltip`" :loading="loading">
+          <template #icon>
+            <dt-icon
+              name="phone"
+              size="300"
+            />
+          </template>
+        </dt-button>
+        <dt-button v-dt-tooltip="`Tooltip`" circle :loading="loading">
+          <template #icon>
+            <dt-icon
+              name="phone"
+              size="300"
+            />
+          </template>
+        </dt-button>
+      </dt-stack>
+      <dt-stack direction="row" gap="400">
+        <dt-button kind="muted" importance="outlined" :loading="loading"> Place Call </dt-button>
+        <dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" :loading="loading">
+          <template #icon>
+            <dt-icon
+              name="phone"
+              size="300"
+            />
+          </template>
+        </dt-button>
+        <dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" circle :loading="loading">
+          <template #icon>
+            <dt-icon
+              name="phone"
+              size="300"
+            />
+          </template>
+        </dt-button>
+      </dt-stack>
     </dt-stack>
   </dt-stack>
 </code-well-header>
@@ -1298,5 +1303,8 @@ We provide the following branded buttons for log-in and sign-up workflows.
 <component-class-table component-name="button"></component-class-table>
 
 <script setup>
+import { ref } from 'vue';
 import ButtonVariantsTable from '@baseComponents/ButtonVariantsTable.vue';
+
+const loading = ref(true);
 </script>

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -561,7 +561,38 @@
 //  $$  LOADING STATE
 //  ----------------------------------------------------------------------------
 .d-btn--loading {
-  .d-btn-loading();
+  //  Disable clicking while the loader is in place
+  pointer-events: none;
+
+  //  Hide anything that was there before
+  .d-btn__icon,
+  .d-btn__label {
+    opacity: 0;
+    transition: opacity 50ms var(--ttf-in-out);
+  }
+
+  //  Pseudo-element spinner (fallback for raw HTML consumers)
+  &::before {
+    position: absolute;
+    width: var(--dt-size-500);
+    height: var(--dt-size-500);
+    border: var(--dt-size-200) solid currentColor;
+    border-left-color: transparent !important;
+    border-radius: var(--dt-size-radius-circle);
+    animation: d-loading-circle 900ms infinite linear;
+    content: "";
+  }
+
+  // When a real DtLoader element is present, suppress the pseudo-element.
+  // Back-compat with old class name.
+  &:has(> .d-btn__loader)::before {
+    content: none;
+  }
+
+  //  Position the DtLoader element within the button
+  > :where(.d-btn__loader) {
+    position: absolute;
+  }
 }
 
 //  $$  DISABLED STATE
@@ -650,35 +681,6 @@
   --brand-color-l: 26%;
 }
 
-//  ============================================================================
-//  @   BUTTON LOADER
-//      Changes the button
-//  ----------------------------------------------------------------------------
-//  @@  BASE STYLE
-//  ----------------------------------------------------------------------------
-.d-btn-loading() {
-  //  Disable clicking while the loader is in place
-  pointer-events: none;
-
-  //  Hide anything that was there before
-  .d-btn__icon,
-  .d-btn__label {
-    opacity: 0;
-    transition: opacity 50ms var(--ttf-in-out);
-  }
-
-  //  Show the loading animation
-  &::before {
-    position: absolute;
-    width: var(--dt-size-500);
-    height: var(--dt-size-500);
-    border: var(--dt-size-200) solid currentColor;
-    border-left-color: transparent !important;
-    border-radius: var(--dt-size-radius-circle);
-    animation: d-loading-circle 900ms infinite linear;
-    content: "";
-  }
-}
 
 //  ============================================================================
 //  $   SPLIT BUTTON

--- a/packages/dialtone-vue/components/button/button.test.js
+++ b/packages/dialtone-vue/components/button/button.test.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import DtButton from './button.vue';
 import EmptyComponentFixture from '@/tests/fixtures/component.vue';
+import { BUTTON_ICON_SIZES } from './button_constants';
 
 const MOCK_BUTTON_STUB = vi.fn();
 
@@ -124,29 +125,36 @@ describe('DtButton Tests', () => {
       });
 
       describe('When button has loading set to true', () => {
-        it('Should have loading class', async () => {
-          await wrapper.setProps({
-            loading: true,
-          });
-
+        beforeEach(async () => {
+          await wrapper.setProps({ loading: true });
           button = wrapper.find('.base-button__button');
+        });
+
+        it('Should have loading class and render a correctly sized loader', () => {
+          const loader = wrapper.find('[data-qa="dt-loader"]');
 
           expect(button.classes().includes('d-btn--loading')).toBe(true);
+          expect(loader.exists()).toBe(true);
+          expect(loader.attributes('aria-hidden')).toBe('true');
+          expect(loader.find('[data-qa="dt-loader-icon"]').classes())
+            .toContain(`d-icon--size-${BUTTON_ICON_SIZES.md}`);
         });
       });
 
       describe('When button has loading set to false', () => {
-        it('should not have loading class', async () => {
-          await wrapper.setProps({
-            loading: false,
-          });
+        it('should not have loading class or loader', async () => {
+          await wrapper.setProps({ loading: false });
 
-          const expected = ['base-button__button', 'd-btn', 'd-btn--primary'];
+          expect(button.classes().includes('d-btn--loading')).toBe(false);
+          expect(wrapper.find('[data-qa="dt-loader"]').exists()).toBe(false);
+        });
+      });
 
-          expect(button
-            .classes()
-            .every(function (value, index) { return value === expected[index]; }))
-            .toBe(true);
+      describe('When button is unstyled and loading', () => {
+        it('Should not render a loader', async () => {
+          await wrapper.setProps({ kind: 'unstyled', loading: true });
+
+          expect(wrapper.find('[data-qa="dt-loader"]').exists()).toBe(false);
         });
       });
 

--- a/packages/dialtone-vue/components/button/button.vue
+++ b/packages/dialtone-vue/components/button/button.vue
@@ -12,6 +12,12 @@
     v-bind="computedAttrs"
     v-on="computedListeners"
   >
+    <dt-loader
+      v-if="loading && kind !== 'unstyled'"
+      class="d-btn__loader"
+      :size="loaderSize"
+      aria-hidden="true"
+    />
     <!-- NOTE(cormac): This span is needed since we can't apply styles to slots. -->
     <span
       v-if="shouldRenderIcon()"
@@ -48,6 +54,7 @@
 <script>
 import { warn, resolveComponent } from 'vue';
 import { hasSlotContent } from '@/common/utils';
+import DtLoader from '@/components/loader/loader.vue';
 
 import {
   BUTTON_SIZE_MODIFIERS,
@@ -71,6 +78,8 @@ import { DialtoneLocalization } from '@/localization';
 export default {
   compatConfig: { MODE: 3 },
   name: 'DtButton',
+
+  components: { DtLoader },
 
   props: {
     /**
@@ -371,6 +380,10 @@ export default {
     },
 
     iconSize () {
+      return BUTTON_ICON_SIZES[this.size];
+    },
+
+    loaderSize () {
       return BUTTON_ICON_SIZES[this.size];
     },
   },


### PR DESCRIPTION
![Obligatory GIF](https://c.tenor.com/jfmI0j5FcpAAAAAd/tenor.gif)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-3086](https://dialpad.atlassian.net/browse/DLT-3086)

## :book: Description

Follow up to https://github.com/dialpad/dialtone/pull/1098 and https://github.com/dialpad/dialtone/pull/1102

- DtButton's loading state now renders a `<DtLoader>` component instead of relying solely on a CSS `::before` pseudo-element spinner.
- The CSS `::before` fallback is preserved for backwards compatibility with raw HTML consumers. A `:has(> .d-btn__loader)` rule suppresses it when the Vue loader is present.
- Loader size scales proportionally to button size via existing `BUTTON_ICON_SIZES` mapping.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

https://github.com/user-attachments/assets/b6f127db-0af1-4c4b-b3f0-46024c9aceb9




[DLT-3086]: https://dialpad.atlassian.net/browse/DLT-3086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ