### PR TITLE
fix(editor): DP-179668 some toolbar buttons not returning focus to editor

### DIFF
--- a/packages/dialtone-vue/recipes/conversation_view/editor/EditorToolbarDropdownButton.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/editor/EditorToolbarDropdownButton.vue
@@ -4,6 +4,7 @@
     padding="small"
     navigation-type="arrow-keys"
     placement="bottom-start"
+    @opened="onDropdownOpened"
   >
     <template #anchor="{ attrs }">
       <dt-button
@@ -28,10 +29,10 @@
         </template>
       </dt-button>
     </template>
-    <template #list="{ close }">
+    <template #list="{ close: dropdownClose }">
       <slot
         name="list"
-        :close="close"
+        :close="(cb) => { pendingCallback = cb; dropdownClose(); }"
       />
     </template>
   </dt-dropdown>
@@ -110,5 +111,22 @@ export default {
      */
     'shift-focus-left',
   ],
+
+  data () {
+    return {
+      pendingCallback: null,
+    };
+  },
+
+  methods: {
+    // Wait until the dropdown is fully closed so the modal's anchor focus
+    // completes first, then the callback can override it (e.g. to focus the editor).
+    onDropdownOpened (isOpen) {
+      if (!isOpen && typeof this.pendingCallback === 'function') {
+        this.pendingCallback();
+        this.pendingCallback = null;
+      }
+    },
+  },
 };
 </script>

--- a/packages/dialtone-vue/recipes/conversation_view/editor/EditorToolbarPopoverButton.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/editor/EditorToolbarPopoverButton.vue
@@ -5,6 +5,7 @@
     navigation-type="arrow-keys"
     placement="bottom-start"
     :open-with-arrow-keys="true"
+    @opened="onPopoverOpened"
   >
     <template #anchor="{ attrs }">
       <dt-button
@@ -29,10 +30,10 @@
         </template>
       </dt-button>
     </template>
-    <template #content="{ close }">
+    <template #content="{ close: popoverClose }">
       <slot
         name="content"
-        :close="close"
+        :close="(cb) => { pendingCallback = cb; popoverClose(); }"
       />
     </template>
   </dt-popover>
@@ -111,5 +112,22 @@ export default {
      */
     'shift-focus-left',
   ],
+
+  data () {
+    return {
+      pendingCallback: null,
+    };
+  },
+
+  methods: {
+    // Wait until the dropdown is fully closed so the modal's anchor focus
+    // completes first, then the callback can override it (e.g. to focus the editor).
+    onPopoverOpened (isOpen) {
+      if (!isOpen && typeof this.pendingCallback === 'function') {
+        this.pendingCallback();
+        this.pendingCallback = null;
+      }
+    },
+  },
 };
 </script>

--- a/packages/dialtone-vue/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/editor/editor.vue
@@ -69,7 +69,7 @@
                       role="option"
                       navigation-type="arrow-keys"
                       @click="
-                        close();
+                        close(focusEditor);
                         onFontStyleSelect(fontStyle.value)
                       "
                     >
@@ -103,7 +103,7 @@
                 role="menuitem"
                 navigation-type="arrow-keys"
                 @click="
-                  close();
+                  close(focusEditor);
                   onFontSizeSelect(fontSize.value, $event)
                 "
               >
@@ -204,7 +204,7 @@
                         navigation-type="arrow-keys"
                         @click="
                           insertVariable(category.name, item);
-                          close();
+                          close(focusEditor);
                         "
                       >
                         {{ item.name }}
@@ -1175,6 +1175,10 @@ export default {
   methods: {
     removeClassStyleAttrs,
     addClassStyleAttrs,
+
+    focusEditor () {
+      this.$refs.richTextEditor?.editor?.commands.focus();
+    },
 
     onInputFocus (event) {
       event?.stopPropagation();


### PR DESCRIPTION
# Some toolbar buttons not returning focus to editor

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZG9ha2wxeTNoZGx5NjJrOGt5cGt4b3U1MTE3MjNvMGswZmQ0cTAxYiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/fV2LPyKvxLBsK1bZXA/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DP-179668

## :book: Description

<!--- Describe specifically what the changes are -->
- Toolbar popover/dropdown buttons now accept an optional callback via `close(cb)` that is called after the popover/dropdown fully closes
- `close()` is passed `focusEditor` as the callback so the editor regains focus after close

## :bulb: Context
When selecting a value from the font style, font size, or variable popover, focus returns to the toolbar button instead of the editor. 
This is not expected as all other editor toolbar buttons return focus to the editor.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

#### Observed bug:

https://github.com/user-attachments/assets/a3a9b920-89e8-4967-b2b6-0aa0435ae6c1

#### Fix:

https://github.com/user-attachments/assets/c59b78f6-00c4-47e4-8a64-0140381e142c

