### PR TITLE
feat(eslint-plugin-dialtone): DLT-3047 physical-to-logical naming migration tooling

### DIFF
--- a/.claude/rules/logical-naming.md
+++ b/.claude/rules/logical-naming.md
@@ -1,5 +1,17 @@
 # Logical Naming Convention
 
+## Enforcement
+
+**Never introduce physical direction names** (`left`, `right`, `top`, `bottom`, `alpha`, `omega`) in new component slots, props, events, or prop values. Always use logical equivalents (`start`, `end`, `blockStart`, `blockEnd`).
+
+When reviewing code or creating new components:
+
+- New slots must use logical names: e.g. `startIcon`, `endIcon`, `start`, `end`, `blockStart`, `blockEnd`
+- New props must use logical names: e.g. `startClass`, `endClass`, `startDisabled`, etc.
+- New prop values for positioning must be logical: e.g. `start`, `end`, `blockStart`, `blockEnd`
+- New events must use logical names: e.g. `start-clicked`, `end-clicked`
+- If touching a component that still has physical-only names, add logical alternatives with deprecated fallbacks.
+
 ## Direction Names
 
 Use logical names in all new component code, e.g.:

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-6.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-6.md
@@ -1,0 +1,272 @@
+---
+heading: 'Migrating to Logical Naming for Slots, Props, and Events'
+author: Francis Rupert
+posted: '2026-4-6'
+excerpt: 'Vue component APIs now use logical direction names (start/end/blockStart/blockEnd) instead of physical names (left/right/top/bottom/alpha/omega). Backward-compatible, with ESLint rule and migration script.'
+---
+
+<BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading" :excerpt="$frontmatter.excerpt">
+
+## TLDR
+
+- Slots, props, prop values, and events now use **logical direction names**: `start`, `end`, `blockStart`, `blockEnd`.
+- Physical names (`left`, `right`, `top`, `bottom`, `alpha`, `omega`) still work -- this is **not a breaking change**.
+- Use the [ESLint rule](#eslint-rule) or [migration script](#migration-script) to update your code.
+- **Manual migration required**: The `#icon` slot on `dt-button` -- see [below](#manual-migration-dt-button-icon-slot).
+
+## Why Logical?
+
+- **RTL and internationalization.** Logical names respect writing direction -- `start` means the inline-start edge regardless of locale.
+- **CSS alignment.** Matches CSS logical properties (`margin-inline-start`, `padding-block-end`) that Dialtone already uses internally.
+- **Consistency.** One naming convention across tokens, CSS utilities, and Vue components.
+
+## Examples
+
+### Slots
+
+<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-badge>
+  <template #leftIcon>...</template>
+</dt-badge>
+
+<dt-item-layout>
+  <template #left>...</template>
+  <template #right>...</template>
+  <template #bottom>...</template>
+</dt-item-layout>
+
+<dt-split-button>
+  <template #alphaIcon>...</template>
+  <template #omegaIcon>...</template>
+</dt-split-button>
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-badge>
+  <template #startIcon>...</template>
+</dt-badge>
+
+<dt-item-layout>
+  <template #start>...</template>
+  <template #end>...</template>
+  <template #blockEnd>...</template>
+</dt-item-layout>
+
+<dt-split-button>
+  <template #startIcon>...</template>
+  <template #endIcon>...</template>
+</dt-split-button>
+```
+
+</div>
+</div>
+
+### Props
+
+<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-item-layout
+  left-class="d-bgc-critical"
+  right-class="d-bgc-warning"
+  bottom-class="d-bgc-info"
+/>
+
+<dt-split-button
+  alpha-active
+  alpha-aria-label="Call"
+  omega-disabled
+/>
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-item-layout
+  start-class="d-bgc-critical"
+  end-class="d-bgc-warning"
+  block-end-class="d-bgc-info"
+/>
+
+<dt-split-button
+  start-active
+  start-aria-label="Call"
+  end-disabled
+/>
+```
+
+</div>
+</div>
+
+### Prop Values
+
+<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-button icon-position="left">
+  ...
+</dt-button>
+
+<dt-root-layout sidebar-position="right" />
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-button icon-position="start">
+  ...
+</dt-button>
+
+<dt-root-layout sidebar-position="end" />
+```
+
+</div>
+</div>
+
+### Events
+
+<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-split-button
+  @alpha-clicked="onPrimary"
+  @omega-clicked="onSecondary"
+/>
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-split-button
+  @start-clicked="onPrimary"
+  @end-clicked="onSecondary"
+/>
+```
+
+</div>
+</div>
+
+## Manual Migration: dt-button #icon Slot
+
+The `#icon` slot on `dt-button` is **ambiguous** -- its position depends on the `iconPosition` prop. The migration tools skip this case. Replace `#icon` with the slot matching your intended position:
+
+| iconPosition value | Replacement slot |
+| --- | --- |
+| `start` (default) | `#startIcon` |
+| `end` | `#endIcon` |
+| `blockStart` | `#blockStartIcon` |
+| `blockEnd` | `#blockEndIcon` |
+
+<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-button icon-position="start">
+  <template #icon>
+    <dt-icon name="phone" />
+  </template>
+  Call
+</dt-button>
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-button icon-position="start">
+  <template #startIcon>
+    <dt-icon name="phone" />
+  </template>
+  Call
+</dt-button>
+```
+
+</div>
+</div>
+
+## What's Affected
+
+**Components:** [DtBadge](/components/badge.html), [DtButton](/components/button.html), [DtInput](/components/input.html), [DtTab](/components/tab-group.html), [DtSplitButton](/components/split-button.html), [DtItemLayout](/components/item-layout.html), [DtRootLayout](/components/root-layout.html)
+
+**Recipes:** Callbox, Contact Centers Row, General Row, Top Banner Info, Grouped Chip
+
+## ESLint Rule
+
+`deprecated-physical-naming` flags all deprecated physical slot, prop, prop value, and event usage on Dialtone components.
+
+Add to your ESLint config:
+
+```js
+// eslint.config.js (flat config)
+import dialtone from '@dialpad/eslint-plugin-dialtone';
+
+export default [
+  {
+    plugins: { dialtone },
+    rules: {
+      'dialtone/deprecated-physical-naming': 'warn',
+    },
+  },
+];
+```
+
+## Migration Script
+
+Run the migration helper from your project root:
+
+```bash
+npx dialtone-migration-helper --cwd ./src
+```
+
+Select **"physical-to-logical"** from the config list. This renames all unambiguous physical names to their logical equivalents across `.vue`, `.md`, `.html`, `.js`, `.ts`, `.jsx`, and `.tsx` files.
+
+To apply changes without interactive confirmation:
+
+```bash
+npx dialtone-migration-helper --cwd ./src --force
+```
+
+**The script handles:** slot directives, prop names, prop values, and event listeners for all affected components.
+
+**Skipped:** The `#icon` slot on `dt-button` (ambiguous), dynamic bindings, and script-block references.
+
+Thanks! -- Dialtone Team
+
+</BlogPost>
+
+<script setup>
+import BlogPost from '@baseComponents/BlogPost.vue';
+import { parse } from 'date-fns';
+</script>

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/physical-to-logical.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/physical-to-logical.mjs
@@ -1,0 +1,86 @@
+// Migration: deprecated physical direction slot/prop/event names → logical equivalents.
+// Covers Vue template directives only. Does NOT cover:
+// - #icon on dt-button (ambiguous — requires manual migration)
+// - Dynamic bindings or script-section references
+
+export default {
+  description:
+    'Renames deprecated physical direction names (left/right/top/bottom/alpha/omega) to\n' +
+    'logical equivalents (start/end/blockStart/blockEnd) in Vue template slots, props,\n' +
+    'prop values, and events. Does NOT rename #icon on dt-button (ambiguous).',
+  patterns: ['**/*.{vue,html,md,js,ts,jsx,tsx}'],
+  expressions: [
+    // ── Slot renames ──────────────────────────────────────────────────────
+    // Longer patterns first to prevent partial matches.
+    // e.g. #leftIcon before #left, #rightIcon before #right
+
+    // #leftIcon → #startIcon
+    { from: /#leftIcon/g, to: '#startIcon' },
+    // #rightIcon → #endIcon
+    { from: /#rightIcon/g, to: '#endIcon' },
+    // #alphaIcon → #startIcon
+    { from: /#alphaIcon/g, to: '#startIcon' },
+    // #omegaIcon → #endIcon
+    { from: /#omegaIcon/g, to: '#endIcon' },
+    // #leftContent → #startContent
+    { from: /#leftContent/g, to: '#startContent' },
+    // #rightContent → #endContent
+    { from: /#rightContent/g, to: '#endContent' },
+    // #omega → #end (word boundary to avoid matching #omegaIcon)
+    // Scoped: only dt-split-button uses #omega
+    { from: /#omega(?=[\s"'>])/g, to: '#end' },
+
+    // Generic short slot names (#left, #right, #bottom) are scoped to known
+    // Dialtone components to avoid renaming slots on non-Dialtone components.
+    // Uses multiline matching to find the slot within a dt-* or dt-recipe-* tag.
+    // Components: dt-item-layout, dt-recipe-callbox, dt-recipe-contact-centers-row,
+    //             dt-recipe-general-row, dt-recipe-top-banner-info
+
+    // #left → #start (only on dt-item-layout, dt-recipe-general-row, dt-recipe-top-banner-info)
+    { from: /(<dt-(?:item-layout|recipe-general-row|recipe-top-banner-info)[\s\S]*?)#left(?=[\s"'>])/gm, to: '$1#start' },
+    // #right → #end (only on dt-item-layout, dt-recipe-callbox, dt-recipe-contact-centers-row, dt-recipe-top-banner-info)
+    { from: /(<dt-(?:item-layout|recipe-callbox|recipe-contact-centers-row|recipe-top-banner-info)[\s\S]*?)#right(?=[\s"'>])/gm, to: '$1#end' },
+    // #bottom → #blockEnd (only on dt-item-layout, dt-recipe-callbox)
+    { from: /(<dt-(?:item-layout|recipe-callbox)[\s\S]*?)#bottom(?=[\s"'>])/gm, to: '$1#blockEnd' },
+
+    // ── Prop renames ──────────────────────────────────────────────────────
+    // Longer patterns first within each prefix group.
+
+    // alpha-* → start-* (longest first)
+    { from: /alpha-trailing-class/g, to: 'start-trailing-class' },
+    { from: /alpha-tooltip-text/g, to: 'start-tooltip-text' },
+    { from: /alpha-leading-class/g, to: 'start-leading-class' },
+    { from: /alpha-icon-position/g, to: 'start-icon-position' },
+    { from: /alpha-aria-label/g, to: 'start-aria-label' },
+    { from: /alpha-label-class/g, to: 'start-label-class' },
+    { from: /alpha-disabled/g, to: 'start-disabled' },
+    { from: /alpha-loading/g, to: 'start-loading' },
+    { from: /alpha-active/g, to: 'start-active' },
+
+    // omega-* → end-* (longest first)
+    { from: /omega-tooltip-text/g, to: 'end-tooltip-text' },
+    { from: /omega-aria-label/g, to: 'end-aria-label' },
+    { from: /omega-disabled/g, to: 'end-disabled' },
+    { from: /omega-active/g, to: 'end-active' },
+    { from: /omega-id/g, to: 'end-id' },
+
+    // layout class props
+    { from: /bottom-class=/g, to: 'block-end-class=' },
+    { from: /left-class=/g, to: 'start-class=' },
+    { from: /right-class=/g, to: 'end-class=' },
+
+    // ── Prop value renames ────────────────────────────────────────────────
+    // icon-position values
+    { from: /icon-position="left"/g, to: 'icon-position="start"' },
+    { from: /icon-position="right"/g, to: 'icon-position="end"' },
+    { from: /icon-position="top"/g, to: 'icon-position="blockStart"' },
+    { from: /icon-position="bottom"/g, to: 'icon-position="blockEnd"' },
+    // sidebar-position values
+    { from: /sidebar-position="left"/g, to: 'sidebar-position="start"' },
+    { from: /sidebar-position="right"/g, to: 'sidebar-position="end"' },
+
+    // ── Event renames ─────────────────────────────────────────────────────
+    { from: /@alpha-clicked/g, to: '@start-clicked' },
+    { from: /@omega-clicked/g, to: '@end-clicked' },
+  ],
+};

--- a/packages/eslint-plugin-dialtone/docs/rules/deprecated-physical-naming.md
+++ b/packages/eslint-plugin-dialtone/docs/rules/deprecated-physical-naming.md
@@ -1,0 +1,63 @@
+# deprecated-physical-naming
+
+Detects deprecated physical direction names (left/right/top/bottom/alpha/omega) in Dialtone component slots, props, prop values, and events. Suggests logical replacements (start/end/blockStart/blockEnd).
+
+## Rule Details
+
+This rule flags usage of deprecated physical naming conventions across Dialtone Vue components and recipes. All deprecated names still work via backward-compatible fallbacks, but consumers should migrate to logical names.
+
+### What it flags
+
+- **Deprecated slots**: `#leftIcon`, `#rightIcon`, `#alphaIcon`, `#omegaIcon`, `#omega`, `#left`, `#right`, `#bottom`, `#leftContent`, `#rightContent`
+- **Deprecated props**: `alpha-*`, `omega-*`, `left-class`, `right-class`, `bottom-class` on applicable components
+- **Deprecated prop values**: `icon-position="left|right|top|bottom"`, `sidebar-position="left|right"`
+- **Deprecated events**: `@alpha-clicked`, `@omega-clicked`
+- **Special case**: `#icon` on `dt-button` (ambiguous — consumer must choose the replacement)
+
+### Examples of **incorrect** code
+
+```vue
+<dt-badge>
+  <template #leftIcon>...</template>
+</dt-badge>
+
+<dt-button icon-position="left">
+  <template #icon>...</template>
+</dt-button>
+
+<dt-split-button alpha-active @alpha-clicked="handler">
+  <template #alphaIcon>...</template>
+</dt-split-button>
+
+<dt-item-layout left-class="d-w32">
+  <template #left>...</template>
+</dt-item-layout>
+```
+
+### Examples of **correct** code
+
+```vue
+<dt-badge>
+  <template #startIcon>...</template>
+</dt-badge>
+
+<dt-button>
+  <template #startIcon>...</template>
+</dt-button>
+
+<dt-split-button start-active @start-clicked="handler">
+  <template #startIcon>...</template>
+</dt-split-button>
+
+<dt-item-layout start-class="d-w32">
+  <template #start>...</template>
+</dt-item-layout>
+```
+
+## Migration
+
+Use `npx dialtone-migration-helper` and select the "physical-to-logical" config to auto-rename unambiguous cases. The `#icon` slot on `dt-button` requires manual migration.
+
+## When Not To Use It
+
+If you are not yet ready to migrate to logical naming and want to suppress warnings.

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-physical-naming.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-physical-naming.js
@@ -1,0 +1,228 @@
+/**
+ * @fileoverview Detect deprecated physical direction names in Dialtone component
+ * slots, props, prop values, and events. Suggests logical replacements.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+/**
+ * Maps component names to their deprecated slot names and replacements.
+ * null value = special handling (ambiguous, e.g. #icon on dt-button).
+ */
+const DEPRECATED_SLOTS = {
+  'dt-badge': { leftIcon: 'startIcon', rightIcon: 'endIcon' },
+  'dt-button': { icon: null },
+  'dt-input': { leftIcon: 'startIcon', rightIcon: 'endIcon' },
+  'dt-tab': { leftIcon: 'startIcon' },
+  'dt-split-button': { alphaIcon: 'startIcon', omegaIcon: 'endIcon', omega: 'end' },
+  'dt-item-layout': { left: 'start', right: 'end', bottom: 'blockEnd' },
+  'dt-recipe-callbox': { right: 'end', bottom: 'blockEnd' },
+  'dt-recipe-contact-centers-row': { right: 'end' },
+  'dt-recipe-general-row': { left: 'start' },
+  'dt-recipe-top-banner-info': { left: 'start', right: 'end' },
+  'dt-recipe-grouped-chip': {
+    leftIcon: 'startIcon',
+    rightIcon: 'endIcon',
+    leftContent: 'startContent',
+    rightContent: 'endContent',
+  },
+};
+
+/**
+ * Maps component names to their deprecated prop names (kebab-case) and replacements.
+ */
+const DEPRECATED_PROPS = {
+  'dt-item-layout': {
+    'left-class': 'start-class',
+    'right-class': 'end-class',
+    'bottom-class': 'block-end-class',
+  },
+  'dt-split-button': {
+    'alpha-active': 'start-active',
+    'alpha-aria-label': 'start-aria-label',
+    'alpha-icon-position': 'start-icon-position',
+    'alpha-leading-class': 'start-leading-class',
+    'alpha-trailing-class': 'start-trailing-class',
+    'alpha-label-class': 'start-label-class',
+    'alpha-disabled': 'start-disabled',
+    'alpha-loading': 'start-loading',
+    'alpha-tooltip-text': 'start-tooltip-text',
+    'omega-active': 'end-active',
+    'omega-aria-label': 'end-aria-label',
+    'omega-disabled': 'end-disabled',
+    'omega-id': 'end-id',
+    'omega-tooltip-text': 'end-tooltip-text',
+  },
+};
+
+/**
+ * Maps component names to props whose specific values are deprecated.
+ */
+const DEPRECATED_PROP_VALUES = {
+  'dt-button': {
+    'icon-position': { left: 'start', right: 'end', top: 'blockStart', bottom: 'blockEnd' },
+  },
+  'dt-root-layout': {
+    'sidebar-position': { left: 'start', right: 'end' },
+  },
+};
+
+/**
+ * Maps component names to their deprecated event names and replacements.
+ */
+const DEPRECATED_EVENTS = {
+  'dt-split-button': { 'alpha-clicked': 'start-clicked', 'omega-clicked': 'end-clicked' },
+};
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Converts PascalCase or camelCase to kebab-case.
+ * e.g. 'DtBadge' → 'dt-badge', 'DtRecipeCallbox' → 'dt-recipe-callbox'
+ */
+function toKebabCase (str) {
+  return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Detect deprecated physical direction names in Dialtone component slots, props, prop values, and events',
+      recommended: false,
+      url: 'https://github.com/dialpad/dialtone/blob/staging/packages/eslint-plugin-dialtone/docs/rules/deprecated-physical-naming.md',
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      deprecatedSlot:
+        '#{{ oldSlot }} on <{{ component }}> is deprecated. Use #{{ newSlot }} instead.',
+      deprecatedIconSlot:
+        'The #icon slot on <dt-button> is deprecated. Use #startIcon, #endIcon, #blockStartIcon, or #blockEndIcon instead.',
+      deprecatedProp:
+        '{{ oldProp }} on <{{ component }}> is deprecated. Use {{ newProp }} instead.',
+      deprecatedPropValue:
+        '{{ prop }}="{{ oldValue }}" on <{{ component }}> is deprecated. Use {{ prop }}="{{ newValue }}" instead.',
+      deprecatedEvent:
+        '@{{ oldEvent }} on <{{ component }}> is deprecated. Use @{{ newEvent }} instead.',
+    },
+  },
+
+  create (context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    return sourceCode.parserServices.defineTemplateBodyVisitor({
+
+      VElement (node) {
+        const rawName = node.rawName || node.name;
+        const elementName = rawName.includes('-') ? rawName : toKebabCase(rawName);
+
+        const slotsMap = DEPRECATED_SLOTS[elementName];
+        const propsMap = DEPRECATED_PROPS[elementName];
+        const propValuesMap = DEPRECATED_PROP_VALUES[elementName];
+        const eventsMap = DEPRECATED_EVENTS[elementName];
+
+        // Check attributes in a single pass (props, prop values, events)
+        if (propsMap || propValuesMap || eventsMap) {
+          for (const attr of node.startTag.attributes) {
+            if (!attr.directive) {
+              // Static props: alpha-active, left-class="x", icon-position="left"
+              const attrName = attr.key && (attr.key.rawName || attr.key.name);
+              if (attrName && propsMap && propsMap[attrName]) {
+                context.report({
+                  node: attr,
+                  messageId: 'deprecatedProp',
+                  data: {
+                    component: elementName,
+                    oldProp: attrName,
+                    newProp: propsMap[attrName],
+                  },
+                });
+              }
+              if (attrName && propValuesMap && propValuesMap[attrName] && attr.value) {
+                const val = attr.value.value;
+                if (propValuesMap[attrName][val]) {
+                  context.report({
+                    node: attr,
+                    messageId: 'deprecatedPropValue',
+                    data: {
+                      component: elementName,
+                      prop: attrName,
+                      oldValue: val,
+                      newValue: propValuesMap[attrName][val],
+                    },
+                  });
+                }
+              }
+            } else if (attr.directive && attr.key.name.name === 'bind') {
+              // Dynamic props: :alpha-active="x", v-bind:omega-disabled="y"
+              const bindName = attr.key.argument && (attr.key.argument.rawName || attr.key.argument.name);
+              if (bindName && propsMap && propsMap[bindName]) {
+                context.report({
+                  node: attr,
+                  messageId: 'deprecatedProp',
+                  data: {
+                    component: elementName,
+                    oldProp: bindName,
+                    newProp: propsMap[bindName],
+                  },
+                });
+              }
+            } else if (eventsMap && attr.key.name.name === 'on') {
+              const eventName = attr.key.argument && (attr.key.argument.rawName || attr.key.argument.name);
+              if (eventName && eventsMap[eventName]) {
+                context.report({
+                  node: attr,
+                  messageId: 'deprecatedEvent',
+                  data: {
+                    component: elementName,
+                    oldEvent: eventName,
+                    newEvent: eventsMap[eventName],
+                  },
+                });
+              }
+            }
+          }
+        }
+
+        // Check child <template> elements for deprecated slot names
+        if (slotsMap) {
+          for (const child of node.children) {
+            if (child.type === 'VElement' && child.name === 'template') {
+              for (const attr of child.startTag.attributes) {
+                if (attr.directive && attr.key.name.name === 'slot') {
+                  const slotName = attr.key.argument && (attr.key.argument.rawName || attr.key.argument.name);
+                  if (slotName && slotName in slotsMap) {
+                    if (slotsMap[slotName] === null) {
+                      // #icon on dt-button is ambiguous — consumer must choose replacement
+                      context.report({ node: attr, messageId: 'deprecatedIconSlot' });
+                    } else {
+                      context.report({
+                        node: attr,
+                        messageId: 'deprecatedSlot',
+                        data: {
+                          component: elementName,
+                          oldSlot: slotName,
+                          newSlot: slotsMap[slotName],
+                        },
+                      });
+                    }
+                  }
+                  break;
+                }
+              }
+            }
+          }
+        }
+      },
+    });
+  },
+};

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-physical-naming.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-physical-naming.js
@@ -1,0 +1,395 @@
+/**
+ * @fileoverview Tests for deprecated-physical-naming rule.
+ *
+ * Coverage:
+ *   - Slots: leftIcon, rightIcon, alphaIcon, omegaIcon, omega, left, right,
+ *            bottom, leftContent, rightContent, icon (dt-button special case)
+ *   - Props: alpha-*, omega-*, left-class, right-class, bottom-class
+ *   - Prop values: icon-position="left|right|top|bottom",
+ *                  sidebar-position="left|right"
+ *   - Events: @alpha-clicked, @omega-clicked
+ *   - Recipe components: dt-recipe-callbox, dt-recipe-contact-centers-row,
+ *                        dt-recipe-general-row, dt-recipe-top-banner-info,
+ *                        dt-recipe-grouped-chip
+ */
+'use strict';
+
+const rule = require('../../../lib/rules/deprecated-physical-naming'),
+  RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    // eslint-disable-next-line n/no-extraneous-require
+    parser: require('vue-eslint-parser'),
+    ecmaVersion: 'latest',
+  },
+});
+
+ruleTester.run('deprecated-physical-naming', rule, {
+
+  // ============================================================
+  // VALID — logical names and unrelated components
+  // ============================================================
+  valid: [
+    // V1: dt-badge with startIcon / endIcon
+    { code: '<template><dt-badge><template #startIcon>x</template></dt-badge></template>' },
+    // V2: dt-button with startIcon
+    { code: '<template><dt-button><template #startIcon>x</template></dt-button></template>' },
+    // V3: dt-button with endIcon
+    { code: '<template><dt-button><template #endIcon>x</template></dt-button></template>' },
+    // V4: dt-button with blockStartIcon
+    { code: '<template><dt-button><template #blockStartIcon>x</template></dt-button></template>' },
+    // V5: dt-button with blockEndIcon
+    { code: '<template><dt-button><template #blockEndIcon>x</template></dt-button></template>' },
+    // V6: dt-input with startIcon
+    { code: '<template><dt-input label="x"><template #startIcon>x</template></dt-input></template>' },
+    // V7: dt-tab with startIcon
+    { code: '<template><dt-tab><template #startIcon>x</template></dt-tab></template>' },
+    // V8: dt-split-button with logical props
+    { code: '<template><dt-split-button start-active start-aria-label="x">x</dt-split-button></template>' },
+    // V9: dt-item-layout with logical props
+    { code: '<template><dt-item-layout start-class="x" end-class="x" block-end-class="x">x</dt-item-layout></template>' },
+    // V10: dt-root-layout with sidebar-position="start"
+    { code: '<template><dt-root-layout sidebar-position="start">x</dt-root-layout></template>' },
+    // V11: dt-button with icon-position="start"
+    { code: '<template><dt-button icon-position="start">x</dt-button></template>' },
+    // V12: dt-split-button with logical events
+    { code: '<template><dt-split-button @start-clicked="x" @end-clicked="x">x</dt-split-button></template>' },
+    // V13: dt-recipe-callbox with end
+    { code: '<template><dt-recipe-callbox><template #end>x</template></dt-recipe-callbox></template>' },
+    // V14: dt-recipe-general-row with start
+    { code: '<template><dt-recipe-general-row><template #start>x</template></dt-recipe-general-row></template>' },
+    // V15: dt-recipe-grouped-chip with startIcon
+    { code: '<template><dt-recipe-grouped-chip><template #startIcon>x</template></dt-recipe-grouped-chip></template>' },
+    // V16: Unrelated component with #left (not in map)
+    { code: '<template><custom-layout><template #left>x</template></custom-layout></template>' },
+    // V17: dt-avatar with #icon (not deprecated on avatar)
+    { code: '<template><dt-avatar><template #icon>x</template></dt-avatar></template>' },
+    // V18: div with #leftIcon (not a Dialtone component)
+    { code: '<template><div><template #leftIcon>x</template></div></template>' },
+    // V19: alpha-active on dt-button (not in dt-button's prop map)
+    { code: '<template><dt-button alpha-active>x</dt-button></template>' },
+  ],
+
+  // ============================================================
+  // INVALID — deprecated physical names
+  // ============================================================
+  invalid: [
+    // ── dt-badge ────────────────────────────────────────────────
+    // I1: #leftIcon
+    {
+      code: '<template><dt-badge><template #leftIcon>x</template></dt-badge></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I2: #rightIcon
+    {
+      code: '<template><dt-badge><template #rightIcon>x</template></dt-badge></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+
+    // ── dt-button ───────────────────────────────────────────────
+    // I3: #icon (special ambiguous message)
+    {
+      code: '<template><dt-button><template #icon>x</template></dt-button></template>',
+      errors: [{ messageId: 'deprecatedIconSlot' }],
+    },
+    // I4: #icon + icon-position="left" (2 errors)
+    {
+      code: '<template><dt-button icon-position="left"><template #icon>x</template></dt-button></template>',
+      errors: [
+        { messageId: 'deprecatedPropValue' },
+        { messageId: 'deprecatedIconSlot' },
+      ],
+    },
+    // I5: #icon + icon-position="right" (2 errors)
+    {
+      code: '<template><dt-button icon-position="right"><template #icon>x</template></dt-button></template>',
+      errors: [
+        { messageId: 'deprecatedPropValue' },
+        { messageId: 'deprecatedIconSlot' },
+      ],
+    },
+    // I6: icon-position="top"
+    {
+      code: '<template><dt-button icon-position="top">x</dt-button></template>',
+      errors: [{ messageId: 'deprecatedPropValue' }],
+    },
+    // I7: icon-position="bottom"
+    {
+      code: '<template><dt-button icon-position="bottom">x</dt-button></template>',
+      errors: [{ messageId: 'deprecatedPropValue' }],
+    },
+
+    // ── dt-input ────────────────────────────────────────────────
+    // I8: #leftIcon
+    {
+      code: '<template><dt-input label="x"><template #leftIcon>x</template></dt-input></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I9: #rightIcon
+    {
+      code: '<template><dt-input label="x"><template #rightIcon>x</template></dt-input></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+
+    // ── dt-tab ──────────────────────────────────────────────────
+    // I10: #leftIcon
+    {
+      code: '<template><dt-tab><template #leftIcon>x</template></dt-tab></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+
+    // ── dt-split-button slots ───────────────────────────────────
+    // I11: #alphaIcon
+    {
+      code: '<template><dt-split-button><template #alphaIcon>x</template></dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I12: #omegaIcon
+    {
+      code: '<template><dt-split-button><template #omegaIcon>x</template></dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I13: #omega
+    {
+      code: '<template><dt-split-button><template #omega>x</template></dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+
+    // ── dt-split-button props ───────────────────────────────────
+    // I14: alpha-active
+    {
+      code: '<template><dt-split-button alpha-active>x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I15: alpha-aria-label
+    {
+      code: '<template><dt-split-button alpha-aria-label="Call">x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I16: alpha-disabled
+    {
+      code: '<template><dt-split-button alpha-disabled>x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I17: alpha-loading
+    {
+      code: '<template><dt-split-button alpha-loading>x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I18: alpha-icon-position
+    {
+      code: '<template><dt-split-button alpha-icon-position="start">x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I19: alpha-leading-class
+    {
+      code: '<template><dt-split-button alpha-leading-class="x">x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I20: alpha-trailing-class
+    {
+      code: '<template><dt-split-button alpha-trailing-class="x">x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I21: alpha-label-class
+    {
+      code: '<template><dt-split-button alpha-label-class="x">x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I22: alpha-tooltip-text
+    {
+      code: '<template><dt-split-button alpha-tooltip-text="x">x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I23: omega-active
+    {
+      code: '<template><dt-split-button omega-active>x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I24: omega-aria-label
+    {
+      code: '<template><dt-split-button omega-aria-label="x">x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I25: omega-disabled
+    {
+      code: '<template><dt-split-button omega-disabled>x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I26: omega-id
+    {
+      code: '<template><dt-split-button omega-id="x">x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I27: omega-tooltip-text
+    {
+      code: '<template><dt-split-button omega-tooltip-text="x">x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+
+    // ── dt-split-button events ──────────────────────────────────
+    // I28: @alpha-clicked
+    {
+      code: '<template><dt-split-button @alpha-clicked="x">x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedEvent' }],
+    },
+    // I29: @omega-clicked
+    {
+      code: '<template><dt-split-button @omega-clicked="x">x</dt-split-button></template>',
+      errors: [{ messageId: 'deprecatedEvent' }],
+    },
+
+    // ── dt-item-layout ──────────────────────────────────────────
+    // I30: #left
+    {
+      code: '<template><dt-item-layout><template #left>x</template></dt-item-layout></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I31: #right
+    {
+      code: '<template><dt-item-layout><template #right>x</template></dt-item-layout></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I32: #bottom
+    {
+      code: '<template><dt-item-layout><template #bottom>x</template></dt-item-layout></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I33: left-class
+    {
+      code: '<template><dt-item-layout left-class="x">x</dt-item-layout></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I34: right-class
+    {
+      code: '<template><dt-item-layout right-class="x">x</dt-item-layout></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+    // I35: bottom-class
+    {
+      code: '<template><dt-item-layout bottom-class="x">x</dt-item-layout></template>',
+      errors: [{ messageId: 'deprecatedProp' }],
+    },
+
+    // ── dt-root-layout ──────────────────────────────────────────
+    // I36: sidebar-position="left"
+    {
+      code: '<template><dt-root-layout sidebar-position="left">x</dt-root-layout></template>',
+      errors: [{ messageId: 'deprecatedPropValue' }],
+    },
+    // I37: sidebar-position="right"
+    {
+      code: '<template><dt-root-layout sidebar-position="right">x</dt-root-layout></template>',
+      errors: [{ messageId: 'deprecatedPropValue' }],
+    },
+
+    // ── Recipe components ───────────────────────────────────────
+    // I38: dt-recipe-callbox #right
+    {
+      code: '<template><dt-recipe-callbox><template #right>x</template></dt-recipe-callbox></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I39: dt-recipe-callbox #bottom
+    {
+      code: '<template><dt-recipe-callbox><template #bottom>x</template></dt-recipe-callbox></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I40: dt-recipe-contact-centers-row #right
+    {
+      code: '<template><dt-recipe-contact-centers-row><template #right>x</template></dt-recipe-contact-centers-row></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I41: dt-recipe-general-row #left
+    {
+      code: '<template><dt-recipe-general-row><template #left>x</template></dt-recipe-general-row></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I42: dt-recipe-top-banner-info #left
+    {
+      code: '<template><dt-recipe-top-banner-info><template #left>x</template></dt-recipe-top-banner-info></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I43: dt-recipe-top-banner-info #right
+    {
+      code: '<template><dt-recipe-top-banner-info><template #right>x</template></dt-recipe-top-banner-info></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I44: dt-recipe-grouped-chip #leftIcon
+    {
+      code: '<template><dt-recipe-grouped-chip><template #leftIcon>x</template></dt-recipe-grouped-chip></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I45: dt-recipe-grouped-chip #rightIcon
+    {
+      code: '<template><dt-recipe-grouped-chip><template #rightIcon>x</template></dt-recipe-grouped-chip></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I46: dt-recipe-grouped-chip #leftContent
+    {
+      code: '<template><dt-recipe-grouped-chip><template #leftContent>x</template></dt-recipe-grouped-chip></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+    // I47: dt-recipe-grouped-chip #rightContent
+    {
+      code: '<template><dt-recipe-grouped-chip><template #rightContent>x</template></dt-recipe-grouped-chip></template>',
+      errors: [{ messageId: 'deprecatedSlot' }],
+    },
+
+    // ── Multi-violation cases ───────────────────────────────────
+    // M1: dt-split-button with slots + props + events
+    {
+      code: `<template>
+  <dt-split-button
+    alpha-active
+    alpha-aria-label="Call"
+    omega-disabled
+    @alpha-clicked="x"
+    @omega-clicked="x"
+  >
+    <template #alphaIcon>x</template>
+    <template #omegaIcon>x</template>
+  </dt-split-button>
+</template>`,
+      errors: [
+        { messageId: 'deprecatedProp' },   // alpha-active
+        { messageId: 'deprecatedProp' },   // alpha-aria-label
+        { messageId: 'deprecatedProp' },   // omega-disabled
+        { messageId: 'deprecatedEvent' },  // @alpha-clicked
+        { messageId: 'deprecatedEvent' },  // @omega-clicked
+        { messageId: 'deprecatedSlot' },   // #alphaIcon
+        { messageId: 'deprecatedSlot' },   // #omegaIcon
+      ],
+    },
+    // M2: dt-item-layout with all deprecated slots and props
+    {
+      code: `<template>
+  <dt-item-layout left-class="x" right-class="x" bottom-class="x">
+    <template #left>x</template>
+    <template #right>x</template>
+    <template #bottom>x</template>
+  </dt-item-layout>
+</template>`,
+      errors: [
+        { messageId: 'deprecatedProp' },   // left-class
+        { messageId: 'deprecatedProp' },   // right-class
+        { messageId: 'deprecatedProp' },   // bottom-class
+        { messageId: 'deprecatedSlot' },   // #left
+        { messageId: 'deprecatedSlot' },   // #right
+        { messageId: 'deprecatedSlot' },   // #bottom
+      ],
+    },
+    // M3: dt-button with #icon + icon-position="left"
+    {
+      code: `<template>
+  <dt-button icon-position="left">
+    <template #icon>x</template>
+  </dt-button>
+</template>`,
+      errors: [
+        { messageId: 'deprecatedPropValue' },  // icon-position="left"
+        { messageId: 'deprecatedIconSlot' },    // #icon
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTnp1puF54wmdYhLAyFtgmU5ghNhBKUV84Vjw&s)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-3047](https://dialpad.atlassian.net/browse/DLT-3047)

## :book: Description

Consumer-facing tooling for the physical-to-logical direction naming migration (`left`/`right`/`top`/`bottom`/`alpha`/`omega` → `start`/`end`/`blockStart`/`blockEnd`).

- **ESLint rule** `deprecated-physical-naming` — flags deprecated slots, props, prop values, and events across 11 components and 5 recipes. Handles PascalCase, v-bind directives, and the ambiguous `#icon` slot on dt-button.
- **Migration helper config** `physical-to-logical` — regex-based auto-rename for unambiguous cases. Generic slot names (`#left`, `#right`, `#bottom`) scoped to known Dialtone components to avoid false positives.
- **What's New blog post** — migration guide with before/after examples, ESLint config, and migration script usage.
- **Claude rules** — enforcement section added to `logical-naming.md` to prevent regression in AI-assisted development.

## :package: Cross-Package Impact

| Package | Changes |
|---|---|
| eslint-plugin-dialtone | New rule + tests + docs |
| dialtone-css | New migration helper config |
| dialtone-documentation | New blog post |
| .claude/rules | Updated logical-naming enforcement |

## :bulb: Context

All 15+ components/recipes on `next` already have logical names with deprecated backward-compatible fallbacks. This PR adds the tooling so consumers can discover and fix deprecated usage. `#icon` on dt-button is flagged but not auto-fixed (ambiguous — consumer must choose `#startIcon`/`#endIcon`/`#blockStartIcon`/`#blockEndIcon`).

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

- Fix ESLint plugin test suite (all 12 existing rules broken by eslint v9 flat config migration — pre-existing, not caused by this PR)
- Run the migration helper against Dialpad consumer codebases after release

## :link: Sources

- Sub-tasks: [DLT-3238](https://dialpad.atlassian.net/browse/DLT-3238), [DLT-3239](https://dialpad.atlassian.net/browse/DLT-3239), [DLT-3240](https://dialpad.atlassian.net/browse/DLT-3240), [DLT-3241](https://dialpad.atlassian.net/browse/DLT-3241)

[DLT-3047]: https://dialpad.atlassian.net/browse/DLT-3047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DLT-3238]: https://dialpad.atlassian.net/browse/DLT-3238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ