### PR TITLE
fix(tabs): DLT-3251 improve accessibility

### DIFF
--- a/packages/dialtone-vue/components/tab/tab.test.js
+++ b/packages/dialtone-vue/components/tab/tab.test.js
@@ -8,6 +8,7 @@ const MOCK_DEFAULT_SLOT = 'Message Slot';
 const MOCK_GROUP_CONTEXT = {
   disabled: false,
   selected: '',
+  focusedTabId: null,
 };
 
 const baseProps = {
@@ -386,6 +387,52 @@ describe('DtTab Tests', () => {
 
       it('tabindex should be -1', () => {
         expect(tab.attributes('tabindex')).toBe('-1');
+      });
+    });
+
+    describe('Roving tabindex', () => {
+      describe('When focusedTabId matches this tab', () => {
+        beforeEach(() => {
+          mockProvide = { groupContext: { ...MOCK_GROUP_CONTEXT, selected: '', focusedTabId: MOCK_ID } };
+
+          updateWrapper();
+        });
+
+        it('tabindex should be 0', () => {
+          expect(tab.attributes('tabindex')).toBe('0');
+        });
+
+        it('aria-selected should still be "false"', () => {
+          expect(tab.attributes('aria-selected')).toBe('false');
+        });
+      });
+
+      describe('When focusedTabId is a different tab', () => {
+        beforeEach(() => {
+          mockProvide = { groupContext: { ...MOCK_GROUP_CONTEXT, selected: MOCK_PANEL_ID, focusedTabId: 'other-tab' } };
+
+          updateWrapper();
+        });
+
+        it('tabindex should be -1 even when selected', () => {
+          expect(tab.attributes('tabindex')).toBe('-1');
+        });
+
+        it('aria-selected should still be "true"', () => {
+          expect(tab.attributes('aria-selected')).toBe('true');
+        });
+      });
+
+      describe('When focusedTabId is null', () => {
+        beforeEach(() => {
+          mockProvide = { groupContext: { ...MOCK_GROUP_CONTEXT, selected: MOCK_PANEL_ID, focusedTabId: null } };
+
+          updateWrapper();
+        });
+
+        it('tabindex should fall back to selected tab', () => {
+          expect(tab.attributes('tabindex')).toBe('0');
+        });
       });
     });
   });

--- a/packages/dialtone-vue/components/tab/tab.vue
+++ b/packages/dialtone-vue/components/tab/tab.vue
@@ -21,7 +21,7 @@
     :leading-class="leadingClass"
     :trailing-class="trailingClass"
     data-qa="dt-tab"
-    :tabindex="isSelected ? '0' : '-1'"
+    :tabindex="isFocusTarget ? '0' : '-1'"
     v-bind="$attrs"
     v-on="tabListeners"
   >
@@ -209,6 +209,11 @@ export default {
 
     isSelected () {
       return this.groupContext.selected === this.panelId;
+    },
+
+    isFocusTarget () {
+      const focusedId = this.groupContext.focusedTabId;
+      return focusedId ? focusedId === this.id : this.isSelected;
     },
 
     buttonKind () {

--- a/packages/dialtone-vue/components/tab/tab.vue
+++ b/packages/dialtone-vue/components/tab/tab.vue
@@ -250,6 +250,12 @@ export default {
     }
   },
 
+  beforeUnmount () {
+    if (this.groupContext.focusedTabId === this.id) {
+      this.setFocus(null);
+    }
+  },
+
   methods: {
   },
 };

--- a/packages/dialtone-vue/components/tab/tab_group.test.js
+++ b/packages/dialtone-vue/components/tab/tab_group.test.js
@@ -4,7 +4,7 @@ import DtTabPanel from './tab_panel.vue';
 import DtTab from './tab.vue';
 import { returnFirstEl } from '@/common/utils';
 import { TAB_LIST_KIND_MODIFIERS, TAB_LIST_SIZE_MODIFIERS, TAB_LIST_IMPORTANCE_MODIFIERS, TAB_ORIENTATION_MODIFIERS, TAB_SPREAD_MODIFIERS } from './tabs_constants';
-import { h } from 'vue';
+import { h, ref } from 'vue';
 
 const optionTabPanel = [
   {
@@ -581,6 +581,56 @@ describe('DtTabGroup Tests', () => {
         await wrapper.setProps(props);
 
         expect(tabs.at(2).attributes('tabindex')).toBe('0');
+        expect(tabs.at(1).attributes('tabindex')).toBe('-1');
+      });
+    });
+
+    describe('When focused tab is removed', () => {
+      const tabOptions = ref([]);
+
+      const dynamicTabs = {
+        setup () {
+          return () => h('div', {}, tabOptions.value.map(opt =>
+            h(DtTab, { id: opt.id, panelId: opt.panelId, selected: opt.selected }, () => opt.slot),
+          ));
+        },
+      };
+
+      beforeEach(async () => {
+        tabOptions.value = [
+          { id: '1', panelId: '2', selected: true, slot: 'First' },
+          { id: '3', panelId: '4', slot: 'Second' },
+          { id: '5', panelId: '6', slot: 'Third' },
+        ];
+
+        wrapper.unmount();
+        wrapper = mount(DtTabGroup, {
+          attachTo: document.body,
+          props: { label: 'area-label' },
+          attrs,
+          slots: {
+            default: tabPanelComponents,
+            tabs: dynamicTabs,
+          },
+        });
+        _setWrappers();
+
+        // Focus third tab via arrow keys
+        returnFirstEl(tabs.at(0).vm.$el).focus();
+        await tabList.trigger('keydown.right');
+        await tabList.trigger('keydown.right');
+
+        // Remove the focused tab
+        tabOptions.value = [tabOptions.value[0], tabOptions.value[1]];
+        await wrapper.vm.$nextTick();
+        _setWrappers();
+      });
+
+      it('should give tabindex 0 to the selected tab', () => {
+        expect(tabs.at(0).attributes('tabindex')).toBe('0');
+      });
+
+      it('should give tabindex -1 to other tabs', () => {
         expect(tabs.at(1).attributes('tabindex')).toBe('-1');
       });
     });

--- a/packages/dialtone-vue/components/tab/tab_group.test.js
+++ b/packages/dialtone-vue/components/tab/tab_group.test.js
@@ -242,11 +242,11 @@ describe('DtTabGroup Tests', () => {
     });
 
     describe('Correct key navigation', () => {
-      describe('On keyup left', () => {
+      describe('On arrow left', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keydown.left');
-          await tabList.trigger('keyup.space');
+          await tabList.trigger('keydown.space');
         });
 
         it('selected element should be correct', () => {
@@ -255,12 +255,12 @@ describe('DtTabGroup Tests', () => {
         });
       });
 
-      describe('On double keyup left and space', () => {
+      describe('On double arrow left and space', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keydown.left');
           await tabList.trigger('keydown.left');
-          await tabList.trigger('keyup.space');
+          await tabList.trigger('keydown.space');
         });
 
         it('selected element should be correct', () => {
@@ -273,7 +273,7 @@ describe('DtTabGroup Tests', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keydown.right');
-          await tabList.trigger('keyup.enter');
+          await tabList.trigger('keydown.enter');
         });
 
         it('selected element should be correct', () => {
@@ -282,12 +282,12 @@ describe('DtTabGroup Tests', () => {
         });
       });
 
-      describe('On double keyup right and enter', () => {
+      describe('On double arrow right and enter', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keydown.right');
           await tabList.trigger('keydown.right');
-          await tabList.trigger('keyup.enter');
+          await tabList.trigger('keydown.enter');
         });
 
         it('selected element should be correct', () => {
@@ -300,7 +300,7 @@ describe('DtTabGroup Tests', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(2).vm.$el).focus();
           await tabList.trigger('keydown.home');
-          await tabList.trigger('keyup.enter');
+          await tabList.trigger('keydown.enter');
         });
 
         it('selected element should be correct', () => {
@@ -313,7 +313,7 @@ describe('DtTabGroup Tests', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keydown.end');
-          await tabList.trigger('keyup.enter');
+          await tabList.trigger('keydown.enter');
         });
 
         it('selected element should be correct', () => {
@@ -346,7 +346,7 @@ describe('DtTabGroup Tests', () => {
         _setWrappers();
       });
 
-      it('should land on disabled tab on keyup right', async () => {
+      it('should land on disabled tab on arrow right', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
         await tabList.trigger('keydown.right');
 
@@ -354,7 +354,7 @@ describe('DtTabGroup Tests', () => {
         expect(tabs.at(0).attributes('aria-selected')).toBe('true');
       });
 
-      it('should land on disabled tab on keyup left', async () => {
+      it('should land on disabled tab on arrow left', async () => {
         returnFirstEl(tabs.at(2).vm.$el).focus();
         await tabList.trigger('keydown.left');
 
@@ -365,7 +365,7 @@ describe('DtTabGroup Tests', () => {
       it('should not select disabled tab on enter', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
         await tabList.trigger('keydown.right');
-        await tabList.trigger('keyup.enter');
+        await tabList.trigger('keydown.enter');
 
         expect(tabs.at(0).attributes('aria-selected')).toBe('true');
         expect(tabs.at(1).attributes('aria-selected')).toBe('false');
@@ -375,7 +375,7 @@ describe('DtTabGroup Tests', () => {
       it('should not select disabled tab on space', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
         await tabList.trigger('keydown.right');
-        await tabList.trigger('keyup.space');
+        await tabList.trigger('keydown.space');
 
         expect(tabs.at(0).attributes('aria-selected')).toBe('true');
         expect(tabs.at(1).attributes('aria-selected')).toBe('false');
@@ -542,10 +542,54 @@ describe('DtTabGroup Tests', () => {
     });
   });
 
+  describe('Roving tabindex', () => {
+    describe('In manual mode', () => {
+      beforeEach(() => {
+        props.selected = optionTabs[0].panelId;
+        delete props.activationMode;
+        _mountWrapper();
+      });
+
+      it('should move tabindex to focused tab on arrow right', async () => {
+        returnFirstEl(tabs.at(0).vm.$el).focus();
+        await tabList.trigger('keydown.right');
+
+        expect(tabs.at(1).attributes('tabindex')).toBe('0');
+        expect(tabs.at(0).attributes('tabindex')).toBe('-1');
+      });
+
+      it('should keep tabindex on focused tab after multiple arrows', async () => {
+        returnFirstEl(tabs.at(0).vm.$el).focus();
+        await tabList.trigger('keydown.right');
+        await tabList.trigger('keydown.right');
+
+        expect(tabs.at(2).attributes('tabindex')).toBe('0');
+        expect(tabs.at(0).attributes('tabindex')).toBe('-1');
+        expect(tabs.at(1).attributes('tabindex')).toBe('-1');
+      });
+    });
+
+    describe('When selected prop changes externally', () => {
+      beforeEach(async () => {
+        _mountWrapper();
+        returnFirstEl(tabs.at(0).vm.$el).focus();
+        await tabList.trigger('keydown.right');
+      });
+
+      it('should reset tabindex to new selected tab', async () => {
+        props.selected = optionTabs[2].panelId;
+        await wrapper.setProps(props);
+
+        expect(tabs.at(2).attributes('tabindex')).toBe('0');
+        expect(tabs.at(1).attributes('tabindex')).toBe('-1');
+      });
+    });
+  });
+
   describe('Accessibility Tests', () => {
     beforeEach(async () => {
       returnFirstEl(tabs.at(0).vm.$el).focus();
-      await tabList.trigger('keyup.enter');
+      await tabList.trigger('keydown.enter');
     });
 
     it('should render correct attributes', () => {
@@ -558,13 +602,13 @@ describe('DtTabGroup Tests', () => {
     });
 
     describe('Correct aria attributes', () => {
-      describe('Attributes after keyup left', () => {
+      describe('Attributes after arrow left', () => {
         let lastTab;
         let lastPanel;
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keydown.left');
-          await tabList.trigger('keyup.space');
+          await tabList.trigger('keydown.space');
           lastTab = tabs.at(2).attributes();
           lastPanel = tabPanels.at(2).attributes();
         });
@@ -575,11 +619,11 @@ describe('DtTabGroup Tests', () => {
         });
       });
 
-      describe('attributes after keyup right', () => {
+      describe('attributes after arrow right', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keydown.right');
-          await tabList.trigger('keyup.enter');
+          await tabList.trigger('keydown.enter');
         });
 
         it(
@@ -597,7 +641,7 @@ describe('DtTabGroup Tests', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(2).vm.$el).focus();
           await tabList.trigger('keydown.home');
-          await tabList.trigger('keyup.enter');
+          await tabList.trigger('keydown.enter');
         });
 
         it(
@@ -615,7 +659,7 @@ describe('DtTabGroup Tests', () => {
         beforeEach(async () => {
           returnFirstEl(tabs.at(0).vm.$el).focus();
           await tabList.trigger('keydown.end');
-          await tabList.trigger('keyup.enter');
+          await tabList.trigger('keydown.enter');
         });
 
         it(
@@ -653,7 +697,7 @@ describe('DtTabGroup Tests', () => {
       it('should navigate to next tab on arrow down', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
         await tabList.trigger('keydown.down');
-        await tabList.trigger('keyup.enter');
+        await tabList.trigger('keydown.enter');
 
         expect(tabs.at(1).attributes('aria-selected')).toBe('true');
         expect(tabPanels.at(1).attributes('aria-hidden')).toBe('false');
@@ -662,7 +706,7 @@ describe('DtTabGroup Tests', () => {
       it('should navigate to previous tab on arrow up', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
         await tabList.trigger('keydown.up');
-        await tabList.trigger('keyup.space');
+        await tabList.trigger('keydown.space');
 
         expect(tabs.at(2).attributes('aria-selected')).toBe('true');
         expect(tabPanels.at(2).attributes('aria-hidden')).toBe('false');
@@ -671,7 +715,7 @@ describe('DtTabGroup Tests', () => {
       it('should NOT navigate on arrow left', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
         await tabList.trigger('keydown.left');
-        await tabList.trigger('keyup.enter');
+        await tabList.trigger('keydown.enter');
 
         expect(wrapper.emitted('change')).toBeUndefined();
       });
@@ -679,7 +723,7 @@ describe('DtTabGroup Tests', () => {
       it('should NOT navigate on arrow right', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
         await tabList.trigger('keydown.right');
-        await tabList.trigger('keyup.enter');
+        await tabList.trigger('keydown.enter');
 
         expect(wrapper.emitted('change')).toBeUndefined();
       });
@@ -687,7 +731,7 @@ describe('DtTabGroup Tests', () => {
       it('should navigate to first tab on home', async () => {
         returnFirstEl(tabs.at(2).vm.$el).focus();
         await tabList.trigger('keydown.home');
-        await tabList.trigger('keyup.enter');
+        await tabList.trigger('keydown.enter');
 
         expect(tabs.at(0).attributes('aria-selected')).toBe('true');
       });
@@ -695,7 +739,7 @@ describe('DtTabGroup Tests', () => {
       it('should navigate to last tab on end', async () => {
         returnFirstEl(tabs.at(0).vm.$el).focus();
         await tabList.trigger('keydown.end');
-        await tabList.trigger('keyup.enter');
+        await tabList.trigger('keydown.enter');
 
         expect(tabs.at(2).attributes('aria-selected')).toBe('true');
       });
@@ -743,7 +787,7 @@ describe('DtTabGroup Tests', () => {
     it('should NOT navigate on arrow up', async () => {
       returnFirstEl(tabs.at(0).vm.$el).focus();
       await tabList.trigger('keydown.up');
-      await tabList.trigger('keyup.enter');
+      await tabList.trigger('keydown.enter');
 
       expect(wrapper.emitted('change')).toBeUndefined();
     });
@@ -751,7 +795,7 @@ describe('DtTabGroup Tests', () => {
     it('should NOT navigate on arrow down', async () => {
       returnFirstEl(tabs.at(0).vm.$el).focus();
       await tabList.trigger('keydown.down');
-      await tabList.trigger('keyup.enter');
+      await tabList.trigger('keydown.enter');
 
       expect(wrapper.emitted('change')).toBeUndefined();
     });

--- a/packages/dialtone-vue/components/tab/tab_group.vue
+++ b/packages/dialtone-vue/components/tab/tab_group.vue
@@ -25,8 +25,8 @@
       @keydown.right="tabRight"
       @keydown.up="tabUp"
       @keydown.down="tabDown"
-      @keyup.enter="selectTab"
-      @keyup.space="selectTab"
+      @keydown.enter="selectTab"
+      @keydown.space="selectTab"
       @click="selectTab"
       @keydown.home.prevent="onHomeButton"
       @keydown.end.prevent="onEndButton"
@@ -228,9 +228,9 @@ export default {
         outlined: false,
         orientation: 'horizontal',
         spread: 'none',
+        focusedTabId: null, // tracks last-focused tab for roving tabindex
       },
 
-      focusId: null,
       tabs: [],
       TAB_LIST_SIZE_MODIFIERS,
       TAB_LIST_KIND_MODIFIERS,
@@ -252,6 +252,7 @@ export default {
       immediate: true,
       handler () {
         this.provideObj.selected = this.selected;
+        this.provideObj.focusedTabId = null;
       },
     },
 
@@ -311,7 +312,7 @@ export default {
     },
 
     setFocus (focusId) {
-      this.focusId = focusId;
+      this.provideObj.focusedTabId = focusId;
     },
 
     getTabChildren () {
@@ -385,13 +386,21 @@ export default {
     },
 
     selectTab (event) {
-      if (this.isSameTabClicked()) return;
+      const tabEl = event.target.closest('[role="tab"]');
+      const index = tabEl
+        ? this.tabs.findIndex(t => t.context === tabEl)
+        : this.getFocusedTabIndex();
 
-      const index = this.getFocusedTabIndex();
+      if (index === -1) return;
       if (this.tabs[index]?.isDisabled) return;
+      if (this.provideObj.selected === this.tabs[index]?.panelId) return;
 
       this.$emit('before-change', event);
       if (event.defaultPrevented) return;
+
+      // Prevent keyboard defaults (Space scroll, Enter form submit)
+      // after confirming the tab change will proceed
+      event.preventDefault();
 
       this.selectTabByIndex(index);
       this.onChange();
@@ -404,11 +413,9 @@ export default {
     },
 
     getFocusedTabIndex () {
-      // Hot fix https://github.com/dialpad/dialtone/pull/849
-      // The main issue is that this.tabs is not being updated at the time this is being triggered.
-
+      const focusedId = this.provideObj.focusedTabId;
       const index = this.tabs.findIndex((context) =>
-        this.focusId ? context.tabId === `${this.focusId}` : context.isSelected,
+        focusedId ? context.tabId === focusedId : context.isSelected,
       );
 
       return index === -1 ? 0 : index;
@@ -422,10 +429,6 @@ export default {
       if (this.tabs.length) this.selectFocusOnTab(this.tabs.length - 1);
     },
 
-    isSameTabClicked () {
-      const tab = this.tabs[this.getFocusedTabIndex()];
-      return this.provideObj.selected === tab.panelId;
-    },
   },
 };
 </script>

--- a/packages/dialtone-vue/components/tab/tab_group.vue
+++ b/packages/dialtone-vue/components/tab/tab_group.vue
@@ -250,9 +250,11 @@ export default {
 
     selected: {
       immediate: true,
-      handler () {
+      handler (newVal, oldVal) {
         this.provideObj.selected = this.selected;
-        this.provideObj.focusedTabId = null;
+        if (newVal !== oldVal) {
+          this.provideObj.focusedTabId = null;
+        }
       },
     },
 
@@ -309,10 +311,17 @@ export default {
         this.provideObj.selected = this.selected;
       }
       this.tabs = this.getTabChildren();
+
+      // Clear stale focusedTabId if the focused tab was removed
+      if (this.provideObj.focusedTabId && !this.tabs.some(t => t.tabId === this.provideObj.focusedTabId)) {
+        this.provideObj.focusedTabId = null;
+      }
     },
 
     setFocus (focusId) {
-      this.provideObj.focusedTabId = focusId;
+      if (this.provideObj.focusedTabId !== focusId) {
+        this.provideObj.focusedTabId = focusId;
+      }
     },
 
     getTabChildren () {


### PR DESCRIPTION
<img width="369" height="215" alt="image" src="https://github.com/user-attachments/assets/0835938d-806f-4fdd-9115-a5a66a368a3b" />

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

[DLT-3251](https://dialpad.atlassian.net/browse/DLT-3251)

## :book: Description

- Enter/Space activation changed from `keyup` to `keydown` — fires on press, not release
- Roving tabindex now tracks last-focused tab instead of selected tab — Tab-back returns to where user left off in manual mode
- `selectTab()` uses `event.target.closest('[role="tab"]')` to identify the activated tab instead of relying on focus-event timing
- Removed `isSameTabClicked()` and `focusId` data property — consolidated into `provideObj.focusedTabId`

## :bulb: Context

DtTabGroup's keyboard behavior deviates from the WAI-ARIA APG Tabs pattern. These are non-breaking behavioral fixes — no prop, slot, or event API changes.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

- Manual testing with VoiceOver + Safari and keyboard-only navigation
- Verify: arrow through disabled tabs, Space doesn't scroll, Tab-back returns to last-focused tab in manual mode

https://github.com/user-attachments/assets/04e9d71b-fc23-4b31-b96a-79a3d52b474e

[DLT-3251]: https://dialpad.atlassian.net/browse/DLT-3251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ