### PR TITLE
fix(editor): NO-JIRA empty div issue with nested block elements

### DIFF
--- a/packages/dialtone-vue/components/rich_text_editor/extensions/div/div.js
+++ b/packages/dialtone-vue/components/rich_text_editor/extensions/div/div.js
@@ -1,13 +1,35 @@
 import { mergeAttributes } from '@tiptap/core';
 import Paragraph from '@tiptap/extension-paragraph';
 
+const BLOCK_TAGS = new Set([
+  'address', 'article', 'aside', 'blockquote', 'dd', 'details',
+  'dialog', 'div', 'dl', 'dt', 'fieldset', 'figcaption', 'figure',
+  'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header',
+  'hgroup', 'hr', 'li', 'main', 'nav', 'ol', 'p', 'pre', 'section',
+  'table', 'ul',
+]);
+
 /** Extension for div tag support
  * Replaces the default p tags when typing text to div tags
  * Extends the following extension: https://github.com/ueberdosis/tiptap/blob/main/packages/extension-paragraph/src/paragraph.ts
  */
 export const DivParagraph = Paragraph.extend({
   parseHTML () {
-    return [{ tag: 'div' }];
+    return [{
+      tag: 'div',
+      getAttrs: (node) => {
+        // Skip divs that contain block-level children. Without this check ProseMirror would
+        // match the container as a paragraph and then immediately close it
+        // (creating an empty <div></div>) before lifting the block children
+        // out, resulting in unwanted blank lines.
+        for (const child of node.children) {
+          if (BLOCK_TAGS.has(child.tagName.toLowerCase())) {
+            return false;
+          }
+        }
+        return null;
+      },
+    }];
   },
 
   renderHTML ({ HTMLAttributes }) {

--- a/packages/dialtone-vue/components/rich_text_editor/extensions/div/div.test.js
+++ b/packages/dialtone-vue/components/rich_text_editor/extensions/div/div.test.js
@@ -1,0 +1,104 @@
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import Text from '@tiptap/extension-text';
+import { DivParagraph } from './div';
+
+const createEditor = () => new Editor({
+  extensions: [Document, Text, DivParagraph],
+  content: '',
+});
+
+const getJSON = (editor, html) => {
+  editor.commands.setContent(html, false);
+  return editor.getJSON();
+};
+
+describe('DivParagraph extension', () => {
+  let editor;
+
+  beforeEach(() => {
+    editor = createEditor();
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  describe('parseHTML getAttrs', () => {
+    it('should parse a div with only inline children as a paragraph', () => {
+      const json = getJSON(editor, '<div><span>hello</span> world</div>');
+      const paragraphs = json.content.filter(n => n.type === 'paragraph');
+
+      expect(paragraphs).toHaveLength(1);
+      expect(paragraphs[0].content.some(n => n.text?.includes('hello'))).toBe(true);
+    });
+
+    it('should parse a div with only text as a paragraph', () => {
+      const json = getJSON(editor, '<div>plain text</div>');
+      const paragraphs = json.content.filter(n => n.type === 'paragraph');
+
+      expect(paragraphs).toHaveLength(1);
+      expect(paragraphs[0].content[0].text).toBe('plain text');
+    });
+
+    it('should reject a div that contains a block-level child (nested div)', () => {
+      const json = getJSON(editor, '<div><div>nested</div></div>');
+      // The outer div should NOT become a paragraph itself.
+      // ProseMirror should lift the inner div into its own paragraph.
+      const paragraphs = json.content.filter(n => n.type === 'paragraph');
+
+      expect(paragraphs).toHaveLength(1);
+      expect(paragraphs[0].content[0].text).toBe('nested');
+    });
+
+    it('should reject a div that contains a <p> child', () => {
+      const json = getJSON(editor, '<div><p>inside p</p></div>');
+      const paragraphs = json.content.filter(n => n.type === 'paragraph');
+
+      expect(paragraphs).toHaveLength(1);
+      expect(paragraphs[0].content[0].text).toBe('inside p');
+    });
+
+    it('should reject a div that contains a <ul> child', () => {
+      const json = getJSON(editor, '<div><ul><li>item</li></ul></div>');
+      const paragraphs = json.content.filter(n => n.type === 'paragraph');
+
+      // The outer div should be skipped (not become a paragraph) because
+      // it contains a block-level <ul>. The text content is still parsed.
+      // There should be no extra empty paragraph from the outer div.
+      expect(paragraphs.every(p => p.content?.length > 0)).toBe(true);
+    });
+
+    it('should reject a div that contains an <h1> child', () => {
+      const json = getJSON(editor, '<div><h1>heading</h1></div>');
+
+      // The heading text should still be parsed, but the outer div
+      // should not produce an extra empty paragraph wrapper.
+      const allText = json.content
+        .flatMap(n => n.content || [])
+        .map(n => n.text)
+        .filter(Boolean);
+
+      expect(allText).toContain('heading');
+    });
+
+    it('should not produce extra empty paragraphs for structural divs', () => {
+      const json = getJSON(editor, '<div><div>a</div><div>b</div></div>');
+      const paragraphs = json.content.filter(n => n.type === 'paragraph');
+
+      // Should get two paragraphs (from the two inner divs), not three
+      expect(paragraphs).toHaveLength(2);
+      expect(paragraphs[0].content[0].text).toBe('a');
+      expect(paragraphs[1].content[0].text).toBe('b');
+    });
+
+    it('should parse multiple sibling inline-only divs as separate paragraphs', () => {
+      const json = getJSON(editor, '<div>first</div><div>second</div>');
+      const paragraphs = json.content.filter(n => n.type === 'paragraph');
+
+      expect(paragraphs).toHaveLength(2);
+      expect(paragraphs[0].content[0].text).toBe('first');
+      expect(paragraphs[1].content[0].text).toBe('second');
+    });
+  });
+});


### PR DESCRIPTION
# Empty div issue with nested block elements

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExODZxNWp4YjRxM2R3MzFxZjc3NGluYnNuNWt4bTBidng1MDRwcTBrdCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/4qw6Eeo8JIq8U/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: NO-JIRA


## :book: Description

<!--- Describe specifically what the changes are -->
- Added logic to not convert divs with block children into paragraphs

## 💡 Context
Nesting a block element in a div would cause it to render an extra newline (see SS below).
This is likely due to how Tiptap tries to flatten the html when parsing it.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :camera: Screenshots / GIFs

#### Observed Issue: 
<img width="1920" height="1080" alt="Screenshot 2026-03-11 at 6 17 09 PM" src="https://github.com/user-attachments/assets/d276eba1-1bf7-4247-bed4-2745c369a7de" />

#### Fix:
<img width="1920" height="1080" alt="Screenshot 2026-03-11 at 6 17 05 PM" src="https://github.com/user-attachments/assets/aac55033-1cd8-410f-a2f5-2102bf6fbaec" />

