### PR TITLE
feat(split-button): DLT-3257 add show-divider prop

### DIFF
--- a/apps/dialtone-documentation/docs/components/split-button.md
+++ b/apps/dialtone-documentation/docs/components/split-button.md
@@ -150,15 +150,6 @@ Use the `disabled` prop to disable both buttons, or use `start-disabled` and `en
 
 Use `:show-divider="false"` to hide the vertical divider between the start and end buttons. This is only available for the `clear` importance variant.
 
-<dt-split-button :show-divider="false" end-tooltip-text="More calling options">
-  Place Call
-  <template #dropdownList>
-    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
-    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
-    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
-  </template>
-</dt-split-button>
-
 ```vue demo
 <!-- @wrapper -->
 <dt-stack direction="row" gap="100">

--- a/apps/dialtone-documentation/docs/components/split-button.md
+++ b/apps/dialtone-documentation/docs/components/split-button.md
@@ -123,32 +123,6 @@ In addition to the [Button component's](button.md) documentation:
 </dt-stack>
 ```
 
-### No Divider
-
-Use `:show-divider="false"` to hide the vertical divider between the start and end buttons. This is only available for the `clear` importance variant.
-
-```vue demo
-<!-- @wrapper -->
-<dt-stack direction="row" gap="100">
-  <dt-split-button importance="clear" kind="muted" :show-divider="false" end-tooltip-text="More calling options">
-    Place Call
-    <template #dropdownList>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
-    </template>
-  </dt-split-button>
-  <dt-split-button importance="clear" :show-divider="false" end-tooltip-text="More calling options">
-    Place Call
-    <template #dropdownList>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
-      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
-    </template>
-  </dt-split-button>
-</dt-stack>
-```
-
 ### Disabled
 
 Use the `disabled` prop to disable both buttons, or use `start-disabled` and `end-disabled` to disable each button independently.
@@ -169,6 +143,41 @@ Use the `disabled` prop to disable both buttons, or use `start-disabled` and `en
 <dt-stack direction="row" gap="100">
   <dt-split-button start-active end-tooltip-text="More calling options"> Start active </dt-split-button>
   <dt-split-button end-active end-tooltip-text="More calling options"> End active </dt-split-button>
+</dt-stack>
+```
+
+### No Divider
+
+Use `:show-divider="false"` to hide the vertical divider between the start and end buttons. This is only available for the `clear` importance variant.
+
+<dt-split-button :show-divider="false" end-tooltip-text="More calling options">
+  Place Call
+  <template #dropdownList>
+    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+    <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+  </template>
+</dt-split-button>
+
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-split-button importance="clear" kind="muted" :show-divider="false" end-tooltip-text="More calling options">
+    Place Call
+    <template #dropdownList>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+    </template>
+  </dt-split-button>
+  <dt-split-button importance="clear" :show-divider="false" end-tooltip-text="More calling options">
+    Place Call
+    <template #dropdownList>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+    </template>
+  </dt-split-button>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/components/split-button.md
+++ b/apps/dialtone-documentation/docs/components/split-button.md
@@ -123,6 +123,32 @@ In addition to the [Button component's](button.md) documentation:
 </dt-stack>
 ```
 
+### No Divider
+
+Use `:show-divider="false"` to hide the vertical divider between the start and end buttons. This is only available for the `clear` importance variant.
+
+```vue demo
+<!-- @wrapper -->
+<dt-stack direction="row" gap="100">
+  <dt-split-button importance="clear" kind="muted" :show-divider="false" end-tooltip-text="More calling options">
+    Place Call
+    <template #dropdownList>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+    </template>
+  </dt-split-button>
+  <dt-split-button importance="clear" :show-divider="false" end-tooltip-text="More calling options">
+    Place Call
+    <template #dropdownList>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>
+      <dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>
+    </template>
+  </dt-split-button>
+</dt-stack>
+```
+
 ### Disabled
 
 Use the `disabled` prop to disable both buttons, or use `start-disabled` and `end-disabled` to disable each button independently.

--- a/packages/combinator/src/variants/variants_split_button.js
+++ b/packages/combinator/src/variants/variants_split_button.js
@@ -1,6 +1,14 @@
 /* eslint-disable max-len */
 
+
 export default {
+  exclusions: [
+    {
+      when: { importance: v => v !== 'clear' },
+      hide: { props: ['showDivider'] },
+    },
+  ],
+
   default: {
     props: {
       endTooltipText: {
@@ -103,6 +111,21 @@ export default {
     slots: {
       default: { initialValue: 'Place Call' },
       leading: { initialValue: '<dt-badge kind="count" text="3" />' },
+      dropdownList: {
+        initialValue: '<dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>\n<dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>\n<dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>',
+      },
+    },
+  },
+
+  'clear muted no divider': {
+    props: {
+      importance: { initialValue: 'clear' },
+      kind: { initialValue: 'muted' },
+      showDivider: { initialValue: false },
+      endTooltipText: { initialValue: 'More calling options' },
+    },
+    slots: {
+      default: { initialValue: 'Place Call' },
       dropdownList: {
         initialValue: '<dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 1 </dt-list-item>\n<dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 2 </dt-list-item>\n<dt-list-item role="menuitem" navigation-type="arrow-keys"> Option 3 </dt-list-item>',
       },

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -826,6 +826,11 @@
     }
   }
 
+  &--no-divider &__omega::before,
+  &--no-divider &__end::before {
+    content: none;
+  }
+
   // adjust x-padding for icon-only button at each size
   &__omega--xs,
   &__end--xs {

--- a/packages/dialtone-vue/components/split_button/split_button.stories.js
+++ b/packages/dialtone-vue/components/split_button/split_button.stories.js
@@ -122,6 +122,10 @@ export const argTypesData = {
     options: Object.keys(ICON_POSITION_MODIFIERS),
   },
 
+  showDivider: {
+    control: 'boolean',
+  },
+
   startLoading: {
     control: 'boolean',
   },

--- a/packages/dialtone-vue/components/split_button/split_button.test.js
+++ b/packages/dialtone-vue/components/split_button/split_button.test.js
@@ -278,6 +278,38 @@ describe('DtSplitButton Tests', function () {
     });
   });
 
+  describe('showDivider Tests', () => {
+    describe('When showDivider is true (default)', () => {
+      it('Should not have no-divider class', () => {
+        expect(wrapper.classes()).not.toContain('d-split-btn--no-divider');
+      });
+    });
+
+    describe('When showDivider is false', () => {
+      it('Should have no-divider class', () => {
+        mockProps = { showDivider: false, importance: 'clear' };
+
+        updateWrapper();
+
+        expect(wrapper.classes()).toContain('d-split-btn--no-divider');
+      });
+    });
+
+    describe('When showDivider is false and importance is not clear', () => {
+      it('Should warn about invalid combination', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockProps = { showDivider: false, importance: 'outlined' };
+
+        updateWrapper();
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('show-divider prop set to false has no effect'),
+        );
+        warnSpy.mockRestore();
+      });
+    });
+  });
+
   describe('Interactivity Tests', () => {
     describe('When start button is clicked', () => {
       beforeEach(async () => {

--- a/packages/dialtone-vue/components/split_button/split_button.vue
+++ b/packages/dialtone-vue/components/split_button/split_button.vue
@@ -1,7 +1,7 @@
 <template>
   <span
     data-qa="dt-split-button"
-    :class="[rootClass, 'd-split-btn']"
+    :class="[rootClass, 'd-split-btn', { 'd-split-btn--no-divider': !showDivider }]"
     :style="{ width }"
   >
     <split-button-start
@@ -490,6 +490,16 @@ export default {
     },
 
     /**
+     * Whether to show the vertical divider between the start and end buttons.
+     * Only applies when importance is "clear".
+     * @values true, false
+     */
+    showDivider: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
      * Additional class name for the root element.
      * Can accept all of: String, Object, and Array, i.e. has the
      * same api as Vue's built-in handling of the class attribute.
@@ -648,6 +658,7 @@ export default {
     validateProps () {
       this.validateStartButtonProps();
       this.validateEndButtonProps();
+      this.validateShowDivider();
     },
 
     validateStartButtonProps () {
@@ -664,6 +675,15 @@ export default {
 
       if (!(this.omegaTooltipText ?? this.endTooltipText)) {
         console.warn('end-tooltip-text prop is required as it is an icon-only button');
+      }
+    },
+
+    validateShowDivider () {
+      if (!this.showDivider && this.importance !== 'clear') {
+        console.warn(
+          'show-divider prop set to false has no effect when importance is not "clear". ' +
+          'The divider is always shown for "outlined" and "primary" importances.',
+        );
       }
     },
   },

--- a/packages/dialtone-vue/components/split_button/split_button.vue
+++ b/packages/dialtone-vue/components/split_button/split_button.vue
@@ -1,7 +1,7 @@
 <template>
   <span
     data-qa="dt-split-button"
-    :class="[rootClass, 'd-split-btn', { 'd-split-btn--no-divider': !showDivider }]"
+    :class="[rootClass, 'd-split-btn', { 'd-split-btn--no-divider': !showDivider && importance === 'clear' }]"
     :style="{ width }"
   >
     <split-button-start


### PR DESCRIPTION
<img width="168" height="300" alt="image" src="https://github.com/user-attachments/assets/e8f58e37-69b0-43c3-8445-cc42cd1eddb0" />

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-3257](https://dialpad.atlassian.net/browse/DLT-3257)

## :book: Description

Add a boolean `show-divider` prop to `DtSplitButton` (default `true`). When `false`, hides the vertical divider between start and end buttons via a `d-split-btn--no-divider` CSS modifier. Only applies to `importance="clear"` — a console warning fires for invalid combinations.

Does not change any existing behavior; the divider still renders by default.

## :package: Cross-Package Impact

| Package | Changes |
|---|---|
| dialtone-css | `d-split-btn--no-divider` modifier (`content: none` on `::before`) |
| dialtone-vue | `showDivider` prop, class binding, validation warning |
| combinator | Exclusion rule + `'clear muted no divider'` preset |
| dialtone-documentation | "No Divider" section in split-button.md |

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

https://github.com/user-attachments/assets/7baf71d0-26b3-4a49-82ad-9fa63cefb1c9


[DLT-3257]: https://dialpad.atlassian.net/browse/DLT-3257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ