### PR TITLE
fix(docs): NO-JIRA fix dt-select-menu value on modal docs page

### DIFF
--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -402,16 +402,9 @@ When there is a need of more context information regarding the content of the Mo
     <dt-select-menu
       label="Kind of Banner"
       size="md"
-      @change="changeBannerKind"
-    >
-      <option
-        v-for="option in bannerKinds()"
-        :key="option"
-        :selected="option === selectedBannerKind"
-        :value="option"
-        v-text="option"
-      />
-    </dt-select-menu>
+      :options="bannerKinds"
+      v-model="selectedBannerKind"
+    />
     <example-modal kind="default" :banner-kind="selectedBannerKind" banner-title="This banner can have different kinds." />
   </dt-stack>
 </code-well-header>
@@ -569,11 +562,6 @@ At minimum, modals contain a title and one button. They could also contain body 
     if (!value) isOpen.value = false;
   };
 
-  const changeBannerKind = (kind) => {
-    selectedBannerKind.value = kind;
-  };
-
-  const bannerKinds = () => {
-    return Object.keys(window.DIALTONE_CONSTANTS.MODAL_BANNER_KINDS);
-  };
+  const bannerKinds = Object.keys(window.DIALTONE_CONSTANTS.MODAL_BANNER_KINDS)
+    .map(kind => ({ value: kind, label: kind }));
 </script>


### PR DESCRIPTION
# fix(docs): NO-JIRA fix dt-select-menu value on modal docs page

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExdWt4Zm9tNW5nZWVwc3B3ZGxtN2QxNzdwaHQzMXVkbmxzcDFzYWZpbyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/gZGlQX3wWAV1u/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Fix `<dt-select-menu>` on the modal docs page to use `v-model` and `:options` prop, resolving the blank initial selected value.

Current (before): https://dialtone.dialpad.com/components/modal.html#has-banner
Preview (after): https://dialtone.dialpad.com/deploy-previews/pr-1132/components/modal.html#has-banner

<!--- Describe specifically what the changes are -->

## :bulb: Context
The `DtSelectMenu` on the modal page was not reflecting the initial value properly -- it appeared blank. Similar to previous fixes: https://github.com/dialpad/dialtone/pull/984
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->
<img width="967" height="773" alt="Screenshot 2026-03-17 at 9 40 44 AM" src="https://github.com/user-attachments/assets/5d3c8d77-5417-4e48-a6e5-dc03920c1fa7" />


## :link: Sources

<!--- Add any links to external reference material -->
