### PR TITLE
feat: DLT-3144 support truncation within message input bottom btns

### DIFF
--- a/packages/dialtone-css/lib/build/less/recipes/message_input.less
+++ b/packages/dialtone-css/lib/build/less/recipes/message_input.less
@@ -46,6 +46,7 @@
 }
 
 .d-recipe-message-input__button {
+  flex-shrink: 0;
   max-width: 2.8rem;
   max-height: 2.8rem;
   border-radius: var(--dt-size-radius-300);
@@ -65,6 +66,7 @@
 
 .d-recipe-message-input__bottom-section {
   display: flex;
+  flex-wrap: nowrap;
   justify-content: space-between;
   padding: var(--dt-space-300) var(--dt-space-400) var(--dt-space-400);
 }
@@ -72,6 +74,12 @@
 .d-recipe-message-input__bottom-section-left,
 .d-recipe-message-input__bottom-section-right {
   display: flex;
+}
+
+.d-recipe-message-input__bottom-section-left,
+.d-recipe-message-input__bottom-section-left-stack {
+  flex: 1 1 auto;
+  min-width: var(--dt-size-0);
 }
 
 .d-recipe-message-input__image-input {

--- a/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.vue
@@ -92,6 +92,7 @@
         <dt-stack
           gap="200"
           direction="row"
+          class="d-recipe-message-input__bottom-section-left-stack"
         >
           <dt-button
             v-if="showImagePicker"


### PR DESCRIPTION
# feat: DLT-3144 support truncation within message input bottom btns

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWhkbHY2MWExdTd0MXdhbmxyN2ZhdWQwcmMzNzVsOG8wOXU1bjljYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/v2buJpsYSREbanxNDn/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3144

## :book: Description

Add some css properties to support truncation within buttons in the lower section

## :bulb: Context

This should make no difference to the current visuals of the message input but allows for truncation of buttons within the stack.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
