### PR TITLE
docs: DLT-3087 improve SEO meta tags, OG, canonical, robots.txt

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/config.js
+++ b/apps/dialtone-documentation/docs/.vuepress/config.js
@@ -74,6 +74,24 @@ export default defineUserConfig({
     ['link', { rel: 'mask-icon', href: baseURL + 'assets/images/favicons/safari-pinned-tab.svg', color: '#7C52FF' }],
     ['meta', { name: 'msapplication-TileColor', content: '#7C52FF' }],
     ['meta', { name: 'theme-color', content: '#ffffff' }],
+    // Site-level SEO defaults
+    ['meta', { name: 'description', content: 'Dialtone is Dialpad\'s design system — tokens, CSS utilities, and Vue components for building consistent UIs.' }],
+    ['meta', { property: 'og:site_name', content: 'Dialtone Design System' }],
+    ['meta', { name: 'twitter:site', content: '@dialpad' }],
+    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    // JSON-LD
+    ['script', { type: 'application/ld+json' }, JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      name: 'Dialtone Design System',
+      url: 'https://dialtone.dialpad.com',
+      description: 'Dialpad\'s design system — tokens, CSS utilities, and Vue components.',
+      publisher: {
+        '@type': 'Organization',
+        name: 'Dialpad',
+        url: 'https://www.dialpad.com',
+      },
+    })],
   ],
 
   // markdown config
@@ -99,5 +117,36 @@ export default defineUserConfig({
     '@projectRoot': path.resolve(__dirname, '../../'),
     '@': path.resolve(__dirname, '../'),
     '@workspaceRoot': path.resolve(__dirname, '../../../../'),
+  },
+
+  extendsPage: (page) => {
+    const SITE_URL = 'https://dialtone.dialpad.com';
+    const DEFAULT_IMAGE = `${SITE_URL}/assets/images/home-hero.png`;
+
+    const title = page.frontmatter.title || page.frontmatter.heading;
+    const desc = page.frontmatter.description;
+    const image = page.frontmatter.image
+      ? `${SITE_URL}/${page.frontmatter.image}`
+      : DEFAULT_IMAGE;
+    const url = `${SITE_URL}${page.path}`;
+
+    page.frontmatter.head ??= [];
+
+    if (desc) {
+      page.frontmatter.head.push(['meta', { name: 'description', content: desc }]);
+      page.frontmatter.head.push(['meta', { property: 'og:description', content: desc }]);
+      page.frontmatter.head.push(['meta', { name: 'twitter:description', content: desc }]);
+    }
+    if (title) {
+      page.frontmatter.head.push(['meta', { property: 'og:title', content: `${title} | Dialtone Design System` }]);
+      page.frontmatter.head.push(['meta', { name: 'twitter:title', content: `${title} | Dialtone Design System` }]);
+    }
+
+    page.frontmatter.head.push(
+      ['meta', { property: 'og:url', content: url }],
+      ['meta', { property: 'og:image', content: image }],
+      ['meta', { property: 'og:type', content: 'website' }],
+      ['link', { rel: 'canonical', href: url }],
+    );
   },
 });

--- a/apps/dialtone-documentation/docs/.vuepress/config.js
+++ b/apps/dialtone-documentation/docs/.vuepress/config.js
@@ -123,7 +123,8 @@ export default defineUserConfig({
     const SITE_URL = 'https://dialtone.dialpad.com';
     const DEFAULT_IMAGE = `${SITE_URL}/assets/images/home-hero.png`;
 
-    const title = page.frontmatter.title || page.frontmatter.heading;
+    const title = page.frontmatter.title || page.frontmatter.heading || page.title || 'Dialtone Design System';
+    const seoTitle = title === 'Dialtone Design System' ? title : `${title} | Dialtone Design System`;
     const desc = page.frontmatter.description;
     const image = page.frontmatter.image
       ? `${SITE_URL}/${page.frontmatter.image}`
@@ -137,10 +138,9 @@ export default defineUserConfig({
       page.frontmatter.head.push(['meta', { property: 'og:description', content: desc }]);
       page.frontmatter.head.push(['meta', { name: 'twitter:description', content: desc }]);
     }
-    if (title) {
-      page.frontmatter.head.push(['meta', { property: 'og:title', content: `${title} | Dialtone Design System` }]);
-      page.frontmatter.head.push(['meta', { name: 'twitter:title', content: `${title} | Dialtone Design System` }]);
-    }
+
+    page.frontmatter.head.push(['meta', { property: 'og:title', content: seoTitle }]);
+    page.frontmatter.head.push(['meta', { name: 'twitter:title', content: seoTitle }]);
 
     page.frontmatter.head.push(
       ['meta', { property: 'og:url', content: url }],

--- a/apps/dialtone-documentation/docs/.vuepress/public/robots.txt
+++ b/apps/dialtone-documentation/docs/.vuepress/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://dialtone.dialpad.com/sitemap.xml

--- a/apps/dialtone-documentation/docs/.vuepress/theme/index.js
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/index.js
@@ -119,6 +119,12 @@ export const dialtoneVuepressTheme = (options) => ({
       }),
       sitemapPlugin({
         hostname: 'https://dialtone.dialpad.com',
+        changefreq: 'weekly',
+        modifyTimeGetter: (page) =>
+          page.git?.updatedTime
+            ? new Date(page.git.updatedTime).toISOString()
+            : new Date().toISOString(),
+        excludePaths: ['/404.html'],
       }),
     ],
 

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2022-11-18.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2022-11-18.md
@@ -2,6 +2,7 @@
 heading: Release of our new blog!
 author: Brad Paugh
 posted: '2022-11-18'
+description: Launch of the Dialtone What's New blog. Covers new icon components, overview pages, small toggle size, presence component, and team news.
 ---
 <!-- Note the date must be in this format YYYY-M-D and wrapped in single quotes -->
 

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2022-12-9.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2022-12-9.md
@@ -2,6 +2,7 @@
 heading: Badge update - breaking change
 author: Brad Paugh
 posted: '2022-12-9'
+description: Badge component redesigned with new type and kind props, icon support, and semantic variants. Breaking changes in Dialtone v7.9.0. Avatar and combobox also updated.
 ---
 <!-- Note the date must be in this format YYYY-M-D and wrapped in single quotes -->
 

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2023-10-30.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2023-10-30.md
@@ -2,6 +2,7 @@
 heading: Deprecated icons, new tooltip directive
 author: Brad Paugh
 posted: '2023-10-30'
+description: Old Dialtone icons removed November 13th — migrate to the new icon set. Introduces the v-dt-tooltip directive for simple tooltip usage.
 ---
 <!-- Note the date must be in this format YYYY-M-D and wrapped in single quotes -->
 

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2023-12-28.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2023-12-28.md
@@ -2,6 +2,7 @@
 heading: Dialtone 9 released and published with @next tag
 author: Tico Ortega
 posted: '2023-12-28'
+description: Dialtone 9 consolidates all packages into the @dialpad/dialtone mono-package, published under the @next tag. Migration steps from v8 included.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2023-2-7.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2023-2-7.md
@@ -2,6 +2,7 @@
 heading: Avatar - breaking change
 author: Brad Paugh
 posted: '2023-2-7'
+description: Avatar HTML/CSS structure updated in v7.16.0 — requires new wrapper divs for initials and icon modes. Vue component users are unaffected.
 ---
 <!-- Note the date must be in this format YYYY-M-D and wrapped in single quotes -->
 

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2023-5-4.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2023-5-4.md
@@ -2,6 +2,7 @@
 heading: Dialtone Vue - upgrade to Vite, Jest, and Storybook 7.0
 author: Brad Paugh
 posted: '2023-5-4'
+description: Dialtone Vue migrates from webpack to Vite, Mocha to Jest, and upgrades to Storybook 7.0. Includes a small breaking change for Vue 2 CSS imports.
 ---
 <!-- Note the date must be in this format YYYY-M-D and wrapped in single quotes -->
 

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2023-8-3.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2023-8-3.md
@@ -2,6 +2,7 @@
 heading: Dialtone 8 released and promoted to the main branch
 author: Brad Paugh
 posted: '2023-8-3'
+description: Dialtone 8 is now on the main branch, featuring design tokens, theming support, dark mode, and multi-platform consistency. Migration guide included.
 ---
 <!-- Note the date must be in this format YYYY-M-D and wrapped in single quotes -->
 

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-10-3.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-10-3.md
@@ -2,6 +2,7 @@
 heading: Dialtone Vue is now fully tree-shakeable (BREAKING CHANGE)
 author: Nina Repetto
 posted: '2024-10-3'
+description: Avatar, Badge, and Empty State now use icon slots instead of name props. Breaking change in v9.77.0 — icon-left and icon-right props removed.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-11-25.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-11-25.md
@@ -2,6 +2,7 @@
 heading: Component class renames (POSSIBLE BREAKING CHANGE)
 author: Brad Paugh
 posted: '2024-11-25'
+description: Internal Dialtone Vue component CSS classes renamed to follow standard conventions. Only affects projects that override Dialtone component CSS directly.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-12-10.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-12-10.md
@@ -2,6 +2,7 @@
 heading: Recipe class renames (POSSIBLE BREAKING CHANGE)
 author: Brad Paugh
 posted: '2024-12-10'
+description: Recipe CSS classes renamed for consistency with the rest of Dialtone components. Only affects projects that reference recipe internals directly.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-3-20.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-3-20.md
@@ -2,6 +2,7 @@
 heading: Updated Text Styles naming convention
 author: Yorbi Barriento
 posted: '2024-3-20'
+description: Typography tokens renamed for consistency across Figma, CSS utilities, and CSS variables. Backwards-compatible — migration to the new convention encouraged.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-4-15.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-4-15.md
@@ -2,6 +2,7 @@
 heading: Added Tree-shaking support for dialtone-vue and dialtone-icons
 author: Tico Ortega
 posted: '2024-4-15'
+description: Dialtone Vue gains tree-shaking support, significantly reducing bundle size. New import patterns and direct dialtone-icons usage introduced.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-5-15.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-5-15.md
@@ -2,6 +2,7 @@
 heading: Promoted Dialtone 9 to latest
 author: Tico Ortega
 posted: '2024-5-15'
+description: Dialtone 9 is now the default — install with @latest. Migration guide linked for those not yet on v9.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-7-8.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-7-8.md
@@ -2,6 +2,7 @@
 heading: New search in the tokens page and new empty state component
 author: Nina Repetto
 posted: '2024-7-8'
+description: Tokens page redesigned with search, copy support, and category sidebar. New Empty State component introduced for handling no-data scenarios.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-8-1.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-8-1.md
@@ -2,6 +2,7 @@
 heading: Dialtone theming released! (BREAKING CHANGE)
 author: Brad Paugh
 posted: '2024-8-1'
+description: Dialtone now supports multiple themes including T-Mobile and Marketing. Breaking change — theme tokens must now be imported separately from @dialpad/dialtone/css.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2024-8-13.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2024-8-13.md
@@ -2,6 +2,7 @@
 heading: Vue and HTML examples on Documentation site
 author: Julio Ortega
 posted: '2024-8-13'
+description: Vue component examples are now available directly on the Dialtone documentation site, unifying Storybook and the main docs site experience.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2025-12-2.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2025-12-2.md
@@ -2,6 +2,7 @@
 heading: 'Migrating from Flex CSS Utilities to DtStack'
 author: Francis Rupert
 posted: '2025-12-2'
+description: Guide and migration tool for replacing d-d-flex utilities with the DtStack component. Covers automatic migration, edge cases, and flex-to-prop mapping.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2025-4-15.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2025-4-15.md
@@ -2,6 +2,7 @@
 heading: Vue 3 input components v-model breaking change
 author: Brad Paugh
 posted: '2025-4-15'
+description: Dialtone Vue 3 input components now use modelValue instead of value and checked props, aligning with Vue 3 standards for v-model.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2025-5-6.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2025-5-6.md
@@ -2,6 +2,7 @@
 heading: Breaking change in postcss-responsive-variations plugin
 author: Nina Repetto
 posted: '2025-5-6'
+description: Responsive variations switch from max-width to min-width media queries, enabling mobile-first design. Migration steps and plugin setup instructions included.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2025-8-22.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2025-8-22.md
@@ -2,6 +2,7 @@
 heading: 'Guide: Replacing Hard-Coded or Base tokens for Chart Tokens'
 author: Federico Sarassola
 posted: '2025-8-22'
+description: Step-by-step guide for replacing hard-coded chart colors with Dialtone's semantic chart tokens in CSS, Google Charts, and Vue components.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">

--- a/apps/dialtone-documentation/docs/about/whats-new/posts/2026-1-14.md
+++ b/apps/dialtone-documentation/docs/about/whats-new/posts/2026-1-14.md
@@ -2,6 +2,7 @@
 heading: 'No More Vue 2 in Dialtone!'
 author: Brad Paugh
 posted: '2026-1-14'
+description: Dialtone drops Vue 2 support — all consumers are already on Vue 3. Last Vue 2 version is 9.154.0.
 ---
 
 <BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/xT9IgG50Lg7russbGB/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation

## :book: Jira Ticket

[DLT-3087](https://dialpad.atlassian.net/browse/DLT-3087)

## :book: Description

`dialtone.dialpad.com` had dropped in search rankings. The raw SEO data (descriptions, images, titles) already existed in VuePress frontmatter on 170+ pages, but nothing was ever wired into `<head>`. This change adds the full SEO signal layer:

- **`extendsPage` hook** (`config.js`): wires each page's frontmatter `description`, `title`, and `image` into `<meta name="description">`, `og:description`, `og:title`, `og:url`, `og:image`, `og:type`, `twitter:description`, `twitter:title`, and `<link rel="canonical">`
- **Site-level head defaults** (`config.js`): adds fallback `<meta name="description">`, `og:site_name`, `twitter:site`, `twitter:card`, and a JSON-LD `WebSite` + `Organization` schema
- **Sitemap tuning** (`theme/index.js`): `changefreq` → `weekly`, git-based `modifyTimeGetter`, excludes `/404.html`
- **`robots.txt`** (`public/robots.txt`): allows all crawlers, points to sitemap
- **Blog post descriptions**: adds `description` frontmatter to all 21 posts in `about/whats-new/posts/` so they get proper meta tags (note: `theme/index.js` deletes `description` from blog index data, but `extendsPage` runs earlier so `<meta>` tags are already injected)

## :bulb: Context

The site had no meta descriptions, no Open Graph tags, no Twitter cards, no canonical URLs, no robots.txt, and no structured data. All the raw data was already in frontmatter — it just wasn't connected to `<head>`.

## :page_facing_up: Documentation Artifacts

| Artifact | Status |
|---|---|
| VuePress documentation site config | ✅ Updated (`config.js`, `theme/index.js`) |
| Blog post frontmatter | ✅ Updated (21 posts) |
| robots.txt | ✅ Added |
| Vue source / Tests / Storybook / MCP | N/A — docs-only change |

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

- Audit remaining non-blog pages missing `description` frontmatter (utilities, some design pages)
- Consider adding `og:image` frontmatter to high-traffic component pages

## :link: Sources

- [VuePress `extendsPage` hook docs](https://v2.vuepress.vuejs.org/reference/plugin-api.html#extendspage)
- [vuepress-plugin-sitemap2 docs](https://vuepress-theme-hope.github.io/v2/sitemap/)
- [Open Graph protocol](https://ogp.me/)

[DLT-3087]: https://dialpad.atlassian.net/browse/DLT-3087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ