### PR TITLE
fix(combobox-multi-select): DP-180791 cursor position

### DIFF
--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -305,6 +305,38 @@ describe('DtComboboxMultiSelect Tests', () => {
     });
   });
 
+  describe('Duplicate Items Tests', () => {
+    beforeEach(async () => {
+      await wrapper.setProps({ selectedItems: ['item1', 'item1', 'item1'] });
+      await flushPromises();
+      _setChildWrappers();
+    });
+
+    it('should render a chip for each duplicate item', () => {
+      expect(chips.length).toBe(3);
+    });
+
+    it('should return distinct elements from getChips for duplicates', () => {
+      const chipElements = wrapper.vm.getChips();
+      const unique = new Set(chipElements);
+      expect(unique.size).toBe(3);
+    });
+  });
+
+  describe('Bulk Update Tests', () => {
+    it('should return chips in selectedItems order after bulk update', async () => {
+      await wrapper.setProps({ selectedItems: ['alpha', 'beta', 'gamma'] });
+      await flushPromises();
+      _setChildWrappers();
+
+      const chipElements = wrapper.vm.getChips();
+      const labels = chipElements.map(
+        el => el.querySelector('.d-chip__label')?.textContent?.trim(),
+      );
+      expect(labels).toEqual(['alpha', 'beta', 'gamma']);
+    });
+  });
+
   describe('Validation Tests', () => {
     beforeEach(async () => {
       await wrapper.setProps({

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
@@ -27,9 +27,9 @@
           :class="['d-recipe-combobox-multi-select__chip-wrapper', chipWrapperClass]"
         >
           <dt-chip
-            v-for="item in selectedItems"
+            v-for="(item, index) in selectedItems"
             ref="chips"
-            :key="item"
+            :key="`${index}-${item}`"
             :label-class="['d-chip__label']"
             :class="[
               'd-recipe-combobox-multi-select__chip',
@@ -586,11 +586,18 @@ export default {
     getChips () {
       if (!this.selectedItems.length || !this.$refs.chips) return null;
 
-      // use the order from selectedItems to not rely on DOM order which may be stale
+      // Use the order from selectedItems to not rely on DOM order which may be stale.
+      // Track matched indices to handle duplicate item names correctly.
+      const matched = new Set();
       const chips = this.selectedItems.map(item => {
-        return this.$refs.chips.find(chip => {
+        return this.$refs.chips.find((chip, index) => {
+          if (matched.has(index)) return false;
           const chipLabel = returnFirstEl(chip.$el)?.querySelector('.d-chip__label')?.textContent?.trim();
-          return chipLabel === item;
+          if (chipLabel === item) {
+            matched.add(index);
+            return true;
+          }
+          return false;
         });
       });
       return chips.filter(Boolean).map(chip => returnFirstEl(chip.$el));


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExZjNmOWY4NDc2ZjI0ZTk0ZGQ2NjU2ZjI3YmI2ZTFmYjI3YjkzMmI4YSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/13FrpeVH09Zrb2/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

[DP-180791](https://dialpad.atlassian.net/browse/DP-180791)

## :book: Description

Fix cursor positioning and text overlap in `DtComboboxMultiSelect` when `selectedItems` contains duplicate values (e.g. adding the same contact twice in bulk SMS).

## :bulb: Context

When `selectedItems` contains duplicates, `getChips()` resolved every duplicate to the **same** DOM element. This caused `getLastChip()` to return the wrong element, making `setInputPadding()` calculate incorrect cursor positioning — the cursor appeared on the wrong line and text overlapped with chips.

The previous `getChips()` implementation (from #1006) used label text matching to preserve `selectedItems` order when `$refs.chips` DOM order was stale after bulk updates. This fix extends that approach to also handle duplicates correctly.

Added tests for both cases.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

### Before
<img width="498" height="189" alt="image" src="https://github.com/user-attachments/assets/5106b6e5-eea7-4a1c-a00d-85abf9b84050" />


### After
<img width="369" height="151" alt="image" src="https://github.com/user-attachments/assets/d19307ad-52f3-4d7a-951f-05bf9133bd90" />





[DP-180791]: https://dialpad.atlassian.net/browse/DP-180791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ