### PR TITLE
docs: DLT-3243 fenced code blocks for examples and snippets

### DIFF
--- a/.claude/rules/documentation-writing.md
+++ b/.claude/rules/documentation-writing.md
@@ -25,69 +25,91 @@ paths:
 - Never write TODO, TBD, "Coming soon", or empty sections
 - If content isn't ready, omit the section entirely
 
-## Code Examples: Use `<code-example>`
+## Code Examples: Fenced Demo Blocks
 
-Prefer the unified `<code-example>` component. The slot content is the single source of truth — a build-time plugin auto-extracts it as the Vue code tab.
+Use fenced ` ```vue demo ` blocks for all new doc examples. A markdown-it plugin (`markdown-it-fenced-demo.js`) transforms them into `<code-example>` tags at build time, so the rendered output is identical — but the authoring experience is cleaner (no entity-encoding, no quote tracking).
 
-```html
-<!-- Default: demo + code tabs, auto-extracted -->
-<code-example>
-  <dt-notice kind="base" title="Base title" />
-</code-example>
+### Info string variants
 
-<!-- Demo only -->
-<code-example only-show="demo">
-  <dt-notice kind="base" title="Base title" />
-</code-example>
-
-<!-- Code only -->
-<code-example only-show="code">
-  <dt-notice kind="base" title="Base title" />
-</code-example>
-
-<!-- Override vueCode ONLY when the code tab genuinely differs -->
-<code-example vueCode='<dt-button disabled>Click</dt-button>'>
-  <dt-toggle v-model="isDisabled" />
-  <dt-button :disabled="isDisabled">Click</dt-button>
-</code-example>
-
-<!-- Strip a demo-only layout wrapper from the code tab -->
-<code-example>
-  <dt-stack direction="row" gap="400" data-demo-wrapper>
-    <dt-button> Place Call </dt-button>
-    <dt-button importance="outlined"> Place Call </dt-button>
-  </dt-stack>
-</code-example>
+````md
+<!-- Default: demo + code tabs -->
+```vue demo
+<dt-notice kind="base" title="Base title" />
 ```
 
-### When to use `vueCode` override
+<!-- Demo only (no code tab) -->
+```vue demo-only
+<dt-notice kind="base" title="Base title" />
+```
 
-Only add `vueCode` when the code tab must show something **genuinely different** from the slot:
+<!-- Code only (no live preview) -->
+```vue code-only
+<dt-notice kind="base" title="Base title" />
+```
+````
 
-**Valid reasons for override:**
+### Directives (HTML comments inside the fenced block)
 
-- Slot uses a **custom example wrapper** (`<example-modal>`, `<example-popover>`, `<ExampleProfileCard>`) — code expands to real component markup
-- Slot has **interactive page state** (v-model, toggles, event handlers) — code shows simplified static version
-- Slot uses **v-for with page data** — code shows single static example
-- Code uses **placeholder syntax** (`{{props}}`, `....`) for API reference
-- Slot has **demo-only styling on child elements** (e.g., `d-bgc-moderate-opaque d-p16 d-bar8` on each child to make items visible) — code shows clean API
+Directives configure the `<code-example>` output. Place them at the top of the block, before content.
 
-**NOT valid reasons (remove the vueCode):**
+| Directive | Purpose | Equivalent `<code-example>` prop |
+| --- | --- | --- |
+| `<!-- @wrapper -->` | Marks first element as demo-only layout wrapper | `data-demo-wrapper` on element |
+| `<!-- @code -->` | Separator: above = live demo, below = code tab | `vueCode='...'` |
+| `<!-- @bg classname -->` | Custom background class | `bgclass="classname"` |
+| `<!-- @class name -->` | Custom CSS class on code-example | `class="name"` |
+| `<!-- @demo-only -->` | Alias for `demo-only` info string | `only-show="demo"` |
+| `<!-- @code-only -->` | Alias for `code-only` info string | `only-show="code"` |
 
-- Slot is wrapped in a layout wrapper — use `data-demo-wrapper` to strip it from the code tab instead
-- Only difference is `class="d-w100p"` or similar layout constraint on the wrapper
+Prefer the info string for `demo-only`/`code-only`. Use the directive form when combining with other directives.
+
+### Common patterns
+
+````md
+<!-- Strip a layout wrapper from the code tab -->
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="400">
+  <dt-button> Place Call </dt-button>
+  <dt-button importance="outlined"> Place Call </dt-button>
+</dt-stack>
+```
+
+<!-- Show different code than what renders (interactive demo vs static code) -->
+```vue demo
+<dt-toggle v-model="isDisabled" />
+<dt-button :disabled="isDisabled">Click</dt-button>
+<!-- @code -->
+<dt-button disabled>Click</dt-button>
+```
+
+<!-- Custom background -->
+```vue demo
+<!-- @bg d-bgc-primary -->
+<dt-button>Click me</dt-button>
+```
+````
+
+### When to use `<!-- @code -->` separator
+
+Only use `<!-- @code -->` when the code tab must show something **genuinely different** from the demo:
+
+**Valid reasons:**
+
+- Demo uses a **custom example wrapper** (`<example-tabs>`, `<example-modal>`) — code shows real component markup
+- Demo has **interactive page state** (v-model, toggles, event handlers) — code shows simplified static version
+- Demo uses **v-for with page data** — code shows single static example
+- Code uses **placeholder syntax** (`{props}`, `....`) for API reference
+- Demo has **demo-only styling on child elements** — code shows clean API
+
+**NOT valid reasons (drop the `<!-- @code -->`):**
+
+- Demo is wrapped in a layout wrapper — use `<!-- @wrapper -->` instead
 - Only difference is formatting, whitespace, or self-closing style
-- vueCode strips the wrapper but the inner components are identical
 
-**Never:**
+### Demo-only wrappers (`<!-- @wrapper -->`)
 
-- Use `vueCode` with an empty slot — slot must always have content
-- Self-close `<code-example />` — always use `</code-example>`
-- Put empty lines inside `<code-example>` — markdown-it splits the block at blank lines, breaking source extraction
-
-### Demo-only wrappers (`data-demo-wrapper`)
-
-When a `<code-example>` slot needs a layout wrapper (e.g., `<dt-stack direction="row">`) purely for the demo but users shouldn't copy it, add `data-demo-wrapper` to that element. The build plugin strips the wrapper from the code tab, showing only its children.
+When a demo needs a layout wrapper (e.g., `<dt-stack direction="row">`) purely for visual arrangement but users shouldn't copy it, add `<!-- @wrapper -->`. The build plugin adds `data-demo-wrapper` to the first element, stripping it from the code tab.
 
 - Use when the wrapper is purely for demo layout (direction, gap, alignment)
 - Do NOT use when the wrapper is meaningful structure users should copy (e.g., stack.md's own examples, nested layout patterns)
@@ -97,11 +119,14 @@ When a `<code-example>` slot needs a layout wrapper (e.g., `<dt-stack direction=
 - Never use raw HTML with component CSS classes (e.g., `<div class="d-card">`) — always use the Vue component (`<dt-card>`)
 - Use `<dt-stack>` for spacing wrappers — never `<div class="d-stack*">` or `<div class="d-flow*">` (deprecated)
 - Layout utility classes like `d-w100p` and `d-d-grid` on wrapper `<div>` elements are fine
-- Use `bgclass` prop for custom background: `<code-example bgclass="d-bgc-primary">`
+- Do NOT put empty lines inside fenced demo blocks — markdown-it splits the block at blank lines
+- Use `<!-- @bg classname -->` for custom background
 
-### Legacy pattern (still supported)
+### Legacy patterns (still supported)
 
-The old `<code-well-header>` + `<code-example-tabs>` pattern still works. When using it:
+**`<code-example>` tag syntax** — the underlying component that fenced blocks compile to. Both syntaxes work and can coexist. Fenced blocks are preferred for new content. Run `node scripts/migrate-code-examples.mjs --dry-run` to preview migrating existing pages.
+
+**`<code-well-header>` + `<code-example-tabs>`** — the oldest pattern. When using it:
 
 - Add `ref="descriptiveName"` to the outermost element in `<code-well-header>`
 - Bind `:htmlCode='() => $refs.refName'` — never static inline HTML strings
@@ -111,7 +136,7 @@ The old `<code-well-header>` + `<code-example-tabs>` pattern still works. When u
 
 1. No static inline HTML strings (`htmlCode='<...`)
 2. No raw HTML component classes in demo areas
-3. `vueCode` override only used when genuinely needed
+3. `<!-- @code -->` separator only used when genuinely needed
 4. Run: `node scripts/lint-doc-examples.mjs` — should pass with 0 violations
 
 ## Component Doc Pages (VuePress)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ When creating or updating a component, ALL must stay in sync:
 2. **Tests** — `.test.js` using Vitest + @vue/test-utils
 3. **Storybook stories** — `.stories.js` + `.mdx`
 4. **Component docs JSON** — via `scripts/build-dialtone-vue-docs.mjs`
-5. **VuePress documentation** — `apps/dialtone-documentation/docs/`, sidebar in `_data/site-nav.json`
+5. **VuePress documentation** — `apps/dialtone-documentation/docs/`, sidebar in `_data/site-nav.json`. Use fenced ` ```vue demo ` blocks for code examples (see `.claude/rules/documentation-writing.md`)
 6. **MCP server data** — `packages/dialtone-mcp-server/src/data.ts`
 
 ## Release Process
@@ -154,3 +154,5 @@ All tracking data lives in `.claude/tsc-cache/<session>/` (gitignored):
 | `packages/dialtone-css/gulpfile.cjs` | CSS build pipeline |
 | `packages/dialtone-tokens/tokens/$metadata.json` | Token sets build order |
 | `apps/dialtone-documentation/docs/_data/site-nav.json` | Sidebar navigation |
+| `apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.js` | Fenced ` ```vue demo ` → `<code-example>` transform |
+| `scripts/migrate-code-examples.mjs` | Migration script: `<code-example>` → fenced demo syntax |

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/BlogPost.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/BlogPost.vue
@@ -86,13 +86,12 @@ const blogLink = computed(() => {
 <style lang="less">
 .blog-post-content {
   .d-docsite--header-2:first-of-type {
-    margin-block-start: var(--dt-size-500);
+    margin-block-start: var(--dt-spacing-200);
   }
   > table:not([class]) {
     color: var(--dt-color-foreground-tertiary);
-    border: 1px solid var(--dt-color-border-default);
     border-collapse: collapse;
-    margin: var(--dt-size-500) 0;
+    margin: var(--dt-spacing-200) 0;
     inline-size: 100%;
     font: var(--dt-text-body-sm);
 
@@ -106,14 +105,17 @@ const blogLink = computed(() => {
 
     :where(th, td) {
       text-align: start;
-      border: 1px solid var(--dt-color-border-default);
-      border-inline: 0;
-      padding: var(--dt-size-500);
+      border-block-end: var(--dt-size-border-100) solid var(--dt-color-border-default);
+      padding: var(--dt-spacing-200);
       vertical-align: baseline;
     }
 
     :where(thead th) {
-      border-block-end-width: 3px;
+      border-block-end-width: var(--dt-size-border-200);
+    }
+
+    :where(tbody tr:last-of-type) :where(td, th) {
+      border-block-end: none;
     }
 
     :where(code, kbd) {

--- a/apps/dialtone-documentation/docs/.vuepress/plugins/fenced-demo-shared.js
+++ b/apps/dialtone-documentation/docs/.vuepress/plugins/fenced-demo-shared.js
@@ -58,7 +58,7 @@ export function parseDirectives (lines, infoMode = 'demo') {
     } else if (trimmed === '<!-- @code-only -->') {
       onlyShow = 'code';
       directiveLines.add(i);
-    } else if (trimmed === '<!-- @code -->') {
+    } else if (trimmed === '<!-- @code -->' && codeSeparatorIndex === -1) {
       codeSeparatorIndex = i;
       directiveLines.add(i);
     } else if (trimmed === '<!-- @wrapper -->') {

--- a/apps/dialtone-documentation/docs/.vuepress/plugins/fenced-demo-shared.js
+++ b/apps/dialtone-documentation/docs/.vuepress/plugins/fenced-demo-shared.js
@@ -1,0 +1,83 @@
+/**
+ * Shared utilities for the fenced-demo / code-example markdown-it plugins
+ * and the raw-markdown source parser.
+ */
+
+/**
+ * Encode a string for safe inclusion in a single-quoted HTML attribute.
+ * Vue auto-decodes these entities when passing to component props.
+ */
+export function encodeForAttr (str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/'/g, '&#39;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Remove leading and trailing blank lines.
+ */
+export function trimBlankLines (str) {
+  return str.replace(/^\n+|\n+$/g, '');
+}
+
+/**
+ * Parse directive HTML comments from fenced-demo content lines.
+ *
+ * Recognised directives:
+ *   <!-- @demo-only -->     → onlyShow = 'demo'
+ *   <!-- @code-only -->     → onlyShow = 'code'
+ *   <!-- @code -->          → codeSeparatorIndex
+ *   <!-- @wrapper -->       → hasWrapper = true
+ *   <!-- @bg classname -->  → bgclass = 'classname'
+ *   <!-- @class name -->    → cssClass = 'name'
+ *
+ * @param {string[]} lines - Content lines (without fences)
+ * @param {string} [infoMode='demo'] - 'demo', 'demo-only', or 'code-only' from the info string
+ * @returns {{ onlyShow: string|null, bgclass: string|null, cssClass: string|null,
+ *             codeSeparatorIndex: number, hasWrapper: boolean, directiveLines: Set<number> }}
+ */
+export function parseDirectives (lines, infoMode = 'demo') {
+  let onlyShow = infoMode === 'demo-only' ? 'demo'
+    : infoMode === 'code-only' ? 'code'
+      : null;
+  let bgclass = null;
+  let cssClass = null;
+  let codeSeparatorIndex = -1;
+  let hasWrapper = false;
+  const directiveLines = new Set();
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+
+    if (trimmed === '<!-- @demo-only -->') {
+      onlyShow = 'demo';
+      directiveLines.add(i);
+    } else if (trimmed === '<!-- @code-only -->') {
+      onlyShow = 'code';
+      directiveLines.add(i);
+    } else if (trimmed === '<!-- @code -->') {
+      codeSeparatorIndex = i;
+      directiveLines.add(i);
+    } else if (trimmed === '<!-- @wrapper -->') {
+      hasWrapper = true;
+      directiveLines.add(i);
+    } else {
+      const bgMatch = trimmed.match(/^<!-- @bg (.+) -->$/);
+      if (bgMatch) {
+        bgclass = bgMatch[1];
+        directiveLines.add(i);
+        continue;
+      }
+      const classMatch = trimmed.match(/^<!-- @class (.+) -->$/);
+      if (classMatch) {
+        cssClass = classMatch[1];
+        directiveLines.add(i);
+      }
+    }
+  }
+
+  return { onlyShow, bgclass, cssClass, codeSeparatorIndex, hasWrapper, directiveLines };
+}

--- a/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-code-example-source.js
+++ b/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-code-example-source.js
@@ -1,3 +1,5 @@
+import { encodeForAttr, trimBlankLines } from './fenced-demo-shared.js';
+
 /**
  * markdown-it plugin that processes <code-example> blocks in two steps:
  *
@@ -65,7 +67,7 @@ function encodeVueCodeAttr (content) {
     if (end === -1) break;
 
     const value = result.slice(valueStart, end);
-    const trimmed = value.replace(/^\n+|\n+$/g, '');
+    const trimmed = trimBlankLines(value);
     if (!trimmed) { searchFrom = end + 1; continue; }
 
     const encoded = encodeForAttr(trimmed);
@@ -98,7 +100,7 @@ function processCodeExample (block) {
   if (closeTagStart === -1) return block;
 
   const innerContent = block.slice(openTagEnd, closeTagStart);
-  let extracted = dedent(innerContent.replace(/^\n+|\n+$/g, ''));
+  let extracted = dedent(trimBlankLines(innerContent));
   if (!extracted) return block;
 
   // Strip wrapper element marked with data-demo-wrapper
@@ -129,7 +131,7 @@ export function stripMarkedWrapper (content) {
 
   // Extract children between the opening and closing tags
   const children = trimmed.slice(openEnd + 1, lastCloseStart);
-  return dedent(children.replace(/^\n+|\n+$/g, ''));
+  return dedent(trimBlankLines(children));
 }
 
 /**
@@ -144,19 +146,6 @@ function findFirstUnquotedClose (str) {
     else if (str[i] === '>' && !inSingleQuote && !inDoubleQuote) return i;
   }
   return -1;
-}
-
-/**
- * Encode a string for safe inclusion in a single-quoted HTML attribute.
- * Vue auto-decodes these entities when passing to component props.
- */
-function encodeForAttr (str) {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/'/g, '&#39;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
 }
 
 /**

--- a/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.js
+++ b/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.js
@@ -53,15 +53,22 @@ export default function fencedDemoPlugin (md) {
  */
 export function transformFencedDemo (raw, infoMode = 'demo') {
   const lines = raw.split('\n');
+  const directives = parseDirectives(lines, infoMode);
 
-  // --- Parse directives (info string takes precedence, directives can override) ---
-  const { onlyShow, bgclass, cssClass, codeSeparatorIndex, hasWrapper, directiveLines } =
-    parseDirectives(lines, infoMode);
+  let { slotContent, sourceCode } = splitContent(lines, directives);
 
-  // --- Build slot content and optional source-code ---
-  let slotContent;
-  let sourceCode = null;
+  if (directives.hasWrapper) {
+    slotContent = addDataDemoWrapper(slotContent);
+  }
 
+  return buildCodeExampleTag(directives, slotContent, sourceCode);
+}
+
+/**
+ * Split lines into slot content (demo) and optional source code (code tab)
+ * based on the @code separator position.
+ */
+function splitContent (lines, { codeSeparatorIndex, directiveLines }) {
   if (codeSeparatorIndex !== -1) {
     const above = [];
     const below = [];
@@ -72,19 +79,20 @@ export function transformFencedDemo (raw, infoMode = 'demo') {
       if (pastSeparator) below.push(lines[i]);
       else above.push(lines[i]);
     }
-    slotContent = trimBlankLines(above.join('\n'));
-    sourceCode = trimBlankLines(below.join('\n'));
-  } else {
-    const content = lines.filter((_, i) => !directiveLines.has(i));
-    slotContent = trimBlankLines(content.join('\n'));
+    return {
+      slotContent: trimBlankLines(above.join('\n')),
+      sourceCode: trimBlankLines(below.join('\n')),
+    };
   }
 
-  // --- Apply @wrapper ---
-  if (hasWrapper) {
-    slotContent = addDataDemoWrapper(slotContent);
-  }
+  const content = lines.filter((_, i) => !directiveLines.has(i));
+  return { slotContent: trimBlankLines(content.join('\n')), sourceCode: null };
+}
 
-  // --- Build <code-example> tag ---
+/**
+ * Build the <code-example> HTML tag string from parsed directives and content.
+ */
+function buildCodeExampleTag ({ onlyShow, bgclass, cssClass }, slotContent, sourceCode) {
   const attrs = [];
   if (onlyShow) attrs.push(`only-show="${onlyShow}"`);
   if (bgclass) attrs.push(`bgclass="${encodeForAttr(bgclass)}"`);

--- a/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.js
+++ b/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.js
@@ -20,6 +20,8 @@
  *   <!-- @class name -->    → class="name"
  */
 
+import { encodeForAttr, trimBlankLines, parseDirectives } from './fenced-demo-shared.js';
+
 const INFO_RE = /^vue\s+(demo-only|code-only|demo)$/;
 
 export default function fencedDemoPlugin (md) {
@@ -53,38 +55,8 @@ export function transformFencedDemo (raw, infoMode = 'demo') {
   const lines = raw.split('\n');
 
   // --- Parse directives (info string takes precedence, directives can override) ---
-  let onlyShow = infoMode === 'demo-only' ? 'demo'
-    : infoMode === 'code-only' ? 'code'
-      : null;
-  let bgclass = null;
-  let cssClass = null;
-  let codeSeparatorIndex = -1;
-  let hasWrapper = false;
-  const directiveLines = new Set();
-
-  for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
-
-    if (trimmed === '<!-- @demo-only -->') {
-      onlyShow = 'demo';
-      directiveLines.add(i);
-    } else if (trimmed === '<!-- @code-only -->') {
-      onlyShow = 'code';
-      directiveLines.add(i);
-    } else if (trimmed === '<!-- @code -->') {
-      codeSeparatorIndex = i;
-      directiveLines.add(i);
-    } else if (trimmed === '<!-- @wrapper -->') {
-      hasWrapper = true;
-      directiveLines.add(i);
-    } else if (/^<!-- @bg .+ -->$/.test(trimmed)) {
-      bgclass = trimmed.slice('<!-- @bg '.length, -' -->'.length);
-      directiveLines.add(i);
-    } else if (/^<!-- @class .+ -->$/.test(trimmed)) {
-      cssClass = trimmed.slice('<!-- @class '.length, -' -->'.length);
-      directiveLines.add(i);
-    }
-  }
+  const { onlyShow, bgclass, cssClass, codeSeparatorIndex, hasWrapper, directiveLines } =
+    parseDirectives(lines, infoMode);
 
   // --- Build slot content and optional source-code ---
   let slotContent;
@@ -135,21 +107,3 @@ function addDataDemoWrapper (content) {
   );
 }
 
-/**
- * Remove leading and trailing blank lines.
- */
-function trimBlankLines (str) {
-  return str.replace(/^\n+|\n+$/g, '');
-}
-
-/**
- * Encode a string for safe inclusion in a single-quoted HTML attribute.
- */
-function encodeForAttr (str) {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/'/g, '&#39;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}

--- a/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.js
+++ b/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.js
@@ -87,9 +87,10 @@ export function transformFencedDemo (raw, infoMode = 'demo') {
   // --- Build <code-example> tag ---
   const attrs = [];
   if (onlyShow) attrs.push(`only-show="${onlyShow}"`);
-  if (bgclass) attrs.push(`bgclass="${bgclass}"`);
-  if (cssClass) attrs.push(`class="${cssClass}"`);
+  if (bgclass) attrs.push(`bgclass="${encodeForAttr(bgclass)}"`);
+  if (cssClass) attrs.push(`class="${encodeForAttr(cssClass)}"`);
   if (sourceCode) {
+    // Single-quoted because source-code contains HTML with double quotes
     attrs.push(`source-code='${encodeForAttr(sourceCode)}'`);
   }
 

--- a/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.js
+++ b/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.js
@@ -1,0 +1,155 @@
+/**
+ * markdown-it plugin that transforms fenced code blocks with `vue demo` info
+ * string into <code-example> HTML blocks.
+ *
+ * Runs as a core rule that converts fence tokens to html_block tokens,
+ * allowing the existing codeExampleSourcePlugin to process them for
+ * auto-extracting source-code attributes.
+ *
+ * Info string variants:
+ *   ```vue demo           → demo + code tabs (default)
+ *   ```vue demo-only      → live preview only, no code tab
+ *   ```vue code-only      → code tab only, no live preview
+ *
+ * Supported directives (HTML comments inside the fenced block):
+ *   <!-- @demo-only -->     → only-show="demo" (alias for info string)
+ *   <!-- @code-only -->     → only-show="code" (alias for info string)
+ *   <!-- @code -->          → separator: above = live demo, below = code tab
+ *   <!-- @wrapper -->       → adds data-demo-wrapper to the first element
+ *   <!-- @bg classname -->  → bgclass="classname"
+ *   <!-- @class name -->    → class="name"
+ */
+
+const INFO_RE = /^vue\s+(demo-only|code-only|demo)$/;
+
+export default function fencedDemoPlugin (md) {
+  md.core.ruler.push('fenced_demo', function (state) {
+    for (let i = 0; i < state.tokens.length; i++) {
+      const token = state.tokens[i];
+      if (token.type !== 'fence') continue;
+
+      const info = token.info.trim();
+      const match = INFO_RE.exec(info);
+      if (!match) continue;
+
+      const infoMode = match[1]; // 'demo', 'demo-only', or 'code-only'
+
+      token.type = 'html_block';
+      token.content = transformFencedDemo(token.content, infoMode) + '\n';
+      token.info = '';
+      token.tag = '';
+      token.nesting = 0;
+      token.children = null;
+    }
+  });
+}
+
+/**
+ * Parse directives from fenced block content and build a <code-example> HTML string.
+ * @param {string} raw - The content inside the fenced block
+ * @param {string} infoMode - 'demo' (default), 'demo-only', or 'code-only' from the info string
+ */
+export function transformFencedDemo (raw, infoMode = 'demo') {
+  const lines = raw.split('\n');
+
+  // --- Parse directives (info string takes precedence, directives can override) ---
+  let onlyShow = infoMode === 'demo-only' ? 'demo'
+    : infoMode === 'code-only' ? 'code'
+      : null;
+  let bgclass = null;
+  let cssClass = null;
+  let codeSeparatorIndex = -1;
+  let hasWrapper = false;
+  const directiveLines = new Set();
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+
+    if (trimmed === '<!-- @demo-only -->') {
+      onlyShow = 'demo';
+      directiveLines.add(i);
+    } else if (trimmed === '<!-- @code-only -->') {
+      onlyShow = 'code';
+      directiveLines.add(i);
+    } else if (trimmed === '<!-- @code -->') {
+      codeSeparatorIndex = i;
+      directiveLines.add(i);
+    } else if (trimmed === '<!-- @wrapper -->') {
+      hasWrapper = true;
+      directiveLines.add(i);
+    } else if (/^<!-- @bg .+ -->$/.test(trimmed)) {
+      bgclass = trimmed.slice('<!-- @bg '.length, -' -->'.length);
+      directiveLines.add(i);
+    } else if (/^<!-- @class .+ -->$/.test(trimmed)) {
+      cssClass = trimmed.slice('<!-- @class '.length, -' -->'.length);
+      directiveLines.add(i);
+    }
+  }
+
+  // --- Build slot content and optional source-code ---
+  let slotContent;
+  let sourceCode = null;
+
+  if (codeSeparatorIndex !== -1) {
+    const above = [];
+    const below = [];
+    let pastSeparator = false;
+    for (let i = 0; i < lines.length; i++) {
+      if (i === codeSeparatorIndex) { pastSeparator = true; continue; }
+      if (directiveLines.has(i)) continue;
+      if (pastSeparator) below.push(lines[i]);
+      else above.push(lines[i]);
+    }
+    slotContent = trimBlankLines(above.join('\n'));
+    sourceCode = trimBlankLines(below.join('\n'));
+  } else {
+    const content = lines.filter((_, i) => !directiveLines.has(i));
+    slotContent = trimBlankLines(content.join('\n'));
+  }
+
+  // --- Apply @wrapper ---
+  if (hasWrapper) {
+    slotContent = addDataDemoWrapper(slotContent);
+  }
+
+  // --- Build <code-example> tag ---
+  const attrs = [];
+  if (onlyShow) attrs.push(`only-show="${onlyShow}"`);
+  if (bgclass) attrs.push(`bgclass="${bgclass}"`);
+  if (cssClass) attrs.push(`class="${cssClass}"`);
+  if (sourceCode) {
+    attrs.push(`source-code='${encodeForAttr(sourceCode)}'`);
+  }
+
+  const attrStr = attrs.length ? ' ' + attrs.join(' ') : '';
+  return `<code-example${attrStr}>\n${slotContent}\n</code-example>`;
+}
+
+/**
+ * Add data-demo-wrapper attribute to the first HTML element in the content.
+ */
+function addDataDemoWrapper (content) {
+  return content.replace(
+    /^(\s*<[a-z][a-z0-9-]*)([\s>])/i,
+    '$1 data-demo-wrapper$2',
+  );
+}
+
+/**
+ * Remove leading and trailing blank lines.
+ */
+function trimBlankLines (str) {
+  return str.replace(/^\n+|\n+$/g, '');
+}
+
+/**
+ * Encode a string for safe inclusion in a single-quoted HTML attribute.
+ */
+function encodeForAttr (str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/'/g, '&#39;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}

--- a/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.test.mjs
+++ b/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.test.mjs
@@ -1,0 +1,154 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { transformFencedDemo } from './markdown-it-fenced-demo.js';
+
+describe('transformFencedDemo', () => {
+  it('converts a plain block to <code-example>', () => {
+    const input = '<dt-button>Click me</dt-button>\n';
+    const result = transformFencedDemo(input);
+    assert.equal(result, '<code-example>\n<dt-button>Click me</dt-button>\n</code-example>');
+  });
+
+  it('handles @demo-only directive', () => {
+    const input = '<!-- @demo-only -->\n<dt-button>Click me</dt-button>\n';
+    const result = transformFencedDemo(input);
+    assert.ok(result.startsWith('<code-example only-show="demo">'));
+    assert.ok(result.includes('<dt-button>Click me</dt-button>'));
+    assert.ok(!result.includes('@demo-only'));
+  });
+
+  it('handles @code-only directive', () => {
+    const input = '<!-- @code-only -->\n<dt-button>Click me</dt-button>\n';
+    const result = transformFencedDemo(input);
+    assert.ok(result.startsWith('<code-example only-show="code">'));
+    assert.ok(!result.includes('@code-only'));
+  });
+
+  it('handles @code separator', () => {
+    const input = [
+      '<dt-toggle v-model="isDisabled" />',
+      '<dt-button :disabled="isDisabled">Click</dt-button>',
+      '<!-- @code -->',
+      '<dt-button disabled>Click</dt-button>',
+      '',
+    ].join('\n');
+    const result = transformFencedDemo(input);
+
+    // Slot should contain the demo content (above @code)
+    assert.ok(result.includes('<dt-toggle v-model="isDisabled" />'));
+    assert.ok(result.includes('<dt-button :disabled="isDisabled">Click</dt-button>'));
+
+    // source-code should contain the code tab content (below @code), entity-encoded
+    assert.ok(result.includes('source-code=\''));
+    assert.ok(result.includes('&lt;dt-button disabled&gt;Click&lt;/dt-button&gt;'));
+
+    // @code comment should not appear in output
+    assert.ok(!result.includes('<!-- @code -->'));
+  });
+
+  it('handles @wrapper directive', () => {
+    const input = [
+      '<!-- @wrapper -->',
+      '<dt-stack direction="row" gap="100">',
+      '  <dt-button>A</dt-button>',
+      '  <dt-button>B</dt-button>',
+      '</dt-stack>',
+      '',
+    ].join('\n');
+    const result = transformFencedDemo(input);
+    assert.ok(result.includes('data-demo-wrapper'));
+    assert.ok(result.includes('<dt-stack data-demo-wrapper direction="row"'));
+    assert.ok(!result.includes('<!-- @wrapper -->'));
+  });
+
+  it('handles @bg directive', () => {
+    const input = '<!-- @bg d-bgc-primary -->\n<dt-button>Click me</dt-button>\n';
+    const result = transformFencedDemo(input);
+    assert.ok(result.includes('bgclass="d-bgc-primary"'));
+    assert.ok(!result.includes('<!-- @bg'));
+  });
+
+  it('handles @class directive', () => {
+    const input = '<!-- @class d-d-block -->\n<dt-button>Click me</dt-button>\n';
+    const result = transformFencedDemo(input);
+    assert.ok(result.includes('class="d-d-block"'));
+    assert.ok(!result.includes('<!-- @class'));
+  });
+
+  it('combines @bg and @class directives', () => {
+    const input = [
+      '<!-- @bg d-bgc-primary -->',
+      '<!-- @class d-d-block -->',
+      '<dt-button>Click me</dt-button>',
+      '',
+    ].join('\n');
+    const result = transformFencedDemo(input);
+    assert.ok(result.includes('bgclass="d-bgc-primary"'));
+    assert.ok(result.includes('class="d-d-block"'));
+  });
+
+  it('preserves multi-line content', () => {
+    const input = [
+      '<dt-stack direction="row" gap="100">',
+      '  <dt-button> Place Call </dt-button>',
+      '  <dt-button importance="outlined"> Place Call </dt-button>',
+      '</dt-stack>',
+      '',
+    ].join('\n');
+    const result = transformFencedDemo(input);
+    assert.ok(result.includes('<dt-stack direction="row" gap="100">'));
+    assert.ok(result.includes('  <dt-button> Place Call </dt-button>'));
+    assert.ok(result.includes('</dt-stack>'));
+  });
+
+  it('strips trailing blank lines from content', () => {
+    const input = '\n\n<dt-button>Click</dt-button>\n\n\n';
+    const result = transformFencedDemo(input);
+    assert.ok(result.includes('<code-example>\n<dt-button>Click</dt-button>\n</code-example>'));
+  });
+
+  it('entity-encodes source-code attribute values', () => {
+    const input = [
+      '<dt-button :disabled="true">Click</dt-button>',
+      '<!-- @code -->',
+      '<dt-button disabled>Click</dt-button>',
+      '',
+    ].join('\n');
+    const result = transformFencedDemo(input);
+    // Quotes in the source-code should be encoded
+    assert.ok(result.includes('&lt;dt-button disabled&gt;'));
+  });
+
+  it('handles demo-only via info string', () => {
+    const input = '<dt-button>Click me</dt-button>\n';
+    const result = transformFencedDemo(input, 'demo-only');
+    assert.ok(result.startsWith('<code-example only-show="demo">'));
+    assert.ok(result.includes('<dt-button>Click me</dt-button>'));
+  });
+
+  it('handles code-only via info string', () => {
+    const input = '<dt-button>Click me</dt-button>\n';
+    const result = transformFencedDemo(input, 'code-only');
+    assert.ok(result.startsWith('<code-example only-show="code">'));
+  });
+
+  it('directive overrides info string mode', () => {
+    // info string says demo, but directive says code-only
+    const input = '<!-- @code-only -->\n<dt-button>Click me</dt-button>\n';
+    const result = transformFencedDemo(input, 'demo');
+    assert.ok(result.startsWith('<code-example only-show="code">'));
+  });
+
+  it('info string demo-only combines with other directives', () => {
+    const input = [
+      '<!-- @wrapper -->',
+      '<dt-stack direction="row">',
+      '  <dt-button>A</dt-button>',
+      '</dt-stack>',
+      '',
+    ].join('\n');
+    const result = transformFencedDemo(input, 'demo-only');
+    assert.ok(result.includes('only-show="demo"'));
+    assert.ok(result.includes('data-demo-wrapper'));
+  });
+});

--- a/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.test.mjs
+++ b/apps/dialtone-documentation/docs/.vuepress/plugins/markdown-it-fenced-demo.test.mjs
@@ -151,4 +151,71 @@ describe('transformFencedDemo', () => {
     assert.ok(result.includes('only-show="demo"'));
     assert.ok(result.includes('data-demo-wrapper'));
   });
+
+  it('handles @wrapper combined with @code separator', () => {
+    const input = [
+      '<!-- @wrapper -->',
+      '<dt-stack direction="row">',
+      '  <dt-button :loading="loading">Call</dt-button>',
+      '</dt-stack>',
+      '<!-- @code -->',
+      '<dt-button loading>Call</dt-button>',
+      '',
+    ].join('\n');
+    const result = transformFencedDemo(input);
+    // Wrapper applied to slot content
+    assert.ok(result.includes('<dt-stack data-demo-wrapper direction="row">'));
+    // Source-code has the clean code (below @code), no wrapper
+    assert.ok(result.includes('source-code=\''));
+    assert.ok(result.includes('&lt;dt-button loading&gt;'));
+    assert.ok(!result.includes('<!-- @wrapper -->'));
+    assert.ok(!result.includes('<!-- @code -->'));
+  });
+
+  it('handles empty fenced block', () => {
+    const result = transformFencedDemo('\n');
+    assert.equal(result, '<code-example>\n\n</code-example>');
+  });
+
+  it('handles @demo-only combined with @code (demo-only wins, code ignored)', () => {
+    const input = [
+      '<!-- @demo-only -->',
+      '<dt-button>Live demo</dt-button>',
+      '<!-- @code -->',
+      '<dt-button>Code tab</dt-button>',
+      '',
+    ].join('\n');
+    const result = transformFencedDemo(input);
+    // Both only-show and source-code are emitted; component handles precedence
+    assert.ok(result.includes('only-show="demo"'));
+    assert.ok(result.includes('<dt-button>Live demo</dt-button>'));
+  });
+
+  it('only uses the first @code separator', () => {
+    const input = [
+      '<dt-button>Demo</dt-button>',
+      '<!-- @code -->',
+      '<dt-button>First code</dt-button>',
+      '<!-- @code -->',
+      '<dt-button>Second code</dt-button>',
+      '',
+    ].join('\n');
+    const result = transformFencedDemo(input);
+    // Second <!-- @code --> is NOT a directive — it's regular content in the code tab
+    assert.ok(result.includes('<dt-button>Demo</dt-button>'));
+    assert.ok(result.includes('&lt;dt-button&gt;First code&lt;/dt-button&gt;'));
+    assert.ok(result.includes('&lt;!-- @code --&gt;'));
+    assert.ok(result.includes('&lt;dt-button&gt;Second code&lt;/dt-button&gt;'));
+  });
+
+  it('handles @code with empty content above', () => {
+    const input = [
+      '<!-- @code -->',
+      '<dt-button>Code only</dt-button>',
+      '',
+    ].join('\n');
+    const result = transformFencedDemo(input);
+    assert.ok(result.includes('source-code=\''));
+    assert.ok(result.includes('&lt;dt-button&gt;Code only&lt;/dt-button&gt;'));
+  });
 });

--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -363,7 +363,6 @@ html body {
   inset-block-start: var(--dt-layout-100);
   // TODO: redo 😜
   block-size: calc(100vh - var(--dt-layout-100));
-  // border-inline-end: var(--dt-size-100) solid var(--dt-shell-color-border-subtle);
 
   &__list {
     padding: var(--dt-spacing-300) 0 calc(var(--dt-spacing-100) * 12) var(--dt-spacing-200);
@@ -389,9 +388,8 @@ html body {
   // the div is hard coded into vuepress
   > table:not([class]) {
     color: var(--dt-color-foreground-tertiary);
-    border: 1px solid var(--dt-color-border-default);
     border-collapse: collapse;
-    margin: var(--dt-size-500) 0;
+    margin: var(--dt-spacing-200) 0;
     inline-size: 100%;
     font: var(--dt-text-body-sm);
 
@@ -405,14 +403,18 @@ html body {
 
     :where(th, td) {
       text-align: start;
-      border: 1px solid var(--dt-color-border-default);
+      border-block-end: var(--dt-size-border-100) solid var(--dt-color-border-default);
       border-inline: 0;
-      padding: var(--dt-size-500);
+      padding: var(--dt-spacing-200);
       vertical-align: baseline;
     }
 
     :where(thead th) {
-      border-block-end-width: 3px;
+      border-block-end-width: var(--dt-size-border-200);
+    }
+
+    :where(tbody tr:last-of-type) :where(td, th) {
+      border-block-end: none;
     }
 
     :where(code, kbd) {
@@ -422,6 +424,7 @@ html body {
     }
   }
 }
+
 
 a.header-anchor {
   float: inline-start;
@@ -519,9 +522,9 @@ a.header-anchor {
 
 :where(:is(.d-docsite--paragraph, .d-docsite--unordered-list, .d-docsite--ordered-list, .d-docsite--list-element, .d-docsite--preview-header) > code) {
   font: var(--dt-text-code-sm);
-  padding: var(--dt-size-200) var(--dt-size-300);
+  padding: var(--dt-spacing-25) var(--dt-spacing-50);
   color: var(--dt-color-blue-800);
-  border-radius: var(--dt-size-200);
+  border-radius: var(--dt-size-radius-200);
   border: var(--dt-size-border-100) solid var(--dt-color-border-subtle);
   user-select: all;
 }
@@ -886,7 +889,7 @@ a.header-anchor {
   // UI Kits variant: keeps description visible and stays 2-column longer
   &--ui-kits {
     .dialtone-wall__details {
-      gap: var(--dt-size-500);
+      gap: var(--dt-spacing-200);
     }
 
     .dialtone-wall__description {

--- a/apps/dialtone-documentation/docs/.vuepress/theme/index.js
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/index.js
@@ -5,6 +5,7 @@ import { backToTopPlugin } from '@vuepress/plugin-back-to-top';
 import { gitPlugin } from '@vuepress/plugin-git';
 import { sitemapPlugin } from 'vuepress-plugin-sitemap2';
 import markdownItClass from '@toycode/markdown-it-class';
+import fencedDemoPlugin from '../plugins/markdown-it-fenced-demo.js';
 import codeExampleSourcePlugin from '../plugins/markdown-it-code-example-source.js';
 import { getDirname, path } from 'vuepress/utils'
 
@@ -272,6 +273,9 @@ export const dialtoneVuepressTheme = (options) => ({
     ],
 
   extendsMarkdown: (md) => {
+      // Transform ```vue demo fenced blocks into <code-example> HTML
+      md.use(fencedDemoPlugin);
+
       md.use(markdownItClass, mapping);
 
       // Auto-extract slot source from <code-example> blocks for the Vue code tab

--- a/apps/dialtone-documentation/docs/components/avatar.md
+++ b/apps/dialtone-documentation/docs/components/avatar.md
@@ -77,40 +77,41 @@ The component prioritizes different sources for content display, sequentially ch
 
 ### Icon
 
-<code-example>
-  <dt-avatar>
-    <template #icon>
-      <dt-icon-user />
-    </template>
-  </dt-avatar>
-</code-example>
+```vue demo
+<dt-avatar>
+  <template #icon>
+    <dt-icon-user />
+  </template>
+</dt-avatar>
+```
 
 ### Initials
 
 Unless otherwise specified via the `color` prop, a background color will be provided based on the `seed` prop. This background is based on a hashed version of the user ID, allowing the colors to be consistent across sessions. Colors are dynamically computed using OKLCH and adapt to the current theme.
 
-<code-example vueCode='
+```vue demo
+<dt-stack direction="row" gap="200" class="d-w-500 d-fw-wrap">
+  <dt-avatar v-for="seed in seeds" :seed="seed" full-name="Daniel Parker" />
+</dt-stack>
+<!-- @code -->
 <!-- Use seed for consistent random colors per user -->
 <dt-avatar
   full-name="Daniel Parker"
   seed="user-unique-id"
 />
-'>
-  <dt-stack direction="row" gap="200" class="d-w-500 d-fw-wrap">
-    <dt-avatar v-for="seed in seeds" :seed="seed" full-name="Daniel Parker" />
-  </dt-stack>
-</code-example>
+```
 
 ### Image
 
 If `image-src` is not provided, or if image fails to load, the avatar will fall back to the initials extracted from the `full-name`.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-avatar image-src="/assets/images/person.png" full-name="Daniel Parker" image-alt="avatar user" />
-    <dt-avatar image-src="/assets/images/broken-image.png" full-name="Daniel Parker" image-alt="avatar user" />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-avatar image-src="/assets/images/person.png" full-name="Daniel Parker" image-alt="avatar user" />
+  <dt-avatar image-src="/assets/images/broken-image.png" full-name="Daniel Parker" image-alt="avatar user" />
+</dt-stack>
+```
 
 ### Sizes
 
@@ -130,73 +131,76 @@ Avatar supports a 100-based sizing scale. T-shirt sizes (`xs`, `sm`, `md`, `lg`,
 | `800` | — | 128px |
 | `900` | — | 256px |
 
-<code-example vueCode='
+```vue demo
+<dt-stack direction="row" align="center" justify="center" gap="200" class="d-fw-wrap">
+  <dt-avatar v-for="size in sizes" :size="size">
+    <template #icon>
+      <dt-icon-user />
+    </template>
+  </dt-avatar>
+</dt-stack>
+<!-- @code -->
 <dt-avatar size="{size}">
   <template #icon>
     <dt-icon-user />
   </template>
 </dt-avatar>
-'>
-  <dt-stack direction="row" align="center" justify="center" gap="200" class="d-fw-wrap">
-    <dt-avatar v-for="size in sizes" :size="size">
-      <template #icon>
-        <dt-icon-user />
-      </template>
-    </dt-avatar>
-  </dt-stack>
-</code-example>
+```
 
 ### Group
 
 The group avatar is used to represent group discussions in a compact form. A count badge is added on top of the avatar. The avatar shown is the last person to send a message in the group. The group avatar is available only from sizes 100-500. At size 100, only the count badge is shown.
 
-<code-example>
-  <dt-stack direction="row" align="center" gap="200" data-demo-wrapper>
-    <dt-avatar size="100" :group="3" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-    <dt-avatar size="150" :group="5" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-    <dt-avatar size="200" :group="12" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-    <dt-avatar size="250" :group="8" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-    <dt-avatar size="300" :group="24" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-    <dt-avatar size="400" :group="100" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-    <dt-avatar size="500" :group="7" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" align="center" gap="200">
+  <dt-avatar size="100" :group="3" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+  <dt-avatar size="150" :group="5" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+  <dt-avatar size="200" :group="12" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+  <dt-avatar size="250" :group="8" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+  <dt-avatar size="300" :group="24" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+  <dt-avatar size="400" :group="100" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+  <dt-avatar size="500" :group="7" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+</dt-stack>
+```
 
 ### Presence
 
 Provides the user's current [presence](/components/presence.md), positioned in the bottom right corner.
 
-<code-example>
-  <dt-stack gap="100" data-demo-wrapper>
-    <dt-stack direction="row" align="center" gap="100">
-      <dt-avatar :size="100" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="200" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="300" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="400" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="500" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-    </dt-stack>
-    <dt-stack direction="row" align="center" gap="100">
-      <dt-avatar :size="100" presence="active" seed="user-1" full-name="Test Name" />
-      <dt-avatar :size="200" presence="away" seed="user-2" full-name="William Steele" />
-      <dt-avatar :size="300" presence="busy" seed="user-3" full-name="Frank Richard" />
-      <dt-avatar :size="400" presence="offline" seed="user-4" full-name="John Hawkins" />
-      <dt-avatar :size="500" presence="active" seed="user-5" full-name="Alice Edwards" />
-    </dt-stack>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="100">
+  <dt-stack direction="row" align="center" gap="100">
+    <dt-avatar :size="100" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    <dt-avatar :size="200" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    <dt-avatar :size="300" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    <dt-avatar :size="400" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    <dt-avatar :size="500" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
   </dt-stack>
-</code-example>
+  <dt-stack direction="row" align="center" gap="100">
+    <dt-avatar :size="100" presence="active" seed="user-1" full-name="Test Name" />
+    <dt-avatar :size="200" presence="away" seed="user-2" full-name="William Steele" />
+    <dt-avatar :size="300" presence="busy" seed="user-3" full-name="Frank Richard" />
+    <dt-avatar :size="400" presence="offline" seed="user-4" full-name="John Hawkins" />
+    <dt-avatar :size="500" presence="active" seed="user-5" full-name="Alice Edwards" />
+  </dt-stack>
+</dt-stack>
+```
 
 ### Overlay
 
-<code-example>
-  <dt-stack direction="row" align="center" gap="200" data-demo-wrapper>
-    <dt-avatar :size="400" image-src="/assets/images/person.png" image-alt="avatar user">
-      <template #overlayIcon>
-        <dt-icon-hear />
-      </template>
-    </dt-avatar>
-    <dt-avatar :size="400" image-src="/assets/images/person.png" image-alt="avatar user" overlay-text="+3" />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" align="center" gap="200">
+  <dt-avatar :size="400" image-src="/assets/images/person.png" image-alt="avatar user">
+    <template #overlayIcon>
+      <dt-icon-hear />
+    </template>
+  </dt-avatar>
+  <dt-avatar :size="400" image-src="/assets/images/person.png" image-alt="avatar user" overlay-text="+3" />
+</dt-stack>
+```
 
 ### Clickable
 
@@ -204,29 +208,30 @@ Avatars that appear alongside a visible label (e.g., a user's name) are decorati
 
 Avatars that convey meaning on their own — such as navigation or actions — should be made interactive using the `clickable` prop. This renders the avatar as a `<button>` with visible focus ring and keyboard activation via Enter and Space. Provide an accessible name via `icon-aria-label` (for icon avatars), `full-name` (for initials avatars), or `image-alt` (for image avatars).
 
-<code-example>
-  <dt-avatar clickable icon-aria-label="user">
-    <template #icon>
-      <dt-icon-user />
-    </template>
-  </dt-avatar>
-</code-example>
+```vue demo
+<dt-avatar clickable icon-aria-label="user">
+  <template #icon>
+    <dt-icon-user />
+  </template>
+</dt-avatar>
+```
 
 ### Deactivated
 
 Use the `deactivated` prop to render the avatar in a desaturated/washed-out state. This is useful to indicate that a user is deactivated or inactive.
 
-<code-example>
-  <dt-stack direction="row" align="center" gap="200" data-demo-wrapper>
-    <dt-avatar deactivated image-src="/assets/images/person.png" image-alt="Deactivated user" />
-    <dt-avatar deactivated full-name="Deactivated User" seed="user-deactivated" />
-    <dt-avatar deactivated>
-      <template #icon>
-        <dt-icon-user />
-      </template>
-    </dt-avatar>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" align="center" gap="200">
+  <dt-avatar deactivated image-src="/assets/images/person.png" image-alt="Deactivated user" />
+  <dt-avatar deactivated full-name="Deactivated User" seed="user-deactivated" />
+  <dt-avatar deactivated>
+    <template #icon>
+      <dt-icon-user />
+    </template>
+  </dt-avatar>
+</dt-stack>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/badge.md
+++ b/apps/dialtone-documentation/docs/components/badge.md
@@ -40,15 +40,15 @@ keywords: ["label","tag","indicator","count","d-badge","DtBadge","dt-badge"]
 
 ### Label
 
-<code-example>
-  <dt-badge text="Label" />
-</code-example>
+```vue demo
+<dt-badge text="Label" />
+```
 
 ### Count
 
-<code-example>
-  <dt-badge kind="count" text="1" />
-</code-example>
+```vue demo
+<dt-badge kind="count" text="1" />
+```
 
 ## Type
 
@@ -133,134 +133,137 @@ keywords: ["label","tag","indicator","count","d-badge","DtBadge","dt-badge"]
   </tbody>
 </table>
 
-<code-example only-show="code">
-  <dt-badge kind="label" text="Label" />
-  <dt-badge type="info" kind="label" text="Label" />
-  <dt-badge type="success" kind="label" text="Label" />
-  <dt-badge type="warning" kind="label" text="Label" />
-  <dt-badge type="critical" kind="label" text="Label" />
-  <dt-badge type="bulletin" kind="label" text="Label" />
-  <dt-badge type="ai" text="Label" kind="label" />
-  <dt-badge type="default" text="1" kind="count" />
-  <dt-badge type="info" text="2" kind="count" />
-  <dt-badge type="success" text="3" kind="count" />
-  <dt-badge type="warning" text="4" kind="count" />
-  <dt-badge type="critical" text="5" kind="count" />
-  <dt-badge type="bulletin" text="6" kind="count" />
-</code-example>
+```vue code-only
+<dt-badge kind="label" text="Label" />
+<dt-badge type="info" kind="label" text="Label" />
+<dt-badge type="success" kind="label" text="Label" />
+<dt-badge type="warning" kind="label" text="Label" />
+<dt-badge type="critical" kind="label" text="Label" />
+<dt-badge type="bulletin" kind="label" text="Label" />
+<dt-badge type="ai" text="Label" kind="label" />
+<dt-badge type="default" text="1" kind="count" />
+<dt-badge type="info" text="2" kind="count" />
+<dt-badge type="success" text="3" kind="count" />
+<dt-badge type="warning" text="4" kind="count" />
+<dt-badge type="critical" text="5" kind="count" />
+<dt-badge type="bulletin" text="6" kind="count" />
+```
 
 ## Outlined
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-badge text="Label" outlined />
-    <dt-badge text="Label" type="info" outlined />
-    <dt-badge text="Label" type="success" outlined />
-    <dt-badge text="Label" type="warning" outlined />
-    <dt-badge text="Label" type="critical" outlined />
-    <dt-badge text="1" kind="count" outlined />
-    <dt-badge text="1" type="info" kind="count" outlined />
-    <dt-badge text="1" type="success" kind="count" outlined />
-    <dt-badge text="1" type="warning" kind="count" outlined />
-    <dt-badge text="1" type="critical" kind="count" outlined />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-badge text="Label" outlined />
+  <dt-badge text="Label" type="info" outlined />
+  <dt-badge text="Label" type="success" outlined />
+  <dt-badge text="Label" type="warning" outlined />
+  <dt-badge text="Label" type="critical" outlined />
+  <dt-badge text="1" kind="count" outlined />
+  <dt-badge text="1" type="info" kind="count" outlined />
+  <dt-badge text="1" type="success" kind="count" outlined />
+  <dt-badge text="1" type="warning" kind="count" outlined />
+  <dt-badge text="1" type="critical" kind="count" outlined />
+</dt-stack>
+```
 
 ## Subtle
 
 At the moment, only the `bulletin` type has a subtle variant.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-badge text="Label" type="bulletin" subtle />
-    <dt-badge text="Label" type="bulletin" subtle outlined />
-    <dt-badge text="1" type="bulletin" subtle kind="count" />
-    <dt-badge text="1" type="bulletin" subtle kind="count" outlined />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-badge text="Label" type="bulletin" subtle />
+  <dt-badge text="Label" type="bulletin" subtle outlined />
+  <dt-badge text="1" type="bulletin" subtle kind="count" />
+  <dt-badge text="1" type="bulletin" subtle kind="count" outlined />
+</dt-stack>
+```
 
 ## Icon
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-badge type="default" text="Label" kind="label">
-      <template #startIcon="{ iconSize }">
-        <dt-icon-lightning-bolt :size="iconSize" />
-      </template>
-    </dt-badge>
-    <dt-badge type="default" text="Label" kind="label">
-      <template #endIcon="{ iconSize }">
-        <dt-icon-lightning-bolt :size="iconSize" />
-      </template>
-    </dt-badge>
-    <dt-badge type="default" text="Label" kind="label">
-      <template #startIcon="{ iconSize }">
-        <dt-icon-lightning-bolt :size="iconSize" />
-      </template>
-      <template #endIcon="{ iconSize }">
-        <dt-icon-lightning-bolt :size="iconSize" />
-      </template>
-    </dt-badge>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-badge type="default" text="Label" kind="label">
+    <template #startIcon="{ iconSize }">
+      <dt-icon-lightning-bolt :size="iconSize" />
+    </template>
+  </dt-badge>
+  <dt-badge type="default" text="Label" kind="label">
+    <template #endIcon="{ iconSize }">
+      <dt-icon-lightning-bolt :size="iconSize" />
+    </template>
+  </dt-badge>
+  <dt-badge type="default" text="Label" kind="label">
+    <template #startIcon="{ iconSize }">
+      <dt-icon-lightning-bolt :size="iconSize" />
+    </template>
+    <template #endIcon="{ iconSize }">
+      <dt-icon-lightning-bolt :size="iconSize" />
+    </template>
+  </dt-badge>
+</dt-stack>
+```
 
 ## Decorative
 
 Decorative badges label and classify items for quick recognition.
 
-<code-example vueCode='
+```vue demo
+<dt-stack direction="row" gap="200" align="baseline">
+  <dt-stack gap="200">
+    <dt-text kind="label" :size="300" density="200">Black</dt-text>
+    <dt-badge text="Label" decoration="black-400" />
+    <dt-badge text="Label" decoration="black-500" />
+    <dt-badge text="Label" decoration="black-900" />
+  </dt-stack>
+  <dt-stack gap="200">
+    <dt-text kind="label" :size="300" density="200">Red</dt-text>
+    <dt-badge text="Label" decoration="red-200" />
+    <dt-badge text="Label" decoration="red-300" />
+    <dt-badge text="Label" decoration="red-400" />
+  </dt-stack>
+  <dt-stack gap="200">
+    <dt-text kind="label" :size="300" density="200">Purple</dt-text>
+    <dt-badge text="Label" decoration="purple-200" />
+    <dt-badge text="Label" decoration="purple-300" />
+    <dt-badge text="Label" decoration="purple-400" />
+    <dt-badge text="Label" decoration="purple-500" />
+  </dt-stack>
+  <dt-stack gap="200">
+    <dt-text kind="label" :size="300" density="200">Blue</dt-text>
+    <dt-badge text="Label" decoration="blue-200" />
+    <dt-badge text="Label" decoration="blue-300" />
+    <dt-badge text="Label" decoration="blue-400" />
+  </dt-stack>
+  <dt-stack gap="200">
+    <dt-text kind="label" :size="300" density="200">Green</dt-text>
+    <dt-badge text="Label" decoration="green-300" />
+    <dt-badge text="Label" decoration="green-400" />
+    <dt-badge text="Label" decoration="green-500" />
+  </dt-stack>
+  <dt-stack gap="200">
+    <dt-text kind="label" :size="300" density="200">Gold</dt-text>
+    <dt-badge text="Label" decoration="gold-300" />
+    <dt-badge text="Label" decoration="gold-400" />
+    <dt-badge text="Label" decoration="gold-500" />
+  </dt-stack>
+  <dt-stack gap="200">
+    <dt-text kind="label" :size="300" density="200">Magenta</dt-text>
+    <dt-badge text="Label" decoration="magenta-200" />
+    <dt-badge text="Label" decoration="magenta-300" />
+    <dt-badge text="Label" decoration="magenta-400" />
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-badge text="Label" decoration="black-400" />
 <dt-badge text="Label" decoration="black-500" />
 <dt-badge text="Label" decoration="black-900" />
 <dt-badge text="Label" decoration="red-200" />
 ...
-'>
-  <dt-stack direction="row" gap="200" align="baseline">
-    <dt-stack gap="200">
-      <dt-text kind="label" :size="300" density="200">Black</dt-text>
-      <dt-badge text="Label" decoration="black-400" />
-      <dt-badge text="Label" decoration="black-500" />
-      <dt-badge text="Label" decoration="black-900" />
-    </dt-stack>
-    <dt-stack gap="200">
-      <dt-text kind="label" :size="300" density="200">Red</dt-text>
-      <dt-badge text="Label" decoration="red-200" />
-      <dt-badge text="Label" decoration="red-300" />
-      <dt-badge text="Label" decoration="red-400" />
-    </dt-stack>
-    <dt-stack gap="200">
-      <dt-text kind="label" :size="300" density="200">Purple</dt-text>
-      <dt-badge text="Label" decoration="purple-200" />
-      <dt-badge text="Label" decoration="purple-300" />
-      <dt-badge text="Label" decoration="purple-400" />
-      <dt-badge text="Label" decoration="purple-500" />
-    </dt-stack>
-    <dt-stack gap="200">
-      <dt-text kind="label" :size="300" density="200">Blue</dt-text>
-      <dt-badge text="Label" decoration="blue-200" />
-      <dt-badge text="Label" decoration="blue-300" />
-      <dt-badge text="Label" decoration="blue-400" />
-    </dt-stack>
-    <dt-stack gap="200">
-      <dt-text kind="label" :size="300" density="200">Green</dt-text>
-      <dt-badge text="Label" decoration="green-300" />
-      <dt-badge text="Label" decoration="green-400" />
-      <dt-badge text="Label" decoration="green-500" />
-    </dt-stack>
-    <dt-stack gap="200">
-      <dt-text kind="label" :size="300" density="200">Gold</dt-text>
-      <dt-badge text="Label" decoration="gold-300" />
-      <dt-badge text="Label" decoration="gold-400" />
-      <dt-badge text="Label" decoration="gold-500" />
-    </dt-stack>
-    <dt-stack gap="200">
-      <dt-text kind="label" :size="300" density="200">Magenta</dt-text>
-      <dt-badge text="Label" decoration="magenta-200" />
-      <dt-badge text="Label" decoration="magenta-300" />
-      <dt-badge text="Label" decoration="magenta-400" />
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 <dialtone-usage>
 <template #do>
@@ -290,78 +293,78 @@ Decorative badges label and classify items for quick recognition.
 
 ### Label
 
-<code-example only-show="demo">
-  <dt-stack gap="200">
-    <dt-stack direction="row" gap="100">
-      <dt-badge text="Co-host" />
-      <dt-badge text="Customer" />
-      <dt-badge text="Locked">
-        <template #startIcon="{ iconSize }">
-          <dt-icon-lock :size="iconSize" />
-        </template>
-      </dt-badge>
-      <dt-badge text="Chat log">
-        <template #startIcon="{ iconSize }">
-          <dt-icon-message :size="iconSize" />
-        </template>
-      </dt-badge>
-    </dt-stack>
-    <dt-stack direction="row" gap="00">
-      <dt-badge text="In progress" type="info" />
-      <dt-badge text="Beta" type="info" />
-      <dt-badge text="Draft" type="info" />
-    </dt-stack>
-    <dt-stack direction="row" gap="100">
-      <dt-badge text="Overdue" type="warning" />
-    </dt-stack>
-    <dt-stack direction="row" gap="100">
-      <dt-badge text="Resolved" type="success" />
-    </dt-stack>
-    <dt-stack direction="row" gap="100">
-      <dt-badge text="Recording" type="critical">
-        <template #startIcon="{ iconSize }">
-          <dt-icon-record-filled :size="iconSize" />
-        </template>
-      </dt-badge>
-    </dt-stack>
-    <dt-stack direction="row" gap="100">
-      <dt-badge text="Live" type="bulletin" />
-      <dt-badge text="Presenter" type="bulletin" />
-    </dt-stack>
-    <dt-stack direction="row" gap="100">
-      <dt-badge type="ai" text="Ai Notes" />
-      <dt-badge type="ai" text="Ai Suggestion" />
-      <dt-badge type="ai" text="Ai enabled" />
-      <dt-badge type="ai" text="Ai Transcript" />
-    </dt-stack>
+```vue demo-only
+<dt-stack gap="200">
+  <dt-stack direction="row" gap="100">
+    <dt-badge text="Co-host" />
+    <dt-badge text="Customer" />
+    <dt-badge text="Locked">
+      <template #startIcon="{ iconSize }">
+        <dt-icon-lock :size="iconSize" />
+      </template>
+    </dt-badge>
+    <dt-badge text="Chat log">
+      <template #startIcon="{ iconSize }">
+        <dt-icon-message :size="iconSize" />
+      </template>
+    </dt-badge>
   </dt-stack>
-</code-example>
+  <dt-stack direction="row" gap="00">
+    <dt-badge text="In progress" type="info" />
+    <dt-badge text="Beta" type="info" />
+    <dt-badge text="Draft" type="info" />
+  </dt-stack>
+  <dt-stack direction="row" gap="100">
+    <dt-badge text="Overdue" type="warning" />
+  </dt-stack>
+  <dt-stack direction="row" gap="100">
+    <dt-badge text="Resolved" type="success" />
+  </dt-stack>
+  <dt-stack direction="row" gap="100">
+    <dt-badge text="Recording" type="critical">
+      <template #startIcon="{ iconSize }">
+        <dt-icon-record-filled :size="iconSize" />
+      </template>
+    </dt-badge>
+  </dt-stack>
+  <dt-stack direction="row" gap="100">
+    <dt-badge text="Live" type="bulletin" />
+    <dt-badge text="Presenter" type="bulletin" />
+  </dt-stack>
+  <dt-stack direction="row" gap="100">
+    <dt-badge type="ai" text="Ai Notes" />
+    <dt-badge type="ai" text="Ai Suggestion" />
+    <dt-badge type="ai" text="Ai enabled" />
+    <dt-badge type="ai" text="Ai Transcript" />
+  </dt-stack>
+</dt-stack>
+```
 
 ### Count
 
-<code-example only-show="demo">
-  <dt-stack gap="200">
-    <dt-stack direction="row" gap="100">
-      <dt-badge kind="count" type="success" text="5%">
-        <template #startIcon="{ iconSize }">
-          <dt-icon-arrow-up :size="iconSize" />
-        </template>
-      </dt-badge>
-    </dt-stack>
-    <dt-stack direction="row" gap="100">
-      <dt-badge kind="count" type="critical" text="-12%">
-        <template #startIcon="{ iconSize }">
-          <dt-icon-arrow-down :size="iconSize" />
-        </template>
-      </dt-badge>
-    </dt-stack>
-    <dt-stack direction="row" gap="100">
-      <dt-badge kind="count" type="bulletin" text="1" />
-      <dt-badge kind="count" type="bulletin" text="18" />
-      <dt-badge kind="count" type="bulletin" text="99+" />
-    </dt-stack>
+```vue demo-only
+<dt-stack gap="200">
+  <dt-stack direction="row" gap="100">
+    <dt-badge kind="count" type="success" text="5%">
+      <template #startIcon="{ iconSize }">
+        <dt-icon-arrow-up :size="iconSize" />
+      </template>
+    </dt-badge>
   </dt-stack>
-</code-example>
+  <dt-stack direction="row" gap="100">
+    <dt-badge kind="count" type="critical" text="-12%">
+      <template #startIcon="{ iconSize }">
+        <dt-icon-arrow-down :size="iconSize" />
+      </template>
+    </dt-badge>
+  </dt-stack>
+  <dt-stack direction="row" gap="100">
+    <dt-badge kind="count" type="bulletin" text="1" />
+    <dt-badge kind="count" type="bulletin" text="18" />
+    <dt-badge kind="count" type="bulletin" text="99+" />
+  </dt-stack>
+</dt-stack>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/banner.md
+++ b/apps/dialtone-documentation/docs/components/banner.md
@@ -9,19 +9,19 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
 keywords: ["alert","notification","message","d-banner","DtBanner","dt-banner"]
 ---
 
-<code-example only-show="demo" class="d-p-0">
-  <dt-stack gap="200" class="d-w100p" align="center">
-    <dt-banner title="Example banner" kind="info" class="d-ps-relative d-zi-base">
-      Message body with a <dt-link kind="muted">Link</dt-link>
-      <template #action>
-        <dt-button :size="200" kind="muted" importance="outlined">Action</dt-button>
-      </template>
-    </dt-banner>
-    <dt-stack direction="row">
-      <dt-button @click="toggleBanner('example-pinned')">Pin to top</dt-button>
-    </dt-stack>
+```vue demo-only
+<dt-stack gap="200" class="d-w100p" align="center">
+  <dt-banner title="Example banner" kind="info" class="d-ps-relative d-zi-base">
+    Message body with a <dt-link kind="muted">Link</dt-link>
+    <template #action>
+      <dt-button :size="200" kind="muted" importance="outlined">Action</dt-button>
+    </template>
+  </dt-banner>
+  <dt-stack direction="row">
+    <dt-button @click="toggleBanner('example-pinned')">Pin to top</dt-button>
   </dt-stack>
-</code-example>
+</dt-stack>
+```
 
 <!-- <component-combinator component-name="DtBanner" /> -->
 
@@ -38,13 +38,13 @@ Banners are a type of notice and so you can use the following [Notice](notice.md
 
 ### Kind
 
-<code-example only-show="demo">
-  <dt-stack direction="row" gap="200">
-    <dt-select-menu :label-visible="false" label="Style" :options="bannerOptions" v-model="selectedKind" />
-    <dt-checkbox value="important" @input="toggleImportant">Important</dt-checkbox>
-    <dt-button @click="toggleBanner('example-kind')">Toggle Example</dt-button>
-  </dt-stack>
-</code-example>
+```vue demo-only
+<dt-stack direction="row" gap="200">
+  <dt-select-menu :label-visible="false" label="Style" :options="bannerOptions" v-model="selectedKind" />
+  <dt-checkbox value="important" @input="toggleImportant">Important</dt-checkbox>
+  <dt-button @click="toggleBanner('example-kind')">Toggle Example</dt-button>
+</dt-stack>
+```
 
 <dt-banner
   :pinned="pinned"
@@ -57,26 +57,26 @@ Banners are a type of notice and so you can use the following [Notice](notice.md
   Message body
 </dt-banner>
 
-<code-example only-show="code">
-  <dt-banner kind="base" title="Optional banner title"> Message body </dt-banner>
-  <dt-banner kind="error" title="Optional banner title"> Message body </dt-banner>
-  <dt-banner kind="info" title="Optional banner title"> Message body </dt-banner>
-  <dt-banner kind="success" title="Optional banner title"> Message body </dt-banner>
-  <dt-banner kind="warning" title="Optional banner title"> Message body </dt-banner>
-  <dt-banner background-image="{$background-image}" background-size="contain"> Message body </dt-banner>
-  <dt-banner pinned="true" kind="warning" title="Optional banner title"> Message body </dt-banner>
-  <dt-banner important="true" kind="warning" title="Optional banner title"> Message body </dt-banner>
-</code-example>
+```vue code-only
+<dt-banner kind="base" title="Optional banner title"> Message body </dt-banner>
+<dt-banner kind="error" title="Optional banner title"> Message body </dt-banner>
+<dt-banner kind="info" title="Optional banner title"> Message body </dt-banner>
+<dt-banner kind="success" title="Optional banner title"> Message body </dt-banner>
+<dt-banner kind="warning" title="Optional banner title"> Message body </dt-banner>
+<dt-banner background-image="{$background-image}" background-size="contain"> Message body </dt-banner>
+<dt-banner pinned="true" kind="warning" title="Optional banner title"> Message body </dt-banner>
+<dt-banner important="true" kind="warning" title="Optional banner title"> Message body </dt-banner>
+```
 
 ### Pinned
 
 Pins the banner to the top of the window.
 
-<code-example only-show="demo">
-  <dt-stack direction="row">
-    <dt-button @click="toggleBanner('example-pinned')">Toggle Example</dt-button>
-  </dt-stack>
-</code-example>
+```vue demo-only
+<dt-stack direction="row">
+  <dt-button @click="toggleBanner('example-pinned')">Toggle Example</dt-button>
+</dt-stack>
+```
 
 <dt-banner
   :pinned="true"
@@ -90,17 +90,17 @@ Pins the banner to the top of the window.
   </template>
 </dt-banner>
 
-<code-example only-show="code">
-  <dt-banner
-    :pinned="true"
-    title="Optional banner title"
-  >
-    Detailed description goes here.
-    <template #action>
-      <dt-button :size="200" kind="muted" importance="outlined">Action</dt-button>
-    </template>
-  </dt-banner>
-</code-example>
+```vue code-only
+<dt-banner
+  :pinned="true"
+  title="Optional banner title"
+>
+  Detailed description goes here.
+  <template #action>
+    <dt-button :size="200" kind="muted" importance="outlined">Action</dt-button>
+  </template>
+</dt-banner>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/breadcrumbs.md
+++ b/apps/dialtone-documentation/docs/components/breadcrumbs.md
@@ -29,17 +29,17 @@ Breadcrumbs are always treated as secondary and should not entirely replace the 
 
 ### Default
 
-<code-example>
-  <dt-breadcrumbs
-    :breadcrumbs="[
-      { href: '#', label: 'Root' },
-      { href: '#', label: 'Section' },
-      { href: '#', label: 'Section' },
-      { href: '#', label: 'Section' },
-      { href: '#', label: 'Current Page', selected: true },
-    ]"
-  />
-</code-example>
+```vue demo
+<dt-breadcrumbs
+  :breadcrumbs="[
+    { href: '#', label: 'Root' },
+    { href: '#', label: 'Section' },
+    { href: '#', label: 'Section' },
+    { href: '#', label: 'Section' },
+    { href: '#', label: 'Current Page', selected: true },
+  ]"
+/>
+```
 
 ### Inverted
 
@@ -51,19 +51,19 @@ Breadcrumbs are always treated as secondary and should not entirely replace the 
 
 In place of the `inverted` prop, use the [v-dt-mode directive](mode-island.html#inverting) on the component element.
 
-<code-example>
-  <div class="d-bgc-contrast">
-    <dt-breadcrumbs
-      v-dt-mode:invert
-      class="d-p-200 d-bar8"
-      :breadcrumbs="[
-        { href: '#', label: 'Root' },
-        { href: '#', label: 'Section' },
-        { href: '#', label: 'Current Page', selected: true },
-      ]"
-    />
-  </div>
-</code-example>
+```vue demo
+<div class="d-bgc-contrast">
+  <dt-breadcrumbs
+    v-dt-mode:invert
+    class="d-p-200 d-bar8"
+    :breadcrumbs="[
+      { href: '#', label: 'Root' },
+      { href: '#', label: 'Section' },
+      { href: '#', label: 'Current Page', selected: true },
+    ]"
+  />
+</div>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/button-group.md
+++ b/apps/dialtone-documentation/docs/components/button-group.md
@@ -17,34 +17,37 @@ The alignment and the order of buttons within it can be customized to suit the s
 
 When aligned to `start`, the `primary` button is on the **left** side of the group.
 
-<code-example class="d-d-block">
-  <dt-button-group alignment="start" class="d-ba d-bas-dashed">
-    <dt-button importance="primary">Confirm</dt-button>
-    <dt-button importance="outlined">Cancel</dt-button>
-  </dt-button-group>
-</code-example>
+```vue demo
+<!-- @class d-d-block -->
+<dt-button-group alignment="start" class="d-ba d-bas-dashed">
+  <dt-button importance="primary">Confirm</dt-button>
+  <dt-button importance="outlined">Cancel</dt-button>
+</dt-button-group>
+```
 
 ### End
 
 When aligned to `end`, the `primary` button is on the **right** side of the group.
 
-<code-example class="d-d-block">
-  <dt-button-group alignment="end" class="d-ba d-bas-dashed">
-    <dt-button importance="outlined">Cancel</dt-button>
-    <dt-button importance="primary">Confirm</dt-button>
-  </dt-button-group>
-</code-example>
+```vue demo
+<!-- @class d-d-block -->
+<dt-button-group alignment="end" class="d-ba d-bas-dashed">
+  <dt-button importance="outlined">Cancel</dt-button>
+  <dt-button importance="primary">Confirm</dt-button>
+</dt-button-group>
+```
 
 ### Space-Between
 
 When set to `space-between`, the elements are evenly distributed within the row, creating a directional flow where the `primary` button is either on the **left** (regressive) or on the **right** (progressive).
 
-<code-example class="d-d-block">
-  <dt-button-group alignment="space-between" class="d-ba d-bas-dashed">
-    <dt-button importance="outlined">Previous</dt-button>
-    <dt-button importance="primary">Next</dt-button>
-  </dt-button-group>
-</code-example>
+```vue demo
+<!-- @class d-d-block -->
+<dt-button-group alignment="space-between" class="d-ba d-bas-dashed">
+  <dt-button importance="outlined">Previous</dt-button>
+  <dt-button importance="primary">Next</dt-button>
+</dt-button-group>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -317,6 +317,7 @@ If you have existing `<a class="d-btn">` or `<router-link class="d-btn">` workar
 >
   Link Text
 </a>
+
 <!-- After: DtButton with href prop -->
 <dt-button
   href="<https://example.com>"
@@ -337,6 +338,7 @@ If you have existing `<a class="d-btn">` or `<router-link class="d-btn">` workar
 >
   Join Room
 </router-link>
+
 <!-- After: DtButton with to prop -->
 <dt-button :to="roomPath" :size="200">
   Join Room
@@ -716,39 +718,6 @@ The width of the button remains determined by the length of the label, which is 
 </dt-stack>
 <!-- @code -->
 <dt-button loading> Place Call </dt-button>
-<dt-button v-dt-tooltip="`Tooltip`" loading>
-  <template #startIcon="{ iconSize }">
-    <dt-icon
-      name="phone"
-      :size="iconSize"
-    />
-  </template>
-</dt-button>
-<dt-button v-dt-tooltip="`Tooltip`" circle loading>
-  <template #startIcon="{ iconSize }">
-    <dt-icon
-      name="phone"
-      :size="iconSize"
-    />
-  </template>
-</dt-button>
-<dt-button kind="muted" importance="outlined" loading> Place Call </dt-button>
-<dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" loading>
-  <template #startIcon="{ iconSize }">
-    <dt-icon
-      name="phone"
-      :size="iconSize"
-    />
-  </template>
-</dt-button>
-<dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" circle loading>
-  <template #startIcon="{ iconSize }">
-    <dt-icon
-      name="phone"
-      :size="iconSize"
-    />
-  </template>
-</dt-button>
 ```
 
 ### With label

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -65,37 +65,40 @@ Dialtone provides five options for `kind`, with three levels of `importance`.
 
 The base button should be the go-to button for most of your needs. When in doubt, use this style. To help provide clarity to users, it is generally recommended to use only one primary button style within a section or page.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-button> Place Call </dt-button>
-    <dt-button importance="outlined"> Place Call </dt-button>
-    <dt-button importance="clear"> Place Call </dt-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-button> Place Call </dt-button>
+  <dt-button importance="outlined"> Place Call </dt-button>
+  <dt-button importance="clear"> Place Call </dt-button>
+</dt-stack>
+```
 
 ### Danger
 
 The danger button style is used to communicate critical or destructive actions such as deleting content, accounts, or canceling services.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-button kind="danger"> Place Call </dt-button>
-    <dt-button kind="danger" importance="outlined"> Place Call </dt-button>
-    <dt-button kind="danger" importance="clear"> Place Call </dt-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-button kind="danger"> Place Call </dt-button>
+  <dt-button kind="danger" importance="outlined"> Place Call </dt-button>
+  <dt-button kind="danger" importance="clear"> Place Call </dt-button>
+</dt-stack>
+```
 
 ### Positive
 
 The positive button style is used to communicate positive actions.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-button kind="positive">Place Call</dt-button>
-    <dt-button kind="positive" importance="outlined">Place Call</dt-button>
-    <dt-button kind="positive" importance="clear">Place Call</dt-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-button kind="positive">Place Call</dt-button>
+  <dt-button kind="positive" importance="outlined">Place Call</dt-button>
+  <dt-button kind="positive" importance="clear">Place Call</dt-button>
+</dt-stack>
+```
 
 ### Muted
 
@@ -103,121 +106,122 @@ The muted button style is used to communicate non-primary actions for contexts i
 (e.g. colored backgrounds, validation components, etc).
 This style's use should be rare. When in doubt, use the [default button style](#default).
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-button kind="muted" importance="clear"> Place Call </dt-button>
-    <dt-button kind="muted" importance="outlined"> Place Call </dt-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-button kind="muted" importance="clear"> Place Call </dt-button>
+  <dt-button kind="muted" importance="outlined"> Place Call </dt-button>
+</dt-stack>
+```
 
 ### Disabled
 
-<code-example vueCode='
-<dt-button disabled {props}>Place Call</dt-button>
-'>
+```vue demo
+<dt-stack gap="100">
+  <dt-toggle v-model="isDisabled" :size="200" wrapperClass="d-g-100 d-m-auto d-pbe-100">Disabled</dt-toggle>
   <dt-stack gap="100">
-    <dt-toggle v-model="isDisabled" :size="200" wrapperClass="d-g-100 d-m-auto d-pbe-100">Disabled</dt-toggle>
-    <dt-stack gap="100">
-      <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
-        <dt-button :disabled="isDisabled"> Place Call </dt-button>
-        <dt-button :disabled="isDisabled" importance="outlined"> Place Call </dt-button>
-        <dt-button :disabled="isDisabled" importance="clear"> Place Call </dt-button>
-      </dt-stack>
-      <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
-        <dt-button :disabled="isDisabled" kind="danger"> Place Call </dt-button>
-        <dt-button :disabled="isDisabled" kind="danger" importance="outlined"> Place Call </dt-button>
-        <dt-button :disabled="isDisabled" kind="danger" importance="clear"> Place Call </dt-button>
-      </dt-stack>
-      <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
-        <dt-button :disabled="isDisabled" kind="positive">Place Call</dt-button>
-        <dt-button :disabled="isDisabled" kind="positive" importance="outlined">Place Call</dt-button>
-        <dt-button :disabled="isDisabled" kind="positive" importance="clear">Place Call</dt-button>
-      </dt-stack>
-      <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
-        <dt-button :disabled="isDisabled" kind="muted" importance="clear"> Place Call </dt-button>
-        <dt-button :disabled="isDisabled" kind="muted" importance="outlined"> Place Call </dt-button>
-      </dt-stack>
+    <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
+      <dt-button :disabled="isDisabled"> Place Call </dt-button>
+      <dt-button :disabled="isDisabled" importance="outlined"> Place Call </dt-button>
+      <dt-button :disabled="isDisabled" importance="clear"> Place Call </dt-button>
+    </dt-stack>
+    <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
+      <dt-button :disabled="isDisabled" kind="danger"> Place Call </dt-button>
+      <dt-button :disabled="isDisabled" kind="danger" importance="outlined"> Place Call </dt-button>
+      <dt-button :disabled="isDisabled" kind="danger" importance="clear"> Place Call </dt-button>
+    </dt-stack>
+    <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
+      <dt-button :disabled="isDisabled" kind="positive">Place Call</dt-button>
+      <dt-button :disabled="isDisabled" kind="positive" importance="outlined">Place Call</dt-button>
+      <dt-button :disabled="isDisabled" kind="positive" importance="clear">Place Call</dt-button>
+    </dt-stack>
+    <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
+      <dt-button :disabled="isDisabled" kind="muted" importance="clear"> Place Call </dt-button>
+      <dt-button :disabled="isDisabled" kind="muted" importance="outlined"> Place Call </dt-button>
     </dt-stack>
   </dt-stack>
-</code-example>
+</dt-stack>
+<!-- @code -->
+<dt-button disabled {props}>Place Call</dt-button>
+```
 
 Buttons can be disabled using the `disabled` attribute or the Dialtone class, `d-btn--disabled`. Use the attribute when a button should appear disabled and not receive focus; use the class when a button should appear disabled but still receive focus (i.e. a disabled button with a tooltip).
 
 Using the class also requires `aria-disabled`, and additional javascript implementation is required to prevent events.
 
-<code-example>
-  <dt-stack
-    gap="100"
-    :direction="{ 'default': 'column', 'md': 'row' }"
-  >
-    <!-- disabled attribute -->
-    <dt-button disabled>Place Call (disabled attribute)</dt-button>
-    <!-- disabled class -->
-    <span v-dt-tooltip="`Tooltip example`" tabindex="0">
-      <dt-button class="d-btn--disabled" aria-disabled="true" tabindex="-1">Place Call (disabled class)</dt-button>
-    </span>
-  </dt-stack>
-</code-example>
+```vue demo
+<dt-stack
+  gap="100"
+  :direction="{ 'default': 'column', 'md': 'row' }"
+>
+  <!-- disabled attribute -->
+  <dt-button disabled>Place Call (disabled attribute)</dt-button>
+  <!-- disabled class -->
+  <span v-dt-tooltip="`Tooltip example`" tabindex="0">
+    <dt-button class="d-btn--disabled" aria-disabled="true" tabindex="-1">Place Call (disabled class)</dt-button>
+  </span>
+</dt-stack>
+```
 
 ### Active
 
 Buttons can be set to active state using the `active` prop or `.d-btn--active` Dialtone class.
 
-<code-example>
-  <dt-stack
-    gap="100"
-    :direction="{ 'default': 'column', 'md': 'row' }"
-    data-demo-wrapper
-  >
-    <dt-button importance="clear" active>Place Call</dt-button>
-    <dt-button active>Place Call</dt-button>
-    <dt-button kind="danger" importance="clear" active>Place Call</dt-button>
-    <dt-button kind="positive" importance="clear" active>Place Call</dt-button>
-    <dt-button kind="muted" active>Place Call</dt-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack
+  gap="100"
+  :direction="{ 'default': 'column', 'md': 'row' }"
+>
+  <dt-button importance="clear" active>Place Call</dt-button>
+  <dt-button active>Place Call</dt-button>
+  <dt-button kind="danger" importance="clear" active>Place Call</dt-button>
+  <dt-button kind="positive" importance="clear" active>Place Call</dt-button>
+  <dt-button kind="muted" active>Place Call</dt-button>
+</dt-stack>
+```
 
 ### Link
 
 Buttons can be styled to match the appearance of a [DtLink](link.md) in situations for which you need the appearance of a link but require the behavior of a button. Using the `button` element provides a better accessibility experience.
 
-<code-example>
-  <dt-stack
-    gap="100"
-    :direction="{ 'default': 'column', 'md': 'row' }"
-    data-demo-wrapper
-  >
-    <dt-button link>Place Call</dt-button>
-    <dt-button link linkKind="warning">Place Call</dt-button>
-    <dt-button link linkKind="danger">Place Call</dt-button>
-    <dt-button link linkKind="success">Place Call</dt-button>
-    <dt-button link linkKind="muted">Place Call</dt-button>
-    <dt-button link disabled>Place Call</dt-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack
+  gap="100"
+  :direction="{ 'default': 'column', 'md': 'row' }"
+>
+  <dt-button link>Place Call</dt-button>
+  <dt-button link linkKind="warning">Place Call</dt-button>
+  <dt-button link linkKind="danger">Place Call</dt-button>
+  <dt-button link linkKind="success">Place Call</dt-button>
+  <dt-button link linkKind="muted">Place Call</dt-button>
+  <dt-button link disabled>Place Call</dt-button>
+</dt-stack>
+```
 
 ### Link no underline
 
 This inverts the underline behavior. With `underline="false"`, the link will not have an underline by default, but will show one on hover.
 
-<code-example>
-  <dt-stack
-    gap="100"
-    :direction="{ 'default': 'column', 'md': 'row' }"
-    data-demo-wrapper
-  >
-    <dt-button link :underline="false">Place Call</dt-button>
-    <dt-button link linkKind="danger" :underline="false">Place Call</dt-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack
+  gap="100"
+  :direction="{ 'default': 'column', 'md': 'row' }"
+>
+  <dt-button link :underline="false">Place Call</dt-button>
+  <dt-button link linkKind="danger" :underline="false">Place Call</dt-button>
+</dt-stack>
+```
 
 ### Unstyled
 
 The unstyled button removes all default Dialtone styling while preserving the semantic HTML `<button>` element and maintaining proper button behavior and accessibility.
 
-<code-example>
-  <dt-button kind="unstyled">Place Call</dt-button>
-</code-example>
+```vue demo
+<dt-button kind="unstyled">Place Call</dt-button>
+```
 
 ### Inverted
 
@@ -232,34 +236,34 @@ The unstyled button removes all default Dialtone styling while preserving the se
 
 Use the [v-dt-mode directive](mode-island.html#inverting) in place of `kind="inverted"` on the component element. The previous `inverted` variant of DtButton was limited to a single presentation style. The directive now makes every combination available as an inverted style.
 
-<code-example vueCode='
-<dt-button v-dt-mode:invert {props}>Place Call</dt-button>
-'>
+```vue demo
+<dt-stack gap="100">
+  <dt-toggle v-model="isInverted" :size="200" wrapperClass="d-g-100 d-m-auto d-pbe-100">Inverted</dt-toggle>
   <dt-stack gap="100">
-    <dt-toggle v-model="isInverted" :size="200" wrapperClass="d-g-100 d-m-auto d-pbe-100">Inverted</dt-toggle>
-    <dt-stack gap="100">
-      <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
-        <dt-button v-dt-mode:invert="isInverted"> Place Call </dt-button>
-        <dt-button v-dt-mode:invert="isInverted" importance="outlined"> Place Call </dt-button>
-        <dt-button v-dt-mode:invert="isInverted" importance="clear"> Place Call </dt-button>
-      </dt-stack>
-      <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
-        <dt-button v-dt-mode:invert="isInverted" kind="danger"> Place Call </dt-button>
-        <dt-button v-dt-mode:invert="isInverted" kind="danger" importance="outlined"> Place Call </dt-button>
-        <dt-button v-dt-mode:invert="isInverted" kind="danger" importance="clear"> Place Call </dt-button>
-      </dt-stack>
-      <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
-        <dt-button v-dt-mode:invert="isInverted" kind="positive">Place Call</dt-button>
-        <dt-button v-dt-mode:invert="isInverted" kind="positive" importance="outlined">Place Call</dt-button>
-        <dt-button v-dt-mode:invert="isInverted" kind="positive" importance="clear">Place Call</dt-button>
-      </dt-stack>
-      <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
-        <dt-button v-dt-mode:invert="isInverted" kind="muted" importance="clear"> Place Call </dt-button>
-        <dt-button v-dt-mode:invert="isInverted" kind="muted" importance="outlined"> Place Call </dt-button>
-      </dt-stack>
+    <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
+      <dt-button v-dt-mode:invert="isInverted"> Place Call </dt-button>
+      <dt-button v-dt-mode:invert="isInverted" importance="outlined"> Place Call </dt-button>
+      <dt-button v-dt-mode:invert="isInverted" importance="clear"> Place Call </dt-button>
+    </dt-stack>
+    <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
+      <dt-button v-dt-mode:invert="isInverted" kind="danger"> Place Call </dt-button>
+      <dt-button v-dt-mode:invert="isInverted" kind="danger" importance="outlined"> Place Call </dt-button>
+      <dt-button v-dt-mode:invert="isInverted" kind="danger" importance="clear"> Place Call </dt-button>
+    </dt-stack>
+    <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
+      <dt-button v-dt-mode:invert="isInverted" kind="positive">Place Call</dt-button>
+      <dt-button v-dt-mode:invert="isInverted" kind="positive" importance="outlined">Place Call</dt-button>
+      <dt-button v-dt-mode:invert="isInverted" kind="positive" importance="clear">Place Call</dt-button>
+    </dt-stack>
+    <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
+      <dt-button v-dt-mode:invert="isInverted" kind="muted" importance="clear"> Place Call </dt-button>
+      <dt-button v-dt-mode:invert="isInverted" kind="muted" importance="outlined"> Place Call </dt-button>
     </dt-stack>
   </dt-stack>
-</code-example>
+</dt-stack>
+<!-- @code -->
+<dt-button v-dt-mode:invert {props}>Place Call</dt-button>
+```
 
 ## Navigation
 
@@ -273,59 +277,59 @@ DtButton can render as an `<a>` or `<router-link>` for cases where you need butt
 
 Pass `href` to render as an `<a>` element. Use `target="_blank"` and `rel="noopener noreferrer"` for external links.
 
-<code-example>
-  <dt-button
-    href="https://dialtone.dialpad.com"
-    target="_blank"
-    rel="noopener noreferrer"
-    kind="muted"
-    importance="outlined"
-    :size="200"
-  >
-    <template #endIcon="{ iconSize }">
-      <dt-icon name="external-link" :size="iconSize" />
-    </template>
-    Dialtone
-  </dt-button>
-</code-example>
+```vue demo
+<dt-button
+  href="https://dialtone.dialpad.com"
+  target="_blank"
+  rel="noopener noreferrer"
+  kind="muted"
+  importance="outlined"
+  :size="200"
+>
+  <template #endIcon="{ iconSize }">
+    <dt-icon name="external-link" :size="iconSize" />
+  </template>
+  Dialtone
+</dt-button>
+```
 
 ### to
 
 Pass `to` to render as `<router-link>` for internal client-side SPA navigation. Use `replace` to navigate without adding a history entry.
 
-<code-example>
-  <dt-button to="/" kind="default" :size="100">
-    Home
-  </dt-button>
-</code-example>
+```vue demo
+<dt-button to="/" kind="default" :size="100">
+  Home
+</dt-button>
+```
 
 ### Migration
 
 If you have existing `<a class="d-btn">` or `<router-link class="d-btn">` workarounds, replace them with DtButton props:
 
-<code-example only-show="code">
-  <!-- Before: raw <a> with manual d-btn classes -->
-  <a
-    class="d-btn d-btn--primary d-btn--outlined d-btn--sm"
-    href="<https://example.com>"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    Link Text
-  </a>
-  <!-- After: DtButton with href prop -->
-  <dt-button
-    href="<https://example.com>"
-    target="_blank"
-    rel="noopener noreferrer"
-    importance="outlined"
-    :size="200"
-  >
-    Link Text
-  </dt-button>
-</code-example>
+```vue code-only
+<!-- Before: raw <a> with manual d-btn classes -->
+<a
+  class="d-btn d-btn--primary d-btn--outlined d-btn--sm"
+  href="<https://example.com>"
+  target="_blank"
+  rel="noopener noreferrer"
+>
+  Link Text
+</a>
+<!-- After: DtButton with href prop -->
+<dt-button
+  href="<https://example.com>"
+  target="_blank"
+  rel="noopener noreferrer"
+  importance="outlined"
+  :size="200"
+>
+  Link Text
+</dt-button>
+```
 
-<code-example only-show="code">
+```vue code-only
 <!-- Before: raw <router-link> with manual d-btn classes -->
 <router-link
   class="d-btn d-btn--primary d-btn--sm"
@@ -337,50 +341,50 @@ If you have existing `<a class="d-btn">` or `<router-link class="d-btn">` workar
 <dt-button :to="roomPath" :size="200">
   Join Room
 </dt-button>
-</code-example>
+```
 
 ## Sizes
 
 The default button size is `300`, but does not need to be explicitly specified.
 
-<code-example>
-  <dt-stack
-    gap="100"
-    :direction="{ 'default': 'column', 'md': 'row' }"
-    data-demo-wrapper
-  >
-    <dt-button :size="100" kind="muted" importance="outlined">
-      Call
-      <template #startIcon="{ iconSize }">
-        <dt-icon name="phone" :size="iconSize" />
-      </template>
-    </dt-button>
-    <dt-button :size="200" kind="muted" importance="outlined">
-      Call
-      <template #startIcon="{ iconSize }">
-        <dt-icon name="phone" :size="iconSize" />
-      </template>
-    </dt-button>
-    <dt-button kind="muted" importance="outlined">
-      Call
-      <template #startIcon="{ iconSize }">
-        <dt-icon name="phone" :size="iconSize" />
-      </template>
-    </dt-button>
-    <dt-button :size="400" kind="muted" importance="outlined">
-      Call
-      <template #startIcon="{ iconSize }">
-        <dt-icon name="phone" :size="iconSize" />
-      </template>
-    </dt-button>
-    <dt-button :size="500" kind="muted" importance="outlined">
-      Call
-      <template #startIcon="{ iconSize }">
-        <dt-icon name="phone" :size="iconSize" />
-      </template>
-    </dt-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack
+  gap="100"
+  :direction="{ 'default': 'column', 'md': 'row' }"
+>
+  <dt-button :size="100" kind="muted" importance="outlined">
+    Call
+    <template #startIcon="{ iconSize }">
+      <dt-icon name="phone" :size="iconSize" />
+    </template>
+  </dt-button>
+  <dt-button :size="200" kind="muted" importance="outlined">
+    Call
+    <template #startIcon="{ iconSize }">
+      <dt-icon name="phone" :size="iconSize" />
+    </template>
+  </dt-button>
+  <dt-button kind="muted" importance="outlined">
+    Call
+    <template #startIcon="{ iconSize }">
+      <dt-icon name="phone" :size="iconSize" />
+    </template>
+  </dt-button>
+  <dt-button :size="400" kind="muted" importance="outlined">
+    Call
+    <template #startIcon="{ iconSize }">
+      <dt-icon name="phone" :size="iconSize" />
+    </template>
+  </dt-button>
+  <dt-button :size="500" kind="muted" importance="outlined">
+    Call
+    <template #startIcon="{ iconSize }">
+      <dt-icon name="phone" :size="iconSize" />
+    </template>
+  </dt-button>
+</dt-stack>
+```
 
 ## Icon Support
 
@@ -397,260 +401,261 @@ The default button size is `300`, but does not need to be explicitly specified.
 
 Place icons before and/or after inline of the label with `startIcon` and `endIcon` slots.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <span>
-      <dt-button importance="outlined">
-        <template #startIcon="{ iconSize }">
-          <dt-icon name="phone" :size="iconSize" />
-        </template>
-        Label
-      </dt-button>
-    </span>
-    <span>
-      <dt-button importance="outlined">
-        Label
-        <template #endIcon="{ iconSize }">
-          <dt-icon name="arrow-right" :size="iconSize" />
-        </template>
-      </dt-button>
-    </span>
-    <span>
-      <dt-button importance="outlined">
-        <template #startIcon="{ iconSize }">
-          <dt-icon name="phone" :size="iconSize" />
-        </template>
-        Label
-        <template #endIcon="{ iconSize }">
-          <dt-icon name="arrow-right" :size="iconSize" />
-        </template>
-      </dt-button>
-    </span>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <span>
+    <dt-button importance="outlined">
+      <template #startIcon="{ iconSize }">
+        <dt-icon name="phone" :size="iconSize" />
+      </template>
+      Label
+    </dt-button>
+  </span>
+  <span>
+    <dt-button importance="outlined">
+      Label
+      <template #endIcon="{ iconSize }">
+        <dt-icon name="arrow-right" :size="iconSize" />
+      </template>
+    </dt-button>
+  </span>
+  <span>
+    <dt-button importance="outlined">
+      <template #startIcon="{ iconSize }">
+        <dt-icon name="phone" :size="iconSize" />
+      </template>
+      Label
+      <template #endIcon="{ iconSize }">
+        <dt-icon name="arrow-right" :size="iconSize" />
+      </template>
+    </dt-button>
+  </span>
+</dt-stack>
+```
 
 ### Top and Bottom
 
 Place icons above or below the label with `blockStartIcon` and `blockEndIcon` slots.
 
-<code-example>
-  <dt-stack
-    gap="100"
-    :direction="{ 'default': 'column', 'md': 'row' }"
-    data-demo-wrapper
-  >
-    <dt-button importance="outlined">
-      <template #blockStartIcon="{ iconSize }">
-        <dt-icon
-          name="phone"
-          :size="iconSize"
-        />
-      </template>
-      Label
-    </dt-button>
-    <dt-button importance="outlined">
-      <template #blockEndIcon="{ iconSize }">
-        <dt-icon
-          name="phone"
-          :size="iconSize"
-        />
-      </template>
-      Label
-    </dt-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack
+  gap="100"
+  :direction="{ 'default': 'column', 'md': 'row' }"
+>
+  <dt-button importance="outlined">
+    <template #blockStartIcon="{ iconSize }">
+      <dt-icon
+        name="phone"
+        :size="iconSize"
+      />
+    </template>
+    Label
+  </dt-button>
+  <dt-button importance="outlined">
+    <template #blockEndIcon="{ iconSize }">
+      <dt-icon
+        name="phone"
+        :size="iconSize"
+      />
+    </template>
+    Label
+  </dt-button>
+</dt-stack>
+```
 
 ### Icon Only
 
 Icon-only buttons are commonly used for toggling actions, navigation, or closing UI elements.
 
-<code-example>
-  <dt-stack
-    gap="300"
-    :direction="{ 'default': 'column', 'md': 'row' }"
-    data-demo-wrapper
-  >
-    <dt-stack direction="row" gap="100">
-      <dt-button v-dt-tooltip="`Tooltip`" kind="muted" importance="clear">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" kind="muted" importance="outlined">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-    </dt-stack>
-    <dt-stack direction="row" gap="100">
-      <dt-button v-dt-tooltip="`Tooltip`" importance="clear">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" importance="outlined">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-    </dt-stack>
-    <dt-stack direction="row" gap="100">
-      <dt-button v-dt-tooltip="`Tooltip`" kind="danger" importance="clear">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" kind="danger" importance="outlined">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" kind="danger">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-    </dt-stack>
-    <dt-stack direction="row" gap="100">
-      <dt-button v-dt-tooltip="`Tooltip`" importance="clear" kind="positive">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" importance="outlined" kind="positive">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" kind="positive">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-    </dt-stack>
+```vue demo
+<!-- @wrapper -->
+<dt-stack
+  gap="300"
+  :direction="{ 'default': 'column', 'md': 'row' }"
+>
+  <dt-stack direction="row" gap="100">
+    <dt-button v-dt-tooltip="`Tooltip`" kind="muted" importance="clear">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+    <dt-button v-dt-tooltip="`Tooltip`" kind="muted" importance="outlined">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
   </dt-stack>
-</code-example>
+  <dt-stack direction="row" gap="100">
+    <dt-button v-dt-tooltip="`Tooltip`" importance="clear">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+    <dt-button v-dt-tooltip="`Tooltip`" importance="outlined">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+    <dt-button v-dt-tooltip="`Tooltip`">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+  </dt-stack>
+  <dt-stack direction="row" gap="100">
+    <dt-button v-dt-tooltip="`Tooltip`" kind="danger" importance="clear">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+    <dt-button v-dt-tooltip="`Tooltip`" kind="danger" importance="outlined">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+    <dt-button v-dt-tooltip="`Tooltip`" kind="danger">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+  </dt-stack>
+  <dt-stack direction="row" gap="100">
+    <dt-button v-dt-tooltip="`Tooltip`" importance="clear" kind="positive">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+    <dt-button v-dt-tooltip="`Tooltip`" importance="outlined" kind="positive">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+    <dt-button v-dt-tooltip="`Tooltip`" kind="positive">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+  </dt-stack>
+</dt-stack>
+```
 
 #### Circle
 
 The following styles are available as a circle shape.
 
-<code-example>
-  <dt-stack
-    gap="300"
-    :direction="{ 'default': 'column', 'md': 'row' }"
-    data-demo-wrapper
-  >
-    <dt-stack direction="row" gap="100">
-      <dt-button v-dt-tooltip="`Tooltip`" circle kind="muted" importance="clear">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" circle kind="muted" importance="outlined">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-    </dt-stack>
-    <dt-stack direction="row" gap="100">
-      <dt-button v-dt-tooltip="`Tooltip`" circle kind="danger" importance="clear">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" circle kind="danger" importance="outlined">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" circle kind="danger">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-    </dt-stack>
-    <dt-stack direction="row" gap="100">
-      <dt-button v-dt-tooltip="`Tooltip`" circle importance="clear" kind="positive">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" circle importance="outlined" kind="positive">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-      <dt-button v-dt-tooltip="`Tooltip`" circle kind="positive">
-        <template #startIcon="{ iconSize }">
-          <dt-icon
-            name="phone"
-            :size="iconSize"
-          />
-        </template>
-      </dt-button>
-    </dt-stack>
+```vue demo
+<!-- @wrapper -->
+<dt-stack
+  gap="300"
+  :direction="{ 'default': 'column', 'md': 'row' }"
+>
+  <dt-stack direction="row" gap="100">
+    <dt-button v-dt-tooltip="`Tooltip`" circle kind="muted" importance="clear">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+    <dt-button v-dt-tooltip="`Tooltip`" circle kind="muted" importance="outlined">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
   </dt-stack>
-</code-example>
+  <dt-stack direction="row" gap="100">
+    <dt-button v-dt-tooltip="`Tooltip`" circle kind="danger" importance="clear">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+    <dt-button v-dt-tooltip="`Tooltip`" circle kind="danger" importance="outlined">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+    <dt-button v-dt-tooltip="`Tooltip`" circle kind="danger">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+  </dt-stack>
+  <dt-stack direction="row" gap="100">
+    <dt-button v-dt-tooltip="`Tooltip`" circle importance="clear" kind="positive">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+    <dt-button v-dt-tooltip="`Tooltip`" circle importance="outlined" kind="positive">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+    <dt-button v-dt-tooltip="`Tooltip`" circle kind="positive">
+      <template #startIcon="{ iconSize }">
+        <dt-icon
+          name="phone"
+          :size="iconSize"
+        />
+      </template>
+    </dt-button>
+  </dt-stack>
+</dt-stack>
+```
 
 ## Loading
 
@@ -660,7 +665,56 @@ Loading buttons are useful for communicating a delay between the button interact
 
 The width of the button remains determined by the length of the label, which is visually hidden in this state.
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="200" align="center">
+  <dt-toggle :size="200" v-model="loading" wrapperClass="d-g-100">
+    Loading
+  </dt-toggle>
+  <dt-stack
+    gap="300"
+    :direction="{ 'default': 'column', 'md': 'row' }"
+  >
+    <dt-stack direction="row" gap="100">
+      <dt-button :loading="loading"> Place Call </dt-button>
+      <dt-button v-dt-tooltip="`Tooltip`" :loading="loading">
+        <template #icon>
+          <dt-icon
+            name="phone"
+            size="300"
+          />
+        </template>
+      </dt-button>
+      <dt-button v-dt-tooltip="`Tooltip`" circle :loading="loading">
+        <template #icon>
+          <dt-icon
+            name="phone"
+            size="300"
+          />
+        </template>
+      </dt-button>
+    </dt-stack>
+    <dt-stack direction="row" gap="100">
+      <dt-button kind="muted" importance="outlined" :loading="loading"> Place Call </dt-button>
+      <dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" :loading="loading">
+        <template #icon>
+          <dt-icon
+            name="phone"
+            size="300"
+          />
+        </template>
+      </dt-button>
+      <dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" circle :loading="loading">
+        <template #icon>
+          <dt-icon
+            name="phone"
+            size="300"
+          />
+        </template>
+      </dt-button>
+    </dt-stack>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-button loading> Place Call </dt-button>
 <dt-button v-dt-tooltip="`Tooltip`" loading>
   <template #startIcon="{ iconSize }">
@@ -695,113 +749,64 @@ The width of the button remains determined by the length of the label, which is 
     />
   </template>
 </dt-button>
-'>
-  <dt-stack gap="200" align="center">
-    <dt-toggle :size="200" v-model="loading" wrapperClass="d-g-100">
-      Loading
-    </dt-toggle>
-    <dt-stack
-      gap="300"
-      :direction="{ 'default': 'column', 'md': 'row' }"
-    >
-      <dt-stack direction="row" gap="100">
-        <dt-button :loading="loading"> Place Call </dt-button>
-        <dt-button v-dt-tooltip="`Tooltip`" :loading="loading">
-          <template #icon>
-            <dt-icon
-              name="phone"
-              size="300"
-            />
-          </template>
-        </dt-button>
-        <dt-button v-dt-tooltip="`Tooltip`" circle :loading="loading">
-          <template #icon>
-            <dt-icon
-              name="phone"
-              size="300"
-            />
-          </template>
-        </dt-button>
-      </dt-stack>
-      <dt-stack direction="row" gap="100">
-        <dt-button kind="muted" importance="outlined" :loading="loading"> Place Call </dt-button>
-        <dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" :loading="loading">
-          <template #icon>
-            <dt-icon
-              name="phone"
-              size="300"
-            />
-          </template>
-        </dt-button>
-        <dt-button kind="muted" importance="outlined" v-dt-tooltip="`Tooltip`" circle :loading="loading">
-          <template #icon>
-            <dt-icon
-              name="phone"
-              size="300"
-            />
-          </template>
-        </dt-button>
-      </dt-stack>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### With label
 
-<code-example vueCode='
+```vue demo
+<dt-stack
+  gap="100"
+  direction="row"
+>
+<dt-button
+  :size="100"
+>
+  Validating
+  <template #endIcon="{ iconSize }">
+    <dt-loader
+      :size="iconSize"
+    />
+  </template>
+</dt-button>
+<dt-button
+  :size="200"
+>
+  Validating
+  <template #endIcon="{ iconSize }">
+    <dt-loader
+      :size="iconSize"
+    />
+  </template>
+</dt-button>
+<dt-button
+  :size="300"
+>
+  Validating
+  <template #endIcon="{ iconSize }">
+    <dt-loader
+      :size="iconSize"
+    />
+  </template>
+</dt-button>
+<dt-button
+  :size="400"
+>
+  Validating
+  <template #endIcon="{ iconSize }">
+    <dt-loader
+      :size="iconSize"
+    />
+  </template>
+</dt-button>
+</dt-stack>
+<!-- @code -->
 <dt-button>
   Validating
   <template #endIcon="{ iconSize }">
     <dt-loader :size="iconSize" />
   </template>
 </dt-button>
-'>
-  <dt-stack
-    gap="100"
-    direction="row"
-  >
-  <dt-button
-    :size="100"
-  >
-    Validating
-    <template #endIcon="{ iconSize }">
-      <dt-loader
-        :size="iconSize"
-      />
-    </template>
-  </dt-button>
-  <dt-button
-    :size="200"
-  >
-    Validating
-    <template #endIcon="{ iconSize }">
-      <dt-loader
-        :size="iconSize"
-      />
-    </template>
-  </dt-button>
-  <dt-button
-    :size="300"
-  >
-    Validating
-    <template #endIcon="{ iconSize }">
-      <dt-loader
-        :size="iconSize"
-      />
-    </template>
-  </dt-button>
-  <dt-button
-    :size="400"
-  >
-    Validating
-    <template #endIcon="{ iconSize }">
-      <dt-loader
-        :size="iconSize"
-      />
-    </template>
-  </dt-button>
-</dt-stack>
-</code-example>
+```
 
 ## Leading & Trailing
 
@@ -816,28 +821,28 @@ Use the `#leading` and `#trailing` slots to render freeform content at the start
 
 ### Leading
 
-<code-example>
-  <dt-button kind="muted" importance="outlined" leading-class="d-pis-150">
-    Caution
-    <template #leading>
-      <span class="d-bgc-critical-strong d-bar4 d-w12 d-h12"></span>
-    </template>
-  </dt-button>
-</code-example>
+```vue demo
+<dt-button kind="muted" importance="outlined" leading-class="d-pis-150">
+  Caution
+  <template #leading>
+    <span class="d-bgc-critical-strong d-bar4 d-w12 d-h12"></span>
+  </template>
+</dt-button>
+```
 
 ### Trailing
 
-<code-example>
-  <dt-button :size="200" kind="muted" importance="outlined" trailing-class="d-pie-25">
-    Copy
-    <template #startIcon="{ iconSize }">
-      <dt-icon name="copy" :size="iconSize" />
-    </template>
-    <template #trailing>
-      <dt-keyboard-shortcut shortcut="{cmd}+C" />
-    </template>
-  </dt-button>
-</code-example>
+```vue demo
+<dt-button :size="200" kind="muted" importance="outlined" trailing-class="d-pie-25">
+  Copy
+  <template #startIcon="{ iconSize }">
+    <dt-icon name="copy" :size="iconSize" />
+  </template>
+  <template #trailing>
+    <dt-keyboard-shortcut shortcut="{cmd}+C" />
+  </template>
+</dt-button>
+```
 
 ## Split Button
 
@@ -848,34 +853,34 @@ Use the `#leading` and `#trailing` slots to render freeform content at the start
   <dt-link to="split-button.html">DtSplitButton</dt-link> is its own component containing multiple DtButtons.
 </dt-notice>
 
-<code-example only-show="demo">
-  <dt-split-button
-    omega-tooltip-text="More calling options"
-  >
-    Place call
-    <template #dropdownList>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
-    </template>
-  </dt-split-button>
-</code-example>
+```vue demo-only
+<dt-split-button
+  omega-tooltip-text="More calling options"
+>
+  Place call
+  <template #dropdownList>
+    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+  </template>
+</dt-split-button>
+```
 
 ## Branded
 
 We provide the following branded buttons for log-in and sign-up workflows.
 
-<code-example>
-  <dt-stack
-    gap="100"
-    :direction="{ 'default': 'column', 'md': 'row' }"
-    data-demo-wrapper
-  >
-    <button class="d-btn d-btn--brand d-btn--google d-w100p" type="button"><span class="d-btn__icon"><dt-icon name="google-glyph" /></span><span class="d-btn__label">Log in with Google</span></button>
-    <button class="d-btn d-btn--brand d-btn--o365 d-w100p" type="button"><span class="d-btn__icon"><dt-icon name="office-365" /></span><span class="d-btn__label">Log in with Office365</span></button>
-    <button class="d-btn d-btn--brand d-btn--linkedin d-w100p" type="button"><span class="d-btn__icon"><dt-icon name="linkedin" /></span><span class="d-btn__label">Log in with LinkedIn</span></button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack
+  gap="100"
+  :direction="{ 'default': 'column', 'md': 'row' }"
+>
+  <button class="d-btn d-btn--brand d-btn--google d-w100p" type="button"><span class="d-btn__icon"><dt-icon name="google-glyph" /></span><span class="d-btn__label">Log in with Google</span></button>
+  <button class="d-btn d-btn--brand d-btn--o365 d-w100p" type="button"><span class="d-btn__icon"><dt-icon name="office-365" /></span><span class="d-btn__label">Log in with Office365</span></button>
+  <button class="d-btn d-btn--brand d-btn--linkedin d-w100p" type="button"><span class="d-btn__icon"><dt-icon name="linkedin" /></span><span class="d-btn__label">Log in with LinkedIn</span></button>
+</dt-stack>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/card.md
+++ b/apps/dialtone-documentation/docs/components/card.md
@@ -40,107 +40,107 @@ They should be easy to scan for relevant and actionable information. Elements, l
 
 ### Base
 
-<code-example>
-  <dt-card class="d-w-400" header-class="h:d-bgc-moderate-opaque" content-class="h:d-bgc-moderate-opaque" footer-class="h:d-bgc-moderate-opaque">
-    <template #header>
-      (header slot)
-    </template>
-    <template #content>
-      (content slot)
-    </template>
-    <template #footer>
-      (footer slot)
-    </template>
-  </dt-card>
-</code-example>
+```vue demo
+<dt-card class="d-w-400" header-class="h:d-bgc-moderate-opaque" content-class="h:d-bgc-moderate-opaque" footer-class="h:d-bgc-moderate-opaque">
+  <template #header>
+    (header slot)
+  </template>
+  <template #content>
+    (content slot)
+  </template>
+  <template #footer>
+    (footer slot)
+  </template>
+</dt-card>
+```
 
 ### With Header
 
-<code-example>
-  <dt-card class="d-w-400">
-    <template #header>
-      <dt-text as="p" kind="headline" :size="300">Lorem ipsum</dt-text>
-      <dt-button
-        :size="100"
-        importance="clear"
-        kind="muted"
-        aria-label="Menu button"
-      >
-        <template #startIcon>
-          <dt-icon
-            name="more-vertical"
-            size="100"
-          />
-        </template>
-      </dt-button>
-    </template>
-    <template #content>
-      Content slot. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec fermentum molestie semper. Morbi finibus nulla turpis, nec molestie mi rutrum.
-    </template>
-  </dt-card>
-</code-example>
+```vue demo
+<dt-card class="d-w-400">
+  <template #header>
+    <dt-text as="p" kind="headline" :size="300">Lorem ipsum</dt-text>
+    <dt-button
+      :size="100"
+      importance="clear"
+      kind="muted"
+      aria-label="Menu button"
+    >
+      <template #startIcon>
+        <dt-icon
+          name="more-vertical"
+          size="100"
+        />
+      </template>
+    </dt-button>
+  </template>
+  <template #content>
+    Content slot. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec fermentum molestie semper. Morbi finibus nulla turpis, nec molestie mi rutrum.
+  </template>
+</dt-card>
+```
 
 ### With Footer
 
-<code-example>
-  <dt-card class="d-w-400">
-    <template #content>
-      Content slot. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec fermentum molestie semper. Morbi finibus nulla turpis, nec molestie mi rutrum.
-    </template>
-    <template #footer>
-      <dt-button
-        importance="outlined"
-        :size="200"
-      >
-        Button
-      </dt-button>
-    </template>
-  </dt-card>
-</code-example>
+```vue demo
+<dt-card class="d-w-400">
+  <template #content>
+    Content slot. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec fermentum molestie semper. Morbi finibus nulla turpis, nec molestie mi rutrum.
+  </template>
+  <template #footer>
+    <dt-button
+      importance="outlined"
+      :size="200"
+    >
+      Button
+    </dt-button>
+  </template>
+</dt-card>
+```
 
 ### Content Only
 
-<code-example>
-  <dt-card class="d-w-400">
-    <template #content>
-      Content slot. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec fermentum molestie semper. Morbi finibus nulla turpis, nec molestie mi rutrum.
-    </template>
-  </dt-card>
-</code-example>
+```vue demo
+<dt-card class="d-w-400">
+  <template #content>
+    Content slot. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec fermentum molestie semper. Morbi finibus nulla turpis, nec molestie mi rutrum.
+  </template>
+</dt-card>
+```
 
 ### With Header, Footer and Scrollable Content
 
-<code-example>
-  <dt-card class="d-w-400" content-class="d-pie-0">
-    <template #header>
-      <dt-text as="p" kind="headline" :size="300">Lorem ipsum</dt-text>
-      <dt-button
-        :size="100"
-        importance="clear"
-        kind="muted"
-        aria-label="Menu button"
-      >
-        <template #startIcon>
-          <dt-icon
-            name="more-vertical"
-            size="100"
-          />
-        </template>
-      </dt-button>
-    </template>
-    <template #content>
-      <div class="d-h-125 d-pie-200" v-dt-scrollbar:never>Content slot. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec fermentum molestie semper. Morbi finibus nulla turpis, nec molestie mi rutrum.</div>
-    </template>
-    <template #footer>
-      <dt-button
-        importance="outlined"
-        :size="200"
-      >
-        Button
-      </dt-button>
-    </template>
-  </dt-card>
-</code-example>
+```vue demo
+<dt-card class="d-w-400" content-class="d-pie-0">
+  <template #header>
+    <dt-text as="p" kind="headline" :size="300">Lorem ipsum</dt-text>
+    <dt-button
+      :size="100"
+      importance="clear"
+      kind="muted"
+      aria-label="Menu button"
+    >
+      <template #startIcon>
+        <dt-icon
+          name="more-vertical"
+          size="100"
+        />
+      </template>
+    </dt-button>
+  </template>
+  <template #content>
+    <div class="d-h-125 d-pie-200" v-dt-scrollbar:never>Content slot. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec fermentum molestie semper. Morbi finibus nulla turpis, nec molestie mi rutrum.</div>
+  </template>
+  <template #footer>
+    <dt-button
+      importance="outlined"
+      :size="200"
+    >
+      Button
+    </dt-button>
+  </template>
+</dt-card>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/checkbox-group.md
+++ b/apps/dialtone-documentation/docs/components/checkbox-group.md
@@ -16,59 +16,95 @@ Checkbox Groups are typically paired with a legend which identifies the group. I
 
 ### Default
 
-<code-example>
-  <dt-checkbox-group
-    name="fruits-checkbox-group"
-    legend="Fruits"
-    :selectedValues="[]"
-  >
-    <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
-    <dt-checkbox value="banana"><span>Banana</span></dt-checkbox>
-    <dt-checkbox value="other"><span>Other</span></dt-checkbox>
-  </dt-checkbox-group>
-</code-example>
+```vue demo
+<dt-checkbox-group
+  name="fruits-checkbox-group"
+  legend="Fruits"
+  :selectedValues="[]"
+>
+  <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
+  <dt-checkbox value="banana"><span>Banana</span></dt-checkbox>
+  <dt-checkbox value="other"><span>Other</span></dt-checkbox>
+</dt-checkbox-group>
+```
 
 ### With Selected Values
 
-<code-example>
-  <dt-checkbox-group
-    name="my-group-name"
-    legend="My Legend"
-    :selected-values="['option1']"
-  >
-    <dt-checkbox
-      value="option1"
-      label="Option 1"
-    />
-    <dt-checkbox
-      value="option2"
-      label="Option 2"
-    />
-  </dt-checkbox-group>
-</code-example>
+```vue demo
+<dt-checkbox-group
+  name="my-group-name"
+  legend="My Legend"
+  :selected-values="['option1']"
+>
+  <dt-checkbox
+    value="option1"
+    label="Option 1"
+  />
+  <dt-checkbox
+    value="option2"
+    label="Option 2"
+  />
+</dt-checkbox-group>
+```
 
 ### Disabled
 
-<code-example>
-  <dt-checkbox-group
-    name="my-group-name"
-    legend="My Legend"
-    disabled
-  >
-    <dt-checkbox
-      value="option1"
-      label="Option 1"
-    />
-    <dt-checkbox
-      value="option2"
-      label="Option 2"
-    />
-  </dt-checkbox-group>
-</code-example>
+```vue demo
+<dt-checkbox-group
+  name="my-group-name"
+  legend="My Legend"
+  disabled
+>
+  <dt-checkbox
+    value="option1"
+    label="Option 1"
+  />
+  <dt-checkbox
+    value="option2"
+    label="Option 2"
+  />
+</dt-checkbox-group>
+```
 
 ### With Validation States
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="200">
+  <div>
+    <dt-checkbox-group
+      name="checkbox-group-with-success-message"
+      legend="Fruits"
+      :messages='[{"message":"Success validation message","type":"success"}]'
+    >
+      <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
+      <dt-checkbox value="banana"><span>Banana</span></dt-checkbox>
+      <dt-checkbox value="other"><span>Other</span></dt-checkbox>
+    </dt-checkbox-group>
+  </div>
+  <div>
+    <dt-checkbox-group
+      name="checkbox-group-with-warning-message"
+      legend="Fruits"
+      :messages='[{"message":"Warning validation message","type":"warning"}]'
+    >
+      <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
+      <dt-checkbox value="banana"><span>Banana</span></dt-checkbox>
+      <dt-checkbox value="other"><span>Other</span></dt-checkbox>
+    </dt-checkbox-group>
+  </div>
+  <div>
+    <dt-checkbox-group
+      name="checkbox-group-with-error-message"
+      legend="Fruits"
+      :messages='[{"message":"Error validation message","type":"error"}]'
+    >
+      <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
+      <dt-checkbox value="banana"><span>Banana</span></dt-checkbox>
+      <dt-checkbox value="other"><span>Other</span></dt-checkbox>
+    </dt-checkbox-group>
+  </div>
+</dt-stack>
+<!-- @code -->
 <dt-checkbox-group
   name="fruits-checkbox-group"
   legend="Fruits"
@@ -99,63 +135,27 @@ Checkbox Groups are typically paired with a legend which identifies the group. I
   <dt-checkbox value="banana"><span>Banana</span></dt-checkbox>
   <dt-checkbox value="other"><span>Other</span></dt-checkbox>
 </dt-checkbox-group>
-'>
-  <dt-stack gap="200">
-    <div>
-      <dt-checkbox-group
-        name="checkbox-group-with-success-message"
-        legend="Fruits"
-        :messages='[{"message":"Success validation message","type":"success"}]'
-      >
-        <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
-        <dt-checkbox value="banana"><span>Banana</span></dt-checkbox>
-        <dt-checkbox value="other"><span>Other</span></dt-checkbox>
-      </dt-checkbox-group>
-    </div>
-    <div>
-      <dt-checkbox-group
-        name="checkbox-group-with-warning-message"
-        legend="Fruits"
-        :messages='[{"message":"Warning validation message","type":"warning"}]'
-      >
-        <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
-        <dt-checkbox value="banana"><span>Banana</span></dt-checkbox>
-        <dt-checkbox value="other"><span>Other</span></dt-checkbox>
-      </dt-checkbox-group>
-    </div>
-    <div>
-      <dt-checkbox-group
-        name="checkbox-group-with-error-message"
-        legend="Fruits"
-        :messages='[{"message":"Error validation message","type":"error"}]'
-      >
-        <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
-        <dt-checkbox value="banana"><span>Banana</span></dt-checkbox>
-        <dt-checkbox value="other"><span>Other</span></dt-checkbox>
-      </dt-checkbox-group>
-    </div>
-  </dt-stack>
-</code-example>
+```
 
 ### With Validation Messages Hidden
 
-<code-example>
-  <dt-checkbox-group
-    name="my-group-name"
-    legend="My Legend"
-    :messages="[{ message: 'My Success Message', type: `success` }]"
-    :show-messages="false"
-  >
-    <dt-checkbox
-      value="option1"
-      label="Option 1"
-    />
-    <dt-checkbox
-      value="option2"
-      label="Option 2"
-    />
-  </dt-checkbox-group>
-</code-example>
+```vue demo
+<dt-checkbox-group
+  name="my-group-name"
+  legend="My Legend"
+  :messages="[{ message: 'My Success Message', type: `success` }]"
+  :show-messages="false"
+>
+  <dt-checkbox
+    value="option1"
+    label="Option 1"
+  />
+  <dt-checkbox
+    value="option2"
+    label="Option 2"
+  />
+</dt-checkbox-group>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/checkbox.md
+++ b/apps/dialtone-documentation/docs/components/checkbox.md
@@ -48,149 +48,152 @@ Checkboxes are an easily understandable way to indicate that users can select on
 
 ### Base Styles
 
-<code-example>
-  <dt-stack gap="100" data-demo-wrapper>
-    <!-- Default -->
-    <dt-checkbox
-      name="default"
-      value="Value"
-      label="Checkbox label"
-    />
-    <!-- Checked -->
-    <dt-checkbox
-      name="checked"
-      value="Value"
-      label="Checkbox label"
-      checked
-    />
-    <!-- Disabled -->
-    <dt-checkbox
-      name="disabled"
-      value="Value"
-      label="Disabled Checkbox label"
-      disabled
-    />
-    <!-- Disabled Checked -->
-    <dt-checkbox
-      name="disabled-checked"
-      value="Value"
-      label="Disabled Checkbox label"
-      checked
-      disabled
-    />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="100">
+  <!-- Default -->
+  <dt-checkbox
+    name="default"
+    value="Value"
+    label="Checkbox label"
+  />
+  <!-- Checked -->
+  <dt-checkbox
+    name="checked"
+    value="Value"
+    label="Checkbox label"
+    checked
+  />
+  <!-- Disabled -->
+  <dt-checkbox
+    name="disabled"
+    value="Value"
+    label="Disabled Checkbox label"
+    disabled
+  />
+  <!-- Disabled Checked -->
+  <dt-checkbox
+    name="disabled-checked"
+    value="Value"
+    label="Disabled Checkbox label"
+    checked
+    disabled
+  />
+</dt-stack>
+```
 
 ### Indeterminate
 
-<code-example>
-  <dt-stack gap="100" data-demo-wrapper>
-    <!-- Indeterminate -->
-    <dt-checkbox
-      name="indeterminate"
-      value="Value"
-      label="Indeterminate checkbox"
-      indeterminate
-    />
-    <!-- Indeterminate disabled -->
-    <dt-checkbox
-      name="indeterminate-disabled"
-      value="Value"
-      label="Indeterminate checkbox disabled"
-      checked
-      disabled
-      indeterminate
-    />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="100">
+  <!-- Indeterminate -->
+  <dt-checkbox
+    name="indeterminate"
+    value="Value"
+    label="Indeterminate checkbox"
+    indeterminate
+  />
+  <!-- Indeterminate disabled -->
+  <dt-checkbox
+    name="indeterminate-disabled"
+    value="Value"
+    label="Indeterminate checkbox disabled"
+    checked
+    disabled
+    indeterminate
+  />
+</dt-stack>
+```
 
 ### Stacked Group
 
-<code-example>
-  <dt-checkbox-group legend="Call Blocking & Spam Protection" :selectedValues="[]">
-    <dt-checkbox
-      name="option1"
-      value="Value"
-      label="Anonymous callers"
-    />
-    <dt-checkbox
-      name="option2"
-      value="Value"
-      label="Block callers not already in contacts list"
-    />
-    <dt-checkbox
-      name="option3"
-      value="Value"
-      label="Block callers with a high spam score"
-    />
-  </dt-checkbox-group>
-</code-example>
+```vue demo
+<dt-checkbox-group legend="Call Blocking & Spam Protection" :selectedValues="[]">
+  <dt-checkbox
+    name="option1"
+    value="Value"
+    label="Anonymous callers"
+  />
+  <dt-checkbox
+    name="option2"
+    value="Value"
+    label="Block callers not already in contacts list"
+  />
+  <dt-checkbox
+    name="option3"
+    value="Value"
+    label="Block callers with a high spam score"
+  />
+</dt-checkbox-group>
+```
 
 ### With Description Text
 
-<code-example>
-  <dt-checkbox-group legend="Call Blocking & Spam Protection" :selectedValues="[]">
-    <dt-checkbox
-      name="option1"
-      value="Value"
-      label="Anonymous callers"
-      description="Select how phone numbers you dont know should be handled."
-    />
-    <dt-checkbox
-      name="option2"
-      value="Value"
-      label="Block callers not already in contacts list"
-      description="You get enough calls. Free up some of your time."
-    />
-    <dt-checkbox
-      name="option3"
-      value="Value"
-      label="Block callers with a high spam score"
-      description="We will only let the legitimate callers through to bother you."
-    />
-  </dt-checkbox-group>
-</code-example>
+```vue demo
+<dt-checkbox-group legend="Call Blocking & Spam Protection" :selectedValues="[]">
+  <dt-checkbox
+    name="option1"
+    value="Value"
+    label="Anonymous callers"
+    description="Select how phone numbers you dont know should be handled."
+  />
+  <dt-checkbox
+    name="option2"
+    value="Value"
+    label="Block callers not already in contacts list"
+    description="You get enough calls. Free up some of your time."
+  />
+  <dt-checkbox
+    name="option3"
+    value="Value"
+    label="Block callers with a high spam score"
+    description="We will only let the legitimate callers through to bother you."
+  />
+</dt-checkbox-group>
+```
 
 ### With Validation States
 
-<code-example>
-  <dt-checkbox-group legend="Call Blocking & Spam Protection" :selectedValues="[]">
-    <dt-checkbox
-      name="option1"
-      value="Value"
-      label="Anonymous callers"
-      validation-state="warning"
-      :messages="[{ message: `Select how phone numbers you dont know should be handled.`, type: `warning` }]"
-    />
-    <dt-checkbox
-      name="option2"
-      value="Value"
-      label="Block callers not already in contacts list"
-      validation-state="error"
-      :messages="[{ message: `You get enough calls. Free up some of your time.`, type: `error` }]"
-    />
-    <dt-checkbox
-      name="option3"
-      value="Value"
-      label="Block callers with a high spam score"
-      validation-state="success"
-      :messages="[{ message: `We will only let the legitimate callers through to bother you.`, type: `success` }]"
-    />
-  </dt-checkbox-group>
-</code-example>
+```vue demo
+<dt-checkbox-group legend="Call Blocking & Spam Protection" :selectedValues="[]">
+  <dt-checkbox
+    name="option1"
+    value="Value"
+    label="Anonymous callers"
+    validation-state="warning"
+    :messages="[{ message: `Select how phone numbers you dont know should be handled.`, type: `warning` }]"
+  />
+  <dt-checkbox
+    name="option2"
+    value="Value"
+    label="Block callers not already in contacts list"
+    validation-state="error"
+    :messages="[{ message: `You get enough calls. Free up some of your time.`, type: `error` }]"
+  />
+  <dt-checkbox
+    name="option3"
+    value="Value"
+    label="Block callers with a high spam score"
+    validation-state="success"
+    :messages="[{ message: `We will only let the legitimate callers through to bother you.`, type: `success` }]"
+  />
+</dt-checkbox-group>
+```
 
 ## Label size
 
 Use the `label-size` prop to override the default label size.
 
-<code-example>
-  <dt-stack gap="100" data-demo-wrapper>
-    <dt-checkbox name="sizeXs" value="Value" label="Extra small label" :label-size="100" />
-    <dt-checkbox name="sizeSm" value="Value" label="Small label" :label-size="200" />
-    <dt-checkbox name="sizeMd" value="Value" label="Medium label (default)" :label-size="300" />
-    <dt-checkbox name="sizeLg" value="Value" label="Large label" :label-size="400" />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="100">
+  <dt-checkbox name="sizeXs" value="Value" label="Extra small label" :label-size="100" />
+  <dt-checkbox name="sizeSm" value="Value" label="Small label" :label-size="200" />
+  <dt-checkbox name="sizeMd" value="Value" label="Medium label (default)" :label-size="300" />
+  <dt-checkbox name="sizeLg" value="Value" label="Large label" :label-size="400" />
+</dt-stack>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/chip.md
+++ b/apps/dialtone-documentation/docs/components/chip.md
@@ -17,98 +17,99 @@ keywords: ["tag", "pill", "token", "badge", "d-chip", "DtChip", "dt-chip", "filt
 
 Add `:interactive="false"` to make it a read-only, non-interactive Chip. This changes it from a `<button>` to a non-interactive, read-only Chip with no events or hover/active state. Note that this does not effect the interactivity of its `×` remove button.
 
-<code-example>
-  <dt-chip :interactive="false">Chip</dt-chip>
-</code-example>
+```vue demo
+<dt-chip :interactive="false">Chip</dt-chip>
+```
 
 ### Default
 
-<code-example>
-  <dt-chip>Chip</dt-chip>
-</code-example>
+```vue demo
+<dt-chip>Chip</dt-chip>
+```
 
 ### Disabled
 
 Use the `disabled` prop to disable both the Chip and its close button. This sets `aria-disabled="true"` and `tabindex="-1"` on the interactive elements and applies disabled styles, preventing pointer and keyboard interaction.
 
-<code-example>
-  <dt-chip disabled>Chip</dt-chip>
-</code-example>
+```vue demo
+<dt-chip disabled>Chip</dt-chip>
+```
 
 ### Without Close Button
 
-<code-example>
-  <dt-chip :hide-close="true">Chip</dt-chip>
-</code-example>
+```vue demo
+<dt-chip :hide-close="true">Chip</dt-chip>
+```
 
 ### With Icon
 
-<code-example>
-  <dt-chip :hide-close="true">
-    <template #icon>
-      <dt-icon
-        name="phone"
-        size="200"
-      />
-    </template>
-    <template #default>
-      Chip
-    </template>
-  </dt-chip>
-</code-example>
+```vue demo
+<dt-chip :hide-close="true">
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="200"
+    />
+  </template>
+  <template #default>
+    Chip
+  </template>
+</dt-chip>
+```
 
 ### With Icon and Close Button
 
-<code-example>
-  <dt-chip>
-    <template #icon>
-      <dt-icon
-        name="phone"
-        size="200"
-      />
-    </template>
-    <template #default>
-      Chip
-    </template>
-  </dt-chip>
-</code-example>
+```vue demo
+<dt-chip>
+  <template #icon>
+    <dt-icon
+      name="phone"
+      size="200"
+    />
+  </template>
+  <template #default>
+    Chip
+  </template>
+</dt-chip>
+```
 
 ### With Avatar and Close Button
 
-<code-example>
-  <dt-chip>
-    <template #avatar>
-      <dt-avatar
-        image-src="/assets/images/person.png"
-        image-alt="Jaqueline Nackos"
-        full-name="Jaqueline Nackos"
-      />
-    </template>
-    <template #default>
-      Chip
-    </template>
-  </dt-chip>
-</code-example>
+```vue demo
+<dt-chip>
+  <template #avatar>
+    <dt-avatar
+      image-src="/assets/images/person.png"
+      image-alt="Jaqueline Nackos"
+      full-name="Jaqueline Nackos"
+    />
+  </template>
+  <template #default>
+    Chip
+  </template>
+</dt-chip>
+```
 
 ### Truncated
 
 To truncate text, add `.d-truncate` to the content element, and set the width of the `.d-chip` element.
 
-<code-example>
-  <dt-chip content-class="d-w-150">
-    <span class="d-chip__text d-truncate">Chip loooooong name</span>
-  </dt-chip>
-</code-example>
+```vue demo
+<dt-chip content-class="d-w-150">
+  <span class="d-chip__text d-truncate">Chip loooooong name</span>
+</dt-chip>
+```
 
 ### Sizes
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-chip :interactive="false" :size="100">Chip</dt-chip>
-    <dt-chip :interactive="false" :size="200">Chip</dt-chip>
-    <dt-chip :interactive="false">Chip</dt-chip>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-chip :interactive="false" :size="100">Chip</dt-chip>
+  <dt-chip :interactive="false" :size="200">Chip</dt-chip>
+  <dt-chip :interactive="false">Chip</dt-chip>
+</dt-stack>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/collapsible.md
+++ b/apps/dialtone-documentation/docs/components/collapsible.md
@@ -15,46 +15,48 @@ The collapsible component consists of two parts: the anchor and the content. If 
 
 ### Basic Usage Without Anchor Slot
 
-<code-example class="d-d-block">
-  <div>
-    <dt-collapsible
-      class="d-fc-primary"
-      anchorText="Label 1"
-      maxWidth="340px"
-      initial-focus-element="first"
-      >
-      <template #content>
-        <div class="d-ta-center d-ba d-bc-warning d-bgc-warning d-bas-dotted d-baw2 d-p-100 d-code--sm">(content slot)</div>
-      </template>
-    </dt-collapsible>
-    <dt-collapsible
-      anchorText="Label 2"
-      maxWidth="340px"
-      initial-focus-element="first"
+```vue demo
+<!-- @class d-d-block -->
+<div>
+  <dt-collapsible
+    class="d-fc-primary"
+    anchorText="Label 1"
+    maxWidth="340px"
+    initial-focus-element="first"
     >
-      <template #content>
-        <div class="d-ta-center d-ba d-bc-warning d-bgc-warning d-bas-dotted d-baw2 d-p-100 d-code--sm">(content slot)</div>
-      </template>
-    </dt-collapsible>
-  </div>
-</code-example>
+    <template #content>
+      <div class="d-ta-center d-ba d-bc-warning d-bgc-warning d-bas-dotted d-baw2 d-p-100 d-code--sm">(content slot)</div>
+    </template>
+  </dt-collapsible>
+  <dt-collapsible
+    anchorText="Label 2"
+    maxWidth="340px"
+    initial-focus-element="first"
+  >
+    <template #content>
+      <div class="d-ta-center d-ba d-bc-warning d-bgc-warning d-bas-dotted d-baw2 d-p-100 d-code--sm">(content slot)</div>
+    </template>
+  </dt-collapsible>
+</div>
+```
 
 ### With Anchor Slot
 
-<code-example class="d-d-block">
-  <dt-collapsible :open="isOpen">
-    <template #anchor>
-      <dt-button @click="toggleIsOpen">
-        Click Me!
-      </dt-button>
-    </template>
-    <template #content>
-      <div>
-        This will be shown in the expanded area.
-      </div>
-    </template>
-  </dt-collapsible>
-</code-example>
+```vue demo
+<!-- @class d-d-block -->
+<dt-collapsible :open="isOpen">
+  <template #anchor>
+    <dt-button @click="toggleIsOpen">
+      Click Me!
+    </dt-button>
+  </template>
+  <template #content>
+    <div>
+      This will be shown in the expanded area.
+    </div>
+  </template>
+</dt-collapsible>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/combobox-multi-select.md
+++ b/apps/dialtone-documentation/docs/components/combobox-multi-select.md
@@ -9,7 +9,33 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-combobox-mul
 
 <!-- <component-combinator component-name="DtComboboxMultiSelect" /> -->
 
-<code-example class="d-d-block" vueCode='
+```vue demo
+<!-- @class d-d-block -->
+<dt-combobox-multi-select
+  label="Label Text"
+  :selected-items="selectedItems"
+  @input="onComboboxInput"
+  @select="onComboboxSelect"
+  @remove="onComboboxRemove"
+>
+  <template #list>
+    <dt-stack as="ul" class="d-ps-relative d-m-50 d-px-0">
+      <dt-list-item
+        v-for="(item, i) in items"
+        :key="item.id"
+        role="option"
+        navigation-type="arrow-keys"
+        @click="onComboboxSelect(i)"
+      >
+        {{ item.value }}
+        <template #right>
+          <span class="d-fc-secondary">{{ item.type }}</span>
+        </template>
+      </dt-list-item>
+    </dt-stack>
+  </template>
+</dt-combobox-multi-select>
+<!-- @code -->
 <dt-combobox-multi-select
   ref="comboboxMultiSelect"
   label="Label Text"
@@ -35,32 +61,7 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-combobox-mul
     </dt-stack>
   </template>
 </dt-combobox-multi-select>
-'>
-  <dt-combobox-multi-select
-    label="Label Text"
-    :selected-items="selectedItems"
-    @input="onComboboxInput"
-    @select="onComboboxSelect"
-    @remove="onComboboxRemove"
-  >
-    <template #list>
-      <dt-stack as="ul" class="d-ps-relative d-m-50 d-px-0">
-        <dt-list-item
-          v-for="(item, i) in items"
-          :key="item.id"
-          role="option"
-          navigation-type="arrow-keys"
-          @click="onComboboxSelect(i)"
-        >
-          {{ item.value }}
-          <template #right>
-            <span class="d-fc-secondary">{{ item.type }}</span>
-          </template>
-        </dt-list-item>
-      </dt-stack>
-    </template>
-  </dt-combobox-multi-select>
-</code-example>
+```
 
 ## Usage
 
@@ -85,7 +86,37 @@ Adds validation for max selection. Make sure to provide the following props:
 - `maxSelected` the maximum number of selections you can make. 0 is unlimited
 - `maxSelectedMessage` should be the message that shown if max selection has been reached
 
-<code-example class="d-d-block" vueCode='
+```vue demo
+<!-- @class d-d-block -->
+<dt-combobox-multi-select
+  label="Label Text"
+  description="Select up to 2 options."
+  :selected-items="maxSelectedItems"
+  :max-selected="2"
+  :max-selected-message="[{ message: 'More than 2 selected', type: 'error' }]"
+  @input="onMaxSelectInput"
+  @select="onMaxSelectSelect"
+  @remove="onMaxSelectRemove"
+  @max-selected="onMaxSelected"
+>
+  <template #list>
+    <dt-stack as="ul" class="d-ps-relative d-m-50 d-px-0">
+      <dt-list-item
+        v-for="(item, i) in maxSelectItems"
+        :key="item.id"
+        role="option"
+        navigation-type="arrow-keys"
+        @click="onMaxSelectSelect(i)"
+      >
+        {{ item.value }}
+        <template #right>
+          <span class="d-fc-secondary">{{ item.type }}</span>
+        </template>
+      </dt-list-item>
+    </dt-stack>
+  </template>
+</dt-combobox-multi-select>
+<!-- @code -->
 <dt-combobox-multi-select
   ref="comboboxMultiSelect"
   label="Label Text"
@@ -115,36 +146,7 @@ Adds validation for max selection. Make sure to provide the following props:
     </dt-stack>
   </template>
 </dt-combobox-multi-select>
-'>
-  <dt-combobox-multi-select
-    label="Label Text"
-    description="Select up to 2 options."
-    :selected-items="maxSelectedItems"
-    :max-selected="2"
-    :max-selected-message="[{ message: 'More than 2 selected', type: 'error' }]"
-    @input="onMaxSelectInput"
-    @select="onMaxSelectSelect"
-    @remove="onMaxSelectRemove"
-    @max-selected="onMaxSelected"
-  >
-    <template #list>
-      <dt-stack as="ul" class="d-ps-relative d-m-50 d-px-0">
-        <dt-list-item
-          v-for="(item, i) in maxSelectItems"
-          :key="item.id"
-          role="option"
-          navigation-type="arrow-keys"
-          @click="onMaxSelectSelect(i)"
-        >
-          {{ item.value }}
-          <template #right>
-            <span class="d-fc-secondary">{{ item.type }}</span>
-          </template>
-        </dt-list-item>
-      </dt-stack>
-    </template>
-  </dt-combobox-multi-select>
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/combobox-with-popover.md
+++ b/apps/dialtone-documentation/docs/components/combobox-with-popover.md
@@ -6,41 +6,41 @@ thumb: true
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-combobox-with-popover--default
 ---
 
-<code-example>
-  <dt-combobox-with-popover
-    label="Label Text"
-    :show-list="showList"
-    content-width="anchor"
-    max-height="300px"
-    @select="onSelect"
-    @opened="onOpened"
-  >
-    <template #input="{ inputProps, onInput }">
-      <dt-input
-        v-model="inputValue"
-        placeholder="Select one or start typing"
-        v-bind="inputProps"
-        @input="onInput"
-      />
-    </template>
-    <template #list="{ listProps }">
-      <ul v-bind="listProps" class="d-p-50">
-        <dt-list-item
-          v-for="(item, i) in items"
-          :key="item.id"
-          role="option"
-          navigation-type="arrow-keys"
-          @click="onSelect(i)"
-        >
-          {{ item.number }}
-          <template #right>
-            <span class="d-fc-secondary">{{ item.type }}</span>
-          </template>
-        </dt-list-item>
-      </ul>
-    </template>
-  </dt-combobox-with-popover>
-</code-example>
+```vue demo
+<dt-combobox-with-popover
+  label="Label Text"
+  :show-list="showList"
+  content-width="anchor"
+  max-height="300px"
+  @select="onSelect"
+  @opened="onOpened"
+>
+  <template #input="{ inputProps, onInput }">
+    <dt-input
+      v-model="inputValue"
+      placeholder="Select one or start typing"
+      v-bind="inputProps"
+      @input="onInput"
+    />
+  </template>
+  <template #list="{ listProps }">
+    <ul v-bind="listProps" class="d-p-50">
+      <dt-list-item
+        v-for="(item, i) in items"
+        :key="item.id"
+        role="option"
+        navigation-type="arrow-keys"
+        @click="onSelect(i)"
+      >
+        {{ item.number }}
+        <template #right>
+          <span class="d-fc-secondary">{{ item.type }}</span>
+        </template>
+      </dt-list-item>
+    </ul>
+  </template>
+</dt-combobox-with-popover>
+```
 
 <!-- <component-combinator component-name="DtComboboxWithPopover" /> -->
 
@@ -68,75 +68,75 @@ methods: {
 
 You can add header and footer content to the popover using the `header` and `footer` slots.
 
-<code-example>
-  <dt-combobox-with-popover
-    label="Label Text"
-    :show-list="showListHeaderFooter"
-    content-width="anchor"
-    max-height="300px"
-    @select="onSelectHeaderFooter"
-    @opened="onOpenedHeaderFooter"
-  >
-    <template #header>
-      <div class="d-px-150 d-py-100 d-fw-semibold">Select an option</div>
-    </template>
-    <template #input="{ inputProps, onInput }">
-      <dt-input
-        v-model="inputValueHeaderFooter"
-        placeholder="Select one or start typing"
-        v-bind="inputProps"
-        @input="onInput"
-      />
-    </template>
-    <template #list="{ listProps }">
-      <ul v-bind="listProps" class="d-p-50">
-        <dt-list-item
-          v-for="(item, i) in items"
-          :key="item.id"
-          role="option"
-          navigation-type="arrow-keys"
-          @click="onSelectHeaderFooter(i)"
-        >
-          {{ item.number }}
-          <template #right>
-            <span class="d-fc-secondary">{{ item.type }}</span>
-          </template>
-        </dt-list-item>
-      </ul>
-    </template>
-    <template #footer>
-      <div class="d-px-150 d-py-100 d-fc-tertiary">Footer content</div>
-    </template>
-  </dt-combobox-with-popover>
-</code-example>
+```vue demo
+<dt-combobox-with-popover
+  label="Label Text"
+  :show-list="showListHeaderFooter"
+  content-width="anchor"
+  max-height="300px"
+  @select="onSelectHeaderFooter"
+  @opened="onOpenedHeaderFooter"
+>
+  <template #header>
+    <div class="d-px-150 d-py-100 d-fw-semibold">Select an option</div>
+  </template>
+  <template #input="{ inputProps, onInput }">
+    <dt-input
+      v-model="inputValueHeaderFooter"
+      placeholder="Select one or start typing"
+      v-bind="inputProps"
+      @input="onInput"
+    />
+  </template>
+  <template #list="{ listProps }">
+    <ul v-bind="listProps" class="d-p-50">
+      <dt-list-item
+        v-for="(item, i) in items"
+        :key="item.id"
+        role="option"
+        navigation-type="arrow-keys"
+        @click="onSelectHeaderFooter(i)"
+      >
+        {{ item.number }}
+        <template #right>
+          <span class="d-fc-secondary">{{ item.type }}</span>
+        </template>
+      </dt-list-item>
+    </ul>
+  </template>
+  <template #footer>
+    <div class="d-px-150 d-py-100 d-fc-tertiary">Footer content</div>
+  </template>
+</dt-combobox-with-popover>
+```
 
 ## Content Mode
 
 Combobox popover content renders outside the DOM tree. Use the `contentMode` prop to apply color mode (invert, light, dark) to the positioned content. See [Positioned Components](/components/mode-island.html#positioned-components) for details.
 
-<code-example vueCode='
+```vue demo
+<dt-combobox-with-popover
+  content-mode="invert"
+  label="Inverted Combobox"
+  content-width="anchor"
+  max-height="300px"
+>
+  <template #input="{ inputProps }">
+    <dt-input placeholder="Type to search..." v-bind="inputProps" />
+  </template>
+  <template #list="{ listProps }">
+    <ul v-bind="listProps">
+      <dt-list-item navigation-type="arrow-keys" role="option">Option 1</dt-list-item>
+      <dt-list-item navigation-type="arrow-keys" role="option">Option 2</dt-list-item>
+      <dt-list-item navigation-type="arrow-keys" role="option">Option 3</dt-list-item>
+    </ul>
+  </template>
+</dt-combobox-with-popover>
+<!-- @code -->
 <dt-combobox-with-popover content-mode="invert">...</dt-combobox-with-popover>
 <dt-combobox-with-popover content-mode="dark">...</dt-combobox-with-popover>
 <dt-combobox-with-popover content-mode="light">...</dt-combobox-with-popover>
-'>
-  <dt-combobox-with-popover
-    content-mode="invert"
-    label="Inverted Combobox"
-    content-width="anchor"
-    max-height="300px"
-  >
-    <template #input="{ inputProps }">
-      <dt-input placeholder="Type to search..." v-bind="inputProps" />
-    </template>
-    <template #list="{ listProps }">
-      <ul v-bind="listProps">
-        <dt-list-item navigation-type="arrow-keys" role="option">Option 1</dt-list-item>
-        <dt-list-item navigation-type="arrow-keys" role="option">Option 2</dt-list-item>
-        <dt-list-item navigation-type="arrow-keys" role="option">Option 3</dt-list-item>
-      </ul>
-    </template>
-  </dt-combobox-with-popover>
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/combobox.md
+++ b/apps/dialtone-documentation/docs/components/combobox.md
@@ -21,73 +21,75 @@ It has 2 core required slots:
 2. `list`: the list of items to display responding to `input`'s value. Almost always this will be a list of `dt-list-item`.
 This will usually be the [List Item component](/components/list-item.md).
 
-<code-example class="d-d-block">
-  <dt-combobox
-    :show-list="!!value"
-    label="Label Text"
-    @escape="onComboboxEscape"
-    @select="onComboboxSelect"
+```vue demo
+<!-- @class d-d-block -->
+<dt-combobox
+  :show-list="!!value"
+  label="Label Text"
+  @escape="onComboboxEscape"
+  @select="onComboboxSelect"
+>
+  <template
+    #input="{ inputProps }"
   >
-    <template
-      #input="{ inputProps }"
+    <dt-input
+      placeholder="Type to show the items"
+      v-model="value"
+      v-bind="inputProps"
+    />
+  </template>
+  <template
+    #list="{ listProps }"
+  >
+    <ol
+      v-bind="listProps"
+      class="d-p-0 d-mbs-100 d-hmx-500 d-of-y-auto"
     >
-      <dt-input
-        placeholder="Type to show the items"
-        v-model="value"
-        v-bind="inputProps"
-      />
-    </template>
-    <template
-      #list="{ listProps }"
-    >
-      <ol
-        v-bind="listProps"
-        class="d-p-0 d-mbs-100 d-hmx-500 d-of-y-auto"
+      <dt-list-item
+        v-for="(item, i) in items"
+        :key="item.id"
+        role="option"
+        navigation-type="arrow-keys"
+        @click="onListItemSelect(i)"
       >
-        <dt-list-item
-          v-for="(item, i) in items"
-          :key="item.id"
-          role="option"
-          navigation-type="arrow-keys"
-          @click="onListItemSelect(i)"
-        >
-          <template #start>
-            <dt-avatar
-              :full-name="(i + 1).toString()"
-              :seed="i.toString()"
-            />
-          </template>
-          {{ item.name }}
-        </dt-list-item>
-      </ol>
-    </template>
-  </dt-combobox>
-</code-example>
+        <template #start>
+          <dt-avatar
+            :full-name="(i + 1).toString()"
+            :seed="i.toString()"
+          />
+        </template>
+        {{ item.name }}
+      </dt-list-item>
+    </ol>
+  </template>
+</dt-combobox>
+```
 
 ## With Empty List Item
 
-<code-example class="d-d-block">
-  <dt-combobox
-    :show-list="!!value"
-    label="Label Text"
-    @escape="onComboboxEscape"
-    @select="onComboboxSelect"
-    :empty-list="true"
+```vue demo
+<!-- @class d-d-block -->
+<dt-combobox
+  :show-list="!!value"
+  label="Label Text"
+  @escape="onComboboxEscape"
+  @select="onComboboxSelect"
+  :empty-list="true"
+>
+  <template
+    #input="{ inputProps }"
   >
-    <template
-      #input="{ inputProps }"
-    >
-      <dt-input
-        placeholder="Type to show the items"
-        v-model="value"
-        v-bind="inputProps"
-      />
-    </template>
-    <template #emptyListItem>
-      <div class="d-py-100 d-fc-tertiary">No matches found.</div>
-    </template>
-  </dt-combobox>
-</code-example>
+    <dt-input
+      placeholder="Type to show the items"
+      v-model="value"
+      v-bind="inputProps"
+    />
+  </template>
+  <template #emptyListItem>
+    <div class="d-py-100 d-fc-tertiary">No matches found.</div>
+  </template>
+</dt-combobox>
+```
 
 ## Accessibility
 

--- a/apps/dialtone-documentation/docs/components/datepicker.md
+++ b/apps/dialtone-documentation/docs/components/datepicker.md
@@ -28,47 +28,54 @@ With this we accomplish the requirement to have the previous year button focused
 
 ### Default
 
-<code-example>
-  <dt-datepicker></dt-datepicker>
-</code-example>
+```vue demo
+<dt-datepicker></dt-datepicker>
+```
 
 ### With Popover
 
-<code-example>
-  <dt-popover
-    :open="datepickerOpened"
-    initial-focus-element="#prevYearButton"
-    padding="none"
-    @opened="(open) => { datepickerOpened = open }"
-    placement="bottom-start"
-  >
-    <template #anchor>
-      <dt-button
-        :size="200"
-        circle
-        importance="clear"
-        aria-label="Open datepicker"
-        @click="toggleDatepicker"
-      >
-        <template #startIcon>
-          <dt-icon
-            name="calendar"
-            size="300"
-          />
-        </template>
-      </dt-button>
-    </template>
-    <template #content>
-      <dt-datepicker></dt-datepicker>
-    </template>
-  </dt-popover>
-</code-example>
+```vue demo
+<dt-popover
+  :open="datepickerOpened"
+  initial-focus-element="#prevYearButton"
+  padding="none"
+  @opened="(open) => { datepickerOpened = open }"
+  placement="bottom-start"
+>
+  <template #anchor>
+    <dt-button
+      :size="200"
+      circle
+      importance="clear"
+      aria-label="Open datepicker"
+      @click="toggleDatepicker"
+    >
+      <template #startIcon>
+        <dt-icon
+          name="calendar"
+          size="300"
+        />
+      </template>
+    </dt-button>
+  </template>
+  <template #content>
+    <dt-datepicker></dt-datepicker>
+  </template>
+</dt-popover>
+```
 
 ### With min/max date
 
 Constrain the selectable date range by providing `min-date` and/or `max-date` props. Days outside the range are disabled and navigation buttons are disabled when the target month is fully out of range.
 
-<code-example vueCode='
+```vue demo
+<dt-datepicker
+  :selected-date="currentSelectedDate"
+  :min-date="minDate"
+  :max-date="maxDate"
+  @selected-date="currentSelectedDate = $event;"
+/>
+<!-- @code -->
 <script>
 const today = new Date();
 const minDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 5);
@@ -79,14 +86,7 @@ const maxDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() 
   :min-date="minDate"
   :max-date="maxDate"
 />
-'>
-  <dt-datepicker
-    :selected-date="currentSelectedDate"
-    :min-date="minDate"
-    :max-date="maxDate"
-    @selected-date="currentSelectedDate = $event;"
-  />
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/description-list.md
+++ b/apps/dialtone-documentation/docs/components/description-list.md
@@ -14,53 +14,57 @@ keywords: ["definition list", "key value", "dl", "d-description-list", "DtDescri
 
 ### Default
 
-<code-example>
-  <div class="d-w-500" data-demo-wrapper>
-    <dt-description-list
-      gap="100"
-      :items="items"
-      direction="row"
-    />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-500">
+  <dt-description-list
+    gap="100"
+    :items="items"
+    direction="row"
+  />
+</div>
+```
 
 ### Column Direction
 
-<code-example>
-  <div class="d-w-500" data-demo-wrapper>
-    <dt-description-list
-      gap="100"
-      :items="items"
-      direction="column"
-    />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-500">
+  <dt-description-list
+    gap="100"
+    :items="items"
+    direction="column"
+  />
+</div>
+```
 
 ### Long Text
 
-<code-example>
-  <div class="d-w-500" data-demo-wrapper>
-    <dt-description-list
-      gap="100"
-      :items="longTextItems"
-      direction="row"
-    />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-500">
+  <dt-description-list
+    gap="100"
+    :items="longTextItems"
+    direction="row"
+  />
+</div>
+```
 
 ### With Term and Description Styles
 
-<code-example>
-  <div class="d-w-500" data-demo-wrapper>
-    <dt-description-list
-      gap="100"
-      :items="items"
-      direction="row"
-      :termClass="[`d-fc-critical`, `d-fw-bold`]"
-      :descriptionClass="[`d-fc-success`]"
-    />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-500">
+  <dt-description-list
+    gap="100"
+    :items="items"
+    direction="row"
+    :termClass="[`d-fc-critical`, `d-fw-bold`]"
+    :descriptionClass="[`d-fc-success`]"
+  />
+</div>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/dropdown.md
+++ b/apps/dialtone-documentation/docs/components/dropdown.md
@@ -24,127 +24,127 @@ Use the Dropdown component when you have a list of links or actions that can be 
 
 ### Default
 
-<code-example>
-  <dt-dropdown navigation-type="arrow-keys">
-    <template #anchor="{ attrs }">
-      <dt-button v-bind="attrs">
-        Click to open
-      </dt-button>
-    </template>
-    <template #list="{ close }">
-      <dt-list-item
-        v-for="(item) in items"
-        :key="item.id"
-        role="menuitem"
-        :navigation-type="arrow-keys"
-        @click="close"
-      >
-        {{ item.name }}
-      </dt-list-item>
-    </template>
-  </dt-dropdown>
-</code-example>
+```vue demo
+<dt-dropdown navigation-type="arrow-keys">
+  <template #anchor="{ attrs }">
+    <dt-button v-bind="attrs">
+      Click to open
+    </dt-button>
+  </template>
+  <template #list="{ close }">
+    <dt-list-item
+      v-for="(item) in items"
+      :key="item.id"
+      role="menuitem"
+      :navigation-type="arrow-keys"
+      @click="close"
+    >
+      {{ item.name }}
+    </dt-list-item>
+  </template>
+</dt-dropdown>
+```
 
 ### With Sections and Headings
 
-<code-example>
-  <dt-dropdown navigation-type="arrow-keys">
-    <template #anchor="{ attrs }">
-      <dt-button v-bind="attrs">
-        Click to open
-      </dt-button>
-    </template>
-    <template #list="{ close }">
-      <dt-list-item-group
-        heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
-        heading="Menu Heading A"
+```vue demo
+<dt-dropdown navigation-type="arrow-keys">
+  <template #anchor="{ attrs }">
+    <dt-button v-bind="attrs">
+      Click to open
+    </dt-button>
+  </template>
+  <template #list="{ close }">
+    <dt-list-item-group
+      heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
+      heading="Menu Heading A"
+    >
+      <dt-list-item
+        role="menuitem"
+        navigation-type="arrow-keys"
+        @click="close"
       >
-        <dt-list-item
-          role="menuitem"
-          navigation-type="arrow-keys"
-          @click="close"
-        >
-          Menu Item 1
-        </dt-list-item>
-        <dt-dropdown-separator />
-        <dt-list-item
-          role="menuitem"
-          navigation-type="arrow-keys"
-          @click="close"
-        >
-          Menu Item 2
-        </dt-list-item>
-      </dt-list-item-group>
+        Menu Item 1
+      </dt-list-item>
       <dt-dropdown-separator />
-      <dt-list-item-group
-        heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
-        heading="Menu Heading B"
+      <dt-list-item
+        role="menuitem"
+        navigation-type="arrow-keys"
+        @click="close"
       >
-        <dt-list-item
-          role="menuitem"
-          navigation-type="arrow-keys"
-          @click="close"
-        >
-          Menu Item 3
-        </dt-list-item>
-      </dt-list-item-group>
-    </template>
-  </dt-dropdown>
-</code-example>
+        Menu Item 2
+      </dt-list-item>
+    </dt-list-item-group>
+    <dt-dropdown-separator />
+    <dt-list-item-group
+      heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
+      heading="Menu Heading B"
+    >
+      <dt-list-item
+        role="menuitem"
+        navigation-type="arrow-keys"
+        @click="close"
+      >
+        Menu Item 3
+      </dt-list-item>
+    </dt-list-item-group>
+  </template>
+</dt-dropdown>
+```
 
 ### Context Menu
 
 Set `openOnContext=true` to open the menu on right-click (context menu) and disable the default trigger behavior.
 
-<code-example>
-  <dt-dropdown navigation-type="arrow-keys" :open-on-context="true">
-    <template #anchor="{ attrs }">
-      <div
-        v-bind="attrs"
-        class="d-ba d-bas-dashed d-w-400 d-py-600 d-ta-center d-bgc-black-300"
-      >
-        Right click to open
-      </div>
-    </template>
-    <template #list="{ close }">
-      <dt-list-item
-        v-for="(item) in items"
-        :key="item.id"
-        role="menuitem"
-        :navigation-type="arrow-keys"
-        @click="close"
-      >
-        {{ item.name }}
-      </dt-list-item>
-    </template>
-  </dt-dropdown>
-</code-example>
+```vue demo
+<dt-dropdown navigation-type="arrow-keys" :open-on-context="true">
+  <template #anchor="{ attrs }">
+    <div
+      v-bind="attrs"
+      class="d-ba d-bas-dashed d-w-400 d-py-600 d-ta-center d-bgc-black-300"
+    >
+      Right click to open
+    </div>
+  </template>
+  <template #list="{ close }">
+    <dt-list-item
+      v-for="(item) in items"
+      :key="item.id"
+      role="menuitem"
+      :navigation-type="arrow-keys"
+      @click="close"
+    >
+      {{ item.name }}
+    </dt-list-item>
+  </template>
+</dt-dropdown>
+```
 
 ## Content Mode
 
 Dropdown content renders outside the DOM tree. Use the `contentMode` prop to apply color mode (invert, light, dark) to the positioned content. See [Positioned Components](/components/mode-island.html#positioned-components) for details.
 
-<code-example vueCode='
+```vue demo
+<dt-dropdown content-mode="invert" navigation-type="arrow-keys" placement="bottom-start">
+  <template #anchor="{ attrs }">
+    <dt-button v-bind="attrs" :size="200" kind="muted" importance="outlined">
+      Inverted Dropdown
+      <template #endIcon="{ iconSize }">
+        <dt-icon name="chevron-down" :size="iconSize" />
+      </template>
+    </dt-button>
+  </template>
+  <template #list="{ close }">
+    <dt-list-item role="menuitem" @click="close">Option 1</dt-list-item>
+    <dt-list-item role="menuitem" @click="close">Option 2</dt-list-item>
+    <dt-list-item role="menuitem" @click="close">Option 3</dt-list-item>
+  </template>
+</dt-dropdown>
+<!-- @code -->
 <dt-dropdown content-mode="invert">...</dt-dropdown>
 <dt-dropdown content-mode="dark">...</dt-dropdown>
 <dt-dropdown content-mode="light">...</dt-dropdown>
-'>
-  <dt-dropdown content-mode="invert" navigation-type="arrow-keys" placement="bottom-start">
-    <template #anchor="{ attrs }">
-      <dt-button v-bind="attrs" :size="200" kind="muted" importance="outlined">
-        Inverted Dropdown
-        <template #endIcon="{ iconSize }">
-          <dt-icon name="chevron-down" :size="iconSize" />
-        </template>
-      </dt-button>
-    </template>
-    <template #list="{ close }">
-      <dt-list-item role="menuitem" @click="close">Option 1</dt-list-item>
-      <dt-list-item role="menuitem" @click="close">Option 2</dt-list-item>
-      <dt-list-item role="menuitem" @click="close">Option 3</dt-list-item>
-    </template>
-  </dt-dropdown>
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/emoji-picker.md
+++ b/apps/dialtone-documentation/docs/components/emoji-picker.md
@@ -13,7 +13,27 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-emoji-picker
 
 ### Default
 
-<code-example vueCode='
+```vue demo
+<dt-emoji-picker
+  skin-tone="Default"
+  skin-selector-button-tooltip-label="Change default skin tone"
+  :tab-set-labels="[
+    'Most recently used',
+    'Smileys and people',
+    'Nature',
+    'Food',
+    'Activity',
+    'Travel',
+    'Objects',
+    'Symbols',
+    'Flags',
+  ]"
+  :recently-used-emojis="recentlyUsedEmojis"
+  search-results-label="Search results"
+  search-no-results-label="No results"
+  search-placeholder-label="Search..."
+/>
+<!-- @code -->
 <dt-emoji-picker
   :skin-tone="Default"
   skin-selector-button-tooltip-label="Change default skin tone"
@@ -40,75 +60,55 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-emoji-picker
   @skin-tone="skinTone = $event"
   @selected-emoji="selectedEmoji"
 />
-'>
-  <dt-emoji-picker
-    skin-tone="Default"
-    skin-selector-button-tooltip-label="Change default skin tone"
-    :tab-set-labels="[
-      'Most recently used',
-      'Smileys and people',
-      'Nature',
-      'Food',
-      'Activity',
-      'Travel',
-      'Objects',
-      'Symbols',
-      'Flags',
-    ]"
-    :recently-used-emojis="recentlyUsedEmojis"
-    search-results-label="Search results"
-    search-no-results-label="No results"
-    search-placeholder-label="Search..."
-  />
-</code-example>
+```
 
 ### With Popover
 
-<code-example>
-  <dt-popover
-    :open="emojiPickerOpened"
-    initial-focus-element="#searchInput"
-    padding="none"
-    @opened="(open) => { emojiPickerOpened = open }"
-  >
-    <template #anchor>
-      <dt-button
-        :size="200"
-        circle
-        importance="clear"
-        @click="toggleEmojiPicker"
-      >
-        <template #startIcon>
-          <dt-icon
-            name="satisfied"
-            size="300"
-          />
-        </template>
-      </dt-button>
-    </template>
-    <template #content>
-      <dt-emoji-picker
-        skin-tone="Default"
-        skin-selector-button-tooltip-label="Change default skin tone"
-        :tab-set-labels="[
-          'Most recently used',
-          'Smileys and people',
-          'Nature',
-          'Food',
-          'Activity',
-          'Travel',
-          'Objects',
-          'Symbols',
-          'Flags',
-        ]"
-        :recently-used-emojis="recentlyUsedEmojis"
-        search-results-label="Search results"
-        search-no-results-label="No results"
-        search-placeholder-label="Search..."
-      />
-    </template>
-  </dt-popover>
-</code-example>
+```vue demo
+<dt-popover
+  :open="emojiPickerOpened"
+  initial-focus-element="#searchInput"
+  padding="none"
+  @opened="(open) => { emojiPickerOpened = open }"
+>
+  <template #anchor>
+    <dt-button
+      :size="200"
+      circle
+      importance="clear"
+      @click="toggleEmojiPicker"
+    >
+      <template #startIcon>
+        <dt-icon
+          name="satisfied"
+          size="300"
+        />
+      </template>
+    </dt-button>
+  </template>
+  <template #content>
+    <dt-emoji-picker
+      skin-tone="Default"
+      skin-selector-button-tooltip-label="Change default skin tone"
+      :tab-set-labels="[
+        'Most recently used',
+        'Smileys and people',
+        'Nature',
+        'Food',
+        'Activity',
+        'Travel',
+        'Objects',
+        'Symbols',
+        'Flags',
+      ]"
+      :recently-used-emojis="recentlyUsedEmojis"
+      search-results-label="Search results"
+      search-no-results-label="No results"
+      search-placeholder-label="Search..."
+    />
+  </template>
+</dt-popover>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/emoji-text-wrapper.md
+++ b/apps/dialtone-documentation/docs/components/emoji-text-wrapper.md
@@ -8,13 +8,13 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-emoji-text-w
 keywords: ["emoji support","emoticon wrapper","d-emoji-text-wrapper","DtEmojiTextWrapper","dt-emoji-text-wrapper"]
 ---
 
-<code-example only-show="demo">
-  <dt-text kind="body" :size="300">
-    <dt-emoji-text-wrapper>
-      Some text with :invalid-emoji: :smile: :cry: and 😄, and custom emojis :octocat: :shipit:
-    </dt-emoji-text-wrapper>
-  </dt-text>
-</code-example>
+```vue demo-only
+<dt-text kind="body" :size="300">
+  <dt-emoji-text-wrapper>
+    Some text with :invalid-emoji: :smile: :cry: and 😄, and custom emojis :octocat: :shipit:
+  </dt-emoji-text-wrapper>
+</dt-text>
+```
 
 <!-- <component-combinator component-name="DtEmojiTextWrapper" /> -->
 
@@ -22,45 +22,46 @@ keywords: ["emoji support","emoticon wrapper","d-emoji-text-wrapper","DtEmojiTex
 
 ### Text Only
 
-<code-example>
-  <dt-text kind="body" :size="300">
-    <dt-emoji-text-wrapper>
-      Some text with :invalid-emoji: :smile: :cry: and 😄, and custom emojis :octocat: :shipit:
-    </dt-emoji-text-wrapper>
-  </dt-text>
-</code-example>
+```vue demo
+<dt-text kind="body" :size="300">
+  <dt-emoji-text-wrapper>
+    Some text with :invalid-emoji: :smile: :cry: and 😄, and custom emojis :octocat: :shipit:
+  </dt-emoji-text-wrapper>
+</dt-text>
+```
 
 ### Variants
 
-<code-example>
-  <dt-stack gap="200" data-demo-wrapper>
-    <dt-button>
-      <dt-emoji-text-wrapper>
-        Button with shortcode :cry: emoji
-      </dt-emoji-text-wrapper>
-    </dt-button>
-    <dt-text kind="body" :size="300">
-      <dt-emoji-text-wrapper>
-        Text only with unicode 😃 emoji
-      </dt-emoji-text-wrapper>
-    </dt-text>
-    <dt-button>
-      <dt-emoji-text-wrapper>
-        Button wrapper :smile:
-      </dt-emoji-text-wrapper>
-    </dt-button>
-    <dt-text kind="body" :size="300">
-      <dt-emoji-text-wrapper size="800">
-        Bigger emoji size :smile:
-      </dt-emoji-text-wrapper>
-    </dt-text>
-    <dt-text kind="body" :size="300">
-      <dt-emoji-text-wrapper size="300">
-        Smaller emoji size :smile:
-      </dt-emoji-text-wrapper>
-    </dt-text>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="200">
+  <dt-button>
+    <dt-emoji-text-wrapper>
+      Button with shortcode :cry: emoji
+    </dt-emoji-text-wrapper>
+  </dt-button>
+  <dt-text kind="body" :size="300">
+    <dt-emoji-text-wrapper>
+      Text only with unicode 😃 emoji
+    </dt-emoji-text-wrapper>
+  </dt-text>
+  <dt-button>
+    <dt-emoji-text-wrapper>
+      Button wrapper :smile:
+    </dt-emoji-text-wrapper>
+  </dt-button>
+  <dt-text kind="body" :size="300">
+    <dt-emoji-text-wrapper size="800">
+      Bigger emoji size :smile:
+    </dt-emoji-text-wrapper>
+  </dt-text>
+  <dt-text kind="body" :size="300">
+    <dt-emoji-text-wrapper size="300">
+      Smaller emoji size :smile:
+    </dt-emoji-text-wrapper>
+  </dt-text>
+</dt-stack>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/emoji.md
+++ b/apps/dialtone-documentation/docs/components/emoji.md
@@ -15,31 +15,31 @@ keywords: ["emoticon","smiley","d-emoji","DtEmoji","dt-emoji"]
 
 ### With Shortcode
 
-<code-example>
-  <dt-emoji code=":smile:" size="500" />
-</code-example>
+```vue demo
+<dt-emoji code=":smile:" size="500" />
+```
 
 ### With Unicode
 
-<code-example>
-  <dt-emoji code="😉" />
-</code-example>
+```vue demo
+<dt-emoji code="😉" />
+```
 
 ### With Skin Tone
 
-<code-example>
-  <dt-emoji code=":raised_hand_tone4:" />
-</code-example>
+```vue demo
+<dt-emoji code=":raised_hand_tone4:" />
+```
 
 ### Sizes
 
-<code-example vueCode='
+```vue demo
+<dt-stack direction="row" gap="100" align="center">
+  <dt-emoji v-for="size in sizes" :size="size" code=":smile:" />
+</dt-stack>
+<!-- @code -->
 <dt-emoji size="100|200|300|400|500|600|700|800" code=":smile:" />
-'>
-  <dt-stack direction="row" gap="100" align="center">
-    <dt-emoji v-for="size in sizes" :size="size" code=":smile:" />
-  </dt-stack>
-</code-example>
+```
 
 ## Vue API
 
@@ -74,9 +74,9 @@ setCustomEmojiUrl('https://my.example.website.com/images/icons/emoji/');
 setCustomEmojiJson(customEmojiJson);
 ```
 
-<code-example>
-  <dt-emoji code=":shipit:" />
-</code-example>
+```vue demo
+<dt-emoji code=":shipit:" />
+```
 
 In this example, the emoji with the :shipit: shortcode from the custom emoji provided will be rendered. Take into account that a custom emoji can only be referenced by the shortcode as no Unicode character is associated with it.
 

--- a/apps/dialtone-documentation/docs/components/empty-state.md
+++ b/apps/dialtone-documentation/docs/components/empty-state.md
@@ -138,167 +138,167 @@ A few rules to keep in nothing-to-see-here when choosing a size variant.
 
 ### Large with Illustration
 
-<code-example>
-  <dt-empty-state
-    header-text="Nothing to see here"
-    body-text="Looks like there is no data to display here."
-  >
-    <template #body>
-      <dt-stack direction="row" gap="50">
-        <dt-button importance="clear">Action</dt-button>
-        <dt-button>Action</dt-button>
-      </dt-stack>
-    </template>
-    <template #illustration>
-      <dt-illustration-nothing-to-see-here></dt-illustration-nothing-to-see-here>
-    </template>
-  </dt-empty-state>
-</code-example>
+```vue demo
+<dt-empty-state
+  header-text="Nothing to see here"
+  body-text="Looks like there is no data to display here."
+>
+  <template #body>
+    <dt-stack direction="row" gap="50">
+      <dt-button importance="clear">Action</dt-button>
+      <dt-button>Action</dt-button>
+    </dt-stack>
+  </template>
+  <template #illustration>
+    <dt-illustration-nothing-to-see-here></dt-illustration-nothing-to-see-here>
+  </template>
+</dt-empty-state>
+```
 
 ### Large with Icon
 
-<code-example>
-  <dt-empty-state
-    header-text="Nothing to see here"
-    body-text="Looks like there is no data to display here."
-  >
-    <template #body>
-      <dt-stack direction="row" gap="50">
-        <dt-button importance="clear">Action</dt-button>
-        <dt-button>Action</dt-button>
-      </dt-stack>
-    </template>
-    <template #icon="{ iconSize }">
-      <dt-icon-box :size="iconSize"></dt-icon-box>
-    </template>
-  </dt-empty-state>
-</code-example>
+```vue demo
+<dt-empty-state
+  header-text="Nothing to see here"
+  body-text="Looks like there is no data to display here."
+>
+  <template #body>
+    <dt-stack direction="row" gap="50">
+      <dt-button importance="clear">Action</dt-button>
+      <dt-button>Action</dt-button>
+    </dt-stack>
+  </template>
+  <template #icon="{ iconSize }">
+    <dt-icon-box :size="iconSize"></dt-icon-box>
+  </template>
+</dt-empty-state>
+```
 
 ### Medium with Illustration
 
-<code-example>
-  <dt-empty-state
-    :size="300"
-    header-text="Nothing to see here"
-    body-text="Looks like there is no data to display here."
-  >
-    <template #body>
-      <dt-stack direction="row" gap="50">
-        <dt-button importance="clear">Action</dt-button>
-        <dt-button>Action</dt-button>
-      </dt-stack>
-    </template>
-    <template #illustration>
-      <dt-illustration-nothing-to-see-here></dt-illustration-nothing-to-see-here>
-    </template>
-  </dt-empty-state>
-</code-example>
+```vue demo
+<dt-empty-state
+  :size="300"
+  header-text="Nothing to see here"
+  body-text="Looks like there is no data to display here."
+>
+  <template #body>
+    <dt-stack direction="row" gap="50">
+      <dt-button importance="clear">Action</dt-button>
+      <dt-button>Action</dt-button>
+    </dt-stack>
+  </template>
+  <template #illustration>
+    <dt-illustration-nothing-to-see-here></dt-illustration-nothing-to-see-here>
+  </template>
+</dt-empty-state>
+```
 
 ### Medium with Icon
 
-<code-example>
-  <dt-empty-state
-    :size="300"
-    header-text="Nothing to see here"
-    body-text="Looks like there is no data to display here."
-  >
-    <template #body>
-      <dt-stack direction="row" gap="50">
-        <dt-button importance="clear">Action</dt-button>
-        <dt-button>Action</dt-button>
-      </dt-stack>
-    </template>
-    <template #icon="{ iconSize }">
-      <dt-icon-box :size="iconSize"></dt-icon-box>
-    </template>
-  </dt-empty-state>
-</code-example>
+```vue demo
+<dt-empty-state
+  :size="300"
+  header-text="Nothing to see here"
+  body-text="Looks like there is no data to display here."
+>
+  <template #body>
+    <dt-stack direction="row" gap="50">
+      <dt-button importance="clear">Action</dt-button>
+      <dt-button>Action</dt-button>
+    </dt-stack>
+  </template>
+  <template #icon="{ iconSize }">
+    <dt-icon-box :size="iconSize"></dt-icon-box>
+  </template>
+</dt-empty-state>
+```
 
 ### Small
 
-<code-example>
-  <dt-empty-state
-    :size="200"
-    header-text="Nothing to see here"
-    body-text="Looks like there is no data to display here."
-  >
-    <template #body>
-      <dt-stack direction="row" gap="50">
-        <dt-button importance="clear">Action</dt-button>
-        <dt-button>Action</dt-button>
-      </dt-stack>
-    </template>
-    <template #icon="{ iconSize }">
-      <dt-icon-box :size="iconSize"></dt-icon-box>
-    </template>
-  </dt-empty-state>
-</code-example>
+```vue demo
+<dt-empty-state
+  :size="200"
+  header-text="Nothing to see here"
+  body-text="Looks like there is no data to display here."
+>
+  <template #body>
+    <dt-stack direction="row" gap="50">
+      <dt-button importance="clear">Action</dt-button>
+      <dt-button>Action</dt-button>
+    </dt-stack>
+  </template>
+  <template #icon="{ iconSize }">
+    <dt-icon-box :size="iconSize"></dt-icon-box>
+  </template>
+</dt-empty-state>
+```
 
 ## Examples
 
 ### No Actions
 
-<code-example>
-  <dt-empty-state
-    header-text="Nothing to see here"
-    body-text="Looks like there is no data to display here."
-  >
-    <template #illustration>
-      <dt-illustration-nothing-to-see-here></dt-illustration-nothing-to-see-here>
-    </template>
-  </dt-empty-state>
-</code-example>
+```vue demo
+<dt-empty-state
+  header-text="Nothing to see here"
+  body-text="Looks like there is no data to display here."
+>
+  <template #illustration>
+    <dt-illustration-nothing-to-see-here></dt-illustration-nothing-to-see-here>
+  </template>
+</dt-empty-state>
+```
 
 ### No Description
 
-<code-example>
-  <dt-empty-state
-    header-text="Nothing to see here"
-  >
-    <template #illustration>
-      <dt-illustration-nothing-to-see-here></dt-illustration-nothing-to-see-here>
-    </template>
-  </dt-empty-state>
-</code-example>
+```vue demo
+<dt-empty-state
+  header-text="Nothing to see here"
+>
+  <template #illustration>
+    <dt-illustration-nothing-to-see-here></dt-illustration-nothing-to-see-here>
+  </template>
+</dt-empty-state>
+```
 
 ### Everything
 
-<code-example>
-  <dt-empty-state
-    header-text="Nothing to see here"
-    body-text="Looks like there is no data to display here."
-  >
-    <template #body>
-      <dt-stack direction="row" gap="50">
-        <dt-button importance="clear">Action</dt-button>
-        <dt-button>Action</dt-button>
-      </dt-stack>
-    </template>
-    <template #illustration>
-      <dt-illustration-nothing-to-see-here></dt-illustration-nothing-to-see-here>
-    </template>
-  </dt-empty-state>
-</code-example>
+```vue demo
+<dt-empty-state
+  header-text="Nothing to see here"
+  body-text="Looks like there is no data to display here."
+>
+  <template #body>
+    <dt-stack direction="row" gap="50">
+      <dt-button importance="clear">Action</dt-button>
+      <dt-button>Action</dt-button>
+    </dt-stack>
+  </template>
+  <template #illustration>
+    <dt-illustration-nothing-to-see-here></dt-illustration-nothing-to-see-here>
+  </template>
+</dt-empty-state>
+```
 
 ### Small, with Muted Actions
 
-<code-example>
-  <dt-empty-state
-    :size="200"
-    header-text="Nothing to see here"
-    body-text="Looks like there is no data to display here."
-  >
-    <template #body>
-      <dt-stack direction="row" gap="50">
-        <dt-button kind="muted" :size="200" importance="clear">Action</dt-button>
-        <dt-button kind="muted" importance="outlined" :size="200">Action</dt-button>
-      </dt-stack>
-    </template>
-    <template #icon="{ iconSize }">
-      <dt-icon-box :size="iconSize"></dt-icon-box>
-    </template>
-  </dt-empty-state>
-</code-example>
+```vue demo
+<dt-empty-state
+  :size="200"
+  header-text="Nothing to see here"
+  body-text="Looks like there is no data to display here."
+>
+  <template #body>
+    <dt-stack direction="row" gap="50">
+      <dt-button kind="muted" :size="200" importance="clear">Action</dt-button>
+      <dt-button kind="muted" importance="outlined" :size="200">Action</dt-button>
+    </dt-stack>
+  </template>
+  <template #icon="{ iconSize }">
+    <dt-icon-box :size="iconSize"></dt-icon-box>
+  </template>
+</dt-empty-state>
+```
 
 ## Writing Guidelines
 

--- a/apps/dialtone-documentation/docs/components/filter-pill.md
+++ b/apps/dialtone-documentation/docs/components/filter-pill.md
@@ -7,60 +7,60 @@ status: beta
 keywords: ["filter tag", "filter chip", "search filter", "d-filter-pill", "DtFilterPill", "dt-filter-pill", "removable tag", "dismissible chip"]
 ---
 
-<code-example only-show="demo">
-  <dt-stack direction="row" gap="100">
-    <dt-filter-pill
-      :model-value="[{name: 'Address', active: true}, {name: 'Call Purpose', active: true}, {name: 'Action Item'}, {name: 'Negative Sentiment'}, {name: 'Warranty Inquiry', active: true}]"
-      label="Moment"
-      end-tooltip-text="Remove"
-    >
-      <template #default="{ label, filters, activeFilters }">
-        {{ label }}<template v-if="activeFilters.length">:
-        <strong>
-          {{ activeFilters.length === filters.length ? 'All' : activeFilters.length }}
-        </strong></template>
-      </template>
-    </dt-filter-pill>
-    <dt-filter-pill
-      v-model="heroConversationTypes"
-      :start-tooltip-text="selectedHeroConversationType !== 'All Conversations'
+```vue demo-only
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    :model-value="[{name: 'Address', active: true}, {name: 'Call Purpose', active: true}, {name: 'Action Item'}, {name: 'Negative Sentiment'}, {name: 'Warranty Inquiry', active: true}]"
+    label="Moment"
+    end-tooltip-text="Remove"
+  >
+    <template #default="{ label, filters, activeFilters }">
+      {{ label }}<template v-if="activeFilters.length">:
+      <strong>
+        {{ activeFilters.length === filters.length ? 'All' : activeFilters.length }}
+      </strong></template>
+    </template>
+  </dt-filter-pill>
+  <dt-filter-pill
+    v-model="heroConversationTypes"
+    :start-tooltip-text="selectedHeroConversationType !== 'All Conversations'
+      ? 'Conversation type'
+      : ''"
+    end-tooltip-text="Remove"
+    use-dropdown
+    @clear="resetHeroConversationType"
+  >
+    <template #default>
+      {{ selectedHeroConversationType === 'All Conversations'
         ? 'Conversation type'
-        : ''"
-      end-tooltip-text="Remove"
-      use-dropdown
-      @clear="resetHeroConversationType"
-    >
-      <template #default>
-        {{ selectedHeroConversationType === 'All Conversations'
-          ? 'Conversation type'
-          : selectedHeroConversationType }}
-      </template>
-      <template #content="{ close }">
-        <dt-list-item
-          v-for="filter in heroConversationTypes"
-          :key="filter.name"
-          role="menuitem"
-          navigation-type="arrow-keys"
-          :selected="filter.name === selectedHeroConversationType"
-          @click="selectHeroConversationType(filter.name, close)"
-        >
-          {{ filter.name }}
-        </dt-list-item>
-      </template>
-    </dt-filter-pill>
-    <dt-filter-pill
-      :model-value="[{name: 'Email'}, {name: 'Phone', active: true}, {name: 'Chat'}, {name: 'Social'}, {name: 'SMS'}]"
-      label="Channel"
-      end-tooltip-text="Remove"
-      popover-footer-class="d-pie-200 d-py-150"
-      defer-selection
-    >
-    </dt-filter-pill>
-    <dt-button :size="200" kind="muted" importance="outlined" :disabled="!heroHasActiveFilters" @click="resetHeroFilters">
-      Reset
-    </dt-button>
-  </dt-stack>
-</code-example>
+        : selectedHeroConversationType }}
+    </template>
+    <template #content="{ close }">
+      <dt-list-item
+        v-for="filter in heroConversationTypes"
+        :key="filter.name"
+        role="menuitem"
+        navigation-type="arrow-keys"
+        :selected="filter.name === selectedHeroConversationType"
+        @click="selectHeroConversationType(filter.name, close)"
+      >
+        {{ filter.name }}
+      </dt-list-item>
+    </template>
+  </dt-filter-pill>
+  <dt-filter-pill
+    :model-value="[{name: 'Email'}, {name: 'Phone', active: true}, {name: 'Chat'}, {name: 'Social'}, {name: 'SMS'}]"
+    label="Channel"
+    end-tooltip-text="Remove"
+    popover-footer-class="d-pie-200 d-py-150"
+    defer-selection
+  >
+  </dt-filter-pill>
+  <dt-button :size="200" kind="muted" importance="outlined" :disabled="!heroHasActiveFilters" @click="resetHeroFilters">
+    Reset
+  </dt-button>
+</dt-stack>
+```
 
 <component-combinator component-name="DtFilterPill" />
 
@@ -96,66 +96,72 @@ keywords: ["filter tag", "filter chip", "search filter", "d-filter-pill", "DtFil
 
 ### Base
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-filter-pill
-      :model-value="[{name: 'Email'}, {name: 'Phone'}, {name: 'Chat'}, {name: 'Social'}, {name: 'SMS'}]"
-      label="Channel"
-    >
-    </dt-filter-pill>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    :model-value="[{name: 'Email'}, {name: 'Phone'}, {name: 'Chat'}, {name: 'Social'}, {name: 'SMS'}]"
+    label="Channel"
+  >
+  </dt-filter-pill>
+</dt-stack>
+```
 
 ### Active
 
 The pill becomes active when any filter item has `active: true`.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-filter-pill
-      :model-value="[{name: 'Headquarters', active: true}, {name: 'Westside'}, {name: 'Downtown'}]"
-      label="Contact centers"
-    >
-    </dt-filter-pill>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    :model-value="[{name: 'Headquarters', active: true}, {name: 'Westside'}, {name: 'Downtown'}]"
+    label="Contact centers"
+  >
+  </dt-filter-pill>
+</dt-stack>
+```
 
 ### Disabled
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-filter-pill label="Conversation type" disabled></dt-filter-pill>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill label="Conversation type" disabled></dt-filter-pill>
+</dt-stack>
+```
 
 ### Read only
 
 Its value is reflected in the filter set but cannot be opened, cleared, or modified. Functionally and visually distinct from disabled.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-filter-pill
-      :model-value="[{name: 'Headquarters', active: true}, {name: 'Westside', active: true}, {name: 'Downtown'}]"
-      label="Contact centers"
-      read-only
-    ></dt-filter-pill>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    :model-value="[{name: 'Headquarters', active: true}, {name: 'Westside', active: true}, {name: 'Downtown'}]"
+    label="Contact centers"
+    read-only
+  ></dt-filter-pill>
+</dt-stack>
+```
 
 ### Size
 
 `200` (small) is the default.
 
-<code-example vueCode='<dt-filter-pill label="{size}" size="{size}" />'>
-  <dt-stack direction="row" gap="100">
-    <dt-filter-pill
-      v-for="size in sizes"
-      :key="size"
-      :label="size"
-      :size="size"
-    ></dt-filter-pill>
-  </dt-stack>
-</code-example>
+```vue demo
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    v-for="size in sizes"
+    :key="size"
+    :label="size"
+    :size="size"
+  ></dt-filter-pill>
+</dt-stack>
+<!-- @code -->
+<dt-filter-pill label="{size}" size="{size}" />
+```
 
 ## Interaction patterns
 
@@ -163,49 +169,52 @@ Its value is reflected in the filter set but cannot be opened, cleared, or modif
 
 A clear button appears when any filter is active. It emits the `reset` event when clicked.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-filter-pill
-      label="Channel"
-      :model-value="[{ name: 'Option 1' }, { name: 'Option 2', active: true }, { name: 'Option 3' }]"
-      end-tooltip-text="Remove"
-    >
-    </dt-filter-pill>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    label="Channel"
+    :model-value="[{ name: 'Option 1' }, { name: 'Option 2', active: true }, { name: 'Option 3' }]"
+    end-tooltip-text="Remove"
+  >
+  </dt-filter-pill>
+</dt-stack>
+```
 
 ### Non clearable
 
 Setting the `hide-clear` prop hides the reset/clear button.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-filter-pill
-      :model-value="[{name: '0–5 min', active: true}, {name: '5–15 min'}, {name: '15–30 min'}, {name: '30+ min'}]"
-      label="Duration"
-      hide-clear
-    >
-    </dt-filter-pill>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    :model-value="[{name: '0–5 min', active: true}, {name: '5–15 min'}, {name: '15–30 min'}, {name: '30+ min'}]"
+    label="Duration"
+    hide-clear
+  >
+  </dt-filter-pill>
+</dt-stack>
+```
 
 ### Defer selection
 
 Setting `defer-selection` holds checkbox changes in a pending state until Apply is clicked.
 Cancel, Escape, or clicking outside discards pending changes.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-filter-pill
-      :model-value="[{name: 'Email'}, {name: 'Phone', active: true}, {name: 'Chat'}, {name: 'Social'}, {name: 'SMS'}]"
-      label="Channel"
-      end-tooltip-text="Remove"
-      defer-selection
-      popover-footer-class="d-pie-200 d-py-150"
-    >
-    </dt-filter-pill>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    :model-value="[{name: 'Email'}, {name: 'Phone', active: true}, {name: 'Chat'}, {name: 'Social'}, {name: 'SMS'}]"
+    label="Channel"
+    end-tooltip-text="Remove"
+    defer-selection
+    popover-footer-class="d-pie-200 d-py-150"
+  >
+  </dt-filter-pill>
+</dt-stack>
+```
 
 ### Dropdown
 
@@ -213,7 +222,38 @@ Setting `use-dropdown` switches the overlay from a popover to a dropdown with ke
 list items. This provides arrow key navigation, highlight management, and Enter/Space selection
 out of the box — ideal for single-select filter patterns.
 
-<code-example vueCode='<dt-filter-pill
+```vue demo
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    v-model="dropdownTypes"
+    :start-tooltip-text="selectedDropdownType !== 'All Conversations'
+      ? 'Conversation type'
+      : ''"
+    end-tooltip-text="Remove"
+    use-dropdown
+    @clear="resetDropdownType"
+  >
+    <template #default>
+      {{ selectedDropdownType === 'All Conversations'
+        ? 'Conversation type'
+        : selectedDropdownType }}
+    </template>
+    <template #content="{ close }">
+      <dt-list-item
+        v-for="filter in dropdownTypes"
+        :key="filter.name"
+        role="menuitem"
+        navigation-type="arrow-keys"
+        :selected="filter.name === selectedDropdownType"
+        @click="selectDropdownType(filter.name, close)"
+      >
+        {{ filter.name }}
+      </dt-list-item>
+    </template>
+  </dt-filter-pill>
+</dt-stack>
+<!-- @code -->
+<dt-filter-pill
   :model-value="[{name: &apos;All Conversations&apos;}, {name: &apos;Only Calls&apos;}, {name: &apos;Only Meetings&apos;}, {name: &apos;Only Digital&apos;}]"
   :start-tooltip-text="selectedType !== &apos;All Conversations&apos;
     ? &apos;Conversation type&apos;
@@ -239,37 +279,8 @@ out of the box — ideal for single-select filter patterns.
       {{ filter.name }}
     </dt-list-item>
   </template>
-</dt-filter-pill>'>
-  <dt-stack direction="row" gap="100">
-    <dt-filter-pill
-      v-model="dropdownTypes"
-      :start-tooltip-text="selectedDropdownType !== 'All Conversations'
-        ? 'Conversation type'
-        : ''"
-      end-tooltip-text="Remove"
-      use-dropdown
-      @clear="resetDropdownType"
-    >
-      <template #default>
-        {{ selectedDropdownType === 'All Conversations'
-          ? 'Conversation type'
-          : selectedDropdownType }}
-      </template>
-      <template #content="{ close }">
-        <dt-list-item
-          v-for="filter in dropdownTypes"
-          :key="filter.name"
-          role="menuitem"
-          navigation-type="arrow-keys"
-          :selected="filter.name === selectedDropdownType"
-          @click="selectDropdownType(filter.name, close)"
-        >
-          {{ filter.name }}
-        </dt-list-item>
-      </template>
-    </dt-filter-pill>
-  </dt-stack>
-</code-example>
+</dt-filter-pill>
+```
 
 ## Slots
 
@@ -281,111 +292,115 @@ Using the `default` slot, you can override the `label` prop.
 
 Using the `default` scoped slot, you can display a count of active filters alongside the label.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-filter-pill
-      :model-value="[{name: 'Address', active: true}, {name: 'Call Purpose', active: true}, {name: 'Action Item'}, {name: 'Negative Sentiment'}, {name: 'Warranty Inquiry', active: true}]"
-      label="Contact centers"
-      end-tooltip-text="Remove"
-    >
-      <template #default="{ label, filters, activeFilters }">
-        {{ label }}<template v-if="activeFilters.length">:
-        <strong>
-          {{ activeFilters.length === filters.length ? 'All' : activeFilters.length }}
-        </strong></template>
-      </template>
-    </dt-filter-pill>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    :model-value="[{name: 'Address', active: true}, {name: 'Call Purpose', active: true}, {name: 'Action Item'}, {name: 'Negative Sentiment'}, {name: 'Warranty Inquiry', active: true}]"
+    label="Contact centers"
+    end-tooltip-text="Remove"
+  >
+    <template #default="{ label, filters, activeFilters }">
+      {{ label }}<template v-if="activeFilters.length">:
+      <strong>
+        {{ activeFilters.length === filters.length ? 'All' : activeFilters.length }}
+      </strong></template>
+    </template>
+  </dt-filter-pill>
+</dt-stack>
+```
 
 #### Example: Active filter list
 
 Shows the first active filter name using `activeFilterList`, with overflow count for remaining selections (e.g., "Email +2").
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-filter-pill
-      :model-value="[{name: 'Email', active: true}, {name: 'Phone', active: true}, {name: 'Chat', active: true}, {name: 'Social'}, {name: 'SMS'}]"
-      label="Channel"
-      end-tooltip-text="Remove"
-    >
-      <template #default="{ label, filters, activeFilters, activeFilterList, activeFilterOverflow }">
-        {{ label }}<template v-if="activeFilters.length">:
-        <strong>
-          {{ activeFilters.length === filters.length ? 'All' : activeFilterList }}
-        </strong>
-        <template v-if="activeFilterOverflow"> {{ activeFilterOverflow }}</template></template>
-      </template>
-    </dt-filter-pill>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    :model-value="[{name: 'Email', active: true}, {name: 'Phone', active: true}, {name: 'Chat', active: true}, {name: 'Social'}, {name: 'SMS'}]"
+    label="Channel"
+    end-tooltip-text="Remove"
+  >
+    <template #default="{ label, filters, activeFilters, activeFilterList, activeFilterOverflow }">
+      {{ label }}<template v-if="activeFilters.length">:
+      <strong>
+        {{ activeFilters.length === filters.length ? 'All' : activeFilterList }}
+      </strong>
+      <template v-if="activeFilterOverflow"> {{ activeFilterOverflow }}</template></template>
+    </template>
+  </dt-filter-pill>
+</dt-stack>
+```
 
 #### Example: Radio selection
 
 Combining the `default` and `content` slots with a radio group creates a single-select filter.
 The label updates to show the selected option, and a clear button resets to the default.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-filter-pill
-      :model-value="[{name: 'All Conversations'}, {name: 'Only Calls'}, {name: 'Only Meetings'}, {name: 'Only Digital'}]"
-      :start-tooltip-text="selectedConversationType !== 'All Conversations'
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    :model-value="[{name: 'All Conversations'}, {name: 'Only Calls'}, {name: 'Only Meetings'}, {name: 'Only Digital'}]"
+    :start-tooltip-text="selectedConversationType !== 'All Conversations'
+      ? 'Conversation type'
+      : ''"
+    end-tooltip-text="Remove"
+    @clear="selectedConversationType = 'All Conversations'"
+  >
+    <template #default>
+      {{ selectedConversationType === 'All Conversations'
         ? 'Conversation type'
-        : ''"
-      end-tooltip-text="Remove"
-      @clear="selectedConversationType = 'All Conversations'"
-    >
-      <template #default>
-        {{ selectedConversationType === 'All Conversations'
-          ? 'Conversation type'
-          : selectedConversationType }}
-      </template>
-      <template #content>
-        <dt-radio-group
-          v-model="selectedConversationType"
-          name="conversation-type-doc-filter"
-        >
-          <dt-radio
-            v-for="filter in conversationTypes"
-            :key="filter.name"
-            :label="filter.name"
-            :value="filter.name"
-            @input="$event => selectedConversationType = $event"
-          />
-        </dt-radio-group>
-      </template>
-    </dt-filter-pill>
-  </dt-stack>
-</code-example>
+        : selectedConversationType }}
+    </template>
+    <template #content>
+      <dt-radio-group
+        v-model="selectedConversationType"
+        name="conversation-type-doc-filter"
+      >
+        <dt-radio
+          v-for="filter in conversationTypes"
+          :key="filter.name"
+          :label="filter.name"
+          :value="filter.name"
+          @input="$event => selectedConversationType = $event"
+        />
+      </dt-radio-group>
+    </template>
+  </dt-filter-pill>
+</dt-stack>
+```
 
 ### Content
 
 Using the `content` slot, you can override the popover content with custom markup.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-filter-pill
-      :model-value="[{name: 'Contains'}, {name: 'Starts with'}]"
-      label="Keyword"
-    >
-      <template #content>
-        Enter a keyword to filter results
-      </template>
-    </dt-filter-pill>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-filter-pill
+    :model-value="[{name: 'Contains'}, {name: 'Starts with'}]"
+    label="Keyword"
+  >
+    <template #content>
+      Enter a keyword to filter results
+    </template>
+  </dt-filter-pill>
+</dt-stack>
+```
 
 ## Content Mode
 
 Filter Pill popover content renders outside the DOM tree. Use the `contentMode` prop to apply color mode (invert, light, dark) to the positioned content. See [Positioned Components](/components/mode-island.html#positioned-components) for details.
 
-<code-example vueCode='
+```vue demo
+<dt-filter-pill content-mode="invert" label="Inverted" :model-value="[{ name: 'Orange', active: true }, { name: 'Apple' }]" end-tooltip-text="Remove" />
+<!-- @code -->
 <dt-filter-pill content-mode="invert">...</dt-filter-pill>
 <dt-filter-pill content-mode="dark">...</dt-filter-pill>
 <dt-filter-pill content-mode="light">...</dt-filter-pill>
-'>
-  <dt-filter-pill content-mode="invert" label="Inverted" :model-value="[{ name: 'Orange', active: true }, { name: 'Apple' }]" end-tooltip-text="Remove" />
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/hovercard.md
+++ b/apps/dialtone-documentation/docs/components/hovercard.md
@@ -11,7 +11,9 @@ keywords: ["hover tooltip", "popover", "card overlay", "d-hovercard", "DtHoverca
 
 The hovercard will appear upon the mouse entering the anchor, with a delay of 300 milliseconds. It will remain open as long as the mouse cursor is over either the open card or the anchor.
 
-<code-example vueCode='
+```vue demo
+<example-hovercard />
+<!-- @code -->
 <dt-hovercard placement="bottom-start">
   <template #anchor>
     <dt-button kind="muted" importance="outlined">
@@ -28,9 +30,7 @@ The hovercard will appear upon the mouse entering the anchor, with a delay of 30
     <div>Footer</div>
   </template>
 </dt-hovercard>
-'>
-  <example-hovercard />
-</code-example>
+```
 
 <!-- <component-combinator component-name="DtHovercard" /> -->
 
@@ -40,30 +40,30 @@ The hovercard will appear upon the mouse entering the anchor, with a delay of 30
 
 After opening one hovercard, moving to another skips the entrance delay — a "warm-up" pattern for faster navigation between targets.
 
-<code-example only-show="demo">
-  <dt-stack direction="row" gap="200">
-    <example-hovercard v-for="data in exampleData" :label="data.label" :content="data.content" />
-  </dt-stack>
-</code-example>
+```vue demo-only
+<dt-stack direction="row" gap="200">
+  <example-hovercard v-for="data in exampleData" :label="data.label" :content="data.content" />
+</dt-stack>
+```
 
 ## Content Mode
 
 Hovercard content renders outside the DOM tree. Use the `contentMode` prop to apply color mode (invert, light, dark) to the positioned content. See [Positioned Components](/components/mode-island.html#positioned-components) for details.
 
-<code-example vueCode='
+```vue demo
+<dt-hovercard content-mode="invert" placement="bottom-start">
+  <template #anchor>
+    <dt-button :size="200" kind="muted" importance="outlined">Hover for Inverted Hovercard</dt-button>
+  </template>
+  <template #content>
+    <dt-text as="p">This hovercard content is in the <dt-text strength="strong">inverted</dt-text> mode.</dt-text>
+  </template>
+</dt-hovercard>
+<!-- @code -->
 <dt-hovercard content-mode="invert">...</dt-hovercard>
 <dt-hovercard content-mode="dark">...</dt-hovercard>
 <dt-hovercard content-mode="light">...</dt-hovercard>
-'>
-  <dt-hovercard content-mode="invert" placement="bottom-start">
-    <template #anchor>
-      <dt-button :size="200" kind="muted" importance="outlined">Hover for Inverted Hovercard</dt-button>
-    </template>
-    <template #content>
-      <dt-text as="p">This hovercard content is in the <dt-text strength="strong">inverted</dt-text> mode.</dt-text>
-    </template>
-  </dt-hovercard>
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/icon.md
+++ b/apps/dialtone-documentation/docs/components/icon.md
@@ -44,14 +44,14 @@ import { DtIcon } from '@dialpad/dialtone'
 Adjust the size using the `size` prop. Note that sizes 600, 700, and 800 are exclusively for devices.
 
 <div class="d-gc2">
-<code-example only-show="demo">
-  <div class="d-d-grid d-g-300 d-g-cols1 md:d-g-cols2 d-w100p">
-    <dt-stack direction="row" align="center" justify="center">
-      <dt-icon-settings :size="selectedSize" />
-    </dt-stack>
-    <dt-select-menu label="Size" :options="sizeValues" v-model="selectedSize" />
-  </div>
-</code-example>
+```vue demo-only
+<div class="d-d-grid d-g-300 d-g-cols1 md:d-g-cols2 d-w100p">
+  <dt-stack direction="row" align="center" justify="center">
+    <dt-icon-settings :size="selectedSize" />
+  </dt-stack>
+  <dt-select-menu label="Size" :options="sizeValues" v-model="selectedSize" />
+</div>
+```
 
 ```js
 <dt-icon-settings size="500" />
@@ -67,17 +67,17 @@ Adjust the size using the `size` prop. Note that sizes 600, 700, and 800 are exc
 The icon's color inherits from the parent's foreground color.
 
 <div class="d-gc2">
-<code-example only-show="demo">
+```vue demo-only
 <div class="d-d-grid d-g-300 d-g-cols1 md:d-g-cols2 d-w100p">
-  <dt-stack direction="row" align="center" justify="center">
-    <dt-stack :class="selectedColor" direction="row" gap="300">
-      <dt-icon-settings size="300" />
-      <dt-text>Settings</dt-text>
-    </dt-stack>
+<dt-stack direction="row" align="center" justify="center">
+  <dt-stack :class="selectedColor" direction="row" gap="300">
+    <dt-icon-settings size="300" />
+    <dt-text>Settings</dt-text>
   </dt-stack>
-  <dt-select-menu label="Color" :options="iconColors" v-model="selectedColor" />
+</dt-stack>
+<dt-select-menu label="Color" :options="iconColors" v-model="selectedColor" />
 </div>
-</code-example>
+```
 
 ```html
 <dt-stack class="d-fc-success" direction="row" gap="300">
@@ -139,17 +139,17 @@ When setting the color of an icon take these into consideration:
 We encourage utilizing the [Stack component](/components/stack.md) for aligning elements both horizontally and vertically.
 
 <div class="d-gc2">
-<code-example only-show="demo">
-  <div class="d-d-grid d-g-300 d-g-cols1 md:d-g-cols2 d-w100p">
-    <dt-stack direction="row" align="center" justify="center">
-      <dt-stack :direction="selectedDirection" class="d-fl-center" gap="300">
-      <dt-icon-settings size="300" />
-      <dt-text>Settings</dt-text>
-      </dt-stack>
+```vue demo-only
+<div class="d-d-grid d-g-300 d-g-cols1 md:d-g-cols2 d-w100p">
+  <dt-stack direction="row" align="center" justify="center">
+    <dt-stack :direction="selectedDirection" class="d-fl-center" gap="300">
+    <dt-icon-settings size="300" />
+    <dt-text>Settings</dt-text>
     </dt-stack>
-    <dt-select-menu label="Direction" :options="stackDirection" v-model="selectedDirection" />
-  </div>
-</code-example>
+  </dt-stack>
+  <dt-select-menu label="Direction" :options="stackDirection" v-model="selectedDirection" />
+</div>
+```
 
 ```html
 <dt-stack direction="row" class="d-fl-center" gap="300">

--- a/apps/dialtone-documentation/docs/components/image-viewer.md
+++ b/apps/dialtone-documentation/docs/components/image-viewer.md
@@ -13,27 +13,27 @@ keywords: ["lightbox", "image modal", "photo viewer", "d-image-viewer", "DtImage
 
 ### JPG Image
 
-<code-example>
-  <dt-image-viewer
-    :image-src="$withBase('/assets/images/test.jpg')"
-    image-alt="Image Alt Text"
-    image-button-class="d-wmn-100 d-hmn-100 d-wmx-500 d-hmx-500"
-    aria-label="Click to open image"
-    close-aria-label="Close"
-  />
-</code-example>
+```vue demo
+<dt-image-viewer
+  :image-src="$withBase('/assets/images/test.jpg')"
+  image-alt="Image Alt Text"
+  image-button-class="d-wmn-100 d-hmn-100 d-wmx-500 d-hmx-500"
+  aria-label="Click to open image"
+  close-aria-label="Close"
+/>
+```
 
 ### GIF Image
 
-<code-example>
-  <dt-image-viewer
-    :image-src="$withBase('/assets/images/fry.gif')"
-    image-alt="Image Alt Text"
-    image-button-class="d-wmn-100 d-hmn-100 d-wmx-500 d-hmx-500"
-    aria-label="Click to open image"
-    close-aria-label="Close"
-  />
-</code-example>
+```vue demo
+<dt-image-viewer
+  :image-src="$withBase('/assets/images/fry.gif')"
+  image-alt="Image Alt Text"
+  image-button-class="d-wmn-100 d-hmn-100 d-wmx-500 d-hmx-500"
+  aria-label="Click to open image"
+  close-aria-label="Close"
+/>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/input-group.md
+++ b/apps/dialtone-documentation/docs/components/input-group.md
@@ -8,16 +8,16 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-input-group-
 keywords: ["input addon", "input prefix", "input suffix", "d-input-group", "DtInputGroup", "dt-input-group", "compound input", "prepend append"]
 ---
 
-<code-example only-show="demo">
-  <dt-input-group
-    name="fruits-input-group"
-    legend="Fruits"
-  >
-    <dt-radio value="apple"><span>Apple</span></dt-radio>
-    <dt-radio value="banana"><span>Banana</span></dt-radio>
-    <dt-radio value="other"><span>Other</span></dt-radio>
-  </dt-input-group>
-</code-example>
+```vue demo-only
+<dt-input-group
+  name="fruits-input-group"
+  legend="Fruits"
+>
+  <dt-radio value="apple"><span>Apple</span></dt-radio>
+  <dt-radio value="banana"><span>Banana</span></dt-radio>
+  <dt-radio value="other"><span>Other</span></dt-radio>
+</dt-input-group>
+```
 
 <component-combinator component-name="DtInputGroup" />
 
@@ -25,15 +25,15 @@ keywords: ["input addon", "input prefix", "input suffix", "d-input-group", "DtIn
 
 Input Groups are typically paired with a legend which identifies the group. If no legend is provided then it is expected that an `aria-label` will be given in order to provide an invisible label to screen readers. Each Input Group should contain one or more inputs which users can interact with.
 
-<code-example>
-  <dt-input-group
-    name="fruits-input-group"
-  >
-    <dt-radio value="apple"><span>Apple</span></dt-radio>
-    <dt-radio value="banana"><span>Banana</span></dt-radio>
-    <dt-radio value="other"><span>Other</span></dt-radio>
-  </dt-input-group>
-</code-example>
+```vue demo
+<dt-input-group
+  name="fruits-input-group"
+>
+  <dt-radio value="apple"><span>Apple</span></dt-radio>
+  <dt-radio value="banana"><span>Banana</span></dt-radio>
+  <dt-radio value="other"><span>Other</span></dt-radio>
+</dt-input-group>
+```
 
 ## Model
 
@@ -98,27 +98,36 @@ export default {
 
 ### With Legend
 
-<code-example vueCode='
+```vue demo
+<dt-input-group
+  name="input-group-with-legend"
+  legend="With Legend"
+>
+  <dt-radio value="apple"><span>Apple</span></dt-radio>
+  <dt-radio value="banana"><span>Banana</span></dt-radio>
+  <dt-radio value="other"><span>Other</span></dt-radio>
+</dt-input-group>
+<!-- @code -->
 <dt-input-group
   name="input-group-with-legend"
   legend="With Legend"
 >
   <!-- Input Elements -->
 </dt-input-group>
-'>
-  <dt-input-group
-    name="input-group-with-legend"
-    legend="With Legend"
-  >
-    <dt-radio value="apple"><span>Apple</span></dt-radio>
-    <dt-radio value="banana"><span>Banana</span></dt-radio>
-    <dt-radio value="other"><span>Other</span></dt-radio>
-  </dt-input-group>
-</code-example>
+```
 
 ### With Slotted Legend
 
-<code-example vueCode='
+```vue demo
+<dt-input-group name="input-group-with-slotted-legend">
+  <dt-radio value="apple"><span>Apple</span></dt-radio>
+  <dt-radio value="banana"><span>Banana</span></dt-radio>
+  <dt-radio value="other"><span>Other</span></dt-radio>
+  <template #legend>
+    With Slotted Legend
+  </template>
+</dt-input-group>
+<!-- @code -->
 <dt-input-group
   name="input-group-with-legend"
 >
@@ -127,20 +136,21 @@ export default {
     With Slotted Legend
   </template>
 </dt-input-group>
-'>
-  <dt-input-group name="input-group-with-slotted-legend">
-    <dt-radio value="apple"><span>Apple</span></dt-radio>
-    <dt-radio value="banana"><span>Banana</span></dt-radio>
-    <dt-radio value="other"><span>Other</span></dt-radio>
-    <template #legend>
-      With Slotted Legend
-    </template>
-  </dt-input-group>
-</code-example>
+```
 
 ### Disabled
 
-<code-example vueCode='
+```vue demo
+<dt-input-group
+  name="input-group-disabled"
+  legend="Disabled"
+  disabled
+>
+  <dt-radio value="apple"><span>Apple</span></dt-radio>
+  <dt-radio value="banana"><span>Banana</span></dt-radio>
+  <dt-radio value="other"><span>Other</span></dt-radio>
+</dt-input-group>
+<!-- @code -->
 <dt-input-group
   name="input-group-disabled"
   legend="Disabled"
@@ -148,21 +158,41 @@ export default {
 >
   <!-- Input Elements -->
 </dt-input-group>
-'>
+```
+
+### With Validation Messages
+
+```vue demo
+<dt-stack gap="500">
   <dt-input-group
-    name="input-group-disabled"
-    legend="Disabled"
-    disabled
+    name="input-group-with-success-message"
+    legend="With Success Message"
+    :messages="[{ message: 'Success validation message', type: 'success' }]"
   >
     <dt-radio value="apple"><span>Apple</span></dt-radio>
     <dt-radio value="banana"><span>Banana</span></dt-radio>
     <dt-radio value="other"><span>Other</span></dt-radio>
   </dt-input-group>
-</code-example>
-
-### With Validation Messages
-
-<code-example vueCode='
+  <dt-input-group
+    name="input-group-with-warning-message"
+    legend="With Warning Message"
+    :messages="[{ message: 'Warning', type: 'warning' }]"
+  >
+    <dt-radio value="apple"><span>Apple</span></dt-radio>
+    <dt-radio value="banana"><span>Banana</span></dt-radio>
+    <dt-radio value="other"><span>Other</span></dt-radio>
+  </dt-input-group>
+  <dt-input-group
+    name="input-group-with-error-message"
+    legend="With Error Message"
+    :messages="[{ message: 'Error', type: 'error' }]"
+  >
+    <dt-radio value="apple"><span>Apple</span></dt-radio>
+    <dt-radio value="banana"><span>Banana</span></dt-radio>
+    <dt-radio value="other"><span>Other</span></dt-radio>
+  </dt-input-group>
+</dt-stack>
+<!-- @code -->
 <dt-input-group
   name="input-group-with-success-message"
   legend="With Success Message"
@@ -184,41 +214,22 @@ export default {
 >
   <!-- Input Elements -->
 </dt-input-group>
-'>
-  <dt-stack gap="500">
-    <dt-input-group
-      name="input-group-with-success-message"
-      legend="With Success Message"
-      :messages="[{ message: 'Success validation message', type: 'success' }]"
-    >
-      <dt-radio value="apple"><span>Apple</span></dt-radio>
-      <dt-radio value="banana"><span>Banana</span></dt-radio>
-      <dt-radio value="other"><span>Other</span></dt-radio>
-    </dt-input-group>
-    <dt-input-group
-      name="input-group-with-warning-message"
-      legend="With Warning Message"
-      :messages="[{ message: 'Warning', type: 'warning' }]"
-    >
-      <dt-radio value="apple"><span>Apple</span></dt-radio>
-      <dt-radio value="banana"><span>Banana</span></dt-radio>
-      <dt-radio value="other"><span>Other</span></dt-radio>
-    </dt-input-group>
-    <dt-input-group
-      name="input-group-with-error-message"
-      legend="With Error Message"
-      :messages="[{ message: 'Error', type: 'error' }]"
-    >
-      <dt-radio value="apple"><span>Apple</span></dt-radio>
-      <dt-radio value="banana"><span>Banana</span></dt-radio>
-      <dt-radio value="other"><span>Other</span></dt-radio>
-    </dt-input-group>
-  </dt-stack>
-</code-example>
+```
 
 ### With Validation Messages Hidden
 
-<code-example vueCode='
+```vue demo
+<dt-input-group
+  name="input-group-with-error-messages-hidden"
+  legend="With Error Messages Hidden"
+  :messages="[{ message: 'Error', type: 'error' }]"
+  :show-messages="false"
+>
+  <dt-radio value="apple"><span>Apple</span></dt-radio>
+  <dt-radio value="banana"><span>Banana</span></dt-radio>
+  <dt-radio value="other"><span>Other</span></dt-radio>
+</dt-input-group>
+<!-- @code -->
 <dt-input-group
   name="input-group-with-error-messages-hidden"
   legend="With Error Messages Hidden"
@@ -227,18 +238,7 @@ export default {
 >
   <!-- Input Elements -->
 </dt-input-group>
-'>
-  <dt-input-group
-    name="input-group-with-error-messages-hidden"
-    legend="With Error Messages Hidden"
-    :messages="[{ message: 'Error', type: 'error' }]"
-    :show-messages="false"
-  >
-    <dt-radio value="apple"><span>Apple</span></dt-radio>
-    <dt-radio value="banana"><span>Banana</span></dt-radio>
-    <dt-radio value="other"><span>Other</span></dt-radio>
-  </dt-input-group>
-</code-example>
+```
 
 ## Extending
 

--- a/apps/dialtone-documentation/docs/components/input.md
+++ b/apps/dialtone-documentation/docs/components/input.md
@@ -41,20 +41,21 @@ This component combines both the `input` and `textarea` elements as options with
 
 We offer different sizes for instances in which the interface requires a smaller or larger input. In general, though, use the base `300` (medium) size input as much as possible, especially in forms.
 
-<code-example>
-  <div class="d-d-grid d-g-200 d-g-cols2" data-demo-wrapper>
-    <dt-input :size="100" type="text" label="Extra Small" placeholder="Placeholder" />
-    <dt-input :size="100" type="textarea" label="Extra Small" placeholder="Placeholder" />
-    <dt-input :size="200" type="text" label="Small" placeholder="Placeholder" />
-    <dt-input :size="200" type="textarea" label="Small" placeholder="Placeholder" />
-    <dt-input :size="300" type="text" label="Medium" placeholder="Placeholder" />
-    <dt-input :size="300" type="textarea" label="Medium" placeholder="Placeholder" />
-    <dt-input :size="400" type="text" label="Large" placeholder="Placeholder" />
-    <dt-input :size="400" type="textarea" label="Large" placeholder="Placeholder" />
-    <dt-input :size="500" type="text" label="Extra large" placeholder="Placeholder" />
-    <dt-input :size="500" type="textarea" label="Extra large" placeholder="Placeholder" />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-d-grid d-g-200 d-g-cols2">
+  <dt-input :size="100" type="text" label="Extra Small" placeholder="Placeholder" />
+  <dt-input :size="100" type="textarea" label="Extra Small" placeholder="Placeholder" />
+  <dt-input :size="200" type="text" label="Small" placeholder="Placeholder" />
+  <dt-input :size="200" type="textarea" label="Small" placeholder="Placeholder" />
+  <dt-input :size="300" type="text" label="Medium" placeholder="Placeholder" />
+  <dt-input :size="300" type="textarea" label="Medium" placeholder="Placeholder" />
+  <dt-input :size="400" type="text" label="Large" placeholder="Placeholder" />
+  <dt-input :size="400" type="textarea" label="Large" placeholder="Placeholder" />
+  <dt-input :size="500" type="text" label="Extra large" placeholder="Placeholder" />
+  <dt-input :size="500" type="textarea" label="Extra large" placeholder="Placeholder" />
+</div>
+```
 
 ## Examples
 
@@ -62,46 +63,49 @@ We offer different sizes for instances in which the interface requires a smaller
 
 An input is normally paired with a label, but there are times when it can be used without a label.  Placeholder text should primarily be used as a content prompt and only provided when needed.
 
-<code-example>
-  <div class="d-d-grid d-g-200 d-g-cols3" data-demo-wrapper>
-    <dt-input label="Label" placeholder="Placeholder" />
-    <dt-input label="Label" model-value="Value" />
-    <dt-input label="Label" placeholder="Placeholder" disabled />
-    <dt-input label="Label" placeholder="Placeholder" type="textarea" />
-    <dt-input label="Label" type="textarea" model-value="Value" />
-    <dt-input label="Label" placeholder="Placeholder" type="textarea" disabled />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-d-grid d-g-200 d-g-cols3">
+  <dt-input label="Label" placeholder="Placeholder" />
+  <dt-input label="Label" model-value="Value" />
+  <dt-input label="Label" placeholder="Placeholder" disabled />
+  <dt-input label="Label" placeholder="Placeholder" type="textarea" />
+  <dt-input label="Label" type="textarea" model-value="Value" />
+  <dt-input label="Label" placeholder="Placeholder" type="textarea" disabled />
+</div>
+```
 
 ### With Description Text
 
-<code-example>
-  <div class="d-d-grid d-g-200 d-g-cols2" data-demo-wrapper>
-    <dt-input label="Label" description="Helpful description text" placeholder="Placeholder"/>
-    <dt-input label="Label" description="Helpful description text" type="textarea" placeholder="Placeholder"/>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-d-grid d-g-200 d-g-cols2">
+  <dt-input label="Label" description="Helpful description text" placeholder="Placeholder"/>
+  <dt-input label="Label" description="Helpful description text" type="textarea" placeholder="Placeholder"/>
+</div>
+```
 
 ### With Validation States
 
 Provides feedback to the user based on their interaction, or lack thereof, with an input.
 
-<code-example>
-  <div class="d-d-grid d-g-200 d-g-cols3" data-demo-wrapper>
-    <dt-input label="Label" type="email" model-value="Value" :messages="[messages.error]"/>
-    <dt-input label="Label" type="email" model-value="Value" :messages="[messages.success]"/>
-    <dt-input label="Label" type="email" model-value="Value" :messages="[messages.warning]"/>
-    <dt-input label="Label" type="textarea" model-value="Value" :messages="[messages.error]"/>
-    <dt-input label="Label" type="textarea" model-value="Value" :messages="[messages.success]"/>
-    <dt-input label="Label" type="textarea" model-value="Value" :messages="[messages.warning]"/>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-d-grid d-g-200 d-g-cols3">
+  <dt-input label="Label" type="email" model-value="Value" :messages="[messages.error]"/>
+  <dt-input label="Label" type="email" model-value="Value" :messages="[messages.success]"/>
+  <dt-input label="Label" type="email" model-value="Value" :messages="[messages.warning]"/>
+  <dt-input label="Label" type="textarea" model-value="Value" :messages="[messages.error]"/>
+  <dt-input label="Label" type="textarea" model-value="Value" :messages="[messages.success]"/>
+  <dt-input label="Label" type="textarea" model-value="Value" :messages="[messages.warning]"/>
+</div>
+```
 
 ### With Multiple Validation Messages
 
-<code-example>
-  <dt-input label="Label" type="email" model-value="Value" :messages="multipleMessages" />
-</code-example>
+```vue demo
+<dt-input label="Label" type="email" model-value="Value" :messages="multipleMessages" />
+```
 
 ### With Maximum Length Validation
 
@@ -128,33 +132,33 @@ length: {
 
 If the input is invalid due to the validation, the validation message will be shown even when the input lost focus, otherwise the validation message will be hidden when the user unfocuses the input.
 
-<code-example>
-  <dt-input
-    model-value="Value"
-    label="Label"
-    placeholder="placeholder"
-    :validate="{
-      length: {
-        description: 'Max 25 characters.',
-        message: 'Max 25 characters allowed.',
-        max: 25,
-        warn: 15,
-        limitMaxLength: false,
-      }
-    }"
-  />
-</code-example>
+```vue demo
+<dt-input
+  model-value="Value"
+  label="Label"
+  placeholder="placeholder"
+  :validate="{
+    length: {
+      description: 'Max 25 characters.',
+      message: 'Max 25 characters allowed.',
+      max: 25,
+      warn: 15,
+      limitMaxLength: false,
+    }
+  }"
+/>
+```
 
 ### With Custom Maximum Length Validation Message
 
-<code-example>
-  <dt-input
-    model-value="Value"
-    label="Label"
-    placeholder="placeholder"
-    :validate="validate()"
-  />
-</code-example>
+```vue demo
+<dt-input
+  model-value="Value"
+  label="Label"
+  placeholder="placeholder"
+  :validate="validate()"
+/>
+```
 
 ```js
 const validateData = {
@@ -190,137 +194,141 @@ const validate = () => {
 
 Use `type="search"` with a clear button in the `icon` slot. When the input is not empty, the clear button will render and will clear the input field when triggered.
 
-<code-example>
-  <dt-input
-    aria-label="Search items"
-    placeholder="Search Items"
-    type="search"
-    model-value="Search Value"
-  >
-    <template #startIcon="{ iconSize }">
-      <dt-icon name="search" :size="iconSize" />
-    </template>
-    <template v-if="inputSearchValue.length !== 0" #endIcon="{ clear }">
-      <dt-stack class="d-pie-25">
-        <dt-button
-          v-dt-tooltip="'Clear search'"
-          kind="muted"
-          importance="clear"
-          :size="100"
-          aria-label="Clear search"
-          @click="clear"
-        >
-          <template #startIcon="{ iconSize }">
-            <dt-icon name="close" :size="iconSize" />
-          </template>
-        </dt-button>
-      </dt-stack>
-    </template>
-  </dt-input>
-</code-example>
+```vue demo
+<dt-input
+  aria-label="Search items"
+  placeholder="Search Items"
+  type="search"
+  model-value="Search Value"
+>
+  <template #startIcon="{ iconSize }">
+    <dt-icon name="search" :size="iconSize" />
+  </template>
+  <template v-if="inputSearchValue.length !== 0" #endIcon="{ clear }">
+    <dt-stack class="d-pie-25">
+      <dt-button
+        v-dt-tooltip="'Clear search'"
+        kind="muted"
+        importance="clear"
+        :size="100"
+        aria-label="Clear search"
+        @click="clear"
+      >
+        <template #startIcon="{ iconSize }">
+          <dt-icon name="close" :size="iconSize" />
+        </template>
+      </dt-button>
+    </dt-stack>
+  </template>
+</dt-input>
+```
 
 ## Icon Support
 
-<code-example>
-  <div class="d-d-grid d-g-200 d-g-cols3" data-demo-wrapper>
-    <dt-input label="Start icon" type="text" placeholder="Placeholder">
-      <template #startIcon="{ iconSize }">
-        <dt-icon name="send" :size="iconSize" />
-      </template>
-    </dt-input>
-    <dt-input label="End icon" type="text" placeholder="Placeholder">
-      <template #endIcon="{ iconSize }">
-        <dt-icon name="lock" :size="iconSize" />
-      </template>
-    </dt-input>
-    <dt-input label="Start and End icon" type="text" placeholder="Placeholder">
-      <template #startIcon="{ iconSize }">
-        <dt-icon name="send" :size="iconSize" />
-      </template>
-      <template #endIcon="{ iconSize }">
-        <dt-icon name="lock" :size="iconSize" />
-      </template>
-    </dt-input>
-    <dt-input label="Start icon" type="textarea" placeholder="Placeholder">
-      <template #startIcon="{ iconSize }">
-        <dt-icon name="send" :size="iconSize" />
-      </template>
-    </dt-input>
-    <dt-input label="End icon" type="textarea" placeholder="Placeholder">
-      <template #endIcon="{ iconSize }">
-        <dt-icon name="lock" :size="iconSize" />
-      </template>
-    </dt-input>
-    <dt-input label="Start and End icon" type="textarea" placeholder="Placeholder">
-      <template #startIcon="{ iconSize }">
-        <dt-icon name="send" :size="iconSize" />
-      </template>
-      <template #endIcon="{ iconSize }">
-        <dt-icon name="lock" :size="iconSize" />
-      </template>
-    </dt-input>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-d-grid d-g-200 d-g-cols3">
+  <dt-input label="Start icon" type="text" placeholder="Placeholder">
+    <template #startIcon="{ iconSize }">
+      <dt-icon name="send" :size="iconSize" />
+    </template>
+  </dt-input>
+  <dt-input label="End icon" type="text" placeholder="Placeholder">
+    <template #endIcon="{ iconSize }">
+      <dt-icon name="lock" :size="iconSize" />
+    </template>
+  </dt-input>
+  <dt-input label="Start and End icon" type="text" placeholder="Placeholder">
+    <template #startIcon="{ iconSize }">
+      <dt-icon name="send" :size="iconSize" />
+    </template>
+    <template #endIcon="{ iconSize }">
+      <dt-icon name="lock" :size="iconSize" />
+    </template>
+  </dt-input>
+  <dt-input label="Start icon" type="textarea" placeholder="Placeholder">
+    <template #startIcon="{ iconSize }">
+      <dt-icon name="send" :size="iconSize" />
+    </template>
+  </dt-input>
+  <dt-input label="End icon" type="textarea" placeholder="Placeholder">
+    <template #endIcon="{ iconSize }">
+      <dt-icon name="lock" :size="iconSize" />
+    </template>
+  </dt-input>
+  <dt-input label="Start and End icon" type="textarea" placeholder="Placeholder">
+    <template #startIcon="{ iconSize }">
+      <dt-icon name="send" :size="iconSize" />
+    </template>
+    <template #endIcon="{ iconSize }">
+      <dt-icon name="lock" :size="iconSize" />
+    </template>
+  </dt-input>
+</div>
+```
 
 ### Icon Sizes
 
 Each Text Input size has a default icon size, keeping it proportional. While rare, customizing the icon size is possible.
 
-<code-example>
-  <dt-stack gap="200" class="d-w100p" data-demo-wrapper>
-    <dt-input label="Medium input with smallest icon" type="text" placeholder="Placeholder" :size="300">
-      <template #startIcon>
-        <dt-icon name="box-select" size="100" />
-      </template>
-      <template #endIcon>
-        <dt-icon name="box-select" size="100" />
-      </template>
-    </dt-input>
-    <dt-input label="Extra large input with medium icon" type="text" placeholder="Placeholder" :size="500">
-      <template #startIcon>
-        <dt-icon name="box-select" size="200" />
-      </template>
-      <template #endIcon>
-        <dt-icon name="box-select" size="200" />
-      </template>
-    </dt-input>
-    <dt-input label="Medium textarea with large icon" type="textarea" placeholder="Placeholder" :icon-size="300" :size="400">
-      <template #startIcon>
-        <dt-icon name="box-select" size="500" />
-      </template>
-    </dt-input>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="200" class="d-w100p">
+  <dt-input label="Medium input with smallest icon" type="text" placeholder="Placeholder" :size="300">
+    <template #startIcon>
+      <dt-icon name="box-select" size="100" />
+    </template>
+    <template #endIcon>
+      <dt-icon name="box-select" size="100" />
+    </template>
+  </dt-input>
+  <dt-input label="Extra large input with medium icon" type="text" placeholder="Placeholder" :size="500">
+    <template #startIcon>
+      <dt-icon name="box-select" size="200" />
+    </template>
+    <template #endIcon>
+      <dt-icon name="box-select" size="200" />
+    </template>
+  </dt-input>
+  <dt-input label="Medium textarea with large icon" type="textarea" placeholder="Placeholder" :icon-size="300" :size="400">
+    <template #startIcon>
+      <dt-icon name="box-select" size="500" />
+    </template>
+  </dt-input>
+</dt-stack>
+```
 
 ## Label size
 
 The label text size is automatically derived from the component's `size` prop. Use the `label-size` prop to override this when you need a different label size independent of the input size. For example, the default label size for a `:size="300"` input is `300`, but you can override it from `100` to `400`.
 
-<code-example vueCode='
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="200" class="d-w100p">
+  <dt-input label="Extra small label" placeholder="Placeholder" :label-size="100" />
+  <dt-input label="Small label" placeholder="Placeholder" :label-size="200" />
+  <dt-input label="Medium label (default)" placeholder="Placeholder" :label-size="300" />
+  <dt-input label="Large label" placeholder="Placeholder" :label-size="400" />
+</dt-stack>
+<!-- @code -->
 <dt-input label="Extra small label" placeholder="Placeholder" :label-size="100" />
-'>
-  <dt-stack gap="200" class="d-w100p" data-demo-wrapper>
-    <dt-input label="Extra small label" placeholder="Placeholder" :label-size="100" />
-    <dt-input label="Small label" placeholder="Placeholder" :label-size="200" />
-    <dt-input label="Medium label (default)" placeholder="Placeholder" :label-size="300" />
-    <dt-input label="Large label" placeholder="Placeholder" :label-size="400" />
-  </dt-stack>
-</code-example>
+```
 
 ## Label strength
 
 Override the label font weight independently of the label size. Valid values are `bold`, `semibold`, `medium`, and `normal`.
 
-<code-example vueCode='
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="200" class="d-w100p">
+  <dt-input label="Bold label" placeholder="Placeholder" label-strength="bold" />
+  <dt-input label="Semibold label" placeholder="Placeholder" label-strength="semibold" />
+  <dt-input label="Medium label" placeholder="Placeholder" label-strength="medium" />
+  <dt-input label="Normal label" placeholder="Placeholder" label-strength="normal" />
+</dt-stack>
+<!-- @code -->
 <dt-input label="Label" placeholder="Placeholder" label-strength="bold|semibold|medium|normal" />
-'>
-  <dt-stack gap="200" class="d-w100p" data-demo-wrapper>
-    <dt-input label="Bold label" placeholder="Placeholder" label-strength="bold" />
-    <dt-input label="Semibold label" placeholder="Placeholder" label-strength="semibold" />
-    <dt-input label="Medium label" placeholder="Placeholder" label-strength="medium" />
-    <dt-input label="Normal label" placeholder="Placeholder" label-strength="normal" />
-  </dt-stack>
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/item-layout.md
+++ b/apps/dialtone-documentation/docs/components/item-layout.md
@@ -14,28 +14,29 @@ keywords: ["list layout","item structure","d-item-layout","DtItemLayout","dt-ite
 
 By default, item layout includes custom styling, like paddings, sizes, colors, etc.
 
-<code-example>
-  <div class="d-d-block d-w-500" data-demo-wrapper>
-    <dt-item-layout>
-      <template #start>
-        <dt-icon size="300" name="lock" />
-      </template>
-      Layout title
-      <template #subtitle>
-        Subtitle
-      </template>
-      <template #bottom>
-        <dt-badge>Content</dt-badge>
-      </template>
-      <template #end>
-        <dt-icon size="300" name="share" />
-      </template>
-      <template #selected>
-        <dt-icon size="300" name="check" />
-      </template>
-    </dt-item-layout>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-d-block d-w-500">
+  <dt-item-layout>
+    <template #start>
+      <dt-icon size="300" name="lock" />
+    </template>
+    Layout title
+    <template #subtitle>
+      Subtitle
+    </template>
+    <template #bottom>
+      <dt-badge>Content</dt-badge>
+    </template>
+    <template #end>
+      <dt-icon size="300" name="share" />
+    </template>
+    <template #selected>
+      <dt-icon size="300" name="check" />
+    </template>
+  </dt-item-layout>
+</div>
+```
 
 ## Without Styling
 
@@ -43,28 +44,29 @@ Setting the `unstyled` property will add `d-item-layout--custom` class. This wil
 
 This way you can utilize the layout and customize your own styling using utility classes.
 
-<code-example>
-  <div class="d-d-block d-w-500" data-demo-wrapper>
-    <dt-item-layout unstyled>
-      <template #start>
-        <dt-icon size="300" name="lock" />
-      </template>
-      Layout title
-      <template #subtitle>
-        Subtitle
-      </template>
-      <template #bottom>
-        <dt-badge>Content</dt-badge>
-      </template>
-      <template #end>
-        <dt-icon size="300" name="share" />
-      </template>
-      <template #selected>
-        <dt-icon size="300" name="check" />
-      </template>
-    </dt-item-layout>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-d-block d-w-500">
+  <dt-item-layout unstyled>
+    <template #start>
+      <dt-icon size="300" name="lock" />
+    </template>
+    Layout title
+    <template #subtitle>
+      Subtitle
+    </template>
+    <template #bottom>
+      <dt-badge>Content</dt-badge>
+    </template>
+    <template #end>
+      <dt-icon size="300" name="share" />
+    </template>
+    <template #selected>
+      <dt-icon size="300" name="check" />
+    </template>
+  </dt-item-layout>
+</div>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/keyboard-shortcut.md
+++ b/apps/dialtone-documentation/docs/components/keyboard-shortcut.md
@@ -15,9 +15,9 @@ keywords: ["hotkey", "key binding", "shortcut key", "d-kbd", "DtKeyboardShortcut
 
 Keyboard shortcut outlines a key combination with a border to represent a keyboard shortcut. `+` will be rendered as an icon rather than text. Supported symbol tags can be used in the shortcut prop, see the [Props, Slots & Events](#vue-api) section.
 
-<code-example>
-  <dt-keyboard-shortcut shortcut="{cmd}+Ctrl+X"/>
-</code-example>
+```vue demo
+<dt-keyboard-shortcut shortcut="{cmd}+Ctrl+X"/>
+```
 
 ## Usage
 
@@ -38,41 +38,41 @@ Keyboard shortcut outlines a key combination with a border to represent a keyboa
 
 In place of the `inverted` prop, use the [v-dt-mode directive](mode-island.html#inverting) on the component element.
 
-<code-example>
-  <div class="d-bgc-contrast d-p-200">
-    <dt-keyboard-shortcut v-dt-mode:invert shortcut="{cmd}+Ctrl+X" />
-  </div>
-</code-example>
+```vue demo
+<div class="d-bgc-contrast d-p-200">
+  <dt-keyboard-shortcut v-dt-mode:invert shortcut="{cmd}+Ctrl+X" />
+</div>
+```
 
 ### Shortcut Size Variation
 
-<code-example>
-  <dt-keyboard-shortcut
-    class="d-fs-200"
-    shortcut="{cmd}+Y"
-  />
-</code-example>
+```vue demo
+<dt-keyboard-shortcut
+  class="d-fs-200"
+  shortcut="{cmd}+Y"
+/>
+```
 
 ### All Available Shortcut Aliases
 
-<code-example>
-  <dt-keyboard-shortcut
-    shortcut="{cmd}+{opt}+{win}+{arrow-right}+{arrow-left}+{arrow-up}+{arrow-down}+A"
-  />
-</code-example>
+```vue demo
+<dt-keyboard-shortcut
+  shortcut="{cmd}+{opt}+{win}+{arrow-right}+{arrow-left}+{arrow-up}+{arrow-down}+A"
+/>
+```
 
 ### Inline with Text and Screen Reader Text
 
-<code-example>
-  <dt-text kind="body" :size="300">
-    Press
-    <dt-keyboard-shortcut
-      screen-reader-text="Control plus F5"
-      shortcut="Ctrl + F5"
-    />
-    to hard refresh the page.
-  </dt-text>
-</code-example>
+```vue demo
+<dt-text kind="body" :size="300">
+  Press
+  <dt-keyboard-shortcut
+    screen-reader-text="Control plus F5"
+    shortcut="Ctrl + F5"
+  />
+  to hard refresh the page.
+</dt-text>
+```
 
 ## Accessibility
 

--- a/apps/dialtone-documentation/docs/components/lazy-show.md
+++ b/apps/dialtone-documentation/docs/components/lazy-show.md
@@ -14,17 +14,17 @@ keywords: ["lazy load","conditional render","d-lazy-show","DtLazyShow","dt-lazy-
 
 The lazy show wraps the slot in a parent `div` in order to achieve this. It also wraps the `v-show` in a `transition`, so you can pass any valid Vue transition class to control the enter/leave transitions.
 
-<code-example>
-  <dt-button @click="isShown = !isShown">
-    Toggle
-  </dt-button>
-  <dt-lazy-show
-    transition="fade"
-    :show="isShown"
-  >
-    I'm Lazy!
-  </dt-lazy-show>
-</code-example>
+```vue demo
+<dt-button @click="isShown = !isShown">
+  Toggle
+</dt-button>
+<dt-lazy-show
+  transition="fade"
+  :show="isShown"
+>
+  I'm Lazy!
+</dt-lazy-show>
+```
 
 <script>
 export default {

--- a/apps/dialtone-documentation/docs/components/link.md
+++ b/apps/dialtone-documentation/docs/components/link.md
@@ -44,24 +44,25 @@ keywords: ["anchor", "hyperlink", "url", "d-link", "DtLink", "dt-link", "text li
 
 ### Default
 
-<code-example>
-  <DtStack gap="100" data-demo-wrapper>
-    <dt-link href="#link">Base link</dt-link>
-    <dt-link href="#link" kind="danger">Danger link</dt-link>
-    <dt-link href="#link" kind="muted">Muted link</dt-link>
-    <dt-link href="#link" kind="success">Success link</dt-link>
-    <dt-link href="#link" kind="warning">Warning link</dt-link>
-    <dt-link href="#link" kind="mention">Mention link</dt-link>
-  </DtStack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<DtStack gap="100">
+  <dt-link href="#link">Base link</dt-link>
+  <dt-link href="#link" kind="danger">Danger link</dt-link>
+  <dt-link href="#link" kind="muted">Muted link</dt-link>
+  <dt-link href="#link" kind="success">Success link</dt-link>
+  <dt-link href="#link" kind="warning">Warning link</dt-link>
+  <dt-link href="#link" kind="mention">Mention link</dt-link>
+</DtStack>
+```
 
 ### No underline
 
 This inverts the underline behavior. With `underline="false"`, the link will not have an underline by default, but will show one on hover.
 
-<code-example>
-  <dt-link href="#link" :underline="false">No underline link</dt-link>
-</code-example>
+```vue demo
+<dt-link href="#link" :underline="false">No underline link</dt-link>
+```
 
 ### Inverted
 
@@ -77,18 +78,18 @@ This inverts the underline behavior. With `underline="false"`, the link will not
 
 In place of the `inverted` prop, use the [v-dt-mode directive](mode-island.html#inverting) on the component element.
 
-<code-example vueCode='
+```vue demo
+<DtStack gap="100" class="d-bgc-contrast d-p-100">
+  <dt-link v-dt-mode:invert href="#link">Base link</dt-link>
+  <dt-link v-dt-mode:invert href="#link" kind="danger">Danger link</dt-link>
+  <dt-link v-dt-mode:invert href="#link" kind="success">Success link</dt-link>
+  <dt-link v-dt-mode:invert href="#link" kind="warning">Warning link</dt-link>
+  <dt-link v-dt-mode:invert href="#link" kind="muted">Muted link</dt-link>
+  <dt-link v-dt-mode:invert href="#link" kind="mention">Mention link</dt-link>
+</DtStack>
+<!-- @code -->
 <dt-link v-dt-mode:invert {props}>Link</dt-link>
-'>
-  <DtStack gap="100" class="d-bgc-contrast d-p-100">
-    <dt-link v-dt-mode:invert href="#link">Base link</dt-link>
-    <dt-link v-dt-mode:invert href="#link" kind="danger">Danger link</dt-link>
-    <dt-link v-dt-mode:invert href="#link" kind="success">Success link</dt-link>
-    <dt-link v-dt-mode:invert href="#link" kind="warning">Warning link</dt-link>
-    <dt-link v-dt-mode:invert href="#link" kind="muted">Muted link</dt-link>
-    <dt-link v-dt-mode:invert href="#link" kind="mention">Mention link</dt-link>
-  </DtStack>
-</code-example>
+```
 
 ## Navigation
 
@@ -98,30 +99,30 @@ DtLink supports both external links and internal SPA navigation via Vue Router.
 
 Use `href` for standard anchor links — external URLs, hash links, etc.
 
-<code-example only-show="code">
-  <dt-link href="https://github.com/dialpad/dialtone" target="_blank" rel="noopener noreferrer">
-    GitHub
-  </dt-link>
-  <dt-link href="#section">Jump to section</dt-link>
-</code-example>
+```vue code-only
+<dt-link href="https://github.com/dialpad/dialtone" target="_blank" rel="noopener noreferrer">
+  GitHub
+</dt-link>
+<dt-link href="#section">Jump to section</dt-link>
+```
 
 ### to
 
 Use `to` for Vue Router navigation. DtLink renders as a `<router-link>` when `to` is provided.
 
-<code-example only-show="code">
-  <dt-link to="/components/">Browse Components</dt-link>
-  <dt-link to="/components/button">Button docs</dt-link>
-  <dt-link :to="{ name: 'component', params: { id: 'button' } }">Button docs</dt-link>
-</code-example>
+```vue code-only
+<dt-link to="/components/">Browse Components</dt-link>
+<dt-link to="/components/button">Button docs</dt-link>
+<dt-link :to="{ name: 'component', params: { id: 'button' } }">Button docs</dt-link>
+```
 
 ### Replace history
 
 Use the `replace` prop to replace the current history entry instead of pushing a new one. Only applies when `to` is provided.
 
-<code-example only-show="code">
-  <dt-link to="/components/" replace>Browse Components</dt-link>
-</code-example>
+```vue code-only
+<dt-link to="/components/" replace>Browse Components</dt-link>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/list-item.md
+++ b/apps/dialtone-documentation/docs/components/list-item.md
@@ -9,25 +9,26 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
 keywords: ["list element", "d-list-item", "DtListItem", "dt-list-item"]
 ---
 
-<code-example only-show="demo" class="d-d-block">
-  <ul>
-    <dt-list-item navigation-type="tab">
-      <template #start>
-        <dt-icon size="300" name="check" />
-      </template>
-      <span>Default List Item</span>
-      <template #subtitle>
-        Description
-      </template>
-      <template #bottom>
-        <dt-badge text="Label" />
-      </template>
-      <template #end>
-        <dt-icon size="300" name="external-link" />
-      </template>
-    </dt-list-item>
-  </ul>
-</code-example>
+```vue demo-only
+<!-- @class d-d-block -->
+<ul>
+  <dt-list-item navigation-type="tab">
+    <template #start>
+      <dt-icon size="300" name="check" />
+    </template>
+    <span>Default List Item</span>
+    <template #subtitle>
+      Description
+    </template>
+    <template #bottom>
+      <dt-badge text="Label" />
+    </template>
+    <template #end>
+      <dt-icon size="300" name="external-link" />
+    </template>
+  </dt-list-item>
+</ul>
+```
 
 <!-- <component-combinator component-name="DtListItem" /> -->
 
@@ -47,25 +48,26 @@ The **subtitle** slot can be used to display content below the default slot. The
 
 The **bottom** slot can be used to display content below the subtitle slot.
 
-<code-example class="d-d-block">
-  <ul>
-    <dt-list-item navigation-type="tab">
-      <template #start>
-        <dt-icon size="300" name="check" />
-      </template>
-      <span>Default List Item</span>
-      <template #subtitle>
-        Description
-      </template>
-      <template #bottom>
-        <dt-badge text="Label" />
-      </template>
-      <template #end>
-        <dt-icon size="300" name="external-link" />
-      </template>
-    </dt-list-item>
-  </ul>
-</code-example>
+```vue demo
+<!-- @class d-d-block -->
+<ul>
+  <dt-list-item navigation-type="tab">
+    <template #start>
+      <dt-icon size="300" name="check" />
+    </template>
+    <span>Default List Item</span>
+    <template #subtitle>
+      Description
+    </template>
+    <template #bottom>
+      <dt-badge text="Label" />
+    </template>
+    <template #end>
+      <dt-icon size="300" name="external-link" />
+    </template>
+  </dt-list-item>
+</ul>
+```
 
 ## Variants
 
@@ -73,71 +75,72 @@ The **bottom** slot can be used to display content below the subtitle slot.
 
 When `type` is set to "custom" the list item will not render any styles or slots. This type can be used when the list item has to support content that does not work with the default structure.
 
-<code-example class="d-d-block">
-  <ul>
-    <dt-list-item
-      navigation-type="tab"
-      type="custom"
-    >
-      <dt-stack direction="row" align="start" justify="between" gap="500" class="d-py-100 d-px-150 d-pie-100">
-        <dt-stack align="baseline" direction="row" gap="400">
-          <dt-text
-            kind="body"
-            tone="muted"
-            :size="100"
-            datetime="10:00"
-          >
-            10:00
-          </dt-text>
-          <dt-text :size="300" density="300" kind="body" tone="secondary">
-            Custom list item example lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
-          </dt-text>
-        </dt-stack>
-        <dt-stack direction="row">
-          <dt-button
-            :size="100"
-            kind="muted"
-            importance="clear"
-            title="share"
-          >
-            <template #startIcon="{ iconSize }">
-              <dt-icon
-                name="share"
-                :size="iconSize"
-              />
-            </template>
-          </dt-button>
-          <dt-button
-            :size="100"
-            kind="muted"
-            importance="clear"
-            title="star"
-          >
-            <template #startIcon="{ iconSize }">
-              <dt-icon
-                name="star"
-                :size="iconSize"
-              />
-            </template>
-          </dt-button>
-          <dt-button
-            :size="100"
-            kind="muted"
-            importance="clear"
-            title="more"
-          >
-            <template #startIcon="{ iconSize }">
-              <dt-icon
-                name="more-vertical"
-                :size="iconSize"
-              />
-            </template>
-          </dt-button>
-        </dt-stack>
+```vue demo
+<!-- @class d-d-block -->
+<ul>
+  <dt-list-item
+    navigation-type="tab"
+    type="custom"
+  >
+    <dt-stack direction="row" align="start" justify="between" gap="500" class="d-py-100 d-px-150 d-pie-100">
+      <dt-stack align="baseline" direction="row" gap="400">
+        <dt-text
+          kind="body"
+          tone="muted"
+          :size="100"
+          datetime="10:00"
+        >
+          10:00
+        </dt-text>
+        <dt-text :size="300" density="300" kind="body" tone="secondary">
+          Custom list item example lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+        </dt-text>
       </dt-stack>
-    </dt-list-item>
-  </ul>
-</code-example>
+      <dt-stack direction="row">
+        <dt-button
+          :size="100"
+          kind="muted"
+          importance="clear"
+          title="share"
+        >
+          <template #startIcon="{ iconSize }">
+            <dt-icon
+              name="share"
+              :size="iconSize"
+            />
+          </template>
+        </dt-button>
+        <dt-button
+          :size="100"
+          kind="muted"
+          importance="clear"
+          title="star"
+        >
+          <template #startIcon="{ iconSize }">
+            <dt-icon
+              name="star"
+              :size="iconSize"
+            />
+          </template>
+        </dt-button>
+        <dt-button
+          :size="100"
+          kind="muted"
+          importance="clear"
+          title="more"
+        >
+          <template #startIcon="{ iconSize }">
+            <dt-icon
+              name="more-vertical"
+              :size="iconSize"
+            />
+          </template>
+        </dt-button>
+      </dt-stack>
+    </dt-stack>
+  </dt-list-item>
+</ul>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/loader.md
+++ b/apps/dialtone-documentation/docs/components/loader.md
@@ -31,31 +31,31 @@ keywords: ["spinner", "loading", "progress", "d-loader", "DtLoader", "dt-loader"
 
 The base loader should be the go-to loader for most of your needs. When in doubt, use this style.
 
-<code-example>
-  <dt-loader></dt-loader>
-</code-example>
+```vue demo
+<dt-loader></dt-loader>
+```
 
 ## Sizes
 
 The base loader size is 24px and should be used in most cases.
 
-<code-example vueCode='
+```vue demo
+<dt-stack
+  gap="200"
+  :direction="{ 'default': 'column', 'md': 'row' }"
+>
+  <dt-loader size="100"></dt-loader>
+  <dt-loader size="200"></dt-loader>
+  <dt-loader size="300"></dt-loader>
+  <dt-loader size="400"></dt-loader>
+  <dt-loader size="500"></dt-loader>
+  <dt-loader size="600"></dt-loader>
+  <dt-loader size="700"></dt-loader>
+  <dt-loader size="800"></dt-loader>
+</dt-stack>
+<!-- @code -->
 <dt-loader size="100|200|300|400|500|600|700|800"></dt-loader>
-'>
-  <dt-stack
-    gap="200"
-    :direction="{ 'default': 'column', 'md': 'row' }"
-  >
-    <dt-loader size="100"></dt-loader>
-    <dt-loader size="200"></dt-loader>
-    <dt-loader size="300"></dt-loader>
-    <dt-loader size="400"></dt-loader>
-    <dt-loader size="500"></dt-loader>
-    <dt-loader size="600"></dt-loader>
-    <dt-loader size="700"></dt-loader>
-    <dt-loader size="800"></dt-loader>
-  </dt-stack>
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -8,9 +8,9 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-modal--defau
 figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Library--Rebrand-2025-?node-id=4454-10944
 keywords: ["dialog", "popup", "overlay", "lightbox", "d-modal", "DtModal", "dt-modal", "alert dialog", "sheet"]
 ---
-<code-example only-show="demo">
-  <example-modal />
-</code-example>
+```vue demo-only
+<example-modal />
+```
 
 <!-- <component-combinator component-name="DtModal" /> -->
 
@@ -67,7 +67,9 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
 
 ### Base Style
 
-<code-example vueCode='
+```vue demo
+<example-modal />
+<!-- @code -->
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -97,15 +99,15 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
 >
   Click to open
 </dt-button>
-'>
-  <example-modal />
-</code-example>
+```
 
 ### Fixed Header and Footer
 
 This is the default behavior that adds the scroll automatically in the modal content and leaves the header and footer fixed.
 
-<code-example vueCode='
+```vue demo
+<example-modal fixed-header-footer :copy="fixedHeaderFooterCopy" />
+<!-- @code -->
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -137,15 +139,15 @@ This is the default behavior that adds the scroll automatically in the modal con
 >
   Click to open
 </dt-button>
-'>
-  <example-modal fixed-header-footer :copy="fixedHeaderFooterCopy" />
-</code-example>
+```
 
 ### Danger
 
 A modal style for destructive or irreversible actions.
 
-<code-example vueCode='
+```vue demo
+<example-modal kind="danger" />
+<!-- @code -->
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -177,15 +179,15 @@ A modal style for destructive or irreversible actions.
 >
   Click to open
 </dt-button>
-'>
-  <example-modal kind="danger" />
-</code-example>
+```
 
 ### Full Screen
 
 To make this modal take up as much of the screen as possible.
 
-<code-example vueCode='
+```vue demo
+<example-modal size="full" />
+<!-- @code -->
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -216,15 +218,23 @@ To make this modal take up as much of the screen as possible.
 >
   Click to open
 </dt-button>
-'>
-  <example-modal size="full" />
-</code-example>
+```
 
 ### Has Banner
 
 When there is a need of more context information regarding the content of the Modal
 
-<code-example vueCode='
+```vue demo
+<dt-stack direction="row" gap="200" align="end">
+  <dt-select-menu
+    v-model="selectedBannerKind"
+    label="Kind of Banner"
+    :size="300"
+    :options="bannerKinds"
+  />
+  <example-modal kind="default" :banner-kind="selectedBannerKind" banner-title="This banner can have different kinds." />
+</dt-stack>
+<!-- @code -->
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -256,17 +266,7 @@ When there is a need of more context information regarding the content of the Mo
 >
   Click to open
 </dt-button>
-'>
-  <dt-stack direction="row" gap="200" align="end">
-    <dt-select-menu
-      v-model="selectedBannerKind"
-      label="Kind of Banner"
-      :size="300"
-      :options="bannerKinds"
-    />
-    <example-modal kind="default" :banner-kind="selectedBannerKind" banner-title="This banner can have different kinds." />
-  </dt-stack>
-</code-example>
+```
 
 ### Custom Header and Content
 
@@ -276,7 +276,28 @@ In addition to the footer, custom elements can be inserted into the header and b
 
 **Please note:** supplied header or body slots will take the place of any provided "title" or "copy" text, respectively.
 
-<code-example vueCode='
+```vue demo
+<div>
+  <dt-modal
+    :show="isOpen"
+    @update:show="updateShow"
+  >
+    <template #header>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-150 d-bgc-purple-100">
+        <div>Custom header</div>
+      </dt-stack>
+    </template>
+    <dt-stack direction="row" align="center" justify="center" class="d-p-400 d-bgc-gold-200">
+      <h2>Custom content</h2>
+    </dt-stack>
+  </dt-modal>
+  <dt-button
+    @click="openModal"
+  >
+    Click to open
+  </dt-button>
+</div>
+<!-- @code -->
 <dt-modal
   :show="isOpen"
   @update:show="updateShow"
@@ -290,49 +311,28 @@ In addition to the footer, custom elements can be inserted into the header and b
     <h2>Custom content</h2>
   </dt-stack>
 </dt-modal>
-'>
-  <div>
-    <dt-modal
-      :show="isOpen"
-      @update:show="updateShow"
-    >
-      <template #header>
-        <dt-stack direction="row" align="center" justify="center" class="d-p-150 d-bgc-purple-100">
-          <div>Custom header</div>
-        </dt-stack>
-      </template>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-400 d-bgc-gold-200">
-        <h2>Custom content</h2>
-      </dt-stack>
-    </dt-modal>
-    <dt-button
-      @click="openModal"
-    >
-      Click to open
-    </dt-button>
-  </div>
-</code-example>
+```
 
 ## Content Mode
 
 Modal content renders outside the DOM tree. Use the `contentMode` prop to apply color mode (invert, light, dark) to the positioned content. See [Positioned Components](/components/mode-island.html#positioned-components) for details.
 
-<code-example vueCode='
+```vue demo
+<div>
+  <dt-button @click="invertedModalOpen = true">Open Inverted Modal</dt-button>
+  <dt-modal
+    content-mode="invert"
+    title="Inverted Modal"
+    copy="This modal's content is in the inverted mode."
+    :show="invertedModalOpen"
+    @update:show="invertedModalOpen = $event"
+  />
+</div>
+<!-- @code -->
 <dt-modal content-mode="invert">...</dt-modal>
 <dt-modal content-mode="dark">...</dt-modal>
 <dt-modal content-mode="light">...</dt-modal>
-'>
-  <div>
-    <dt-button @click="invertedModalOpen = true">Open Inverted Modal</dt-button>
-    <dt-modal
-      content-mode="invert"
-      title="Inverted Modal"
-      copy="This modal's content is in the inverted mode."
-      :show="invertedModalOpen"
-      @update:show="invertedModalOpen = $event"
-    />
-  </div>
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/mode-island.md
+++ b/apps/dialtone-documentation/docs/components/mode-island.md
@@ -5,161 +5,161 @@ status: beta
 keywords: ["theme island","mode override","v-dt-mode","directive","light","dark","invert","v-dt"]
 ---
 
-<code-example only-show="demo">
-  <dt-stack gap="200">
-    <dt-stack direction="row" gap="200" justify="space-between" class="d-w100p">
-      <dt-text as="h4" kind="headline" :size="400">Demo</dt-text>
-      <dt-dropdown
-        navigation-type="arrow-keys"
-        placement="bottom-end"
-      >
-        <template #anchor>
-          <dt-button
-            importance="outlined"
-            kind="muted"
-            :size="200"
+```vue demo-only
+<dt-stack gap="200">
+  <dt-stack direction="row" gap="200" justify="space-between" class="d-w100p">
+    <dt-text as="h4" kind="headline" :size="400">Demo</dt-text>
+    <dt-dropdown
+      navigation-type="arrow-keys"
+      placement="bottom-end"
+    >
+      <template #anchor>
+        <dt-button
+          importance="outlined"
+          kind="muted"
+          :size="200"
+        >
+          <dt-stack gap="100" direction="row">
+            <span>
+              <dt-text strength="bold">Mode:</dt-text>
+              <dt-text tone="tertiary">{{ currentMode.charAt(0).toUpperCase() + currentMode.slice(1) }}</dt-text>
+            </span>
+            <span>
+              <dt-text strength="bold">Contrast:</dt-text>
+              <dt-text tone="tertiary">{{ currentContrast.charAt(0).toUpperCase() + currentContrast.slice(1) }}</dt-text>
+            </span>
+          </dt-stack>
+          <template #startIcon="{ iconSize }">
+            <dt-icon
+              :size="iconSize"
+              :name="currentModeIconName"
+            />
+          </template>
+          <template #endIcon="{ iconSize }">
+            <dt-icon
+              :size="iconSize"
+              name="chevron-down"
+            />
+          </template>
+        </dt-button>
+      </template>
+      <template #list>
+        <dt-list-item-group
+          heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
+          heading="Mode"
+        >
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setMode('system')"
           >
-            <dt-stack gap="100" direction="row">
-              <span>
-                <dt-text strength="bold">Mode:</dt-text>
-                <dt-text tone="tertiary">{{ currentMode.charAt(0).toUpperCase() + currentMode.slice(1) }}</dt-text>
-              </span>
-              <span>
-                <dt-text strength="bold">Contrast:</dt-text>
-                <dt-text tone="tertiary">{{ currentContrast.charAt(0).toUpperCase() + currentContrast.slice(1) }}</dt-text>
-              </span>
-            </dt-stack>
-            <template #startIcon="{ iconSize }">
-              <dt-icon
-                :size="iconSize"
-                :name="currentModeIconName"
-              />
+            System
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentMode !== 'system' }" name="check" size="200" />
             </template>
-            <template #endIcon="{ iconSize }">
-              <dt-icon
-                :size="iconSize"
-                name="chevron-down"
-              />
+          </dt-list-item>
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setMode('light')"
+          >
+            Light
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentMode !== 'light' }" name="check" size="200" />
             </template>
-          </dt-button>
-        </template>
-        <template #list>
-          <dt-list-item-group
-            heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
-            heading="Mode"
+          </dt-list-item>
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setMode('dark')"
           >
-            <dt-list-item
-              role="menuitem"
-              navigation-type="arrow-keys"
-              @click="setMode('system')"
-            >
-              System
-              <template #end>
-                <dt-icon :class="{ 'd-o0': currentMode !== 'system' }" name="check" size="200" />
-              </template>
-            </dt-list-item>
-            <dt-list-item
-              role="menuitem"
-              navigation-type="arrow-keys"
-              @click="setMode('light')"
-            >
-              Light
-              <template #end>
-                <dt-icon :class="{ 'd-o0': currentMode !== 'light' }" name="check" size="200" />
-              </template>
-            </dt-list-item>
-            <dt-list-item
-              role="menuitem"
-              navigation-type="arrow-keys"
-              @click="setMode('dark')"
-            >
-              Dark
-              <template #end>
-                <dt-icon :class="{ 'd-o0': currentMode !== 'dark' }" name="check" size="200" />
-              </template>
-            </dt-list-item>
-          </dt-list-item-group>
-          <dt-dropdown-separator />
-          <dt-list-item-group
-            heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
-            heading="Contrast"
+            Dark
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentMode !== 'dark' }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+        </dt-list-item-group>
+        <dt-dropdown-separator />
+        <dt-list-item-group
+          heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
+          heading="Contrast"
+        >
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setContrast('default')"
           >
-            <dt-list-item
-              role="menuitem"
-              navigation-type="arrow-keys"
-              @click="setContrast('default')"
-            >
-              Default
-              <template #end>
-                <dt-icon :class="{ 'd-o0': currentContrast !== 'default' }" name="check" size="200" />
-              </template>
-            </dt-list-item>
-            <dt-list-item
-              role="menuitem"
-              navigation-type="arrow-keys"
-              @click="setContrast('high')"
-            >
-              High
-              <template #end>
-                <dt-icon :class="{ 'd-o0': currentContrast !== 'high' }" name="check" size="200" />
-              </template>
-            </dt-list-item>
-          </dt-list-item-group>
-        </template>
-      </dt-dropdown>
+            Default
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentContrast !== 'default' }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setContrast('high')"
+          >
+            High
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentContrast !== 'high' }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+        </dt-list-item-group>
+      </template>
+    </dt-dropdown>
+  </dt-stack>
+  <dt-stack :direction="{ 'default': 'column', 'lg': 'row' }" gap="200" class="d-w100p">
+    <dt-stack gap="100" class="d-fl1">
+      <dt-text as="h3" kind="headline" :size="300">Inverted <dt-text strength="normal">(auto)</dt-text></dt-text>
+      <dt-stack v-dt-mode:invert gap="100" class="d-bgc-secondary d-p-200 d-bar8 d-ba d-bc-default">
+        <dt-stack gap="100" direction="row">
+          <dt-icon name="circle-half-filled" size="300" class="d-fc-success" />
+          <dt-text as="p" kind="body" :size="200">Primary</dt-text>
+          <dt-text as="p" kind="body" :size="200" tone="muted">Muted</dt-text>
+          <dt-text as="p" kind="body" :size="200" tone="critical">Critical</dt-text>
+          <dt-link>Link</dt-link>
+        </dt-stack>
+        <dt-stack direction="row" gap="100" class="d-100p">
+          <dt-button :size="200" class="d-fl1">Button</dt-button>
+          <dt-button :size="200" class="d-fl1" kind="danger">Button</dt-button>
+        </dt-stack>
+      </dt-stack>
     </dt-stack>
-    <dt-stack :direction="{ 'default': 'column', 'lg': 'row' }" gap="200" class="d-w100p">
-      <dt-stack gap="100" class="d-fl1">
-        <dt-text as="h3" kind="headline" :size="300">Inverted <dt-text strength="normal">(auto)</dt-text></dt-text>
-        <dt-stack v-dt-mode:invert gap="100" class="d-bgc-secondary d-p-200 d-bar8 d-ba d-bc-default">
-          <dt-stack gap="100" direction="row">
-            <dt-icon name="circle-half-filled" size="300" class="d-fc-success" />
-            <dt-text as="p" kind="body" :size="200">Primary</dt-text>
-            <dt-text as="p" kind="body" :size="200" tone="muted">Muted</dt-text>
-            <dt-text as="p" kind="body" :size="200" tone="critical">Critical</dt-text>
-            <dt-link>Link</dt-link>
-          </dt-stack>
-          <dt-stack direction="row" gap="100" class="d-100p">
-            <dt-button :size="200" class="d-fl1">Button</dt-button>
-            <dt-button :size="200" class="d-fl1" kind="danger">Button</dt-button>
-          </dt-stack>
+    <dt-stack gap="100" class="d-fl1">
+      <dt-text as="h3" kind="headline" :size="300">Explicit light</dt-text>
+      <dt-stack v-dt-mode:light gap="100" class="d-bgc-secondary d-p-200 d-bar8 d-ba d-bc-default">
+        <dt-stack gap="100" direction="row">
+          <dt-icon name="sun" size="300" class="d-fc-success" />
+          <dt-text as="p" kind="body" :size="200">Primary</dt-text>
+          <dt-text as="p" kind="body" :size="200" tone="muted">Muted</dt-text>
+          <dt-text as="p" kind="body" :size="200" tone="critical">Critical</dt-text>
+          <dt-link>Link</dt-link>
+        </dt-stack>
+        <dt-stack direction="row" gap="100" class="d-100p">
+          <dt-button :size="200" class="d-fl1">Button</dt-button>
+          <dt-button :size="200" class="d-fl1" kind="danger">Button</dt-button>
         </dt-stack>
       </dt-stack>
-      <dt-stack gap="100" class="d-fl1">
-        <dt-text as="h3" kind="headline" :size="300">Explicit light</dt-text>
-        <dt-stack v-dt-mode:light gap="100" class="d-bgc-secondary d-p-200 d-bar8 d-ba d-bc-default">
-          <dt-stack gap="100" direction="row">
-            <dt-icon name="sun" size="300" class="d-fc-success" />
-            <dt-text as="p" kind="body" :size="200">Primary</dt-text>
-            <dt-text as="p" kind="body" :size="200" tone="muted">Muted</dt-text>
-            <dt-text as="p" kind="body" :size="200" tone="critical">Critical</dt-text>
-            <dt-link>Link</dt-link>
-          </dt-stack>
-          <dt-stack direction="row" gap="100" class="d-100p">
-            <dt-button :size="200" class="d-fl1">Button</dt-button>
-            <dt-button :size="200" class="d-fl1" kind="danger">Button</dt-button>
-          </dt-stack>
+    </dt-stack>
+    <dt-stack gap="100" class="d-fl1">
+      <dt-text as="h3" kind="headline" :size="300">Explicit dark</dt-text>
+      <dt-stack v-dt-mode:dark gap="100" class="d-bgc-secondary d-p-200 d-bar8 d-ba d-bc-default">
+        <dt-stack gap="100" direction="row">
+          <dt-icon name="moon" size="300" class="d-fc-success" />
+          <dt-text as="p" kind="body" :size="200">Primary</dt-text>
+          <dt-text as="p" kind="body" :size="200" tone="muted">Muted</dt-text>
+          <dt-text as="p" kind="body" :size="200" tone="critical">Critical</dt-text>
+          <dt-link>Link</dt-link>
         </dt-stack>
-      </dt-stack>
-      <dt-stack gap="100" class="d-fl1">
-        <dt-text as="h3" kind="headline" :size="300">Explicit dark</dt-text>
-        <dt-stack v-dt-mode:dark gap="100" class="d-bgc-secondary d-p-200 d-bar8 d-ba d-bc-default">
-          <dt-stack gap="100" direction="row">
-            <dt-icon name="moon" size="300" class="d-fc-success" />
-            <dt-text as="p" kind="body" :size="200">Primary</dt-text>
-            <dt-text as="p" kind="body" :size="200" tone="muted">Muted</dt-text>
-            <dt-text as="p" kind="body" :size="200" tone="critical">Critical</dt-text>
-            <dt-link>Link</dt-link>
-          </dt-stack>
-          <dt-stack direction="row" gap="100" class="d-100p">
-            <dt-button :size="200" class="d-fl1">Button</dt-button>
-            <dt-button :size="200" class="d-fl1" kind="danger">Button</dt-button>
-          </dt-stack>
+        <dt-stack direction="row" gap="100" class="d-100p">
+          <dt-button :size="200" class="d-fl1">Button</dt-button>
+          <dt-button :size="200" class="d-fl1" kind="danger">Button</dt-button>
         </dt-stack>
       </dt-stack>
     </dt-stack>
   </dt-stack>
-</code-example>
+</dt-stack>
+```
 
 <!-- <component-combinator component-name="DtModeIsland" /> -->
 
@@ -167,13 +167,14 @@ keywords: ["theme island","mode override","v-dt-mode","directive","light","dark"
 
 Use the `v-dt-mode` directive to control the color mode of a region, component, or element. It creates a scoped region with the specified mode. Descendant elements retain their original styling but are rendered with the specified mode.
 
-<code-example>
-  <dt-stack gap="100" data-demo-wrapper>
-    <dt-text v-dt-mode:dark tone="success"> Dark content </dt-text>
-    <dt-text v-dt-mode:light tone="success"> Light content </dt-text>
-    <dt-text v-dt-mode:invert tone="success"> Inverted — opposite of parent or root </dt-text>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="100">
+  <dt-text v-dt-mode:dark tone="success"> Dark content </dt-text>
+  <dt-text v-dt-mode:light tone="success"> Light content </dt-text>
+  <dt-text v-dt-mode:invert tone="success"> Inverted — opposite of parent or root </dt-text>
+</dt-stack>
+```
 
 ### Inverting
 
@@ -181,44 +182,45 @@ This effectively removes the need for `inverted` props or variants on elements o
 
 For example, instead of using `inverted` on a DtButton, use `v-dt-mode:invert`
 
-<code-example>
-  <dt-stack gap="200" direction="row" data-demo-wrapper>
-    <dt-button>Button</dt-button>
-    <dt-button v-dt-mode:invert>Button</dt-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="200" direction="row">
+  <dt-button>Button</dt-button>
+  <dt-button v-dt-mode:invert>Button</dt-button>
+</dt-stack>
+```
 
 ### Dynamic mode
 
 Bind a reactive variable as the directive arg to switch modes at runtime.
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="200">
+  <dt-segmented-control :size="100" v-model="dynamicMode" aria-label="Mode">
+    <dt-segmented-control-item value="invert" :selected="dynamicMode === 'invert'">
+      <template #startIcon="{ iconSize }">
+        <dt-icon name="circle-half-filled" :size="iconSize" />
+      </template>
+      Invert
+    </dt-segmented-control-item>
+    <dt-segmented-control-item value="light" :selected="dynamicMode === 'light'">
+      <template #startIcon="{ iconSize }">
+        <dt-icon name="sun" :size="iconSize" />
+      </template>
+      Light
+    </dt-segmented-control-item>
+    <dt-segmented-control-item value="dark" :selected="dynamicMode === 'dark'">
+      <template #startIcon="{ iconSize }">
+        <dt-icon name="moon" :size="iconSize" />
+      </template>
+      Dark
+    </dt-segmented-control-item>
+  </dt-segmented-control>
+  <dt-text v-dt-mode:[dynamicMode] align="center" tone="success"> {{ dynamicMode }} mode </dt-text>
+</dt-stack>
+<!-- @code -->
 <dt-text v-dt-mode:{mode} align="center" tone="success"> ... mode </dt-text>
-'>
-  <dt-stack gap="200">
-    <dt-segmented-control :size="100" v-model="dynamicMode" aria-label="Mode">
-      <dt-segmented-control-item value="invert" :selected="dynamicMode === 'invert'">
-        <template #startIcon="{ iconSize }">
-          <dt-icon name="circle-half-filled" :size="iconSize" />
-        </template>
-        Invert
-      </dt-segmented-control-item>
-      <dt-segmented-control-item value="light" :selected="dynamicMode === 'light'">
-        <template #startIcon="{ iconSize }">
-          <dt-icon name="sun" :size="iconSize" />
-        </template>
-        Light
-      </dt-segmented-control-item>
-      <dt-segmented-control-item value="dark" :selected="dynamicMode === 'dark'">
-        <template #startIcon="{ iconSize }">
-          <dt-icon name="moon" :size="iconSize" />
-        </template>
-        Dark
-      </dt-segmented-control-item>
-    </dt-segmented-control>
-    <dt-text v-dt-mode:[dynamicMode] align="center" tone="success"> {{ dynamicMode }} mode </dt-text>
-  </dt-stack>
-</code-example>
+```
 
 ### Conditional
 
@@ -264,88 +266,89 @@ Pass a boolean value to conditionally apply or remove the directive. When `false
 
 The default mode — inverts relative to the nearest parent mode boundary or the root. When no arg is provided, `v-dt-mode` defaults to invert.
 
-<code-example>
-  <section v-dt-mode class="d-p-200 d-bar8">
-    <dt-text as="p" tone="success">Inverted mode (opposite of parent)</dt-text>
-  </section>
-</code-example>
+```vue demo
+<section v-dt-mode class="d-p-200 d-bar8">
+  <dt-text as="p" tone="success">Inverted mode (opposite of parent)</dt-text>
+</section>
+```
 
 ### Light
 
 Explicitly set to light mode regardless of parent or root mode.
 
-<code-example>
-  <section v-dt-mode:light class="d-p-200 d-bar8">
-    <dt-text as="p" tone="success">Always light mode</dt-text>
-  </section>
-</code-example>
+```vue demo
+<section v-dt-mode:light class="d-p-200 d-bar8">
+  <dt-text as="p" tone="success">Always light mode</dt-text>
+</section>
+```
 
 ### Dark
 
 Explicitly set to dark mode regardless of parent or root mode.
 
-<code-example>
-  <section v-dt-mode:dark class="d-p-200 d-bar8">
-    <dt-text as="p" tone="success">Always dark mode</dt-text>
-  </section>
-</code-example>
+```vue demo
+<section v-dt-mode:dark class="d-p-200 d-bar8">
+  <dt-text as="p" tone="success">Always dark mode</dt-text>
+</section>
+```
 
 ## Nesting
 
 Mode boundaries can be nested. Each `v-dt-mode:invert` reads the nearest parent boundary and flips. In this example the first level is explicitly set to light mode, the second level inverts against that, and the third level inverts again.
 
-<code-example>
-  <dt-stack gap="200" v-dt-mode:light class="d-p-200 d-bar8 d-bgc-secondary d-ba">
-    <dt-text as="p" tone="success" text-box-trim="both">Explicit Light</dt-text>
-    <dt-stack v-dt-mode gap="200" class="d-p-200 d-bar8 d-bgc-secondary">
-      <dt-text as="p" tone="success" text-box-trim="both">Inverted (Dark)</dt-text>
-      <dt-stack v-dt-mode gap="200" class="d-p-200 d-bar4 d-bgc-secondary">
-        <dt-text as="p" tone="success" text-box-trim="both">Inverted again (Light)</dt-text>
-      </dt-stack>
+```vue demo
+<dt-stack gap="200" v-dt-mode:light class="d-p-200 d-bar8 d-bgc-secondary d-ba">
+  <dt-text as="p" tone="success" text-box-trim="both">Explicit Light</dt-text>
+  <dt-stack v-dt-mode gap="200" class="d-p-200 d-bar8 d-bgc-secondary">
+    <dt-text as="p" tone="success" text-box-trim="both">Inverted (Dark)</dt-text>
+    <dt-stack v-dt-mode gap="200" class="d-p-200 d-bar4 d-bgc-secondary">
+      <dt-text as="p" tone="success" text-box-trim="both">Inverted again (Light)</dt-text>
     </dt-stack>
   </dt-stack>
-</code-example>
+</dt-stack>
+```
 
 ## Custom background
 
 The background surface of a Mode Island defaults to the root surface color. To override, use a CSS Utility class.
 
-<code-example>
-  <dt-stack gap="200" data-demo-wrapper>
-    <dt-mode-island class="d-p-200 d-bar8 d-w100p d-bgc-transparent">
-        <dt-stack gap="200">
-          <dt-text as="p" kind="code" :size="100" tone="tertiary">Transparent background, inverted mode island</dt-text>
-          <div>
-            <dt-button>Button</dt-button>
-          </div>
-        </dt-stack>
-      </dt-mode-island>
-      <dt-mode-island class="d-p-200 d-bar8 d-w100p">
-        <dt-stack gap="200">
-          <dt-text as="p" kind="code" :size="100" tone="tertiary">Default background, inverted mode island</dt-text>
-          <div>
-            <dt-button>Button</dt-button>
-          </div>
-        </dt-stack>
-      </dt-mode-island>
-      <dt-mode-island mode="dark" class="d-p-200 d-bar8 d-w100p d-bgc-critical">
-        <dt-stack gap="200">
-          <dt-text as="p" kind="code" :size="100" tone="tertiary">critical background, dark mode island</dt-text>
-          <div>
-            <dt-button>Button</dt-button>
-          </div>
-        </dt-stack>
-      </dt-mode-island>
-      <dt-mode-island mode="light" class="d-p-200 d-bar8 d-w100p d-bgc-critical">
-        <dt-stack gap="200">
-          <dt-text as="p" kind="code" :size="100" tone="tertiary">critical background, light mode island</dt-text>
-          <div>
-            <dt-button>Button</dt-button>
-          </div>
-        </dt-stack>
-      </dt-mode-island>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="200">
+  <dt-mode-island class="d-p-200 d-bar8 d-w100p d-bgc-transparent">
+      <dt-stack gap="200">
+        <dt-text as="p" kind="code" :size="100" tone="tertiary">Transparent background, inverted mode island</dt-text>
+        <div>
+          <dt-button>Button</dt-button>
+        </div>
+      </dt-stack>
+    </dt-mode-island>
+    <dt-mode-island class="d-p-200 d-bar8 d-w100p">
+      <dt-stack gap="200">
+        <dt-text as="p" kind="code" :size="100" tone="tertiary">Default background, inverted mode island</dt-text>
+        <div>
+          <dt-button>Button</dt-button>
+        </div>
+      </dt-stack>
+    </dt-mode-island>
+    <dt-mode-island mode="dark" class="d-p-200 d-bar8 d-w100p d-bgc-critical">
+      <dt-stack gap="200">
+        <dt-text as="p" kind="code" :size="100" tone="tertiary">critical background, dark mode island</dt-text>
+        <div>
+          <dt-button>Button</dt-button>
+        </div>
+      </dt-stack>
+    </dt-mode-island>
+    <dt-mode-island mode="light" class="d-p-200 d-bar8 d-w100p d-bgc-critical">
+      <dt-stack gap="200">
+        <dt-text as="p" kind="code" :size="100" tone="tertiary">critical background, light mode island</dt-text>
+        <div>
+          <dt-button>Button</dt-button>
+        </div>
+      </dt-stack>
+    </dt-mode-island>
+</dt-stack>
+```
 
 ## Examples
 
@@ -353,59 +356,225 @@ The background surface of a Mode Island defaults to the root surface color. To o
 
 A real-world pattern: the callbar container already exists as a semantic element. The directive applies mode theming directly — no wrapper needed.
 
-<code-example>
-  <dt-stack v-dt-mode class="d-ba d-bc-subtle d-bgc-secondary d-p-75 d-py-50 d-bar12 d-bs-md d-w100p" direction="row" gap="400">
-    <dt-stack gap="100" direction="row">
-      <dt-avatar
-        full-name="TA"
-        seed="ted-anderson"
-        :size="400"
-      />
-      <dt-stack gap="25">
-        <dt-text kind="label" :size="300" density="200">Ted Anderson</dt-text>
-        <dt-stack direction="row" gap="50" align="baseline">
-          <dt-text kind="body" :size="100" tone="tertiary" wrap="nowrap" numeric>(913) 555-6745</dt-text>
-          <dt-text kind="body" :size="100" tone="muted">&bull;</dt-text>
-          <dt-text kind="body" :size="100" tone="tertiary" numeric>21:18</dt-text>
-        </dt-stack>
+```vue demo
+<dt-stack v-dt-mode class="d-ba d-bc-subtle d-bgc-secondary d-p-75 d-py-50 d-bar12 d-bs-md d-w100p" direction="row" gap="400">
+  <dt-stack gap="100" direction="row">
+    <dt-avatar
+      full-name="TA"
+      seed="ted-anderson"
+      :size="400"
+    />
+    <dt-stack gap="25">
+      <dt-text kind="label" :size="300" density="200">Ted Anderson</dt-text>
+      <dt-stack direction="row" gap="50" align="baseline">
+        <dt-text kind="body" :size="100" tone="tertiary" wrap="nowrap" numeric>(913) 555-6745</dt-text>
+        <dt-text kind="body" :size="100" tone="muted">&bull;</dt-text>
+        <dt-text kind="body" :size="100" tone="tertiary" numeric>21:18</dt-text>
       </dt-stack>
     </dt-stack>
-    <dt-stack class="d-fl1" direction="row" gap="25" justify="center">
-      <dt-button class="d-px-100 d-w-100" :size="100" kind="danger">
-        <template #blockStartIcon> <dt-icon name="mic" size="300" /> </template>
-        Unmute
-      </dt-button>
-      <dt-button class="d-px-100 d-w-100" :size="100" kind="muted" importance="clear">
-        <template #blockStartIcon> <dt-icon name="record-filled" size="300" /> </template>
-        Record
-      </dt-button>
-      <dt-button class="d-px-100 d-w-100" :size="100" kind="muted" importance="clear">
-        <template #blockStartIcon> <dt-icon name="keypad" size="300" /> </template>
-        Keypad
-      </dt-button>
-      <dt-button class="d-px-100 d-w-100" :size="100" kind="muted" importance="clear">
-        <template #blockStartIcon> <dt-icon name="user-plus" size="300" /> </template>
-        Add
-      </dt-button>
-      <dt-button class="d-px-100 d-w-100" :size="100" kind="muted" importance="clear">
-        <template #blockStartIcon> <dt-icon name="more-horizontal" size="300" /> </template>
-        More
-      </dt-button>
-    </dt-stack>
-    <dt-stack>
-      <dt-button class="d-p-150" circle :size="400" kind="danger">
-        <template #startIcon> <dt-icon name="phone-hang-up" size="500" /> </template>
-      </dt-button>
-    </dt-stack>
   </dt-stack>
-  <dt-text as="p" kind="label" :size="200" tone="muted" class="d-mbs-100">* Not real, still just an example</dt-text>
-</code-example>
+  <dt-stack class="d-fl1" direction="row" gap="25" justify="center">
+    <dt-button class="d-px-100 d-w-100" :size="100" kind="danger">
+      <template #blockStartIcon> <dt-icon name="mic" size="300" /> </template>
+      Unmute
+    </dt-button>
+    <dt-button class="d-px-100 d-w-100" :size="100" kind="muted" importance="clear">
+      <template #blockStartIcon> <dt-icon name="record-filled" size="300" /> </template>
+      Record
+    </dt-button>
+    <dt-button class="d-px-100 d-w-100" :size="100" kind="muted" importance="clear">
+      <template #blockStartIcon> <dt-icon name="keypad" size="300" /> </template>
+      Keypad
+    </dt-button>
+    <dt-button class="d-px-100 d-w-100" :size="100" kind="muted" importance="clear">
+      <template #blockStartIcon> <dt-icon name="user-plus" size="300" /> </template>
+      Add
+    </dt-button>
+    <dt-button class="d-px-100 d-w-100" :size="100" kind="muted" importance="clear">
+      <template #blockStartIcon> <dt-icon name="more-horizontal" size="300" /> </template>
+      More
+    </dt-button>
+  </dt-stack>
+  <dt-stack>
+    <dt-button class="d-p-150" circle :size="400" kind="danger">
+      <template #startIcon> <dt-icon name="phone-hang-up" size="500" /> </template>
+    </dt-button>
+  </dt-stack>
+</dt-stack>
+<dt-text as="p" kind="label" :size="200" tone="muted" class="d-mbs-100">* Not real, still just an example</dt-text>
+```
 
 ### Positioned Components
 
 [Popovers](/components/popover.html), [Dropdowns](/components/dropdown.html), [Modals](/components/modal.html), and [Hovercards](/components/hovercard.html) render their content *outside* the normal DOM tree, so `v-dt-mode` on the component itself won't reach the positioned element. These components provide a `contentMode` prop that applies the mode directly to the positioned content.
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="200">
+  <dt-stack gap="25">
+    <dt-text as="p" kind="headline" :size="300">Hovercard</dt-text>
+    <dt-stack gap="100" direction="row">
+      <dt-hovercard placement="top-start">
+        <template #anchor>
+          <dt-button :size="200" kind="muted" importance="outlined">Default </dt-button>
+        </template>
+        <template #content>
+          <ExampleProfileCard />
+        </template>
+      </dt-hovercard>
+      <dt-hovercard content-mode="invert" placement="top-start">
+        <template #anchor>
+          <dt-button :size="200" kind="muted" importance="outlined">Inverted </dt-button>
+        </template>
+        <template #content>
+          <ExampleProfileCard />
+        </template>
+      </dt-hovercard>
+      <dt-hovercard content-mode="light" placement="top-start">
+        <template #anchor>
+          <dt-button :size="200" kind="muted" importance="outlined">Light </dt-button>
+        </template>
+        <template #content>
+          <ExampleProfileCard />
+        </template>
+      </dt-hovercard>
+      <dt-hovercard content-mode="dark" placement="top-start">
+        <template #anchor>
+          <dt-button :size="200" kind="muted" importance="outlined">Dark </dt-button>
+        </template>
+        <template #content>
+          <ExampleProfileCard />
+        </template>
+      </dt-hovercard>
+    </dt-stack>
+  </dt-stack>
+  <dt-stack gap="25">
+    <dt-text as="p" kind="headline" :size="300">Popover</dt-text>
+    <dt-stack gap="100" direction="row">
+      <dt-popover placement="top-start" dialogClass="d-w-350">
+        <template #anchor>
+          <dt-button :size="200" kind="muted" importance="outlined"> Default </dt-button>
+        </template>
+        <template #content="{ close }">
+          <dt-text as="p">This is just a default Popover, and does not use Mode Island.</dt-text>
+        </template>
+      </dt-popover>
+      <dt-popover content-mode="invert" placement="top-start" dialogClass="d-w-350">
+        <template #anchor>
+          <dt-button :size="200" kind="muted" importance="outlined"> Inverted </dt-button>
+        </template>
+        <template #content="{ close }">
+          <dt-text as="p">This Popover's content is in the <dt-text strength="strong">inverted</dt-text> mode.</dt-text>
+        </template>
+      </dt-popover>
+      <dt-popover content-mode="light" placement="top-start" dialogClass="d-w-350">
+        <template #anchor>
+          <dt-button :size="200" kind="muted" importance="outlined"> Light </dt-button>
+        </template>
+        <template #content="{ close }">
+          <dt-text as="p">This Popover's content is in explicit <dt-text strength="strong">light</dt-text> mode.</dt-text>
+        </template>
+      </dt-popover>
+      <dt-popover content-mode="dark" placement="top-start" dialogClass="d-w-350">
+        <template #anchor>
+          <dt-button :size="200" kind="muted" importance="outlined"> Dark </dt-button>
+        </template>
+        <template #content="{ close }">
+          <dt-text as="p">This Popover's content is in explicit <dt-text strength="strong">dark</dt-text> mode.</dt-text>
+        </template>
+      </dt-popover>
+    </dt-stack>
+  </dt-stack>
+  <dt-stack gap="25">
+    <dt-text as="p" kind="headline" :size="300">Dropdown</dt-text>
+    <dt-stack gap="100" direction="row">
+      <dt-dropdown navigation-type="arrow-keys" placement="bottom-start">
+        <template #anchor="{ attrs }">
+          <dt-button v-bind="attrs" :size="200" kind="muted" importance="outlined">
+            Default
+            <template #endIcon="{ iconSize }">
+              <dt-icon name="chevron-down" :size="iconSize" />
+            </template>
+          </dt-button>
+        </template>
+        <template #list="{ close }">
+          <dt-list-item
+            v-for="item in items"
+            :key="item.id"
+            role="menuitem"
+            :navigation-type="arrow - keys"
+            @click="close"
+          >
+            {{ item.name }}
+          </dt-list-item>
+        </template>
+      </dt-dropdown>
+      <dt-dropdown content-mode="invert" navigation-type="arrow-keys" placement="bottom-start">
+        <template #anchor="{ attrs }">
+          <dt-button v-bind="attrs" :size="200" kind="muted" importance="outlined">
+            Inverted
+            <template #endIcon="{ iconSize }">
+              <dt-icon name="chevron-down" :size="iconSize" />
+            </template>
+          </dt-button>
+        </template>
+        <template #list="{ close }">
+          <dt-list-item
+            v-for="item in items"
+            :key="item.id"
+            role="menuitem"
+            :navigation-type="arrow - keys"
+            @click="close"
+          >
+            {{ item.name }}
+          </dt-list-item>
+        </template>
+      </dt-dropdown>
+      <dt-dropdown content-mode="light" navigation-type="arrow-keys" placement="bottom-start">
+        <template #anchor="{ attrs }">
+          <dt-button v-bind="attrs" :size="200" kind="muted" importance="outlined">
+            Light
+            <template #endIcon="{ iconSize }">
+              <dt-icon name="chevron-down" :size="iconSize" />
+            </template>
+          </dt-button>
+        </template>
+        <template #list="{ close }">
+          <dt-list-item
+            v-for="item in items"
+            :key="item.id"
+            role="menuitem"
+            :navigation-type="arrow - keys"
+            @click="close"
+          >
+            {{ item.name }}
+          </dt-list-item>
+        </template>
+      </dt-dropdown>
+      <dt-dropdown content-mode="dark" navigation-type="arrow-keys" placement="bottom-start">
+        <template #anchor="{ attrs }">
+          <dt-button v-bind="attrs" :size="200" kind="muted" importance="outlined">
+            Dark
+            <template #endIcon="{ iconSize }">
+              <dt-icon name="chevron-down" :size="iconSize" />
+            </template>
+          </dt-button>
+        </template>
+        <template #list="{ close }">
+          <dt-list-item
+            v-for="item in items"
+            :key="item.id"
+            role="menuitem"
+            :navigation-type="arrow - keys"
+            @click="close"
+          >
+            {{ item.name }}
+          </dt-list-item>
+        </template>
+      </dt-dropdown>
+    </dt-stack>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <!-- Hovercard -->
 <dt-hovercard placement="top-start" content-mode="invert">
   <template #anchor>
@@ -446,173 +615,7 @@ A real-world pattern: the callbar container already exists as a semantic element
     </dt-list-item>
   </template>
 </dt-dropdown>
-'>
-  <dt-stack gap="200">
-    <dt-stack gap="25">
-      <dt-text as="p" kind="headline" :size="300">Hovercard</dt-text>
-      <dt-stack gap="100" direction="row">
-        <dt-hovercard placement="top-start">
-          <template #anchor>
-            <dt-button :size="200" kind="muted" importance="outlined">Default </dt-button>
-          </template>
-          <template #content>
-            <ExampleProfileCard />
-          </template>
-        </dt-hovercard>
-        <dt-hovercard content-mode="invert" placement="top-start">
-          <template #anchor>
-            <dt-button :size="200" kind="muted" importance="outlined">Inverted </dt-button>
-          </template>
-          <template #content>
-            <ExampleProfileCard />
-          </template>
-        </dt-hovercard>
-        <dt-hovercard content-mode="light" placement="top-start">
-          <template #anchor>
-            <dt-button :size="200" kind="muted" importance="outlined">Light </dt-button>
-          </template>
-          <template #content>
-            <ExampleProfileCard />
-          </template>
-        </dt-hovercard>
-        <dt-hovercard content-mode="dark" placement="top-start">
-          <template #anchor>
-            <dt-button :size="200" kind="muted" importance="outlined">Dark </dt-button>
-          </template>
-          <template #content>
-            <ExampleProfileCard />
-          </template>
-        </dt-hovercard>
-      </dt-stack>
-    </dt-stack>
-    <dt-stack gap="25">
-      <dt-text as="p" kind="headline" :size="300">Popover</dt-text>
-      <dt-stack gap="100" direction="row">
-        <dt-popover placement="top-start" dialogClass="d-w-350">
-          <template #anchor>
-            <dt-button :size="200" kind="muted" importance="outlined"> Default </dt-button>
-          </template>
-          <template #content="{ close }">
-            <dt-text as="p">This is just a default Popover, and does not use Mode Island.</dt-text>
-          </template>
-        </dt-popover>
-        <dt-popover content-mode="invert" placement="top-start" dialogClass="d-w-350">
-          <template #anchor>
-            <dt-button :size="200" kind="muted" importance="outlined"> Inverted </dt-button>
-          </template>
-          <template #content="{ close }">
-            <dt-text as="p">This Popover's content is in the <dt-text strength="strong">inverted</dt-text> mode.</dt-text>
-          </template>
-        </dt-popover>
-        <dt-popover content-mode="light" placement="top-start" dialogClass="d-w-350">
-          <template #anchor>
-            <dt-button :size="200" kind="muted" importance="outlined"> Light </dt-button>
-          </template>
-          <template #content="{ close }">
-            <dt-text as="p">This Popover's content is in explicit <dt-text strength="strong">light</dt-text> mode.</dt-text>
-          </template>
-        </dt-popover>
-        <dt-popover content-mode="dark" placement="top-start" dialogClass="d-w-350">
-          <template #anchor>
-            <dt-button :size="200" kind="muted" importance="outlined"> Dark </dt-button>
-          </template>
-          <template #content="{ close }">
-            <dt-text as="p">This Popover's content is in explicit <dt-text strength="strong">dark</dt-text> mode.</dt-text>
-          </template>
-        </dt-popover>
-      </dt-stack>
-    </dt-stack>
-    <dt-stack gap="25">
-      <dt-text as="p" kind="headline" :size="300">Dropdown</dt-text>
-      <dt-stack gap="100" direction="row">
-        <dt-dropdown navigation-type="arrow-keys" placement="bottom-start">
-          <template #anchor="{ attrs }">
-            <dt-button v-bind="attrs" :size="200" kind="muted" importance="outlined">
-              Default
-              <template #endIcon="{ iconSize }">
-                <dt-icon name="chevron-down" :size="iconSize" />
-              </template>
-            </dt-button>
-          </template>
-          <template #list="{ close }">
-            <dt-list-item
-              v-for="item in items"
-              :key="item.id"
-              role="menuitem"
-              :navigation-type="arrow - keys"
-              @click="close"
-            >
-              {{ item.name }}
-            </dt-list-item>
-          </template>
-        </dt-dropdown>
-        <dt-dropdown content-mode="invert" navigation-type="arrow-keys" placement="bottom-start">
-          <template #anchor="{ attrs }">
-            <dt-button v-bind="attrs" :size="200" kind="muted" importance="outlined">
-              Inverted
-              <template #endIcon="{ iconSize }">
-                <dt-icon name="chevron-down" :size="iconSize" />
-              </template>
-            </dt-button>
-          </template>
-          <template #list="{ close }">
-            <dt-list-item
-              v-for="item in items"
-              :key="item.id"
-              role="menuitem"
-              :navigation-type="arrow - keys"
-              @click="close"
-            >
-              {{ item.name }}
-            </dt-list-item>
-          </template>
-        </dt-dropdown>
-        <dt-dropdown content-mode="light" navigation-type="arrow-keys" placement="bottom-start">
-          <template #anchor="{ attrs }">
-            <dt-button v-bind="attrs" :size="200" kind="muted" importance="outlined">
-              Light
-              <template #endIcon="{ iconSize }">
-                <dt-icon name="chevron-down" :size="iconSize" />
-              </template>
-            </dt-button>
-          </template>
-          <template #list="{ close }">
-            <dt-list-item
-              v-for="item in items"
-              :key="item.id"
-              role="menuitem"
-              :navigation-type="arrow - keys"
-              @click="close"
-            >
-              {{ item.name }}
-            </dt-list-item>
-          </template>
-        </dt-dropdown>
-        <dt-dropdown content-mode="dark" navigation-type="arrow-keys" placement="bottom-start">
-          <template #anchor="{ attrs }">
-            <dt-button v-bind="attrs" :size="200" kind="muted" importance="outlined">
-              Dark
-              <template #endIcon="{ iconSize }">
-                <dt-icon name="chevron-down" :size="iconSize" />
-              </template>
-            </dt-button>
-          </template>
-          <template #list="{ close }">
-            <dt-list-item
-              v-for="item in items"
-              :key="item.id"
-              role="menuitem"
-              :navigation-type="arrow - keys"
-              @click="close"
-            >
-              {{ item.name }}
-            </dt-list-item>
-          </template>
-        </dt-dropdown>
-      </dt-stack>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ## Component
 
@@ -627,20 +630,20 @@ The `<dt-mode-island>` component is the underlying abstraction that the directiv
   The only real case where you might want to use the component is when you need to create a container element that doesn't already exist, but even then, you can create any kind of containing element with the directive e.g. <code>&lt;span v-dt-mode:invert"&gt;...&lt;/span&gt;</code>.
 </dt-notice>
 
-<code-example only-show="code">
-  <dt-mode-island as="section">
-    Rendered as a section element inverted
-  </dt-mode-island>
-  <dt-mode-island>
-    Inverted (default)
-  </dt-mode-island>
-  <dt-mode-island mode="light">
-    Light
-  </dt-mode-island>
-  <dt-mode-island mode="dark">
-    Dark
-  </dt-mode-island>
-</code-example>
+```vue code-only
+<dt-mode-island as="section">
+  Rendered as a section element inverted
+</dt-mode-island>
+<dt-mode-island>
+  Inverted (default)
+</dt-mode-island>
+<dt-mode-island mode="light">
+  Light
+</dt-mode-island>
+<dt-mode-island mode="dark">
+  Dark
+</dt-mode-island>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/motion-text.md
+++ b/apps/dialtone-documentation/docs/components/motion-text.md
@@ -6,16 +6,16 @@ thumb: true
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-motion-text--default
 ---
 
-<code-example>
-  <dt-text kind="headline" :size="600">
-    <dt-motion-text
-      text="Welcome to Dialtone Motion Text"
-      animation-mode="shimmer"
-      :auto-start="true"
-      loop
-    />
-  </dt-text>
-</code-example>
+```vue demo
+<dt-text kind="headline" :size="600">
+  <dt-motion-text
+    text="Welcome to Dialtone Motion Text"
+    animation-mode="shimmer"
+    :auto-start="true"
+    loop
+  />
+</dt-text>
+```
 
 ## Usage
 
@@ -25,41 +25,60 @@ The Motion Text component provides beautiful text animations with zero configura
 
 The component supports six different animation modes:
 
-<code-example  vueCode='
+```vue demo
+<dt-stack gap="200" align="center" class="d-hmn84">
+  <dt-stack direction="row" gap="100">
+    <dt-button
+      v-for="mode in animationModes"
+      :key="mode"
+      :size="100"
+      kind="muted"
+      importance="outlined"
+      @click="playMode(mode)"
+    >
+      {{ mode }}
+    </dt-button>
+  </dt-stack>
+  <dt-text kind="headline" :size="600">
+    <dt-motion-text
+      ref="animDemoRef"
+      text="Welcome to Dialtone Motion Text"
+      :animation-mode="activeMode"
+      :speed="300"
+    />
+  </dt-text>
+</dt-stack>
+<!-- @code -->
 <dt-text kind="headline" :size="600">
   <dt-motion-text
     text="Welcome to Dialtone Motion Text"
     :animation-mode="{mode}"
   />
 </dt-text>
-'>
-  <dt-stack gap="200" align="center" class="d-hmn84">
-    <dt-stack direction="row" gap="100">
-      <dt-button
-        v-for="mode in animationModes"
-        :key="mode"
-        :size="100"
-        kind="muted"
-        importance="outlined"
-        @click="playMode(mode)"
-      >
-        {{ mode }}
-      </dt-button>
-    </dt-stack>
-    <dt-text kind="headline" :size="600">
-      <dt-motion-text
-        ref="animDemoRef"
-        text="Welcome to Dialtone Motion Text"
-        :animation-mode="activeMode"
-        :speed="300"
-      />
-    </dt-text>
-  </dt-stack>
-</code-example>
+```
 
 ### Speed Control
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="200">
+  <dt-segmented-control :size="100" v-model="selected" aria-label="Speed Control">
+    <dt-segmented-control-item  v-dt-tooltip="'Near-instant'" value="100" :selected="selected === '100'">100</dt-segmented-control-item>
+    <dt-segmented-control-item  v-dt-tooltip="'Fast'" value="200" :selected="selected === '200'">200</dt-segmented-control-item>
+    <dt-segmented-control-item  v-dt-tooltip="'Medium (default)'" value="300" :selected="selected === '300'">300</dt-segmented-control-item>
+    <dt-segmented-control-item  v-dt-tooltip="'Slow'" value="400" :selected="selected === '400'">400</dt-segmented-control-item>
+    <dt-segmented-control-item  v-dt-tooltip="'Very slow'" value="500" :selected="selected === '500'">500</dt-segmented-control-item>
+  </dt-segmented-control>
+  <dt-text kind="headline" :size="600">
+    <dt-motion-text
+      text="Welcome to Dialtone Motion Text"
+      animation-mode="shimmer"
+      :speed="Number(selected)"
+      :auto-start="true"
+      loop
+    />
+  </dt-text>
+</dt-stack>
+<!-- @code -->
 <dt-text kind="headline" :size="600">
   <dt-motion-text
     text="Welcome to Dialtone Motion Text"
@@ -69,32 +88,32 @@ The component supports six different animation modes:
     loop
   />
 </dt-text>
-'>
-  <dt-stack gap="200">
-    <dt-segmented-control :size="100" v-model="selected" aria-label="Speed Control">
-      <dt-segmented-control-item  v-dt-tooltip="'Near-instant'" value="100" :selected="selected === '100'">100</dt-segmented-control-item>
-      <dt-segmented-control-item  v-dt-tooltip="'Fast'" value="200" :selected="selected === '200'">200</dt-segmented-control-item>
-      <dt-segmented-control-item  v-dt-tooltip="'Medium (default)'" value="300" :selected="selected === '300'">300</dt-segmented-control-item>
-      <dt-segmented-control-item  v-dt-tooltip="'Slow'" value="400" :selected="selected === '400'">400</dt-segmented-control-item>
-      <dt-segmented-control-item  v-dt-tooltip="'Very slow'" value="500" :selected="selected === '500'">500</dt-segmented-control-item>
-    </dt-segmented-control>
-    <dt-text kind="headline" :size="600">
-      <dt-motion-text
-        text="Welcome to Dialtone Motion Text"
-        animation-mode="shimmer"
-        :speed="Number(selected)"
-        :auto-start="true"
-        loop
-      />
-    </dt-text>
-  </dt-stack>
-</code-example>
+```
 
 ### Manual Control
 
 Take full control of the animation lifecycle:
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="200" align="center">
+  <dt-stack direction="row" gap="100">
+    <dt-button :size="100" kind="muted" importance="outlined" @click="manualDemoRef.start()">Start</dt-button>
+    <dt-button :size="100" kind="muted" importance="outlined" @click="manualDemoRef.pause()">Pause</dt-button>
+    <dt-button :size="100" kind="muted" importance="outlined" @click="manualDemoRef.resume()">Resume</dt-button>
+    <dt-button :size="100" kind="muted" importance="outlined" @click="manualDemoRef.reset()">Reset</dt-button>
+    <dt-button :size="100" kind="muted" importance="outlined" @click="manualDemoRef.skipToEnd()">Skip to End</dt-button>
+  </dt-stack>
+  <dt-text kind="headline" :size="600">
+    <dt-motion-text
+      ref="manualDemoRef"
+      text="Welcome to Dialtone Motion Text"
+      animation-mode="shimmer"
+      :auto-start="true"
+      loop
+    />
+  </dt-text>
+</dt-stack>
+<!-- @code -->
 <dt-button @click="$refs.textRef.start()">Start</dt-button>
 <dt-button @click="$refs.textRef.pause()">Pause</dt-button>
 <dt-button @click="$refs.textRef.resume()">Resume</dt-button>
@@ -106,50 +125,31 @@ Take full control of the animation lifecycle:
   animation-mode="shimmer"
   :auto-start="false"
 />
-'>
-  <dt-stack gap="200" align="center">
-    <dt-stack direction="row" gap="100">
-      <dt-button :size="100" kind="muted" importance="outlined" @click="manualDemoRef.start()">Start</dt-button>
-      <dt-button :size="100" kind="muted" importance="outlined" @click="manualDemoRef.pause()">Pause</dt-button>
-      <dt-button :size="100" kind="muted" importance="outlined" @click="manualDemoRef.resume()">Resume</dt-button>
-      <dt-button :size="100" kind="muted" importance="outlined" @click="manualDemoRef.reset()">Reset</dt-button>
-      <dt-button :size="100" kind="muted" importance="outlined" @click="manualDemoRef.skipToEnd()">Skip to End</dt-button>
-    </dt-stack>
-    <dt-text kind="headline" :size="600">
-      <dt-motion-text
-        ref="manualDemoRef"
-        text="Welcome to Dialtone Motion Text"
-        animation-mode="shimmer"
-        :auto-start="true"
-        loop
-      />
-    </dt-text>
-  </dt-stack>
-</code-example>
+```
 
 ### Looping Animation
 
 Perfect for attention-grabbing headers or hero sections:
 
-<code-example only-show="code">
-  <dt-motion-text
-    text="Continuous animation"
-    animation-mode="slide-in"
-    :loop="true"
-    :speed="200"
-  />
-</code-example>
+```vue code-only
+<dt-motion-text
+  text="Continuous animation"
+  animation-mode="slide-in"
+  :loop="true"
+  :speed="200"
+/>
+```
 
 ### Using Slots
 
 You can also use the default slot instead of the text prop:
 
-<code-example only-show="code">
-  <dt-motion-text animation-mode="fade-in">
-    <span>Animated </span>
-    <strong>text</strong>
-  </dt-motion-text>
-</code-example>
+```vue code-only
+<dt-motion-text animation-mode="fade-in">
+  <span>Animated </span>
+  <strong>text</strong>
+</dt-motion-text>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/notice.md
+++ b/apps/dialtone-documentation/docs/components/notice.md
@@ -21,7 +21,16 @@ A notice delivers informational and assistive messages that inform the user abou
 
 Used in most scenarios when the message should be noticeable but not dominate.
 
-<code-example bgclass="d-bgc-primary" vueCode='
+```vue demo
+<!-- @bg d-bgc-primary -->
+<dt-stack gap="100">
+  <example-notice kind="base" title="Base title (optional)" />
+  <example-notice kind="error" title="Error title (optional)" />
+  <example-notice kind="info" title="Info title (optional)" />
+  <example-notice kind="success" title="Success title (optional)" />
+  <example-notice kind="warning" title="Warning title (optional)" />
+</dt-stack>
+<!-- @code -->
 <dt-notice
   title="Base title (optional)"
 >
@@ -136,21 +145,21 @@ Used in most scenarios when the message should be noticeable but not dominate.
     </dt-button>
   </template>
 </dt-notice>
-'>
-  <dt-stack gap="100">
-    <example-notice kind="base" title="Base title (optional)" />
-    <example-notice kind="error" title="Error title (optional)" />
-    <example-notice kind="info" title="Info title (optional)" />
-    <example-notice kind="success" title="Success title (optional)" />
-    <example-notice kind="warning" title="Warning title (optional)" />
-  </dt-stack>
-</code-example>
+```
 
 ### Important
 
 Used occasionally in scenarios when the message needs to dominate.
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="100">
+  <example-notice important kind="base" title="Base title (optional)" />
+  <example-notice important kind="error" title="Error title (optional)" />
+  <example-notice important kind="info" title="Info title (optional)" />
+  <example-notice important kind="success" title="Success title (optional)" />
+  <example-notice important kind="warning" title="Warning title (optional)" />
+</dt-stack>
+<!-- @code -->
 <dt-notice
   title="Base title (optional)"
   important
@@ -270,32 +279,25 @@ Used occasionally in scenarios when the message needs to dominate.
     </dt-button>
   </template>
 </dt-notice>
-'>
-  <dt-stack gap="100">
-    <example-notice important kind="base" title="Base title (optional)" />
-    <example-notice important kind="error" title="Error title (optional)" />
-    <example-notice important kind="info" title="Info title (optional)" />
-    <example-notice important kind="success" title="Success title (optional)" />
-    <example-notice important kind="warning" title="Warning title (optional)" />
-  </dt-stack>
-</code-example>
+```
 
 ### Truncate Text
 
 Truncates the text instead of wrapping it. Useful when the Notice needs to have a fixed height.
 
-<code-example bgclass="d-bgc-primary">
-  <dt-notice
-    :truncate-text="true"
-    title="Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-      sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-  >
-    <span>
-      Duis aute irure dolor in reprehenderit in voluptate velit
-      esse cillum dolore eu fugiat nulla pariatur.
-    </span>
-  </dt-notice>
-</code-example>
+```vue demo
+<!-- @bg d-bgc-primary -->
+<dt-notice
+  :truncate-text="true"
+  title="Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+>
+  <span>
+    Duis aute irure dolor in reprehenderit in voluptate velit
+    esse cillum dolore eu fugiat nulla pariatur.
+  </span>
+</dt-notice>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/pagination.md
+++ b/apps/dialtone-documentation/docs/components/pagination.md
@@ -15,21 +15,21 @@ keywords: ["pager", "page navigation", "page numbers", "d-pagination", "DtPagina
 
 ### With Active Page
 
-<code-example>
-  <dt-pagination
-    :total-pages="25"
-    :active-page="5"
-  />
-</code-example>
+```vue demo
+<dt-pagination
+  :total-pages="25"
+  :active-page="5"
+/>
+```
 
 ### With Max-Visible
 
-<code-example>
-  <dt-pagination
-    :total-pages="25"
-    :max-visible="7"
-  />
-</code-example>
+```vue demo
+<dt-pagination
+  :total-pages="25"
+  :max-visible="7"
+/>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/popover.md
+++ b/apps/dialtone-documentation/docs/components/popover.md
@@ -9,9 +9,9 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
 keywords: ["popup", "overlay", "floating", "d-popover", "DtPopover", "dt-popover", "flyout", "tooltip panel"]
 ---
 
-<code-example only-show="demo">
-  <example-popover modal />
-</code-example>
+```vue demo-only
+<example-popover modal />
+```
 
 <component-combinator component-name="DtPopover" />
 
@@ -66,7 +66,9 @@ The content slot will be rendered lazily when the popover is open. By default, t
 
 ### Popover - Modal
 
-<code-example vueCode='
+```vue demo
+<example-popover modal />
+<!-- @code -->
 <dt-popover
   :open="onOpen"
 >
@@ -90,13 +92,13 @@ The content slot will be rendered lazily when the popover is open. By default, t
     </div>
   </template>
 </dt-popover>
-'>
-  <example-popover modal />
-</code-example>
+```
 
 ### Popover - Non Modal
 
-<code-example vueCode='
+```vue demo
+<example-popover />
+<!-- @code -->
 <dt-popover
   :open="onOpen"
   :modal="false"
@@ -121,13 +123,17 @@ The content slot will be rendered lazily when the popover is open. By default, t
     </div>
   </template>
 </dt-popover>
-'>
-  <example-popover />
-</code-example>
+```
 
 ### With Header - Modal
 
-<code-example vueCode='
+```vue demo
+<example-popover modal header>
+  <template #content>
+    <div class="d-mbe-100">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae.<br></div>
+  </template>
+</example-popover>
+<!-- @code -->
 <dt-popover
   :open="onOpen"
 >
@@ -156,17 +162,17 @@ The content slot will be rendered lazily when the popover is open. By default, t
     </div>
   </template>
 </dt-popover>
-'>
-  <example-popover modal header>
-    <template #content>
-      <div class="d-mbe-100">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae.<br></div>
-    </template>
-  </example-popover>
-</code-example>
+```
 
 ### With Footer - Modal
 
-<code-example vueCode='
+```vue demo
+<example-popover modal footer>
+  <template #content>
+    <div class="d-mbe-100">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae.<br></div>
+  </template>
+</example-popover>
+<!-- @code -->
 <dt-popover
   :open="onOpen"
 >
@@ -195,13 +201,7 @@ The content slot will be rendered lazily when the popover is open. By default, t
     </div>
   </template>
 </dt-popover>
-'>
-  <example-popover modal footer>
-    <template #content>
-      <div class="d-mbe-100">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae.<br></div>
-    </template>
-  </example-popover>
-</code-example>
+```
 
 ### Fallback Placements
 
@@ -210,7 +210,9 @@ The popover uses [headless-tippy](https://atomiks.github.io/tippyjs/v6/headless-
 be clipped, it will move to a new position. It will do this automatically by default, but if you want to
 manually specify which position it will move to in what order you can do so via the `fallbackPlacements` prop.
 
-<code-example vueCode='
+```vue demo
+<example-popover :fallback-placements="['top']" button-text="Fallback placement: top" />
+<!-- @code -->
 <dt-popover
   :open="onOpen"
   :fallback-placements="[`top`]"
@@ -235,15 +237,15 @@ manually specify which position it will move to in what order you can do so via 
     </div>
   </template>
 </dt-popover>
-'>
-  <example-popover :fallback-placements="['top']" button-text="Fallback placement: top" />
-</code-example>
+```
 
 ### Padding
 
 Padding options for the popover content are provided via size classes "small", "medium" or "large" in order to standardize the look of the popover content between usages. To remove the padding from the content, you can pass "none". Setting none will also allow you to set custom padding via utility classes (Ex: you only want padding on the left.).
 
-<code-example vueCode='
+```vue demo
+<example-popover padding="small" />
+<!-- @code -->
 <dt-popover
   :open="onOpen"
   padding="small"
@@ -268,9 +270,7 @@ Padding options for the popover content are provided via size classes "small", "
     </div>
   </template>
 </dt-popover>
-'>
-  <example-popover padding="small" />
-</code-example>
+```
 
 ### Force Close All Opened Instances
 
@@ -285,20 +285,20 @@ window.dispatchEvent(e);
 
 Popover content renders outside the DOM tree. Use the `contentMode` prop to apply color mode (invert, light, dark) to the positioned content. See [Positioned Components](/components/mode-island.html#positioned-components) for details.
 
-<code-example vueCode='
+```vue demo
+<dt-popover content-mode="invert" placement="bottom-start" dialogClass="d-w-350">
+  <template #anchor>
+    <dt-button :size="200" kind="muted" importance="outlined">Inverted Popover</dt-button>
+  </template>
+  <template #content="{ close }">
+    <dt-text as="p">This Popover's content is in the <dt-text strength="strong">inverted</dt-text> mode.</dt-text>
+  </template>
+</dt-popover>
+<!-- @code -->
 <dt-popover content-mode="invert">...</dt-popover>
 <dt-popover content-mode="dark">...</dt-popover>
 <dt-popover content-mode="light">...</dt-popover>
-'>
-  <dt-popover content-mode="invert" placement="bottom-start" dialogClass="d-w-350">
-    <template #anchor>
-      <dt-button :size="200" kind="muted" importance="outlined">Inverted Popover</dt-button>
-    </template>
-    <template #content="{ close }">
-      <dt-text as="p">This Popover's content is in the <dt-text strength="strong">inverted</dt-text> mode.</dt-text>
-    </template>
-  </dt-popover>
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/presence.md
+++ b/apps/dialtone-documentation/docs/components/presence.md
@@ -20,38 +20,38 @@ Located at the bottom right of an avatar, the `presence` indicator displays a us
 ### Active
 
 When a user is available.
-<code-example vueCode='
+```vue demo
+<example-presence presence="active" />
+<!-- @code -->
 <dt-presence presence="active" />
-'>
-  <example-presence presence="active" />
-</code-example>
+```
 
 ### Busy
 
 When a user is unavailable, either due to being **'On a call'**, **'In a meeting'**, or set to **'DND (Do Not Disturb)'**. Additionally, a text label indicating their specific status will appear under the user's name.
-<code-example vueCode='
+```vue demo
+<example-presence presence="busy" />
+<!-- @code -->
 <dt-presence presence="busy" />
-'>
-  <example-presence presence="busy" />
-</code-example>
+```
 
 ### Away
 
 When a user has a scheduled meeting on their synced calendar (Google G Suite or Microsoft Office 365) and is not actively participating in it through the app. Additionally, **'In a meeting'** will appear under the user's name.
-<code-example vueCode='
+```vue demo
+<example-presence presence="away" />
+<!-- @code -->
 <dt-presence presence="away" />
-'>
-  <example-presence presence="away" />
-</code-example>
+```
 
 ### Offline
 
 When a user has not logged in for their first time.
-<code-example vueCode='
+```vue demo
+<example-presence presence="offline" />
+<!-- @code -->
 <dt-presence presence="offline" />
-'>
-  <example-presence presence="offline" />
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/progress-circle.md
+++ b/apps/dialtone-documentation/docs/components/progress-circle.md
@@ -30,59 +30,59 @@ Use a progress circle to communicate deterministic progress to the user — for 
 
 ## Demo
 
-<code-example only-show="demo">
-  <dt-stack gap="200" align="center">
-    <dt-progress-circle size="800" :progress="demoProgress" :aria-label="`${demoProgress}% complete`" />
-    <dt-stack direction="row" gap="100">
-      <dt-button :size="200" kind="muted" importance="outlined" :disabled="atMin" @click="setProgress(0)">0%</dt-button>
-      <dt-button :size="200" kind="muted" importance="outlined" :disabled="atMin" @click="setProgress(demoProgress - 10)">-10</dt-button>
-      <dt-button :size="200" kind="muted" importance="outlined" :disabled="atMax" @click="setProgress(demoProgress + 10)">+10</dt-button>
-      <dt-button :size="200" kind="muted" importance="outlined" :disabled="atMax" @click="setProgress(100)">100%</dt-button>
-    </dt-stack>
+```vue demo-only
+<dt-stack gap="200" align="center">
+  <dt-progress-circle size="800" :progress="demoProgress" :aria-label="`${demoProgress}% complete`" />
+  <dt-stack direction="row" gap="100">
+    <dt-button :size="200" kind="muted" importance="outlined" :disabled="atMin" @click="setProgress(0)">0%</dt-button>
+    <dt-button :size="200" kind="muted" importance="outlined" :disabled="atMin" @click="setProgress(demoProgress - 10)">-10</dt-button>
+    <dt-button :size="200" kind="muted" importance="outlined" :disabled="atMax" @click="setProgress(demoProgress + 10)">+10</dt-button>
+    <dt-button :size="200" kind="muted" importance="outlined" :disabled="atMax" @click="setProgress(100)">100%</dt-button>
   </dt-stack>
-</code-example>
+</dt-stack>
+```
 
 ## Variants
 
 ### Progress
 
-<code-example vueCode='
-<dt-progress-circle :progress="{value}" aria-label="{value} complete" />
-'>
-  <dt-stack direction="row" gap="200">
-    <dt-stack v-for="v in [0, 25, 50, 75, 100]" :key="v" gap="200">
-      <dt-progress-circle :progress="v" :aria-label="`${v}% complete`" />
-    </dt-stack>
+```vue demo
+<dt-stack direction="row" gap="200">
+  <dt-stack v-for="v in [0, 25, 50, 75, 100]" :key="v" gap="200">
+    <dt-progress-circle :progress="v" :aria-label="`${v}% complete`" />
   </dt-stack>
-</code-example>
+</dt-stack>
+<!-- @code -->
+<dt-progress-circle :progress="{value}" aria-label="{value} complete" />
+```
 
 ### Sizes
 
 The `size` prop controls the diameter of the progress circle, aligning to Dialtone icon sizes.
 
-<code-example vueCode='
-<dt-progress-circle size="{size}" :progress="66" aria-label="value" />
-'>
-  <dt-stack direction="row" gap="200">
-    <dt-stack v-for="s in ['100', '200', '300', '400', '500', '600', '700', '800']" :key="s" gap="100">
-      <dt-progress-circle :size="s" :progress="66" :aria-label="`size ${s}`" />
-    </dt-stack>
+```vue demo
+<dt-stack direction="row" gap="200">
+  <dt-stack v-for="s in ['100', '200', '300', '400', '500', '600', '700', '800']" :key="s" gap="100">
+    <dt-progress-circle :size="s" :progress="66" :aria-label="`size ${s}`" />
   </dt-stack>
-</code-example>
+</dt-stack>
+<!-- @code -->
+<dt-progress-circle size="{size}" :progress="66" aria-label="value" />
+```
 
 ### Kinds
 
 The `kind` prop sets the color variant of the progress circle.
 
-<code-example vueCode='
-<dt-progress-circle kind="{kind}" :progress="66" aria-label="value" />
-'>
-  <dt-stack direction="row" gap="200">
-    <dt-stack v-for="k in ['default', 'brand', 'critical', 'positive', 'warning', 'info', 'ai']" :key="k" gap="100">
-      <dt-progress-circle :kind="k" :progress="66" :aria-label="`kind ${k}`" />
-    </dt-stack>
+```vue demo
+<dt-stack direction="row" gap="200">
+  <dt-stack v-for="k in ['default', 'brand', 'critical', 'positive', 'warning', 'info', 'ai']" :key="k" gap="100">
+    <dt-progress-circle :kind="k" :progress="66" :aria-label="`kind ${k}`" />
   </dt-stack>
-</code-example>
+</dt-stack>
+<!-- @code -->
+<dt-progress-circle kind="{kind}" :progress="66" aria-label="value" />
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/radio-group.md
+++ b/apps/dialtone-documentation/docs/components/radio-group.md
@@ -14,123 +14,124 @@ keywords: ["radio buttons","radio options","form fields","d-radio-group","DtRadi
 
 ### Default
 
-<code-example>
-  <dt-radio-group
-    model-value=""
-    name="fruits-radio-group-01"
-    legend="Fruits"
-  >
-    <dt-radio value="apple"><span >Apple</span></dt-radio>
-    <dt-radio value="banana"><span >Banana</span></dt-radio>
-    <dt-radio value="other"><span >Other</span></dt-radio>
-  </dt-radio-group>
-</code-example>
+```vue demo
+<dt-radio-group
+  model-value=""
+  name="fruits-radio-group-01"
+  legend="Fruits"
+>
+  <dt-radio value="apple"><span >Apple</span></dt-radio>
+  <dt-radio value="banana"><span >Banana</span></dt-radio>
+  <dt-radio value="other"><span >Other</span></dt-radio>
+</dt-radio-group>
+```
 
 ### With Options
 
 Passing in Radio components programmatically using an options object.
 
-<code-example>
-  <dt-radio-group
-    v-model="selectedFruits"
-    name="fruits-radio-group"
-    legend="Fruits"
+```vue demo
+<dt-radio-group
+  v-model="selectedFruits"
+  name="fruits-radio-group"
+  legend="Fruits"
+>
+  <dt-radio
+    v-for="option in options"
+    :key="option.value"
+    :value="option.value"
   >
-    <dt-radio
-      v-for="option in options"
-      :key="option.value"
-      :value="option.value"
-    >
-      <span>{{ option.label }}</span>
-    </dt-radio>
-  </dt-radio-group>
-</code-example>
+    <span>{{ option.label }}</span>
+  </dt-radio>
+</dt-radio-group>
+```
 
 ### Without Legend
 
 When no legend is provided it is expected that an `aria-label` is passed into the component.
 
-<code-example>
-  <dt-radio-group
-    name="fruits-radio-group"
-    aria-label="Fruits"
-  >
-    <dt-radio value="pear">Pear</dt-radio>
-    <dt-radio value="kiwi">Kiwi</dt-radio>
-  </dt-radio-group>
-</code-example>
+```vue demo
+<dt-radio-group
+  name="fruits-radio-group"
+  aria-label="Fruits"
+>
+  <dt-radio value="pear">Pear</dt-radio>
+  <dt-radio value="kiwi">Kiwi</dt-radio>
+</dt-radio-group>
+```
 
 ### With Slotted Legend
 
 The legend can also be passed by slot.
 
-<code-example>
-  <dt-radio-group
-    name="fruits-radio-group"
-  >
-    <dt-radio value="pear">Pear</dt-radio>
-    <dt-radio value="kiwi">Kiwi</dt-radio>
-    <template #legend>
-      Fruits
-    </template>
-  </dt-radio-group>
-</code-example>
+```vue demo
+<dt-radio-group
+  name="fruits-radio-group"
+>
+  <dt-radio value="pear">Pear</dt-radio>
+  <dt-radio value="kiwi">Kiwi</dt-radio>
+  <template #legend>
+    Fruits
+  </template>
+</dt-radio-group>
+```
 
 ### With Event Hander
 
 The event handler is only needed if you need to do additional processing. The v-model is automatically updated.
 
-<code-example>
-  <dt-radio-group
-    v-model="selectedFruits"
-    name="fruits-radio-group"
-    legend="Fruits"
-    @input="onInput"
-  >
-    <dt-radio value="pear">Pear</dt-radio>
-    <dt-radio value="kiwi">Kiwi</dt-radio>
-  </dt-radio-group>
-</code-example>
+```vue demo
+<dt-radio-group
+  v-model="selectedFruits"
+  name="fruits-radio-group"
+  legend="Fruits"
+  @input="onInput"
+>
+  <dt-radio value="pear">Pear</dt-radio>
+  <dt-radio value="kiwi">Kiwi</dt-radio>
+</dt-radio-group>
+```
 
 ### With Validation States
 
-<code-example>
-  <dt-stack gap="200" data-demo-wrapper>
-    <div>
-      <dt-radio-group
-        name="radio-group-with-success-message"
-        legend="With Success Message"
-        :messages='[{"message":"Success validation message","type":"success"}]'
-      >
-        <dt-radio value="apple"><span >Apple</span></dt-radio>
-        <dt-radio value="banana"><span >Banana</span></dt-radio>
-        <dt-radio value="other"><span >Other</span></dt-radio>
-      </dt-radio-group>
-    </div>
-    <div>
-      <dt-radio-group
-        name="radio-group-with-warning-message"
-        legend="With Warning Message"
-        :messages='[{"message":"Warning validation message","type":"warning"}]'
-      >
-        <dt-radio value="apple"><span >Apple</span></dt-radio>
-        <dt-radio value="banana"><span >Banana</span></dt-radio>
-        <dt-radio value="other"><span >Other</span></dt-radio>
-      </dt-radio-group>
-    </div>
-    <div>
-      <dt-radio-group
-        name="radio-group-with-error-message"
-        legend="With Error Message"
-        :messages='[{"message":"Error validation message","type":"error"}]'
-      >
-        <dt-radio value="apple"><span >Apple</span></dt-radio>
-        <dt-radio value="banana"><span >Banana</span></dt-radio>
-        <dt-radio value="other"><span >Other</span></dt-radio>
-      </dt-radio-group>
-    </div>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="200">
+  <div>
+    <dt-radio-group
+      name="radio-group-with-success-message"
+      legend="With Success Message"
+      :messages='[{"message":"Success validation message","type":"success"}]'
+    >
+      <dt-radio value="apple"><span >Apple</span></dt-radio>
+      <dt-radio value="banana"><span >Banana</span></dt-radio>
+      <dt-radio value="other"><span >Other</span></dt-radio>
+    </dt-radio-group>
+  </div>
+  <div>
+    <dt-radio-group
+      name="radio-group-with-warning-message"
+      legend="With Warning Message"
+      :messages='[{"message":"Warning validation message","type":"warning"}]'
+    >
+      <dt-radio value="apple"><span >Apple</span></dt-radio>
+      <dt-radio value="banana"><span >Banana</span></dt-radio>
+      <dt-radio value="other"><span >Other</span></dt-radio>
+    </dt-radio-group>
+  </div>
+  <div>
+    <dt-radio-group
+      name="radio-group-with-error-message"
+      legend="With Error Message"
+      :messages='[{"message":"Error validation message","type":"error"}]'
+    >
+      <dt-radio value="apple"><span >Apple</span></dt-radio>
+      <dt-radio value="banana"><span >Banana</span></dt-radio>
+      <dt-radio value="other"><span >Other</span></dt-radio>
+    </dt-radio-group>
+  </div>
+</dt-stack>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/radio.md
+++ b/apps/dialtone-documentation/docs/components/radio.md
@@ -44,88 +44,90 @@ Radio buttons are a common way to allow users to make a single selection from a 
 
 ### Base Styles
 
-<code-example>
-  <dt-stack gap="100" data-demo-wrapper>
-    <dt-radio name="Value" value="Value" label="Radio label"/>
-    <dt-radio name="Disabled" value="Disabled" label="Radio label thats been disabled" disabled/>
-    <dt-radio name="CheckedDisabled" value="Checked" label="Radio label thats been disabled & checked" :model-value="true" disabled />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="100">
+  <dt-radio name="Value" value="Value" label="Radio label"/>
+  <dt-radio name="Disabled" value="Disabled" label="Radio label thats been disabled" disabled/>
+  <dt-radio name="CheckedDisabled" value="Checked" label="Radio label thats been disabled & checked" :model-value="true" disabled />
+</dt-stack>
+```
 
 ### With Description Text
 
-<code-example>
-  <dt-radio-group legend="Advanced missed call routing" model-value="">
-    <dt-radio name="ValueWDesc" value="Value" label="To voicemail" description="So they can hear your voice"/>
-    <dt-radio name="DisabledWDesc" value="Disabled" label="Disabled" description="With Description" disabled />
-  </dt-radio-group>
-</code-example>
+```vue demo
+<dt-radio-group legend="Advanced missed call routing" model-value="">
+  <dt-radio name="ValueWDesc" value="Value" label="To voicemail" description="So they can hear your voice"/>
+  <dt-radio name="DisabledWDesc" value="Disabled" label="Disabled" description="With Description" disabled />
+</dt-radio-group>
+```
 
 ### With Validation States
 
-<code-example>
-  <dt-radio-group legend="Advanced missed call routing" model-value="">
-    <dt-radio
-      name="ValidationMessages"
-      value="Validation Message Warning"
-      label="To voicemail"
-      validation-state="warning"
-      :messages="[{ message: `So they can hear your voice`, type: `warning` }]"
-    />
-    <dt-radio
-      name="ValidationMessages"
-      value="Validation Message Error"
-      label="To a message (no voicemail)"
-      validation-state="error"
-      :messages="[{ message: `Because they probably don't need to leave a message anyway.`, type: `error` }]"
-    />
-    <dt-radio
-      name="ValidationMessages"
-      value="Validation Message Success"
-      label="To a team member or room phone"
-      validation-state="success"
-      :messages="[{ message: `Because someone else might be able to talk to them.`, type: `success` }]"
-    />
-  </dt-radio-group>
-</code-example>
+```vue demo
+<dt-radio-group legend="Advanced missed call routing" model-value="">
+  <dt-radio
+    name="ValidationMessages"
+    value="Validation Message Warning"
+    label="To voicemail"
+    validation-state="warning"
+    :messages="[{ message: `So they can hear your voice`, type: `warning` }]"
+  />
+  <dt-radio
+    name="ValidationMessages"
+    value="Validation Message Error"
+    label="To a message (no voicemail)"
+    validation-state="error"
+    :messages="[{ message: `Because they probably don't need to leave a message anyway.`, type: `error` }]"
+  />
+  <dt-radio
+    name="ValidationMessages"
+    value="Validation Message Success"
+    label="To a team member or room phone"
+    validation-state="success"
+    :messages="[{ message: `Because someone else might be able to talk to them.`, type: `success` }]"
+  />
+</dt-radio-group>
+```
 
 ### With Slotted Label
 
-<code-example>
-  <dt-radio
-    name="ValueWSlot"
-    value="Value"
-  >
-    With Slotted Label
-  </dt-radio>
-</code-example>
+```vue demo
+<dt-radio
+  name="ValueWSlot"
+  value="Value"
+>
+  With Slotted Label
+</dt-radio>
+```
 
 ### With Slotted Description
 
-<code-example>
-  <dt-radio
-    name="ValueWSlottedDescription"
-    value="Value"
-    label="With"
-  >
-    <template #description>
-      Slotted Description
-    </template>
-  </dt-radio>
-</code-example>
+```vue demo
+<dt-radio
+  name="ValueWSlottedDescription"
+  value="Value"
+  label="With"
+>
+  <template #description>
+    Slotted Description
+  </template>
+</dt-radio>
+```
 
 ## Label size
 
 Use the `label-size` prop to override the default label size.
 
-<code-example>
-  <dt-stack gap="100" data-demo-wrapper>
-    <dt-radio name="labelSizeExample1" value="xs" label="Extra small label" :label-size="100" checked />
-    <dt-radio name="labelSizeExample1" value="sm" label="Small label" :label-size="200" />
-    <dt-radio name="labelSizeExample1" value="md" label="Medium label (default)" :label-size="300" />
-    <dt-radio name="labelSizeExample1" value="lg" label="Large label" :label-size="400" />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="100">
+  <dt-radio name="labelSizeExample1" value="xs" label="Extra small label" :label-size="100" checked />
+  <dt-radio name="labelSizeExample1" value="sm" label="Small label" :label-size="200" />
+  <dt-radio name="labelSizeExample1" value="md" label="Medium label (default)" :label-size="300" />
+  <dt-radio name="labelSizeExample1" value="lg" label="Large label" :label-size="400" />
+</dt-stack>
+```
 
 ## Classes
 

--- a/apps/dialtone-documentation/docs/components/rich-text-editor.md
+++ b/apps/dialtone-documentation/docs/components/rich-text-editor.md
@@ -30,7 +30,9 @@ keywords: ["rte", "wysiwyg", "markdown", "d-rte", "DtRichTextEditor", "dt-rich-t
 
 The editor itself is without any styling and the intention is to wrap it with another component, such as Message Input, that provides the UI.
 
-<code-example vueCode='
+```vue demo
+<example-rich-text-editor :modelValue="defaultValue" />
+<!-- @code -->
 <dt-rich-text-editor
   v-model="value"
   :editable="true"
@@ -41,17 +43,15 @@ The editor itself is without any styling and the intention is to wrap it with an
   placeholder="Type here..."
   :link="true"
 />
-'>
-  <example-rich-text-editor :modelValue="defaultValue" />
-</code-example>
+```
 
 ## With Links
 
-<code-example only-show="demo">
-  <example-rich-text-editor
-    modelValue="<p>The editor can autolink URLs: <a target='_blank' rel='noopener noreferrer nofollow' class='d-link d-wb-break-all' href='http://dialpad.com'>dialpad.com</a>, <a target='_blank' rel='noopener noreferrer nofollow' class='d-link d-wb-break-all' href='https://www.dialpad.com/about-us/'>https://www.dialpad.com/about-us/</a>, email addresses: <a target='_blank' rel='noopener noreferrer nofollow' class='d-link d-wb-break-all' href='mailto:noreply@dialpad.com'>noreply@dialpad.com</a></p>"
-  />
-</code-example>
+```vue demo-only
+<example-rich-text-editor
+  modelValue="<p>The editor can autolink URLs: <a target='_blank' rel='noopener noreferrer nofollow' class='d-link d-wb-break-all' href='http://dialpad.com'>dialpad.com</a>, <a target='_blank' rel='noopener noreferrer nofollow' class='d-link d-wb-break-all' href='https://www.dialpad.com/about-us/'>https://www.dialpad.com/about-us/</a>, email addresses: <a target='_blank' rel='noopener noreferrer nofollow' class='d-link d-wb-break-all' href='mailto:noreply@dialpad.com'>noreply@dialpad.com</a></p>"
+/>
+```
 
 ## Output Format
 
@@ -117,7 +117,12 @@ If this mentionSuggestion Object prop is not supplied, the mention plugin is dis
 
 To see it in action type char '@' into rich editor With channel mentions.
 
-<code-example vueCode='
+```vue demo
+<example-rich-text-editor
+  modelValue="<p>The editor can also suggest mentions: <mention-component name='Test Person' avatarsrc='' id='test.person'></mention-component>, <mention-component name='Test Person 2' avatarsrc='' id='test.person2'></mention-component>! The suggestions dropdown will wait 1000ms to simulate an API call.</p>"
+  :mentionSuggestion="{ items }"
+/>
+<!-- @code -->
 <dt-rich-text-editor
   v-model="value"
   :editable="true"
@@ -129,12 +134,7 @@ To see it in action type char '@' into rich editor With channel mentions.
   :link="true"
   :mentionSuggestion="{ items }"
 />
-'>
-  <example-rich-text-editor
-    modelValue="<p>The editor can also suggest mentions: <mention-component name='Test Person' avatarsrc='' id='test.person'></mention-component>, <mention-component name='Test Person 2' avatarsrc='' id='test.person2'></mention-component>! The suggestions dropdown will wait 1000ms to simulate an API call.</p>"
-    :mentionSuggestion="{ items }"
-  />
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/root-layout.md
+++ b/apps/dialtone-documentation/docs/components/root-layout.md
@@ -8,29 +8,30 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-root-layout-
 keywords: ["app layout","page layout","d-root-layout","DtRootLayout","dt-root-layout"]
 ---
 
-<code-example class="d-d-block" only-show="demo">
+```vue demo-only
+<!-- @class d-d-block -->
 <dt-root-layout
-  :fixed="false"
-  class="d-w100p d-h-500"
+:fixed="false"
+class="d-w100p d-h-500"
 >
-  <template
-    #header
-  >
-    <div class="d-h-100 d-bgc-purple-100">Header</div>
-  </template>
-  <template
-    #sidebar
-  >
-    <div class="d-w-200 d-h100p d-bgc-black-100"><div>Sidebar item 1</div><div>Sidebar item 2</div><div>Sidebar item 3</div></div>
-  </template>
-  <div class="d-bgc-green-100 d-w100p d-h100p">Content</div>
-  <template
-    #footer
-  >
-    <div class="d-h-100 d-bgc-gold-100">Footer</div>
-  </template>
+<template
+  #header
+>
+  <div class="d-h-100 d-bgc-purple-100">Header</div>
+</template>
+<template
+  #sidebar
+>
+  <div class="d-w-200 d-h100p d-bgc-black-100"><div>Sidebar item 1</div><div>Sidebar item 2</div><div>Sidebar item 3</div></div>
+</template>
+<div class="d-bgc-green-100 d-w100p d-h100p">Content</div>
+<template
+  #footer
+>
+  <div class="d-h-100 d-bgc-gold-100">Footer</div>
+</template>
 </dt-root-layout>
-</code-example>
+```
 
 <!-- <component-combinator component-name="DtRootLayout" /> -->
 
@@ -40,61 +41,63 @@ A root layout consists of a header, body, sidebar and footer. Content can option
 will be displayed in the respective area. The sidebar is designed to be responsive and will reposition above the
 body according to the `responsiveBreakpoint` prop.
 
-<code-example class="d-d-block">
+```vue demo
+<!-- @class d-d-block -->
 <dt-root-layout
-  :fixed="false"
-  class="d-w100p d-h-500"
+:fixed="false"
+class="d-w100p d-h-500"
 >
-  <template
-    #header
-  >
-    <div class="d-h-100 d-bgc-purple-100">Header</div>
-  </template>
-  <template
-    #sidebar
-  >
-    <div class="d-w-200 d-h100p d-bgc-black-100"><div>Sidebar item 1</div><div>Sidebar item 2</div><div>Sidebar item 3</div></div>
-  </template>
-  <div class="d-bgc-green-100 d-w100p d-h100p">Content</div>
-  <template
-    #footer
-  >
-    <div class="d-h-100 d-bgc-gold-100">Footer</div>
-  </template>
+<template
+  #header
+>
+  <div class="d-h-100 d-bgc-purple-100">Header</div>
+</template>
+<template
+  #sidebar
+>
+  <div class="d-w-200 d-h100p d-bgc-black-100"><div>Sidebar item 1</div><div>Sidebar item 2</div><div>Sidebar item 3</div></div>
+</template>
+<div class="d-bgc-green-100 d-w100p d-h100p">Content</div>
+<template
+  #footer
+>
+  <div class="d-h-100 d-bgc-gold-100">Footer</div>
+</template>
 </dt-root-layout>
-</code-example>
+```
 
 ## Variants and Examples
 
 ### Header Sticky
 
-<code-example class="d-d-block">
-  <div
-    class="d-h-500 d-of-scroll"
+```vue demo
+<!-- @class d-d-block -->
+<div
+  class="d-h-500 d-of-scroll"
+>
+  <dt-root-layout
+    header-sticky
+    class="d-w100p d-h-500"
   >
-    <dt-root-layout
-      header-sticky
-      class="d-w100p d-h-500"
+    <template
+      #header
     >
-      <template
-        #header
-      >
-        <div class="d-h-100 d-bgc-purple-100">Header</div>
-      </template>
-      <template
-        #sidebar
-      >
-        <div class="d-w-200 d-h100p d-bgc-black-100"><div>Sidebar item 1</div><div>Sidebar item 2</div><div>Sidebar item 3</div></div>
-      </template>
-        <div class="d-bgc-green-100 d-w100p d-h100p">Content</div>
-      <template
-        #footer
-      >
-        <div class="d-h-100 d-bgc-gold-100">Footer</div>
-      </template>
-    </dt-root-layout>
-  </div>
-</code-example>
+      <div class="d-h-100 d-bgc-purple-100">Header</div>
+    </template>
+    <template
+      #sidebar
+    >
+      <div class="d-w-200 d-h100p d-bgc-black-100"><div>Sidebar item 1</div><div>Sidebar item 2</div><div>Sidebar item 3</div></div>
+    </template>
+      <div class="d-bgc-green-100 d-w100p d-h100p">Content</div>
+    <template
+      #footer
+    >
+      <div class="d-h-100 d-bgc-gold-100">Footer</div>
+    </template>
+  </dt-root-layout>
+</div>
+```
 
 ## Usage
 

--- a/apps/dialtone-documentation/docs/components/scrollbar.md
+++ b/apps/dialtone-documentation/docs/components/scrollbar.md
@@ -13,15 +13,15 @@ keywords: ["scrollable", "d-scrollbar", "DtScrollbar", "dt-scrollbar", "custom s
 
 Allows to add overlay scrollbars that will look the same for every browser. The directive sets up the scrollbars from the library [OverlayScrollbars](https://kingsora.github.io/OverlayScrollbars/).
 
-<code-example>
-  <div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar>
-    <dt-stack>
-      <div v-for="item in items" class="item">
-        {{ item}}
-      </div>
-    </dt-stack>
-  </div>
-</code-example>
+```vue demo
+<div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar>
+  <dt-stack>
+    <div v-for="item in items" class="item">
+      {{ item}}
+    </div>
+  </dt-stack>
+</div>
+```
 
 ## Usage
 
@@ -61,57 +61,57 @@ To customize the behavior of the scrollbar, you can use different arguments with
 
 Show the scrollbar when the mouse enters the scrollable area. This is the default option, so no argument is needed.
 
-<code-example>
-  <div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar>
-    <dt-stack>
-      <div v-for="item in items" class="item">
-        {{ item}}
-      </div>
-    </dt-stack>
-  </div>
-</code-example>
+```vue demo
+<div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar>
+  <dt-stack>
+    <div v-for="item in items" class="item">
+      {{ item}}
+    </div>
+  </dt-stack>
+</div>
+```
 
 ### Always
 
 Always show the scrollbar if the region is overflowing the available space.
 
-<code-example>
-  <div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar:never>
-    <dt-stack>
-      <div v-for="item in items" class="item">
-        {{ item}}
-      </div>
-    </dt-stack>
-  </div>
-</code-example>
+```vue demo
+<div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar:never>
+  <dt-stack>
+    <div v-for="item in items" class="item">
+      {{ item}}
+    </div>
+  </dt-stack>
+</div>
+```
 
 ### Scroll
 
 Show the scrollbar on scroll.
 
-<code-example>
-  <div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar:scroll>
-    <dt-stack>
-      <div v-for="item in items" class="item">
-        {{ item}}
-      </div>
-    </dt-stack>
-  </div>
-</code-example>
+```vue demo
+<div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar:scroll>
+  <dt-stack>
+    <div v-for="item in items" class="item">
+      {{ item}}
+    </div>
+  </dt-stack>
+</div>
+```
 
 ### Move
 
 Show the scrollbar when the mouse moves inside the scrollable area.
 
-<code-example>
-  <div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar:move>
-    <dt-stack>
-      <div v-for="item in items" class="item">
-        {{ item}}
-      </div>
-    </dt-stack>
-  </div>
-</code-example>
+```vue demo
+<div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar:move>
+  <dt-stack>
+    <div v-for="item in items" class="item">
+      {{ item}}
+    </div>
+  </dt-stack>
+</div>
+```
 
 ## Limitations
 

--- a/apps/dialtone-documentation/docs/components/scroller.md
+++ b/apps/dialtone-documentation/docs/components/scroller.md
@@ -27,153 +27,156 @@ The rule of thumb: if every item in your list is the same height, use fixed. If 
 
 Use when all items share a known, uniform height. Set `:item-size` to that height in pixels.
 
-<code-example>
-  <div class="d-w-400" data-demo-wrapper>
-    <dt-scroller
-      :items="[
-        { id: 1, name: 'James Cooper' }, { id: 2, name: 'Sarah Mitchell' }, { id: 3, name: 'Tyler Brooks' },
-        { id: 4, name: 'Emma Davidson' }, { id: 5, name: 'Connor Hayes' }, { id: 6, name: 'Rachel Foster' },
-        { id: 7, name: 'Brandon Williams' }, { id: 8, name: 'Megan Clark' }, { id: 9, name: 'Sofia Reyes' },
-        { id: 10, name: 'Diego Herrera' }, { id: 11, name: 'Valentina Cruz' }, { id: 12, name: 'Mateo Vargas' },
-        { id: 13, name: 'Lucia Mendoza' }, { id: 14, name: 'Carlos Romero' }, { id: 15, name: 'Isabella Flores' },
-        { id: 16, name: 'Alejandro Vega' }, { id: 17, name: 'Lucas Dubois' }, { id: 18, name: 'Camille Rousseau' },
-        { id: 19, name: 'Julien Moreau' }, { id: 20, name: 'Claire Bernard' }, { id: 21, name: 'Antoine Laurent' },
-        { id: 22, name: 'Isabelle Lefevre' }, { id: 23, name: 'Pierre Dumont' }, { id: 24, name: 'Margot Girard' },
-        { id: 25, name: 'Tobias Fischer' }, { id: 26, name: 'Lena Hoffmann' }, { id: 27, name: 'Klaus Weber' },
-        { id: 28, name: 'Mia Becker' }, { id: 29, name: 'Hans Braun' }, { id: 30, name: 'Anna Müller' },
-        { id: 31, name: 'Felix Wagner' }, { id: 32, name: 'Sophie Richter' }, { id: 33, name: 'Ezra Cohen' },
-        { id: 34, name: 'Rachel Levy' }, { id: 35, name: 'Noah Goldstein' }, { id: 36, name: 'Miriam Shapiro' },
-        { id: 37, name: 'Aaron Berkowitz' }, { id: 38, name: 'Leah Rosenberg' }, { id: 39, name: 'David Katz' },
-        { id: 40, name: 'Hannah Stein' }, { id: 41, name: 'Samuel Weiss' }, { id: 42, name: 'Omar Hassan' },
-        { id: 43, name: 'Fatima Al-Rashid' }, { id: 44, name: 'Layla Mansouri' }, { id: 45, name: 'Tariq Al-Farsi' },
-        { id: 46, name: 'Amira El-Amin' }, { id: 47, name: 'Zaid Khalil' }, { id: 48, name: 'Nour Abboud' },
-        { id: 49, name: 'Yusuf Al-Sayed' }, { id: 50, name: 'Dina Qureshi' },
-      ]"
-      :item-size="32"
-      :scroller-height="200"
-      list-tag="div"
-      item-tag="div"
-      direction="vertical"
-      class="d-ba d-bar8 d-p-50"
-      >
-      <template #default="{ item }">
-        <dt-text class="d-px-50">{{ item.name }}</dt-text>
-      </template>
-    </dt-scroller>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-400">
+  <dt-scroller
+    :items="[
+      { id: 1, name: 'James Cooper' }, { id: 2, name: 'Sarah Mitchell' }, { id: 3, name: 'Tyler Brooks' },
+      { id: 4, name: 'Emma Davidson' }, { id: 5, name: 'Connor Hayes' }, { id: 6, name: 'Rachel Foster' },
+      { id: 7, name: 'Brandon Williams' }, { id: 8, name: 'Megan Clark' }, { id: 9, name: 'Sofia Reyes' },
+      { id: 10, name: 'Diego Herrera' }, { id: 11, name: 'Valentina Cruz' }, { id: 12, name: 'Mateo Vargas' },
+      { id: 13, name: 'Lucia Mendoza' }, { id: 14, name: 'Carlos Romero' }, { id: 15, name: 'Isabella Flores' },
+      { id: 16, name: 'Alejandro Vega' }, { id: 17, name: 'Lucas Dubois' }, { id: 18, name: 'Camille Rousseau' },
+      { id: 19, name: 'Julien Moreau' }, { id: 20, name: 'Claire Bernard' }, { id: 21, name: 'Antoine Laurent' },
+      { id: 22, name: 'Isabelle Lefevre' }, { id: 23, name: 'Pierre Dumont' }, { id: 24, name: 'Margot Girard' },
+      { id: 25, name: 'Tobias Fischer' }, { id: 26, name: 'Lena Hoffmann' }, { id: 27, name: 'Klaus Weber' },
+      { id: 28, name: 'Mia Becker' }, { id: 29, name: 'Hans Braun' }, { id: 30, name: 'Anna Müller' },
+      { id: 31, name: 'Felix Wagner' }, { id: 32, name: 'Sophie Richter' }, { id: 33, name: 'Ezra Cohen' },
+      { id: 34, name: 'Rachel Levy' }, { id: 35, name: 'Noah Goldstein' }, { id: 36, name: 'Miriam Shapiro' },
+      { id: 37, name: 'Aaron Berkowitz' }, { id: 38, name: 'Leah Rosenberg' }, { id: 39, name: 'David Katz' },
+      { id: 40, name: 'Hannah Stein' }, { id: 41, name: 'Samuel Weiss' }, { id: 42, name: 'Omar Hassan' },
+      { id: 43, name: 'Fatima Al-Rashid' }, { id: 44, name: 'Layla Mansouri' }, { id: 45, name: 'Tariq Al-Farsi' },
+      { id: 46, name: 'Amira El-Amin' }, { id: 47, name: 'Zaid Khalil' }, { id: 48, name: 'Nour Abboud' },
+      { id: 49, name: 'Yusuf Al-Sayed' }, { id: 50, name: 'Dina Qureshi' },
+    ]"
+    :item-size="32"
+    :scroller-height="200"
+    list-tag="div"
+    item-tag="div"
+    direction="vertical"
+    class="d-ba d-bar8 d-p-50"
+    >
+    <template #default="{ item }">
+      <dt-text class="d-px-50">{{ item.name }}</dt-text>
+    </template>
+  </dt-scroller>
+</div>
+```
 
 ### Variable height items
 
 Use when item heights depend on their content. Set `dynamic="true"` and `:min-item-size` to the smallest expected item height — the component measures actual sizes after render.
 
-<code-example>
-  <div class="d-w-400" data-demo-wrapper>
-    <dt-scroller
-      :items="[
-        { id: 'J.C.', message: 'Lorem ipsum dolor sit amet' },
-        { id: 'S.M.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'T.B.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
-        { id: 'E.D.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'C.H.', message: 'Lorem ipsum dolor sit amet' },
-        { id: 'R.F.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
-        { id: 'B.W.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'S.R.', message: 'Lorem ipsum dolor sit amet' },
-        { id: 'D.H.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'V.C.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
-        { id: 'M.V.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'L.M.', message: 'Lorem ipsum dolor sit amet' },
-        { id: 'C.R.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
-        { id: 'I.F.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'L.D.', message: 'Lorem ipsum dolor sit amet' },
-        { id: 'C.R.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'J.M.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
-        { id: 'C.B.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'A.L.', message: 'Lorem ipsum dolor sit amet' },
-        { id: 'I.L.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
-        { id: 'P.D.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'T.F.', message: 'Lorem ipsum dolor sit amet' },
-        { id: 'L.H.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'K.W.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
-        { id: 'M.B.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'H.B.', message: 'Lorem ipsum dolor sit amet' },
-        { id: 'A.M.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
-        { id: 'F.W.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'E.C.', message: 'Lorem ipsum dolor sit amet' },
-        { id: 'R.L.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'N.G.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
-        { id: 'M.S.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'A.B.', message: 'Lorem ipsum dolor sit amet' },
-        { id: 'L.R.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
-        { id: 'D.K.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'O.H.', message: 'Lorem ipsum dolor sit amet' },
-        { id: 'F.A.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'L.M.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
-        { id: 'T.A.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-        { id: 'A.E.', message: 'Lorem ipsum dolor sit amet' },
-        { id: 'Z.K.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
-        { id: 'N.A.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
-      ]"
-      :min-item-size="54"
-      :scroller-height="300"
-      list-tag="div"
-      item-tag="div"
-      direction="vertical"
-      :dynamic="true"
-      class="d-ba d-bar8 d-p-50"
-    >
-      <template #default="{ item }">
-        <dt-stack gap="100" direction="row" align="start" class="d-p-50">
-          <dt-avatar :size="300" :full-name="item.id" />
-          <dt-stack>
-            <dt-text kind="headline" :size="200" tone="secondary">{{ item.id }}</dt-text>
-            <dt-text kind="body" :size="200" tone="primary">{{ item.message }}</dt-text>
-          </dt-stack>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-400">
+  <dt-scroller
+    :items="[
+      { id: 'J.C.', message: 'Lorem ipsum dolor sit amet' },
+      { id: 'S.M.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'T.B.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
+      { id: 'E.D.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'C.H.', message: 'Lorem ipsum dolor sit amet' },
+      { id: 'R.F.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
+      { id: 'B.W.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'S.R.', message: 'Lorem ipsum dolor sit amet' },
+      { id: 'D.H.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'V.C.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
+      { id: 'M.V.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'L.M.', message: 'Lorem ipsum dolor sit amet' },
+      { id: 'C.R.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
+      { id: 'I.F.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'L.D.', message: 'Lorem ipsum dolor sit amet' },
+      { id: 'C.R.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'J.M.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
+      { id: 'C.B.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'A.L.', message: 'Lorem ipsum dolor sit amet' },
+      { id: 'I.L.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
+      { id: 'P.D.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'T.F.', message: 'Lorem ipsum dolor sit amet' },
+      { id: 'L.H.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'K.W.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
+      { id: 'M.B.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'H.B.', message: 'Lorem ipsum dolor sit amet' },
+      { id: 'A.M.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
+      { id: 'F.W.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'E.C.', message: 'Lorem ipsum dolor sit amet' },
+      { id: 'R.L.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'N.G.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
+      { id: 'M.S.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'A.B.', message: 'Lorem ipsum dolor sit amet' },
+      { id: 'L.R.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
+      { id: 'D.K.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'O.H.', message: 'Lorem ipsum dolor sit amet' },
+      { id: 'F.A.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'L.M.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
+      { id: 'T.A.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+      { id: 'A.E.', message: 'Lorem ipsum dolor sit amet' },
+      { id: 'Z.K.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl' },
+      { id: 'N.A.', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam, nunc nisl aliquet nunc, eget aliquam nisl ni lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor, nisl eget ultrices aliquam' },
+    ]"
+    :min-item-size="54"
+    :scroller-height="300"
+    list-tag="div"
+    item-tag="div"
+    direction="vertical"
+    :dynamic="true"
+    class="d-ba d-bar8 d-p-50"
+  >
+    <template #default="{ item }">
+      <dt-stack gap="100" direction="row" align="start" class="d-p-50">
+        <dt-avatar :size="300" :full-name="item.id" />
+        <dt-stack>
+          <dt-text kind="headline" :size="200" tone="secondary">{{ item.id }}</dt-text>
+          <dt-text kind="body" :size="200" tone="primary">{{ item.message }}</dt-text>
         </dt-stack>
-      </template>
-    </dt-scroller>
-  </div>
-</code-example>
+      </dt-stack>
+    </template>
+  </dt-scroller>
+</div>
+```
 
 ### Direction
 
 Defaults to `vertical`. Set to `horizontal` for a horizontal scroller.
 
-<code-example>
-  <div class="d-w-400" data-demo-wrapper>
-    <dt-scroller
-      :items="[
-        { id: 1, name: 'JC' }, { id: 2, name: 'SM' }, { id: 3, name: 'TB' },
-        { id: 4, name: 'ED' }, { id: 5, name: 'CH' }, { id: 6, name: 'RF' },
-        { id: 7, name: 'BW' }, { id: 8, name: 'MC' }, { id: 9, name: 'SR' },
-        { id: 10, name: 'DH' }, { id: 11, name: 'VC' }, { id: 12, name: 'MV' },
-        { id: 13, name: 'LM' }, { id: 14, name: 'CR' }, { id: 15, name: 'IF' },
-        { id: 16, name: 'AV' }, { id: 17, name: 'LD' }, { id: 18, name: 'CR' },
-        { id: 19, name: 'JM' }, { id: 20, name: 'CB' }, { id: 21, name: 'AL' },
-        { id: 22, name: 'IL' }, { id: 23, name: 'PD' }, { id: 24, name: 'MG' },
-        { id: 25, name: 'TF' }, { id: 26, name: 'LH' }, { id: 27, name: 'KW' },
-        { id: 28, name: 'MB' }, { id: 29, name: 'HB' }, { id: 30, name: 'AM' },
-        { id: 31, name: 'FW' }, { id: 32, name: 'SR' }, { id: 33, name: 'EC' },
-        { id: 34, name: 'RL' }, { id: 35, name: 'NG' }, { id: 36, name: 'MS' },
-        { id: 37, name: 'AB' }, { id: 38, name: 'LR' }, { id: 39, name: 'DK' },
-        { id: 40, name: 'HS' }, { id: 41, name: 'SW' }, { id: 42, name: 'OH' },
-        { id: 43, name: 'FA' }, { id: 44, name: 'LM' }, { id: 45, name: 'TA' },
-        { id: 46, name: 'AE' }, { id: 47, name: 'ZK' }, { id: 48, name: 'NA' },
-        { id: 49, name: 'YA' }, { id: 50, name: 'DQ' },
-      ]"
-      :item-size="50"
-      :scroller-height="56"
-      list-tag="div"
-      item-tag="div"
-      direction="horizontal"
-      class="d-ba d-bar8 d-p-50"
-      >
-      <template #default="{ item }">
-        <dt-stack class="d-p-150 d-ba h:d-bgc-secondary d-bc-subtle d-bar4 d-c-default" align="center" justify="center"><dt-text kind="code">{{ item.name }}</dt-text></dt-stack>
-      </template>
-    </dt-scroller>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-400">
+  <dt-scroller
+    :items="[
+      { id: 1, name: 'JC' }, { id: 2, name: 'SM' }, { id: 3, name: 'TB' },
+      { id: 4, name: 'ED' }, { id: 5, name: 'CH' }, { id: 6, name: 'RF' },
+      { id: 7, name: 'BW' }, { id: 8, name: 'MC' }, { id: 9, name: 'SR' },
+      { id: 10, name: 'DH' }, { id: 11, name: 'VC' }, { id: 12, name: 'MV' },
+      { id: 13, name: 'LM' }, { id: 14, name: 'CR' }, { id: 15, name: 'IF' },
+      { id: 16, name: 'AV' }, { id: 17, name: 'LD' }, { id: 18, name: 'CR' },
+      { id: 19, name: 'JM' }, { id: 20, name: 'CB' }, { id: 21, name: 'AL' },
+      { id: 22, name: 'IL' }, { id: 23, name: 'PD' }, { id: 24, name: 'MG' },
+      { id: 25, name: 'TF' }, { id: 26, name: 'LH' }, { id: 27, name: 'KW' },
+      { id: 28, name: 'MB' }, { id: 29, name: 'HB' }, { id: 30, name: 'AM' },
+      { id: 31, name: 'FW' }, { id: 32, name: 'SR' }, { id: 33, name: 'EC' },
+      { id: 34, name: 'RL' }, { id: 35, name: 'NG' }, { id: 36, name: 'MS' },
+      { id: 37, name: 'AB' }, { id: 38, name: 'LR' }, { id: 39, name: 'DK' },
+      { id: 40, name: 'HS' }, { id: 41, name: 'SW' }, { id: 42, name: 'OH' },
+      { id: 43, name: 'FA' }, { id: 44, name: 'LM' }, { id: 45, name: 'TA' },
+      { id: 46, name: 'AE' }, { id: 47, name: 'ZK' }, { id: 48, name: 'NA' },
+      { id: 49, name: 'YA' }, { id: 50, name: 'DQ' },
+    ]"
+    :item-size="50"
+    :scroller-height="56"
+    list-tag="div"
+    item-tag="div"
+    direction="horizontal"
+    class="d-ba d-bar8 d-p-50"
+    >
+    <template #default="{ item }">
+      <dt-stack class="d-p-150 d-ba h:d-bgc-secondary d-bc-subtle d-bar4 d-c-default" align="center" justify="center"><dt-text kind="code">{{ item.name }}</dt-text></dt-stack>
+    </template>
+  </dt-scroller>
+</div>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/segmented-control.md
+++ b/apps/dialtone-documentation/docs/components/segmented-control.md
@@ -7,14 +7,14 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-segmented-co
 keywords: ["segmented control", "toggle group", "button toggle", "radio group", "d-segmented-control", "DtSegmentedControl", "dt-segmented-control", "select", "scope", "content switcher"]
 ---
 
-<code-example only-show="demo">
-  <dt-segmented-control v-model="selected" aria-label="View filter">
-    <dt-segmented-control-item value="all">All</dt-segmented-control-item>
-    <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
-    <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
-    <dt-segmented-control-item value="groups">Groups</dt-segmented-control-item>
-  </dt-segmented-control>
-</code-example>
+```vue demo-only
+<dt-segmented-control v-model="selected" aria-label="View filter">
+  <dt-segmented-control-item value="all">All</dt-segmented-control-item>
+  <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
+  <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
+  <dt-segmented-control-item value="groups">Groups</dt-segmented-control-item>
+</dt-segmented-control>
+```
 
 <component-combinator component-name="DtSegmentedControl" />
 
@@ -64,138 +64,145 @@ Each `dt-segmented-control-item` wraps a `DtButton` internally and inherits its 
 
 ### Default
 
-<code-example>
-  <div class="d-w100p" data-demo-wrapper>
-    <dt-segmented-control v-model="selected" aria-label="View filter">
-      <dt-segmented-control-item value="all">All</dt-segmented-control-item>
-      <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
-      <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
-      <dt-segmented-control-item value="groups">Groups</dt-segmented-control-item>
-    </dt-segmented-control>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w100p">
+  <dt-segmented-control v-model="selected" aria-label="View filter">
+    <dt-segmented-control-item value="all">All</dt-segmented-control-item>
+    <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
+    <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
+    <dt-segmented-control-item value="groups">Groups</dt-segmented-control-item>
+  </dt-segmented-control>
+</div>
+```
 
 ### Borderless
 
 Remove the border and padding from the container.
 
-<code-example vueCode='
+```vue demo
+<!-- @wrapper -->
+<div class="d-w100p">
+  <dt-segmented-control v-model="selected" borderless aria-label="View filter">
+    <dt-segmented-control-item value="all">All</dt-segmented-control-item>
+    <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
+    <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
+    <dt-segmented-control-item value="groups">Groups</dt-segmented-control-item>
+  </dt-segmented-control>
+</div>
+<!-- @code -->
 <dt-segmented-control v-model="selected" borderless>
   ...
 </dt-segmented-control>
-'>
-  <div class="d-w100p" data-demo-wrapper>
-    <dt-segmented-control v-model="selected" borderless aria-label="View filter">
-      <dt-segmented-control-item value="all">All</dt-segmented-control-item>
-      <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
-      <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
-      <dt-segmented-control-item value="groups">Groups</dt-segmented-control-item>
-    </dt-segmented-control>
-  </div>
-</code-example>
+```
 
 ### Hide Divider
 
-<code-example vueCode='
+```vue demo
+<!-- @wrapper -->
+<div class="d-w100p">
+  <dt-segmented-control v-model="selected" hide-divider aria-label="View filter">
+    <dt-segmented-control-item value="all">All</dt-segmented-control-item>
+    <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
+    <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
+    <dt-segmented-control-item value="groups">Groups</dt-segmented-control-item>
+  </dt-segmented-control>
+</div>
+<!-- @code -->
 <dt-segmented-control v-model="selected" hide-divider>
   ...
 </dt-segmented-control>
-'>
-  <div class="d-w100p" data-demo-wrapper>
-    <dt-segmented-control v-model="selected" hide-divider aria-label="View filter">
-      <dt-segmented-control-item value="all">All</dt-segmented-control-item>
-      <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
-      <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
-      <dt-segmented-control-item value="groups">Groups</dt-segmented-control-item>
-    </dt-segmented-control>
-  </div>
-</code-example>
+```
 
 ### Spread Evenly
 
 Items share space equally. Only applies in horizontal orientation.
 
-<code-example vueCode='
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-750">
+  <dt-segmented-control v-model="spreadSelected" spread="evenly" aria-label="Spread example">
+    <dt-segmented-control-item value="1">1</dt-segmented-control-item>
+    <dt-segmented-control-item value="two">Two</dt-segmented-control-item>
+    <dt-segmented-control-item value="three">Three</dt-segmented-control-item>
+    <dt-segmented-control-item value="four">Four long label</dt-segmented-control-item>
+  </dt-segmented-control>
+</div>
+<!-- @code -->
 <dt-segmented-control v-model="selected" spread="evenly">
   ...
 </dt-segmented-control>
-'>
-  <div class="d-w-750" data-demo-wrapper>
-    <dt-segmented-control v-model="spreadSelected" spread="evenly" aria-label="Spread example">
-      <dt-segmented-control-item value="1">1</dt-segmented-control-item>
-      <dt-segmented-control-item value="two">Two</dt-segmented-control-item>
-      <dt-segmented-control-item value="three">Three</dt-segmented-control-item>
-      <dt-segmented-control-item value="four">Four long label</dt-segmented-control-item>
-    </dt-segmented-control>
-  </div>
-</code-example>
+```
 
 ### Disabled
 
 Add `disabled` to the group to disable all items.
 
-<code-example vueCode='
+```vue demo
+<!-- @wrapper -->
+<div class="d-w100p">
+  <dt-segmented-control v-model="selected" disabled aria-label="Disabled example" hide-divider>
+    <dt-segmented-control-item value="all">All</dt-segmented-control-item>
+    <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
+    <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
+  </dt-segmented-control>
+</div>
+<!-- @code -->
 <dt-segmented-control v-model="selected" disabled>
   ...
 </dt-segmented-control>
-'>
-  <div class="d-w100p" data-demo-wrapper>
-    <dt-segmented-control v-model="selected" disabled aria-label="Disabled example" hide-divider>
-      <dt-segmented-control-item value="all">All</dt-segmented-control-item>
-      <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
-      <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
-    </dt-segmented-control>
-  </div>
-</code-example>
+```
 
 Add `disabled` to an individual item.
 
-<code-example>
-  <div class="d-w100p" data-demo-wrapper>
-    <dt-segmented-control v-model="selected" aria-label="Individual disabled example">
-      <dt-segmented-control-item value="all">All</dt-segmented-control-item>
-      <dt-segmented-control-item value="favorites" disabled>Favorites</dt-segmented-control-item>
-      <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
-      <dt-segmented-control-item value="groups">Groups</dt-segmented-control-item>
-    </dt-segmented-control>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w100p">
+  <dt-segmented-control v-model="selected" aria-label="Individual disabled example">
+    <dt-segmented-control-item value="all">All</dt-segmented-control-item>
+    <dt-segmented-control-item value="favorites" disabled>Favorites</dt-segmented-control-item>
+    <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
+    <dt-segmented-control-item value="groups">Groups</dt-segmented-control-item>
+  </dt-segmented-control>
+</div>
+```
 
 ## Sizes
 
-<code-example vueCode='
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="100" class="d-w100p">
+  <dt-segmented-control v-model="selected" :size="100" aria-label="Extra small">
+    <dt-segmented-control-item value="all">All</dt-segmented-control-item>
+    <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
+    <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
+  </dt-segmented-control>
+  <dt-segmented-control v-model="selected" aria-label="Small (default)">
+    <dt-segmented-control-item value="all">All</dt-segmented-control-item>
+    <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
+    <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
+  </dt-segmented-control>
+  <dt-segmented-control v-model="selected" :size="300" aria-label="Medium">
+    <dt-segmented-control-item value="all">All</dt-segmented-control-item>
+    <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
+    <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
+  </dt-segmented-control>
+  <dt-segmented-control v-model="selected" :size="400" aria-label="Large">
+    <dt-segmented-control-item value="all">All</dt-segmented-control-item>
+    <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
+    <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
+  </dt-segmented-control>
+  <dt-segmented-control v-model="selected" :size="500" aria-label="Extra large">
+    <dt-segmented-control-item value="all">All</dt-segmented-control-item>
+    <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
+    <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
+  </dt-segmented-control>
+</dt-stack>
+<!-- @code -->
 <dt-segmented-control v-model="selected" :size="100|200|300|400|500">
   ...
 </dt-segmented-control>
-'>
-  <dt-stack gap="100" class="d-w100p" data-demo-wrapper>
-    <dt-segmented-control v-model="selected" :size="100" aria-label="Extra small">
-      <dt-segmented-control-item value="all">All</dt-segmented-control-item>
-      <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
-      <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
-    </dt-segmented-control>
-    <dt-segmented-control v-model="selected" aria-label="Small (default)">
-      <dt-segmented-control-item value="all">All</dt-segmented-control-item>
-      <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
-      <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
-    </dt-segmented-control>
-    <dt-segmented-control v-model="selected" :size="300" aria-label="Medium">
-      <dt-segmented-control-item value="all">All</dt-segmented-control-item>
-      <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
-      <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
-    </dt-segmented-control>
-    <dt-segmented-control v-model="selected" :size="400" aria-label="Large">
-      <dt-segmented-control-item value="all">All</dt-segmented-control-item>
-      <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
-      <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
-    </dt-segmented-control>
-    <dt-segmented-control v-model="selected" :size="500" aria-label="Extra large">
-      <dt-segmented-control-item value="all">All</dt-segmented-control-item>
-      <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
-      <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
-    </dt-segmented-control>
-  </dt-stack>
-</code-example>
+```
 
 ## Slots
 
@@ -203,138 +210,41 @@ Add `disabled` to an individual item.
 
 Use the `#startIcon` or `#endIcon` slot on `dt-segmented-control-item` to add an icon. The slot provides `iconSize` to match the control's size.
 
-<code-example>
-  <div class="d-w100p" data-demo-wrapper>
-    <dt-segmented-control v-model="iconSelected" aria-label="List spacing">
-      <dt-segmented-control-item value="compact">
-        <template #startIcon="{ iconSize }">
-          <dt-icon name="list-spacing-compact" :size="iconSize" />
-        </template>
-        Compact
-      </dt-segmented-control-item>
-      <dt-segmented-control-item value="regular">
-        <template #startIcon="{ iconSize }">
-          <dt-icon name="list-spacing-regular" :size="iconSize" />
-        </template>
-        Regular
-      </dt-segmented-control-item>
-      <dt-segmented-control-item value="expanded">
-        <template #startIcon="{ iconSize }">
-          <dt-icon name="list-spacing-expanded" :size="iconSize" />
-        </template>
-        Expanded
-      </dt-segmented-control-item>
-    </dt-segmented-control>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w100p">
+  <dt-segmented-control v-model="iconSelected" aria-label="List spacing">
+    <dt-segmented-control-item value="compact">
+      <template #startIcon="{ iconSize }">
+        <dt-icon name="list-spacing-compact" :size="iconSize" />
+      </template>
+      Compact
+    </dt-segmented-control-item>
+    <dt-segmented-control-item value="regular">
+      <template #startIcon="{ iconSize }">
+        <dt-icon name="list-spacing-regular" :size="iconSize" />
+      </template>
+      Regular
+    </dt-segmented-control-item>
+    <dt-segmented-control-item value="expanded">
+      <template #startIcon="{ iconSize }">
+        <dt-icon name="list-spacing-expanded" :size="iconSize" />
+      </template>
+      Expanded
+    </dt-segmented-control-item>
+  </dt-segmented-control>
+</div>
+```
 
 ### Icon Only
 
 Omit the default slot text to create icon-only items. Use the `label` prop for accessibility.
 
-<code-example>
-  <dt-stack gap="100" align="center" data-demo-wrapper>
-    <div class="d-w-750">
-      <dt-segmented-control v-model="iconOnlySelected" aria-label="Appearance mode">
-        <dt-segmented-control-item value="system" label="System">
-          <template #startIcon="{ iconSize }">
-            <dt-icon name="laptop-2" :size="iconSize" />
-          </template>
-        </dt-segmented-control-item>
-        <dt-segmented-control-item value="light" label="Light">
-          <template #startIcon="{ iconSize }">
-            <dt-icon name="sun" :size="iconSize" />
-          </template>
-        </dt-segmented-control-item>
-        <dt-segmented-control-item value="dark" label="Dark">
-          <template #startIcon="{ iconSize }">
-            <dt-icon name="moon" :size="iconSize" />
-          </template>
-        </dt-segmented-control-item>
-      </dt-segmented-control>
-    </div>
-    <div>
-      <dt-segmented-control v-model="iconOnlySelected" aria-label="Appearance mode" class="d-d-inline-flex">
-        <dt-segmented-control-item value="system" label="System">
-          <template #startIcon="{ iconSize }">
-            <dt-icon name="laptop-2" :size="iconSize" />
-          </template>
-        </dt-segmented-control-item>
-        <dt-segmented-control-item value="light" label="Light">
-          <template #startIcon="{ iconSize }">
-            <dt-icon name="sun" :size="iconSize" />
-          </template>
-        </dt-segmented-control-item>
-        <dt-segmented-control-item value="dark" label="Dark">
-          <template #startIcon="{ iconSize }">
-            <dt-icon name="moon" :size="iconSize" />
-          </template>
-        </dt-segmented-control-item>
-      </dt-segmented-control>
-    </div>
-  </dt-stack>
-</code-example>
-
-### Leading & Trailing
-
-Use the `#leading` and `#trailing` slots on `dt-segmented-control-item` to render content alongside labels, such as badges or count indicators.
-
-<code-example>
-  <dt-segmented-control v-model="trailingSelected" aria-label="Fruit counts">
-    <dt-segmented-control-item value="apples" trailingClass="d-pie-100">
-      Apples
-      <template #trailing>
-        <dt-badge kind="count">24</dt-badge>
-      </template>
-    </dt-segmented-control-item>
-    <dt-segmented-control-item value="oranges" trailingClass="d-pie-100">
-      Oranges
-      <template #trailing>
-        <dt-badge kind="count">8</dt-badge>
-      </template>
-    </dt-segmented-control-item>
-    <dt-segmented-control-item value="bananas" trailingClass="d-pie-100">
-      Bananas
-      <template #trailing>
-        <dt-badge kind="count">15</dt-badge>
-      </template>
-    </dt-segmented-control-item>
-  </dt-segmented-control>
-</code-example>
-
-## Orientation
-
-Set `orientation="vertical"` to stack items vertically.
-
-<code-example vueCode='
-<dt-segmented-control v-model="selected" orientation="vertical">
-  ...
-</dt-segmented-control>
-'>
-  <dt-stack direction="row" gap="200" align="start">
-    <div class="d-w-250">
-      <dt-segmented-control v-model="selected" orientation="vertical" aria-label="Vertical example">
-        <dt-segmented-control-item value="all">
-          System
-          <template #startIcon="{ iconSize }">
-            <dt-icon name="laptop-2" :size="iconSize" />
-          </template>
-        </dt-segmented-control-item>
-        <dt-segmented-control-item value="favorites">
-          Light
-          <template #startIcon="{ iconSize }">
-            <dt-icon name="sun" :size="iconSize" />
-          </template>
-        </dt-segmented-control-item>
-        <dt-segmented-control-item value="recent">
-          Dark
-          <template #startIcon="{ iconSize }">
-            <dt-icon name="moon" :size="iconSize" />
-          </template>
-        </dt-segmented-control-item>
-      </dt-segmented-control>
-    </div>
-    <dt-segmented-control v-model="iconOnlySelected" aria-label="Appearance mode" orientation="vertical">
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="100" align="center">
+  <div class="d-w-750">
+    <dt-segmented-control v-model="iconOnlySelected" aria-label="Appearance mode">
       <dt-segmented-control-item value="system" label="System">
         <template #startIcon="{ iconSize }">
           <dt-icon name="laptop-2" :size="iconSize" />
@@ -351,8 +261,107 @@ Set `orientation="vertical"` to stack items vertically.
         </template>
       </dt-segmented-control-item>
     </dt-segmented-control>
-  </dt-stack>
-</code-example>
+  </div>
+  <div>
+    <dt-segmented-control v-model="iconOnlySelected" aria-label="Appearance mode" class="d-d-inline-flex">
+      <dt-segmented-control-item value="system" label="System">
+        <template #startIcon="{ iconSize }">
+          <dt-icon name="laptop-2" :size="iconSize" />
+        </template>
+      </dt-segmented-control-item>
+      <dt-segmented-control-item value="light" label="Light">
+        <template #startIcon="{ iconSize }">
+          <dt-icon name="sun" :size="iconSize" />
+        </template>
+      </dt-segmented-control-item>
+      <dt-segmented-control-item value="dark" label="Dark">
+        <template #startIcon="{ iconSize }">
+          <dt-icon name="moon" :size="iconSize" />
+        </template>
+      </dt-segmented-control-item>
+    </dt-segmented-control>
+  </div>
+</dt-stack>
+```
+
+### Leading & Trailing
+
+Use the `#leading` and `#trailing` slots on `dt-segmented-control-item` to render content alongside labels, such as badges or count indicators.
+
+```vue demo
+<dt-segmented-control v-model="trailingSelected" aria-label="Fruit counts">
+  <dt-segmented-control-item value="apples" trailingClass="d-pie-100">
+    Apples
+    <template #trailing>
+      <dt-badge kind="count">24</dt-badge>
+    </template>
+  </dt-segmented-control-item>
+  <dt-segmented-control-item value="oranges" trailingClass="d-pie-100">
+    Oranges
+    <template #trailing>
+      <dt-badge kind="count">8</dt-badge>
+    </template>
+  </dt-segmented-control-item>
+  <dt-segmented-control-item value="bananas" trailingClass="d-pie-100">
+    Bananas
+    <template #trailing>
+      <dt-badge kind="count">15</dt-badge>
+    </template>
+  </dt-segmented-control-item>
+</dt-segmented-control>
+```
+
+## Orientation
+
+Set `orientation="vertical"` to stack items vertically.
+
+```vue demo
+<dt-stack direction="row" gap="200" align="start">
+  <div class="d-w-250">
+    <dt-segmented-control v-model="selected" orientation="vertical" aria-label="Vertical example">
+      <dt-segmented-control-item value="all">
+        System
+        <template #startIcon="{ iconSize }">
+          <dt-icon name="laptop-2" :size="iconSize" />
+        </template>
+      </dt-segmented-control-item>
+      <dt-segmented-control-item value="favorites">
+        Light
+        <template #startIcon="{ iconSize }">
+          <dt-icon name="sun" :size="iconSize" />
+        </template>
+      </dt-segmented-control-item>
+      <dt-segmented-control-item value="recent">
+        Dark
+        <template #startIcon="{ iconSize }">
+          <dt-icon name="moon" :size="iconSize" />
+        </template>
+      </dt-segmented-control-item>
+    </dt-segmented-control>
+  </div>
+  <dt-segmented-control v-model="iconOnlySelected" aria-label="Appearance mode" orientation="vertical">
+    <dt-segmented-control-item value="system" label="System">
+      <template #startIcon="{ iconSize }">
+        <dt-icon name="laptop-2" :size="iconSize" />
+      </template>
+    </dt-segmented-control-item>
+    <dt-segmented-control-item value="light" label="Light">
+      <template #startIcon="{ iconSize }">
+        <dt-icon name="sun" :size="iconSize" />
+      </template>
+    </dt-segmented-control-item>
+    <dt-segmented-control-item value="dark" label="Dark">
+      <template #startIcon="{ iconSize }">
+        <dt-icon name="moon" :size="iconSize" />
+      </template>
+    </dt-segmented-control-item>
+  </dt-segmented-control>
+</dt-stack>
+<!-- @code -->
+<dt-segmented-control v-model="selected" orientation="vertical">
+  ...
+</dt-segmented-control>
+```
 
 ## Advanced Usages
 
@@ -360,17 +369,17 @@ Set `orientation="vertical"` to stack items vertically.
 
 By default, items select immediately on focus via arrow keys, following the <a class="d-link" href="https://www.w3.org/WAI/ARIA/apg/patterns/radio/" target="_blank">WAI-ARIA Radio Group pattern</a>. Set `activation-mode="manual"` to require an explicit `Enter` or `Space` keypress after focusing an item.
 
-<code-example vueCode='
+```vue demo
+<dt-segmented-control v-model="selected" activation-mode="manual" aria-label="Manual activation">
+  <dt-segmented-control-item value="all">All</dt-segmented-control-item>
+  <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
+  <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
+</dt-segmented-control>
+<!-- @code -->
 <dt-segmented-control v-model="selected" activation-mode="manual">
   ...
 </dt-segmented-control>
-'>
-  <dt-segmented-control v-model="selected" activation-mode="manual" aria-label="Manual activation">
-    <dt-segmented-control-item value="all">All</dt-segmented-control-item>
-    <dt-segmented-control-item value="favorites">Favorites</dt-segmented-control-item>
-    <dt-segmented-control-item value="recent">Recent</dt-segmented-control-item>
-  </dt-segmented-control>
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/select-menu.md
+++ b/apps/dialtone-documentation/docs/components/select-menu.md
@@ -43,7 +43,12 @@ keywords: ["dropdown", "picker", "d-select-menu", "DtSelectMenu", "dt-select-men
 
 A select is normally paired with a label, but there are times when it can be used without a label. Don't rely on the placeholder text as a label.
 
-<code-example vueCode='
+```vue demo
+<div class="d-d-grid d-g-200 d-g-cols2">
+  <example-select-menu label="Default" />
+  <example-select-menu label="Disabled" disabled />
+</div>
+<!-- @code -->
 <dt-select-menu
   :options="[
         { value: ``, label: `Please select one` },
@@ -69,16 +74,13 @@ A select is normally paired with a label, but there are times when it can be use
   @input="onInput"
   @change="onChange"
 />
-'>
-  <div class="d-d-grid d-g-200 d-g-cols2">
-    <example-select-menu label="Default" />
-    <example-select-menu label="Disabled" disabled />
-  </div>
-</code-example>
+```
 
 ### With Description Text
 
-<code-example vueCode='
+```vue demo
+<example-select-menu label="Label" description="Optional description text" />
+<!-- @code -->
 <dt-select-menu
   :options="[
         { value: ``, label: `Please select one` },
@@ -92,15 +94,28 @@ A select is normally paired with a label, but there are times when it can be use
   @input="onInput"
   @change="onChange"
 />
-'>
-  <example-select-menu label="Label" description="Optional description text" />
-</code-example>
+```
 
 ### With Validation States
 
 Provides feedback to the user based on their interaction, or lack thereof, with a select.
 
-<code-example vueCode='
+```vue demo
+<div class="d-d-grid d-g-200 d-g-cols3">
+  <example-select-menu
+    label="Label"
+    :messages='[{"message":"Error validation message","type":"error"}]'
+  />
+  <example-select-menu
+    label="Label"
+    :messages='[{"message":"Success validation message","type":"success"}]'
+  />
+  <example-select-menu
+    label="Label"
+    :messages='[{"message":"Warning validation message","type":"warning"}]'
+  />
+</div>
+<!-- @code -->
 <dt-select-menu
   :options="[
     { value: ``, label: `Please select one` },
@@ -140,26 +155,29 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
   @input="onInput"
   @change="onChange"
 />
-'>
-  <div class="d-d-grid d-g-200 d-g-cols3">
-    <example-select-menu
-      label="Label"
-      :messages='[{"message":"Error validation message","type":"error"}]'
-    />
-    <example-select-menu
-      label="Label"
-      :messages='[{"message":"Success validation message","type":"success"}]'
-    />
-    <example-select-menu
-      label="Label"
-      :messages='[{"message":"Warning validation message","type":"warning"}]'
-    />
-  </div>
-</code-example>
+```
 
 ### With Validation States Hidden
 
-<code-example vueCode='
+```vue demo
+<div class="d-d-grid d-g-200 d-g-cols3">
+  <example-select-menu
+    label="Label"
+    :messages='[{"message":"Error validation message","type":"error"}]'
+    :show-messages="false"
+  />
+  <example-select-menu
+    label="Label"
+    :messages='[{"message":"Success validation message","type":"success"}]'
+    :show-messages="false"
+  />
+  <example-select-menu
+    label="Label"
+    :messages='[{"message":"Warning validation message","type":"warning"}]'
+    :show-messages="false"
+  />
+</div>
+<!-- @code -->
 <dt-select-menu
   :options="[
     { value: ``, label: `Please select one` },
@@ -202,29 +220,17 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
   @change="onChange"
   :show-messages="false"
 />
-'>
-  <div class="d-d-grid d-g-200 d-g-cols3">
-    <example-select-menu
-      label="Label"
-      :messages='[{"message":"Error validation message","type":"error"}]'
-      :show-messages="false"
-    />
-    <example-select-menu
-      label="Label"
-      :messages='[{"message":"Success validation message","type":"success"}]'
-      :show-messages="false"
-    />
-    <example-select-menu
-      label="Label"
-      :messages='[{"message":"Warning validation message","type":"warning"}]'
-      :show-messages="false"
-    />
-  </div>
-</code-example>
+```
 
 ### With Slotted Label
 
-<code-example vueCode='
+```vue demo
+<example-select-menu>
+  <template #label>
+    <div>Slotted label</div>
+  </template>
+</example-select-menu>
+<!-- @code -->
 <dt-select-menu
   :options="[
     { value: ``, label: `Please select one` },
@@ -240,17 +246,17 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
     <div>Slotted label</div>
   </template>
 </dt-select-menu>
-'>
-  <example-select-menu>
-    <template #label>
-      <div>Slotted label</div>
-    </template>
-  </example-select-menu>
-</code-example>
+```
 
 ### With Slotted Description
 
-<code-example vueCode='
+```vue demo
+<example-select-menu>
+  <template #description>
+    <div>Slotted description</div>
+  </template>
+</example-select-menu>
+<!-- @code -->
 <dt-select-menu
   :options="[
     { value: ``, label: `Please select one` },
@@ -266,17 +272,20 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
     <div>Slotted description</div>
   </template>
 </dt-select-menu>
-'>
-  <example-select-menu>
-    <template #description>
-      <div>Slotted description</div>
-    </template>
-  </example-select-menu>
-</code-example>
+```
 
 ### With Slotted Options
 
-<code-example vueCode='
+```vue demo
+<dt-select-menu
+  label="With Slotted Options"
+>
+  <option value="">Slotted options</option>
+  <option value="1">Option 1</option>
+  <option value="2">Option 2</option>
+  <option value="3">Option 3</option>
+</dt-select-menu>
+<!-- @code -->
 <dt-select-menu
   :model-value="modelValue"
   @input="onInput"
@@ -292,22 +301,21 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
     </option>
   </template>
 </dt-select-menu>
-'>
-  <dt-select-menu
-    label="With Slotted Options"
-  >
-    <option value="">Slotted options</option>
-    <option value="1">Option 1</option>
-    <option value="2">Option 2</option>
-    <option value="3">Option 3</option>
-  </dt-select-menu>
-</code-example>
+```
 
 ## Sizes
 
 We offer different sizes for instances in which the interface requires a smaller or larger select. In general, though, use the base `300` (medium) size select as much as possible, especially in forms.
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="200">
+  <example-select-menu label="Label" :size="100" />
+  <example-select-menu label="Label" :size="200" />
+  <example-select-menu label="Label" :size="300" />
+  <example-select-menu label="Label" :size="400" />
+  <example-select-menu label="Label" :size="500" />
+</dt-stack>
+<!-- @code -->
 <dt-select-menu
   :options="[
     { value: ``, label: `Please select one` },
@@ -321,54 +329,46 @@ We offer different sizes for instances in which the interface requires a smaller
   @input="onInput"
   @change="onChange"
 />
-'>
-  <dt-stack gap="200">
-    <example-select-menu label="Label" :size="100" />
-    <example-select-menu label="Label" :size="200" />
-    <example-select-menu label="Label" :size="300" />
-    <example-select-menu label="Label" :size="400" />
-    <example-select-menu label="Label" :size="500" />
-  </dt-stack>
-</code-example>
+```
 
 ## Label size
 
 The label text size is automatically derived from the component's `size` prop. Use the `label-size` prop to override this when you need a different label size independent of the select size. For example, the default label size for a `:size="300"` select menu is `300`, but you can override it from `100` to `400`.
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="200">
+  <example-select-menu label="Extra small label" :label-size="100" />
+  <example-select-menu label="Small label" :label-size="200" />
+  <example-select-menu label="Medium label (default)" :label-size="300" />
+  <example-select-menu label="Large label" :label-size="400" />
+</dt-stack>
+<!-- @code -->
 <dt-select-menu
   :options="options"
   label="Label"
   :size="100"
   :label-size="100"
 />
-'>
-  <dt-stack gap="200">
-    <example-select-menu label="Extra small label" :label-size="100" />
-    <example-select-menu label="Small label" :label-size="200" />
-    <example-select-menu label="Medium label (default)" :label-size="300" />
-    <example-select-menu label="Large label" :label-size="400" />
-  </dt-stack>
-</code-example>
+```
 
 ## Label strength
 
 Override the label font weight independently of the label size. Valid values are `bold`, `semibold`, `medium`, and `normal`.
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="200">
+  <example-select-menu label="Bold label" label-strength="bold" />
+  <example-select-menu label="Semibold label" label-strength="semibold" />
+  <example-select-menu label="Medium label" label-strength="medium" />
+  <example-select-menu label="Normal label" label-strength="normal" />
+</dt-stack>
+<!-- @code -->
 <dt-select-menu
   :options="options"
   label="Label"
   label-strength="bold|semibold|medium|normal"
 />
-'>
-  <dt-stack gap="200">
-    <example-select-menu label="Bold label" label-strength="bold" />
-    <example-select-menu label="Semibold label" label-strength="semibold" />
-    <example-select-menu label="Medium label" label-strength="medium" />
-    <example-select-menu label="Normal label" label-strength="normal" />
-  </dt-stack>
-</code-example>
+```
 
 ## Accessibility
 

--- a/apps/dialtone-documentation/docs/components/skeleton.md
+++ b/apps/dialtone-documentation/docs/components/skeleton.md
@@ -9,11 +9,11 @@ figma: planned
 keywords: ["loading placeholder", "shimmer", "ghost", "d-skeleton", "DtSkeleton", "dt-skeleton", "content loader", "placeholder ui"]
 ---
 
-<code-example only-show="demo">
-  <div class="d-w-400">
-    <dt-skeleton :animate="false" />
-  </div>
-</code-example>
+```vue demo-only
+<div class="d-w-400">
+  <dt-skeleton :animate="false" />
+</div>
+```
 
 <!-- <component-combinator component-name="DtSkeleton" /> -->
 
@@ -61,48 +61,52 @@ keywords: ["loading placeholder", "shimmer", "ghost", "d-skeleton", "DtSkeleton"
 
 ### Default
 
-<code-example>
-  <div class="d-w-400" data-demo-wrapper>
-    <dt-skeleton :animate="false" arial-label="Loading" />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-400">
+  <dt-skeleton :animate="false" arial-label="Loading" />
+</div>
+```
 
 ### Animation
 
-<code-example>
-  <div class="d-w-400" data-demo-wrapper>
-    <dt-skeleton arial-label="Loading" />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-400">
+  <dt-skeleton arial-label="Loading" />
+</div>
+```
 
 ## Custom
 
 To customize a non-animating Skeleton background color modify the `--placeholder-from-color` variable with an inline `style`.
 
-<code-example>
-  <div class="d-w-400" data-demo-wrapper>
-    <dt-skeleton
-      :animate="false"
-      :text-option="{
-        style: '--placeholder-from-color: var(--dt-color-blue-400)',
-      }"
-      arial-label="Loading"
-    />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-400">
+  <dt-skeleton
+    :animate="false"
+    :text-option="{
+      style: '--placeholder-from-color: var(--dt-color-blue-400)',
+    }"
+    arial-label="Loading"
+  />
+</div>
+```
 
 Customize an animating Skeleton by modifying the `--placeholder-from-color` and `--placeholder-to-color` variables with an inline `style`.
 
-<code-example>
-  <div class="d-w-400" data-demo-wrapper>
-    <dt-skeleton
-      :text-option="{
-        style: '--placeholder-from-color: var(--dt-color-blue-400); --placeholder-to-color: var(--dt-color-blue-200);',
-      }"
-      arial-label="Loading"
-    />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-400">
+  <dt-skeleton
+    :text-option="{
+      style: '--placeholder-from-color: var(--dt-color-blue-400); --placeholder-to-color: var(--dt-color-blue-200);',
+    }"
+    arial-label="Loading"
+  />
+</div>
+```
 
 ## Shapes
 
@@ -110,96 +114,103 @@ Customize an animating Skeleton by modifying the `--placeholder-from-color` and 
 
 Default sizes match the avatar size. Size is customizable when needed.
 
-<code-example>
-  <dt-stack gap="100" data-demo-wrapper>
-    <p>S (24x24px)</p>
-    <dt-skeleton :shape-option="{ shape: 'circle', size: 'sm' }" :animate="false" />
-    <p>M (32x32px)</p>
-    <dt-skeleton :shape-option="{ shape: 'circle' }" :animate="false" />
-    <p>L (48x48px)</p>
-    <dt-skeleton :shape-option="{ shape: 'circle', size: 'lg' }" :animate="false" />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="100">
+  <p>S (24x24px)</p>
+  <dt-skeleton :shape-option="{ shape: 'circle', size: 'sm' }" :animate="false" />
+  <p>M (32x32px)</p>
+  <dt-skeleton :shape-option="{ shape: 'circle' }" :animate="false" />
+  <p>L (48x48px)</p>
+  <dt-skeleton :shape-option="{ shape: 'circle', size: 'lg' }" :animate="false" />
+</dt-stack>
+```
 
 ### Image / Icon
 
-<code-example>
-  <dt-stack gap="100" data-demo-wrapper>
-    <p>S (24x24px)</p>
-    <dt-skeleton :shape-option="{ shape: 'square', size: 'sm' }" :animate="false" />
-    <p>M (32x32px)</p>
-    <dt-skeleton :shape-option="{ shape: 'square' }" :animate="false" />
-    <p>L (48x48px)</p>
-    <dt-skeleton :shape-option="{ shape: 'square', size: 'lg' }" :animate="false" />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="100">
+  <p>S (24x24px)</p>
+  <dt-skeleton :shape-option="{ shape: 'square', size: 'sm' }" :animate="false" />
+  <p>M (32x32px)</p>
+  <dt-skeleton :shape-option="{ shape: 'square' }" :animate="false" />
+  <p>L (48x48px)</p>
+  <dt-skeleton :shape-option="{ shape: 'square', size: 'lg' }" :animate="false" />
+</dt-stack>
+```
 
 ### Headings
 
-<code-example>
-  <dt-stack gap="100" data-demo-wrapper>
-    <p>Small</p>
-    <dt-skeleton :text-option="{ type: 'heading', headingHeight: 'sm', width: '160px' }" :animate="false" />
-    <p>Medium</p>
-    <dt-skeleton :text-option="{ type: 'heading', width: '240px' }" :animate="false" />
-    <p>Large</p>
-    <dt-skeleton :text-option="{ type: 'heading', headingHeight: 'lg', width: '320px' }" :animate="false" />
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="100">
+  <p>Small</p>
+  <dt-skeleton :text-option="{ type: 'heading', headingHeight: 'sm', width: '160px' }" :animate="false" />
+  <p>Medium</p>
+  <dt-skeleton :text-option="{ type: 'heading', width: '240px' }" :animate="false" />
+  <p>Large</p>
+  <dt-skeleton :text-option="{ type: 'heading', headingHeight: 'lg', width: '320px' }" :animate="false" />
+</dt-stack>
+```
 
 ## Prefabricated Combinations
 
 ### Paragraphs
 
-<code-example>
-  <div class="d-w-400" data-demo-wrapper>
-    <dt-skeleton :paragraph-option="{ rows: 5, randomWidth: true }" :animate="false" />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-400">
+  <dt-skeleton :paragraph-option="{ rows: 5, randomWidth: true }" :animate="false" />
+</div>
+```
 
 ### Avatar + Name
 
-<code-example>
-  <div class="d-w-400" data-demo-wrapper>
-    <dt-skeleton
-      :list-item-option="{ shapeSize: 'sm', paragraphs: { rows: 1 } }"
-    />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-400">
+  <dt-skeleton
+    :list-item-option="{ shapeSize: 'sm', paragraphs: { rows: 1 } }"
+  />
+</div>
+```
 
 ### Icon + Text
 
-<code-example>
-  <div class="d-w-400" data-demo-wrapper>
-    <dt-skeleton
-      :list-item-option="{
-        shapeSize: '2rem',
-        shape: 'square',
-        paragraphs: {
-          rows: 1,
-        },
-      }"
-    />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-400">
+  <dt-skeleton
+    :list-item-option="{
+      shapeSize: '2rem',
+      shape: 'square',
+      paragraphs: {
+        rows: 1,
+      },
+    }"
+  />
+</div>
+```
 
 ### Messages / Transcript / Comment
 
-<code-example>
-  <div class="d-w-400" data-demo-wrapper>
-    <dt-skeleton
-      :list-item-option="{
-        shapeSize: '3.6rem',
-        paragraphs: {
-          rows: 4,
-          width: [
-            '120px', '311px', '371px', '279px',
-          ],
-        },
-      }"
-    />
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-400">
+  <dt-skeleton
+    :list-item-option="{
+      shapeSize: '3.6rem',
+      paragraphs: {
+        rows: 4,
+        width: [
+          '120px', '311px', '371px', '279px',
+        ],
+      },
+    }"
+  />
+</div>
+```
 
 ## Accessibility
 

--- a/apps/dialtone-documentation/docs/components/split-button.md
+++ b/apps/dialtone-documentation/docs/components/split-button.md
@@ -40,127 +40,135 @@ In addition to the [Button component's](button.md) documentation:
 
 ### Base
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-split-button end-tooltip-text="More calling options">
-      Place Call
-      <template #dropdownList>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
-      </template>
-    </dt-split-button>
-    <dt-split-button importance="outlined" end-tooltip-text="More calling options">
-      Place Call
-      <template #dropdownList>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
-      </template>
-    </dt-split-button>
-    <dt-split-button importance="clear" end-tooltip-text="More calling options">
-      Place Call
-      <template #dropdownList>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
-      </template>
-    </dt-split-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-split-button end-tooltip-text="More calling options">
+    Place Call
+    <template #dropdownList>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+    </template>
+  </dt-split-button>
+  <dt-split-button importance="outlined" end-tooltip-text="More calling options">
+    Place Call
+    <template #dropdownList>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+    </template>
+  </dt-split-button>
+  <dt-split-button importance="clear" end-tooltip-text="More calling options">
+    Place Call
+    <template #dropdownList>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+    </template>
+  </dt-split-button>
+</dt-stack>
+```
 
 ### Danger
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-split-button kind="danger" end-tooltip-text="More calling options">
-      Place Call
-      <template #dropdownList>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
-      </template>
-    </dt-split-button>
-    <dt-split-button importance="outlined" kind="danger" end-tooltip-text="More calling options">
-      Place Call
-      <template #dropdownList>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
-      </template>
-    </dt-split-button>
-    <dt-split-button importance="clear" kind="danger" end-tooltip-text="More calling options">
-      Place Call
-      <template #dropdownList>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
-        <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
-      </template>
-    </dt-split-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-split-button kind="danger" end-tooltip-text="More calling options">
+    Place Call
+    <template #dropdownList>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+    </template>
+  </dt-split-button>
+  <dt-split-button importance="outlined" kind="danger" end-tooltip-text="More calling options">
+    Place Call
+    <template #dropdownList>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+    </template>
+  </dt-split-button>
+  <dt-split-button importance="clear" kind="danger" end-tooltip-text="More calling options">
+    Place Call
+    <template #dropdownList>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+    </template>
+  </dt-split-button>
+</dt-stack>
+```
 
 ### Positive
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-      <dt-split-button kind="positive" end-tooltip-text="More calling options"> Place Call </dt-split-button>
-      <dt-split-button importance="outlined" kind="positive" end-tooltip-text="More calling options"> Place Call </dt-split-button>
-      <dt-split-button importance="clear" kind="positive" end-tooltip-text="More calling options"> Place Call </dt-split-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+    <dt-split-button kind="positive" end-tooltip-text="More calling options"> Place Call </dt-split-button>
+    <dt-split-button importance="outlined" kind="positive" end-tooltip-text="More calling options"> Place Call </dt-split-button>
+    <dt-split-button importance="clear" kind="positive" end-tooltip-text="More calling options"> Place Call </dt-split-button>
+</dt-stack>
+```
 
 ### Muted
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-      <dt-split-button importance="outlined" kind="muted" end-tooltip-text="More calling options"> Place Call </dt-split-button>
-      <dt-split-button importance="clear" kind="muted" end-tooltip-text="More calling options"> Place Call </dt-split-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+    <dt-split-button importance="outlined" kind="muted" end-tooltip-text="More calling options"> Place Call </dt-split-button>
+    <dt-split-button importance="clear" kind="muted" end-tooltip-text="More calling options"> Place Call </dt-split-button>
+</dt-stack>
+```
 
 ### Disabled
 
 Use the `disabled` prop to disable both buttons, or use `start-disabled` and `end-disabled` to disable each button independently.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-      <dt-split-button disabled end-tooltip-text="More calling options"> Both disabled </dt-split-button>
-      <dt-split-button start-disabled end-tooltip-text="More calling options"> Start disabled </dt-split-button>
-      <dt-split-button end-disabled end-tooltip-text="More calling options"> End disabled </dt-split-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+    <dt-split-button disabled end-tooltip-text="More calling options"> Both disabled </dt-split-button>
+    <dt-split-button start-disabled end-tooltip-text="More calling options"> Start disabled </dt-split-button>
+    <dt-split-button end-disabled end-tooltip-text="More calling options"> End disabled </dt-split-button>
+</dt-stack>
+```
 
 ### Active
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-split-button start-active end-tooltip-text="More calling options"> Start active </dt-split-button>
-    <dt-split-button end-active end-tooltip-text="More calling options"> End active </dt-split-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-split-button start-active end-tooltip-text="More calling options"> Start active </dt-split-button>
+  <dt-split-button end-active end-tooltip-text="More calling options"> End active </dt-split-button>
+</dt-stack>
+```
 
 ## Sizes
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-split-button :size="100" end-tooltip-text="More calling options"> 100 </dt-split-button>
-    <dt-split-button :size="200" end-tooltip-text="More calling options"> 200 </dt-split-button>
-    <dt-split-button :size="300" end-tooltip-text="More calling options"> 300 </dt-split-button>
-    <dt-split-button :size="400" end-tooltip-text="More calling options"> 400 </dt-split-button>
-    <dt-split-button :size="500" end-tooltip-text="More calling options"> 500 </dt-split-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-split-button :size="100" end-tooltip-text="More calling options"> 100 </dt-split-button>
+  <dt-split-button :size="200" end-tooltip-text="More calling options"> 200 </dt-split-button>
+  <dt-split-button :size="300" end-tooltip-text="More calling options"> 300 </dt-split-button>
+  <dt-split-button :size="400" end-tooltip-text="More calling options"> 400 </dt-split-button>
+  <dt-split-button :size="500" end-tooltip-text="More calling options"> 500 </dt-split-button>
+</dt-stack>
+```
 
 ## Loading
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-split-button start-loading end-tooltip-text="More calling options"> Place call </dt-split-button>
-    <dt-split-button start-loading importance="outlined" end-tooltip-text="More calling options"> Place call </dt-split-button>
-    <dt-split-button start-loading importance="clear" end-tooltip-text="More calling options"> Place call </dt-split-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-split-button start-loading end-tooltip-text="More calling options"> Place call </dt-split-button>
+  <dt-split-button start-loading importance="outlined" end-tooltip-text="More calling options"> Place call </dt-split-button>
+  <dt-split-button start-loading importance="clear" end-tooltip-text="More calling options"> Place call </dt-split-button>
+</dt-stack>
+```
 
 ## Navigation
 
@@ -168,152 +176,155 @@ The start button supports navigation via `start-href` (renders as `<a>`) or `sta
 
 ### External Link
 
-<code-example>
-  <dt-split-button
-    start-href="https://dialpad.com"
-    start-target="_blank"
-    start-rel="noopener noreferrer"
-    end-tooltip-text="More options"
-  >
-    Visit Dialpad
-    <template #dropdownList>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
-    </template>
-  </dt-split-button>
-</code-example>
+```vue demo
+<dt-split-button
+  start-href="https://dialpad.com"
+  start-target="_blank"
+  start-rel="noopener noreferrer"
+  end-tooltip-text="More options"
+>
+  Visit Dialpad
+  <template #dropdownList>
+    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+  </template>
+</dt-split-button>
+```
 
 ### Router Link
 
-<code-example>
-  <dt-split-button
-    start-to="/components/button"
-    end-tooltip-text="More options"
-  >
-    Go to DtButton docs
-    <template #dropdownList>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
-    </template>
-  </dt-split-button>
-</code-example>
+```vue demo
+<dt-split-button
+  start-to="/components/button"
+  end-tooltip-text="More options"
+>
+  Go to DtButton docs
+  <template #dropdownList>
+    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+  </template>
+</dt-split-button>
+```
 
 ## Icon Support
 
 ### Icon and Label
 
-<code-example>
-  <dt-stack direction="row" gap="100" class="d-fw-wrap" data-demo-wrapper>
-    <dt-split-button importance="outlined" end-tooltip-text="More calling options">
-      <template #startIcon="{ size }">
-        <dt-icon name="phone" :size="size" />
-      </template>
-      Place call
-    </dt-split-button>
-    <dt-split-button importance="outlined" start-icon-position="blockStart" end-tooltip-text="More calling options">
-      <template #startIcon="{ size }">
-        <dt-icon name="phone" :size="size" />
-      </template>
-      Place call
-    </dt-split-button>
-    <dt-split-button importance="outlined" start-icon-position="end" end-tooltip-text="More calling options">
-      <template #startIcon="{ size }">
-        <dt-icon name="phone" :size="size" />
-      </template>
-      Place call
-    </dt-split-button>
-    <dt-split-button importance="outlined" start-icon-position="blockEnd" end-tooltip-text="More calling options">
-      <template #startIcon="{ size }">
-        <dt-icon name="phone" :size="size" />
-      </template>
-      Place call
-    </dt-split-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100" class="d-fw-wrap">
+  <dt-split-button importance="outlined" end-tooltip-text="More calling options">
+    <template #startIcon="{ size }">
+      <dt-icon name="phone" :size="size" />
+    </template>
+    Place call
+  </dt-split-button>
+  <dt-split-button importance="outlined" start-icon-position="blockStart" end-tooltip-text="More calling options">
+    <template #startIcon="{ size }">
+      <dt-icon name="phone" :size="size" />
+    </template>
+    Place call
+  </dt-split-button>
+  <dt-split-button importance="outlined" start-icon-position="end" end-tooltip-text="More calling options">
+    <template #startIcon="{ size }">
+      <dt-icon name="phone" :size="size" />
+    </template>
+    Place call
+  </dt-split-button>
+  <dt-split-button importance="outlined" start-icon-position="blockEnd" end-tooltip-text="More calling options">
+    <template #startIcon="{ size }">
+      <dt-icon name="phone" :size="size" />
+    </template>
+    Place call
+  </dt-split-button>
+</dt-stack>
+```
 
 ### Dual Icons on Start Button
 
 Use `#startIcon` and `#startEndIcon` together to place icons at both the start and end positions
 within the start button. This uses the same dual-icon pattern as [DtButton](/components/button.html#start-and-end-icons).
 
-<code-example>
-  <dt-split-button importance="outlined" end-tooltip-text="More calling options">
-    <template #startIcon="{ size }">
-      <dt-icon name="phone" :size="size" />
-    </template>
-    <template #startEndIcon="{ size }">
-      <dt-icon name="arrow-down" :size="size" />
-    </template>
-    Place call
-  </dt-split-button>
-</code-example>
+```vue demo
+<dt-split-button importance="outlined" end-tooltip-text="More calling options">
+  <template #startIcon="{ size }">
+    <dt-icon name="phone" :size="size" />
+  </template>
+  <template #startEndIcon="{ size }">
+    <dt-icon name="arrow-down" :size="size" />
+  </template>
+  Place call
+</dt-split-button>
+```
 
 ### Custom End Button Icon
 
 Use `#endIcon` to replace the default chevron icon on the end (omega) button.
 
-<code-example>
-  <dt-split-button importance="outlined" end-tooltip-text="More calling options">
-    <template #startIcon="{ size }">
-      <dt-icon name="phone" :size="size" />
-    </template>
-    <template #endIcon="{ size }">
-      <dt-icon name="more-vertical" :size="size" />
-    </template>
-    Place call
-  </dt-split-button>
-</code-example>
+```vue demo
+<dt-split-button importance="outlined" end-tooltip-text="More calling options">
+  <template #startIcon="{ size }">
+    <dt-icon name="phone" :size="size" />
+  </template>
+  <template #endIcon="{ size }">
+    <dt-icon name="more-vertical" :size="size" />
+  </template>
+  Place call
+</dt-split-button>
+```
 
 ### Icon Only
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-split-button end-tooltip-text="More calling options" start-tooltip-text="Place call">
-      <template #startIcon="{ size }">
-        <dt-icon name="phone" :size="size" />
-      </template>
-    </dt-split-button>
-    <dt-split-button importance="outlined" kind="muted" end-tooltip-text="More calling options" start-tooltip-text="Place call">
-      <template #startIcon="{ size }">
-        <dt-icon name="phone" :size="size" />
-      </template>
-    </dt-split-button>
-    <dt-split-button importance="clear" kind="danger" end-tooltip-text="More calling options" start-tooltip-text="Place call">
-      <template #startIcon="{ size }">
-        <dt-icon name="phone" :size="size" />
-      </template>
-    </dt-split-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-split-button end-tooltip-text="More calling options" start-tooltip-text="Place call">
+    <template #startIcon="{ size }">
+      <dt-icon name="phone" :size="size" />
+    </template>
+  </dt-split-button>
+  <dt-split-button importance="outlined" kind="muted" end-tooltip-text="More calling options" start-tooltip-text="Place call">
+    <template #startIcon="{ size }">
+      <dt-icon name="phone" :size="size" />
+    </template>
+  </dt-split-button>
+  <dt-split-button importance="clear" kind="danger" end-tooltip-text="More calling options" start-tooltip-text="Place call">
+    <template #startIcon="{ size }">
+      <dt-icon name="phone" :size="size" />
+    </template>
+  </dt-split-button>
+</dt-stack>
+```
 
 ## Leading & Trailing
 
 The `#leading` and `#trailing` slots are forwarded to the alpha button. Use `alpha-leading-class` and `alpha-trailing-class` to style the containers.
 
-<code-example>
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-split-button
-      importance="outlined"
-      omega-tooltip-text="More calling options"
-      alpha-trailing-class="d-pie-100"
-    >
-      Place Call
-      <template #trailing>
-        <dt-keyboard-shortcut shortcut="{cmd}+N" />
-      </template>
-    </dt-split-button>
-    <dt-split-button
-      importance="outlined"
-      omega-tooltip-text="More calling options"
-      alpha-leading-class="d-pis-100"
-    >
-      Place Call
-      <template #leading>
-        <dt-badge kind="count" text="3" />
-      </template>
-    </dt-split-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-split-button
+    importance="outlined"
+    omega-tooltip-text="More calling options"
+    alpha-trailing-class="d-pie-100"
+  >
+    Place Call
+    <template #trailing>
+      <dt-keyboard-shortcut shortcut="{cmd}+N" />
+    </template>
+  </dt-split-button>
+  <dt-split-button
+    importance="outlined"
+    omega-tooltip-text="More calling options"
+    alpha-leading-class="d-pis-100"
+  >
+    Place Call
+    <template #leading>
+      <dt-badge kind="count" text="3" />
+    </template>
+  </dt-split-button>
+</dt-stack>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/stack.md
+++ b/apps/dialtone-documentation/docs/components/stack.md
@@ -16,36 +16,50 @@ keywords: ["layout", "vertical", "horizontal", "d-stack", "DtStack", "dt-stack",
 
 `direction="column"` will flow child items vertically, i.e. top to bottom. It is the default direction and doesn't need to be explictily set.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  gap="200"
+  class="d-bgc-moderate-opaque d-bar8"
+>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Stack item 1
+  </div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Stack item 2
+  </div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Stack item 3
+  </div>
+</dt-stack>
+<!-- @code -->
 <dt-stack gap="200">
   <div> Stack item 1 </div>
   <div> Stack item 2 </div>
   <div> Stack item 3 </div>
 </dt-stack>
-'>
-  <dt-stack
-    gap="200"
-    class="d-bgc-moderate-opaque d-bar8"
-  >
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Stack item 1
-    </div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Stack item 2
-    </div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Stack item 3
-    </div>
-  </dt-stack>
-</code-example>
+```
 
 ### Row
 
 `direction="row"` will flow child items horizontally, i.e. left to right.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  gap="200"
+  direction="row"
+  class="d-bgc-moderate-opaque d-bar8"
+>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Stack item 1
+  </div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Stack item 2
+  </div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Stack item 3
+  </div>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   gap="200"
   direction="row"
@@ -54,28 +68,27 @@ vueCode='
   <div> Stack item 2 </div>
   <div> Stack item 3 </div>
 </dt-stack>
-'>
-  <dt-stack
-    gap="200"
-    direction="row"
-    class="d-bgc-moderate-opaque d-bar8"
-  >
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Stack item 1
-    </div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Stack item 2
-    </div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Stack item 3
-    </div>
-  </dt-stack>
-</code-example>
+```
 
 ### Row Reverse
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  gap="200"
+  direction="row-reverse"
+  class="d-bgc-moderate-opaque d-bar8"
+>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Stack item 1
+  </div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Stack item 2
+  </div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Stack item 3
+  </div>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   gap="200"
   direction="row-reverse"
@@ -84,28 +97,27 @@ vueCode='
   <div> Stack item 2 </div>
   <div> Stack item 3 </div>
 </dt-stack>
-'>
-  <dt-stack
-    gap="200"
-    direction="row-reverse"
-    class="d-bgc-moderate-opaque d-bar8"
-  >
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Stack item 1
-    </div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Stack item 2
-    </div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Stack item 3
-    </div>
-  </dt-stack>
-</code-example>
+```
 
 ### Column Reverse
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  gap="200"
+  direction="column-reverse"
+  class="d-bgc-moderate-opaque d-bar8"
+>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Stack item 1
+  </div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Stack item 2
+  </div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Stack item 3
+  </div>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   gap="200"
   direction="column-reverse"
@@ -114,23 +126,7 @@ vueCode='
   <div> Stack item 2 </div>
   <div> Stack item 3 </div>
 </dt-stack>
-'>
-  <dt-stack
-    gap="200"
-    direction="column-reverse"
-    class="d-bgc-moderate-opaque d-bar8"
-  >
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Stack item 1
-    </div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Stack item 2
-    </div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Stack item 3
-    </div>
-  </dt-stack>
-</code-example>
+```
 
 ## Render as
 
@@ -144,8 +140,17 @@ Declaring as an appropriate HTML element improves accessibility by helping scree
 
 Use `as="section"` to create a thematic grouping of content.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  as="section"
+  gap="100"
+  class="d-bgc-moderate-opaque d-bar8"
+>
+  <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 1</div>
+  <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 2</div>
+  <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 3</div>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   as="section"
   gap="100"
@@ -154,24 +159,24 @@ vueCode='
   <div>Stack item 2</div>
   <div>Stack item 3</div>
 </dt-stack>
-'>
-  <dt-stack
-    as="section"
-    gap="100"
-    class="d-bgc-moderate-opaque d-bar8"
-  >
-    <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 1</div>
-    <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 2</div>
-    <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 3</div>
-  </dt-stack>
-</code-example>
+```
 
 ### Example: span
 
 Use `as="span"` when you need an inline container.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  as="span"
+  direction="row"
+  gap="100"
+  class="d-bgc-moderate-opaque d-bar8"
+>
+  <span class="d-bgc-moderate-opaque d-bar8 d-p-200">Inline item 1</span>
+  <span class="d-bgc-moderate-opaque d-bar8 d-p-200">Inline item 2<br>with a second line</span>
+  <span class="d-bgc-moderate-opaque d-bar8 d-p-200">Inline item 3</span>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   as="span"
   direction="row"
@@ -181,80 +186,68 @@ vueCode='
   <span>Inline item 2</span>
   <span>Inline item 3</span>
 </dt-stack>
-'>
-  <dt-stack
-    as="span"
-    direction="row"
-    gap="100"
-    class="d-bgc-moderate-opaque d-bar8"
-  >
-    <span class="d-bgc-moderate-opaque d-bar8 d-p-200">Inline item 1</span>
-    <span class="d-bgc-moderate-opaque d-bar8 d-p-200">Inline item 2<br>with a second line</span>
-    <span class="d-bgc-moderate-opaque d-bar8 d-p-200">Inline item 3</span>
-  </dt-stack>
-</code-example>
+```
 
 ## Gap
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack gap="200" class="d-w100p">
+  <div class="d-d-none xl:d-d-flex d-jc-center">
+    <dt-segmented-control
+      :size="100"
+      :model-value="selectedGap"
+      aria-label="Gap size"
+      @update:model-value="setGap"
+    >
+      <dt-segmented-control-item
+        v-for="gap in gaps"
+        v-dt-tooltip="{ message: gapToPx(gap), delay: false }"
+        :key="gap"
+        :value="gap"
+        :selected="gap === selectedGap"
+      >
+        {{ gap }}
+      </dt-segmented-control-item>
+    </dt-segmented-control>
+  </div>
+  <dt-stack
+    :direction="{ 'default': 'column', 'md': 'row' }"
+    gap="200"
+    class="d-w100p"
+    align="start"
+  >
+    <dt-stack class="d-w100p md:d-w50p" gap="50">
+      <dt-text as="h3" kind="headline" :size="300">Column</dt-text>
+      <dt-stack
+        :gap="selectedGap"
+        class="d-bgc-moderate-opaque d-t d-td300 d-bar8 d-ttf-quint"
+      >
+        <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 1</div>
+        <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 2</div>
+        <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 3</div>
+      </dt-stack>
+    </dt-stack>
+    <dt-stack class="d-w100p md:d-w50p" gap="50">
+      <dt-text as="h3" kind="headline" :size="300">Row</dt-text>
+      <dt-stack
+        direction="row"
+        :gap="selectedGap"
+        class="d-bgc-moderate-opaque d-t d-td300 d-bar8 d-ttf-quint"
+      >
+        <div class="d-bgc-moderate-opaque d-bar8 d-p-200 d-fl1">Stack item 1</div>
+        <div class="d-bgc-moderate-opaque d-bar8 d-p-200 d-fl1">Stack item 2</div>
+        <div class="d-bgc-moderate-opaque d-bar8 d-p-200 d-fl1">Stack item 3</div>
+      </dt-stack>
+    </dt-stack>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack gap="100">
   <div> Stack item 1 </div>
   <div> Stack item 2 </div>
   <div> Stack item 3 </div>
 </dt-stack>
-'>
-  <dt-stack gap="200" class="d-w100p">
-    <div class="d-d-none xl:d-d-flex d-jc-center">
-      <dt-segmented-control
-        :size="100"
-        :model-value="selectedGap"
-        aria-label="Gap size"
-        @update:model-value="setGap"
-      >
-        <dt-segmented-control-item
-          v-for="gap in gaps"
-          v-dt-tooltip="{ message: gapToPx(gap), delay: false }"
-          :key="gap"
-          :value="gap"
-          :selected="gap === selectedGap"
-        >
-          {{ gap }}
-        </dt-segmented-control-item>
-      </dt-segmented-control>
-    </div>
-    <dt-stack
-      :direction="{ 'default': 'column', 'md': 'row' }"
-      gap="200"
-      class="d-w100p"
-      align="start"
-    >
-      <dt-stack class="d-w100p md:d-w50p" gap="50">
-        <dt-text as="h3" kind="headline" :size="300">Column</dt-text>
-        <dt-stack
-          :gap="selectedGap"
-          class="d-bgc-moderate-opaque d-t d-td300 d-bar8 d-ttf-quint"
-        >
-          <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 1</div>
-          <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 2</div>
-          <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 3</div>
-        </dt-stack>
-      </dt-stack>
-      <dt-stack class="d-w100p md:d-w50p" gap="50">
-        <dt-text as="h3" kind="headline" :size="300">Row</dt-text>
-        <dt-stack
-          direction="row"
-          :gap="selectedGap"
-          class="d-bgc-moderate-opaque d-t d-td300 d-bar8 d-ttf-quint"
-        >
-          <div class="d-bgc-moderate-opaque d-bar8 d-p-200 d-fl1">Stack item 1</div>
-          <div class="d-bgc-moderate-opaque d-bar8 d-p-200 d-fl1">Stack item 2</div>
-          <div class="d-bgc-moderate-opaque d-bar8 d-p-200 d-fl1">Stack item 3</div>
-        </dt-stack>
-      </dt-stack>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### Available gaps
 
@@ -299,8 +292,44 @@ Available `align` values: `start`, `center`, `end`, `stretch`, `baseline`.
 
 The `align` prop is optional. Unless specified, it will default vertical stacks to `align-items="stretch"` and horizontal stacks to `align-items="center"`.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  gap="200"
+  :direction="{ default: `column`, md: `row` }"
+>
+  <dt-stack
+    gap="100"
+    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-stretch"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Taller item<br>
+      with more content
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+  </dt-stack>
+  <dt-stack
+    gap="100"
+    direction="row"
+    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Taller item<br>
+      with more content
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack gap="100">
   <div>Short</div>
   <div>
@@ -317,51 +346,52 @@ vueCode='
   </div>
   <div>Short</div>
 </dt-stack>
-'>
-  <dt-stack
-    gap="200"
-    :direction="{ default: `column`, md: `row` }"
-  >
-    <dt-stack
-      gap="100"
-      class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-stretch"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Taller item<br>
-        with more content
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-    </dt-stack>
-    <dt-stack
-      gap="100"
-      direction="row"
-      class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Taller item<br>
-        with more content
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### Start
 
 Align items to the start of the cross-axis.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  gap="100"
+  :direction="{ default: `column`, md: `row` }"
+>
+  <dt-stack
+    gap="100"
+    align="start"
+    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-start"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Taller item<br>
+      with more content
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+  </dt-stack>
+  <dt-stack
+    direction="row"
+    gap="100"
+    align="start"
+    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-start"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Taller item<br>
+      with more content
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   gap="100"
   align="start"
@@ -385,53 +415,52 @@ vueCode='
   </div>
   <div>Short</div>
 </dt-stack>
-'>
-  <dt-stack
-    gap="100"
-    :direction="{ default: `column`, md: `row` }"
-  >
-    <dt-stack
-      gap="100"
-      align="start"
-      class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-start"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Taller item<br>
-        with more content
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-    </dt-stack>
-    <dt-stack
-      direction="row"
-      gap="100"
-      align="start"
-      class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-start"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Taller item<br>
-        with more content
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### Center
 
 Center items along the cross-axis.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  gap="200"
+  :direction="{ default: `column`, md: `row` }"
+>
+  <dt-stack
+    gap="100"
+    align="center"
+    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Taller item<br>
+      with more content
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+  </dt-stack>
+  <dt-stack
+    direction="row"
+    gap="100"
+    align="center"
+    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Taller item<br>
+      with more content
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   direction="row"
   gap="100"
@@ -444,53 +473,52 @@ vueCode='
   </div>
   <div>Short</div>
 </dt-stack>
-'>
-  <dt-stack
-    gap="200"
-    :direction="{ default: `column`, md: `row` }"
-  >
-    <dt-stack
-      gap="100"
-      align="center"
-      class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Taller item<br>
-        with more content
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-    </dt-stack>
-    <dt-stack
-      direction="row"
-      gap="100"
-      align="center"
-      class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Taller item<br>
-        with more content
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### End
 
 Align items to the end of the cross-axis.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  gap="200"
+  :direction="{ default: `column`, md: `row` }"
+>
+  <dt-stack
+    gap="100"
+    align="end"
+    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-end"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Taller item<br>
+      with more content
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+  </dt-stack>
+  <dt-stack
+    direction="row"
+    gap="100"
+    align="end"
+    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-end"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Taller item<br>
+      with more content
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   gap="100"
   align="end"
@@ -514,53 +542,52 @@ vueCode='
   </div>
   <div>Short</div>
 </dt-stack>
-'>
-  <dt-stack
-    gap="200"
-    :direction="{ default: `column`, md: `row` }"
-  >
-    <dt-stack
-      gap="100"
-      align="end"
-      class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-end"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Taller item<br>
-        with more content
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-    </dt-stack>
-    <dt-stack
-      direction="row"
-      gap="100"
-      align="end"
-      class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-end"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Taller item<br>
-        with more content
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### Stretch
 
 Stretch items to fill the container height.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  gap="200"
+  :direction="{ default: `column`, md: `row` }"
+>
+  <dt-stack
+    gap="100"
+    align="stretch"
+    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-stretch"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Taller item<br>
+      with more content
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+  </dt-stack>
+  <dt-stack
+    direction="row"
+    gap="100"
+    align="stretch"
+    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-stretch"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Taller item<br>
+      with more content
+    </div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+      Short
+    </div>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   direction="row"
   gap="100"
@@ -573,53 +600,30 @@ vueCode='
   </div>
   <div>Short</div>
 </dt-stack>
-'>
-  <dt-stack
-    gap="200"
-    :direction="{ default: `column`, md: `row` }"
-  >
-    <dt-stack
-      gap="100"
-      align="stretch"
-      class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-stretch"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Taller item<br>
-        with more content
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-    </dt-stack>
-    <dt-stack
-      direction="row"
-      gap="100"
-      align="stretch"
-      class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-stretch"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Taller item<br>
-        with more content
-      </div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-        Short
-      </div>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### Baseline
 
 Align items along their text baselines.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  direction="row"
+  gap="100"
+  align="baseline"
+  class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--baseline"
+>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    <dt-text kind="body" :size="100">Small body</dt-text>
+  </div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    <dt-text kind="body" :size="300">Medium body</dt-text>
+  </div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    <dt-text kind="headline" :size="600">Large headline</dt-text>
+  </div>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   direction="row"
   gap="100"
@@ -629,24 +633,7 @@ vueCode='
   <dt-text kind="body" :size="300">Medium body</dt-text>
   <dt-text kind="headline" :size="600">Large headline</dt-text>
 </dt-stack>
-'>
-  <dt-stack
-    direction="row"
-    gap="100"
-    align="baseline"
-    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--baseline"
-  >
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      <dt-text kind="body" :size="100">Small body</dt-text>
-    </div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      <dt-text kind="body" :size="300">Medium body</dt-text>
-    </div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      <dt-text kind="headline" :size="600">Large headline</dt-text>
-    </div>
-  </dt-stack>
-</code-example>
+```
 
 ## Justify
 
@@ -658,165 +645,186 @@ Available `justify` values: `start` (default), `center`, `end`, `space-around`, 
 
 Align items to the start of the main axis (default).
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  class="d-w100p"
+  gap="200"
+  align="stretch"
+  :direction="{ default: `column`, md: `row` }"
+>
+  <dt-stack
+    gap="100"
+    justify="start"
+    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-start"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+  </dt-stack>
+  <dt-stack
+    direction="row"
+    gap="100"
+    justify="start"
+    class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-start"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack justify="start">
   <div>Item 1</div>
   <div>Item 2</div>
   <div>Item 3</div>
 </dt-stack>
-'>
-  <dt-stack
-    class="d-w100p"
-    gap="200"
-    align="stretch"
-    :direction="{ default: `column`, md: `row` }"
-  >
-    <dt-stack
-      gap="100"
-      justify="start"
-      class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-start"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-    </dt-stack>
-    <dt-stack
-      direction="row"
-      gap="100"
-      justify="start"
-      class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-start"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### Center
 
 Center items along the main axis.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  class="d-w100p"
+  gap="200"
+  :direction="{ default: `column`, md: `row` }"
+>
+  <dt-stack
+    gap="100"
+    justify="center"
+    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+  </dt-stack>
+  <dt-stack
+    direction="row"
+    gap="100"
+    justify="center"
+    class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack justify="center">
   <div>Item 1</div>
   <div>Item 2</div>
   <div>Item 3</div>
 </dt-stack>
-'>
-  <dt-stack
-    class="d-w100p"
-    gap="200"
-    :direction="{ default: `column`, md: `row` }"
-  >
-    <dt-stack
-      gap="100"
-      justify="center"
-      class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-    </dt-stack>
-    <dt-stack
-      direction="row"
-      gap="100"
-      justify="center"
-      class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### End
 
 Align items to the end of the main axis.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  class="d-w100p"
+  gap="200"
+  :direction="{ default: `column`, md: `row` }"
+>
+  <dt-stack
+    gap="100"
+    justify="end"
+    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-end"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+  </dt-stack>
+  <dt-stack
+    direction="row"
+    gap="100"
+    justify="end"
+    class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-end"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack justify="end">
   <div>Item 1</div>
   <div>Item 2</div>
   <div>Item 3</div>
 </dt-stack>
-'>
-  <dt-stack
-    class="d-w100p"
-    gap="200"
-    :direction="{ default: `column`, md: `row` }"
-  >
-    <dt-stack
-      gap="100"
-      justify="end"
-      class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-end"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-    </dt-stack>
-    <dt-stack
-      direction="row"
-      gap="100"
-      justify="end"
-      class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-end"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### Space Around
 
 Distribute items with equal space around each item.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  class="d-w100p"
+  gap="200"
+  :direction="{ default: `column`, md: `row` }"
+>
+  <dt-stack
+    gap="100"
+    justify="space-around"
+    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+  </dt-stack>
+  <dt-stack
+    direction="row"
+    gap="100"
+    justify="space-around"
+    class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack justify="space-around">
   <div>Item 1</div>
   <div>Item 2</div>
   <div>Item 3</div>
 </dt-stack>
-'>
-  <dt-stack
-    class="d-w100p"
-    gap="200"
-    :direction="{ default: `column`, md: `row` }"
-  >
-    <dt-stack
-      gap="100"
-      justify="space-around"
-      class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-    </dt-stack>
-    <dt-stack
-      direction="row"
-      gap="100"
-      justify="space-around"
-      class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### Space Between
 
 Distribute items with space between them, edges flush to container.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  class="d-w100p"
+  gap="200"
+  :direction="{ default: `column`, md: `row` }"
+>
+  <dt-stack
+    gap="100"
+    justify="space-between"
+    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+  </dt-stack>
+  <dt-stack
+    direction="row"
+    gap="100"
+    justify="space-between"
+    class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   direction="row"
   gap="100"
@@ -827,72 +835,45 @@ vueCode='
   <div>Item 2</div>
   <div>Item 3</div>
 </dt-stack>
-'>
-  <dt-stack
-    class="d-w100p"
-    gap="200"
-    :direction="{ default: `column`, md: `row` }"
-  >
-    <dt-stack
-      gap="100"
-      justify="space-between"
-      class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-    </dt-stack>
-    <dt-stack
-      direction="row"
-      gap="100"
-      justify="space-between"
-      class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### Space Evenly
 
 Distribute items with equal space between all items, including edges.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  class="d-w100p"
+  gap="200"
+  :direction="{ default: `column`, md: `row` }"
+>
+  <dt-stack
+    gap="100"
+    justify="space-evenly"
+    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+  </dt-stack>
+  <dt-stack
+    direction="row"
+    gap="100"
+    justify="space-evenly"
+    class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
+  >
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack justify="space-evenly">
   <div>Item 1</div>
   <div>Item 2</div>
   <div>Item 3</div>
 </dt-stack>
-'>
-  <dt-stack
-    class="d-w100p"
-    gap="200"
-    :direction="{ default: `column`, md: `row` }"
-  >
-    <dt-stack
-      gap="100"
-      justify="space-evenly"
-      class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-    </dt-stack>
-    <dt-stack
-      direction="row"
-      gap="100"
-      justify="space-evenly"
-      class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
-    >
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-      <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ## Responsive
 
@@ -900,8 +881,23 @@ vueCode='
 
 Stacks column at small screen size and column reverse at large screen
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  :direction="{ default: `row`, sm: `column`, lg: `column-reverse` }"
+  gap="100"
+  class="d-bgc-moderate-opaque"
+>
+  <div class="d-bgc-moderate-opaque d-bar8 d-p-200">
+    Stack item 1
+  </div>
+  <div class="d-bgc-moderate-opaque d-bar8 d-p-200">
+    Stack item 2
+  </div>
+  <div class="d-bgc-moderate-opaque d-bar8 d-p-200">
+    Stack item 3
+  </div>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   :direction="{ `default`: `row`, `sm`: `column`, `lg`: `column-reverse` }"
   gap="200"
@@ -916,56 +912,59 @@ vueCode='
     Stack item 3
   </div>
 </dt-stack>
-'>
-  <dt-stack
-    :direction="{ default: `row`, sm: `column`, lg: `column-reverse` }"
-    gap="100"
-    class="d-bgc-moderate-opaque"
-  >
-    <div class="d-bgc-moderate-opaque d-bar8 d-p-200">
-      Stack item 1
-    </div>
-    <div class="d-bgc-moderate-opaque d-bar8 d-p-200">
-      Stack item 2
-    </div>
-    <div class="d-bgc-moderate-opaque d-bar8 d-p-200">
-      Stack item 3
-    </div>
-  </dt-stack>
-</code-example>
+```
 
 Set `200` as the default gap, `300` for small and larger, `400` for medium, `500` for large, and `600` for extra large. Learn more about how our breakpoints work in the [Responsive Breakpoints documentation](/utilities/responsive/breakpoints.md).
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  :gap="{ default: '200', xl: '600', lg: '500', md: '400', sm: '300' }"
+  class="d-bgc-moderate-opaque"
+>
+  <div class="d-bgc-moderate-opaque d-bar8 d-p-200">
+    Stack item 1
+  </div>
+  <div class="d-bgc-moderate-opaque d-bar8 d-p-200">
+    Stack item 2
+  </div>
+  <div class="d-bgc-moderate-opaque d-bar8 d-p-200">
+    Stack item 3
+  </div>
+</dt-stack>
+<!-- @code -->
 <dt-stack :gap="{ default: `300`, xl: `600`, lg: `500`, md: `400`, sm: `300` }">
   <div> Stack item 1 </div>
   <div> Stack item 2 </div>
   <div> Stack item 3 </div>
 </dt-stack>
-'>
-  <dt-stack
-    :gap="{ default: '200', xl: '600', lg: '500', md: '400', sm: '300' }"
-    class="d-bgc-moderate-opaque"
-  >
-    <div class="d-bgc-moderate-opaque d-bar8 d-p-200">
-      Stack item 1
-    </div>
-    <div class="d-bgc-moderate-opaque d-bar8 d-p-200">
-      Stack item 2
-    </div>
-    <div class="d-bgc-moderate-opaque d-bar8 d-p-200">
-      Stack item 3
-    </div>
-  </dt-stack>
-</code-example>
+```
 
 ### Nested Example
 
 Stacks row with gap 500 and stacks in row reverse the nested stack with gap 500.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  direction="row"
+  as="section"
+  gap="200"
+  class="d-bgc-moderate-opaque d-bar8"
+>
+  <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-200">
+    Stack item 1
+  </dt-stack>
+  <dt-stack gap="200" class="d-bgc-moderate-opaque">
+    <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 2</div>
+    <dt-stack
+      direction="row-reverse"
+      gap="200"
+    >
+      <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 3<br>with multiple lines</div>
+      <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 4</div>
+    </dt-stack>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   direction="row"
   as="section"
@@ -985,35 +984,31 @@ vueCode='
     </dt-stack>
   </dt-stack>
 </dt-stack>
-'>
-  <dt-stack
-    direction="row"
-    as="section"
-    gap="200"
-    class="d-bgc-moderate-opaque d-bar8"
-  >
-    <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-200">
-      Stack item 1
-    </dt-stack>
-    <dt-stack gap="200" class="d-bgc-moderate-opaque">
-      <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 2</div>
-      <dt-stack
-        direction="row-reverse"
-        gap="200"
-      >
-        <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 3<br>with multiple lines</div>
-        <div class="d-bgc-moderate-opaque d-bar8 d-p-200">Stack item 4</div>
-      </dt-stack>
-    </dt-stack>
-  </dt-stack>
-</code-example>
+```
 
 ### Example: Align and Justify
 
 Like `direction` and `gap`, the `align` and `justify` props support responsive object syntax to change alignment at different breakpoints.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  direction="row"
+  gap="100"
+  :align="{ default: 'start', md: 'center', lg: 'end' }"
+  class="d-bgc-moderate-opaque d-bar8"
+>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Short
+  </div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Taller<br>
+    item
+  </div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+    Short
+  </div>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   direction="row"
   gap="100"
@@ -1026,30 +1021,22 @@ vueCode='
   </div>
   <div>Short</div>
 </dt-stack>
-'>
-  <dt-stack
-    direction="row"
-    gap="100"
-    :align="{ default: 'start', md: 'center', lg: 'end' }"
-    class="d-bgc-moderate-opaque d-bar8"
-  >
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Short
-    </div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Taller<br>
-      item
-    </div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
-      Short
-    </div>
-  </dt-stack>
-</code-example>
+```
 
 Resize your browser to see the alignment change at different breakpoints.
 
-<code-example
-vueCode='
+```vue demo
+<dt-stack
+  direction="row"
+  gap="0"
+  :justify="{ default: 'start', md: 'center', lg: 'space-between' }"
+  class="d-w100p d-bgc-moderate-opaque d-bar8"
+>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
+</dt-stack>
+<!-- @code -->
 <dt-stack
   direction="row"
   :justify="{ default: `start`, md: `center`, lg: `space-between` }"
@@ -1059,18 +1046,7 @@ vueCode='
   <div>Item 2</div>
   <div>Item 3</div>
 </dt-stack>
-'>
-  <dt-stack
-    direction="row"
-    gap="0"
-    :justify="{ default: 'start', md: 'center', lg: 'space-between' }"
-    class="d-w100p d-bgc-moderate-opaque d-bar8"
-  >
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 1</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 2</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Item 3</div>
-  </dt-stack>
-</code-example>
+```
 
 Resize your browser to see the justification change at different breakpoints.
 
@@ -1082,8 +1058,9 @@ View the [Migrating from Flex CSS Utilities to DtStack](/about/whats-new/posts/2
 
 ### Profile Card
 
-<code-example
-vueCode='
+```vue demo
+<ExampleProfileCard />
+<!-- @code -->
 <dt-stack gap="200">
   <dt-stack gap="100" justify="space-between">
     <dt-stack>
@@ -1132,33 +1109,31 @@ vueCode='
     </dt-button>
   </dt-stack>
 </dt-stack>
-'>
-  <ExampleProfileCard />
-</code-example>
+```
 
 ### Call Log
 
-<code-example>
-  <dt-stack gap="100" class="d-w-800">
-    <dt-text as="h2" kind="headline" :size="400">Saturday, May 24, 2025</dt-text>
-    <dt-stack direction="row" gap="100" class="d-w100p">
-      <dt-avatar full-name="Ashanti Trevor" />
-      <dt-stack class="d-fl1">
-        <dt-text kind="body" :size="200" strength="bold">Ashanti Trevor</dt-text>
-        <dt-stack direction="row" gap="50">
-          <dt-stack direction="row" gap="100">
-            <dt-icon name="phone-outgoing" size="200" class="d-fc-tertiary" />
-            <dt-text kind="body" :size="100" tone="tertiary">Outgoing call</dt-text>
-          </dt-stack>
-          <dt-text kind="body" :size="100" tone="tertiary">&bull;</dt-text>
-          <dt-text kind="body" :size="100" tone="tertiary">2 minutes 10 seconds</dt-text>
+```vue demo
+<dt-stack gap="100" class="d-w-800">
+  <dt-text as="h2" kind="headline" :size="400">Saturday, May 24, 2025</dt-text>
+  <dt-stack direction="row" gap="100" class="d-w100p">
+    <dt-avatar full-name="Ashanti Trevor" />
+    <dt-stack class="d-fl1">
+      <dt-text kind="body" :size="200" strength="bold">Ashanti Trevor</dt-text>
+      <dt-stack direction="row" gap="50">
+        <dt-stack direction="row" gap="100">
+          <dt-icon name="phone-outgoing" size="200" class="d-fc-tertiary" />
+          <dt-text kind="body" :size="100" tone="tertiary">Outgoing call</dt-text>
         </dt-stack>
+        <dt-text kind="body" :size="100" tone="tertiary">&bull;</dt-text>
+        <dt-text kind="body" :size="100" tone="tertiary">2 minutes 10 seconds</dt-text>
       </dt-stack>
-      <dt-text kind="body" :size="200" tone="tertiary" numeric>3:23 pm</dt-text>
-      <dt-badge kind="count" type="bulletin" text="6" />
     </dt-stack>
+    <dt-text kind="body" :size="200" tone="tertiary" numeric>3:23 pm</dt-text>
+    <dt-badge kind="count" type="bulletin" text="6" />
   </dt-stack>
-</code-example>
+</dt-stack>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/table.md
+++ b/apps/dialtone-documentation/docs/components/table.md
@@ -14,27 +14,29 @@ keywords: ["data table", "grid", "rows", "d-table", "DtTable", "dt-table", "data
 
 ### Base Style
 
-<code-example bgclass="d-bgc-primary" class="d-d-block">
-  <table class="d-table dialtone-doc-table">
-    <caption class="d-table__caption">Office List</caption>
-    <thead>
-      <tr>
-        <th scope="col">Office</th>
-        <th scope="col">Country</th>
-        <th scope="col" width="10%">Employees</th>
-        <th scope="col">Contact</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr v-for="i in examples">
-        <th scope="row">{{ i.office }}</th>
-        <td>{{ i.country }}</td>
-        <td>{{ i.size }}</td>
-        <td>{{ i.contact }}</td>
-      </tr>
-    </tbody>
-  </table>
-</code-example>
+```vue demo
+<!-- @bg d-bgc-primary -->
+<!-- @class d-d-block -->
+<table class="d-table dialtone-doc-table">
+  <caption class="d-table__caption">Office List</caption>
+  <thead>
+    <tr>
+      <th scope="col">Office</th>
+      <th scope="col">Country</th>
+      <th scope="col" width="10%">Employees</th>
+      <th scope="col">Contact</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr v-for="i in examples">
+      <th scope="row">{{ i.office }}</th>
+      <td>{{ i.country }}</td>
+      <td>{{ i.size }}</td>
+      <td>{{ i.contact }}</td>
+    </tr>
+  </tbody>
+</table>
+```
 
 ### Inverted Style
 
@@ -44,27 +46,29 @@ keywords: ["data table", "grid", "rows", "d-table", "DtTable", "dt-table", "data
 
 ### Striped
 
-<code-example bgclass="d-bgc-primary" class="d-d-block">
-  <table class="d-table dialtone-doc-table d-table--striped">
-    <caption class="d-table__caption">Office List</caption>
-    <thead>
-      <tr>
-        <th scope="col">Office</th>
-        <th scope="col">Country</th>
-        <th scope="col" width="10%">Employees</th>
-        <th scope="col">Contact</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr v-for="i in examples">
-        <th scope="row">{{ i.office }}</th>
-        <td>{{ i.country }}</td>
-        <td>{{ i.size }}</td>
-        <td>{{ i.contact }}</td>
-      </tr>
-    </tbody>
-  </table>
-</code-example>
+```vue demo
+<!-- @bg d-bgc-primary -->
+<!-- @class d-d-block -->
+<table class="d-table dialtone-doc-table d-table--striped">
+  <caption class="d-table__caption">Office List</caption>
+  <thead>
+    <tr>
+      <th scope="col">Office</th>
+      <th scope="col">Country</th>
+      <th scope="col" width="10%">Employees</th>
+      <th scope="col">Contact</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr v-for="i in examples">
+      <th scope="row">{{ i.office }}</th>
+      <td>{{ i.country }}</td>
+      <td>{{ i.size }}</td>
+      <td>{{ i.contact }}</td>
+    </tr>
+  </tbody>
+</table>
+```
 
 ## Classes
 

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -14,7 +14,11 @@ keywords: ["tab panel", "tab navigation", "d-tabs", "DtTabs", "dt-tabs", "segmen
 
 ### Default
 
-<code-example vueCode='
+```vue demo
+<div class="d-w100p">
+  <example-tabs />
+</div>
+<!-- @code -->
 <dt-tab-group>
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>First</dt-tab>
@@ -22,31 +26,31 @@ keywords: ["tab panel", "tab navigation", "d-tabs", "DtTabs", "dt-tabs", "segmen
     <dt-tab id="5" panel-id="6">Third</dt-tab>
   </template>
 </dt-tab-group>
-'>
-  <div class="d-w100p">
-    <example-tabs />
-  </div>
-</code-example>
+```
 
 ### Borderless
 
 Remove the bottom border of any tablist.
 
-<code-example vueCode='
+```vue demo
+<div class="d-w100p">
+  <example-tabs borderless />
+</div>
+<!-- @code -->
 <dt-tab-group borderless>
   ...
 </dt-tab-group>
-'>
-  <div class="d-w100p">
-    <example-tabs borderless />
-  </div>
-</code-example>
+```
 
 ### Muted
 
 All tabs render as muted buttons. The selected tab is distinguished with active styling.
 
-<code-example vueCode='
+```vue demo
+<div class="d-w100p">
+  <example-tabs kind="muted" />
+</div>
+<!-- @code -->
 <dt-tab-group kind="muted">
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>First</dt-tab>
@@ -54,17 +58,17 @@ All tabs render as muted buttons. The selected tab is distinguished with active 
     <dt-tab id="5" panel-id="6">Third</dt-tab>
   </template>
 </dt-tab-group>
-'>
-  <div class="d-w100p">
-    <example-tabs kind="muted" />
-  </div>
-</code-example>
+```
 
 ### Outlined
 
 The selected tab renders with an outlined border instead of a filled style.
 
-<code-example vueCode='
+```vue demo
+<div class="d-w100p">
+  <example-tabs outlined />
+</div>
+<!-- @code -->
 <dt-tab-group outlined>
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>First</dt-tab>
@@ -72,17 +76,17 @@ The selected tab renders with an outlined border instead of a filled style.
     <dt-tab id="5" panel-id="6">Third</dt-tab>
   </template>
 </dt-tab-group>
-'>
-  <div class="d-w100p">
-    <example-tabs outlined />
-  </div>
-</code-example>
+```
 
 ### Muted Outlined
 
 Combines muted kind with outlined selected state.
 
-<code-example vueCode='
+```vue demo
+<div class="d-w100p">
+  <example-tabs kind="muted" outlined />
+</div>
+<!-- @code -->
 <dt-tab-group kind="muted" outlined>
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>First</dt-tab>
@@ -90,30 +94,28 @@ Combines muted kind with outlined selected state.
     <dt-tab id="5" panel-id="6">Third</dt-tab>
   </template>
 </dt-tab-group>
-'>
-  <div class="d-w100p">
-    <example-tabs kind="muted" outlined />
-  </div>
-</code-example>
+```
 
 ### Disabled
 
 Add `disabled` to a specific tab.
 
-<code-example>
-  <dt-tab-group>
-    <template #tabs>
-      <dt-tab id="1" panel-id="2" selected>First</dt-tab>
-      <dt-tab id="3" panel-id="4">Second</dt-tab>
-      <dt-tab id="5" panel-id="6">Third</dt-tab>
-      <dt-tab id="7" panel-id="8" disabled>Fourth</dt-tab>
-    </template>
-  </dt-tab-group>
-</code-example>
+```vue demo
+<dt-tab-group>
+  <template #tabs>
+    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
+    <dt-tab id="3" panel-id="4">Second</dt-tab>
+    <dt-tab id="5" panel-id="6">Third</dt-tab>
+    <dt-tab id="7" panel-id="8" disabled>Fourth</dt-tab>
+  </template>
+</dt-tab-group>
+```
 
 Add `disabled` to the tab group to disable all.
 
-<code-example vueCode='
+```vue demo
+<example-tabs disabled />
+<!-- @code -->
 <dt-tab-group disabled>
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>First</dt-tab>
@@ -121,9 +123,7 @@ Add `disabled` to the tab group to disable all.
     <dt-tab id="5" panel-id="6">Third</dt-tab>
   </template>
 </dt-tab-group>
-'>
-  <example-tabs disabled />
-</code-example>
+```
 
 ### Inverted
 
@@ -133,20 +133,20 @@ Add `disabled` to the tab group to disable all.
 
 In place of the `inverted` prop, use the [v-dt-mode directive](mode-island.html#inverting) on the component element.
 
-<code-example vueCode='
+```vue demo
+<div class="d-p-100 d-bgc-contrast d-w100p">
+  <div v-dt-mode:invert class="d-p-200 d-bar8">
+    <example-tabs />
+  </div>
+</div>
+<!-- @code -->
 <dt-tab-group v-dt-mode:invert>
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>First</dt-tab>
     <dt-tab id="3" panel-id="4">Second</dt-tab>
   </template>
 </dt-tab-group>
-'>
-  <div class="d-p-100 d-bgc-contrast d-w100p">
-    <div v-dt-mode:invert class="d-p-200 d-bar8">
-      <example-tabs />
-    </div>
-  </div>
-</code-example>
+```
 
 ## Spread
 
@@ -156,109 +156,111 @@ Control how tabs distribute available horizontal space within the tab list. It o
 
 Tabs expand proportionally to fill the container. Longer labels receive more space.
 
-<code-example>
-  <div class="d-w100p" data-demo-wrapper>
-    <dt-tab-group spread="grow">
-      <template #tabs>
-        <dt-tab id="sg1" panel-id="sg2" selected>Tab 1</dt-tab>
-        <dt-tab id="sg3" panel-id="sg4">Tab the second</dt-tab>
-        <dt-tab id="sg5" panel-id="sg6">Tab the third</dt-tab>
-      </template>
-    </dt-tab-group>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w100p">
+  <dt-tab-group spread="grow">
+    <template #tabs>
+      <dt-tab id="sg1" panel-id="sg2" selected>Tab 1</dt-tab>
+      <dt-tab id="sg3" panel-id="sg4">Tab the second</dt-tab>
+      <dt-tab id="sg5" panel-id="sg6">Tab the third</dt-tab>
+    </template>
+  </dt-tab-group>
+</div>
+```
 
 ### Equal
 
 All tabs share the same width, regardless of label length.
 
-<code-example>
-  <div class="d-w-800" data-demo-wrapper>
-    <dt-tab-group spread="equal">
-      <template #tabs>
-        <dt-tab id="se1" panel-id="se2" selected>Tab 1</dt-tab>
-        <dt-tab id="se3" panel-id="se4">Tab the second</dt-tab>
-        <dt-tab id="se5" panel-id="se6">Tab the third</dt-tab>
-      </template>
-    </dt-tab-group>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w-800">
+  <dt-tab-group spread="equal">
+    <template #tabs>
+      <dt-tab id="se1" panel-id="se2" selected>Tab 1</dt-tab>
+      <dt-tab id="se3" panel-id="se4">Tab the second</dt-tab>
+      <dt-tab id="se5" panel-id="se6">Tab the third</dt-tab>
+    </template>
+  </dt-tab-group>
+</div>
+```
 
 ## Sizes
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="200" class="d-w100p">
+  <dt-tab-group :size="100">
+    <template #tabs>
+      <dt-tab id="1" panel-id="2" selected>
+        First
+      </dt-tab>
+      <dt-tab id="3" panel-id="4">
+        Second
+      </dt-tab>
+      <dt-tab id="5" panel-id="6">
+        Third
+      </dt-tab>
+    </template>
+  </dt-tab-group>
+  <dt-tab-group :size="200">
+    <template #tabs>
+      <dt-tab id="1" panel-id="2" selected>
+        First
+      </dt-tab>
+      <dt-tab id="3" panel-id="4">
+        Second
+      </dt-tab>
+      <dt-tab id="5" panel-id="6">
+        Third
+      </dt-tab>
+    </template>
+  </dt-tab-group>
+  <dt-tab-group>
+    <template #tabs>
+      <dt-tab id="1" panel-id="2" selected>
+        First
+      </dt-tab>
+      <dt-tab id="3" panel-id="4">
+        Second
+      </dt-tab>
+      <dt-tab id="5" panel-id="6">
+        Third
+      </dt-tab>
+    </template>
+  </dt-tab-group>
+  <dt-tab-group :size="400">
+    <template #tabs>
+      <dt-tab id="1" panel-id="2" selected>
+        First
+      </dt-tab>
+      <dt-tab id="3" panel-id="4">
+        Second
+      </dt-tab>
+      <dt-tab id="5" panel-id="6">
+        Third
+      </dt-tab>
+    </template>
+  </dt-tab-group>
+  <dt-tab-group :size="500">
+    <template #tabs>
+      <dt-tab id="1" panel-id="2" selected>
+        First
+      </dt-tab>
+      <dt-tab id="3" panel-id="4">
+        Second
+      </dt-tab>
+      <dt-tab id="5" panel-id="6">
+        Third
+      </dt-tab>
+    </template>
+  </dt-tab-group>
+</dt-stack>
+<!-- @code -->
 <dt-tab-group :size="100|200|300|400|500">
   ...
 </dt-tab-group>
-'>
-  <dt-stack gap="200" class="d-w100p">
-    <dt-tab-group :size="100">
-      <template #tabs>
-        <dt-tab id="1" panel-id="2" selected>
-          First
-        </dt-tab>
-        <dt-tab id="3" panel-id="4">
-          Second
-        </dt-tab>
-        <dt-tab id="5" panel-id="6">
-          Third
-        </dt-tab>
-      </template>
-    </dt-tab-group>
-    <dt-tab-group :size="200">
-      <template #tabs>
-        <dt-tab id="1" panel-id="2" selected>
-          First
-        </dt-tab>
-        <dt-tab id="3" panel-id="4">
-          Second
-        </dt-tab>
-        <dt-tab id="5" panel-id="6">
-          Third
-        </dt-tab>
-      </template>
-    </dt-tab-group>
-    <dt-tab-group>
-      <template #tabs>
-        <dt-tab id="1" panel-id="2" selected>
-          First
-        </dt-tab>
-        <dt-tab id="3" panel-id="4">
-          Second
-        </dt-tab>
-        <dt-tab id="5" panel-id="6">
-          Third
-        </dt-tab>
-      </template>
-    </dt-tab-group>
-    <dt-tab-group :size="400">
-      <template #tabs>
-        <dt-tab id="1" panel-id="2" selected>
-          First
-        </dt-tab>
-        <dt-tab id="3" panel-id="4">
-          Second
-        </dt-tab>
-        <dt-tab id="5" panel-id="6">
-          Third
-        </dt-tab>
-      </template>
-    </dt-tab-group>
-    <dt-tab-group :size="500">
-      <template #tabs>
-        <dt-tab id="1" panel-id="2" selected>
-          First
-        </dt-tab>
-        <dt-tab id="3" panel-id="4">
-          Second
-        </dt-tab>
-        <dt-tab id="5" panel-id="6">
-          Third
-        </dt-tab>
-      </template>
-    </dt-tab-group>
-  </dt-stack>
-</code-example>
+```
 
 ## Slots
 
@@ -270,69 +272,73 @@ Use the `#startIcon` or `#endIcon` slot on `dt-tab` to add an icon. The slot pro
   The <code>#icon</code> slot has been deprecated. Use <code>#startIcon</code> or <code>#endIcon</code> instead.
 </dt-notice>
 
-<code-example>
-  <div class="d-w100p" data-demo-wrapper>
-    <dt-tab-group>
-      <template #tabs>
-        <dt-tab id="1" panel-id="2" selected>
-          First
-          <template #startIcon="{ iconSize }">
-            <dt-icon name="box-select" :size="iconSize" />
-          </template>
-        </dt-tab>
-        <dt-tab id="3" panel-id="4">
-          Second
-          <template #startIcon="{ iconSize }">
-            <dt-icon name="box-select" :size="iconSize" />
-          </template>
-          <template #endIcon="{ iconSize }">
-            <dt-icon name="box-select" :size="iconSize" />
-          </template>
-        </dt-tab>
-        <dt-tab id="5" panel-id="6">
-          Third
-          <template #endIcon="{ iconSize }">
-            <dt-icon name="box-select" :size="iconSize" />
-          </template>
-        </dt-tab>
-      </template>
-    </dt-tab-group>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w100p">
+  <dt-tab-group>
+    <template #tabs>
+      <dt-tab id="1" panel-id="2" selected>
+        First
+        <template #startIcon="{ iconSize }">
+          <dt-icon name="box-select" :size="iconSize" />
+        </template>
+      </dt-tab>
+      <dt-tab id="3" panel-id="4">
+        Second
+        <template #startIcon="{ iconSize }">
+          <dt-icon name="box-select" :size="iconSize" />
+        </template>
+        <template #endIcon="{ iconSize }">
+          <dt-icon name="box-select" :size="iconSize" />
+        </template>
+      </dt-tab>
+      <dt-tab id="5" panel-id="6">
+        Third
+        <template #endIcon="{ iconSize }">
+          <dt-icon name="box-select" :size="iconSize" />
+        </template>
+      </dt-tab>
+    </template>
+  </dt-tab-group>
+</div>
+```
 
 ### Leading & Trailing
 
 Use the `#leading` and `#trailing` slots on `dt-tab` to render content like badges or count indicators alongside tab labels. Use `leading-class` and `trailing-class` to adjust padding.
 
-<code-example>
-  <div class="d-w100p" data-demo-wrapper>
-    <dt-tab-group>
-      <template #tabs>
-        <dt-tab id="lt1" panel-id="lt2" selected trailing-class="d-pie-100">
-          Inbox
-          <template #trailing>
-            <dt-badge kind="count" type="bulletin" text="9" />
-          </template>
-        </dt-tab>
-        <dt-tab id="lt3" panel-id="lt4" trailing-class="d-pie-100">
-          Archive
-          <template #trailing>
-            <dt-badge kind="count" text="99+" />
-          </template>
-        </dt-tab>
-        <dt-tab id="lt5" panel-id="lt6">
-          Drafts
-        </dt-tab>
-      </template>
-    </dt-tab-group>
-  </div>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<div class="d-w100p">
+  <dt-tab-group>
+    <template #tabs>
+      <dt-tab id="lt1" panel-id="lt2" selected trailing-class="d-pie-100">
+        Inbox
+        <template #trailing>
+          <dt-badge kind="count" type="bulletin" text="9" />
+        </template>
+      </dt-tab>
+      <dt-tab id="lt3" panel-id="lt4" trailing-class="d-pie-100">
+        Archive
+        <template #trailing>
+          <dt-badge kind="count" text="99+" />
+        </template>
+      </dt-tab>
+      <dt-tab id="lt5" panel-id="lt6">
+        Drafts
+      </dt-tab>
+    </template>
+  </dt-tab-group>
+</div>
+```
 
 ## Orientation
 
 Set `orientation="vertical"` to stack tabs vertically alongside the panel.
 
-<code-example vueCode='
+```vue demo
+<example-tabs orientation="vertical" />
+<!-- @code -->
 <dt-tab-group orientation="vertical">
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>First</dt-tab>
@@ -340,9 +346,7 @@ Set `orientation="vertical"` to stack tabs vertically alongside the panel.
     <dt-tab id="5" panel-id="6">Third</dt-tab>
   </template>
 </dt-tab-group>
-'>
-  <example-tabs orientation="vertical" />
-</code-example>
+```
 
 ## Advanced Usages
 
@@ -350,7 +354,9 @@ Set `orientation="vertical"` to stack tabs vertically alongside the panel.
 
 By default, tabs use manual activation — the user must press `Enter` or `Space` after focusing a tab to select it. Set `activation-mode="auto"` to select tabs immediately on focus via arrow keys, following the <a class="d-link" href="https://www.w3.org/WAI/ARIA/apg/patterns/tabs/" target="_blank">WAI-ARIA Tabs pattern</a>.
 
-<code-example vueCode='
+```vue demo
+<example-tabs activation-mode="auto" />
+<!-- @code -->
 <dt-tab-group activation-mode="auto">
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>First</dt-tab>
@@ -358,15 +364,15 @@ By default, tabs use manual activation — the user must press `Enter` or `Space
     <dt-tab id="5" panel-id="6">Third</dt-tab>
   </template>
 </dt-tab-group>
-'>
-  <example-tabs activation-mode="auto" />
-</code-example>
+```
 
 ### Validation Before Changing Tabs
 
 If you need to do some validation before changing tabs, you can use the `before-change` event. If the event handler is prevented, the tab change will be cancelled.
 
-<code-example vueCode='
+```vue demo
+<example-tabs validate />
+<!-- @code -->
 <dt-tab-group @before-change="confirmBeforeLeave">
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>First</dt-tab>
@@ -382,9 +388,7 @@ If you need to do some validation before changing tabs, you can use the `before-
     }
   }
 </script>
-'>
-  <example-tabs validate />
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/text.md
+++ b/apps/dialtone-documentation/docs/components/text.md
@@ -10,9 +10,9 @@ image: assets/images/components/text.png
 
 ## Usage
 
-<code-example only-show="code">
-  <dt-text> ... </dt-text>
-</code-example>
+```vue code-only
+<dt-text> ... </dt-text>
+```
 
 Use in place of manually applying Text Styles. Examples of manual application **you should avoid** include:
 
@@ -50,15 +50,16 @@ Use in place of manually applying Text Styles. Examples of manual application **
 
 Declare the role of the content. Default will inherit styles from the parent.
 
-<code-example>
-  <dt-stack gap="400" :direction="{ 'default': 'column', 'md': 'row' }" align="baseline" data-demo-wrapper>
-    <dt-text kind="headline" as="span">Headline</dt-text>
-    <dt-text kind="body">Body</dt-text>
-    <dt-text kind="label">Label</dt-text>
-    <dt-text kind="code">Code</dt-text>
-    <dt-text>Default (inherits)</dt-text>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="400" :direction="{ 'default': 'column', 'md': 'row' }" align="baseline">
+  <dt-text kind="headline" as="span">Headline</dt-text>
+  <dt-text kind="body">Body</dt-text>
+  <dt-text kind="label">Label</dt-text>
+  <dt-text kind="code">Code</dt-text>
+  <dt-text>Default (inherits)</dt-text>
+</dt-stack>
+```
 
 ### Size
 
@@ -84,229 +85,230 @@ All kinds support `size` prop, but not all sizes are available for each kind. Wh
   </table>
 </dt-stack>
 
-<code-example only-show="code">
-  <dt-text kind="{kind}" :size="{size}">....</dt-text>
-</code-example>
+```vue code-only
+<dt-text kind="{kind}" :size="{size}">....</dt-text>
+```
 
 ### Numeric
 
 The `numeric` prop applies styles that ensure that each number is set with consistent width, making them align properly when displayed together. Ideal for displaying aligned data such as phone numbers or numbers in a table.
 
-<code-example vueCode='
-<dt-text numeric>(913) 555-3170</dt-text>
-'>
-  <dt-stack direction="row" gap="200">
-    <dt-stack>
-      <dt-text kind="label" :size="200" tone="critical">Without numeric</dt-text>
-      <dt-text>(913) 555-3170</dt-text>
-      <dt-text>(908) 555-1111</dt-text>
-      <dt-text>(805) 555-8413</dt-text>
-      <dt-text>(816) 555-1203</dt-text>
-      <dt-text>(886) 555-8888</dt-text>
-    </dt-stack>
-    <dt-stack>
-      <dt-text kind="label" :size="200" tone="success">With numeric</dt-text>
-      <dt-text numeric>(913) 555-3170</dt-text>
-      <dt-text numeric>(908) 555-1111</dt-text>
-      <dt-text numeric>(805) 555-8413</dt-text>
-      <dt-text numeric>(816) 555-1203</dt-text>
-      <dt-text numeric>(886) 555-8888</dt-text>
-    </dt-stack>
+```vue demo
+<dt-stack direction="row" gap="200">
+  <dt-stack>
+    <dt-text kind="label" :size="200" tone="critical">Without numeric</dt-text>
+    <dt-text>(913) 555-3170</dt-text>
+    <dt-text>(908) 555-1111</dt-text>
+    <dt-text>(805) 555-8413</dt-text>
+    <dt-text>(816) 555-1203</dt-text>
+    <dt-text>(886) 555-8888</dt-text>
   </dt-stack>
-</code-example>
+  <dt-stack>
+    <dt-text kind="label" :size="200" tone="success">With numeric</dt-text>
+    <dt-text numeric>(913) 555-3170</dt-text>
+    <dt-text numeric>(908) 555-1111</dt-text>
+    <dt-text numeric>(805) 555-8413</dt-text>
+    <dt-text numeric>(816) 555-1203</dt-text>
+    <dt-text numeric>(886) 555-8888</dt-text>
+  </dt-stack>
+</dt-stack>
+<!-- @code -->
+<dt-text numeric>(913) 555-3170</dt-text>
+```
 
 ### Strength
 
 Override the font-weight of the text. Applies to any kind/size combination. If omitted, the default weight from the typography token is used.
 
-<code-example vueCode='
+```vue demo
+<dt-stack :direction="{ 'default': 'column', 'md': 'row' }" gap="200" class="d-fw-wrap">
+  <dt-text strength="bold">Bold</dt-text>
+  <dt-text strength="semibold">Semibold</dt-text>
+  <dt-text strength="medium">Medium</dt-text>
+  <dt-text strength="normal">Normal</dt-text>
+</dt-stack>
+<!-- @code -->
 <dt-text strength="{{strength}}">...</dt-text>
-'>
-  <dt-stack :direction="{ 'default': 'column', 'md': 'row' }" gap="200" class="d-fw-wrap">
-    <dt-text strength="bold">Bold</dt-text>
-    <dt-text strength="semibold">Semibold</dt-text>
-    <dt-text strength="medium">Medium</dt-text>
-    <dt-text strength="normal">Normal</dt-text>
-  </dt-stack>
-</code-example>
+```
 
 ### Density
 
 Override the line-height of the text. Applies to any kind/size combination. If omitted, the default line-height from the typography token is used.
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="100">
+  <dt-text kind="body" as="p" density="100" class="d-bgc-moderate-opaque"><dt-text kind="code" as="code" :size="200" class="d-bgc-transparent">100</dt-text> The quick brown fox jumped over the lazy dog.</dt-text>
+  <dt-text kind="body" as="p" density="200" class="d-bgc-moderate-opaque"><dt-text kind="code" as="code" :size="200" class="d-bgc-transparent">200</dt-text> The quick brown fox jumped over the lazy dog.</dt-text>
+  <dt-text kind="body" as="p" density="300" class="d-bgc-moderate-opaque"><dt-text kind="code" as="code" :size="200" class="d-bgc-transparent">300</dt-text> The quick brown fox jumped over the lazy dog.</dt-text>
+  <dt-text kind="body" as="p" density="400" class="d-bgc-moderate-opaque"><dt-text kind="code" as="code" :size="200" class="d-bgc-transparent">400</dt-text> The quick brown fox jumped over the lazy dog.</dt-text>
+  <dt-text kind="body" as="p" density="500" class="d-bgc-moderate-opaque"><dt-text kind="code" as="code" :size="200" class="d-bgc-transparent">500</dt-text> The quick brown fox jumped over the lazy dog.</dt-text>
+  <dt-text kind="body" as="p" density="600" class="d-bgc-moderate-opaque"><dt-text kind="code" as="code" :size="200" class="d-bgc-transparent">600</dt-text> The quick brown fox jumped over the lazy dog.</dt-text>
+</dt-stack>
+<!-- @code -->
 <dt-text density="{{density}}">...</dt-text>
-'>
-  <dt-stack gap="100">
-    <dt-text kind="body" as="p" density="100" class="d-bgc-moderate-opaque"><dt-text kind="code" as="code" :size="200" class="d-bgc-transparent">100</dt-text> The quick brown fox jumped over the lazy dog.</dt-text>
-    <dt-text kind="body" as="p" density="200" class="d-bgc-moderate-opaque"><dt-text kind="code" as="code" :size="200" class="d-bgc-transparent">200</dt-text> The quick brown fox jumped over the lazy dog.</dt-text>
-    <dt-text kind="body" as="p" density="300" class="d-bgc-moderate-opaque"><dt-text kind="code" as="code" :size="200" class="d-bgc-transparent">300</dt-text> The quick brown fox jumped over the lazy dog.</dt-text>
-    <dt-text kind="body" as="p" density="400" class="d-bgc-moderate-opaque"><dt-text kind="code" as="code" :size="200" class="d-bgc-transparent">400</dt-text> The quick brown fox jumped over the lazy dog.</dt-text>
-    <dt-text kind="body" as="p" density="500" class="d-bgc-moderate-opaque"><dt-text kind="code" as="code" :size="200" class="d-bgc-transparent">500</dt-text> The quick brown fox jumped over the lazy dog.</dt-text>
-    <dt-text kind="body" as="p" density="600" class="d-bgc-moderate-opaque"><dt-text kind="code" as="code" :size="200" class="d-bgc-transparent">600</dt-text> The quick brown fox jumped over the lazy dog.</dt-text>
-  </dt-stack>
-</code-example>
+```
 
 ## Tone
 
 Use `tone` to declare the text's tone, which will map to a foreground color. By default, the tone is inherited from its parent.
 
-<code-example>
-  <dt-stack class="d-py-100 d-px-200 d-bar4" data-demo-wrapper>
-    <dt-text>primary</dt-text>
-    <dt-text tone="secondary">secondary</dt-text>
-    <dt-text tone="tertiary">tertiary</dt-text>
-    <dt-text tone="muted">muted</dt-text>
-    <dt-text tone="disabled">disabled</dt-text>
-    <dt-text tone="placeholder">placeholder</dt-text>
-    <dt-text tone="success">success</dt-text>
-    <dt-text tone="success-strong">success-strong</dt-text>
-    <dt-text tone="warning">warning</dt-text>
-    <dt-text tone="critical">critical</dt-text>
-    <dt-text tone="critical-strong">critical-strong</dt-text>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<dt-stack class="d-py-100 d-px-200 d-bar4">
+  <dt-text>primary</dt-text>
+  <dt-text tone="secondary">secondary</dt-text>
+  <dt-text tone="tertiary">tertiary</dt-text>
+  <dt-text tone="muted">muted</dt-text>
+  <dt-text tone="disabled">disabled</dt-text>
+  <dt-text tone="placeholder">placeholder</dt-text>
+  <dt-text tone="success">success</dt-text>
+  <dt-text tone="success-strong">success-strong</dt-text>
+  <dt-text tone="warning">warning</dt-text>
+  <dt-text tone="critical">critical</dt-text>
+  <dt-text tone="critical-strong">critical-strong</dt-text>
+</dt-stack>
+```
 
 ### Inverted
 
 Rather than use the `-inverted` tone variants, use the [v-dt-mode](/components/mode-island.html) directive.
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="100" class="d-py-100 d-px-200 d-bar4">
+  <div class="d-p-100 d-px-150 d-bgc-transparent d-baw2 d-bas-dashed d-bc-subtle">
+    <dt-text as="p" align="center" tone="critical">critical tone on default surface</dt-text>
+  </div>
+  <div class="d-p-100 d-px-150 d-bgc-contrast">
+    <dt-text as="p" align="center" v-dt-mode:invert tone="critical">critical tone on contrasting surface</dt-text>
+  </div>
+</dt-stack>
+<!-- @code -->
 <dt-text v-dt-mode:invert tone="critical">critical tone on contrasting surface</dt-text>
-'>
-  <dt-stack gap="100" class="d-py-100 d-px-200 d-bar4">
-    <div class="d-p-100 d-px-150 d-bgc-transparent d-baw2 d-bas-dashed d-bc-subtle">
-      <dt-text as="p" align="center" tone="critical">critical tone on default surface</dt-text>
-    </div>
-    <div class="d-p-100 d-px-150 d-bgc-contrast">
-      <dt-text as="p" align="center" v-dt-mode:invert tone="critical">critical tone on contrasting surface</dt-text>
-    </div>
-  </dt-stack>
-</code-example>
+```
 
 ## Render as
 
 Use `as` to declare the underlying HTML tag that the component should render, independent of the visual styling. Defaults to `span`.
 
-<code-example>
-  <dt-stack class="d-w100p" gap="200">
+```vue demo
+<dt-stack class="d-w100p" gap="200">
+  <dt-stack gap="100">
+    <dt-text kind="headline" as="h1" :size="600">The Complete Agentic AI Platform</dt-text>
+    <dt-text kind="body" as="p" :size="400">Our AI Agents come equipped with the core skills businesses need to deliver seamless customer experiences.</dt-text>
+  </dt-stack>
+  <dt-stack direction="row" gap="500" align="start">
     <dt-stack gap="100">
-      <dt-text kind="headline" as="h1" :size="600">The Complete Agentic AI Platform</dt-text>
-      <dt-text kind="body" as="p" :size="400">Our AI Agents come equipped with the core skills businesses need to deliver seamless customer experiences.</dt-text>
+      <dt-text kind="headline" as="h2" :size="500" density="200">Try before you AI</dt-text>
+      <dt-text kind="body" as="p">Build, run and optimize your agents - no code, just your expertise and our built-in intelligence.</dt-text>
     </dt-stack>
-    <dt-stack direction="row" gap="500" align="start">
-      <dt-stack gap="100">
-        <dt-text kind="headline" as="h2" :size="500" density="200">Try before you AI</dt-text>
-        <dt-text kind="body" as="p">Build, run and optimize your agents - no code, just your expertise and our built-in intelligence.</dt-text>
-      </dt-stack>
-      <dt-stack gap="100">
-        <dt-text kind="headline" as="h2" :size="500" density="200">Great minds sync alike</dt-text>
-        <dt-text kind="body" as="p">Our AI learns and balances speed with quality using one data plane that keeps customers coming back.</dt-text>
-      </dt-stack>
-      <dt-stack gap="100">
-        <dt-text kind="headline" as="h2" :size="500" density="200">History repeats itself. Customers shouldn't.</dt-text>
-        <dt-text kind="body" as="p">Whatever your customer types or says, our AI and your human agents stay in sync.</dt-text>
-      </dt-stack>
+    <dt-stack gap="100">
+      <dt-text kind="headline" as="h2" :size="500" density="200">Great minds sync alike</dt-text>
+      <dt-text kind="body" as="p">Our AI learns and balances speed with quality using one data plane that keeps customers coming back.</dt-text>
+    </dt-stack>
+    <dt-stack gap="100">
+      <dt-text kind="headline" as="h2" :size="500" density="200">History repeats itself. Customers shouldn't.</dt-text>
+      <dt-text kind="body" as="p">Whatever your customer types or says, our AI and your human agents stay in sync.</dt-text>
     </dt-stack>
   </dt-stack>
-</code-example>
+</dt-stack>
+```
 
 ## Align
 
 Since `DtText`'s default element is a `<span>`, which is inline by default, the `align` prop will only work if its element is styled in a block context.
 
-<code-example vueCode='
+```vue demo
+<dt-stack class="d-w100p" gap="300">
+  <div class="d-bgc-moderate-opaque">
+    <dt-text as="p" align="start">Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. </dt-text>
+  </div>
+  <div class="d-bgc-moderate-opaque">
+    <dt-text as="p" align="center">Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. </dt-text>
+  </div>
+  <div class="d-bgc-moderate-opaque">
+    <dt-text as="p" align="end">Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. </dt-text>
+  </div>
+  <div class="d-bgc-moderate-opaque">
+    <dt-text as="p" align="justify">Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. </dt-text>
+  </div>
+</dt-stack>
+<!-- @code -->
 <dt-text align="start">....</dt-text>
 <dt-text align="center">....</dt-text>
 <dt-text align="end">....</dt-text>
 <dt-text align="justify">....</dt-text>
-'>
-  <dt-stack class="d-w100p" gap="300">
-    <div class="d-bgc-moderate-opaque">
-      <dt-text as="p" align="start">Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. </dt-text>
-    </div>
-    <div class="d-bgc-moderate-opaque">
-      <dt-text as="p" align="center">Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. </dt-text>
-    </div>
-    <div class="d-bgc-moderate-opaque">
-      <dt-text as="p" align="end">Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. </dt-text>
-    </div>
-    <div class="d-bgc-moderate-opaque">
-      <dt-text as="p" align="justify">Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. </dt-text>
-    </div>
-  </dt-stack>
-</code-example>
+```
 
 ## Truncate
 
 Since `DtText`'s default element is a `<span>`, the `truncate` will only work if its element is in block or inline-block context, e.g. `<div>...</div>`.
 
-<code-example>
-  <div class="d-w-700">
-    <dt-text as="p" truncate>Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app.</dt-text>
-  </div>
-</code-example>
+```vue demo
+<div class="d-w-700">
+  <dt-text as="p" truncate>Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app.</dt-text>
+</div>
+```
 
 ## Max Lines
 
-<code-example only-show="demo">
-  <dt-stack gap="100">
-    <dt-stack direction="row" gap="200" justify="space-between" align="center">
-      <dt-text kind="headline" :size="400" as="h3" tone="secondary">Demo</dt-text>
-      <dt-stack direction="row" gap="200" align="center">
-        <dt-text v-if="state.isApplied" as="code" kind="code" :size="100" tone="tertiary">
-          max-lines="<strong>{{ state.value }}</strong>"
-        </dt-text>
-        <dt-stack direction="row" gap="25" align="center">
-          <dt-stack direction="row">
-            <dt-button
-              class="d-as-stretch d-brr0 d-brw0"
-              :size="200"
-              importance="outlined"
-              kind="muted"
-              @click="toggleMaxLines"
-            >
-              Toggle
-            </dt-button>
-            <dt-button
-              v-dt-tooltip="`Decrement`"
-              class="d-as-stretch d-g-0 d-blr0 d-brr0 d-brw0"
-              :size="200"
-              importance="outlined"
-              kind="muted"
-              :disabled="!canDecreaseMaxLines"
-              @click="decrementMaxLines"
-            >
-              <template #startIcon="{ iconSize }">
-                <dt-icon name="dash" :size="iconSize" />
-              </template>
-            </dt-button>
-            <dt-button
-              v-dt-tooltip="`Increment`"
-              class="d-as-stretch d-g-0 d-blr0"
-              :size="200"
-              importance="outlined"
-              kind="muted"
-              :disabled="!canIncreaseMaxLines"
-              @click="incrementMaxLines"
-            >
-              <template #startIcon="{ iconSize }">
-                <dt-icon name="plus" :size="iconSize" />
-              </template>
-            </dt-button>
-          </dt-stack>
+```vue demo-only
+<dt-stack gap="100">
+  <dt-stack direction="row" gap="200" justify="space-between" align="center">
+    <dt-text kind="headline" :size="400" as="h3" tone="secondary">Demo</dt-text>
+    <dt-stack direction="row" gap="200" align="center">
+      <dt-text v-if="state.isApplied" as="code" kind="code" :size="100" tone="tertiary">
+        max-lines="<strong>{{ state.value }}</strong>"
+      </dt-text>
+      <dt-stack direction="row" gap="25" align="center">
+        <dt-stack direction="row">
+          <dt-button
+            class="d-as-stretch d-brr0 d-brw0"
+            :size="200"
+            importance="outlined"
+            kind="muted"
+            @click="toggleMaxLines"
+          >
+            Toggle
+          </dt-button>
+          <dt-button
+            v-dt-tooltip="`Decrement`"
+            class="d-as-stretch d-g-0 d-blr0 d-brr0 d-brw0"
+            :size="200"
+            importance="outlined"
+            kind="muted"
+            :disabled="!canDecreaseMaxLines"
+            @click="decrementMaxLines"
+          >
+            <template #startIcon="{ iconSize }">
+              <dt-icon name="dash" :size="iconSize" />
+            </template>
+          </dt-button>
+          <dt-button
+            v-dt-tooltip="`Increment`"
+            class="d-as-stretch d-g-0 d-blr0"
+            :size="200"
+            importance="outlined"
+            kind="muted"
+            :disabled="!canIncreaseMaxLines"
+            @click="incrementMaxLines"
+          >
+            <template #startIcon="{ iconSize }">
+              <dt-icon name="plus" :size="iconSize" />
+            </template>
+          </dt-button>
         </dt-stack>
       </dt-stack>
     </dt-stack>
-    <dt-stack justify="start" gap="500">
-      <dt-text :max-lines="maxLinesBinding" as="p">Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. Calling a client? Meeting with your team? Texting a colleague? It's all here, on all your devices. AI is by your side to transform your conversations into something you can see and use, giving you and your team a deeper look into action items and insights. Dialpad AI does the legwork to capture the details that matter most while you make and receive calls, send messages, and join meetings in an instant. Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. Calling a client? Meeting with your team? Texting a colleague? It's all here, on all your devices. AI is by your side to transform your conversations into something you can see and use, giving you and your team a deeper look into action items and insights. Dialpad AI does the legwork to capture the details that matter most while you make and receive calls, send messages, and join meetings in an instant. Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. Calling a client? Meeting with your team? Texting a colleague? It's all here, on all your devices. AI is by your side to transform your conversations into something you can see and use, giving you and your team a deeper look into action items and insights. Dialpad AI does the legwork to capture the details that matter most while you make and receive calls, send messages, and join meetings in an instant.</dt-text>
-    </dt-stack>
   </dt-stack>
-</code-example>
+  <dt-stack justify="start" gap="500">
+    <dt-text :max-lines="maxLinesBinding" as="p">Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. Calling a client? Meeting with your team? Texting a colleague? It's all here, on all your devices. AI is by your side to transform your conversations into something you can see and use, giving you and your team a deeper look into action items and insights. Dialpad AI does the legwork to capture the details that matter most while you make and receive calls, send messages, and join meetings in an instant. Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. Calling a client? Meeting with your team? Texting a colleague? It's all here, on all your devices. AI is by your side to transform your conversations into something you can see and use, giving you and your team a deeper look into action items and insights. Dialpad AI does the legwork to capture the details that matter most while you make and receive calls, send messages, and join meetings in an instant. Welcome to Dialpad, the most modern, AI-powered business communications platform. We've taken every form of communication that you rely on and unified it into one app. Calling a client? Meeting with your team? Texting a colleague? It's all here, on all your devices. AI is by your side to transform your conversations into something you can see and use, giving you and your team a deeper look into action items and insights. Dialpad AI does the legwork to capture the details that matter most while you make and receive calls, send messages, and join meetings in an instant.</dt-text>
+  </dt-stack>
+</dt-stack>
+```
 
-<code-example only-show="code">
-  <dt-text as="p" :max-lines="4">....</dt-text>
-</code-example>
+```vue code-only
+<dt-text as="p" :max-lines="4">....</dt-text>
+```
 
 ## Wrap
 
@@ -314,19 +316,19 @@ Control text wrapping behavior. Particularly useful for headlines where balanced
 
 Since `DtText`'s default element is a `<span>`, which is inline by default, the `wrap` prop will only work if its element is styled in a block context.
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="400" align="start" class="d-w-700">
+  <dt-text as="p"><strong>Default</strong>. Lorem ipsum dolor sit amet consectetur adipisicing consequatur deleniti non doloremque autem adipisci in omnis voluptatibus </dt-text>
+  <dt-text as="p" wrap="balance"><strong>Balance</strong>. Lorem ipsum dolor sit amet consectetur adipisicing consequatur deleniti non doloremque autem adipisci in omnis voluptatibus </dt-text>
+  <dt-text as="p" wrap="pretty"><strong>Pretty</strong>. Lorem ipsum dolor sit amet consectetur adipisicing consequatur deleniti non doloremque autem adipisci in omnis voluptatibus </dt-text>
+  <dt-text as="p" wrap="nowrap"><strong>No Wrap</strong>. Lorem ipsum dolor sit amet consectetur adipisicing consequatur deleniti non doloremque autem adipisci in omnis voluptatibus </dt-text>
+</dt-stack>
+<!-- @code -->
 <dt-text>....</dt-text>
 <dt-text wrap="balance">....</dt-text>
 <dt-text wrap="pretty">....</dt-text>
 <dt-text wrap="nowrap">....</dt-text>
-'>
-  <dt-stack gap="400" align="start" class="d-w-700">
-    <dt-text as="p"><strong>Default</strong>. Lorem ipsum dolor sit amet consectetur adipisicing consequatur deleniti non doloremque autem adipisci in omnis voluptatibus </dt-text>
-    <dt-text as="p" wrap="balance"><strong>Balance</strong>. Lorem ipsum dolor sit amet consectetur adipisicing consequatur deleniti non doloremque autem adipisci in omnis voluptatibus </dt-text>
-    <dt-text as="p" wrap="pretty"><strong>Pretty</strong>. Lorem ipsum dolor sit amet consectetur adipisicing consequatur deleniti non doloremque autem adipisci in omnis voluptatibus </dt-text>
-    <dt-text as="p" wrap="nowrap"><strong>No Wrap</strong>. Lorem ipsum dolor sit amet consectetur adipisicing consequatur deleniti non doloremque autem adipisci in omnis voluptatibus </dt-text>
-  </dt-stack>
-</code-example>
+```
 
 ## Text Box Trim
 
@@ -334,18 +336,18 @@ Remove extra leading space above and/or below text. Useful for tight component l
 
 Text box trim will only affect elements with block or inline-block styled context. It may have no effect on elements with inline or flex context.
 
-<code-example vueCode='
+```vue demo
+<dt-stack gap="200" :direction="{ 'default': 'column', 'md': 'row' }">
+  <dt-text as="p" class="d-bgc-moderate-opaque"><strong>No trim:</strong> lorem ipsum dolor sit amet</dt-text>
+  <dt-text as="p" text-box-trim="start" class="d-bgc-moderate-opaque"><strong>Trim start:</strong> lorem ipsum dolor sit amet</dt-text>
+  <dt-text as="p" text-box-trim="end" class="d-bgc-moderate-opaque"><strong>Trim end:</strong> lorem ipsum dolor sit amet</dt-text>
+  <dt-text as="p" text-box-trim="both" class="d-bgc-moderate-opaque"><strong>Trim both:</strong> lorem ipsum dolor sit amet</dt-text>
+</dt-stack>
+<!-- @code -->
 <dt-text as="p" text-box-trim="start">....</dt-text>
 <dt-text as="p" text-box-trim="end">....</dt-text>
 <dt-text as="p" text-box-trim="both">....</dt-text>
-'>
-  <dt-stack gap="200" :direction="{ 'default': 'column', 'md': 'row' }">
-    <dt-text as="p" class="d-bgc-moderate-opaque"><strong>No trim:</strong> lorem ipsum dolor sit amet</dt-text>
-    <dt-text as="p" text-box-trim="start" class="d-bgc-moderate-opaque"><strong>Trim start:</strong> lorem ipsum dolor sit amet</dt-text>
-    <dt-text as="p" text-box-trim="end" class="d-bgc-moderate-opaque"><strong>Trim end:</strong> lorem ipsum dolor sit amet</dt-text>
-    <dt-text as="p" text-box-trim="both" class="d-bgc-moderate-opaque"><strong>Trim both:</strong> lorem ipsum dolor sit amet</dt-text>
-  </dt-stack>
-</code-example>
+```
 
 <dialtone-usage>
 <template #do>
@@ -374,7 +376,9 @@ Text box trim will only affect elements with block or inline-block styled contex
 
 ### Profile Card
 
-<code-example vueCode='
+```vue demo
+<ExampleProfileCard />
+<!-- @code -->
 <dt-stack gap="500">
   <dt-stack gap="400" justify="space-between">
     <dt-stack>
@@ -423,33 +427,31 @@ Text box trim will only affect elements with block or inline-block styled contex
     </dt-button>
   </dt-stack>
 </dt-stack>
-'>
-  <ExampleProfileCard />
-</code-example>
+```
 
 ### Call Log
 
-<code-example>
-  <dt-stack gap="100" class="d-w-700">
-    <dt-text as="h2" kind="headline" :size="400">Saturday, May 24, 2025</dt-text>
-    <dt-stack direction="row" gap="150">
-      <dt-avatar full-name="Ashanti Trevor" />
-      <dt-stack class="d-fl1">
-        <dt-text kind="body" :size="200" strength="bold">Ashanti Trevor</dt-text>
-        <dt-stack direction="row" gap="50">
-          <dt-stack direction="row" gap="100">
-            <dt-icon name="phone-outgoing" size="200" class="d-fc-tertiary" />
-            <dt-text kind="body" :size="100" tone="tertiary">Outgoing call</dt-text>
-          </dt-stack>
-          <dt-text kind="body" :size="100" tone="tertiary">&bull;</dt-text>
-          <dt-text kind="body" :size="100" tone="tertiary">2 minutes 10 seconds</dt-text>
+```vue demo
+<dt-stack gap="100" class="d-w-700">
+  <dt-text as="h2" kind="headline" :size="400">Saturday, May 24, 2025</dt-text>
+  <dt-stack direction="row" gap="150">
+    <dt-avatar full-name="Ashanti Trevor" />
+    <dt-stack class="d-fl1">
+      <dt-text kind="body" :size="200" strength="bold">Ashanti Trevor</dt-text>
+      <dt-stack direction="row" gap="50">
+        <dt-stack direction="row" gap="100">
+          <dt-icon name="phone-outgoing" size="200" class="d-fc-tertiary" />
+          <dt-text kind="body" :size="100" tone="tertiary">Outgoing call</dt-text>
         </dt-stack>
+        <dt-text kind="body" :size="100" tone="tertiary">&bull;</dt-text>
+        <dt-text kind="body" :size="100" tone="tertiary">2 minutes 10 seconds</dt-text>
       </dt-stack>
-      <dt-text kind="body" :size="200" tone="tertiary">3:23 pm</dt-text>
-      <dt-badge kind="count" type="bulletin" text="6" />
     </dt-stack>
+    <dt-text kind="body" :size="200" tone="tertiary">3:23 pm</dt-text>
+    <dt-badge kind="count" type="bulletin" text="6" />
   </dt-stack>
-</code-example>
+</dt-stack>
+```
 
 ## Accessibility
 

--- a/apps/dialtone-documentation/docs/components/toast.md
+++ b/apps/dialtone-documentation/docs/components/toast.md
@@ -13,7 +13,15 @@ keywords: ["notification", "snackbar", "alert", "message", "d-toast", "DtToast",
 
 ## Variants and Examples
 
-<code-example vueCode='
+```vue demo
+<dt-stack direction="row" gap="200" class="d-w100p">
+  <div class="d-fl-grow1">
+    <dt-select-menu :label-visible="false" label="Style" :options="toastOptions" v-model="selectedKind" />
+  </div>
+  <dt-checkbox value="important" @input="toggleImportant">Important</dt-checkbox>
+  <dt-button @click="toggleToast">Toggle Example</dt-button>
+</dt-stack>
+<!-- @code -->
 <dt-toast
   title="Title"
   :show="showToast"
@@ -35,15 +43,7 @@ keywords: ["notification", "snackbar", "alert", "message", "d-toast", "DtToast",
     </dt-button>
   </template>
 </dt-toast>
-'>
-  <dt-stack direction="row" gap="200" class="d-w100p">
-    <div class="d-fl-grow1">
-      <dt-select-menu :label-visible="false" label="Style" :options="toastOptions" v-model="selectedKind" />
-    </div>
-    <dt-checkbox value="important" @input="toggleImportant">Important</dt-checkbox>
-    <dt-button @click="toggleToast">Toggle Example</dt-button>
-  </dt-stack>
-</code-example>
+```
 
 <example-toast
   class="d-zi-notification"
@@ -59,7 +59,17 @@ keywords: ["notification", "snackbar", "alert", "message", "d-toast", "DtToast",
 It's recommended to use a time of at least 6000 ms (minimum duration validated in the component) to give users enough time to read the toast. Take into account that the time necessary to read and comprehend the message could vary in users. For instance, users using assistive technology, or users with language barriers could potentially need more time to read and understand the message.
 If the duration is not provided the toast won't disappear automatically.
 
-<code-example vueCode='
+```vue demo
+<dt-button @click="toggleDurationToast(true)">Show Example</dt-button>
+<example-toast
+  class="d-zi-notification"
+  :show="showDurationToast"
+  title="Title"
+  @close="toggleDurationToast(false)"
+  @update:show="updateShow"
+  :duration="6000"
+/>
+<!-- @code -->
 <dt-toast
   title="Title"
   :show="showDurationToast"
@@ -80,31 +90,21 @@ If the duration is not provided the toast won't disappear automatically.
     </dt-button>
   </template>
 </dt-toast>
-'>
-  <dt-button @click="toggleDurationToast(true)">Show Example</dt-button>
-  <example-toast
-    class="d-zi-notification"
-    :show="showDurationToast"
-    title="Title"
-    @close="toggleDurationToast(false)"
-    @update:show="updateShow"
-    :duration="6000"
-  />
-</code-example>
+```
 
 ### With Self-Positioning
 
 If you need to self-position the toast at the top center, use the `d-toast-wrapper` Dialtone class:
 
-<code-example only-show="code">
-  <aside class="d-toast-wrapper">
-    <dt-toast
-      :title="title"
-      :message="message"
-      :show="isShown"
-    ></dt-toast>
-  </aside>
-</code-example>
+```vue code-only
+<aside class="d-toast-wrapper">
+  <dt-toast
+    :title="title"
+    :message="message"
+    :show="isShown"
+  ></dt-toast>
+</aside>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/toggle.md
+++ b/apps/dialtone-documentation/docs/components/toggle.md
@@ -41,32 +41,32 @@ The Toggle component acts as a way to allow the User to switch between two mutua
 
 ### Base Styles
 
-<code-example>
-  <dt-stack as="fieldset" gap="100">
-    <dt-toggle wrapper-class="d-g-200">Unchecked Toggle</dt-toggle>
-    <dt-toggle :model-value="true" wrapper-class="d-g-200">Checked Toggle</dt-toggle>
-    <dt-toggle disabled wrapper-class="d-g-200">Unchecked Disabled</dt-toggle>
-    <dt-toggle :model-value="true" disabled wrapper-class="d-g-200">Checked Disabled</dt-toggle>
-    <dt-toggle :model-value="mixed" wrapper-class="d-g-200">Indeterminate Toggle</dt-toggle>
-    <dt-toggle :model-value="mixed" wrapper-class="d-g-200" disabled>Indeterminate Disabled</dt-toggle>
-    <dt-toggle wrapper-class="d-g-200" :show-icon="false">Without icon</dt-toggle>
-  </dt-stack>
-</code-example>
+```vue demo
+<dt-stack as="fieldset" gap="100">
+  <dt-toggle wrapper-class="d-g-200">Unchecked Toggle</dt-toggle>
+  <dt-toggle :model-value="true" wrapper-class="d-g-200">Checked Toggle</dt-toggle>
+  <dt-toggle disabled wrapper-class="d-g-200">Unchecked Disabled</dt-toggle>
+  <dt-toggle :model-value="true" disabled wrapper-class="d-g-200">Checked Disabled</dt-toggle>
+  <dt-toggle :model-value="mixed" wrapper-class="d-g-200">Indeterminate Toggle</dt-toggle>
+  <dt-toggle :model-value="mixed" wrapper-class="d-g-200" disabled>Indeterminate Disabled</dt-toggle>
+  <dt-toggle wrapper-class="d-g-200" :show-icon="false">Without icon</dt-toggle>
+</dt-stack>
+```
 
 ### Sizes
 
-<code-example>
-  <dt-stack as="fieldset" gap="100">
-    <dt-toggle :size="200" wrapper-class="d-g-200">Small size</dt-toggle>
-    <dt-toggle wrapper-class="d-g-200">Default size</dt-toggle>
-  </dt-stack>
-</code-example>
+```vue demo
+<dt-stack as="fieldset" gap="100">
+  <dt-toggle :size="200" wrapper-class="d-g-200">Small size</dt-toggle>
+  <dt-toggle wrapper-class="d-g-200">Default size</dt-toggle>
+</dt-stack>
+```
 
 ### With v-model
 
-<code-example>
-  <dt-toggle v-model="checked" wrapper-class="d-g-200">Toggle</dt-toggle>
-</code-example>
+```vue demo
+<dt-toggle v-model="checked" wrapper-class="d-g-200">Toggle</dt-toggle>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/tooltip.md
+++ b/apps/dialtone-documentation/docs/components/tooltip.md
@@ -9,9 +9,9 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
 keywords: ["hint", "help text", "d-tooltip", "DtTooltip", "dt-tooltip"]
 ---
 
-<code-example only-show="demo">
-  <dt-button v-dt-tooltip="`Simple tooltip`">Hover me</dt-button>
-</code-example>
+```vue demo-only
+<dt-button v-dt-tooltip="`Simple tooltip`">Hover me</dt-button>
+```
 
 <!-- <component-combinator component-name="DtTooltip" /> -->
 
@@ -23,36 +23,38 @@ keywords: ["hint", "help text", "d-tooltip", "DtTooltip", "dt-tooltip"]
 
 Default tooltip directive uses top as default placement
 
-<code-example>
-  <dt-button v-dt-tooltip="`Tooltip text`">Hover me</dt-button>
-</code-example>
+```vue demo
+<dt-button v-dt-tooltip="`Tooltip text`">Hover me</dt-button>
+```
 
 #### With Placement
 
 It's possible to change the tooltip default placement with directive arguments, possible values: bottom, bottom-start, bottom-end, right, right-start, right-end, left, left-start, left-end, top, top-start, top-end.
 
-<code-example>
-  <dt-button v-dt-tooltip:bottom-start="`Tooltip text`">Placeholder Button</dt-button>
-</code-example>
+```vue demo
+<dt-button v-dt-tooltip:bottom-start="`Tooltip text`">Placeholder Button</dt-button>
+```
 
 #### With Object Syntax
 
 It's possible to change any property of the tooltip with object syntax.
 
-<code-example>
-  <dt-button v-dt-tooltip="{ message: 'Tooltip text', placement: 'bottom-start', delay: false }">Placeholder Button</dt-button>
-</code-example>
+```vue demo
+<dt-button v-dt-tooltip="{ message: 'Tooltip text', placement: 'bottom-start', delay: false }">Placeholder Button</dt-button>
+```
 
 #### Content Mode
 
 Tooltip content renders outside the DOM tree via Tippy.js. Use the `contentMode` modifier or object property to apply a color mode to the tooltip content. See [Positioned Components](/components/mode-island.html#positioned-components) for details.
 
-<code-example bgclass="d-bgc-contrast d-py-800">
-  <dt-stack direction="row" gap="100" data-demo-wrapper>
-    <dt-button v-dt-tooltip.invert="`Tooltip`">Invert via Modifier</dt-button>
-    <dt-button v-dt-tooltip="{ message: 'Tooltip', contentMode: 'invert' }">Invert via Object</dt-button>
-  </dt-stack>
-</code-example>
+```vue demo
+<!-- @wrapper -->
+<!-- @bg d-bgc-contrast d-py-800 -->
+<dt-stack direction="row" gap="100">
+  <dt-button v-dt-tooltip.invert="`Tooltip`">Invert via Modifier</dt-button>
+  <dt-button v-dt-tooltip="{ message: 'Tooltip', contentMode: 'invert' }">Invert via Object</dt-button>
+</dt-stack>
+```
 
 ### Import
 
@@ -82,19 +84,21 @@ A tooltip has two slots:
 
 ### Base Styles
 
-<code-example>
-  <dt-tooltip message="tooltip">
-    <template #anchor>
-      <dt-button>
-        Hover me
-      </dt-button>
-    </template>
-  </dt-tooltip>
-</code-example>
+```vue demo
+<dt-tooltip message="tooltip">
+  <template #anchor>
+    <dt-button>
+      Hover me
+    </dt-button>
+  </template>
+</dt-tooltip>
+```
 
 ### Placement
 
-<code-example vueCode='
+```vue demo
+<example-tooltip-directions :directions="directions" />
+<!-- @code -->
 <dt-tooltip
   message="This is a simple tooltip. The tooltip can be positioned in different directions."
   :placement="placement"
@@ -105,25 +109,23 @@ A tooltip has two slots:
     </dt-button>
   </template>
 </dt-tooltip>
-'>
-  <example-tooltip-directions :directions="directions" />
-</code-example>
+```
 
 ### External anchor
 
-<code-example>
-  <dt-button
-    id="external-tooltip-anchor"
-    importance="outlined"
-  >
-    External anchor
-  </dt-button>
-  <dt-tooltip
-    external-anchor="#external-tooltip-anchor"
-  >
-    This is a tooltip with external anchor
-  </dt-tooltip>
-</code-example>
+```vue demo
+<dt-button
+  id="external-tooltip-anchor"
+  importance="outlined"
+>
+  External anchor
+</dt-button>
+<dt-tooltip
+  external-anchor="#external-tooltip-anchor"
+>
+  This is a tooltip with external anchor
+</dt-tooltip>
+```
 
 ### Fallback Placements
 
@@ -136,7 +138,16 @@ manually specify which position it will move to in what order you can do so via 
 
 Tooltip content renders outside the DOM tree via Tippy.js. Use the `contentMode` prop to apply a color mode to the tooltip content. See [Positioned Components](/components/mode-island.html#positioned-components) for details.
 
-<code-example bgclass="d-bgc-contrast" vueCode='
+```vue demo
+<!-- @bg d-bgc-contrast -->
+<dt-tooltip content-mode="invert" message="Inverted tooltip">
+  <template #anchor>
+    <dt-button>
+      Inverted
+    </dt-button>
+  </template>
+</dt-tooltip>
+<!-- @code -->
 <dt-tooltip content-mode="invert|dark|light" message="Tooltip">
   <template #anchor>
     <dt-button>
@@ -144,15 +155,7 @@ Tooltip content renders outside the DOM tree via Tippy.js. Use the `contentMode`
     </dt-button>
   </template>
 </dt-tooltip>
-'>
-  <dt-tooltip content-mode="invert" message="Inverted tooltip">
-    <template #anchor>
-      <dt-button>
-        Inverted
-      </dt-button>
-    </template>
-  </dt-tooltip>
-</code-example>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/validation-messages.md
+++ b/apps/dialtone-documentation/docs/components/validation-messages.md
@@ -19,30 +19,30 @@ Validation messages are typically paired with an input element. They are current
 
 ### Success / Positive
 
-<code-example>
-  <dt-validation-messages
-    id="sample--02"
-    :validationMessages='[{"message":"Positive validation message","type":"success"}]'
-  />
-</code-example>
+```vue demo
+<dt-validation-messages
+  id="sample--02"
+  :validationMessages='[{"message":"Positive validation message","type":"success"}]'
+/>
+```
 
 ### Critical / Error
 
-<code-example>
-  <dt-validation-messages
-    id="sample--03"
-    :validationMessages='[{"message":"Critical validation message","type":"error"}]'
-  />
-</code-example>
+```vue demo
+<dt-validation-messages
+  id="sample--03"
+  :validationMessages='[{"message":"Critical validation message","type":"error"}]'
+/>
+```
 
 ### Warning
 
-<code-example>
-  <dt-validation-messages
-    id="sample--04"
-    :validationMessages='[{"message":"Warning validation message","type":"warning"}]'
-  />
-</code-example>
+```vue demo
+<dt-validation-messages
+  id="sample--04"
+  :validationMessages='[{"message":"Warning validation message","type":"warning"}]'
+/>
+```
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/utilities/borders/direction.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/direction.md
@@ -83,7 +83,7 @@ Use `d-b{t|r|b|l|x|y}` to add a border to only specific sides of your element.
             border: var(--dt-size-border-100) solid !important;
           </span>
           <span v-else>
-            border-{{ i === 'top' ? 'block-start' : i === 'bottom' ? 'block-end' : i === 'left' ? 'inline-start' : i === 'right' ? 'inline-end' : i }}: var(--dt-size-100) solid !important;
+            border-{{ i === 'top' ? 'block-start' : i === 'bottom' ? 'block-end' : i === 'left' ? 'inline-start' : i === 'right' ? 'inline-end' : i }}: var(--dt-size-border-100) solid !important;
           </span>
         </td>
       </tr>

--- a/apps/dialtone-documentation/scripts/lib/parse-source-markdown.mjs
+++ b/apps/dialtone-documentation/scripts/lib/parse-source-markdown.mjs
@@ -6,6 +6,7 @@
  *   NORMAL          — default, pass-through for standard markdown
  *   FRONTMATTER     — inside YAML --- block
  *   FENCED_CODE     — inside ``` fenced code block (highest priority)
+ *   FENCED_DEMO     — inside ```vue demo block (transforms directives to clean code)
  *   CODE_WELL_HEADER — inside <code-well-header>...</code-well-header> (remove)
  *   CODE_EXAMPLE    — inside <code-example>...</code-example> (extract slot as code)
  *   CODE_EXAMPLE_TABS — accumulating <code-example-tabs ... /> lines
@@ -29,6 +30,7 @@ const S = {
   NORMAL: 'NORMAL',
   FRONTMATTER: 'FRONTMATTER',
   FENCED_CODE: 'FENCED_CODE',
+  FENCED_DEMO: 'FENCED_DEMO',
   CODE_WELL_HEADER: 'CODE_WELL_HEADER',
   CODE_EXAMPLE_TABS: 'CODE_EXAMPLE_TABS',
   DIALTONE_USAGE: 'DIALTONE_USAGE',
@@ -132,6 +134,146 @@ function handleFencedCode (ctx) {
     ctx.state = S.NORMAL;
     ctx.fencedCodeMarker = '';
   }
+}
+
+// ── State handler: FENCED_DEMO ──────────────────────────────────
+function handleFencedDemoState (ctx) {
+  // Detect the closing fence
+  if (ctx.trimmed.startsWith(ctx.fencedCodeMarker) && ctx.trimmed.slice(ctx.fencedCodeMarker.length).trim() === '') {
+    const result = transformFencedDemoBlock(ctx.accumulator, ctx.fencedDemoInfoMode);
+    if (result !== null) {
+      ctx.output.push('');
+      ctx.output.push('```vue');
+      ctx.output.push(...result);
+      ctx.output.push('```');
+      ctx.output.push('');
+    }
+    ctx.accumulator = [];
+    ctx.fencedCodeMarker = '';
+    ctx.state = S.NORMAL;
+    return;
+  }
+  ctx.accumulator.push(ctx.line);
+}
+
+/**
+ * Transform accumulated lines from a ```vue demo block into clean code lines.
+ *
+ * Handles directives:
+ *   <!-- @demo-only -->  → return null (skip entire block)
+ *   <!-- @code-only -->  → stripped (content emitted normally)
+ *   <!-- @code -->       → emit only content below the separator
+ *   <!-- @wrapper -->    → strip the wrapper element, keep children
+ *   <!-- @bg ... -->     → stripped
+ *   <!-- @class ... -->  → stripped
+ *
+ * @param {string[]} lines - Accumulated content lines (without fences)
+ * @param {string} [infoMode='demo'] - 'demo', 'demo-only', or 'code-only' from the info string
+ * @returns {string[]|null} - Cleaned lines, or null to skip the block
+ */
+export function transformFencedDemoBlock (lines, infoMode = 'demo') {
+  let hasDemoOnly = infoMode === 'demo-only';
+  let hasWrapper = false;
+  let codeSeparatorIndex = -1;
+  const directiveIndices = new Set();
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed === '<!-- @demo-only -->') {
+      hasDemoOnly = true;
+      directiveIndices.add(i);
+    } else if (trimmed === '<!-- @code-only -->') {
+      directiveIndices.add(i);
+    } else if (trimmed === '<!-- @code -->') {
+      codeSeparatorIndex = i;
+      directiveIndices.add(i);
+    } else if (trimmed === '<!-- @wrapper -->') {
+      hasWrapper = true;
+      directiveIndices.add(i);
+    } else if (/^<!-- @bg .+ -->$/.test(trimmed)) {
+      directiveIndices.add(i);
+    } else if (/^<!-- @class .+ -->$/.test(trimmed)) {
+      directiveIndices.add(i);
+    }
+  }
+
+  // @demo-only: skip the entire block
+  if (hasDemoOnly) return null;
+
+  let contentLines;
+
+  if (codeSeparatorIndex !== -1) {
+    // @code separator: emit only lines below the separator (excluding directives)
+    contentLines = [];
+    for (let i = codeSeparatorIndex + 1; i < lines.length; i++) {
+      if (!directiveIndices.has(i)) contentLines.push(lines[i]);
+    }
+  } else {
+    // No separator: emit all non-directive lines
+    contentLines = lines.filter((_, i) => !directiveIndices.has(i));
+  }
+
+  // Trim leading/trailing blank lines
+  while (contentLines.length > 0 && contentLines[0].trim() === '') contentLines.shift();
+  while (contentLines.length > 0 && contentLines[contentLines.length - 1].trim() === '') contentLines.pop();
+
+  if (contentLines.length === 0) return null;
+
+  // @wrapper: strip the wrapper element, keeping only its children.
+  // Only applies when there's no @code separator (with @code, the code content
+  // is already explicitly specified below the separator).
+  if (hasWrapper && codeSeparatorIndex === -1) {
+    contentLines = stripWrapperElement(contentLines);
+  }
+
+  // Dedent
+  const nonEmpty = contentLines.filter(l => l.trim().length > 0);
+  if (nonEmpty.length > 0) {
+    const minIndent = Math.min(...nonEmpty.map(l => l.match(/^(\s*)/)[1].length));
+    if (minIndent > 0) {
+      contentLines = contentLines.map(l => l.slice(minIndent));
+    }
+  }
+
+  return contentLines;
+}
+
+/**
+ * Strip the outermost wrapper element from content lines, keeping only
+ * its children. Used when @wrapper directive is present.
+ *
+ * @param {string[]} lines - Content lines (wrapper element is the outer element)
+ * @returns {string[]} - Children lines with wrapper removed
+ */
+function stripWrapperElement (lines) {
+  const joined = lines.join('\n');
+  const trimmed = joined.trim();
+
+  // Find the end of the opening tag (first > not inside quotes)
+  let inSQ = false;
+  let inDQ = false;
+  let openEnd = -1;
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (ch === '\'' && !inDQ) inSQ = !inSQ;
+    else if (ch === '"' && !inSQ) inDQ = !inDQ;
+    else if (ch === '>' && !inSQ && !inDQ) { openEnd = i; break; }
+  }
+  if (openEnd === -1) return lines;
+
+  // Find the last closing tag
+  const lastCloseStart = trimmed.lastIndexOf('</');
+  if (lastCloseStart === -1 || lastCloseStart <= openEnd) return lines;
+
+  // Extract children between the opening and closing tags
+  const children = trimmed.slice(openEnd + 1, lastCloseStart);
+  const childLines = children.replace(/^\n+|\n+$/g, '').split('\n');
+
+  // Trim leading/trailing blank lines
+  while (childLines.length > 0 && childLines[0].trim() === '') childLines.shift();
+  while (childLines.length > 0 && childLines[childLines.length - 1].trim() === '') childLines.pop();
+
+  return childLines;
 }
 
 // ── State handler: FRONTMATTER ───────────────────────────────────
@@ -254,6 +396,16 @@ function tryDetectFencedCode (ctx) {
   const fenceMatch = ctx.trimmed.match(/^(`{3,}|~{3,})/);
   if (!fenceMatch) return false;
   ctx.fencedCodeMarker = fenceMatch[1];
+
+  // Check if the info string is "vue demo", "vue demo-only", or "vue code-only"
+  const infoString = ctx.trimmed.slice(fenceMatch[1].length).trim();
+  if (/^vue\s+(demo-only|code-only|demo)$/.test(infoString)) {
+    ctx.state = S.FENCED_DEMO;
+    ctx.accumulator = [];
+    ctx.fencedDemoInfoMode = infoString.split(/\s+/)[1]; // 'demo', 'demo-only', or 'code-only'
+    return true;
+  }
+
   ctx.state = S.FENCED_CODE;
   ctx.output.push(ctx.line);
   return true;
@@ -570,6 +722,7 @@ function processNormalLine (ctx) {
  */
 const STATE_HANDLERS = {
   [S.FENCED_CODE]: handleFencedCode,
+  [S.FENCED_DEMO]: handleFencedDemoState,
   [S.FRONTMATTER]: handleFrontmatter,
   [S.HTML_COMMENT]: (ctx) => handleSkipUntilClose(ctx, '-->', S.NORMAL),
   [S.SCRIPT_SETUP]: (ctx) => handleSkipUntilClose(ctx, '</script>', S.NORMAL),

--- a/apps/dialtone-documentation/scripts/lib/parse-source-markdown.mjs
+++ b/apps/dialtone-documentation/scripts/lib/parse-source-markdown.mjs
@@ -25,6 +25,7 @@ import { transformHtmlTable } from './transform-html-table.mjs';
 import { transformNewUtilityClassTable, transformOldUtilityClassTable } from './transform-utility-class-table.mjs';
 import { isStandaloneVueComponentLine, cleanupOutput, PASSTHROUGH_COMPONENTS } from './utils.mjs';
 import { INLINE_HANDLERS, consumeUntilClose, parseFrontmatterField } from './component-handlers.mjs';
+import { parseDirectives, trimBlankLines } from '../../docs/.vuepress/plugins/fenced-demo-shared.js';
 
 const S = {
   NORMAL: 'NORMAL',
@@ -172,33 +173,11 @@ function handleFencedDemoState (ctx) {
  * @returns {string[]|null} - Cleaned lines, or null to skip the block
  */
 export function transformFencedDemoBlock (lines, infoMode = 'demo') {
-  let hasDemoOnly = infoMode === 'demo-only';
-  let hasWrapper = false;
-  let codeSeparatorIndex = -1;
-  const directiveIndices = new Set();
-
-  for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
-    if (trimmed === '<!-- @demo-only -->') {
-      hasDemoOnly = true;
-      directiveIndices.add(i);
-    } else if (trimmed === '<!-- @code-only -->') {
-      directiveIndices.add(i);
-    } else if (trimmed === '<!-- @code -->') {
-      codeSeparatorIndex = i;
-      directiveIndices.add(i);
-    } else if (trimmed === '<!-- @wrapper -->') {
-      hasWrapper = true;
-      directiveIndices.add(i);
-    } else if (/^<!-- @bg .+ -->$/.test(trimmed)) {
-      directiveIndices.add(i);
-    } else if (/^<!-- @class .+ -->$/.test(trimmed)) {
-      directiveIndices.add(i);
-    }
-  }
+  const { onlyShow, hasWrapper, codeSeparatorIndex, directiveLines: directiveIndices } =
+    parseDirectives(lines, infoMode);
 
   // @demo-only: skip the entire block
-  if (hasDemoOnly) return null;
+  if (onlyShow === 'demo') return null;
 
   let contentLines;
 
@@ -267,7 +246,7 @@ function stripWrapperElement (lines) {
 
   // Extract children between the opening and closing tags
   const children = trimmed.slice(openEnd + 1, lastCloseStart);
-  const childLines = children.replace(/^\n+|\n+$/g, '').split('\n');
+  const childLines = trimBlankLines(children).split('\n');
 
   // Trim leading/trailing blank lines
   while (childLines.length > 0 && childLines[0].trim() === '') childLines.shift();
@@ -340,7 +319,7 @@ function transformCodeExample (lines) {
   const closeTagStart = joined.lastIndexOf('</code-example>');
   if (closeTagStart === -1) return [];
 
-  const slotContent = joined.slice(openTagEnd, closeTagStart).replace(/^\n+|\n+$/g, '');
+  const slotContent = trimBlankLines(joined.slice(openTagEnd, closeTagStart));
   if (!slotContent.trim()) return [];
 
   // Dedent

--- a/scripts/migrate-code-examples.mjs
+++ b/scripts/migrate-code-examples.mjs
@@ -159,7 +159,7 @@ function handleDemoWrapper (slotContent) {
  * Component-level classes on slot content should NOT be converted.
  */
 function isUtilityClass (classValue) {
-  // Check if all classes start with d-
+  // Check if any class starts with d-
   const classes = classValue.trim().split(/\s+/);
   return classes.some(c => c.startsWith('d-'));
 }
@@ -186,11 +186,14 @@ function convertBlock (attrs, slotContent) {
   const wrapper = handleDemoWrapper(content);
   content = wrapper.content;
 
+  // Determine info string variant based on onlyShow
+  let infoString = '```vue demo';
+  if (attrs.onlyShow === 'demo') infoString = '```vue demo-only';
+  if (attrs.onlyShow === 'code') infoString = '```vue code-only';
+
   // Build directives
   const directives = [];
 
-  if (attrs.onlyShow === 'demo') directives.push('<!-- @demo-only -->');
-  if (attrs.onlyShow === 'code') directives.push('<!-- @code-only -->');
   if (wrapper.hasWrapper) directives.push('<!-- @wrapper -->');
   if (attrs.bgclass) directives.push(`<!-- @bg ${attrs.bgclass} -->`);
   if (attrs.class && isUtilityClass(attrs.class)) {
@@ -199,7 +202,7 @@ function convertBlock (attrs, slotContent) {
 
   // Build the fenced block
   const lines = [];
-  lines.push('```vue demo');
+  lines.push(infoString);
 
   for (const d of directives) {
     lines.push(d);

--- a/scripts/migrate-code-examples.mjs
+++ b/scripts/migrate-code-examples.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+
+/**
+ * Migration script: converts <code-example> blocks to fenced ```vue demo syntax.
+ *
+ * Usage:
+ *   node scripts/migrate-code-examples.mjs [--dry-run] [--verbose] [file ...]
+ *
+ * --dry-run   Show what would change without writing files
+ * --verbose   Show detailed conversion info
+ * No file args: process all .md files in apps/dialtone-documentation/docs/components/
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { resolve, basename, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const COMPONENTS_DIR = resolve(ROOT, 'apps/dialtone-documentation/docs/components');
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const verbose = args.includes('--verbose');
+const fileArgs = args.filter(a => !a.startsWith('--'));
+
+function getFilesToProcess () {
+  if (fileArgs.length > 0) {
+    return fileArgs.map(f => resolve(f));
+  }
+  return readdirSync(COMPONENTS_DIR)
+    .filter(f => f.endsWith('.md'))
+    .map(f => resolve(COMPONENTS_DIR, f));
+}
+
+// ---------------------------------------------------------------------------
+// Attribute parsing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the opening <code-example ...> tag, which may span multiple lines.
+ * Returns { endIndex, attrs } where endIndex is the position after the closing '>'.
+ *
+ * attrs is an object with keys: onlyShow, vueCode, bgclass, class
+ */
+function parseOpeningTag (content, startIndex) {
+  // Find the end of the opening tag — but we need stateful quote tracking
+  // because vueCode can contain '>' inside quoted strings.
+  let i = startIndex;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+
+  // Skip past '<code-example'
+  const tagStart = content.indexOf('<code-example', i);
+  i = tagStart + '<code-example'.length;
+
+  while (i < content.length) {
+    const ch = content[i];
+    if (inSingleQuote) {
+      if (ch === '\'') inSingleQuote = false;
+    } else if (inDoubleQuote) {
+      if (ch === '"') inDoubleQuote = false;
+    } else {
+      if (ch === '\'') inSingleQuote = true;
+      else if (ch === '"') inDoubleQuote = true;
+      else if (ch === '>') {
+        // Found the end of the opening tag
+        break;
+      }
+    }
+    i++;
+  }
+
+  const endIndex = i + 1; // past the '>'
+  const tagText = content.slice(tagStart, endIndex);
+
+  const attrs = {};
+
+  // Extract vueCode FIRST — single-quoted, may span multiple lines and contain
+  // double quotes and class= attributes. We need to strip it before parsing
+  // other attributes so inner content doesn't produce false matches.
+  let tagTextForAttrs = tagText;
+  const vueCodeStart = tagText.indexOf('vueCode=\'');
+  if (vueCodeStart !== -1) {
+    const valueStart = vueCodeStart + 'vueCode=\''.length;
+    // Find matching closing single quote
+    let j = valueStart;
+    while (j < tagText.length && tagText[j] !== '\'') {
+      j++;
+    }
+    attrs.vueCode = tagText.slice(valueStart, j);
+    // Remove vueCode='...' from the tag text used for other attribute parsing
+    tagTextForAttrs = tagText.slice(0, vueCodeStart) + tagText.slice(j + 1);
+  }
+
+  // Extract only-show attribute
+  const onlyShowMatch = tagTextForAttrs.match(/only-show=["']([^"']+)["']/);
+  if (onlyShowMatch) attrs.onlyShow = onlyShowMatch[1];
+
+  // Extract bgclass attribute
+  const bgclassMatch = tagTextForAttrs.match(/bgclass=["']([^"']+)["']/);
+  if (bgclassMatch) attrs.bgclass = bgclassMatch[1];
+
+  // Extract class attribute (on the code-example itself)
+  // Be careful: only match class= not bgclass=
+  const classMatch = tagTextForAttrs.match(/(?<![a-z])class=["']([^"']+)["']/);
+  if (classMatch) attrs.class = classMatch[1];
+
+  return { endIndex, attrs };
+}
+
+/**
+ * Find the closing </code-example> tag.
+ * Returns the index of the character after the closing tag.
+ */
+function findClosingTag (content, fromIndex) {
+  const tag = '</code-example>';
+  const idx = content.indexOf(tag, fromIndex);
+  if (idx === -1) return null;
+  return { start: idx, end: idx + tag.length };
+}
+
+// ---------------------------------------------------------------------------
+// Content transformation
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip leading 2-space indentation from every line of slot content.
+ */
+function stripIndent (text) {
+  const lines = text.split('\n');
+  const stripped = lines.map(line => {
+    if (line.startsWith('  ')) return line.slice(2);
+    return line;
+  });
+  return stripped.join('\n');
+}
+
+/**
+ * Check if the first element in slotContent has data-demo-wrapper,
+ * and if so remove the attribute and return { hasWrapper: true, content }.
+ */
+function handleDemoWrapper (slotContent) {
+  const wrapperPattern = /^(<[a-z][^\n>]*?) data-demo-wrapper([^\n>]*>)/i;
+  const match = slotContent.match(wrapperPattern);
+  if (match) {
+    const cleaned = slotContent.replace(wrapperPattern, '$1$2');
+    return { hasWrapper: true, content: cleaned };
+  }
+  return { hasWrapper: false, content: slotContent };
+}
+
+/**
+ * Determine if a class value is a utility class (starts with d-).
+ * Component-level classes on slot content should NOT be converted.
+ */
+function isUtilityClass (classValue) {
+  // Check if all classes start with d-
+  const classes = classValue.trim().split(/\s+/);
+  return classes.some(c => c.startsWith('d-'));
+}
+
+/**
+ * Clean up vueCode value: trim leading/trailing newlines.
+ */
+function cleanVueCode (vueCode) {
+  // Remove leading and trailing newlines, but preserve internal formatting
+  return vueCode.replace(/^\n+/, '').replace(/\n+$/, '');
+}
+
+/**
+ * Convert a single <code-example> block to fenced demo syntax.
+ */
+function convertBlock (attrs, slotContent) {
+  // Strip the 2-space indentation from slot content
+  let content = stripIndent(slotContent);
+
+  // Trim leading/trailing blank lines
+  content = content.replace(/^\n+/, '').replace(/\n+$/, '');
+
+  // Check for data-demo-wrapper
+  const wrapper = handleDemoWrapper(content);
+  content = wrapper.content;
+
+  // Build directives
+  const directives = [];
+
+  if (attrs.onlyShow === 'demo') directives.push('<!-- @demo-only -->');
+  if (attrs.onlyShow === 'code') directives.push('<!-- @code-only -->');
+  if (wrapper.hasWrapper) directives.push('<!-- @wrapper -->');
+  if (attrs.bgclass) directives.push(`<!-- @bg ${attrs.bgclass} -->`);
+  if (attrs.class && isUtilityClass(attrs.class)) {
+    directives.push(`<!-- @class ${attrs.class} -->`);
+  }
+
+  // Build the fenced block
+  const lines = [];
+  lines.push('```vue demo');
+
+  for (const d of directives) {
+    lines.push(d);
+  }
+
+  lines.push(content);
+
+  if (attrs.vueCode) {
+    lines.push('<!-- @code -->');
+    lines.push(cleanVueCode(attrs.vueCode));
+  }
+
+  lines.push('```');
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main processing
+// ---------------------------------------------------------------------------
+
+function processFile (filePath) {
+  let content = readFileSync(filePath, 'utf8');
+  const fileName = basename(filePath);
+  let convertedCount = 0;
+
+  // We process iteratively — find each <code-example> from the start,
+  // convert it, and replace in the string. We loop because indices shift
+  // after each replacement.
+  let searchFrom = 0;
+
+  while (true) {
+    // Find the next <code-example that is NOT <code-example-tabs
+    const idx = content.indexOf('<code-example', searchFrom);
+    if (idx === -1) break;
+
+    // Check it's not <code-example-tabs or <code-example-
+    const afterTag = content.slice(idx + '<code-example'.length);
+    if (afterTag.startsWith('-')) {
+      // It's <code-example-tabs or <code-example-something — skip
+      searchFrom = idx + '<code-example'.length;
+      continue;
+    }
+
+    // Parse the opening tag
+    const { endIndex, attrs } = parseOpeningTag(content, idx);
+
+    // Find the closing tag
+    const closing = findClosingTag(content, endIndex);
+    if (!closing) {
+      console.error(`[error] ${fileName}: unclosed <code-example> at offset ${idx}`);
+      searchFrom = endIndex;
+      continue;
+    }
+
+    // Extract slot content (between opening tag end and closing tag start)
+    const slotContent = content.slice(endIndex, closing.start);
+
+    // Convert
+    const fenced = convertBlock(attrs, slotContent);
+
+    if (verbose) {
+      const lineNum = content.slice(0, idx).split('\n').length;
+      const preview = attrs.vueCode ? ' (has vueCode)' : '';
+      const onlyShow = attrs.onlyShow ? ` only-show="${attrs.onlyShow}"` : '';
+      const bg = attrs.bgclass ? ` bgclass="${attrs.bgclass}"` : '';
+      console.log(`  line ${lineNum}:${onlyShow}${bg}${preview}`);
+    }
+
+    // Replace the entire block
+    content = content.slice(0, idx) + fenced + content.slice(closing.end);
+    convertedCount++;
+
+    // Move search past the replacement
+    searchFrom = idx + fenced.length;
+  }
+
+  return { content, convertedCount };
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+const files = getFilesToProcess();
+let totalConverted = 0;
+let totalFiles = 0;
+
+for (const filePath of files) {
+  const fileName = basename(filePath);
+  const { content, convertedCount } = processFile(filePath);
+
+  if (convertedCount === 0) continue;
+
+  totalFiles++;
+  totalConverted += convertedCount;
+
+  if (dryRun) {
+    console.log(`[dry-run] ${fileName}: would convert ${convertedCount} blocks`);
+  } else {
+    writeFileSync(filePath, content, 'utf8');
+    console.log(`[migrate] ${fileName}: ${convertedCount} blocks converted`);
+  }
+}
+
+if (totalConverted === 0) {
+  console.log('[migrate] No <code-example> blocks found to convert.');
+} else if (dryRun) {
+  console.log(`[dry-run] Done: ${totalConverted} blocks would be converted in ${totalFiles} files`);
+} else {
+  console.log(`[migrate] Done: ${totalConverted} blocks converted in ${totalFiles} files`);
+}

--- a/scripts/migrate-code-examples.mjs
+++ b/scripts/migrate-code-examples.mjs
@@ -87,9 +87,13 @@ function parseOpeningTag (content, startIndex) {
   const vueCodeStart = tagText.indexOf('vueCode=\'');
   if (vueCodeStart !== -1) {
     const valueStart = vueCodeStart + 'vueCode=\''.length;
-    // Find matching closing single quote
+    // Find matching closing single quote (track double-quote state because
+    // vueCode content can contain ' inside "..." Vue bindings)
     let j = valueStart;
-    while (j < tagText.length && tagText[j] !== '\'') {
+    let inDQ = false;
+    while (j < tagText.length) {
+      if (tagText[j] === '"') inDQ = !inDQ;
+      else if (tagText[j] === '\'' && !inDQ) break;
       j++;
     }
     attrs.vueCode = tagText.slice(valueStart, j);


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :book: Jira Ticket

[DLT-3243](https://dialpad.atlassian.net/browse/DLT-3243)

## :book: Description

Replaces `<code-example>` tag syntax with fenced ` ```vue demo ` blocks across all 59 component doc pages (~381 blocks). Follow-up to the `<code-example>` unification in #1147 — this layer eliminates the remaining authoring friction (entity-encoding, quote tracking, `vueCode` attribute juggling).

**New files:**
- `markdown-it-fenced-demo.js` — markdown-it core rule that transforms fence tokens → `<code-example>` html_block tokens
- `fenced-demo-shared.js` — shared directive parser, `encodeForAttr`, `trimBlankLines`
- `migrate-code-examples.mjs` — one-shot migration script (`--dry-run` supported)

### Syntax

**Default** — renders live demo + code tab:

> [!NOTE]
> `demo`, `demo-only`, or `code-only` are required, otherwise it reverts to regular fenced vue block.

````md
```vue demo
<dt-button kind="muted" :size="200">...</dt-button>
```
````

**Demo only** — live preview, no code tab:

````md
```vue demo-only
<dt-button kind="muted" :size="200">...</dt-button>
```
````

**Code only** — code snippet, no live preview:

````md
```vue code-only
<dt-button kind="muted" :size="200">...</dt-button>
```
````

**Wrapper** — strips the layout scaffolding from code tab:

In this example, it removes `<dt-stack ...>` and renders _just_ the two buttons.

````md
```vue demo
<!-- @wrapper -->
<dt-stack direction="row" gap="100">
  <dt-button kind="muted" :size="200">Cancel</dt-button>
  <dt-button :size="200">Save</dt-button>
</dt-stack>
```
````

**Code separator** — show different code than rendered demo:

````md
```vue demo
<example-tabs />
<!-- @code -->
<dt-tab-group>
  <template #tabs>
    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
    <dt-tab id="3" panel-id="4">Second</dt-tab>
  </template>
</dt-tab-group>
```
````

## :bulb: Context

PR #1147 unified `<code-well-header>` + `<code-example-tabs>` into a single `<code-example>` component. This PR takes the next step: the tag syntax itself becomes fenced markdown. Benefits:

- **DX** — no more single-quote attribute values with entity-encoded HTML. Content sits naturally in the fenced block.
- **Drift prevention** — `<!-- @code -->` separator is a visible marker, harder to accidentally break than a `vueCode='...'` attribute spanning 30 lines.
- **Raw markdown pipeline** — fenced blocks are easier to parse into clean GFM for the llms.txt / AI-consumable output (`parse-source-markdown.mjs` updated with `FENCED_DEMO` state).
- **Both syntaxes coexist** — existing `<code-example>` tags still work. Fenced blocks are the preferred authoring format going forward.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

- Run migration on non-component doc pages (utilities, foundations, guides) if desired
- Remove `<code-example>` tag support once all pages are migrated (not urgent — both syntaxes coexist)

[DLT-3243]: https://dialpad.atlassian.net/browse/DLT-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ