### PR TITLE
feat(hovercard): DP-175404 expose functions to control hide/show

### DIFF
--- a/packages/dialtone-vue/.storybook/main.js
+++ b/packages/dialtone-vue/.storybook/main.js
@@ -34,6 +34,9 @@ const config = {
       css: {
         devSourcemap: true,
       },
+      optimizeDeps: {
+        include: ['react-dom/client'],
+      },
     });
   },
 

--- a/packages/dialtone-vue/components/hovercard/hovercard.stories.js
+++ b/packages/dialtone-vue/components/hovercard/hovercard.stories.js
@@ -3,6 +3,7 @@ import DtHovercard from './hovercard.vue';
 import DtHovercardDefaultTemplate from './hovercard_default.story.vue';
 import DtHovercardManyTemplate from './hovercard_many.story.vue';
 import DtHovercardWithInputTemplate from './hovercard_with_input.story.vue';
+import DtHovercardExternalAnchorTemplate from './hovercard_external_anchor.story.vue';
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import { action } from 'storybook/actions';
 import {
@@ -211,4 +212,31 @@ export const WithInput = {
     </dt-stack>`,
   })],
   args: { ...Default.args, offset: [0, 5] },
+};
+
+const ExternalAnchorTemplate = (args, { argTypes }) => createTemplateFromVueFile(
+  args,
+  argTypes,
+  DtHovercardExternalAnchorTemplate,
+);
+export const ExternalAnchor = {
+  render: ExternalAnchorTemplate,
+  decorators: [() => ({
+    template: `<dt-stack direction="row" justify="center" align="center" class="d-h464">
+      <div class="d-w332">
+        <story />
+      </div>
+    </dt-stack>`,
+  })],
+  args: { ...Default.args },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Demonstrates using <code>externalAnchorElement</code> with the exposed <code>show()</code>/<code>hide()</code> API. ' +
+          'This pattern is used when the anchor lives outside the hovercard\'s DOM scope (e.g. inside a Shadow DOM), ' +
+          'so the hovercard cannot detect hover events automatically. ' +
+          'The parent listens for hover events and calls <code>show()</code>/<code>hide()</code> directly on the hovercard ref.',
+      },
+    },
+  },
 };

--- a/packages/dialtone-vue/components/hovercard/hovercard.test.js
+++ b/packages/dialtone-vue/components/hovercard/hovercard.test.js
@@ -160,6 +160,58 @@ describe('DtHovercard Tests', () => {
     });
   });
 
+  describe('With externalAnchorElement — show/hide API Tests', () => {
+    let externalAnchorWrapper;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+
+      const externalEl = document.createElement('span');
+      document.body.appendChild(externalEl);
+
+      externalAnchorWrapper = mount(DtHovercard, {
+        props: {
+          ...baseProps,
+          id: 'hovercard-external',
+          externalAnchorElement: externalEl,
+        },
+        slots: { content: MOCK_DEFAULT_SLOT_MESSAGE },
+        global: { stubs: { transition: false } },
+        attachTo: document.body,
+      });
+    });
+
+    afterEach(() => {
+      externalAnchorWrapper.unmount();
+    });
+
+    describe('When show() is called', () => {
+      beforeEach(() => {
+        externalAnchorWrapper.vm.show();
+        vi.runAllTimers();
+      });
+
+      it('should show the hovercard after the enter delay', () => {
+        content = getHovercardContent();
+        expect(content.textContent).toBe(MOCK_DEFAULT_SLOT_MESSAGE);
+      });
+    });
+
+    describe('When hide() is called after show()', () => {
+      beforeEach(() => {
+        externalAnchorWrapper.vm.show();
+        vi.runAllTimers();
+        externalAnchorWrapper.vm.hide();
+        vi.runAllTimers();
+      });
+
+      it('should hide the hovercard after the leave delay', () => {
+        content = getHovercardContent();
+        expect(content).toBeNull();
+      });
+    });
+  });
+
   describe('Accessibility Tests', () => {
     describe('When hovercard is open', () => {
       beforeEach(async () => {

--- a/packages/dialtone-vue/components/hovercard/hovercard.vue
+++ b/packages/dialtone-vue/components/hovercard/hovercard.vue
@@ -262,6 +262,8 @@ watch(() => props.open, (open) => {
   hovercardOpen.value = open;
 }, { immediate: true });
 
+defineExpose({ show: onMouseEnter, hide: onMouseLeave });
+
 function setInTimer () {
   if (props.open === null) {
     clearTimeout(outTimer.value);

--- a/packages/dialtone-vue/components/hovercard/hovercard_external_anchor.story.vue
+++ b/packages/dialtone-vue/components/hovercard/hovercard_external_anchor.story.vue
@@ -123,6 +123,5 @@ function onMentionEnter () {
 
 function onMentionLeave () {
   hovercard.value?.hide();
-  mentionElement.value = null;
 }
 </script>

--- a/packages/dialtone-vue/components/hovercard/hovercard_external_anchor.story.vue
+++ b/packages/dialtone-vue/components/hovercard/hovercard_external_anchor.story.vue
@@ -1,0 +1,128 @@
+<!-- eslint-disable vuejs-accessibility/no-static-element-interactions -->
+<!-- eslint-disable vuejs-accessibility/mouse-events-have-key-events -->
+<template>
+  <p class="d-body--md">
+    Send a message to
+    <span
+      ref="mentionEl"
+      class="d-fw-bold d-fc-primary d-c-pointer"
+      @mouseenter="onMentionEnter"
+      @mouseleave="onMentionLeave"
+    >@Jaqueline Nackos</span>
+    to get started.
+  </p>
+
+  <dt-hovercard
+    :id="$attrs.id"
+    ref="hovercard"
+    :placement="$attrs.placement"
+    :content-class="$attrs.contentClass"
+    :fallback-placements="$attrs.fallbackPlacements"
+    :padding="$attrs.padding"
+    :transition="$attrs.transition"
+    :offset="$attrs.offset"
+    :header-class="$attrs.headerClass"
+    :footer-class="$attrs.footerClass"
+    :append-to="$attrs.appendTo"
+    :enter-delay="$attrs.enterDelay"
+    :leave-delay="$attrs.leaveDelay"
+    :external-anchor-element="mentionElement"
+    @opened="$attrs.onOpened"
+  >
+    <template #content>
+      <dt-stack
+        direction="column"
+        gap="400"
+      >
+        <dt-stack
+          direction="row"
+          gap="300"
+        >
+          <dt-avatar
+            full-name="Jaqueline Nackos"
+            :image-src="defaultImage"
+            image-alt="Person avatar"
+            seed="JN"
+            size="md"
+            presence="busy"
+          />
+          <dt-stack
+            direction="column"
+            gap="0"
+          >
+            <p class="d-headline--md-compact">
+              Jaqueline Nackos
+            </p>
+            <p class="d-body--sm d-fc-tertiary">
+              <span class="d-fc-critical">In a meeting</span> • Working from SF
+            </p>
+          </dt-stack>
+        </dt-stack>
+        <dt-stack
+          direction="column"
+          gap="300"
+          class="d-fc-secondary"
+        >
+          <p>
+            Vice President of Sales Enablement Aerolabs
+          </p>
+          <dt-stack
+            direction="row"
+            gap="300"
+          >
+            <dt-icon
+              name="clock-4"
+              size="200"
+            />
+            <p class="d-body--sm">
+              <b>Local Time:</b> 12:32 PM
+            </p>
+          </dt-stack>
+        </dt-stack>
+        <dt-stack
+          direction="row"
+          gap="400"
+        >
+          <dt-button
+            width="var(--dt-size-100-percent)"
+            importance="outlined"
+            kind="muted"
+          >
+            Call
+          </dt-button>
+          <dt-button
+            width="var(--dt-size-100-percent)"
+            importance="outlined"
+            kind="muted"
+          >
+            Message
+          </dt-button>
+        </dt-stack>
+      </dt-stack>
+    </template>
+  </dt-hovercard>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import DtHovercard from './hovercard.vue';
+import defaultImage from '@/common/assets/avatar2.png';
+import DtStack from '../stack/stack.vue';
+import DtIcon from '../icon/icon.vue';
+import DtButton from '../button/button.vue';
+import DtAvatar from '../avatar/avatar.vue';
+
+const hovercard = ref(null);
+const mentionEl = ref(null);
+const mentionElement = ref(null);
+
+function onMentionEnter () {
+  mentionElement.value = mentionEl.value;
+  hovercard.value?.show();
+}
+
+function onMentionLeave () {
+  hovercard.value?.hide();
+  mentionElement.value = null;
+}
+</script>


### PR DESCRIPTION
  ## Obligatory GIF (super important!)

  ![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExbTBleWVyOGRpeGo0NmNqY2N3MXExZzIzenYydDZ3ZDk1cmdiemR3aSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT9IgG50Fb7Mi0prBC/giphy.gif)

  ## :hammer_and_wrench: Type Of Change

  - [x] Feature

  ## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-175404

  ## :book: Description

  Exposes `show()` and `hide()` methods on `DtHovercard` via `defineExpose`, enabling parent components to programmatically control hovercard visibility. This is needed when the anchor element lives outside the hovercard's DOM scope

  ## :bulb: Context

Needed when using hovercard with externalAnchorElement, you need to be able to trigger show/hide while retaining the internal timing behaviour.

  ## :pencil: Checklist

  For all PRs:

  - [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
  - [x] I have reviewed my changes.
  - [x] I have added all relevant documentation.
  - [x] I have considered the performance impact of my change.

  For all Vue changes:

  - [x] I have added / updated unit tests.