### PR TITLE
fix(split-button, filter-pill): DLT-3260 DLT-3261 correct misalignment at size 100

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -718,11 +718,13 @@
   align-items: stretch;
   justify-content: center;
 
-  .d-popover,
-  .d-popover div,
-  .d-popover &__omega,
-  .d-popover &__end {
-    block-size: 100%;
+  // Nested popover wrappers shouldn't affect layout
+  > :where(div:not([class])) {
+    display: contents;
+  }
+
+  :where(.d-popover, .d-popover div) {
+    display: contents;
   }
 
   &__alpha,

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -723,7 +723,7 @@
     display: contents;
   }
 
-  :where(.d-popover, .d-popover div) {
+  :where(.d-popover, .d-popover > div) {
     display: contents;
   }
 

--- a/packages/dialtone-css/lib/build/less/components/filter-pill.less
+++ b/packages/dialtone-css/lib/build/less/components/filter-pill.less
@@ -23,7 +23,7 @@
     display: contents;
   }
 
-  :where(.d-popover, .d-popover div) {
+  :where(.d-popover, .d-popover > div) {
     display: contents;
   }
 

--- a/packages/dialtone-css/lib/build/less/components/filter-pill.less
+++ b/packages/dialtone-css/lib/build/less/components/filter-pill.less
@@ -16,6 +16,16 @@
 
   display: inline-flex;
   gap: 0;
+  align-items: stretch;
+
+  // Nested popover wrappers shouldn't affect layout
+  > div:not([class]) {
+    display: contents;
+  }
+
+  :where(.d-popover, .d-popover div) {
+    display: contents;
+  }
 
   &--read-only {
     --filter-pill-color-background-selected-hover: transparent;

--- a/packages/dialtone-vue/components/filter_pill/filter_pill.vue
+++ b/packages/dialtone-vue/components/filter_pill/filter_pill.vue
@@ -197,8 +197,8 @@
       importance="outlined"
       @click="clearFilter"
     >
-      <template #icon="{ iconSize }">
-        <dt-icon-close :size="iconSize" />
+      <template #icon>
+        <dt-icon-close :size="clearIconSize" />
       </template>
     </dt-button>
   </div>
@@ -207,7 +207,7 @@
 <script>
 import { DtPopover, POPOVER_APPEND_TO_VALUES, POPOVER_PADDING_CLASSES } from '@/components/popover';
 import { CONTENT_MODE_PROP } from '@/common/mode_constants';
-import { BUTTON_SIZE_MODIFIERS, DtButton } from '@/components/button';
+import { BUTTON_SIZE_MODIFIERS, BUTTON_ICON_SIZES, DtButton } from '@/components/button';
 import { DtIconChevronDown, DtIconClose } from '@dialpad/dialtone-icons/vue';
 import { DialtoneLocalization } from '@/localization';
 import { DtCheckbox } from '@/components/checkbox';
@@ -580,6 +580,11 @@ export default {
 
     applyButtonLabel () {
       return this.i18n.$t('DIALTONE_FILTER_PILL_APPLY_BUTTON_LABEL');
+    },
+
+    clearIconSize () {
+      if (String(this.size) === '100') return '100';
+      return BUTTON_ICON_SIZES[String(this.size)];
     },
   },
 


### PR DESCRIPTION
![5OjI2vCzxo2kM](https://github.com/user-attachments/assets/0ed95225-f735-477d-aaea-bb4c2bb2140d)

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

[DLT-3260](https://dialpad.atlassian.net/browse/DLT-3260)
[DLT-3261](https://dialpad.atlassian.net/browse/DLT-3261)

## :book: Description

| Before | After |
|--------|--------|
| <img width="186" height="54" alt="dialtone dialpad com_next_components_split-button html" src="https://github.com/user-attachments/assets/1694a845-503a-45c8-9264-778bc37a6a23" /> | <img width="186" height="52" alt="localhost_4001_components_split-button html" src="https://github.com/user-attachments/assets/60c06adb-2284-4cc9-931e-818521980871" /> | 
| <img width="422" height="52" alt="dialtone dialpad com_next_components_filter-pill html" src="https://github.com/user-attachments/assets/92e5b41a-bd0c-4fce-87a1-4d4b16554180" /> | <img width="418" height="52" alt="localhost_4001_components_filter-pill html" src="https://github.com/user-attachments/assets/cc62008e-7e44-4d94-81a1-c0a7c7547055" /> | 

- **Filter pill & split button:** Primary and secondary buttons had mismatched heights because the popover wrapper divs broke the flex stretch chain. Applied `display: contents` on the popover wrappers so both buttons participate directly in the parent flex layout.
- **Filter pill:** Clear button icon now uses size `100` when the pill is `size="100"`. All other sizes unchanged.

## :bulb: Context

Both components nest one button inside a popover (`div > .d-popover > div#anchor > button`) while the sibling button is a direct flex child. `align-items: stretch` only reaches direct children, so the nested button didn't match the sibling's height. `display: contents` removes the intermediate wrappers from layout, making both buttons effective flex siblings.

> [!CAUTION]
> This `display: contents` approach here is **scoped to these just two components**, but honestly I'd prefer it be done for the actual DtPopover component. But that could be extremely risky given how much products implement Popover, Hovercard, Dropdown. But it can be something to consider. 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

[DLT-3260]: https://dialpad.atlassian.net/browse/DLT-3260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DLT-3261]: https://dialpad.atlassian.net/browse/DLT-3261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ