### PR TITLE
feat: DLT-3049 add code review rules, skill, agent, and command

### DIFF
--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -1,0 +1,64 @@
+---
+description: "Background code review agent for large diffs (10+ files). Spawned by the review skill when the diff is too large for inline review. Reads .claude/rules/code-review.md and applies rules to all changed files in isolation."
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+---
+
+# Code Review Agent
+
+Background review agent for large diffs. Spawned by the `/review` skill when 10+ files are in scope. Runs the same review logic in an isolated context to avoid bloating the main conversation.
+
+## Workflow
+
+### 1. Load the rules
+
+Read `.claude/rules/code-review.md` to load the full review checklist (9 categories).
+
+### 2. Get the diff
+
+Run `git diff --name-only` (unstaged) and `git diff --cached --name-only` (staged) to get the list of changed files. If neither has changes, detect the base branch dynamically:
+- Try: `git rev-parse --abbrev-ref HEAD@{upstream} 2>/dev/null`
+- Fallback: `git remote show origin | sed -n 's/.*HEAD branch: //p'`
+- Then: `git diff --name-only <base>...HEAD`
+
+### 3. Map files to rule categories
+
+Read `.claude/skills/review.md` and use the file type → category mapping table from Step 4. That table is the single source of truth — the agent has `Read` in its tool list specifically for this cross-file dependency.
+
+### 4. Review each file
+
+For each file:
+
+1. Read the full file for context
+2. Read the diff for that file: `git diff -- <filepath>`
+3. Check each applicable rule from the checklist
+4. Record findings with file path and line number
+
+### 5. Return findings
+
+Return a single summary message with all findings grouped by file:
+
+```text
+## Code Review Results (N files reviewed)
+
+### path/to/file.vue
+- [Rule category] Finding description (line N)
+
+### path/to/other_file.less
+- [Rule category] Finding description (line N)
+
+---
+Clean files: path/to/clean.test.js, path/to/clean.stories.js
+```
+
+## Rules
+
+- **Report only** — never modify files
+- **Read before judging** — always read the full file for context, not just the diff
+- **Be specific** — include file path, line number, and which rule was checked
+- **Skip irrelevant categories** — don't check CSS rules on test files
+- **Flag uncertainty** — if unsure, say so
+- **Don't duplicate linting** — skip issues ESLint/Stylelint already catch

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -33,7 +33,7 @@ Read `.claude/skills/review.md` and use the file type → category mapping table
 For each file:
 
 1. Read the full file for context
-2. Read the diff for that file: `git diff -- <filepath>`
+2. Read the diff for that file: `git diff HEAD -- <filepath>`
 3. Check each applicable rule from the checklist
 4. Record findings with file path and line number
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,11 @@
+---
+description: Run a local code review against Dialtone review rules. Reviews staged/unstaged changes or specific files.
+---
+
+Run the **review** skill to check changed code against the Dialtone code review checklist.
+
+## Usage
+
+- `/review` — Review all changed files
+- `/review <area>` — Focus on one category: `reuse`, `quality`, `vue`, `css`, `api`, `testing`, `storybook`, `i18n`, `accessibility`
+- `/review <file>` — Review a specific file

--- a/.claude/rules/code-review.md
+++ b/.claude/rules/code-review.md
@@ -1,0 +1,69 @@
+---
+paths:
+  - "packages/dialtone-vue/**"
+  - "packages/dialtone-css/**"
+  - "packages/dialtone-tokens/**"
+  - "packages/dialtone-icons/**"
+---
+
+# Code Review Rules
+
+Dialtone code review checklist. Each rule is a verification question to check against changed code. See DLT-3049 for context.
+
+## 1. Reuse & Duplication
+
+- Is the component too similar to another component in the system?
+- Can any code or functions already written in the system be used in this change?
+- Is there any repeated code that should be extracted into a function?
+
+## 2. Code Quality & Readability
+
+- Is the code written in a way that is easily human readable?
+- Is the code maintainable? If we have to add on more, or change the functionality in the future is it easy to do that or do we have to rewrite the entire thing?
+- Does the code have comments for any complex code that is not immediately easy to understand by looking at it?
+
+## 3. Vue Correctness
+
+- Is the component reactive on both initialization, and when props are changed after initialization?
+- Does the component avoid using `$slots` in computed properties? (`$slots` is not reactive in computed.)
+- Is object syntax used for conditional classes in the template?
+
+See `.claude/rules/vue-components.md` for detailed Vue conventions (props, events, slots, file structure).
+
+## 4. CSS / Styling
+
+- Does the code use Dialtone design tokens everywhere possible for CSS/LESS values?
+- Does the code use flat CSS selectors as much as possible?
+- Does the CSS follow BEM (Block Element Modifier) principles?
+
+See `.claude/rules/css-utilities.md` for token reference and naming conventions.
+
+## 5. API & Library Design
+
+- Is the component, function, or const exported as part of the library?
+- Are there any breaking changes for consumers of the library?
+- Do class props support all possible class types: `String`, `Object`, `Array`?
+
+## 6. Testing
+
+- Do the tests have one assertion per test?
+- Do the tests take advantage of using `beforeAll` and `beforeEach` as much as possible to cut down on repetition?
+- Have we used `it.each` for tests with a very similar process, but different values?
+
+See `.claude/rules/vue-tests.md` for test framework details and patterns.
+
+## 7. Storybook
+
+- Is the change correctly rendered and easy to change parameters for in Storybook?
+
+## 8. Internationalization & Assets
+
+- Are all English language strings in the design system components translated via i18n?
+- Are all images stored locally? (no external URLs)
+
+## 9. Accessibility
+
+- Will the component read correctly on a screenreader?
+- Does it meet contrast requirements?
+- Is it keyboard navigable?
+- Does it meet WCAG 2.1 AA accessibility guidelines?

--- a/.claude/skills/review.md
+++ b/.claude/skills/review.md
@@ -23,9 +23,8 @@ Read `.claude/rules/code-review.md` to load the full review checklist.
 Determine what to review:
 
 1. If user specified a file path → review that file
-2. If there are staged changes → `git diff --cached --name-only`
-3. If there are unstaged changes → `git diff --name-only`
-4. If no local changes → diff against the base branch:
+2. Collect **both** staged and unstaged changed files: `git diff --cached --name-only` + `git diff --name-only`, deduplicate the union
+3. If no local changes → diff against the base branch:
    - Detect base: `git rev-parse --abbrev-ref HEAD@{upstream} 2>/dev/null` — extracts the remote tracking branch (e.g., `origin/staging`, `origin/next`)
    - If no upstream is set, fall back to the repo's default branch: `git remote show origin | sed -n 's/.*HEAD branch: //p'`
    - Then: `git diff --name-only <base>...HEAD`
@@ -44,7 +43,7 @@ For each changed file, determine which review categories apply:
 |---|---|
 | `*.vue` | Reuse & Duplication, Code Quality, Vue Correctness, API & Library Design, i18n & Assets, Accessibility |
 | `*.less` | CSS / Styling |
-| `*.test.js` | Testing |
+| `*.test.js`, `*.test.ts` | Testing |
 | `*.stories.js`, `*.mdx` | Storybook |
 | JS helpers (`*_constants.js`, `validators.js`, `utils.js`, `index.js`, and similar) | Reuse & Duplication, Code Quality, API & Library Design |
 | `packages/dialtone-tokens/**/*.json` | CSS / Styling (token usage) |

--- a/.claude/skills/review.md
+++ b/.claude/skills/review.md
@@ -1,0 +1,91 @@
+---
+description: "Local code review against Dialtone review rules. Triggered by '/review', natural language ('review my changes', 'check this code'), or '/review <area>' for focused review (e.g., '/review accessibility', '/review css'). Reads the rules from .claude/rules/code-review.md and applies them to changed files."
+---
+
+# Dialtone Code Review
+
+Reviews changed code against the Dialtone code review checklist defined in `.claude/rules/code-review.md`. Reports findings only — does not auto-fix or commit.
+
+## Usage
+
+- `/review` — Review all staged and unstaged changes
+- `/review <area>` — Focus on one category: `reuse`, `quality`, `vue`, `css`, `api`, `testing`, `storybook`, `i18n`, `accessibility`
+- `/review <file>` — Review a specific file
+
+## Workflow
+
+### Step 1 — Load the rules
+
+Read `.claude/rules/code-review.md` to load the full review checklist.
+
+### Step 2 — Detect scope
+
+Determine what to review:
+
+1. If user specified a file path → review that file
+2. If there are staged changes → `git diff --cached --name-only`
+3. If there are unstaged changes → `git diff --name-only`
+4. If no local changes → diff against the base branch:
+   - Detect base: `git rev-parse --abbrev-ref HEAD@{upstream} 2>/dev/null` — extracts the remote tracking branch (e.g., `origin/staging`, `origin/next`)
+   - If no upstream is set, fall back to the repo's default branch: `git remote show origin | sed -n 's/.*HEAD branch: //p'`
+   - Then: `git diff --name-only <base>...HEAD`
+
+### Step 3 — Check file count and delegate if needed
+
+Count the changed files. If **10 or more files** are in scope (threshold chosen to protect the main conversation's context window), delegate to the `.claude/agents/review.md` agent running in the background instead of continuing inline. Tell the user: "Large diff detected (N files) — running review in the background. I'll share the results when it's done."
+
+If under 10 files, continue inline.
+
+### Step 4 — Map files to rule categories
+
+For each changed file, determine which review categories apply:
+
+| File pattern | Categories |
+|---|---|
+| `*.vue` | Reuse & Duplication, Code Quality, Vue Correctness, API & Library Design, i18n & Assets, Accessibility |
+| `*.less` | CSS / Styling |
+| `*.test.js` | Testing |
+| `*.stories.js`, `*.mdx` | Storybook |
+| JS helpers (`*_constants.js`, `validators.js`, `utils.js`, `index.js`, and similar) | Reuse & Duplication, Code Quality, API & Library Design |
+| `packages/dialtone-tokens/**/*.json` | CSS / Styling (token usage) |
+
+If user specified a focus area (e.g., `/review accessibility`), only apply that category regardless of file type.
+
+### Step 5 — Review each file
+
+For each file in scope:
+
+1. Read the full file content (not just the diff) to understand context
+2. Read the diff to understand what changed
+3. Check each applicable rule from the checklist against the changed code
+4. Note any findings — include the file path and the specific line or area
+
+### Step 6 — Output findings
+
+Present findings as a flat list grouped by file:
+
+```text
+## Review: <scope description>
+
+### path/to/file.vue
+- [Rule category] Finding description (line N)
+- [Rule category] Finding description (line N)
+
+### path/to/other_file.less
+- [Rule category] Finding description (line N)
+
+---
+No issues found in: path/to/clean_file.test.js
+```
+
+If no findings at all: "No issues found. All changes pass the Dialtone review checklist."
+
+## Rules
+
+- **Report only** — never auto-fix code or create commits
+- **Read before judging** — always read the full file for context, not just the diff
+- **Be specific** — include file path, line number, and the rule that was violated
+- **Skip irrelevant categories** — don't check CSS rules on `.test.js` files
+- **Flag uncertainty** — if unsure whether something is a violation, say so rather than guessing
+- **Don't duplicate linting** — skip issues that ESLint or Stylelint would already catch (formatting, unused vars, etc.)
+- **Cross-reference existing rules** — the path-scoped rules in `.claude/rules/vue-components.md`, `css-utilities.md`, `vue-tests.md` have deeper conventions; reference them when relevant


### PR DESCRIPTION
## Summary

- Add `.claude/rules/code-review.md` — path-scoped rules file with 9 categories (25 rules) from Brad's DLT-3049 checklist. Auto-loads when editing files in dialtone-vue, dialtone-css, dialtone-tokens, dialtone-icons.
- Add `.claude/skills/review.md` — review logic skill that reads the rules file, detects scope from git diff, maps files to rule categories, and outputs findings. Delegates to a background agent for diffs with 10+ files.
- Add `.claude/agents/review.md` — background agent fallback for large reviews. Runs in isolated context to protect the main conversation.
- Add `.claude/commands/review.md` — `/review` slash command trigger.

## Ticket

https://dialpad.atlassian.net/browse/DLT-3049

## Test plan

- [ ] Run `/review` with staged changes on a few `.vue` files — verify findings reference the correct rule categories
- [ ] Run `/review accessibility` — verify only accessibility rules are applied
- [ ] Edit a file in `packages/dialtone-vue/` — verify `code-review.md` rules load alongside `vue-components.md`
- [ ] Verify `/review` appears in skill listing