### PR TITLE
fix(docs): NO-JIRA override default theme code example text color

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-syntax.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-syntax.less
@@ -4,6 +4,7 @@
  */
 
 div[class*="language-"] {
+	--code-c-text: var(--dt-color-foreground-secondary);
 	margin: var(--dt-size-500) 0;
 	padding: var(--dt-size-500);
 	background-color: var(--dt-color-surface-secondary);


### PR DESCRIPTION
# fix(docs): NO-JIRA fix next code example text color

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExemt4enhlaW1wM2ZodzdsNzVqaDEwbzZ0MnhmeHgxMXNyZzFheXphYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JUh0yTz4h931K/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

<!--- Describe specifically what the changes are -->

This change sets the default code color to a token that will be legible in both light & dark modes.

## :bulb: Context

In light mode, some text within the code examples becomes illegible due to the specificity of the default theme.

Examples of pages with this issue:
https://dialtone.dialpad.com/next/components/badge.html#vue-api
https://dialtone.dialpad.com/next/utilities/#_8-and-change-the-border-color
https://dialtone.dialpad.com/next/ui-kits/what-are-ui-kits/#component-grouping

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

<img width="1383" height="1048" alt="Screenshot 2026-03-16 at 1 24 44 PM" src="https://github.com/user-attachments/assets/4f78d192-3f47-40d5-8318-806c7b8e79cc" />

<img width="1364" height="1057" alt="Screenshot 2026-03-16 at 1 24 55 PM" src="https://github.com/user-attachments/assets/284f368e-ada0-44d3-b931-66a7c91f23a9" />


## :link: Sources

<!--- Add any links to external reference material -->
