### PR TITLE
feat(dialtone-vue): DLT-3225 migrate component size props to numeric ordinal scale

### DIFF
--- a/.claude/rules/vue-components.md
+++ b/.claude/rules/vue-components.md
@@ -30,9 +30,14 @@ paths:
 
 ## Sizes
 
-- Interactive components: `xs`, `sm`, `md`, `lg`, `xl` (string).
-- Icons: numeric scale `100`–`800`.
-- Export from `*_constants.js`: `COMPONENT_SIZES` object + `COMPONENT_SIZE_DEFAULT`.
+- All component size props use a numeric ordinal scale: `100` (xs), `200` (sm), `300` (md), `400` (lg), `500` (xl).
+- Prop type: `[String, Number]`. Default: numeric (e.g., `default: 300`).
+- T-shirt aliases (`xs`, `sm`, `md`, `lg`, `xl`) remain in constants for backward compat but are deprecated.
+- `@values` JSDoc: list numeric only (e.g., `@values 100, 200, 300, 400, 500`). Do not list t-shirt aliases.
+- Text headline extends the scale: `500` (xl), `600` (2xl), `700` (3xl).
+- Icons: separate numeric scale `100`–`800` (unchanged, do not modify).
+- Shared scale definition: `packages/dialtone-vue/common/constants/sizes.js`.
+- Export from `*_constants.js`: `COMPONENT_SIZE_MODIFIERS` object with both numeric and t-shirt keys.
 
 ## Separation of Concerns
 

--- a/packages/dialtone-cli/package.json
+++ b/packages/dialtone-cli/package.json
@@ -23,7 +23,7 @@
     "@dialpad/dialtone-css": "workspace:*",
     "@dialpad/dialtone-icons": "workspace:*",
     "@dialpad/dialtone-query-core": "workspace:*",
-    "@dialpad/dialtone-vue": "workspace:^3",
+    "@dialpad/dialtone-vue": "workspace:*",
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.2.0",

--- a/packages/dialtone-query-core/package.json
+++ b/packages/dialtone-query-core/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@dialpad/dialtone-css": "workspace:*",
     "@dialpad/dialtone-icons": "workspace:*",
-    "@dialpad/dialtone-vue": "workspace:^3",
+    "@dialpad/dialtone-vue": "workspace:*",
     "@types/node": "24.3.1",
     "typescript": "^5.2"
   },

--- a/packages/dialtone-vue/common/constants/index.js
+++ b/packages/dialtone-vue/common/constants/index.js
@@ -22,6 +22,13 @@ export const DESCRIPTION_SIZE_TYPES = {
 
 // Description size variants
 export const DESCRIPTION_SIZE_MODIFIERS = {
+  // Numeric (preferred)
+  100: 'd-description--xs',
+  200: 'd-description--sm',
+  300: '',
+  400: 'd-description--lg',
+  500: 'd-description--xl',
+  // T-shirt aliases (deprecated)
   xs: 'd-description--xs',
   sm: 'd-description--sm',
   md: '',
@@ -31,6 +38,13 @@ export const DESCRIPTION_SIZE_MODIFIERS = {
 
 // Label size variants
 export const LABEL_SIZE_MODIFIERS = {
+  // Numeric (preferred)
+  100: 'd-label--xs',
+  200: 'd-label--sm',
+  300: '',
+  400: 'd-label--lg',
+  500: 'd-label--xl',
+  // T-shirt aliases (deprecated)
   xs: 'd-label--xs',
   sm: 'd-label--sm',
   md: '',
@@ -65,6 +79,9 @@ export const DEFAULT_VALIDATION_MESSAGE_TYPE = VALIDATION_MESSAGE_TYPES.ERROR;
 
 // Default prefix used for ids
 export const DEFAULT_PREFIX = 'dt';
+
+// Component size scale
+export { COMPONENT_SIZES, TEXT_HEADLINE_SIZES } from './sizes.js';
 
 export default {
   VALIDATION_MESSAGE_TYPES,

--- a/packages/dialtone-vue/common/constants/sizes.js
+++ b/packages/dialtone-vue/common/constants/sizes.js
@@ -1,0 +1,31 @@
+/**
+ * Canonical numeric-to-t-shirt size mapping for component size props.
+ *
+ * Scale: 100-unit ordinal steps with 50-unit half-steps reserved for future sizes.
+ * Convention matches Dialtone's existing token scales (dt-size-*, dt-icon-size-*, colors).
+ *
+ * @example
+ *   <DtButton :size="200" />   <!-- equivalent to size="sm" -->
+ *   <DtButton :size="250" />   <!-- future "smedium" -->
+ */
+
+// Numeric → t-shirt label mapping
+export const COMPONENT_SIZES = {
+  100: 'xs',
+  200: 'sm',
+  300: 'md',
+  400: 'lg',
+  500: 'xl',
+};
+
+// Extended sizes for Text headline kind
+export const TEXT_HEADLINE_SIZES = {
+  ...COMPONENT_SIZES,
+  600: '2xl',
+  700: '3xl',
+};
+
+export default {
+  COMPONENT_SIZES,
+  TEXT_HEADLINE_SIZES,
+};

--- a/packages/dialtone-vue/components/avatar/avatar.stories.js
+++ b/packages/dialtone-vue/components/avatar/avatar.stories.js
@@ -11,7 +11,7 @@ const ICONS_LIST = getIconNames();
 
 export const argsData = {
   onClick: action('click'),
-  size: 'md',
+  size: 300,
   presence: null,
   fullName: 'Jaqueline Nackos',
   imageAlt: 'profile image',

--- a/packages/dialtone-vue/components/avatar/avatar.vue
+++ b/packages/dialtone-vue/components/avatar/avatar.vue
@@ -171,7 +171,7 @@ export default {
      * The size of the avatar.
      * T-shirt sizes (xs, sm, md, lg, xl) are deprecated and will be removed in the next major version.
      * Please use the numeric scale instead.
-     * @values 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, xs, sm, md, lg, xl
+     * @values 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900
      */
     size: {
       type: [String, Number],

--- a/packages/dialtone-vue/components/button/button.stories.js
+++ b/packages/dialtone-vue/components/button/button.stories.js
@@ -17,7 +17,7 @@ export const argsData = {
   onClick: action('click'),
   onFocusIn: action('focusin'),
   onFocusOut: action('focusout'),
-  size: 'md',
+  size: 300,
   link: false,
 };
 

--- a/packages/dialtone-vue/components/button/button.test.js
+++ b/packages/dialtone-vue/components/button/button.test.js
@@ -227,6 +227,18 @@ describe('DtButton Tests', () => {
         });
       });
 
+      describe('When size is numeric', () => {
+        it('should apply the correct size class for numeric size 200', async () => {
+          await wrapper.setProps({
+            size: 200,
+          });
+
+          button = wrapper.find('.base-button__button');
+
+          expect(button.classes().includes('d-btn--sm')).toBe(true);
+        });
+      });
+
       describe('When button has an invalid size prop', () => {
         it('should not have a size class', async () => {
           await wrapper.setProps({

--- a/packages/dialtone-vue/components/button/button.vue
+++ b/packages/dialtone-vue/components/button/button.vue
@@ -281,12 +281,12 @@ export default {
 
     /**
      * The size of the button.
-     * @values xs, sm, md, lg, xl
+     * @values 100, 200, 300, 400, 500
      */
     size: {
-      type: String,
-      default: 'md',
-      validator: (s) => Object.keys(BUTTON_SIZE_MODIFIERS).includes(s),
+      type: [String, Number],
+      default: 300,
+      validator: (s) => Object.keys(BUTTON_SIZE_MODIFIERS).includes(String(s)),
     },
 
     /**
@@ -508,11 +508,11 @@ export default {
     },
 
     iconSize () {
-      return BUTTON_ICON_SIZES[this.size];
+      return BUTTON_ICON_SIZES[String(this.size)];
     },
 
     loaderSize () {
-      return BUTTON_ICON_SIZES[this.size];
+      return BUTTON_ICON_SIZES[String(this.size)];
     },
   },
 
@@ -547,7 +547,7 @@ export default {
         return [
           'd-link',
           getLinkKindModifier(this.linkKind, this.linkInverted),
-          BUTTON_SIZE_MODIFIERS[this.size],
+          BUTTON_SIZE_MODIFIERS[String(this.size)],
           { 'd-link--no-underline': !this.resolvedUnderline },
         ];
       }
@@ -558,7 +558,7 @@ export default {
         'd-btn',
         BUTTON_IMPORTANCE_MODIFIERS[this.importance],
         BUTTON_KIND_MODIFIERS[this.kind],
-        BUTTON_SIZE_MODIFIERS[this.size],
+        BUTTON_SIZE_MODIFIERS[String(this.size)],
         {
           'd-btn--circle': this.circle,
           'd-btn--loading': this.loading,

--- a/packages/dialtone-vue/components/button/button_constants.js
+++ b/packages/dialtone-vue/components/button/button_constants.js
@@ -1,6 +1,13 @@
 export const BUTTON_UNSTYLED_CLASS = 'd-btn--unstyled';
 
 export const BUTTON_SIZE_MODIFIERS = {
+  // Numeric (preferred)
+  100: 'd-btn--xs',
+  200: 'd-btn--sm',
+  300: '',
+  400: 'd-btn--lg',
+  500: 'd-btn--xl',
+  // T-shirt aliases (deprecated)
   xs: 'd-btn--xs',
   sm: 'd-btn--sm',
   md: '',
@@ -64,6 +71,13 @@ export const INVALID_COMBINATION = [
 ];
 
 export const BUTTON_ICON_SIZES = {
+  // Numeric (preferred)
+  100: '200',
+  200: '200',
+  300: '300',
+  400: '400',
+  500: '500',
+  // T-shirt aliases (deprecated)
   xs: '200',
   sm: '200',
   md: '300',

--- a/packages/dialtone-vue/components/checkbox/checkbox.test.js
+++ b/packages/dialtone-vue/components/checkbox/checkbox.test.js
@@ -105,10 +105,10 @@ describe('DtCheckbox Tests', () => {
         expect(dtText.props('tone')).toBe('primary');
       });
 
-      it('should render label DtText with default size="md"', () => {
+      it('should render label DtText with default size 300', () => {
         const dtText = wrapper.findComponent(DtText);
 
-        expect(dtText.props('size')).toBe('md');
+        expect(dtText.props('size')).toBe(300);
       });
     });
 

--- a/packages/dialtone-vue/components/checkbox/checkbox.vue
+++ b/packages/dialtone-vue/components/checkbox/checkbox.vue
@@ -41,7 +41,7 @@
       <dt-text
         v-if="$slots.description || description"
         kind="body"
-        size="sm"
+        :size="200"
         tone="tertiary"
         as="div"
         :class="['d-description', descriptionClass]"
@@ -104,12 +104,12 @@ export default {
 
     /**
      * Overrides the label text size.
-     * @values lg, md, sm, xs
+     * @values 100, 200, 300, 400
      */
     labelSize: {
-      type: String,
+      type: [String, Number],
       default: null,
-      validator: (s) => TEXT_SIZE_MODIFIERS.label.includes(s),
+      validator: (s) => TEXT_SIZE_MODIFIERS.label.includes(String(s)),
     },
 
     /**
@@ -158,7 +158,7 @@ export default {
 
   computed: {
     resolvedLabelSize () {
-      return this.labelSize ?? 'md';
+      return this.labelSize ?? 300;
     },
 
     inputValidationClass () {

--- a/packages/dialtone-vue/components/chip/chip.stories.js
+++ b/packages/dialtone-vue/components/chip/chip.stories.js
@@ -11,7 +11,7 @@ const iconsList = getIconNames();
 export const argsData = {
   onClose: action('close'),
   onClick: action('click'),
-  size: 'md',
+  size: 300,
   avatarSeed: '',
 };
 

--- a/packages/dialtone-vue/components/chip/chip.test.js
+++ b/packages/dialtone-vue/components/chip/chip.test.js
@@ -89,6 +89,16 @@ describe('DtChip Tests', () => {
       });
     });
 
+    describe('When size is numeric', () => {
+      it('should render correct size class', () => {
+        mockProps = { size: 100 };
+
+        updateWrapper();
+
+        expect(chip.classes()).toContain('d-chip__label--xs');
+      });
+    });
+
     describe('When interactive is false', () => {
       it('should not be interactive', () => {
         mockProps = { interactive: false };

--- a/packages/dialtone-vue/components/chip/chip.vue
+++ b/packages/dialtone-vue/components/chip/chip.vue
@@ -103,12 +103,12 @@ export default {
 
     /**
      * The size of the chip.
-     * @values xs, sm, md
+     * @values 100, 200, 300
      */
     size: {
-      type: String,
-      default: 'md',
-      validator: (s) => Object.keys(CHIP_SIZE_MODIFIERS).includes(s),
+      type: [String, Number],
+      default: 300,
+      validator: (s) => Object.keys(CHIP_SIZE_MODIFIERS).includes(String(s)),
     },
 
     /**
@@ -218,7 +218,7 @@ export default {
     },
 
     closeButtonIconSize () {
-      return CHIP_ICON_SIZES[this.size];
+      return CHIP_ICON_SIZES[String(this.size)];
     },
 
     closeButtonTitle () {
@@ -230,7 +230,7 @@ export default {
     chipClasses () {
       return [
         this.$attrs['grouped-chip'] ? 'd-chip' : 'd-chip__label',
-        CHIP_SIZE_MODIFIERS[this.size],
+        CHIP_SIZE_MODIFIERS[String(this.size)],
         this.labelClass,
         this.disabled && 'd-chip--disabled',
       ];
@@ -239,7 +239,7 @@ export default {
     chipCloseButtonClasses () {
       return [
         'd-chip__close',
-        CHIP_CLOSE_BUTTON_SIZE_MODIFIERS[this.size],
+        CHIP_CLOSE_BUTTON_SIZE_MODIFIERS[String(this.size)],
         this.disabled && 'd-chip__close--disabled',
       ];
     },

--- a/packages/dialtone-vue/components/chip/chip_constants.js
+++ b/packages/dialtone-vue/components/chip/chip_constants.js
@@ -1,16 +1,31 @@
 export const CHIP_SIZE_MODIFIERS = {
+  // Numeric (preferred)
+  100: 'd-chip__label--xs',
+  200: 'd-chip__label--sm',
+  300: '',
+  // T-shirt aliases (deprecated)
   xs: 'd-chip__label--xs',
   sm: 'd-chip__label--sm',
   md: '',
 };
 
 export const CHIP_CLOSE_BUTTON_SIZE_MODIFIERS = {
+  // Numeric (preferred)
+  100: 'd-chip__close--xs',
+  200: 'd-chip__close--sm',
+  300: '',
+  // T-shirt aliases (deprecated)
   xs: 'd-chip__close--xs',
   sm: 'd-chip__close--sm',
   md: '',
 };
 
 export const CHIP_ICON_SIZES = {
+  // Numeric (preferred)
+  100: '200',
+  200: '200',
+  300: '200',
+  // T-shirt aliases (deprecated)
   xs: '200',
   sm: '200',
   md: '200',

--- a/packages/dialtone-vue/components/codeblock/codeblock.stories.js
+++ b/packages/dialtone-vue/components/codeblock/codeblock.stories.js
@@ -42,7 +42,7 @@ export const Default = {
   args: {
     text: 'function someFunction() {\n  return "some result";\n}',
     bordered: false,
-    size: 'sm',
+    size: 200,
   },
 };
 

--- a/packages/dialtone-vue/components/codeblock/codeblock.test.js
+++ b/packages/dialtone-vue/components/codeblock/codeblock.test.js
@@ -63,5 +63,12 @@ describe('DtCodeblock Tests', () => {
         expect(wrapper.find('code').classes()).toContain('d-codeblock__code--lg');
       });
     });
+
+    describe('When size prop is numeric', () => {
+      it('should apply the correct size modifier class', async () => {
+        await wrapper.setProps({ size: 400 });
+        expect(wrapper.find('code').classes()).toContain('d-codeblock__code--lg');
+      });
+    });
   });
 });

--- a/packages/dialtone-vue/components/codeblock/codeblock.vue
+++ b/packages/dialtone-vue/components/codeblock/codeblock.vue
@@ -4,12 +4,12 @@
     :class="{ 'd-codeblock--bordered': bordered }"
   ><code
     class="d-codeblock__code"
-    :class="`d-codeblock__code--${size}`"
+    :class="`d-codeblock__code--${sizeClass}`"
   >{{ text }}</code></pre> <!-- this must be a single line -->
 </template>
 
 <script>
-import { CODEBLOCK_SIZES } from './codeblock_constants';
+import { CODEBLOCK_SIZES, CODEBLOCK_SIZE_MAP } from './codeblock_constants';
 
 export default {
   compatConfig: { MODE: 3 },
@@ -34,12 +34,18 @@ export default {
 
     /**
      * Font size of the code block.
-     * @values xs, sm, md, lg
+     * @values 100, 200, 300, 400
      */
     size: {
-      type: String,
-      default: 'sm',
-      validator: (val) => CODEBLOCK_SIZES.includes(val),
+      type: [String, Number],
+      default: 200,
+      validator: (val) => CODEBLOCK_SIZES.includes(String(val)),
+    },
+  },
+
+  computed: {
+    sizeClass () {
+      return CODEBLOCK_SIZE_MAP[String(this.size)] || String(this.size);
     },
   },
 };

--- a/packages/dialtone-vue/components/codeblock/codeblock_constants.js
+++ b/packages/dialtone-vue/components/codeblock/codeblock_constants.js
@@ -1,2 +1,10 @@
-export const CODEBLOCK_SIZES = ['xs', 'sm', 'md', 'lg'];
-export const CODEBLOCK_SIZE_DEFAULT = 'sm';
+export const CODEBLOCK_SIZES = ['100', '200', '300', '400', 'xs', 'sm', 'md', 'lg'];
+export const CODEBLOCK_SIZE_DEFAULT = 200;
+
+// Numeric → CSS class suffix mapping (numeric values use the t-shirt class suffix)
+export const CODEBLOCK_SIZE_MAP = {
+  100: 'xs',
+  200: 'sm',
+  300: 'md',
+  400: 'lg',
+};

--- a/packages/dialtone-vue/components/combobox/combobox.vue
+++ b/packages/dialtone-vue/components/combobox/combobox.vue
@@ -54,6 +54,7 @@ import ComboboxEmptyList from './combobox_empty-list.vue';
 import { DtKeyboardListNavigationMixin } from '@/common/mixins';
 import { getUniqueString, hasSlotContent } from '@/common/utils';
 import { COMBOBOX_LABEL_SIZES } from '@/components/combobox';
+import { COMPONENT_SIZES } from '@/common/constants';
 
 /**
  * A combobox is a semantic component that displays an input element combined with a listbox,
@@ -100,13 +101,15 @@ export default {
     },
 
     /**
-     * Size of the input, one of `xs`, `sm`, `md`, `lg`, `xl`
-     * @values null, xs, sm, md, lg, xl
+     * Size of the input.
+     * @values 100, 200, 300, 400, 500
      */
     size: {
-      type: String,
+      type: [String, Number],
       default: null,
-      validator: (t) => Object.values(COMBOBOX_LABEL_SIZES).includes(t),
+      validator: (t) => t === null
+        || Object.values(COMBOBOX_LABEL_SIZES).includes(t)
+        || Object.keys(COMPONENT_SIZES).includes(String(t)),
     },
 
     /**

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
@@ -36,7 +36,7 @@
               { 'd-recipe-combobox-multi-select__chip--truncate': !!chipMaxWidth },
             ]"
             :style="{ maxWidth: chipMaxWidth }"
-            :size="CHIP_SIZES[size]"
+            :size="CHIP_SIZES[String(size)]"
             :disabled="disabled"
             v-on="chipListeners"
             @keydown.backspace="onChipRemove(item)"
@@ -128,10 +128,10 @@ import {
   POPOVER_APPEND_TO_VALUES,
 } from '@/components/popover/popover_constants';
 import {
-  MULTI_SELECT_SIZES,
   CHIP_SIZES,
   CHIP_TOP_POSITION,
 } from './combobox_multi_select_constants';
+import { COMPONENT_SIZES } from '@/common/constants';
 
 export default {
   compatConfig: { MODE: 3 },
@@ -278,12 +278,12 @@ export default {
 
     /**
      * Size of the chip.
-     * @values xs, sm, md
+     * @values 100, 200, 300
      */
     size: {
-      type: String,
-      default: 'md',
-      validator: (t) => Object.values(MULTI_SELECT_SIZES).includes(t),
+      type: [String, Number],
+      default: 300,
+      validator: (t) => Object.keys(CHIP_SIZES).includes(String(t)),
     },
 
     /**
@@ -490,7 +490,7 @@ export default {
 
     chipWrapperClass () {
       return {
-        [`d-recipe-combobox-multi-select__chip-wrapper-${this.size}--collapsed`]: !this.inputFocused && this.collapseOnFocusOut,
+        [`d-recipe-combobox-multi-select__chip-wrapper-${COMPONENT_SIZES[String(this.size)] || this.size}--collapsed`]: !this.inputFocused && this.collapseOnFocusOut,
       };
     },
   },
@@ -691,7 +691,7 @@ export default {
       const top = input.getBoundingClientRect().top -
                   inputSlotWrapper.getBoundingClientRect().top;
       const chipsWrapper = this.$refs.chipsWrapper;
-      chipsWrapper.style.top = (top - CHIP_TOP_POSITION[this.size]) + 'px';
+      chipsWrapper.style.top = (top - CHIP_TOP_POSITION[String(this.size)]) + 'px';
     },
 
     setInputPadding () {

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select_constants.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select_constants.js
@@ -6,12 +6,22 @@ export const MULTI_SELECT_SIZES = {
 };
 
 export const CHIP_SIZES = {
+  // Numeric (preferred)
+  100: 'xs',
+  200: 'xs',
+  300: 'sm',
+  // T-shirt aliases (deprecated)
   xs: 'xs',
   sm: 'xs',
   md: 'sm',
 };
 
 export const CHIP_TOP_POSITION = {
+  // Numeric (preferred)
+  100: 1.4,
+  200: 0.4,
+  300: 0.2,
+  // T-shirt aliases (deprecated)
   xs: 1.4,
   sm: 0.4,
   md: 0.2,

--- a/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.vue
+++ b/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.vue
@@ -119,6 +119,7 @@ import ComboboxEmptyList from '@/components/combobox/combobox_empty-list.vue';
 import { DtCombobox, COMBOBOX_LABEL_SIZES } from '@/components/combobox';
 import { DtPopover, POPOVER_APPEND_TO_VALUES, POPOVER_CONTENT_WIDTHS } from '@/components/popover';
 import { getUniqueString, hasSlotContent } from '@/common/utils';
+import { COMPONENT_SIZES } from '@/common/constants';
 import { DROPDOWN_PADDING_CLASSES } from '@/components/dropdown';
 import { CONTENT_MODE_PROP } from '@/common/mode_constants';
 
@@ -158,13 +159,15 @@ export default {
     },
 
     /**
-     * Size of the input, one of `xs`, `sm`, `md`, `lg`, `xl`
-     * @values null, xs, sm, md, lg, xl
+     * Size of the input.
+     * @values 100, 200, 300, 400, 500
      */
     size: {
-      type: String,
+      type: [String, Number],
       default: null,
-      validator: (t) => Object.values(COMBOBOX_LABEL_SIZES).includes(t),
+      validator: (t) => t === null
+        || Object.values(COMBOBOX_LABEL_SIZES).includes(t)
+        || Object.keys(COMPONENT_SIZES).includes(String(t)),
     },
 
     /**

--- a/packages/dialtone-vue/components/datepicker/modules/calendar.vue
+++ b/packages/dialtone-vue/components/datepicker/modules/calendar.vue
@@ -33,7 +33,7 @@
           <dt-button
             :ref="el => { if (el) setDayRef(el, day) }"
             class="d-datepicker__day"
-            size="sm"
+            :size="200"
             kind="muted"
             importance="clear"
             :disabled="day.disabled"

--- a/packages/dialtone-vue/components/datepicker/modules/month-year-picker.vue
+++ b/packages/dialtone-vue/components/datepicker/modules/month-year-picker.vue
@@ -24,14 +24,14 @@
             kind="muted"
             class="d-datepicker__nav-btn"
             importance="clear"
-            size="xs"
+            :size="100"
             type="button"
             @click="changeYear(-1)"
             @keydown="handleKeyDown($event)"
           >
-            <dt-icon-chevrons-left
-              size="200"
-            />
+            <template #icon="{ iconSize }">
+              <dt-icon-chevrons-left :size="iconSize" />
+            </template>
           </dt-button>
         </template>
       </dt-tooltip>
@@ -49,14 +49,14 @@
             class="d-datepicker__nav-btn"
             importance="clear"
             kind="muted"
-            size="xs"
+            :size="100"
             type="button"
             @click="changeMonth(-1)"
             @keydown="handleKeyDown($event)"
           >
-            <dt-icon-chevron-left
-              size="200"
-            />
+            <template #icon="{ iconSize }">
+              <dt-icon-chevron-left :size="iconSize" />
+            </template>
           </dt-button>
         </template>
       </dt-tooltip>
@@ -89,14 +89,14 @@
             class="d-datepicker__nav-btn"
             importance="clear"
             kind="muted"
-            size="xs"
+            :size="100"
             type="button"
             @click="changeMonth(1)"
             @keydown="handleKeyDown($event)"
           >
-            <dt-icon-chevron-right
-              size="200"
-            />
+            <template #icon="{ iconSize }">
+              <dt-icon-chevron-right :size="iconSize" />
+            </template>
           </dt-button>
         </template>
       </dt-tooltip>
@@ -114,14 +114,14 @@
             class="d-datepicker__nav-btn"
             importance="clear"
             kind="muted"
-            size="xs"
+            :size="100"
             type="button"
             @click="changeYear(1)"
             @keydown="handleKeyDown($event)"
           >
-            <dt-icon-chevrons-right
-              size="200"
-            />
+            <template #icon="{ iconSize }">
+              <dt-icon-chevrons-right :size="iconSize" />
+            </template>
           </dt-button>
         </template>
       </dt-tooltip>

--- a/packages/dialtone-vue/components/dropdown/dropdown_list.vue
+++ b/packages/dialtone-vue/components/dropdown/dropdown_list.vue
@@ -9,7 +9,7 @@
     >
       <dt-text
         kind="label"
-        size="xs"
+        :size="100"
         strength="bold"
         tone="muted"
       >

--- a/packages/dialtone-vue/components/emoji_picker/modules/emoji_search.vue
+++ b/packages/dialtone-vue/components/emoji_picker/modules/emoji_search.vue
@@ -21,7 +21,7 @@
       >
         <dt-button
           importance="clear"
-          size="xs"
+          :size="100"
           class="d-emoji-picker__search-x-button"
           circle
           kind="muted"

--- a/packages/dialtone-vue/components/emoji_picker/modules/emoji_tabset.vue
+++ b/packages/dialtone-vue/components/emoji_picker/modules/emoji_tabset.vue
@@ -2,7 +2,7 @@
   <div class="d-emoji-picker__tabset">
     <dt-tab-group
       :selected="selectedTab"
-      size="sm"
+      :size="200"
       spread="equal"
       tab-list-class="d-emoji-picker__tabset-list"
     >

--- a/packages/dialtone-vue/components/empty_state/empty_state.stories.js
+++ b/packages/dialtone-vue/components/empty_state/empty_state.stories.js
@@ -97,7 +97,7 @@ export const Default = {
 
   args: {
     illustration: 'mind',
-    size: 'lg',
+    size: 400,
     headerText: 'Nothing to see here',
     bodyText: 'Lorem ipsum dolor sit amet consectetur. Diam in aliquam arcu elit pulvinar morbi lorem ac neque.',
     body: '<div class="d-mt8 d-stack d-stack--row d-stack--gap-300"><button class="d-btn">Click me</button><button class="d-btn d-btn--primary">Click me</button></div>',

--- a/packages/dialtone-vue/components/empty_state/empty_state.test.js
+++ b/packages/dialtone-vue/components/empty_state/empty_state.test.js
@@ -83,6 +83,16 @@ describe('DtIllustration Tests', () => {
     });
   });
 
+  describe('Numeric size', () => {
+    it('Should render correct size class with numeric value', () => {
+      mockProps = { size: 200 };
+
+      updateWrapper();
+
+      expect(wrapper.classes()).toContain('d-empty-state--size-sm');
+    });
+  });
+
   describe('Interactivity Tests', () => {
     describe('On size change', () => {
       it('Should update size classes in wrapper', () => {

--- a/packages/dialtone-vue/components/empty_state/empty_state.vue
+++ b/packages/dialtone-vue/components/empty_state/empty_state.vue
@@ -77,12 +77,12 @@ const slots = useSlots();
 const props = defineProps({
   /**
     * The empty state size.
-    * @values 'sm', 'md', 'lg'
+    * @values 200, 300, 400
     */
   size: {
-    type: String,
-    default: 'lg',
-    validator: (s) => Object.keys(EMPTY_STATE_SIZE_MODIFIERS).includes(s),
+    type: [String, Number],
+    default: 400,
+    validator: (s) => Object.keys(EMPTY_STATE_SIZE_MODIFIERS).includes(String(s)),
   },
 
   /**
@@ -108,7 +108,6 @@ const hasIcon = computed(() => {
   return hasSlotContent(slots.icon);
 });
 const hasIllustration = computed(() => hasSlotContent(slots.illustration));
-const isSmallSize = computed(() => props.size === 'sm');
 
 /**
  * Icon will be shown in lg and md size only if illustration is not provided
@@ -122,17 +121,20 @@ const showIcon = computed(() => hasIcon.value && (!hasIllustration.value || isSm
  */
 const showIllustration = computed(() => hasIllustration.value && !isSmallSize.value);
 
-const sizeClass = computed(() => EMPTY_STATE_SIZE_MODIFIERS[props.size]);
+const sizeKey = computed(() => String(props.size));
+const isSmallSize = computed(() => sizeKey.value === 'sm' || sizeKey.value === '200');
+
+const sizeClass = computed(() => EMPTY_STATE_SIZE_MODIFIERS[sizeKey.value]);
 
 const emptyStateClasses = computed(() => ['d-empty-state', sizeClass.value]);
 
-const contentClass = computed(() => EMPTY_STATE_CONTENT_SIZE_MODIFIERS[props.size]);
+const contentClass = computed(() => EMPTY_STATE_CONTENT_SIZE_MODIFIERS[sizeKey.value]);
 
-const headlineSize = computed(() => EMPTY_STATE_HEADLINE_SIZES[props.size]);
-const headlineDensity = computed(() => EMPTY_STATE_HEADLINE_DENSITIES[props.size]);
+const headlineSize = computed(() => EMPTY_STATE_HEADLINE_SIZES[sizeKey.value]);
+const headlineDensity = computed(() => EMPTY_STATE_HEADLINE_DENSITIES[sizeKey.value]);
 
-const bodySize = computed(() => EMPTY_STATE_BODY_SIZES[props.size]);
-const bodyDensity = computed(() => EMPTY_STATE_BODY_DENSITIES[props.size]);
+const bodySize = computed(() => EMPTY_STATE_BODY_SIZES[sizeKey.value]);
+const bodyDensity = computed(() => EMPTY_STATE_BODY_DENSITIES[sizeKey.value]);
 
 onMounted(() => {
   if (!props.bodyText && !hasSlotContent(slots.body)) {

--- a/packages/dialtone-vue/components/empty_state/empty_state_constants.js
+++ b/packages/dialtone-vue/components/empty_state/empty_state_constants.js
@@ -1,34 +1,64 @@
 export const EMPTY_STATE_SIZE_MODIFIERS = {
+  // Numeric (preferred)
+  200: 'd-empty-state--size-sm',
+  300: 'd-empty-state--size-md',
+  400: 'd-empty-state--size-lg',
+  // T-shirt aliases (deprecated)
   sm: 'd-empty-state--size-sm',
   md: 'd-empty-state--size-md',
   lg: 'd-empty-state--size-lg',
 };
 
 export const EMPTY_STATE_CONTENT_SIZE_MODIFIERS = {
+  // Numeric (preferred)
+  200: 'd-empty-state__content--sm',
+  300: 'd-empty-state__content--md',
+  400: 'd-empty-state__content--lg',
+  // T-shirt aliases (deprecated)
   sm: 'd-empty-state__content--sm',
   md: 'd-empty-state__content--md',
   lg: 'd-empty-state__content--lg',
 };
 
 export const EMPTY_STATE_HEADLINE_SIZES = {
+  // Numeric (preferred)
+  200: 'md',
+  300: 'xl',
+  400: '2xl',
+  // T-shirt aliases (deprecated)
   sm: 'md',
   md: 'xl',
   lg: '2xl',
 };
 
 export const EMPTY_STATE_HEADLINE_DENSITIES = {
+  // Numeric (preferred)
+  200: '200',
+  300: '200',
+  400: undefined,
+  // T-shirt aliases (deprecated)
   sm: '200',
   md: '200',
   lg: undefined,
 };
 
 export const EMPTY_STATE_BODY_SIZES = {
+  // Numeric (preferred)
+  200: 'sm',
+  300: 'md',
+  400: 'lg',
+  // T-shirt aliases (deprecated)
   sm: 'sm',
   md: 'md',
   lg: 'lg',
 };
 
 export const EMPTY_STATE_BODY_DENSITIES = {
+  // Numeric (preferred)
+  200: undefined,
+  300: '300',
+  400: '300',
+  // T-shirt aliases (deprecated)
   sm: undefined,
   md: '300',
   lg: '300',

--- a/packages/dialtone-vue/components/filter_pill/filter_pill.vue
+++ b/packages/dialtone-vue/components/filter_pill/filter_pill.vue
@@ -141,7 +141,7 @@
             <dt-button
               importance="clear"
               kind="muted"
-              size="sm"
+              :size="200"
               data-qa="dt-filter-pill__cancel-button"
               @click="cancelSelection"
             >
@@ -149,7 +149,7 @@
             </dt-button>
             <dt-button
               importance="primary"
-              size="sm"
+              :size="200"
               data-qa="dt-filter-pill__apply-button"
               @click="applySelection"
             >
@@ -444,12 +444,12 @@ export default {
 
     /**
      * The size of the button.
-     * @values xs, sm, md, lg, xl
+     * @values 100, 200, 300, 400, 500
      */
     size: {
-      type: String,
-      default: 'sm',
-      validator: (s) => Object.keys(BUTTON_SIZE_MODIFIERS).includes(s),
+      type: [String, Number],
+      default: 200,
+      validator: (s) => Object.keys(BUTTON_SIZE_MODIFIERS).includes(String(s)),
     },
   },
 

--- a/packages/dialtone-vue/components/image_viewer/image_viewer.vue
+++ b/packages/dialtone-vue/components/image_viewer/image_viewer.vue
@@ -47,7 +47,7 @@
             data-qa="dt-image-viewer-close-btn"
             class="d-modal__close"
             circle
-            size="lg"
+            :size="400"
             importance="clear"
             kind="inverted"
             :aria-label="closeButtonTitle"

--- a/packages/dialtone-vue/components/input/input.stories.js
+++ b/packages/dialtone-vue/components/input/input.stories.js
@@ -361,28 +361,28 @@ export const WithMultipleMessages = {
 export const ExtraSmall = {
   ...Default,
   args: {
-    size: 'xs',
+    size: 100,
   },
 };
 
 export const Small = {
   ...Default,
   args: {
-    size: 'sm',
+    size: 200,
   },
 };
 
 export const Large = {
   ...Default,
   args: {
-    size: 'lg',
+    size: 400,
   },
 };
 
 export const ExtraLarge = {
   ...Default,
   args: {
-    size: 'xl',
+    size: 500,
   },
 };
 

--- a/packages/dialtone-vue/components/input/input.test.js
+++ b/packages/dialtone-vue/components/input/input.test.js
@@ -468,6 +468,18 @@ describe('DtInput tests', () => {
         });
       });
 
+      describe('When size is numeric', () => {
+        it('should add input size class for numeric size 200', () => {
+          mockProps = { size: 200 };
+
+          updateWrapper();
+
+          nativeInput = wrapper.find('input');
+
+          expect(nativeInput.classes().includes('d-input--sm')).toBe(true);
+        });
+      });
+
       describe('When size is EXTRA_LARGE', () => {
         const MOCK_INPUT_SIZE_EXTRA_LARGE = INPUT_SIZES.EXTRA_LARGE;
 

--- a/packages/dialtone-vue/components/input/input.vue
+++ b/packages/dialtone-vue/components/input/input.vue
@@ -247,13 +247,13 @@ export default {
     },
 
     /**
-     * Size of the input, one of `xs`, `sm`, `md`, `lg`, `xl`
-     * @values xs, sm, md, lg, xl
+     * Size of the input.
+     * @values 100, 200, 300, 400, 500
      */
     size: {
-      type: String,
-      default: 'md',
-      validator: (t) => Object.values(INPUT_SIZES).includes(t),
+      type: [String, Number],
+      default: 300,
+      validator: (t) => Object.keys(INPUT_ICON_SIZES).includes(String(t)),
     },
 
     /**
@@ -327,12 +327,12 @@ export default {
     /**
      * Overrides the label text size. When not provided, the label size
      * is derived from the component size prop.
-     * @values lg, md, sm, xs
+     * @values 100, 200, 300, 400
      */
     labelSize: {
-      type: String,
+      type: [String, Number],
       default: null,
-      validator: (s) => TEXT_SIZE_MODIFIERS.label.includes(s),
+      validator: (s) => TEXT_SIZE_MODIFIERS.label.includes(String(s)),
     },
 
     /**
@@ -443,15 +443,15 @@ export default {
     },
 
     isDefaultSize () {
-      return this.size === INPUT_SIZES.DEFAULT;
+      return String(this.size) === INPUT_SIZES.DEFAULT || String(this.size) === '300';
     },
 
     iconSize () {
-      return INPUT_ICON_SIZES[this.size];
+      return INPUT_ICON_SIZES[String(this.size)];
     },
 
     isValidSize () {
-      return Object.values(INPUT_SIZES).includes(this.size);
+      return Object.keys(INPUT_ICON_SIZES).includes(String(this.size));
     },
 
     isValidDescriptionSize () {
@@ -583,16 +583,24 @@ export default {
     },
 
     resolvedLabelSize () {
-      return this.labelSize ?? (this.size === 'xl' ? 'lg' : this.size);
+      if (this.labelSize != null) return this.labelSize;
+      const sizeStr = String(this.size);
+      // xl/500 exceeds label's max size — cap at lg/400
+      if (sizeStr === 'xl' || sizeStr === '500') return sizeStr === '500' ? '400' : 'lg';
+      return this.size;
     },
 
     resolvedDescriptionSize () {
-      const map = { xs: 'xs', sm: 'xs', md: 'sm', lg: 'sm', xl: 'md' };
-      return map[this.size] || 'sm';
+      const map = {
+        100: 'xs', 200: 'xs', 300: 'sm', 400: 'sm', 500: 'md',
+        xs: 'xs', sm: 'xs', md: 'sm', lg: 'sm', xl: 'md',
+      };
+      return map[String(this.size)] || 'sm';
     },
 
     resolvedDescriptionDensity () {
-      return this.size === 'xl' ? '300' : undefined;
+      const sizeStr = String(this.size);
+      return (sizeStr === 'xl' || sizeStr === '500') ? '300' : undefined;
     },
 
     sizeModifierClass () {
@@ -600,7 +608,7 @@ export default {
         return '';
       }
 
-      return INPUT_SIZE_CLASSES[this.inputComponent][this.size];
+      return INPUT_SIZE_CLASSES[this.inputComponent][String(this.size)];
     },
 
     stateClass () {

--- a/packages/dialtone-vue/components/input/input_constants.js
+++ b/packages/dialtone-vue/components/input/input_constants.js
@@ -23,6 +23,13 @@ export const INPUT_SIZES = {
 };
 
 export const INPUT_ICON_SIZES = {
+  // Numeric (preferred)
+  100: '100',
+  200: '200',
+  300: '200',
+  400: '400',
+  500: '500',
+  // T-shirt aliases (deprecated)
   xs: '100',
   sm: '200',
   md: '200',
@@ -32,6 +39,12 @@ export const INPUT_ICON_SIZES = {
 
 export const INPUT_SIZE_CLASSES = {
   input: {
+    // Numeric (preferred)
+    100: 'd-input--xs',
+    200: 'd-input--sm',
+    400: 'd-input--lg',
+    500: 'd-input--xl',
+    // T-shirt aliases (deprecated)
     xs: 'd-input--xs',
     sm: 'd-input--sm',
     lg: 'd-input--lg',
@@ -39,6 +52,12 @@ export const INPUT_SIZE_CLASSES = {
   },
 
   textarea: {
+    // Numeric (preferred)
+    100: 'd-textarea--xs',
+    200: 'd-textarea--sm',
+    400: 'd-textarea--lg',
+    500: 'd-textarea--xl',
+    // T-shirt aliases (deprecated)
     xs: 'd-textarea--xs',
     sm: 'd-textarea--sm',
     lg: 'd-textarea--lg',
@@ -53,6 +72,13 @@ export const INPUT_STATE_CLASSES = {
 };
 
 export const DESCRIPTION_SIZE_CLASSES = {
+  // Numeric (preferred)
+  100: 'd-description--xs',
+  200: 'd-description--sm',
+  300: '',
+  400: 'd-description--lg',
+  500: 'd-description--xl',
+  // T-shirt aliases (deprecated)
   xs: 'd-description--xs',
   sm: 'd-description--sm',
   md: '',

--- a/packages/dialtone-vue/components/input_group/decorators/input.vue
+++ b/packages/dialtone-vue/components/input_group/decorators/input.vue
@@ -54,12 +54,12 @@ export default {
   props: {
     /**
      * Overrides the label text size.
-     * @values lg, md, sm, xs
+     * @values 100, 200, 300, 400
      */
     labelSize: {
-      type: String,
+      type: [String, Number],
       default: null,
-      validator: (s) => TEXT_SIZE_MODIFIERS.label.includes(s),
+      validator: (s) => TEXT_SIZE_MODIFIERS.label.includes(String(s)),
     },
   },
 
@@ -82,7 +82,7 @@ export default {
 
   computed: {
     resolvedLabelSize () {
-      return this.labelSize ?? 'md';
+      return this.labelSize ?? 300;
     },
 
     inputValidationClass () {

--- a/packages/dialtone-vue/components/keyboard_shortcut/keyboard_shortcut.vue
+++ b/packages/dialtone-vue/components/keyboard_shortcut/keyboard_shortcut.vue
@@ -26,7 +26,7 @@
         v-else-if="item.trim()"
         :key="`text-${i}-${item}`"
         kind="body"
-        size="sm"
+        :size="200"
         numeric
         :density="400"
         :tone="inverted ? 'secondary-inverted' : 'tertiary'"

--- a/packages/dialtone-vue/components/modal/modal.vue
+++ b/packages/dialtone-vue/components/modal/modal.vue
@@ -61,7 +61,7 @@
             v-else
             :id="labelledById"
             kind="headline"
-            size="2xl"
+            :size="600"
             strength="medium"
             density="100"
             text-box-trim="start"
@@ -107,7 +107,7 @@
             v-else
             class="d-modal__close"
             data-qa="dt-modal-close-button"
-            size="md"
+            :size="300"
             kind="muted"
             importance="clear"
             :aria-label="closeButtonTitle"

--- a/packages/dialtone-vue/components/motion_text/motion_text.stories.js
+++ b/packages/dialtone-vue/components/motion_text/motion_text.stories.js
@@ -14,7 +14,7 @@ import DtMotionTextVariantsTemplate from './motion_text_variants.story.vue';
 export const argsData = {
   text: 'Experience the magic of animated text',
   animationMode: 'gradient-in',
-  speed: 'md',
+  speed: 300,
   autoStart: true,
   loop: false,
   respectsReducedMotion: true,
@@ -57,7 +57,7 @@ export const argTypesData = {
       type: 'select',
     },
     options: MOTION_TEXT_SPEEDS,
-    description: 'Animation speed using t-shirt sizing (sm: fast, md: medium, lg: slow)',
+    description: 'Animation speed (100: near-instant, 200: fast, 300: medium, 400: slow, 500: very slow)',
     table: {
       type: {
         summary: MOTION_TEXT_SPEEDS.join(' | '),

--- a/packages/dialtone-vue/components/motion_text/motion_text.test.js
+++ b/packages/dialtone-vue/components/motion_text/motion_text.test.js
@@ -100,22 +100,22 @@ describe('DtMotionText Tests', () => {
     });
 
     describe('Speed variants', () => {
-      it('should apply timing for sm speed', async () => {
-        await wrapper.setProps({ speed: 'sm' });
+      it('should apply timing for 200 speed', async () => {
+        await wrapper.setProps({ speed: 200 });
         expect(wrapper.vm.timing.characterDelay).toBe(20);
         expect(wrapper.vm.timing.wordDelay).toBe(30);
         expect(wrapper.vm.timing.duration).toBe(600);
       });
 
-      it('should apply timing for md speed', async () => {
-        await wrapper.setProps({ speed: 'md' });
+      it('should apply timing for 300 speed', async () => {
+        await wrapper.setProps({ speed: 300 });
         expect(wrapper.vm.timing.characterDelay).toBe(30);
         expect(wrapper.vm.timing.wordDelay).toBe(50);
         expect(wrapper.vm.timing.duration).toBe(1000);
       });
 
-      it('should apply timing for lg speed', async () => {
-        await wrapper.setProps({ speed: 'lg' });
+      it('should apply timing for 400 speed', async () => {
+        await wrapper.setProps({ speed: 400 });
         expect(wrapper.vm.timing.characterDelay).toBe(50);
         expect(wrapper.vm.timing.wordDelay).toBe(100);
         expect(wrapper.vm.timing.duration).toBe(1500);

--- a/packages/dialtone-vue/components/motion_text/motion_text.vue
+++ b/packages/dialtone-vue/components/motion_text/motion_text.vue
@@ -103,13 +103,13 @@ export default {
     },
 
     /**
-     * Animation speed using t-shirt sizing.
-     * @values sm, md, lg
+     * Animation speed.
+     * @values 100, 200, 300, 400, 500
      */
     speed: {
-      type: String,
-      default: 'md',
-      validator: (value) => MOTION_TEXT_SPEEDS.includes(value),
+      type: [String, Number],
+      default: 300,
+      validator: (value) => MOTION_TEXT_SPEEDS.includes(String(value)),
     },
 
     /**
@@ -202,7 +202,7 @@ export default {
      * Get timing preset based on speed prop
      */
     timing () {
-      return MOTION_TEXT_TIMING_PRESETS[this.speed];
+      return MOTION_TEXT_TIMING_PRESETS[String(this.speed)];
     },
 
     /**

--- a/packages/dialtone-vue/components/motion_text/motion_text_constants.js
+++ b/packages/dialtone-vue/components/motion_text/motion_text_constants.js
@@ -8,25 +8,35 @@ export const MOTION_TEXT_ANIMATION_MODES = [
   'none',
 ];
 
-// Speed options (t-shirt sizing)
-export const MOTION_TEXT_SPEEDS = ['sm', 'md', 'lg'];
+// Speed options
+export const MOTION_TEXT_SPEEDS = ['100', '200', '300', '400', '500'];
 
 // Timing presets based on speed
 export const MOTION_TEXT_TIMING_PRESETS = {
-  sm: {
+  100: {
+    characterDelay: 10,
+    wordDelay: 15,
+    duration: 300,
+  },
+  200: {
     characterDelay: 20,
     wordDelay: 30,
     duration: 600,
   },
-  md: {
+  300: {
     characterDelay: 30,
     wordDelay: 50,
     duration: 1000,
   },
-  lg: {
+  400: {
     characterDelay: 50,
     wordDelay: 100,
     duration: 1500,
+  },
+  500: {
+    characterDelay: 80,
+    wordDelay: 180,
+    duration: 2100,
   },
 };
 

--- a/packages/dialtone-vue/components/notice/notice_action.vue
+++ b/packages/dialtone-vue/components/notice/notice_action.vue
@@ -11,7 +11,7 @@
       data-qa="dt-notice-action-close-button"
       importance="clear"
       kind="muted"
-      size="sm"
+      :size="200"
       :aria-label="closeButtonTitle"
       :title="closeButtonTitle"
       @click="close"

--- a/packages/dialtone-vue/components/notice/notice_content.vue
+++ b/packages/dialtone-vue/components/notice/notice_content.vue
@@ -7,7 +7,7 @@
       v-if="title || hasSlotContent($slots.titleOverride)"
       :id="titleId"
       kind="headline"
-      size="md"
+      :size="300"
       density="200"
       as="p"
       class="d-notice__title"
@@ -21,7 +21,7 @@
     <dt-text
       :id="contentId"
       kind="body"
-      size="sm"
+      :size="200"
       wrap="pretty"
       as="p"
       class="d-notice__message"

--- a/packages/dialtone-vue/components/radio/radio.test.js
+++ b/packages/dialtone-vue/components/radio/radio.test.js
@@ -95,10 +95,10 @@ describe('DtRadio Tests', () => {
           expect(dtText.props('tone')).toBe('primary');
         });
 
-        it('should render label DtText with default size="md"', () => {
+        it('should render label DtText with default size 300', () => {
           const dtText = wrapper.findComponent(DtText);
 
-          expect(dtText.props('size')).toBe('md');
+          expect(dtText.props('size')).toBe(300);
         });
       });
     });

--- a/packages/dialtone-vue/components/radio/radio.vue
+++ b/packages/dialtone-vue/components/radio/radio.vue
@@ -40,7 +40,7 @@
       <dt-text
         v-if="$slots.description || description"
         kind="body"
-        size="sm"
+        :size="200"
         tone="tertiary"
         as="div"
         :class="['d-description', descriptionClass]"
@@ -110,12 +110,12 @@ export default {
 
     /**
      * Overrides the label text size.
-     * @values lg, md, sm, xs
+     * @values 100, 200, 300, 400
      */
     labelSize: {
-      type: String,
+      type: [String, Number],
       default: null,
-      validator: (s) => TEXT_SIZE_MODIFIERS.label.includes(s),
+      validator: (s) => TEXT_SIZE_MODIFIERS.label.includes(String(s)),
     },
 
     /**
@@ -186,7 +186,7 @@ export default {
     },
 
     resolvedLabelSize () {
-      return this.labelSize ?? 'md';
+      return this.labelSize ?? 300;
     },
 
     inputValidationClass () {

--- a/packages/dialtone-vue/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
+++ b/packages/dialtone-vue/components/rich_text_editor/extensions/mentions/MentionSuggestion.vue
@@ -10,7 +10,7 @@
       :image-alt="name"
       :show-presence="showDetails"
       :presence="presence"
-      size="sm"
+      :size="200"
     />
     <dt-stack
       class="d-mention-suggestion__details-container"
@@ -28,7 +28,7 @@
         <dt-text
           v-if="presenceText"
           kind="label"
-          size="sm"
+          :size="200"
           strength="normal"
           class="d-mention-suggestion__presence"
           :class="[presenceFontColorClass]"
@@ -38,7 +38,7 @@
         <dt-text
           v-if="status && presenceText"
           kind="label"
-          size="sm"
+          :size="200"
           strength="normal"
           as="div"
           class="d-mention-suggestion__divider"
@@ -48,7 +48,7 @@
         <dt-text
           v-if="status"
           kind="label"
-          size="sm"
+          :size="200"
           strength="normal"
           as="div"
           class="d-mention-suggestion__status"

--- a/packages/dialtone-vue/components/rich_text_editor/extensions/slash_command/SlashCommandSuggestion.vue
+++ b/packages/dialtone-vue/components/rich_text_editor/extensions/slash_command/SlashCommandSuggestion.vue
@@ -2,7 +2,7 @@
   <div>
     <dt-text
       kind="body"
-      size="md"
+      :size="300"
       :density="300"
       as="div"
     >
@@ -10,7 +10,7 @@
     </dt-text>
     <dt-text
       kind="body"
-      size="sm"
+      :size="200"
       tone="tertiary"
       as="div"
     >

--- a/packages/dialtone-vue/components/segmented_control/segmented_control.test.js
+++ b/packages/dialtone-vue/components/segmented_control/segmented_control.test.js
@@ -68,6 +68,16 @@ describe('DtSegmentedControl Tests', () => {
     });
   });
 
+  describe('When size is numeric', () => {
+    it('should apply the correct size class for numeric size 200', () => {
+      _setWrapper({ size: 200 });
+
+      const container = wrapper.find('[data-qa="dt-segmented-control"]');
+
+      expect(container.classes()).toContain('d-segmented-control--sm');
+    });
+  });
+
   describe('Interactivity Tests', () => {
     it('emits update:modelValue on child click', async () => {
       _setWrapper();

--- a/packages/dialtone-vue/components/segmented_control/segmented_control.vue
+++ b/packages/dialtone-vue/components/segmented_control/segmented_control.vue
@@ -77,12 +77,12 @@ const props = defineProps({
 
   /**
    * DtButton size for all items. Inherited by children via provide.
-   * @values xs, sm, md, lg, xl
+   * @values 100, 200, 300, 400, 500
    */
   size: {
-    type: String,
+    type: [String, Number],
     default: SEGMENTED_CONTROL_SIZE_DEFAULT,
-    validator: (v) => SEGMENTED_CONTROL_SIZES.includes(v),
+    validator: (v) => SEGMENTED_CONTROL_SIZES.includes(String(v)),
   },
 
   /**
@@ -172,7 +172,7 @@ const stackDirection = computed(() => props.orientation === 'vertical' ? 'column
 
 const containerClasses = computed(() => [
   'd-segmented-control',
-  SEGMENTED_CONTROL_SIZE_MODIFIERS[props.size],
+  SEGMENTED_CONTROL_SIZE_MODIFIERS[String(props.size)],
   props.hideDivider ? 'd-segmented-control--hide-divider' : null,
   props.borderless ? 'd-segmented-control--borderless' : null,
   props.orientation === 'vertical' ? 'd-segmented-control--vertical' : null,

--- a/packages/dialtone-vue/components/segmented_control/segmented_control_constants.js
+++ b/packages/dialtone-vue/components/segmented_control/segmented_control_constants.js
@@ -1,7 +1,14 @@
-export const SEGMENTED_CONTROL_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'];
-export const SEGMENTED_CONTROL_SIZE_DEFAULT = 'sm';
+export const SEGMENTED_CONTROL_SIZES = ['100', '200', '300', '400', '500', 'xs', 'sm', 'md', 'lg', 'xl'];
+export const SEGMENTED_CONTROL_SIZE_DEFAULT = 200;
 
 export const SEGMENTED_CONTROL_SIZE_MODIFIERS = {
+  // Numeric (preferred)
+  100: 'd-segmented-control--xs',
+  200: 'd-segmented-control--sm',
+  300: 'd-segmented-control--md',
+  400: 'd-segmented-control--lg',
+  500: 'd-segmented-control--xl',
+  // T-shirt aliases (deprecated)
   xs: 'd-segmented-control--xs',
   sm: 'd-segmented-control--sm',
   md: 'd-segmented-control--md',

--- a/packages/dialtone-vue/components/select_menu/select_menu.stories.js
+++ b/packages/dialtone-vue/components/select_menu/select_menu.stories.js
@@ -16,7 +16,7 @@ const SELECT_OPTIONS = [
 // Default Prop Values
 export const argsData = {
   label: 'Label',
-  size: 'md',
+  size: 300,
   name: '',
   disabled: false,
   modelValue: SELECT_OPTIONS[0].value,

--- a/packages/dialtone-vue/components/select_menu/select_menu.test.js
+++ b/packages/dialtone-vue/components/select_menu/select_menu.test.js
@@ -206,6 +206,18 @@ describe('DtSelectMenu Tests', () => {
       });
     });
 
+    describe('When size is numeric', () => {
+      it('should have size variant class on select menu for numeric size 200', () => {
+        mockProps = { size: 200 };
+
+        updateWrapper();
+
+        selectWrapper = wrapper.find('[data-qa="dt-select-wrapper"]');
+
+        expect(selectWrapper.classes()).toContain('d-select--sm');
+      });
+    });
+
     describe('When labelSize is provided', () => {
       it('should override the default label size', () => {
         mockProps = { labelSize: 'xs' };

--- a/packages/dialtone-vue/components/select_menu/select_menu.vue
+++ b/packages/dialtone-vue/components/select_menu/select_menu.vue
@@ -40,7 +40,7 @@
       <div
         :class="[
           'd-select',
-          SELECT_SIZE_MODIFIERS[size],
+          SELECT_SIZE_MODIFIERS[String(size)],
           selectClass,
           { 'd-select--disabled': disabled },
         ]"
@@ -160,12 +160,12 @@ export default {
 
     /**
      * Controls the size of the select
-     * @values xs, sm, md, lg, xl
+     * @values 100, 200, 300, 400, 500
      */
     size: {
-      type: String,
-      default: 'md',
-      validator: (s) => Object.keys(SELECT_SIZE_MODIFIERS).includes(s),
+      type: [String, Number],
+      default: 300,
+      validator: (s) => Object.keys(SELECT_SIZE_MODIFIERS).includes(String(s)),
     },
 
     /**
@@ -254,12 +254,12 @@ export default {
     /**
      * Overrides the label text size. When not provided, the label size
      * is derived from the component size prop.
-     * @values lg, md, sm, xs
+     * @values 100, 200, 300, 400
      */
     labelSize: {
-      type: String,
+      type: [String, Number],
       default: null,
-      validator: (s) => TEXT_SIZE_MODIFIERS.label.includes(s),
+      validator: (s) => TEXT_SIZE_MODIFIERS.label.includes(String(s)),
     },
 
     /**
@@ -309,16 +309,24 @@ export default {
 
   computed: {
     resolvedLabelSize () {
-      return this.labelSize ?? (this.size === 'xl' ? 'lg' : this.size);
+      if (this.labelSize != null) return this.labelSize;
+      const sizeStr = String(this.size);
+      // xl/500 exceeds label's max size — cap at lg/400
+      if (sizeStr === 'xl' || sizeStr === '500') return sizeStr === '500' ? '400' : 'lg';
+      return this.size;
     },
 
     resolvedDescriptionSize () {
-      const map = { xs: 'xs', sm: 'xs', md: 'sm', lg: 'sm', xl: 'md' };
-      return map[this.size] || 'sm';
+      const map = {
+        100: 'xs', 200: 'xs', 300: 'sm', 400: 'sm', 500: 'md',
+        xs: 'xs', sm: 'xs', md: 'sm', lg: 'sm', xl: 'md',
+      };
+      return map[String(this.size)] || 'sm';
     },
 
     resolvedDescriptionDensity () {
-      return this.size === 'xl' ? '300' : undefined;
+      const sizeStr = String(this.size);
+      return (sizeStr === 'xl' || sizeStr === '500') ? '300' : undefined;
     },
 
     selectListeners () {

--- a/packages/dialtone-vue/components/select_menu/select_menu_constants.js
+++ b/packages/dialtone-vue/components/select_menu/select_menu_constants.js
@@ -1,4 +1,11 @@
 export const SELECT_SIZE_MODIFIERS = {
+  // Numeric (preferred)
+  100: 'd-select--xs',
+  200: 'd-select--sm',
+  300: '',
+  400: 'd-select--lg',
+  500: 'd-select--xl',
+  // T-shirt aliases (deprecated)
   xs: 'd-select--xs',
   sm: 'd-select--sm',
   md: '',

--- a/packages/dialtone-vue/components/skeleton/skeleton-list-item.vue
+++ b/packages/dialtone-vue/components/skeleton/skeleton-list-item.vue
@@ -56,11 +56,11 @@ export default {
 
     /**
      * Size of the shape
-     * @values xs, sm, md, lg, xl
+     * @values 100, 200, 300, 400, 500
      */
     shapeSize: {
-      type: String,
-      default: 'md',
+      type: [String, Number],
+      default: 300,
     },
 
     /**

--- a/packages/dialtone-vue/components/skeleton/skeleton-shape.vue
+++ b/packages/dialtone-vue/components/skeleton/skeleton-shape.vue
@@ -40,11 +40,11 @@ export default {
 
     /**
      * Size of the shape
-     * @values xs, sm, md, lg, xl
+     * @values 100, 200, 300, 400, 500
      */
     size: {
-      type: String,
-      default: 'md',
+      type: [String, Number],
+      default: 300,
     },
 
     /**
@@ -94,7 +94,7 @@ export default {
 
   computed: {
     shapeStyles () {
-      const size = SKELETON_SHAPE_SIZES[this.size] || this.size;
+      const size = SKELETON_SHAPE_SIZES[String(this.size)] || this.size;
       return {
         ...this.skeletonStyle,
         'min-width': size,

--- a/packages/dialtone-vue/components/skeleton/skeleton.test.js
+++ b/packages/dialtone-vue/components/skeleton/skeleton.test.js
@@ -104,6 +104,18 @@ describe('DtSkeleton Tests', () => {
 
         expect(skeletonShape.exists()).toBe(true);
       });
+
+      it('should render correct dimensions with numeric size', () => {
+        mockProps = {
+          shapeOption: { size: 200, shape: 'circle' },
+        };
+
+        updateWrapper();
+
+        skeletonShape = wrapper.find('[data-qa="skeleton-shape"]');
+
+        expect(skeletonShape.attributes('style')).toContain('min-width: 24px');
+      });
     });
   });
 

--- a/packages/dialtone-vue/components/skeleton/skeleton_constants.js
+++ b/packages/dialtone-vue/components/skeleton/skeleton_constants.js
@@ -17,12 +17,24 @@ export const SKELETON_TEXT_TYPES = [
 ];
 
 export const SKELETON_SHAPE_SIZES = {
+  // Numeric (preferred)
+  100: '16px',
+  200: '24px',
+  300: '32px',
+  400: '48px',
+  500: '64px',
+  // T-shirt aliases (deprecated)
   sm: '24px',
   md: '32px',
   lg: '48px',
 };
 
 export const SKELETON_HEADING_HEIGHTS = {
+  // Numeric (preferred)
+  200: 'd-h16',
+  300: 'd-h24',
+  400: 'd-h32',
+  // T-shirt aliases (deprecated)
   sm: 'd-h16',
   md: 'd-h24',
   lg: 'd-h32',

--- a/packages/dialtone-vue/components/split_button/split_button-end.vue
+++ b/packages/dialtone-vue/components/split_button/split_button-end.vue
@@ -14,9 +14,9 @@
     <template #icon>
       <slot
         name="icon"
-        :size="SPLIT_BUTTON_ICON_SIZES[size]"
+        :size="SPLIT_BUTTON_ICON_SIZES[String(size)]"
       >
-        <dt-icon-chevron-down :size="SPLIT_BUTTON_ICON_SIZES[size]" />
+        <dt-icon-chevron-down :size="SPLIT_BUTTON_ICON_SIZES[String(size)]" />
       </slot>
     </template>
   </dt-button>
@@ -90,8 +90,8 @@ export default {
      * The size of the button.
      */
     size: {
-      type: String,
-      default: 'md',
+      type: [String, Number],
+      default: 300,
     },
 
     /**

--- a/packages/dialtone-vue/components/split_button/split_button-start.vue
+++ b/packages/dialtone-vue/components/split_button/split_button-start.vue
@@ -177,8 +177,8 @@ export default {
      * The size of the button.
      */
     size: {
-      type: String,
-      default: 'md',
+      type: [String, Number],
+      default: 300,
     },
 
     /**

--- a/packages/dialtone-vue/components/split_button/split_button.vue
+++ b/packages/dialtone-vue/components/split_button/split_button.vue
@@ -469,12 +469,12 @@ export default {
 
     /**
      * The size of the button.
-     * @values xs, sm, md, lg, xl
+     * @values 100, 200, 300, 400, 500
      */
     size: {
-      type: String,
-      default: 'md',
-      validator: (s) => Object.keys(BUTTON_SIZE_MODIFIERS).includes(s),
+      type: [String, Number],
+      default: 300,
+      validator: (s) => Object.keys(BUTTON_SIZE_MODIFIERS).includes(String(s)),
     },
 
     /**

--- a/packages/dialtone-vue/components/split_button/split_button_constants.js
+++ b/packages/dialtone-vue/components/split_button/split_button_constants.js
@@ -1,4 +1,11 @@
 export const SPLIT_BUTTON_ICON_SIZES = {
+  // Numeric (preferred)
+  100: '100',
+  200: '100',
+  300: '200',
+  400: '200',
+  500: '300',
+  // T-shirt aliases (deprecated)
   xs: '100',
   sm: '100',
   md: '200',

--- a/packages/dialtone-vue/components/tab/tab_group.vue
+++ b/packages/dialtone-vue/components/tab/tab_group.vue
@@ -8,7 +8,7 @@
       ref="tabs"
       :class="[
         'd-tablist',
-        TAB_LIST_SIZE_MODIFIERS[size],
+        TAB_LIST_SIZE_MODIFIERS[String(size)],
         TAB_ORIENTATION_MODIFIERS[orientation],
         orientation !== 'vertical' && TAB_SPREAD_MODIFIERS[spread],
         {
@@ -139,13 +139,13 @@ export default {
 
     /**
      * If provided, applies size styles to the tab group
-     * @values default, xs, sm, lg, xl
+     * @values 100, 200, 300, 400, 500
      */
     size: {
-      type: String,
-      default: 'default',
+      type: [String, Number],
+      default: 300,
       validator (size) {
-        return TAB_LIST_SIZES.includes(size);
+        return TAB_LIST_SIZES.includes(String(size));
       },
     },
 
@@ -223,7 +223,7 @@ export default {
       provideObj: {
         selected: '', // the currently displayed tab id
         disabled: false, // disable group
-        size: 'default',
+        size: 300,
         kind: 'default',
         outlined: false,
         orientation: 'horizontal',

--- a/packages/dialtone-vue/components/tab/tabs.stories.js
+++ b/packages/dialtone-vue/components/tab/tabs.stories.js
@@ -8,7 +8,7 @@ import { TAB_LIST_SIZES, TAB_SPREADS } from './tabs_constants';
 
 // Default Prop Values
 export const argsData = {
-  size: 'default',
+  size: 300,
   spread: 'none',
   onChange: action('change'),
 };

--- a/packages/dialtone-vue/components/tab/tabs_constants.js
+++ b/packages/dialtone-vue/components/tab/tabs_constants.js
@@ -1,10 +1,20 @@
-export const TAB_LIST_SIZES = ['default', 'xs', 'sm', 'lg', 'xl'];
+export const TAB_LIST_SIZES = ['100', '200', '300', '400', '500', 'default', 'xs', 'sm', 'md', 'lg', 'xl'];
 
 export const TAB_LIST_SIZE_MODIFIERS = {
+  // Numeric (preferred)
+  100: 'd-tablist--xs',
+  200: 'd-tablist--sm',
+  300: '',
+  400: 'd-tablist--lg',
+  500: 'd-tablist--xl',
+  // T-shirt aliases (deprecated)
   xs: 'd-tablist--xs',
   sm: 'd-tablist--sm',
+  md: '',
   lg: 'd-tablist--lg',
   xl: 'd-tablist--xl',
+  // Legacy alias
+  default: '',
 };
 
 export const TAB_LIST_KIND_MODIFIERS = {

--- a/packages/dialtone-vue/components/text/text.stories.js
+++ b/packages/dialtone-vue/components/text/text.stories.js
@@ -25,7 +25,7 @@ export const argsData = {
   default: 'The quick brown fox jumps over the lazy dog.',
   as: 'span',
   kind: 'body',
-  size: 'md',
+  size: 300,
   strength: undefined,
   density: undefined,
   tone: undefined,

--- a/packages/dialtone-vue/components/text/text.test.js
+++ b/packages/dialtone-vue/components/text/text.test.js
@@ -80,6 +80,14 @@ describe('DtText', () => {
     expect(wrapper.classes()).toContain('d-text-headline--3xl');
   });
 
+  describe('When size is numeric', () => {
+    it('should apply the correct typography class for numeric size 200 with body kind', () => {
+      const wrapper = mountComponent({ kind: 'body', size: 200 });
+
+      expect(wrapper.classes()).toContain('d-text-body--sm');
+    });
+  });
+
   it('applies truncate class when truncate prop is true', () => {
     const wrapper = mountComponent({ truncate: true });
 

--- a/packages/dialtone-vue/components/text/text.vue
+++ b/packages/dialtone-vue/components/text/text.vue
@@ -14,6 +14,7 @@
 import {
   TEXT_KIND_MODIFIERS,
   TEXT_SIZE_MODIFIERS,
+  TEXT_SIZE_MAP,
   TEXT_HEADLINE_ONLY_SIZES,
   TEXT_ALIGN_MODIFIERS,
   TEXT_TONE_PREFIX,
@@ -27,7 +28,7 @@ import {
   TEXT_DENSITY_MODIFIERS,
 } from './text_constants';
 
-const DEFAULT_SIZE = 'md';
+const DEFAULT_SIZE = '300';
 const SEMANTIC_HEADING_ELEMENTS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
 
 // Module-level flag to emit info only once per session
@@ -69,12 +70,12 @@ export default {
     },
 
     /**
-     * Size variant within the selected `kind`. Falls back to `md` if unsupported.
-     * Headline supports all sizes; body/label/code support lg, md, sm, xs.
-     * @values 3xl, 2xl, xl, lg, md, sm, xs
+     * Size variant within the selected `kind`. Falls back to `md`/300 if unsupported.
+     * Headline supports all sizes; body/label/code support 100-400.
+     * @values 100, 200, 300, 400, 500, 600, 700
      */
     size: {
-      type: String,
+      type: [String, Number],
       default: null,
     },
 
@@ -266,11 +267,12 @@ export default {
       }
 
       const allowedSizes = TEXT_SIZE_MODIFIERS[this.kind] || [];
-      const requestedSize = this.size || DEFAULT_SIZE;
+      const rawSize = this.size != null ? String(this.size) : null;
+      const requestedSize = rawSize || DEFAULT_SIZE;
       let resolvedSize = requestedSize;
 
       if (!allowedSizes.includes(requestedSize)) {
-        // Headline-only sizes (3xl, 2xl, xl) throw an error when used with incompatible kinds
+        // Headline-only sizes (3xl, 2xl, xl, 500, 600, 700) throw an error when used with incompatible kinds
         if (TEXT_HEADLINE_ONLY_SIZES.includes(requestedSize)) {
           throw new Error(
             `[DtText] size="${requestedSize}" is only valid for kind="headline". ` +
@@ -278,7 +280,7 @@ export default {
           );
         }
 
-        // Universal sizes (lg, md, sm, xs) fall back gracefully with a warning
+        // Universal sizes fall back gracefully with a warning
         const fallbackSize = allowedSizes.includes(DEFAULT_SIZE) ? DEFAULT_SIZE : allowedSizes[0];
         if (fallbackSize) {
           resolvedSize = fallbackSize;
@@ -290,7 +292,9 @@ export default {
         return null;
       }
 
-      return `${TEXT_KIND_MODIFIERS[this.kind]}--${resolvedSize}`;
+      // Map numeric sizes to t-shirt CSS class suffix
+      const cssSuffix = TEXT_SIZE_MAP[resolvedSize] || resolvedSize;
+      return `${TEXT_KIND_MODIFIERS[this.kind]}--${cssSuffix}`;
     },
 
     getModifierClass (value, modifiers, propName) {

--- a/packages/dialtone-vue/components/text/text_constants.js
+++ b/packages/dialtone-vue/components/text/text_constants.js
@@ -6,14 +6,25 @@ export const TEXT_KIND_MODIFIERS = {
 };
 
 export const TEXT_SIZE_MODIFIERS = {
-  headline: ['3xl', '2xl', 'xl', 'lg', 'md', 'sm', 'xs'],
-  body: ['lg', 'md', 'sm', 'xs'],
-  label: ['lg', 'md', 'sm', 'xs'],
-  code: ['lg', 'md', 'sm', 'xs'],
+  headline: ['700', '600', '500', '400', '300', '200', '100', '3xl', '2xl', 'xl', 'lg', 'md', 'sm', 'xs'],
+  body: ['400', '300', '200', '100', 'lg', 'md', 'sm', 'xs'],
+  label: ['400', '300', '200', '100', 'lg', 'md', 'sm', 'xs'],
+  code: ['400', '300', '200', '100', 'lg', 'md', 'sm', 'xs'],
 };
 
 // Sizes that are only valid for headline kind - using these with other kinds throws an error
-export const TEXT_HEADLINE_ONLY_SIZES = ['3xl', '2xl', 'xl'];
+export const TEXT_HEADLINE_ONLY_SIZES = ['700', '600', '500', '3xl', '2xl', 'xl'];
+
+// Numeric → t-shirt CSS class suffix mapping
+export const TEXT_SIZE_MAP = {
+  100: 'xs',
+  200: 'sm',
+  300: 'md',
+  400: 'lg',
+  500: 'xl',
+  600: '2xl',
+  700: '3xl',
+};
 
 import TEXT_TONE_TOKENS from './text_tone_tokens.js';
 export { TEXT_TONE_TOKENS };

--- a/packages/dialtone-vue/components/toast/layouts/toast_layout_alternate.vue
+++ b/packages/dialtone-vue/components/toast/layouts/toast_layout_alternate.vue
@@ -35,7 +35,7 @@
         <dt-notice-action
           :hide-action="true"
           :hide-close="hideClose"
-          button-size="xs"
+          :button-size="100"
           v-bind="toastListeners"
           @close="$emit('close')"
         />

--- a/packages/dialtone-vue/components/toggle/toggle.stories.js
+++ b/packages/dialtone-vue/components/toggle/toggle.stories.js
@@ -48,7 +48,7 @@ export const argTypesData = {
   },
 
   size: {
-    description: 'Used to set the size of the toggle',
+    description: 'Used to set the size of the toggle.',
     options: Object.keys(TOGGLE_SIZE_MODIFIERS),
     control: {
       type: 'select',

--- a/packages/dialtone-vue/components/toggle/toggle.test.js
+++ b/packages/dialtone-vue/components/toggle/toggle.test.js
@@ -82,10 +82,21 @@ describe('DtToggle Tests', () => {
           expect(button.classes().includes('d-toggle--disabled')).toBe(true);
         });
 
-        it('should set correct size class', async () => {
+        it('should set correct size class with t-shirt alias', async () => {
           await wrapper.setProps({ size: 'sm' });
 
           expect(button.classes().includes('d-toggle--small')).toBe(true);
+        });
+
+        it('should set correct size class with numeric size', async () => {
+          await wrapper.setProps({ size: 200 });
+
+          expect(button.classes().includes('d-toggle--small')).toBe(true);
+        });
+
+        it('should render default size with numeric 300', () => {
+          expect(button.classes().includes('d-toggle--small')).toBe(false);
+          expect(button.classes().includes('d-toggle')).toBe(true);
         });
       });
     });

--- a/packages/dialtone-vue/components/toggle/toggle.vue
+++ b/packages/dialtone-vue/components/toggle/toggle.vue
@@ -88,12 +88,12 @@ export default {
 
     /**
      * The size of the toggle.
-     * @values sm, md
+     * @values 200, 300
      */
     size: {
-      type: String,
-      default: 'md',
-      validator: (s) => Object.keys(TOGGLE_SIZE_MODIFIERS).includes(s),
+      type: [String, Number],
+      default: 300,
+      validator: (s) => Object.keys(TOGGLE_SIZE_MODIFIERS).includes(String(s)),
     },
 
     /**
@@ -185,7 +185,7 @@ export default {
     toggleClasses () {
       return [
         'd-toggle',
-        TOGGLE_SIZE_MODIFIERS[this.size],
+        TOGGLE_SIZE_MODIFIERS[String(this.size)],
         {
           'd-toggle--checked': this.internalChecked === true,
           'd-toggle--disabled': this.disabled,

--- a/packages/dialtone-vue/components/toggle/toggle_constants.js
+++ b/packages/dialtone-vue/components/toggle/toggle_constants.js
@@ -1,4 +1,8 @@
 export const TOGGLE_SIZE_MODIFIERS = {
+  // Numeric (preferred)
+  200: 'd-toggle--small',
+  300: '',
+  // T-shirt aliases (deprecated)
   sm: 'd-toggle--small',
   md: '',
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,7 +512,7 @@ importers:
         specifier: workspace:*
         version: link:../dialtone-query-core
       '@dialpad/dialtone-vue':
-        specifier: workspace:^3
+        specifier: workspace:*
         version: link:../dialtone-vue
       '@rollup/plugin-commonjs':
         specifier: ^28.0.0
@@ -705,7 +705,7 @@ importers:
         specifier: workspace:*
         version: link:../dialtone-icons
       '@dialpad/dialtone-vue':
-        specifier: workspace:^3
+        specifier: workspace:*
         version: link:../dialtone-vue
       '@types/node':
         specifier: 24.3.1


### PR DESCRIPTION
<img width="120" height="126" alt="image" src="https://github.com/user-attachments/assets/d8686e74-ad1f-4de3-bdf9-a005cd6658ce" />

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-3225](https://dialpad.atlassian.net/browse/DLT-3225)

## :book: Description

> [!NOTE]
> **Part 1 of 3** — This PR must merge before [Part 2 (docs/consuming code)](https://dialpad.atlassian.net/browse/DLT-3226) and [Part 3 (ESLint rule + codemod)](https://dialpad.atlassian.net/browse/DLT-3227).

> [!TIP]
> I've created a NO-MERGE draft PR that combines all three into a single deploy preview  so you can see the end result of all three:
> 
> https://dialtone.dialpad.com/deploy-previews/pr-1160/
> https://dialtone.dialpad.com/vue/deploy-previews/pr-1160/
> 
> The deploy preview **specific** to this PR is
> 
> https://dialtone.dialpad.com/deploy-previews/pr-1157/
> https://dialtone.dialpad.com/vue/deploy-previews/pr-1157/

Migrate all component `size` props from t-shirt labels (xs, sm, md, lg, xl) to a numeric ordinal scale (100, 200, 300, 400, 500).

**What this PR changes:**
- Shared scale definition: `common/constants/sizes.js`
- 16 components: prop type `[String, Number]`, default numeric, `String()` coercion on lookups
- Constants: numeric keys added alongside t-shirt aliases (backward compat)
- `@values` JSDoc: numeric only
- Tests: one numeric size test per component
- Storybook: argsData defaults to numeric
- Text headline extended scale: 600=2xl, 700=3xl
- Motion Text: added 100/500 speed tiers (near-zero adoption, no t-shirt aliases)
- Skeleton shape: added 100 (16px) and 500 (64px) sizes
- Tab List: fixed `default` → `md`/`300`
- `labelSize` fallbacks: `?? 'md'` → `?? 300` (radio, checkbox, input_group)

**What this PR does NOT change:**
- Icon sizes (100–800 on dt-icon/loader/emoji/progress-circle) — unchanged
- CSS classes — numeric keys map to existing t-shirt CSS classes
- No breaking changes — t-shirt aliases remain as permanent deprecated aliases

**Also includes:**
- `workspace:^3` → `workspace:*` fix for dialtone-cli and dialtone-query-core (pre-existing pnpm install failure)
- `.claude/rules/vue-components.md` updated with numeric scale convention

## :bulb: Context

T-shirt labels are non-extensible (can't name something between `sm` and `md`), inconsistent across components, and don't follow the 100-unit convention used elsewhere in Dialtone tokens. The numeric scale solves all three: `250` is a valid future "smedium", the convention matches `dt-size-*` / `dt-icon-size-*` / color scales, and both humans and LLMs can reason about ordinal relationships without lookup tables.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

1. **Part 2** — Update all documentation, examples, stories, recipes, combinator variants to use numeric sizes ([DLT-3226](https://dialpad.atlassian.net/browse/DLT-3226))
2. **Part 3** — ESLint deprecation rule + batch migration codemod for consumers ([DLT-3227](https://dialpad.atlassian.net/browse/DLT-3227), [DLT-3228](https://dialpad.atlassian.net/browse/DLT-3228))

## :link: Sources

- [Shaping doc](docs/shaping/numeric-size-scale-slices.md)
- [Size mapping: xs=100, sm=200, md=300, lg=400, xl=500](packages/dialtone-vue/common/constants/sizes.js)

[DLT-3225]: https://dialpad.atlassian.net/browse/DLT-3225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DLT-3226]: https://dialpad.atlassian.net/browse/DLT-3226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ