### PR TITLE
feat(editor): DP-181154 replacing 0 width tables with full width

### DIFF
--- a/packages/dialtone-vue/components/rich_text_editor/extensions/table/table.js
+++ b/packages/dialtone-vue/components/rich_text_editor/extensions/table/table.js
@@ -10,6 +10,20 @@ const createAttribute = (name) => ({
   },
 });
 
+const createTableStyleAttribute = () => {
+  let attribute = createAttribute('style');
+  attribute.renderHTML = (attributes) => {
+    if (!attributes['style']) return {};
+    return { ['style']: replaceZeroWidth(attributes['style']) };
+  }
+  return attribute;
+};
+
+function replaceZeroWidth(style) {
+  return style.replace(/width\s*:\s*([^;]+);/gi, (match, value) => {
+    return /^\s*0\s*[a-z%]*\s*$/i.test(value) ? 'width: 100%;' : match;
+  });
+}
 export const CustomTable = Table.extend({
   addAttributes () {
     return {
@@ -17,7 +31,7 @@ export const CustomTable = Table.extend({
       border: createAttribute('border'),
       cellpadding: createAttribute('cellpadding'),
       cellspacing: createAttribute('cellspacing'),
-      style: createAttribute('style'),
+      style: createTableStyleAttribute(),
     };
   },
 

--- a/packages/dialtone-vue/components/rich_text_editor/extensions/table/table.js
+++ b/packages/dialtone-vue/components/rich_text_editor/extensions/table/table.js
@@ -20,10 +20,11 @@ const createTableStyleAttribute = () => {
 };
 
 function replaceZeroWidth(style) {
-  return style.replace(/width\s*:\s*([^;]+);/gi, (match, value) => {
-    return /^\s*0\s*[a-z%]*\s*$/i.test(value) ? 'width: 100%;' : match;
+  return style.replace(/(?<![a-z-])width\s*:\s*([^;]+);?/gi, (match, value) => {
+    return /^\s*0\s*[a-z%]*\s*(!important)?\s*$/i.test(value) ? 'width: 100%;' : match;
   });
 }
+
 export const CustomTable = Table.extend({
   addAttributes () {
     return {


### PR DESCRIPTION
# Addressing 0 Width Tables

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExMzI0azB1dXFuZWIxN2EzNjZub2gzcTFzcDhtZWllMGthbHFxc2I5MSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5wM2zlgRLG9KU/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DP-181154
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

Table width in Editor will now be enforced to 100% when the value is 0px

## :bulb: Context

Tables sometimes get pasted with a width of 0px when being pasted from excel/sheets. This gets rendered by email editors improperly since they show up compressed. Furthermore, tables with a width of 0 px get displayed in the editor as 100%. Consolidating the behavior so that the displayed table and css of the table within the editor output is the same.

This deals with various forms of 0 (px, %, rem, em, vw, vh, etc)
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [ ] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [ ] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.


## :camera: Screenshots / GIFs
### Before
<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->
<img width="1624" height="969" alt="Screenshot 2026-03-20 at 2 34 59 AM" src="https://github.com/user-attachments/assets/f9064712-1dbe-4031-9ea2-56ec9eaa896e" />

### After

<img width="1624" height="969" alt="Screenshot 2026-03-20 at 2 36 37 AM" src="https://github.com/user-attachments/assets/38a45c3a-6b57-4c67-b901-cb8fffae49b3" />

## :link: Sources

<!--- Add any links to external reference material -->
