### PR TITLE
feat(tabs): DLT-3114 add vertical orientation variant

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ClampedTableWrapper.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ClampedTableWrapper.vue
@@ -51,14 +51,14 @@
     </div>
     <div
       v-if="shouldShowButton"
-      class="dialtone-doc-table-clamped__more d-ps-absolute d-bn16 d-l50p"
+      class="dialtone-doc-table-clamped__more d-ps-absolute d-bn8 d-l50p"
       aria-hidden="true"
     >
       <dt-button
         class="dialtone-doc-table-clamped__more-btn d-bgc-secondary d-bs-sm"
         kind="muted"
         importance="outlined"
-        size="sm"
+        size="xs"
         @click="() => handleExpand(scrollRef)"
       >
         {{ buttonLabel }}

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
@@ -2,7 +2,7 @@
   <dt-tab-group
     class="code-example-tab-group"
     activation-mode="auto"
-    size="sm"
+    size="xs"
     @change="selectedPanelId = $event.selected"
   >
     <template #tabs>
@@ -38,7 +38,7 @@
       :id="vuePanelId"
       :tab-id="vueTabId"
     >
-      <div ref="vuePanelRef" v-dt-scrollbar class="language-html d-hmx332" data-ext="html">
+      <div ref="vuePanelRef" v-dt-scrollbar class="language-html d-hmx164" data-ext="html">
         <pre class="language-html" v-html="highlightedVue" />
       </div>
     </dt-tab-panel>
@@ -55,20 +55,20 @@
       >
         Raw HTML renders visuals only. You may need to add JS to replicate its functionality.
       </dt-banner>
-      <div ref="htmlPanelRef" v-dt-scrollbar class="language-html d-hmx332" data-ext="html">
+      <div ref="htmlPanelRef" v-dt-scrollbar class="language-html d-hmx164" data-ext="html">
         <pre class="language-html" v-html="highlightedHtml" />
       </div>
     </dt-tab-panel>
     <div
       v-if="shouldShowButton"
-      class="code-example-tab-group__more d-ps-absolute d-bn16 d-l50p"
+      class="code-example-tab-group__more d-ps-absolute d-bn8 d-l50p"
       aria-hidden="true"
     >
       <dt-button
         class="code-example-tab-group__more-btn d-bgc-secondary d-bs-sm"
         kind="muted"
         importance="outlined"
-        size="sm"
+        size="xs"
         @click="expandCodeBlocks"
       >
         Show all
@@ -148,7 +148,7 @@ const selectedPanelId = ref(vuePanelId);
 const vuePanelRef = ref(null);
 const htmlPanelRef = ref(null);
 const { shouldShowButton, handleExpand, initExpandable } = useDocExpandable({
-  maxHeightClass: 'd-hmx332',
+  maxHeightClass: 'd-hmx164',
 });
 
 /**

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleTabs.vue
@@ -6,6 +6,8 @@
     :inverted="inverted"
     :borderless="borderless"
     :disabled="disabled"
+    :orientation="orientation"
+    :tab-list-class="orientation === 'vertical' ? 'd-w264' : undefined"
     :activation-mode="activationMode"
     @before-change="confirmBeforeLeave"
   >
@@ -38,7 +40,7 @@
       </dt-tab>
     </template>
     <div
-      class="d-ba d-bas-dashed d-mt16 d-bar4 d-bc-subtle"
+      class="d-ba d-baw2 d-bas-dashed d-bc-subtle d-w100p d-plc-center d-py48"
       :class="{
         'd-fc-primary-inverted': inverted,
       }"
@@ -114,6 +116,11 @@ export default {
     activationMode: {
       type: String,
       default: 'manual',
+    },
+
+    orientation: {
+      type: String,
+      default: 'horizontal',
     },
   },
 

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -9,9 +9,10 @@ keywords: ["tab panel", "tab navigation", "d-tabs", "DtTabs", "dt-tabs", "segmen
 ---
 
 <code-well-header>
-  <div class="d-w100p">
+  <dt-stack class="d-w100p" gap="500">
     <example-tabs />
-  </div>
+    <example-tabs ref="verticalTabsExample" orientation="vertical" />
+  </dt-stack>
 </code-well-header>
 
 ## Variants
@@ -282,7 +283,9 @@ vueCode='
 '
 showHtmlWarning />
 
-## Icon Support
+## Slots
+
+### Icon
 
 Use the `#startIcon` or `#endIcon` slot on `dt-tab` to add an icon. The slot provides `iconSize` to match the tab's size.
 
@@ -292,22 +295,28 @@ Use the `#startIcon` or `#endIcon` slot on `dt-tab` to add an icon. The slot pro
 
 <code-well-header>
   <div class="d-w100p">
-    <dt-tab-group>
+    <dt-tab-group ref="iconTabsExample">
       <template #tabs>
         <dt-tab id="1" panel-id="2" selected>
+          First
           <template #startIcon="{ iconSize }">
             <dt-icon name="box-select" :size="iconSize" />
           </template>
-          First
         </dt-tab>
         <dt-tab id="3" panel-id="4">
           Second
-        </dt-tab>
-        <dt-tab id="5" panel-id="6">
+          <template #startIcon="{ iconSize }">
+            <dt-icon name="box-select" :size="iconSize" />
+          </template>
           <template #endIcon="{ iconSize }">
             <dt-icon name="box-select" :size="iconSize" />
           </template>
+        </dt-tab>
+        <dt-tab id="5" panel-id="6">
           Third
+          <template #endIcon="{ iconSize }">
+            <dt-icon name="box-select" :size="iconSize" />
+          </template>
         </dt-tab>
       </template>
     </dt-tab-group>
@@ -315,36 +324,43 @@ Use the `#startIcon` or `#endIcon` slot on `dt-tab` to add an icon. The slot pro
 </code-well-header>
 
 <code-example-tabs
+:htmlCode='() => $refs.iconTabsExample'
 vueCode='
 <dt-tab-group>
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>
+      First
       <template #startIcon="{ iconSize }">
         <dt-icon name="box-select" :size="iconSize" />
       </template>
-      First
     </dt-tab>
     <dt-tab id="3" panel-id="4">
       Second
-    </dt-tab>
-    <dt-tab id="5" panel-id="6">
+      <template #startIcon="{ iconSize }">
+        <dt-icon name="box-select" :size="iconSize" />
+      </template>
       <template #endIcon="{ iconSize }">
         <dt-icon name="box-select" :size="iconSize" />
       </template>
+    </dt-tab>
+    <dt-tab id="5" panel-id="6">
       Third
+      <template #endIcon="{ iconSize }">
+        <dt-icon name="box-select" :size="iconSize" />
+      </template>
     </dt-tab>
   </template>
 </dt-tab-group>
 '
 showHtmlWarning />
 
-## Leading & Trailing
+### Leading & Trailing
 
 Use the `#leading` and `#trailing` slots on `dt-tab` to render content like badges or count indicators alongside tab labels. Use `leading-class` and `trailing-class` to adjust padding.
 
 <code-well-header>
   <div class="d-w100p">
-    <dt-tab-group>
+    <dt-tab-group ref="leadingTrailingTabsExample">
       <template #tabs>
         <dt-tab id="lt1" panel-id="lt2" selected trailing-class="d-pr8">
           Inbox
@@ -367,6 +383,7 @@ Use the `#leading` and `#trailing` slots on `dt-tab` to render content like badg
 </code-well-header>
 
 <code-example-tabs
+:htmlCode='() => $refs.leadingTrailingTabsExample'
 vueCode='
 <dt-tab-group>
   <template #tabs>
@@ -385,6 +402,27 @@ vueCode='
     <dt-tab id="lt5" panel-id="lt6">
       Drafts
     </dt-tab>
+  </template>
+</dt-tab-group>
+'
+showHtmlWarning />
+
+## Orientation
+
+Set `orientation="vertical"` to stack tabs vertically alongside the panel.
+
+<code-well-header>
+  <example-tabs ref="verticalTabsExample" orientation="vertical" />
+</code-well-header>
+
+<code-example-tabs
+:htmlCode='() => $refs.verticalTabsExample'
+vueCode='
+<dt-tab-group orientation="vertical">
+  <template #tabs>
+    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
+    <dt-tab id="3" panel-id="4">Second</dt-tab>
+    <dt-tab id="5" panel-id="6">Third</dt-tab>
   </template>
 </dt-tab-group>
 '

--- a/apps/dialtone-documentation/docs/scratch.md
+++ b/apps/dialtone-documentation/docs/scratch.md
@@ -667,35 +667,35 @@ const checkRadioDisabled = ref(false);
       <div class="d-py8">
         <dt-tab-panel id="2" tab-id="1">
           <dt-stack gap="400">
-            <dt-text as="p" kind="body" size="md">Argentina stretches from subtropical forests in the north to glacial landscapes in the south, encompassing the towering Andes mountains and the vast Pampas grasslands in between.</dt-text>
+            <dt-text as="p" kind="body" size="md">The <dt-link href="https://en.wikipedia.org/wiki/Argentina" target="_blank">Argentina</dt-link> stretches from subtropical forests in the north to glacial landscapes in the south, encompassing the towering Andes mountains and the vast Pampas grasslands in between.</dt-text>
             <dt-text as="p" kind="body" size="md">Its cities blend European architectural influences with a vibrant local character, while rural traditions of horsemanship and cattle ranching continue to shape the national identity.</dt-text>
             <dt-text as="p" kind="body" size="md">The country is celebrated for its contributions to tango, wine production, and a culinary culture built around shared meals and regional flavors.</dt-text>
           </dt-stack>
         </dt-tab-panel>
         <dt-tab-panel id="4" tab-id="3">
           <dt-stack gap="400">
-            <dt-text as="p" kind="body" size="md">The United States spans a broad continental range, from Atlantic coastlines and Appalachian ridges to Great Plains, Rocky Mountain summits, and Pacific shores beyond.</dt-text>
+            <dt-text as="p" kind="body" size="md">The <dt-link href="https://en.wikipedia.org/wiki/United_States">United States</dt-link> spans a broad continental range, from Atlantic coastlines and Appalachian ridges to Great Plains, Rocky Mountain summits, and Pacific shores beyond.</dt-text>
             <dt-text as="p" kind="body" size="md">Major metropolitan areas serve as centers for finance, technology, and the arts, while smaller communities maintain distinct regional customs, dialects, and culinary traditions.</dt-text>
             <dt-text as="p" kind="body" size="md">The nation's history of immigration has produced a diverse cultural fabric, with influences from virtually every corner of the globe woven into daily life.</dt-text>
           </dt-stack>
         </dt-tab-panel>
         <dt-tab-panel id="6" tab-id="5">
           <dt-stack gap="400">
-            <dt-text as="p" kind="body" size="md">The United Kingdom comprises England, Scotland, Wales, and Northern Ireland, each with distinct landscapes ranging from chalk cliffs and moors to highland lochs and green valleys.</dt-text>
+            <dt-text as="p" kind="body" size="md">The <dt-link href="https://en.wikipedia.org/wiki/United_Kingdom" target="_blank">United Kingdom</dt-link> comprises England, Scotland, Wales, and Northern Ireland, each with distinct landscapes ranging from chalk cliffs and moors to highland lochs and green valleys.</dt-text>
             <dt-text as="p" kind="body" size="md">Its cities layer centuries of history alongside modern architecture, with institutions in education, finance, and governance that have influenced systems around the world.</dt-text>
             <dt-text as="p" kind="body" size="md">A strong tradition in literature, theater, and music continues to thrive, supported by public institutions and a widespread culture of creative expression.</dt-text>
           </dt-stack>
         </dt-tab-panel>
         <dt-tab-panel id="8" tab-id="7">
           <dt-stack gap="400">
-            <dt-text as="p" kind="body" size="md">India extends from the Himalayan ranges in the north through fertile river plains to tropical coastlines in the south, supporting an extraordinary range of ecosystems and climates.</dt-text>
+            <dt-text as="p" kind="body" size="md">The <dt-link href="https://en.wikipedia.org/wiki/India" target="_blank">India</dt-link> extends from the Himalayan ranges in the north through fertile river plains to tropical coastlines in the south, supporting an extraordinary range of ecosystems and climates.</dt-text>
             <dt-text as="p" kind="body" size="md">Hundreds of languages and traditions coexist across its states and territories, producing one of the most culturally varied societies on earth with deep historical roots.</dt-text>
             <dt-text as="p" kind="body" size="md">A growing technology sector and expanding urban centers complement longstanding agricultural and artisan economies that continue to sustain millions of people.</dt-text>
           </dt-stack>
         </dt-tab-panel>
         <dt-tab-panel id="10" tab-id="9">
           <dt-stack gap="400">
-            <dt-text as="p" kind="body" size="md">Canada stretches from the Atlantic to the Pacific and northward into the Arctic, encompassing boreal forests, prairies, mountain ranges, and thousands of lakes and waterways.</dt-text>
+            <dt-text as="p" kind="body" size="md">The <dt-link href="https://en.wikipedia.org/wiki/Canada" target="_blank">Canada</dt-link> stretches from the Atlantic to the Pacific and northward into the Arctic, encompassing boreal forests, prairies, mountain ranges, and thousands of lakes and waterways.</dt-text>
             <dt-text as="p" kind="body" size="md">Its cities are known for cultural diversity and livability, while vast rural and wilderness areas support forestry, mining, and agriculture across multiple climate zones.</dt-text>
             <dt-text as="p" kind="body" size="md">Official bilingualism in English and French reflects a history shaped by Indigenous peoples, European settlement, and ongoing immigration from around the world.</dt-text>
           </dt-stack>
@@ -765,28 +765,28 @@ const checkRadioDisabled = ref(false);
       <div class="d-pl24 d-w100p d-py4">
         <dt-tab-panel id="2" tab-id="1">
           <dt-stack gap="400">
-            <dt-text as="p" kind="body" size="md">Argentina stretches from subtropical forests in the north to glacial landscapes in the south, encompassing the towering Andes mountains and the vast Pampas grasslands in between.</dt-text>
+            <dt-text as="p" kind="body" size="md">The <dt-link href="https://en.wikipedia.org/wiki/Argentina" target="_blank">Argentina</dt-link> stretches from subtropical forests in the north to glacial landscapes in the south, encompassing the towering Andes mountains and the vast Pampas grasslands in between.</dt-text>
             <dt-text as="p" kind="body" size="md">Its cities blend European architectural influences with a vibrant local character, while rural traditions of horsemanship and cattle ranching continue to shape the national identity.</dt-text>
             <dt-text as="p" kind="body" size="md">The country is celebrated for its contributions to tango, wine production, and a culinary culture built around shared meals and regional flavors.</dt-text>
           </dt-stack>
         </dt-tab-panel>
         <dt-tab-panel id="4" tab-id="3">
           <dt-stack gap="400">
-            <dt-text as="p" kind="body" size="md">The United States spans a broad continental range, from Atlantic coastlines and Appalachian ridges to Great Plains, Rocky Mountain summits, and Pacific shores beyond.</dt-text>
+            <dt-text as="p" kind="body" size="md">The <dt-link href="https://en.wikipedia.org/wiki/United_States" target="_blank">United States</dt-link> spans a broad continental range, from Atlantic coastlines and Appalachian ridges to Great Plains, Rocky Mountain summits, and Pacific shores beyond.</dt-text>
             <dt-text as="p" kind="body" size="md">Major metropolitan areas serve as centers for finance, technology, and the arts, while smaller communities maintain distinct regional customs, dialects, and culinary traditions.</dt-text>
             <dt-text as="p" kind="body" size="md">The nation's history of immigration has produced a diverse cultural fabric, with influences from virtually every corner of the globe woven into daily life.</dt-text>
           </dt-stack>
         </dt-tab-panel>
         <dt-tab-panel id="6" tab-id="5">
           <dt-stack gap="400">
-            <dt-text as="p" kind="body" size="md">The United Kingdom comprises England, Scotland, Wales, and Northern Ireland, each with distinct landscapes ranging from chalk cliffs and moors to highland lochs and green valleys.</dt-text>
+            <dt-text as="p" kind="body" size="md">The <dt-link href="https://en.wikipedia.org/wiki/United_Kingdom" target="_blank">United Kingdom</dt-link> comprises England, Scotland, Wales, and Northern Ireland, each with distinct landscapes ranging from chalk cliffs and moors to highland lochs and green valleys.</dt-text>
             <dt-text as="p" kind="body" size="md">Its cities layer centuries of history alongside modern architecture, with institutions in education, finance, and governance that have influenced systems around the world.</dt-text>
             <dt-text as="p" kind="body" size="md">A strong tradition in literature, theater, and music continues to thrive, supported by public institutions and a widespread culture of creative expression.</dt-text>
           </dt-stack>
         </dt-tab-panel>
         <dt-tab-panel id="8" tab-id="7">
           <dt-stack gap="400">
-            <dt-text as="p" kind="body" size="md">India extends from the Himalayan ranges in the north through fertile river plains to tropical coastlines in the south, supporting an extraordinary range of ecosystems and climates.</dt-text>
+            <dt-text as="p" kind="body" size="md">The <dt-link href="https://en.wikipedia.org/wiki/India" target="_blank">India</dt-link> extends from the Himalayan ranges in the north through fertile river plains to tropical coastlines in the south, supporting an extraordinary range of ecosystems and climates.</dt-text>
             <dt-text as="p" kind="body" size="md">Hundreds of languages and traditions coexist across its states and territories, producing one of the most culturally varied societies on earth with deep historical roots.</dt-text>
             <dt-text as="p" kind="body" size="md">A growing technology sector and expanding urban centers complement longstanding agricultural and artisan economies that continue to sustain millions of people.</dt-text>
             <dt-text as="p" kind="body" size="md">A growing technology sector and expanding urban centers complement longstanding agricultural and artisan economies that continue to sustain millions of people.</dt-text>

--- a/apps/dialtone-documentation/docs/scratch.md
+++ b/apps/dialtone-documentation/docs/scratch.md
@@ -604,6 +604,33 @@ const checkRadioDisabled = ref(false);
         @change="size = $event"
       />
     </dt-stack>
+    <dt-stack gap="200" hidden>
+      <dt-text as="h3" kind="headline" size="md">
+        Backwards-compatible old tabs html
+      </dt-text>
+      <div>
+        <div class="d-tablist" role="tablist" aria-label=""><button
+            class="base-button__button d-btn d-btn--primary d-tab d-tab--selected" data-qa="dt-tab" aria-label=""
+            type="button" id="dt-tab-1" role="tab" aria-selected="true" aria-controls="dt-panel-2"
+            tabindex="0"><!----><!----><span data-qa="dt-button-label" class="base-button__label d-btn__label">
+              <p>
+                First tab
+              </p>
+            </span></button> <button class="base-button__button d-btn d-btn--primary d-tab" data-qa="dt-tab" aria-label=""
+            type="button" id="dt-tab-3" role="tab" aria-selected="false" aria-controls="dt-panel-4"
+            tabindex="-1"><!----><!----><span data-qa="dt-button-label" class="base-button__label d-btn__label">
+              <p>
+                Second tab
+              </p>
+            </span></button> <button class="base-button__button d-btn d-btn--primary d-tab" data-qa="dt-tab"
+            aria-label="Third Label" type="button" id="dt-tab-5" role="tab" aria-selected="false" aria-controls="dt-panel-6"
+            tabindex="-1"><!----><!----><span data-qa="dt-button-label" class="base-button__label d-btn__label">
+              <p>
+                Third tab
+              </p>
+            </span></button></div>
+      </div>
+    </dt-stack>
     <dt-tab-group :borderless="borderless" :kind="muted ? 'muted' : 'default'" :outlined="outlined" :size="size" :activation-mode="selectOnFocus ? 'auto' : 'manual'">
       <template #tabs>
         <dt-tab id="1" panel-id="2" selected leading-class="d-pl8" trailing-class="d-pr8" :label-class="resolvedTabLabelClass">

--- a/apps/dialtone-documentation/docs/scratch.md
+++ b/apps/dialtone-documentation/docs/scratch.md
@@ -218,7 +218,7 @@ const checkRadioDisabled = ref(false);
       <dt-button kind="muted" importance="outlined" size="xs" :leading-class="[removeBtnSlotClass ? undefined : 'd-pl2', highlightBtnSlotClass ? 'd-bgc-warning' : undefined]" :trailing-class="[removeBtnSlotClass ? undefined : 'd-pr1', highlightBtnSlotClass ? 'd-bgc-warning' : undefined]" :label-class="resolvedBtnLabelClass">
         Place Call
         <template v-if="showBtnLeading" #leading>
-          <dt-badge kind="count" text="1" />
+          <dt-badge kind="count" type="bulletin" text="1" />
         </template>
         <template v-if="showBtnTrailing" #trailing>
           <dt-badge text="Label" />
@@ -229,7 +229,7 @@ const checkRadioDisabled = ref(false);
       <dt-button kind="muted" importance="outlined" size="sm" :leading-class="[removeBtnSlotClass ? undefined : 'd-pl2', highlightBtnSlotClass ? 'd-bgc-warning' : undefined]" :trailing-class="[removeBtnSlotClass ? undefined : 'd-pr4', highlightBtnSlotClass ? 'd-bgc-warning' : undefined]" :label-class="resolvedBtnLabelClass">
         Place Call
         <template v-if="showBtnLeading" #leading>
-          <dt-badge kind="count" text="1" />
+          <dt-badge kind="count" type="bulletin" text="1" />
         </template>
         <template v-if="showBtnTrailing" #trailing>
           <dt-badge text="Label" />
@@ -240,7 +240,7 @@ const checkRadioDisabled = ref(false);
       <dt-button kind="muted" importance="outlined" size="md" :leading-class="[removeBtnSlotClass ? undefined : 'd-pl4', highlightBtnSlotClass ? 'd-bgc-warning' : undefined]" :trailing-class="[removeBtnSlotClass ? undefined : 'd-pr8', highlightBtnSlotClass ? 'd-bgc-warning' : undefined]" :label-class="resolvedBtnLabelClass">
         Place Call
         <template v-if="showBtnLeading" #leading>
-          <dt-badge kind="count" text="1" />
+          <dt-badge kind="count" type="bulletin" text="1" />
         </template>
         <template v-if="showBtnTrailing" #trailing>
           <dt-badge text="Label" />
@@ -251,7 +251,7 @@ const checkRadioDisabled = ref(false);
       <dt-button kind="muted" importance="outlined" size="lg" :leading-class="[removeBtnSlotClass ? undefined : 'd-pl8', highlightBtnSlotClass ? 'd-bgc-warning' : undefined]" :trailing-class="[removeBtnSlotClass ? undefined : 'd-pr10', highlightBtnSlotClass ? 'd-bgc-warning' : undefined]" :label-class="resolvedBtnLabelClass">
         Place Call
         <template v-if="showBtnLeading" #leading>
-          <dt-badge kind="count" text="1" />
+          <dt-badge kind="count" type="bulletin" text="1" />
         </template>
         <template v-if="showBtnTrailing" #trailing>
           <dt-badge text="Label" />
@@ -262,7 +262,7 @@ const checkRadioDisabled = ref(false);
       <dt-button kind="muted" importance="outlined" size="xl" :leading-class="[removeBtnSlotClass ? undefined : 'd-pl8', highlightBtnSlotClass ? 'd-bgc-warning' : undefined]" :trailing-class="[removeBtnSlotClass ? undefined : 'd-pr12', highlightBtnSlotClass ? 'd-bgc-warning' : undefined]" :label-class="resolvedBtnLabelClass">
         Place Call
         <template v-if="showBtnLeading" #leading>
-          <dt-badge kind="count" text="1" />
+          <dt-badge kind="count" type="bulletin" text="1" />
         </template>
         <template v-if="showBtnTrailing" #trailing>
           <dt-badge text="Label" />
@@ -615,10 +615,10 @@ const checkRadioDisabled = ref(false);
           </template>
           Argentina
           <template v-if="showLeading" #leading>
-            <dt-badge kind="count" text="1" />
+            <dt-badge kind="count" type="bulletin" text="1" />
           </template>
           <template v-if="showTrailing" #trailing>
-            <dt-badge kind="count" text="1" />
+            <dt-badge kind="count" type="bulletin" text="1" />
           </template>
         </dt-tab>
         <dt-tab id="3" panel-id="4" leading-class="d-pl8" trailing-class="d-pr8" :label-class="resolvedTabLabelClass">
@@ -630,10 +630,10 @@ const checkRadioDisabled = ref(false);
           </template>
           United States
           <template v-if="showLeading" #leading>
-            <dt-badge kind="count" text="1" />
+            <dt-badge kind="count" type="bulletin" text="1" />
           </template>
           <template v-if="showTrailing" #trailing>
-            <dt-badge kind="count" text="1" />
+            <dt-badge kind="count" type="bulletin" text="1" />
           </template>
         </dt-tab>
         <dt-tab id="5" panel-id="6" :label-class="resolvedTabLabelClass">
@@ -690,6 +690,106 @@ const checkRadioDisabled = ref(false);
           <dt-stack gap="400">
             <dt-text as="p" kind="body" size="md">India extends from the Himalayan ranges in the north through fertile river plains to tropical coastlines in the south, supporting an extraordinary range of ecosystems and climates.</dt-text>
             <dt-text as="p" kind="body" size="md">Hundreds of languages and traditions coexist across its states and territories, producing one of the most culturally varied societies on earth with deep historical roots.</dt-text>
+            <dt-text as="p" kind="body" size="md">A growing technology sector and expanding urban centers complement longstanding agricultural and artisan economies that continue to sustain millions of people.</dt-text>
+          </dt-stack>
+        </dt-tab-panel>
+        <dt-tab-panel id="10" tab-id="9">
+          <dt-stack gap="400">
+            <dt-text as="p" kind="body" size="md">Canada stretches from the Atlantic to the Pacific and northward into the Arctic, encompassing boreal forests, prairies, mountain ranges, and thousands of lakes and waterways.</dt-text>
+            <dt-text as="p" kind="body" size="md">Its cities are known for cultural diversity and livability, while vast rural and wilderness areas support forestry, mining, and agriculture across multiple climate zones.</dt-text>
+            <dt-text as="p" kind="body" size="md">Official bilingualism in English and French reflects a history shaped by Indigenous peoples, European settlement, and ongoing immigration from around the world.</dt-text>
+          </dt-stack>
+        </dt-tab-panel>
+      </div>
+    </dt-tab-group>
+    <dt-tab-group tab-list-class="d-w264" orientation="vertical" :borderless="borderless" :kind="muted ? 'muted' : 'default'" :outlined="outlined" :size="size" :activation-mode="selectOnFocus ? 'auto' : 'manual'">
+      <template #tabs>
+        <dt-tab id="1" panel-id="2" selected leading-class="d-pl8" trailing-class="d-pr8" :label-class="resolvedTabLabelClass">
+          <template v-if="showIcon" #startIcon="{ iconSize }">
+            <dt-icon name="box-select" :size="iconSize" />
+          </template>
+          <template v-if="showTabEndIcon" #endIcon="{ iconSize }">
+            <dt-icon name="box-select" :size="iconSize" />
+          </template>
+          Argentina
+          <template v-if="showLeading" #leading>
+            <dt-badge kind="count" type="bulletin" text="1" />
+          </template>
+          <template v-if="showTrailing" #trailing>
+            <dt-badge kind="count" type="bulletin" text="1" />
+          </template>
+        </dt-tab>
+        <dt-tab id="3" panel-id="4" leading-class="d-pl8" trailing-class="d-pr8" :label-class="resolvedTabLabelClass">
+          <template v-if="showIcon" #startIcon="{ iconSize }">
+            <dt-icon name="box-select" :size="iconSize" />
+          </template>
+          <template v-if="showTabEndIcon" #endIcon="{ iconSize }">
+            <dt-icon name="box-select" :size="iconSize" />
+          </template>
+          United States
+          <template v-if="showLeading" #leading>
+            <dt-badge kind="count" type="bulletin" text="1" />
+          </template>
+          <template v-if="showTrailing" #trailing>
+            <dt-badge kind="count" type="bulletin" text="1" />
+          </template>
+        </dt-tab>
+        <dt-tab id="5" panel-id="6" :label-class="resolvedTabLabelClass">
+          <template v-if="showIcon" #startIcon="{ iconSize }">
+            <dt-icon name="box-select" :size="iconSize" />
+          </template>
+          <template v-if="showTabEndIcon" #endIcon="{ iconSize }">
+            <dt-icon name="box-select" :size="iconSize" />
+          </template>
+          United Kingdom
+        </dt-tab>
+        <dt-tab id="7" panel-id="8" :label-class="resolvedTabLabelClass">
+          <template v-if="showIcon" #startIcon="{ iconSize }">
+            <dt-icon name="box-select" :size="iconSize" />
+          </template>
+          <template v-if="showTabEndIcon" #endIcon="{ iconSize }">
+            <dt-icon name="box-select" :size="iconSize" />
+          </template>
+          India
+        </dt-tab>
+        <dt-tab id="9" panel-id="10" disabled :label-class="resolvedTabLabelClass">
+          <template v-if="showIcon" #startIcon="{ iconSize }">
+            <dt-icon name="box-select" :size="iconSize" />
+          </template>
+          <template v-if="showTabEndIcon" #endIcon="{ iconSize }">
+            <dt-icon name="box-select" :size="iconSize" />
+          </template>
+          Canada
+        </dt-tab>
+      </template>
+      <div class="d-pl24 d-w100p d-py4">
+        <dt-tab-panel id="2" tab-id="1">
+          <dt-stack gap="400">
+            <dt-text as="p" kind="body" size="md">Argentina stretches from subtropical forests in the north to glacial landscapes in the south, encompassing the towering Andes mountains and the vast Pampas grasslands in between.</dt-text>
+            <dt-text as="p" kind="body" size="md">Its cities blend European architectural influences with a vibrant local character, while rural traditions of horsemanship and cattle ranching continue to shape the national identity.</dt-text>
+            <dt-text as="p" kind="body" size="md">The country is celebrated for its contributions to tango, wine production, and a culinary culture built around shared meals and regional flavors.</dt-text>
+          </dt-stack>
+        </dt-tab-panel>
+        <dt-tab-panel id="4" tab-id="3">
+          <dt-stack gap="400">
+            <dt-text as="p" kind="body" size="md">The United States spans a broad continental range, from Atlantic coastlines and Appalachian ridges to Great Plains, Rocky Mountain summits, and Pacific shores beyond.</dt-text>
+            <dt-text as="p" kind="body" size="md">Major metropolitan areas serve as centers for finance, technology, and the arts, while smaller communities maintain distinct regional customs, dialects, and culinary traditions.</dt-text>
+            <dt-text as="p" kind="body" size="md">The nation's history of immigration has produced a diverse cultural fabric, with influences from virtually every corner of the globe woven into daily life.</dt-text>
+          </dt-stack>
+        </dt-tab-panel>
+        <dt-tab-panel id="6" tab-id="5">
+          <dt-stack gap="400">
+            <dt-text as="p" kind="body" size="md">The United Kingdom comprises England, Scotland, Wales, and Northern Ireland, each with distinct landscapes ranging from chalk cliffs and moors to highland lochs and green valleys.</dt-text>
+            <dt-text as="p" kind="body" size="md">Its cities layer centuries of history alongside modern architecture, with institutions in education, finance, and governance that have influenced systems around the world.</dt-text>
+            <dt-text as="p" kind="body" size="md">A strong tradition in literature, theater, and music continues to thrive, supported by public institutions and a widespread culture of creative expression.</dt-text>
+          </dt-stack>
+        </dt-tab-panel>
+        <dt-tab-panel id="8" tab-id="7">
+          <dt-stack gap="400">
+            <dt-text as="p" kind="body" size="md">India extends from the Himalayan ranges in the north through fertile river plains to tropical coastlines in the south, supporting an extraordinary range of ecosystems and climates.</dt-text>
+            <dt-text as="p" kind="body" size="md">Hundreds of languages and traditions coexist across its states and territories, producing one of the most culturally varied societies on earth with deep historical roots.</dt-text>
+            <dt-text as="p" kind="body" size="md">A growing technology sector and expanding urban centers complement longstanding agricultural and artisan economies that continue to sustain millions of people.</dt-text>
+            <dt-text as="p" kind="body" size="md">A growing technology sector and expanding urban centers complement longstanding agricultural and artisan economies that continue to sustain millions of people.</dt-text>
             <dt-text as="p" kind="body" size="md">A growing technology sector and expanding urban centers complement longstanding agricultural and artisan economies that continue to sustain millions of people.</dt-text>
           </dt-stack>
         </dt-tab-panel>

--- a/packages/dialtone-css/lib/build/less/components/tabs.less
+++ b/packages/dialtone-css/lib/build/less/components/tabs.less
@@ -67,6 +67,27 @@
         block-size: var(--dt-size-border-100);
         background-color: var(--dt-color-border-default);
         content: '';
+
+    }
+
+    &.d-tablist--vertical:not(.d-tablist--no-border)::after {
+        block-size: auto;
+        inset-inline-start: calc(100% - var(--dt-size-200));
+        inline-size: var(--dt-size-border-100);
+        inset-block: 1px;
+    }
+
+
+    &__item {
+        text-align: start;
+
+        &--vertical {
+            inline-size: 100%;
+
+            > .d-btn__label {
+                justify-content: flex-start;
+            }
+        }
     }
 }
 
@@ -178,32 +199,6 @@
         }
     }
 
-    //  ============================================================================
-    //  $   LABEL
-    //  ----------------------------------------------------------------------------
-    &__label {
-    //   font-weight: normal;
-
-      transition: font-weight var(--ttf-out) var(--td50);
-
-      .d-btn--active &,
-      .d-btn--outlined &,
-      .d-tab--is-selected & {
-        font-weight: var(--dt-font-weight-bold) !important;
-      }
-
-      &[data-content]::after {
-          display: block;
-          font-weight: var(--dt-font-weight-bold);
-          white-space: nowrap;
-          text-align: center;
-          background-color: #666;
-          visibility: hidden;
-          content: attr(data-content);
-          block-size: 0;
-      }
-    }
-
 }
 
 //  ============================================================================
@@ -245,7 +240,34 @@
         block-size: var(--dt-size-200);
         inset-block-start: calc(calc(100% + var(--tablist-padding-bottom)) - var(--dt-size-100));
         inset-inline: 0;
+
+        .d-tablist--vertical & {
+            inset-block: 0;
+            inset-inline: auto 0;
+            inset-inline-start: calc(100% + var(--dt-size-350));
+            block-size: auto;
+            inline-size: var(--dt-size-200);
+        }
     }
+}
+
+//  ============================================================================
+//  $   VERTICAL ORIENTATION
+//  ----------------------------------------------------------------------------
+.d-tab-neux--vertical {
+    display: flex;
+
+    > .d-tablist {
+        --tablist-padding-bottom: 0;
+
+        padding-block-end: 0;
+        padding-inline-end: var(--dt-size-400);
+    }
+}
+
+.d-tablist--vertical {
+    flex-flow: column nowrap;
+    align-items: flex-start;
 }
 
 //  ============================================================================

--- a/packages/dialtone-css/lib/build/less/components/tabs.less
+++ b/packages/dialtone-css/lib/build/less/components/tabs.less
@@ -7,20 +7,13 @@
 //  visit https://dialtone.dialpad.com/components/tabs
 //
 //  TABLE OF CONTENTS
-//  • WRAPPER
-//  • TABLIST
-//  • TABLIST SIZES
-//  • TAB BASE
-//  • TAB SELECTED (CSS-only legacy, used by emoji-picker)
-//  • TAB INDICATOR (Vue component indicator line)
-//  • NO-BORDER
-//  • VERTICAL
-//  • INVERTED
+//  • .d-tab-neux   — wrapper + --vertical
+//  • .d-tablist    — tablist + sizes, no-border, vertical, inverted
+//  • .d-tab        — tab base + --selected, --is-selected
 //
-//  ============================================================================
-//  $   WRAPPER
-//  ----------------------------------------------------------------------------
 @layer dialtone.components {
+
+//  WRAPPER
 .d-tab-neux {
     --tablist-padding-bottom: var(--dt-size-400);
 
@@ -30,7 +23,7 @@
         box-shadow: none;
     }
 
-    :where(> .d-tablist) {
+    > :where(.d-tablist) {
         padding-block-end: var(--tablist-padding-bottom);
     }
 
@@ -42,11 +35,22 @@
     .d-tablist--no-border {
         border-block-end: 0;
     }
+
+    //  Vertical
+    &--vertical {
+        display: flex;
+        padding-block-end: 0;
+
+        > :where(.d-tablist) {
+            --tablist-padding-bottom: 0;
+
+            padding-block-end: 0;
+            padding-inline-end: var(--dt-size-400);
+        }
+    }
 }
 
-//  ============================================================================
-//  $   TABLIST
-//  ----------------------------------------------------------------------------
+//  TABLIST
 .d-tablist {
     //  --  COMPONENT CSS VARS
     //  ------------------------------------------------------------------------
@@ -108,34 +112,65 @@
             }
         }
     }
+
+    //  Sizes
+    &--sm {
+        --tab-padding-x: calc(var(--dt-size-400) - var(--dt-size-border-100));
+        --tab-border-radius: var(--dt-button-size-radius-xs);
+        --tab-font-style: var(--dt-typography-button-xs);
+    }
+
+    &--lg {
+        --tab-padding-x: calc(var(--dt-size-500) - var(--dt-size-border-100));
+        --tab-padding-y: calc((var(--dt-size-400) + var(--dt-size-200)) - var(--dt-size-border-100));
+        --tab-border-radius: var(--dt-button-size-radius-lg);
+        --tab-font-style: var(--dt-typography-button-lg);
+    }
+
+    &--xl {
+        --tab-padding-x: calc(var(--dt-size-500) - var(--dt-size-border-100));
+        --tab-padding-y: calc(var(--dt-size-450) - var(--dt-size-border-100));
+        --tab-border-radius: var(--dt-button-size-radius-xl);
+        --tab-font-style: var(--dt-typography-button-xl);
+    }
+
+    //  No-border
+    &--no-border {
+        --tablist-border-opacity: 0;
+        --tab-border-radius-end: var(--tab-border-radius);
+        --tab-after-bg: transparent;
+    }
+
+    //  Vertical
+    &--vertical {
+        flex-flow: column nowrap;
+        align-items: flex-start;
+
+        &::after {
+            block-size: auto;
+            inset-inline-start: calc(100% - var(--dt-size-200));
+            inline-size: var(--dt-size-border-100);
+            inset-block: 1px;
+        }
+    }
+
+    //  Inverted
+    &--inverted {
+        --tab-color-text: var(--dt-action-color-foreground-inverted-default);
+        --tab-color-text-hover: var(--dt-action-color-foreground-inverted-hover);
+        --tab-color-background-hover: var(--dt-action-color-background-inverted-hover);
+        --tab-color-text-active: var(--dt-action-color-foreground-inverted-active);
+        --tab-color-background-active: var(--dt-action-color-background-inverted-active);
+        --tab-color-text-selected: var(--dt-action-color-foreground-inverted-default);
+        --tab-selected-indicator: currentColor;
+
+        &::after {
+            background-color: var(--dt-color-foreground-primary-inverted);
+        }
+    }
 }
 
-//  ============================================================================
-//  $   TABLIST SIZES
-//  ----------------------------------------------------------------------------
-.d-tablist--sm {
-    --tab-padding-x: calc(var(--dt-size-400) - var(--dt-size-border-100));
-    --tab-border-radius: var(--dt-button-size-radius-xs);
-    --tab-font-style: var(--dt-typography-button-xs);
-}
-
-.d-tablist--lg {
-    --tab-padding-x: calc(var(--dt-size-500) - var(--dt-size-border-100));
-    --tab-padding-y: calc((var(--dt-size-400) + var(--dt-size-200)) - var(--dt-size-border-100));
-    --tab-border-radius: var(--dt-button-size-radius-lg);
-    --tab-font-style: var(--dt-typography-button-lg);
-}
-
-.d-tablist--xl {
-    --tab-padding-x: calc(var(--dt-size-500) - var(--dt-size-border-100));
-    --tab-padding-y: calc(var(--dt-size-450) - var(--dt-size-border-100));
-    --tab-border-radius: var(--dt-button-size-radius-xl);
-    --tab-font-style: var(--dt-typography-button-xl);
-}
-
-//  ============================================================================
-//  $   TAB BASE
-//  ----------------------------------------------------------------------------
+//  TAB
 .d-tab {
     position: relative;
     display: inline-flex;
@@ -198,105 +233,50 @@
     @media (prefers-reduced-motion) {
         transition: none;
     }
-}
 
-//  ============================================================================
-//  $   TAB SELECTED (CSS-only legacy, used by emoji-picker)
-//  ----------------------------------------------------------------------------
-.d-tab--selected {
-    --tab-color-text: var(--tab-color-text-selected);
-    --tab-border-radius-end: 0;
-    --tab-after-bg: var(--tab-selected-indicator);
+    //  Selected (CSS-only legacy, used by emoji-picker)
+    &--selected {
+        --tab-color-text: var(--tab-color-text-selected);
+        --tab-border-radius-end: 0;
+        --tab-after-bg: var(--tab-selected-indicator);
 
-    z-index: var(--zi-selected);
+        z-index: var(--zi-selected);
 
-    &:not(:disabled):hover {
-        --tab-color-background: var(--dt-action-color-background-base-hover);
-        --tab-color-text: var(--dt-action-color-foreground-base-hover);
+        &:not(:disabled):hover {
+            --tab-color-background: var(--dt-action-color-background-base-hover);
+            --tab-color-text: var(--dt-action-color-foreground-base-hover);
+        }
+
+        &:not(:disabled):active {
+            --tab-color-background: var(--dt-action-color-background-base-active);
+            --tab-color-text: var(--dt-action-color-foreground-base-active);
+        }
     }
 
-    &:not(:disabled):active {
-        --tab-color-background: var(--dt-action-color-background-base-active);
-        --tab-color-text: var(--dt-action-color-foreground-base-active);
-    }
-}
+    //  Is-selected (Vue component indicator line)
+    &--is-selected {
+        position: relative;
+        z-index: var(--zi-selected);
 
-//  ============================================================================
-//  $   TAB INDICATOR (Vue component indicator line)
-//  ----------------------------------------------------------------------------
-.d-tab--is-selected {
-    position: relative;
-    z-index: var(--zi-selected);
+        &::after {
+            position: absolute;
+            background-color: var(--tab-selected-indicator);
+            border-radius: var(--dt-size-radius-pill);
+            content: '';
+            block-size: var(--dt-size-200);
+            inset-block-start: calc(calc(100% + var(--tablist-padding-bottom)) - var(--dt-size-100));
+            inset-inline: var(--dt-size-100-negative);
+        }
 
-    &::after {
-        position: absolute;
-        background-color: var(--tab-selected-indicator);
-        border-radius: var(--dt-size-radius-pill);
-        content: '';
-        block-size: var(--dt-size-200);
-        inset-block-start: calc(calc(100% + var(--tablist-padding-bottom)) - var(--dt-size-100));
-        inset-inline: var(--dt-size-100-negative);
-    }
-}
-
-//  ============================================================================
-//  $   NO-BORDER
-//  ----------------------------------------------------------------------------
-.d-tablist--no-border {
-    --tablist-border-opacity: 0;
-    --tab-border-radius-end: var(--tab-border-radius);
-    --tab-after-bg: transparent;
-}
-
-//  ============================================================================
-//  $   VERTICAL
-//  ----------------------------------------------------------------------------
-.d-tab-neux--vertical {
-    display: flex;
-    padding-block-end: 0;
-
-    > :where(.d-tablist) {
-        --tablist-padding-bottom: 0;
-
-        padding-block-end: 0;
-        padding-inline-end: var(--dt-size-400);
+        // Vertical context override
+        :where(.d-tablist--vertical) &::after {
+            inset-block: var(--dt-size-100-negative);
+            inset-inline: auto 0;
+            inset-inline-start: calc(100% + var(--dt-size-350));
+            block-size: auto;
+            inline-size: var(--dt-size-200);
+        }
     }
 }
 
-.d-tablist--vertical {
-    flex-flow: column nowrap;
-    align-items: flex-start;
-
-    &::after {
-        block-size: auto;
-        inset-inline-start: calc(100% - var(--dt-size-200));
-        inline-size: var(--dt-size-border-100);
-        inset-block: 1px;
-    }
-}
-
-:where(.d-tablist--vertical) .d-tab--is-selected::after {
-    inset-block: var(--dt-size-100-negative);
-    inset-inline: auto 0;
-    inset-inline-start: calc(100% + var(--dt-size-350));
-    block-size: auto;
-    inline-size: var(--dt-size-200);
-}
-
-//  ============================================================================
-//  $   INVERTED
-//  ----------------------------------------------------------------------------
-.d-tablist--inverted {
-    --tab-color-text: var(--dt-action-color-foreground-inverted-default);
-    --tab-color-text-hover: var(--dt-action-color-foreground-inverted-hover);
-    --tab-color-background-hover: var(--dt-action-color-background-inverted-hover);
-    --tab-color-text-active: var(--dt-action-color-foreground-inverted-active);
-    --tab-color-background-active: var(--dt-action-color-background-inverted-active);
-    --tab-color-text-selected: var(--dt-action-color-foreground-inverted-default);
-    --tab-selected-indicator: currentColor;
-
-    &::after {
-        background-color: var(--dt-color-foreground-primary-inverted);
-    }
-}
-}
+} // end @layer

--- a/packages/dialtone-css/lib/build/less/components/tabs.less
+++ b/packages/dialtone-css/lib/build/less/components/tabs.less
@@ -7,37 +7,46 @@
 //  visit https://dialtone.dialpad.com/components/tabs
 //
 //  TABLE OF CONTENTS
-//  • BASE STYLE
-//  • ALTERNATE STYLES
+//  • WRAPPER
+//  • TABLIST
+//  • TABLIST SIZES
+//  • TAB BASE
+//  • TAB SELECTED (CSS-only legacy, used by emoji-picker)
+//  • TAB INDICATOR (Vue component indicator line)
+//  • NO-BORDER
+//  • VERTICAL
+//  • INVERTED
 //
 //  ============================================================================
-//  $   WRAPPERS
+//  $   WRAPPER
 //  ----------------------------------------------------------------------------
 @layer dialtone.components {
 .d-tab-neux {
+    --tablist-padding-bottom: var(--dt-size-400);
+
     inline-size: 100%;
 
-    [role="tabpanel"] {
+    :where([role="tabpanel"]) {
         box-shadow: none;
     }
 
-    > .d-tablist {
-        --tablist-padding-bottom: var(--dt-size-400);
-
+    :where(> .d-tablist) {
         padding-block-end: var(--tablist-padding-bottom);
-
-        &--xs { --tablist-padding-bottom: var(--dt-size-350); }
-        &--sm { --tablist-padding-bottom: var(--dt-size-400); }
-        &--md { /* default */ }
-        &--lg { --tablist-padding-bottom: var(--dt-size-400); }
-        &--xl { --tablist-padding-bottom: var(--dt-size-450); }
     }
+
+    > :where(.d-tablist--xs) { --tablist-padding-bottom: var(--dt-size-350); }
+    > :where(.d-tablist--sm) { --tablist-padding-bottom: var(--dt-size-400); }
+    > :where(.d-tablist--lg) { --tablist-padding-bottom: var(--dt-size-400); }
+    > :where(.d-tablist--xl) { --tablist-padding-bottom: var(--dt-size-450); }
 
     .d-tablist--no-border {
         border-block-end: 0;
     }
 }
 
+//  ============================================================================
+//  $   TABLIST
+//  ----------------------------------------------------------------------------
 .d-tablist {
     //  --  COMPONENT CSS VARS
     //  ------------------------------------------------------------------------
@@ -48,35 +57,45 @@
     --tab-padding-x: calc(var(--dt-size-450) - var(--dt-size-border-100));
     --tab-padding-y: calc(var(--dt-size-400) - var(--dt-size-border-100));
 
+    //  --  CSS VARS: border opacity (toggled by --no-border)
+    --tablist-border-opacity: 1;
+
+    //  --  CSS VARS: border-radius end corners (toggled by --no-border / --selected)
+    --tab-border-radius-end: 0;
+
+    //  --  CSS VARS: ::after cover-up background (toggled by --no-border / --selected)
+    --tab-after-bg: var(--tab-color-background);
+
+    //  --  CSS VARS: state colors (overridden by --inverted)
+    --tab-color-text-hover: var(--dt-action-color-foreground-muted-hover);
+    --tab-color-background-hover: var(--dt-action-color-background-muted-hover);
+    --tab-color-text-active: var(--dt-action-color-foreground-muted-active);
+    --tab-color-background-active: var(--dt-action-color-background-muted-active);
+    --tab-color-text-disabled: var(--dt-action-color-foreground-disabled-default);
+    --tab-color-text-selected: var(--dt-action-color-foreground-base-default);
+    --tab-selected-indicator: var(--dt-action-color-foreground-base-default);
+
     position: relative;
     display: flex;
     flex-wrap: wrap;
     gap: var(--dt-size-300);
     align-items: center;
+    padding-block-end: var(--tablist-padding-bottom);
 
     &:focus {
         outline: 0;
     }
 
-    // Add a bottom border unless no border is requested
-    &:not(.d-tablist--no-border)::after {
+    &::after {
         position: absolute;
         inset-inline: 0;
         inset-block-end: 0;
         z-index: var(--zi-base1);
         block-size: var(--dt-size-border-100);
         background-color: var(--dt-color-border-default);
+        opacity: var(--tablist-border-opacity);
         content: '';
-
     }
-
-    &.d-tablist--vertical:not(.d-tablist--no-border)::after {
-        block-size: auto;
-        inset-inline-start: calc(100% - var(--dt-size-200));
-        inline-size: var(--dt-size-border-100);
-        inset-block: 1px;
-    }
-
 
     &__item {
         text-align: start;
@@ -84,7 +103,7 @@
         &--vertical {
             inline-size: 100%;
 
-            > .d-btn__label {
+            > :where(.d-btn__label) {
                 justify-content: flex-start;
             }
         }
@@ -92,7 +111,30 @@
 }
 
 //  ============================================================================
-//  $   BASE STYLE
+//  $   TABLIST SIZES
+//  ----------------------------------------------------------------------------
+.d-tablist--sm {
+    --tab-padding-x: calc(var(--dt-size-400) - var(--dt-size-border-100));
+    --tab-border-radius: var(--dt-button-size-radius-xs);
+    --tab-font-style: var(--dt-typography-button-xs);
+}
+
+.d-tablist--lg {
+    --tab-padding-x: calc(var(--dt-size-500) - var(--dt-size-border-100));
+    --tab-padding-y: calc((var(--dt-size-400) + var(--dt-size-200)) - var(--dt-size-border-100));
+    --tab-border-radius: var(--dt-button-size-radius-lg);
+    --tab-font-style: var(--dt-typography-button-lg);
+}
+
+.d-tablist--xl {
+    --tab-padding-x: calc(var(--dt-size-500) - var(--dt-size-border-100));
+    --tab-padding-y: calc(var(--dt-size-450) - var(--dt-size-border-100));
+    --tab-border-radius: var(--dt-button-size-radius-xl);
+    --tab-font-style: var(--dt-typography-button-xl);
+}
+
+//  ============================================================================
+//  $   TAB BASE
 //  ----------------------------------------------------------------------------
 .d-tab {
     position: relative;
@@ -106,36 +148,29 @@
     font: var(--tab-font-style);
     background-color: var(--tab-color-background);
     border: var(--dt-size-border-100) solid var(--dt-action-color-border-base-default);
-    border-radius: var(--tab-border-radius) var(--tab-border-radius) 0 0;
+    border-radius: var(--tab-border-radius) var(--tab-border-radius) var(--tab-border-radius-end) var(--tab-border-radius-end);
     cursor: pointer;
     transition-timing-function: var(--ttf-out-quint);
     transition-duration: var(--td100);
     transition-property: background-color, border, color, box-shadow;
     fill: currentColor;
 
-    .d-tablist--no-border &:not(.d-tab--selected) {
-        border-radius: var(--tab-border-radius);
-    }
-
-    &:first-of-type {
+    &:where(:first-of-type) {
         margin-inline-start: 0;
     }
 
-    &:last-of-type {
+    &:where(:last-of-type) {
         margin-inline-end: 0;
     }
 
+    // Cover-up pseudo-element that hides the tablist border behind the active tab
     &::after {
         position: absolute;
         block-size: var(--dt-size-border-200);
-        background-color: var(--tab-color-background);
+        background-color: var(--tab-after-bg);
         content: '';
         inset-inline: var(--dt-size-100-negative) var(--dt-size-100-negative);
         inset-block-end: var(--dt-size-100-negative);
-
-        .d-tablist--no-border & {
-            background-color: transparent;
-        }
     }
 
     &:focus-visible {
@@ -144,68 +179,34 @@
     }
 
     &:disabled {
-        --tab-color-text: var(--dt-action-color-foreground-disabled-default);
+        --tab-color-text: var(--tab-color-text-disabled);
 
         cursor: not-allowed;
     }
 
     &:not(:disabled):hover {
-        --tab-color-background: var(--dt-action-color-background-muted-hover);
-        --tab-color-text: var(--dt-action-color-foreground-muted-hover);
+        --tab-color-background: var(--tab-color-background-hover);
+        --tab-color-text: var(--tab-color-text-hover);
     }
 
     &:not(:disabled):active {
-        --tab-color-background: var(--dt-action-color-background-muted-active);
-        --tab-color-text: var(--dt-action-color-foreground-muted-active);
+        --tab-color-background: var(--tab-color-background-active);
+        --tab-color-text: var(--tab-color-text-active);
     }
 
     //  Turn off animations if someone doesn't want them.
     @media (prefers-reduced-motion) {
         transition: none;
     }
-
-    //  ============================================================================
-    //  $   SIZES
-    //  ----------------------------------------------------------------------------
-    .d-tablist--sm & {
-        --tab-padding-x: calc(var(--dt-size-400) - var(--dt-size-border-100));
-        --tab-border-radius: var(--dt-button-size-radius-xs);
-        --tab-font-style: var(--dt-typography-button-xs);
-
-        .d-tablist--no-border &:not(.d-tab--selected) {
-            border-radius: var(--tab-border-radius);
-        }
-    }
-
-    .d-tablist--lg & {
-        --tab-padding-x: calc(var(--dt-size-500) - var(--dt-size-border-100));
-        --tab-padding-y: calc((var(--dt-size-400) + var(--dt-size-200)) - var(--dt-size-border-100));
-        --tab-border-radius: var(--dt-button-size-radius-lg);
-        --tab-font-style: var(--dt-typography-button-lg);
-
-        .d-tablist--no-border &:not(.d-tab--selected) {
-            border-radius: var(--tab-border-radius);
-        }
-    }
-
-    .d-tablist--xl & {
-        --tab-padding-x: calc(var(--dt-size-500) - var(--dt-size-border-100));
-        --tab-padding-y: calc(var(--dt-size-450) - var(--dt-size-border-100));
-        --tab-border-radius: var(--dt-button-size-radius-xl);
-        --tab-font-style: var(--dt-typography-button-xl);
-
-        .d-tablist--no-border &:not(.d-tab--selected) {
-            border-radius: var(--tab-border-radius);
-        }
-    }
-
 }
 
 //  ============================================================================
-//  $   SELECTED STYLE
+//  $   TAB SELECTED (CSS-only legacy, used by emoji-picker)
 //  ----------------------------------------------------------------------------
 .d-tab--selected {
-    --tab-color-text: var(--dt-action-color-foreground-base-default);
+    --tab-color-text: var(--tab-color-text-selected);
+    --tab-border-radius-end: 0;
+    --tab-after-bg: var(--tab-selected-indicator);
 
     z-index: var(--zi-selected);
 
@@ -218,46 +219,42 @@
         --tab-color-background: var(--dt-action-color-background-base-active);
         --tab-color-text: var(--dt-action-color-foreground-base-active);
     }
-
-    &::after,
-    &:hover::after {
-        --tab-color-background: var(--dt-action-color-foreground-base-default);
-
-        .d-tablist--no-border & {
-            background-color: var(--tab-color-background);
-        }
-    }
 }
 
+//  ============================================================================
+//  $   TAB INDICATOR (Vue component indicator line)
+//  ----------------------------------------------------------------------------
 .d-tab--is-selected {
     position: relative;
     z-index: var(--zi-selected);
 
     &::after {
         position: absolute;
-        background-color: var(--dt-action-color-foreground-base-default);
+        background-color: var(--tab-selected-indicator);
         content: '';
         block-size: var(--dt-size-200);
         inset-block-start: calc(calc(100% + var(--tablist-padding-bottom)) - var(--dt-size-100));
         inset-inline: 0;
-
-        .d-tablist--vertical & {
-            inset-block: 0;
-            inset-inline: auto 0;
-            inset-inline-start: calc(100% + var(--dt-size-350));
-            block-size: auto;
-            inline-size: var(--dt-size-200);
-        }
     }
 }
 
 //  ============================================================================
-//  $   VERTICAL ORIENTATION
+//  $   NO-BORDER
+//  ----------------------------------------------------------------------------
+.d-tablist--no-border {
+    --tablist-border-opacity: 0;
+    --tab-border-radius-end: var(--tab-border-radius);
+    --tab-after-bg: transparent;
+}
+
+//  ============================================================================
+//  $   VERTICAL
 //  ----------------------------------------------------------------------------
 .d-tab-neux--vertical {
     display: flex;
+    padding-block-end: 0;
 
-    > .d-tablist {
+    > :where(.d-tablist) {
         --tablist-padding-bottom: 0;
 
         padding-block-end: 0;
@@ -268,48 +265,37 @@
 .d-tablist--vertical {
     flex-flow: column nowrap;
     align-items: flex-start;
+
+    &::after {
+        block-size: auto;
+        inset-inline-start: calc(100% - var(--dt-size-200));
+        inline-size: var(--dt-size-border-100);
+        inset-block: 1px;
+    }
+}
+
+:where(.d-tablist--vertical) .d-tab--is-selected::after {
+    inset-block: 0;
+    inset-inline: auto 0;
+    inset-inline-start: calc(100% + var(--dt-size-350));
+    block-size: auto;
+    inline-size: var(--dt-size-200);
 }
 
 //  ============================================================================
-//  $   INVERTED STYLE
+//  $   INVERTED
 //  ----------------------------------------------------------------------------
 .d-tablist--inverted {
     --tab-color-text: var(--dt-action-color-foreground-inverted-default);
+    --tab-color-text-hover: var(--dt-action-color-foreground-inverted-hover);
+    --tab-color-background-hover: var(--dt-action-color-background-inverted-hover);
+    --tab-color-text-active: var(--dt-action-color-foreground-inverted-active);
+    --tab-color-background-active: var(--dt-action-color-background-inverted-active);
+    --tab-color-text-selected: var(--dt-action-color-foreground-inverted-default);
+    --tab-selected-indicator: currentColor;
 
     &::after {
-        background-color: var(--dt-color-border-moderate-inverted);
-    }
-
-    &:not(.d-tablist--no-border)::after {
         background-color: var(--dt-color-foreground-primary-inverted);
-    }
-
-    .d-tab {
-        --tab-color-text: var(--dt-action-color-foreground-inverted-default);
-
-        &:not(:disabled):hover {
-            --tab-color-text: var(--dt-action-color-foreground-inverted-hover);
-            --tab-color-background: var(--dt-action-color-background-inverted-hover);
-        }
-
-        &:not(:disabled):active {
-            --tab-color-text: var(--dt-action-color-foreground-inverted-active);
-            --tab-color-background: var(--dt-action-color-background-inverted-active);
-        }
-
-        &:disabled {
-            --tab-color-text: var(--dt-action-color-foreground-disabled-default);
-
-            cursor: not-allowed;
-        }
-    }
-
-    .d-tab--selected {
-        --tab-color-text: var(--dt-action-color-foreground-inverted-default);
-
-        &::after {
-            --tab-color-background: currentColor;
-        }
     }
 }
 }

--- a/packages/dialtone-css/lib/build/less/components/tabs.less
+++ b/packages/dialtone-css/lib/build/less/components/tabs.less
@@ -231,10 +231,11 @@
     &::after {
         position: absolute;
         background-color: var(--tab-selected-indicator);
+        border-radius: var(--dt-size-radius-pill);
         content: '';
         block-size: var(--dt-size-200);
         inset-block-start: calc(calc(100% + var(--tablist-padding-bottom)) - var(--dt-size-100));
-        inset-inline: 0;
+        inset-inline: var(--dt-size-100-negative);
     }
 }
 
@@ -275,7 +276,7 @@
 }
 
 :where(.d-tablist--vertical) .d-tab--is-selected::after {
-    inset-block: 0;
+    inset-block: var(--dt-size-100-negative);
     inset-inline: auto 0;
     inset-inline-start: calc(100% + var(--dt-size-350));
     block-size: auto;

--- a/packages/dialtone-vue/components/tab/tab.test.js
+++ b/packages/dialtone-vue/components/tab/tab.test.js
@@ -62,7 +62,7 @@ describe('DtTab Tests', () => {
     });
 
     it('should set data-content to match the slot text', () => {
-      const label = tab.find('.d-tablist__item-label');
+      const label = tab.find('[data-qa="dt-tab-label"]');
 
       expect(label.attributes('data-content')).toBe(MOCK_DEFAULT_SLOT);
     });

--- a/packages/dialtone-vue/components/tab/tab.test.js
+++ b/packages/dialtone-vue/components/tab/tab.test.js
@@ -62,7 +62,7 @@ describe('DtTab Tests', () => {
     });
 
     it('should set data-content to match the slot text', () => {
-      const label = tab.find('.d-tab__label');
+      const label = tab.find('.d-tablist__item-label');
 
       expect(label.attributes('data-content')).toBe(MOCK_DEFAULT_SLOT);
     });

--- a/packages/dialtone-vue/components/tab/tab.vue
+++ b/packages/dialtone-vue/components/tab/tab.vue
@@ -2,7 +2,9 @@
   <dt-button
     :id="`dt-tab-${id}`"
     :class="[
+      'd-tablist__item',
       tabClass,
+      { 'd-tablist__item--vertical': groupContext.orientation === 'vertical' },
       { 'd-btn--disabled': isDisabled },
       { 'd-tab--is-selected': !groupContext.outlined && groupContext.kind !== 'muted' && isSelected },
     ]"
@@ -68,7 +70,7 @@
     <!-- @slot default slot, defaults contains dt-button -->
     <span
       ref="tabLabel"
-      class="d-tab__label"
+      class="d-tablist__item-label"
     >
       <slot />
     </span>

--- a/packages/dialtone-vue/components/tab/tab.vue
+++ b/packages/dialtone-vue/components/tab/tab.vue
@@ -71,6 +71,7 @@
     <span
       ref="tabLabel"
       class="d-tablist__item-label"
+      data-qa="dt-tab-label"
     >
       <slot />
     </span>

--- a/packages/dialtone-vue/components/tab/tab_group.test.js
+++ b/packages/dialtone-vue/components/tab/tab_group.test.js
@@ -3,7 +3,7 @@ import DtTabGroup from './tab_group.vue';
 import DtTabPanel from './tab_panel.vue';
 import DtTab from './tab.vue';
 import { returnFirstEl } from '@/common/utils';
-import { TAB_LIST_KIND_MODIFIERS, TAB_LIST_SIZE_MODIFIERS, TAB_LIST_IMPORTANCE_MODIFIERS } from './tabs_constants';
+import { TAB_LIST_KIND_MODIFIERS, TAB_LIST_SIZE_MODIFIERS, TAB_LIST_IMPORTANCE_MODIFIERS, TAB_ORIENTATION_MODIFIERS } from './tabs_constants';
 import { h } from 'vue';
 
 const optionTabPanel = [
@@ -599,6 +599,132 @@ describe('DtTabGroup Tests', () => {
           },
         );
       });
+    });
+  });
+
+  describe('Vertical orientation', () => {
+    beforeEach(() => {
+      props.orientation = 'vertical';
+      _mountWrapper();
+    });
+
+    it('should render the vertical class on the tablist', () => {
+      expect(tabList.classes(TAB_ORIENTATION_MODIFIERS.vertical)).toBe(true);
+    });
+
+    it('should render the vertical class on the wrapper', () => {
+      expect(wrapper.find('[data-qa="dt-tab-group"]').classes('d-tab-neux--vertical')).toBe(true);
+    });
+
+    it('should set aria-orientation to vertical', () => {
+      expect(tabList.attributes('aria-orientation')).toBe('vertical');
+    });
+
+    describe('Keyboard navigation', () => {
+      it('should navigate to next tab on arrow down', async () => {
+        returnFirstEl(tabs.at(0).vm.$el).focus();
+        await tabList.trigger('keydown.down');
+        await tabList.trigger('keyup.enter');
+
+        expect(tabs.at(1).attributes('aria-selected')).toBe('true');
+        expect(tabPanels.at(1).attributes('aria-hidden')).toBe('false');
+      });
+
+      it('should navigate to previous tab on arrow up', async () => {
+        returnFirstEl(tabs.at(0).vm.$el).focus();
+        await tabList.trigger('keydown.up');
+        await tabList.trigger('keyup.space');
+
+        expect(tabs.at(2).attributes('aria-selected')).toBe('true');
+        expect(tabPanels.at(2).attributes('aria-hidden')).toBe('false');
+      });
+
+      it('should NOT navigate on arrow left', async () => {
+        returnFirstEl(tabs.at(0).vm.$el).focus();
+        await tabList.trigger('keyup.left');
+        await tabList.trigger('keyup.enter');
+
+        expect(wrapper.emitted('change')).toBeUndefined();
+      });
+
+      it('should NOT navigate on arrow right', async () => {
+        returnFirstEl(tabs.at(0).vm.$el).focus();
+        await tabList.trigger('keyup.right');
+        await tabList.trigger('keyup.enter');
+
+        expect(wrapper.emitted('change')).toBeUndefined();
+      });
+
+      it('should navigate to first tab on home', async () => {
+        returnFirstEl(tabs.at(2).vm.$el).focus();
+        await tabList.trigger('keydown.home');
+        await tabList.trigger('keyup.enter');
+
+        expect(tabs.at(0).attributes('aria-selected')).toBe('true');
+      });
+
+      it('should navigate to last tab on end', async () => {
+        returnFirstEl(tabs.at(0).vm.$el).focus();
+        await tabList.trigger('keydown.end');
+        await tabList.trigger('keyup.enter');
+
+        expect(tabs.at(2).attributes('aria-selected')).toBe('true');
+      });
+    });
+
+    describe('Auto activation mode', () => {
+      beforeEach(() => {
+        props.activationMode = 'auto';
+        props.orientation = 'vertical';
+        _mountWrapper();
+      });
+
+      it('should auto-select tab on arrow down', async () => {
+        returnFirstEl(tabs.at(0).vm.$el).focus();
+        await tabList.trigger('keydown.down');
+
+        expect(tabs.at(1).attributes('aria-selected')).toBe('true');
+        expect(wrapper.emitted('change').length).toBe(1);
+      });
+
+      it('should auto-select tab on arrow up', async () => {
+        returnFirstEl(tabs.at(0).vm.$el).focus();
+        await tabList.trigger('keydown.up');
+
+        expect(tabs.at(2).attributes('aria-selected')).toBe('true');
+        expect(wrapper.emitted('change').length).toBe(1);
+      });
+    });
+  });
+
+  describe('Horizontal orientation (default)', () => {
+    beforeEach(() => {
+      delete props.orientation;
+      _mountWrapper();
+    });
+
+    it('should set aria-orientation to horizontal by default', () => {
+      expect(tabList.attributes('aria-orientation')).toBe('horizontal');
+    });
+
+    it('should not render the vertical class', () => {
+      expect(tabList.classes(TAB_ORIENTATION_MODIFIERS.vertical)).toBe(false);
+    });
+
+    it('should NOT navigate on arrow up', async () => {
+      returnFirstEl(tabs.at(0).vm.$el).focus();
+      await tabList.trigger('keydown.up');
+      await tabList.trigger('keyup.enter');
+
+      expect(wrapper.emitted('change')).toBeUndefined();
+    });
+
+    it('should NOT navigate on arrow down', async () => {
+      returnFirstEl(tabs.at(0).vm.$el).focus();
+      await tabList.trigger('keydown.down');
+      await tabList.trigger('keyup.enter');
+
+      expect(wrapper.emitted('change')).toBeUndefined();
     });
   });
 

--- a/packages/dialtone-vue/components/tab/tab_group.test.js
+++ b/packages/dialtone-vue/components/tab/tab_group.test.js
@@ -216,7 +216,7 @@ describe('DtTabGroup Tests', () => {
       describe('On keyup left', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
-          await tabList.trigger('keyup.left');
+          await tabList.trigger('keydown.left');
           await tabList.trigger('keyup.space');
         });
 
@@ -229,8 +229,8 @@ describe('DtTabGroup Tests', () => {
       describe('On double keyup left and space', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
-          await tabList.trigger('keyup.left');
-          await tabList.trigger('keyup.left');
+          await tabList.trigger('keydown.left');
+          await tabList.trigger('keydown.left');
           await tabList.trigger('keyup.space');
         });
 
@@ -243,7 +243,7 @@ describe('DtTabGroup Tests', () => {
       describe('On right and enter', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
-          await tabList.trigger('keyup.right');
+          await tabList.trigger('keydown.right');
           await tabList.trigger('keyup.enter');
         });
 
@@ -256,8 +256,8 @@ describe('DtTabGroup Tests', () => {
       describe('On double keyup right and enter', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
-          await tabList.trigger('keyup.right');
-          await tabList.trigger('keyup.right');
+          await tabList.trigger('keydown.right');
+          await tabList.trigger('keydown.right');
           await tabList.trigger('keyup.enter');
         });
 
@@ -319,7 +319,7 @@ describe('DtTabGroup Tests', () => {
 
       it('should land on disabled tab on keyup right', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
-        await tabList.trigger('keyup.right');
+        await tabList.trigger('keydown.right');
 
         expect(document.activeElement.id).toBe('dt-tab-3');
         expect(tabs.at(0).attributes('aria-selected')).toBe('true');
@@ -327,7 +327,7 @@ describe('DtTabGroup Tests', () => {
 
       it('should land on disabled tab on keyup left', async () => {
         returnFirstEl(tabs.at(2).vm.$el).focus();
-        await tabList.trigger('keyup.left');
+        await tabList.trigger('keydown.left');
 
         expect(document.activeElement.id).toBe('dt-tab-3');
         expect(tabs.at(0).attributes('aria-selected')).toBe('true');
@@ -335,7 +335,7 @@ describe('DtTabGroup Tests', () => {
 
       it('should not select disabled tab on enter', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
-        await tabList.trigger('keyup.right');
+        await tabList.trigger('keydown.right');
         await tabList.trigger('keyup.enter');
 
         expect(tabs.at(0).attributes('aria-selected')).toBe('true');
@@ -345,7 +345,7 @@ describe('DtTabGroup Tests', () => {
 
       it('should not select disabled tab on space', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
-        await tabList.trigger('keyup.right');
+        await tabList.trigger('keydown.right');
         await tabList.trigger('keyup.space');
 
         expect(tabs.at(0).attributes('aria-selected')).toBe('true');
@@ -437,7 +437,7 @@ describe('DtTabGroup Tests', () => {
 
       it('should focus disabled tab but not auto-select it', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
-        await tabList.trigger('keyup.right');
+        await tabList.trigger('keydown.right');
 
         expect(document.activeElement.id).toBe('dt-tab-3');
         expect(tabs.at(0).attributes('aria-selected')).toBe('true');
@@ -446,8 +446,8 @@ describe('DtTabGroup Tests', () => {
 
       it('should auto-select enabled tab', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
-        await tabList.trigger('keyup.right');
-        await tabList.trigger('keyup.right');
+        await tabList.trigger('keydown.right');
+        await tabList.trigger('keydown.right');
 
         expect(document.activeElement.id).toBe('dt-tab-5');
         expect(tabs.at(2).attributes('aria-selected')).toBe('true');
@@ -482,7 +482,7 @@ describe('DtTabGroup Tests', () => {
 
     it('should select tab on arrow right', async () => {
       returnFirstEl(tabs.at(0).vm.$el).focus();
-      await tabList.trigger('keyup.right');
+      await tabList.trigger('keydown.right');
 
       expect(tabs.at(1).attributes('aria-selected')).toBe('true');
       expect(wrapper.emitted('change').length).toBe(1);
@@ -490,7 +490,7 @@ describe('DtTabGroup Tests', () => {
 
     it('should select tab on arrow left', async () => {
       returnFirstEl(tabs.at(0).vm.$el).focus();
-      await tabList.trigger('keyup.left');
+      await tabList.trigger('keydown.left');
 
       expect(tabs.at(2).attributes('aria-selected')).toBe('true');
       expect(wrapper.emitted('change').length).toBe(1);
@@ -534,7 +534,7 @@ describe('DtTabGroup Tests', () => {
         let lastPanel;
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
-          await tabList.trigger('keyup.left');
+          await tabList.trigger('keydown.left');
           await tabList.trigger('keyup.space');
           lastTab = tabs.at(2).attributes();
           lastPanel = tabPanels.at(2).attributes();
@@ -549,7 +549,7 @@ describe('DtTabGroup Tests', () => {
       describe('attributes after keyup right', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
-          await tabList.trigger('keyup.right');
+          await tabList.trigger('keydown.right');
           await tabList.trigger('keyup.enter');
         });
 
@@ -641,7 +641,7 @@ describe('DtTabGroup Tests', () => {
 
       it('should NOT navigate on arrow left', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
-        await tabList.trigger('keyup.left');
+        await tabList.trigger('keydown.left');
         await tabList.trigger('keyup.enter');
 
         expect(wrapper.emitted('change')).toBeUndefined();
@@ -649,7 +649,7 @@ describe('DtTabGroup Tests', () => {
 
       it('should NOT navigate on arrow right', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
-        await tabList.trigger('keyup.right');
+        await tabList.trigger('keydown.right');
         await tabList.trigger('keyup.enter');
 
         expect(wrapper.emitted('change')).toBeUndefined();

--- a/packages/dialtone-vue/components/tab/tab_group.vue
+++ b/packages/dialtone-vue/components/tab/tab_group.vue
@@ -20,8 +20,8 @@
       role="tablist"
       :aria-label="label"
       :aria-orientation="orientation"
-      @keyup.left="tabLeft"
-      @keyup.right="tabRight"
+      @keydown.left="tabLeft"
+      @keydown.right="tabRight"
       @keydown.up="tabUp"
       @keydown.down="tabDown"
       @keyup.enter="selectTab"
@@ -129,7 +129,7 @@ export default {
     size: {
       type: String,
       default: 'default',
-      validate (size) {
+      validator (size) {
         return TAB_LIST_SIZES.includes(size);
       },
     },

--- a/packages/dialtone-vue/components/tab/tab_group.vue
+++ b/packages/dialtone-vue/components/tab/tab_group.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     data-qa="dt-tab-group"
-    class="d-tab-neux"
+    :class="['d-tab-neux', { 'd-tab-neux--vertical': orientation === 'vertical' }]"
   >
     <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
     <div
@@ -9,6 +9,7 @@
       :class="[
         'd-tablist',
         TAB_LIST_SIZE_MODIFIERS[size],
+        TAB_ORIENTATION_MODIFIERS[orientation],
         {
           [TAB_LIST_KIND_MODIFIERS.inverted]: inverted,
           [TAB_LIST_IMPORTANCE_MODIFIERS.borderless]: borderless,
@@ -18,9 +19,11 @@
       v-bind="tabListChildProps"
       role="tablist"
       :aria-label="label"
-      aria-orientation="horizontal"
+      :aria-orientation="orientation"
       @keyup.left="tabLeft"
       @keyup.right="tabRight"
+      @keydown.up="tabUp"
+      @keydown.down="tabDown"
       @keyup.enter="selectTab"
       @keyup.space="selectTab"
       @click="selectTab"
@@ -41,6 +44,8 @@ import {
   TAB_LIST_KIND_MODIFIERS,
   TAB_LIST_IMPORTANCE_MODIFIERS,
   TAB_LIST_SIZE_MODIFIERS,
+  TAB_ORIENTATIONS,
+  TAB_ORIENTATION_MODIFIERS,
   TAB_ACTIVATION_MODES,
   TAB_GROUP_KINDS,
 } from './tabs_constants';
@@ -103,6 +108,18 @@ export default {
     borderless: {
       type: Boolean,
       default: false,
+    },
+
+    /**
+     * The orientation of the tab list
+     * @values horizontal, vertical
+     */
+    orientation: {
+      type: String,
+      default: 'horizontal',
+      validator (value) {
+        return TAB_ORIENTATIONS.includes(value);
+      },
     },
 
     /**
@@ -194,6 +211,7 @@ export default {
         size: 'default',
         kind: 'default',
         outlined: false,
+        orientation: 'horizontal',
       },
 
       focusId: null,
@@ -201,6 +219,7 @@ export default {
       TAB_LIST_SIZE_MODIFIERS,
       TAB_LIST_KIND_MODIFIERS,
       TAB_LIST_IMPORTANCE_MODIFIERS,
+      TAB_ORIENTATION_MODIFIERS,
     };
   },
 
@@ -237,6 +256,13 @@ export default {
       immediate: true,
       handler () {
         this.provideObj.outlined = this.outlined;
+      },
+    },
+
+    orientation: {
+      immediate: true,
+      handler () {
+        this.provideObj.orientation = this.orientation;
       },
     },
   },
@@ -283,6 +309,28 @@ export default {
     },
 
     tabLeft () {
+      if (this.orientation !== 'horizontal') return;
+      this.navigatePrevious();
+    },
+
+    tabRight () {
+      if (this.orientation !== 'horizontal') return;
+      this.navigateNext();
+    },
+
+    tabUp (event) {
+      if (this.orientation !== 'vertical') return;
+      event.preventDefault();
+      this.navigatePrevious();
+    },
+
+    tabDown (event) {
+      if (this.orientation !== 'vertical') return;
+      event.preventDefault();
+      this.navigateNext();
+    },
+
+    navigatePrevious () {
       const index = this.getFocusedTabIndex();
       if (index === -1) return;
 
@@ -290,7 +338,7 @@ export default {
       this.selectFocusOnTab(nextIndex);
     },
 
-    tabRight () {
+    navigateNext () {
       const index = this.getFocusedTabIndex();
       if (index === -1) return;
 

--- a/packages/dialtone-vue/components/tab/tabs_constants.js
+++ b/packages/dialtone-vue/components/tab/tabs_constants.js
@@ -15,6 +15,12 @@ export const TAB_LIST_IMPORTANCE_MODIFIERS = {
   borderless: 'd-tablist--no-border',
 };
 
+export const TAB_ORIENTATIONS = ['horizontal', 'vertical'];
+
+export const TAB_ORIENTATION_MODIFIERS = {
+  vertical: 'd-tablist--vertical',
+};
+
 export const TAB_ACTIVATION_MODES = ['auto', 'manual'];
 
 export const TAB_GROUP_KINDS = ['default', 'muted'];


### PR DESCRIPTION
<img width="232" height="174" alt="image" src="https://github.com/user-attachments/assets/ad362d74-8d2c-4864-a134-638f12a8dc33" />

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-3114](https://dialpad.atlassian.net/browse/DLT-3114)

## :book: Description

- Add `orientation` prop (`horizontal` (default) | `vertical`)
- Vertical keyboard navigation: Up/Down arrows
- Assign `aria-orientation`
- Restructure `tabs.less` with custom properties and idiomatic BEM nesting
- Fix pre-existing `validate` → `validator` typo on `size` prop
- Unify all arrow keypress handlers to `keydown` over `keyup`

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

https://github.com/user-attachments/assets/a26650cb-3889-45dd-92eb-35bf0c0298ed




[DLT-3114]: https://dialpad.atlassian.net/browse/DLT-3114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ