### PR TITLE
fix(deprecated-component): NO-JIRA fix deprecated component regex

### DIFF
--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-component.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-component.js
@@ -67,10 +67,16 @@ module.exports = {
     return {
       ImportDeclaration(node) {
         let foundIndex;
+        const importPath = node.source.value.toLowerCase();
+
+        // Skip Dialtone's own component imports to avoid false positives
+        if (importPath.includes('@dialpad/dialtone')) {
+          return;
+        }
 
         deprecatedComponents.forEach(item => {
           const regex = new RegExp(`^.*/${item.fileName}(?:\\.vue)?$`, 'g');
-          foundIndex = node.source.value.toLowerCase().search(regex);
+          foundIndex = importPath.search(regex);
 
           if (foundIndex !== -1) {
             context.report({


### PR DESCRIPTION
# NO-JIRA fix deprecated component regex

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix


## :book: Description

Using treeshaking import, trigger a false-positive eslint issue with 
`import { DtCheckbox } from '@dialpad/dialtone/vue3/lib/checkbox`

This because our regex detect the end of the import as `checkbox`, this is a deprecated component.



## :bulb: Context

Added an early return to skip imports from dialpad/dialtone packages.

