### PR TITLE
docs: DLT-3258 DLT-3259 improve sidebar search with logical keywords and fuzzy matching

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Sidebar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Sidebar.vue
@@ -83,6 +83,11 @@ const focusedIndex = ref(-1);
 // Ref to the search input element
 const searchInput = ref(null);
 
+// Normalize a string for separator-insensitive matching.
+// Strips non-alphanumeric characters so "border-color", "border color",
+// and "bordercolor" all normalize to "bordercolor".
+const normalize = (str) => str.toLowerCase().replace(/[^a-z0-9]/g, '');
+
 // Recursive filter function for sidebar items
 const filterItems = (items, searchTerm) => {
   if (!searchTerm) return items;
@@ -90,13 +95,14 @@ const filterItems = (items, searchTerm) => {
   const term = searchTerm.toLowerCase().trim();
   if (!term) return items;
 
+  const normalizedTerm = normalize(term);
   const filtered = [];
 
   items.forEach(item => {
     // Check if current item matches (text or keywords)
-    const itemMatches = item.text.toLowerCase().includes(term) ||
+    const itemMatches = normalize(item.text).includes(normalizedTerm) ||
       (item.keywords?.some(keyword =>
-        keyword.toLowerCase().includes(term),
+        normalize(keyword).includes(normalizedTerm),
       ) ?? false);
 
     // Recursively filter children if they exist

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Sidebar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Sidebar.vue
@@ -94,6 +94,8 @@ const filterItems = (items, searchTerm) => {
   if (!term) return items;
 
   const normalizedTerm = normalize(term);
+  if (!normalizedTerm) return [];
+
   const filtered = [];
 
   items.forEach(item => {

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Sidebar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Sidebar.vue
@@ -83,16 +83,14 @@ const focusedIndex = ref(-1);
 // Ref to the search input element
 const searchInput = ref(null);
 
-// Normalize a string for separator-insensitive matching.
-// Strips non-alphanumeric characters so "border-color", "border color",
-// and "bordercolor" all normalize to "bordercolor".
+// Strip separators and case for fuzzy matching.
 const normalize = (str) => str.toLowerCase().replace(/[^a-z0-9]/g, '');
 
 // Recursive filter function for sidebar items
 const filterItems = (items, searchTerm) => {
   if (!searchTerm) return items;
 
-  const term = searchTerm.toLowerCase().trim();
+  const term = searchTerm.trim();
   if (!term) return items;
 
   const normalizedTerm = normalize(term);

--- a/apps/dialtone-documentation/docs/utilities/borders/direction.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/direction.md
@@ -1,7 +1,7 @@
 ---
 title: Border Directions
 description: Utilities for controlling an element's border.
-keywords: ["border top", "border bottom", "border left", "border right"]
+keywords: ["border top", "border bottom", "border left", "border right", "border inline start", "border inline end", "border block start", "border block end"]
 ---
 
 ## All Sides

--- a/apps/dialtone-documentation/docs/utilities/borders/divide-width.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/divide-width.md
@@ -1,7 +1,7 @@
 ---
 title: Divide Width
 description: Utilities for controlling the divider width between an element's child items.
-keywords: ["divider width","separator width","divider size"]
+keywords: ["divider width","separator width","divider size","divide inline size","divide block size"]
 ---
 
 ## Default Width

--- a/apps/dialtone-documentation/docs/utilities/borders/radius.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/radius.md
@@ -1,7 +1,7 @@
 ---
 title: Border Radius
 description: Utilities for controlling an element's border radius.
-keywords: ["rounded", "corner", "pill", "circle"]
+keywords: ["rounded", "corner", "pill", "circle", "radius start", "radius end"]
 ---
 
 ## All Corners

--- a/apps/dialtone-documentation/docs/utilities/borders/width.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/width.md
@@ -1,7 +1,7 @@
 ---
 title: Border Widths
 description: Utilities for controlling an element's border width.
-keywords: ["border size", "border thickness"]
+keywords: ["border size", "border thickness", "border inline size", "border block size"]
 ---
 
 ## All Sides

--- a/apps/dialtone-documentation/docs/utilities/layout/coordinates.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/coordinates.md
@@ -1,7 +1,7 @@
 ---
 title: Coordinates
 description: Utility classes to assign an element’s top, right, bottom, or left position.
-keywords: ["top","right","bottom","left","inset","position offset"]
+keywords: ["top","right","bottom","left","inset","position offset","inset inline start","inset inline end","inset block start","inset block end"]
 ---
 
 ## Positive Coordinates

--- a/apps/dialtone-documentation/docs/utilities/sizing/height.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/height.md
@@ -1,7 +1,7 @@
 ---
 title: Height
 description: Utilities to control an element's height.
-keywords: ["size", "tall", "vh", "viewport height"]
+keywords: ["size", "tall", "vh", "viewport height", "block size", "block-size"]
 ---
 
 ## Layout stops

--- a/apps/dialtone-documentation/docs/utilities/sizing/max-height.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/max-height.md
@@ -1,7 +1,7 @@
 ---
 title: Max-height
 description: Utilities to control an element's maximum height.
-keywords: ["maximum height", "mxh"]
+keywords: ["maximum height", "mxh", "max block size", "max block-size"]
 ---
 
 ## Layout stops

--- a/apps/dialtone-documentation/docs/utilities/sizing/max-width.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/max-width.md
@@ -1,7 +1,7 @@
 ---
 title: Max-width
 description: Utilities to control an element's maximum width.
-keywords: ["maximum width", "mxw"]
+keywords: ["maximum width", "mxw", "max inline size", "max inline-size"]
 ---
 
 ## Layout stops

--- a/apps/dialtone-documentation/docs/utilities/sizing/min-height.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/min-height.md
@@ -1,7 +1,7 @@
 ---
 title: Min-height
 description: Utilities to control an element's minimum height.
-keywords: ["minimum height", "mnh"]
+keywords: ["minimum height", "mnh", "min block size", "min block-size"]
 ---
 
 ## Layout stops

--- a/apps/dialtone-documentation/docs/utilities/sizing/min-width.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/min-width.md
@@ -1,7 +1,7 @@
 ---
 title: Min-width
 description: Utilities to control an element's minimum width.
-keywords: ["minimum width", "mnw"]
+keywords: ["minimum width", "mnw", "min inline size", "min inline-size"]
 ---
 
 ## Layout stops

--- a/apps/dialtone-documentation/docs/utilities/sizing/size.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/size.md
@@ -1,7 +1,7 @@
 ---
 title: Size
 description: Utilities to set both width and height simultaneously.
-keywords: ["size", "square", "aspect", "both dimensions"]
+keywords: ["size", "square", "aspect", "both dimensions", "inline size", "block size"]
 ---
 
 Size utilities set both `inline-size` (width) and `block-size` (height) at once. Useful for icons, avatars, thumbnails, and any element that needs to be square or have matching dimensions.

--- a/apps/dialtone-documentation/docs/utilities/sizing/width.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/width.md
@@ -1,7 +1,7 @@
 ---
 title: Width
 description: Utilities to control an element's width.
-keywords: ["size", "wide", "vw", "viewport width"]
+keywords: ["size", "wide", "vw", "viewport width", "inline size", "inline-size"]
 ---
 
 ## Layout stops

--- a/apps/dialtone-documentation/docs/utilities/spacing/margin.md
+++ b/apps/dialtone-documentation/docs/utilities/spacing/margin.md
@@ -1,7 +1,7 @@
 ---
 title: Margins
 description: Utilities to adjust an element's exterior spacing between other objects.
-keywords: ["outer spacing", "gap", "offset"]
+keywords: ["outer spacing", "gap", "offset", "margin inline start", "margin inline end", "margin block start", "margin block end"]
 ---
 
 <dt-notice kind="warning" class="d-wmx100p d-my-200" hideClose>

--- a/apps/dialtone-documentation/docs/utilities/spacing/padding.md
+++ b/apps/dialtone-documentation/docs/utilities/spacing/padding.md
@@ -1,7 +1,7 @@
 ---
 title: Padding
 description: Utilities for setting an element's interior spacing between child elements and the element's box edge.
-keywords: ["inner spacing", "inset"]
+keywords: ["inner spacing", "inset", "padding inline start", "padding inline end", "padding block start", "padding block end"]
 ---
 
 <dt-notice kind="info" class="d-wmx100p d-my-200" hideClose>


### PR DESCRIPTION
![tom-and-jerry-looking-for](https://github.com/user-attachments/assets/ace8ed6b-2704-40ed-8243-9cb80c085f67)

## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :book: Jira Ticket

- [DLT-3258](https://dialpad.atlassian.net/browse/DLT-3258) — Add CSS logical property keywords to utility doc search
- [DLT-3259](https://dialpad.atlassian.net/browse/DLT-3259) — Add separator-insensitive sidebar search matching

## :book: Description

- Add CSS logical property keywords to 14 utility doc pages (spacing, sizing, borders, layout) so searches like "padding inline", "margin block", "inline size" surface the correct pages
- Add separator-insensitive matching to sidebar search — normalize both query and targets by stripping non-alphanumeric chars before comparing, so "border-color", "bordercolor", and "border color" all match

## :bulb: Context

After converting CSS utilities to logical properties, the doc site's sidebar search didn't surface pages when searching with logical terms. Separately, searches using hyphens or concatenated words (e.g. "bordercolor") returned no results because the search used strict substring matching.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

None — self-contained improvement.

[DLT-3258]: https://dialpad.atlassian.net/browse/DLT-3258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DLT-3259]: https://dialpad.atlassian.net/browse/DLT-3259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

https://github.com/user-attachments/assets/a01d5733-c887-481e-a6c4-8d75187b041a


