### PR TITLE
docs: DLT-3250 display component status badges in sidebar and page headers

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/PageHeader.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/PageHeader.vue
@@ -14,9 +14,9 @@
             v-text="$frontmatter.title"
           />
           <dt-badge
-            v-if="$frontmatter.new"
-            type="bulletin"
-            text="New"
+            v-if="$frontmatter.status === 'beta'"
+            type="info"
+            text="Beta"
           />
         </dt-stack>
         <dt-stack direction="row" gap="25">

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/SidebarItem.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/SidebarItem.vue
@@ -129,7 +129,24 @@
                 },
               ]"
             >
-              {{ subItem.text }}
+              <dt-stack
+                v-if="subItem.status === 'beta'"
+                as="span"
+                direction="row"
+                justify="space-between"
+                class="d-w100p"
+              >
+                {{ subItem.text }}
+                <dt-badge
+                  class="d-fw-normal d-mis-50"
+                  type="info"
+                >
+                  Beta
+                </dt-badge>
+              </dt-stack>
+              <template v-else>
+                {{ subItem.text }}
+              </template>
             </dt-button>
           </li>
         </dt-stack>

--- a/apps/dialtone-documentation/docs/.vuepress/theme/index.js
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/index.js
@@ -145,37 +145,49 @@ function _extractComponentStatus (app) {
     .sort((a, b) => _sortAlphabetically(a.name, b.name));
 }
 
-function _injectKeywordsFromFrontmatter (app, options) {
-  // Create a map of page paths to keywords for faster lookup
+function _injectFrontmatterIntoSidebar (app, options) {
+  // Create maps of page paths to frontmatter data for faster lookup
   const pageKeywords = new Map();
+  const pageStatus = new Map();
   app.pages.forEach(page => {
+    const normalizedPath = page.path.replace(/\/$/, '').replace(/\.html$/, '');
+
     if (page.frontmatter?.keywords && Array.isArray(page.frontmatter.keywords)) {
-      // Normalize path by removing trailing slash and .html
-      const normalizedPath = page.path.replace(/\/$/, '').replace(/\.html$/, '');
       pageKeywords.set(normalizedPath, page.frontmatter.keywords);
-      // Also store with original path for exact matches
       pageKeywords.set(page.path, page.frontmatter.keywords);
+    }
+
+    if (page.frontmatter?.status) {
+      pageStatus.set(normalizedPath, page.frontmatter.status);
+      pageStatus.set(page.path, page.frontmatter.status);
     }
   });
 
-  // Recursive function to inject keywords into sidebar items
-  const injectKeywords = (items) => {
+  // Recursive function to inject frontmatter data into sidebar items
+  const injectData = (items) => {
     if (!items || !Array.isArray(items)) return;
 
     items.forEach(item => {
       if (item.link) {
-        // Try to find keywords for this link (normalize for matching)
         const normalizedLink = item.link.replace(/\/$/, '').replace(/\.html$/, '');
-        const keywords = pageKeywords.get(normalizedLink) || pageKeywords.get(item.link);
 
+        const keywords = pageKeywords.get(normalizedLink) || pageKeywords.get(item.link);
         if (keywords) {
           item.keywords = keywords;
+        }
+
+        // Only inject status from frontmatter if not already set in site-nav.json
+        if (!item.status) {
+          const status = pageStatus.get(normalizedLink) || pageStatus.get(item.link);
+          if (status) {
+            item.status = status;
+          }
         }
       }
 
       // Recursively process children
       if (item.children && Array.isArray(item.children)) {
-        injectKeywords(item.children);
+        injectData(item.children);
       }
     });
   };
@@ -185,7 +197,7 @@ function _injectKeywordsFromFrontmatter (app, options) {
     Object.values(options.sidebar.topLevelGroups).forEach(group => {
       if (group.sections) {
         Object.values(group.sections).forEach(section => {
-          injectKeywords(section);
+          injectData(section);
         });
       }
     });
@@ -302,7 +314,7 @@ export const dialtoneVuepressTheme = (options) => ({
       _extractFrontmatter(app, '/foundations/', options, ['/foundations/typography/', '/foundations/typography.html', '/foundations/colors/usage/', '/foundations/colors/palette/', '/foundations/colors/themes/', '/foundations/colors/chart-colors/', '/foundations/icons/usage/', '/foundations/icons/crafting-an-icon/', '/foundations/brand/using-our-logo/', '/foundations/brand/our-icon/', '/foundations/brand/sub-brands-and-co-branding/', '/foundations/brand/samples/', '/foundations/size/', '/foundations/space/']);
       _extractFrontmatter(app, '/foundations/colors/', options);
       _extractComponentStatus(app);
-      _injectKeywordsFromFrontmatter(app, options);
+      _injectFrontmatterIntoSidebar(app, options);
     },
 
     extendsPage: (page) => {

--- a/apps/dialtone-documentation/docs/components/datepicker.md
+++ b/apps/dialtone-documentation/docs/components/datepicker.md
@@ -3,7 +3,7 @@ title: Datepicker
 thumb: true
 image: assets/images/components/datepicker.png
 description: Datepicker component will provide a calendar to select a date.
-status: beta
+status: ready
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-datepicker--default
 figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Library--Rebrand-2025-?node-id=13998-86
 keywords: ["date picker", "calendar", "date selector", "d-datepicker", "DtDatepicker", "dt-datepicker", "date input", "schedule"]

--- a/apps/dialtone-documentation/docs/components/dropdown.md
+++ b/apps/dialtone-documentation/docs/components/dropdown.md
@@ -1,7 +1,7 @@
 ---
 title: Dropdown
 description: A Dropdown presents a list of options or actions.
-status: planned
+status: ready
 thumb: true
 image: assets/images/components/dropdown.png
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-dropdown--default

--- a/apps/dialtone-documentation/docs/components/emoji-picker.md
+++ b/apps/dialtone-documentation/docs/components/emoji-picker.md
@@ -3,7 +3,7 @@ title: Emoji Picker
 thumb: true
 image: assets/images/components/emoji-picker.png
 description: A emoji picker component that allows you to view and select an emoji from a list.
-status: beta
+status: ready
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-emoji-picker--default
 ---
 

--- a/apps/dialtone-documentation/docs/components/loader.md
+++ b/apps/dialtone-documentation/docs/components/loader.md
@@ -1,7 +1,7 @@
 ---
 title: Loader
 description: A loader is a visual indicator that a task is in progress.
-status: beta
+status: ready
 thumb: false
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-loader--default
 keywords: ["spinner", "loading", "progress", "d-loader", "DtLoader", "dt-loader", "activity indicator", "spin"]

--- a/apps/dialtone-documentation/docs/components/scrollbar.md
+++ b/apps/dialtone-documentation/docs/components/scrollbar.md
@@ -1,7 +1,7 @@
 ---
 title: Scrollbar
 description: A directive that adds a custom overlay scrollbar to any scrollable region.
-status: beta
+status: ready
 thumb: true
 image: assets/images/components/scrollbar.png
 keywords: ["scrollable", "d-scrollbar", "DtScrollbar", "dt-scrollbar", "custom scrollbar", "scroll container", "v-dt", "directive"]

--- a/apps/dialtone-documentation/docs/components/scroller.md
+++ b/apps/dialtone-documentation/docs/components/scroller.md
@@ -1,7 +1,7 @@
 ---
 title: Scroller
 description: A virtualized list that renders only what's visible, so large datasets scroll without slowing down the page.
-status: beta
+status: ready
 thumb: true
 image: assets/images/components/scroller.png
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-scroller--default

--- a/apps/dialtone-documentation/docs/components/split-button.md
+++ b/apps/dialtone-documentation/docs/components/split-button.md
@@ -1,7 +1,7 @@
 ---
 title: Split Button
 description: A Split Button offers a default action paired with a secondary action to reveal alternate or related actions.
-status: beta
+status: ready
 thumb: true
 image: assets/images/components/split-button.png
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-split-button--default

--- a/apps/dialtone-documentation/docs/components/text.md
+++ b/apps/dialtone-documentation/docs/components/text.md
@@ -1,7 +1,7 @@
 ---
 title: Text
 description: Consistent typography styling through semantic text kinds and sizes.
-status: beta
+status: ready
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-text--default
 image: assets/images/components/text.png
 ---

--- a/packages/combinator/src/components/combinator.vue
+++ b/packages/combinator/src/components/combinator.vue
@@ -76,7 +76,7 @@
         </template>
       </dt-dropdown>
       <dt-stack
-        gap="400"
+        gap="100"
         direction="row"
       >
         <dt-button


### PR DESCRIPTION
<img width="509" height="396" alt="image" src="https://github.com/user-attachments/assets/db95336e-b546-48d8-be66-33850834a7a7" />

## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :book: Jira Ticket

[DLT-3250](https://dialpad.atlassian.net/browse/DLT-3250)

## :book: Description

Component status badges (beta/planned) were missing from the sidebar nav and page headers for internal component pages. Only external UI kit links showed badges because they had `status` set explicitly in `site-nav.json`.

Now status is derived from page frontmatter at build time — single source of truth, no duplication.

Also updated status for:

- dt-datepicker
- dt-dropdown
- dt-emoji-picker
- dt-loader
- dt-scrollbar
- dt-scroller
- dt-split-button
- dt-text

## :bulb: Context

Reported when noticing Filter Pill (marked `status: beta` in frontmatter) had no badge in the sidebar.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

<img width="1469" height="917" alt="image" src="https://github.com/user-attachments/assets/3d16606f-1c76-4256-895c-04bd6bf3ee43" />

[DLT-3250]: https://dialpad.atlassian.net/browse/DLT-3250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ