### PR TITLE
docs(playground): DLT-3242 segmented control for compact enum props

### DIFF
--- a/packages/combinator/src/components/controls/control_segmented.vue
+++ b/packages/combinator/src/components/controls/control_segmented.vue
@@ -1,0 +1,81 @@
+<template>
+  <dt-text
+    kind="label"
+    :size="100"
+    tone="secondary"
+    class="d-input__label-text d-c-default"
+  >
+    <slot />
+  </dt-text>
+  <dt-segmented-control
+    :model-value="String(value)"
+    :size="100"
+    :disabled="disabled"
+    @change="onInput"
+  >
+    <dt-segmented-control-item
+      v-for="option in options"
+      :key="option.value"
+      :value="String(option.value)"
+    >
+      {{ option.label }}
+    </dt-segmented-control-item>
+  </dt-segmented-control>
+</template>
+
+<script setup>
+import { DtSegmentedControl, DtSegmentedControlItem, DtText } from '@dialpad/dialtone-vue';
+
+import { VALUE_UPDATE_EVENT } from '@/src/lib/constants';
+import { computed } from 'vue';
+
+const props = defineProps({
+  value: {
+    type: undefined,
+    required: true,
+  },
+  validValues: {
+    type: Array,
+    default: undefined,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  generateLabel: {
+    type: Function,
+    default: (value) => value.toString(),
+  },
+});
+
+const emit = defineEmits([VALUE_UPDATE_EVENT]);
+
+const options = computed(() => {
+  return props.validValues?.map(v => ({
+    value: v,
+    label: props.generateLabel(v),
+  })) ?? [];
+});
+
+// DtSegmentedControl coerces values to strings — map back to original types on selection
+const valueMap = computed(() => {
+  const map = {};
+  props.validValues?.forEach(v => {
+    map[String(v)] = v;
+  });
+  return map;
+});
+
+function onInput (stringValue) {
+  emit(VALUE_UPDATE_EVENT, valueMap.value[stringValue]);
+}
+</script>
+
+<script>
+/**
+ * Control that renders a segmented control for enum props with few, short options.
+ */
+export default {
+  name: 'DtcControlSegmented',
+};
+</script>

--- a/packages/combinator/src/lib/control.js
+++ b/packages/combinator/src/lib/control.js
@@ -14,8 +14,12 @@ import DtcControlString from '@/src/components/controls/control_string.vue';
 import DtcControlNullish from '@/src/components/controls/control_nullish.vue';
 import DtcControlBase from '@/src/components/controls/control_base.vue';
 import DtcControlIconSlot from '@/src/components/controls/control_icon_slot.vue';
+import DtcControlSegmented from '@/src/components/controls/control_segmented.vue';
 
 import { typeOfMemberValue } from '@/src/lib/utils';
+
+const MAX_SEGMENTED_COUNT = 6;
+const MAX_SEGMENTED_LABEL_LENGTH = 4;
 
 /**
  * Symbol representing a value that is "not set".
@@ -56,6 +60,10 @@ export const controlMap = Object.freeze({
   },
   selection: {
     component: DtcControlSelection,
+    default ({ values } = {}) { return values?.[0]; },
+  },
+  segmented: {
+    component: DtcControlSegmented,
     default ({ values } = {}) { return values?.[0]; },
   },
   string: {
@@ -102,12 +110,18 @@ export function getControlByValue (value) {
 export function getControlByMemberType (type, args) {
   if (type === 'boolean') return 'boolean';
   if (args?.values?.length > 0) {
+    if (shouldUseSegmented(args.values)) return 'segmented';
     return 'selection';
   }
   switch (type) {
     case 'string': return 'string';
     default: return type;
   }
+}
+
+function shouldUseSegmented (values) {
+  return values.length <= MAX_SEGMENTED_COUNT &&
+    values.every(v => String(v).length <= MAX_SEGMENTED_LABEL_LENGTH);
 }
 
 /**


### PR DESCRIPTION
![small-lakers](https://github.com/user-attachments/assets/2fead78a-8301-4885-9f46-b913f521e002)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-3242](https://dialpad.atlassian.net/browse/DLT-3242)

## :book: Description

Enum props with few, short options (e.g. `size: [100, 200, 300, 400, 500]`) now render as `DtSegmentedControl` instead of `DtDropdown` in the combinator option bar.

Heuristic in `getControlByMemberType()`: ≤6 values and all labels ≤4 chars → segmented; otherwise dropdown.

**New file:** `control_segmented.vue` — wraps `DtSegmentedControl`, same prop contract as `control_selection.vue`.

**Modified:** `control.js` — `segmented` entry in `controlMap`, `shouldUseSegmented()` heuristic.

## :bulb: Context

Dropdown controls require two interactions (open + select) for props that have only 3–5 short options. Segmented controls show all options inline — single click to change.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description.
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

- Validate threshold tuning against all Dialtone component enum props
- Consider variant config override (`controlType`) if heuristic needs manual correction (deferred — current escape hatch is the control-type switcher)

[DLT-3242]: https://dialpad.atlassian.net/browse/DLT-3242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

https://github.com/user-attachments/assets/77bd8fd4-2efa-4e19-a606-a8994af08143