### PR TITLE
refactor(modal): DLT-3262 migrate DtModal to native dialog element

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/modal.less
+++ b/packages/dialtone-css/lib/build/less/components/modal.less
@@ -119,13 +119,37 @@
     will-change: visibility, z-index, opacity;
 }
 
+//  $$  DIALOG ELEMENT RESET
+//  ----------------------------------------------------------------------------
+//  When used as a native <dialog>, reset UA styles and hide the native backdrop
+//  since .d-modal itself serves as the visual backdrop overlay.
+//  The :not([open]) rule restores UA hidden behavior that .d-modal's display: flex
+//  would otherwise override.
+:where(dialog).d-modal {
+  margin: 0;
+  color: inherit;
+  border: none;
+  inline-size: auto;
+  block-size: auto;
+  max-inline-size: none;
+  max-block-size: none;
+
+  &:not([open]) {
+    display: none;
+  }
+
+  &::backdrop {
+    background: transparent;
+  }
+}
+
 .d-modal--transparent {
   --modal-backdrop-color-background: var(--d-bgc-transparent);
 
   // If we don't set this the native app header region will override all click events on the modal overlay
   -webkit-app-region: no-drag;
 
-  &[aria-hidden='false'] {
+  &:is([aria-hidden='false'], [open]) {
     position: fixed;
     inset-block-start: 0;
     inset-inline-start: 0;
@@ -169,10 +193,10 @@
 
 //  $$   MAKE THEM APPEAR
 //  ----------------------------------------------------------------------------
-.d-modal[aria-hidden='false'],
-.d-modal[aria-hidden='false'] .d-modal__dialog,
-.d-modal--transparent[aria-hidden='false'],
-.d-modal--transparent[aria-hidden='false'] .d-modal__dialog {
+//  [aria-hidden='false'] — raw HTML usage (div-based)
+//  [open] — native <dialog> element usage
+:is(.d-modal, .d-modal--transparent):is([aria-hidden='false'], [open]),
+:is(.d-modal, .d-modal--transparent):is([aria-hidden='false'], [open]) .d-modal__dialog {
   z-index: var(--zi-modal);
   transform: translate3d(0, 0, 0) scale3d(1, 1, 1);
   visibility: visible;

--- a/packages/dialtone-vue/components/modal/modal.test.js
+++ b/packages/dialtone-vue/components/modal/modal.test.js
@@ -22,6 +22,21 @@ const baseSlots = {};
 let mockProps = {};
 let mockSlots = {};
 
+// Mock native <dialog> methods not supported in JSDOM
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function () {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function () {
+    this.removeAttribute('open');
+  });
+});
+
+afterAll(() => {
+  delete HTMLDialogElement.prototype.showModal;
+  delete HTMLDialogElement.prototype.close;
+});
+
 describe('DtModal Tests', () => {
   let wrapper;
   let closeBtn;
@@ -47,6 +62,7 @@ describe('DtModal Tests', () => {
   };
 
   beforeEach(() => {
+    vi.clearAllMocks();
     updateWrapper();
   });
 
@@ -56,15 +72,13 @@ describe('DtModal Tests', () => {
     wrapper.unmount();
   });
 
-  afterAll(() => {
-    // Restore RequestAnimationFrame and cancelAnimationFrame
-    global.requestAnimationFrame = undefined;
-    global.cancelAnimationFrame = undefined;
-  });
-
   describe('Presentation Tests', () => {
     it('should render the component', () => {
       expect(wrapper.exists()).toBe(true);
+    });
+
+    it('should render using a native dialog element', () => {
+      expect(overlay.element.tagName).toBe('DIALOG');
     });
 
     it('should render the title content', () => {
@@ -92,6 +106,10 @@ describe('DtModal Tests', () => {
 
     it('Should set default banner kind when no kind is set', async () => {
       expect(banner.classes(MODAL_BANNER_KINDS[DtModal.props.bannerKind.default])).toBe(true);
+    });
+
+    it('Should call showModal when show is true', () => {
+      expect(overlay.element.showModal).toHaveBeenCalled();
     });
 
     describe('When hideClose prop is true', () => {
@@ -162,13 +180,19 @@ describe('DtModal Tests', () => {
       expect(wrapper.emitted()[SYNC_EVENT_NAME][0][0]).toBe(false);
     });
 
-    it('Should emit a sync-able update event when escape key is pressed', async () => {
+    it('Should emit a sync-able update event when cancel event fires (escape key)', async () => {
       expect(wrapper.emitted(SYNC_EVENT_NAME)).toBeFalsy();
 
-      await overlay.trigger('keydown', { code: 'Escape' });
+      await overlay.trigger('cancel');
 
       expect(wrapper.emitted()[SYNC_EVENT_NAME].length).toBe(1);
       expect(wrapper.emitted()[SYNC_EVENT_NAME][0][0]).toBe(false);
+    });
+
+    it('Should emit keydown event to parent', async () => {
+      await overlay.trigger('keydown', { code: 'Escape' });
+
+      expect(wrapper.emitted().keydown).toBeTruthy();
     });
   });
 

--- a/packages/dialtone-vue/components/modal/modal.vue
+++ b/packages/dialtone-vue/components/modal/modal.vue
@@ -3,10 +3,9 @@
     :disabled="!appendTo"
     :to="appendTo"
   >
-    <dt-lazy-show
-      ref="modalRoot"
-      transition="d-zoom"
-      :show="show"
+    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
+    <dialog
+      ref="dialogEl"
       :class="[
         'd-modal',
         MODAL_KIND_MODIFIERS[kind],
@@ -14,9 +13,12 @@
         modalClass,
       ]"
       data-qa="dt-modal"
-      :aria-hidden="open"
+      :aria-describedby="describedById"
+      :aria-labelledby="labelledById"
       v-bind="modeAttrs"
-      v-on="modalListeners"
+      @cancel.prevent="close"
+      @click="onBackdropClick"
+      @keydown="onKeydown"
     >
       <div
         v-if="show && (hasSlotContent($slots.banner) || bannerTitle)"
@@ -33,8 +35,10 @@
         </slot>
       </div>
       <transition
-        appear
+        :appear="show"
         name="d-modal__dialog"
+        @after-enter="onAfterEnter"
+        @after-leave="onAfterLeave"
       >
         <div
           v-show="show"
@@ -43,10 +47,6 @@
             { 'd-modal__dialog--scrollable': fixedHeaderFooter },
             dialogClass,
           ]"
-          role="dialog"
-          aria-modal="true"
-          :aria-describedby="describedById"
-          :aria-labelledby="labelledById"
         >
           <div
             v-if="hasSlotContent($slots.header)"
@@ -122,7 +122,7 @@
           </dt-button>
         </div>
       </transition>
-    </dt-lazy-show>
+    </dialog>
   </teleport>
 </template>
 
@@ -131,22 +131,22 @@
 import { DtButton } from '@/components/button';
 import { DtText } from '@/components/text';
 import { DtIconClose } from '@dialpad/dialtone-icons/vue';
-import Modal from '@/common/mixins/modal';
 import ModeMixin from '@/common/mixins/mode';
 import {
   MODAL_BANNER_KINDS,
   MODAL_KIND_MODIFIERS,
   MODAL_SIZE_MODIFIERS,
 } from './modal_constants';
-import { returnFirstEl, getUniqueString, hasSlotContent, disableRootScrolling, enableRootScrolling } from '@/common/utils';
-import { DtLazyShow } from '@/components/lazy_show';
-import { EVENT_KEYNAMES } from '@/common/constants';
+import { getUniqueString, hasSlotContent, returnFirstEl, disableRootScrolling, enableRootScrolling } from '@/common/utils';
 import SrOnlyCloseButton from '@/common/sr_only_close_button.vue';
 import { NOTICE_KINDS } from '@/components/notice';
 import { DialtoneLocalization } from '@/localization';
 
+const focusableSelector = 'button:not(:disabled),[href],input:not(:disabled),select:not(:disabled),' +
+  'textarea:not(:disabled),details,[tabindex]:not([tabindex="-1"]):not(:disabled):not([aria-disabled="true"])';
+
 /**
- * Modals focus the user’s attention exclusively on one task or piece of information
+ * Modals focus the user's attention exclusively on one task or piece of information
  * via a window that sits on top of the page content.
  * @see https://dialtone.dialpad.com/components/modal.html
  */
@@ -155,14 +155,13 @@ export default {
   name: 'DtModal',
 
   components: {
-    DtLazyShow,
     DtButton,
     DtText,
     DtIconClose,
     SrOnlyCloseButton,
   },
 
-  mixins: [Modal, ModeMixin],
+  mixins: [ModeMixin],
 
   props: {
     /**
@@ -374,60 +373,12 @@ export default {
       MODAL_KIND_MODIFIERS,
       MODAL_SIZE_MODIFIERS,
       MODAL_BANNER_KINDS,
-      EVENT_KEYNAMES,
       hasSlotContent,
       i18n: new DialtoneLocalization(),
     };
   },
 
   computed: {
-    modalListeners () {
-      return {
-        click: event => {
-          // Handle backdrop clicks for closing modal
-          if (this.closeOnClick && event.target === event.currentTarget) {
-            this.close();
-          } else if (this.show && event.target !== event.currentTarget) {
-            // Ensure focus stays within modal when clicking inside it
-            this.handleModalClick(event);
-          }
-
-          this.$emit('click', event);
-        },
-
-        keydown: event => {
-          switch (event.code) {
-            case EVENT_KEYNAMES.esc:
-            case EVENT_KEYNAMES.escape:
-              this.close();
-              break;
-            case EVENT_KEYNAMES.tab:
-              this.trapFocus(event);
-              break;
-          }
-          this.$emit('keydown', event);
-        },
-
-        'after-enter': async () => {
-          this.$emit('update:show', true);
-          await this.setFocusAfterTransition();
-        },
-
-        focusin: event => {
-          // Ensure focus stays within modal
-          const modalEl = this.$refs.modalRoot?.$el || this.$el;
-          if (this.show && modalEl && !modalEl.contains(event.target)) {
-            event.preventDefault();
-            this.focusFirstElement(modalEl);
-          }
-        },
-      };
-    },
-
-    open () {
-      return `${!this.show}`;
-    },
-
     hasFooterSlot () {
       return !!this.$slots.footer;
     },
@@ -442,59 +393,108 @@ export default {
   },
 
   watch: {
-    show: {
-      handler (isShowing) {
-        if (isShowing) {
-          // Set a reference to the previously-active element, to which we'll return focus on modal close.
-          this.previousActiveElement = document.activeElement;
-          const modalEl = this.$refs.modalRoot?.$el || this.$el;
-          disableRootScrolling(returnFirstEl(modalEl).getRootNode().host);
-        } else {
-          const modalEl = this.$refs.modalRoot?.$el || this.$el;
-          enableRootScrolling(returnFirstEl(modalEl).getRootNode().host);
-          // Modal is being hidden, so return focus to the previously active element before clearing the reference.
-          this.previousActiveElement?.focus();
-          this.previousActiveElement = null;
-        }
-      },
+    show (isShowing) {
+      this.syncDialogState(isShowing);
     },
   },
 
+  mounted () {
+    if (this.show) {
+      this.syncDialogState(true);
+    }
+  },
+
+  beforeUnmount () {
+    const dialogEl = this.$refs.dialogEl;
+    if (dialogEl?.open) {
+      dialogEl.close();
+      enableRootScrolling(this.getScrollRoot());
+    }
+    this.previousActiveElement = null;
+  },
+
   methods: {
+    getScrollRoot () {
+      return returnFirstEl(this.$refs.dialogEl)?.getRootNode()?.host;
+    },
+
+    syncDialogState (isShowing) {
+      const dialogEl = this.$refs.dialogEl;
+      if (!dialogEl) return;
+
+      if (isShowing) {
+        this.previousActiveElement = document.activeElement;
+        if (!dialogEl.open) {
+          dialogEl.showModal();
+        }
+        disableRootScrolling(this.getScrollRoot());
+      } else if (dialogEl.open) {
+        // Leave transition plays via v-show on inner content.
+        // close() is called in onAfterLeave when transition completes.
+        enableRootScrolling(this.getScrollRoot());
+      }
+    },
+
     close () {
       this.$emit('update:show', false);
     },
 
+    onBackdropClick (event) {
+      if (this.closeOnClick && event.target === event.currentTarget) {
+        this.close();
+      }
+      this.$emit('click', event);
+    },
+
+    onKeydown (event) {
+      this.$emit('keydown', event);
+    },
+
+    async onAfterEnter () {
+      this.$emit('update:show', true);
+      await this.setFocusAfterTransition();
+    },
+
+    onAfterLeave () {
+      const dialogEl = this.$refs.dialogEl;
+      if (dialogEl?.open) {
+        dialogEl.close();
+      }
+      this.previousActiveElement?.focus();
+      this.previousActiveElement = null;
+    },
+
+    focusFirstTabbable (container) {
+      const focusable = [...container.querySelectorAll(focusableSelector)];
+      if (!focusable.length) return;
+      let target = focusable[0];
+      // If first focusable is an unchecked radio, prefer the checked radio in the same group.
+      if (target.matches('[type="radio"]:not(:checked)')) {
+        target = focusable.find(el => el.checked && el.name === target.name) || target;
+      }
+      target.focus({ preventScroll: true });
+    },
+
     async setFocusAfterTransition () {
-      const modalEl = this.$refs.modalRoot?.$el || this.$el;
+      const dialogEl = this.$refs.dialogEl;
+      if (!dialogEl) return;
+
+      await this.$nextTick();
+
       if (this.initialFocusElement === 'first') {
-        await this.focusFirstElement(modalEl);
-      } else if (this.initialFocusElement.startsWith('#')) {
-        await this.focusElementById(this.initialFocusElement);
+        this.focusFirstTabbable(dialogEl);
+      } else if (typeof this.initialFocusElement === 'string' && this.initialFocusElement.startsWith('#')) {
+        const el = dialogEl.querySelector(this.initialFocusElement);
+        if (el) {
+          el.focus();
+        } else {
+          // eslint-disable-next-line no-console
+          console.warn('Could not find the element specified in dt-modal prop "initialFocusElement". ' +
+            'Defaulting to focusing the first element.');
+          this.focusFirstTabbable(dialogEl);
+        }
       } else if (this.initialFocusElement instanceof HTMLElement) {
         this.initialFocusElement.focus();
-      }
-    },
-
-    trapFocus (e) {
-      if (this.show) {
-        const modalEl = this.$refs.modalRoot?.$el || this.$el;
-        this.focusTrappedTabPress(e, modalEl);
-      }
-    },
-
-    handleModalClick (event) {
-      // Ensure focus stays within modal when clicking inside it
-      const clickedElement = event.target;
-      const modalEl = this.$refs.modalRoot?.$el || this.$el;
-      const focusableElements = this._getFocusableElements(modalEl);
-
-      // If the clicked element is not focusable, ensure focus stays in modal
-      if (focusableElements.length && !focusableElements.includes(clickedElement)) {
-        // Check if current active element is still within the modal
-        if (!focusableElements.includes(document.activeElement)) {
-          this.focusFirstElement(modalEl);
-        }
       }
     },
   },

--- a/packages/dialtone-vue/components/modal/modal.vue
+++ b/packages/dialtone-vue/components/modal/modal.vue
@@ -13,7 +13,7 @@
         modalClass,
       ]"
       data-qa="dt-modal"
-      :aria-describedby="describedById"
+      :aria-describedby="describedById || undefined"
       :aria-labelledby="labelledById"
       v-bind="modeAttrs"
       @cancel.prevent="close"

--- a/packages/dialtone-vue/components/popover/popover.vue
+++ b/packages/dialtone-vue/components/popover/popover.vue
@@ -796,7 +796,7 @@ export default {
     calculateAnchorZindex () {
       // if a modal is currently active render at modal-element z-index, otherwise at popover z-index
       if (returnFirstEl(this.$el).getRootNode()
-        .querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"]') ||
+        .querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"], .d-modal[open], .d-modal--transparent[open]') ||
         // Special case because we don't have any dialtone drawer component yet. Render at 650 when
         // anchor of popover is within a drawer.
         this.anchorEl?.closest('.d-zi-drawer')) {

--- a/packages/dialtone-vue/components/tooltip/tooltip.test.js
+++ b/packages/dialtone-vue/components/tooltip/tooltip.test.js
@@ -270,10 +270,11 @@ describe('DtTooltip tests', () => {
         expect(tooltipZIndex).toBeGreaterThan(650); // Greater than modal-element z-index
       });
 
-      it('should have higher z-index when modal without aria-hidden is present', async () => {
-        // Create a mock modal element without aria-hidden attribute
-        const modalElement = document.createElement('div');
+      it('should have higher z-index when native dialog modal is open', async () => {
+        // Create a mock native dialog modal with [open] attribute
+        const modalElement = document.createElement('dialog');
         modalElement.className = 'd-modal';
+        modalElement.setAttribute('open', '');
         document.body.appendChild(modalElement);
 
         mockProps = { show: true };

--- a/packages/dialtone-vue/components/tooltip/tooltip.vue
+++ b/packages/dialtone-vue/components/tooltip/tooltip.vue
@@ -399,11 +399,7 @@ export default {
     calculateAnchorZindex () {
       // if a modal is currently active render at modal-element z-index, otherwise at tooltip z-index
       if (returnFirstEl(this.$el).getRootNode()
-        .querySelector(
-          `.d-modal[aria-hidden="false"],
-          .d-modal--transparent[aria-hidden="false"],
-          .d-modal:not([aria-hidden]),
-          .d-modal--transparent:not([aria-hidden])`) ||
+        .querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"], .d-modal[open], .d-modal--transparent[open]') ||
         // Special case because we don't have any dialtone drawer component yet. Render at 651 when
         // anchor of popover is within a drawer.
         returnFirstEl(this.$el).closest('.d-zi-drawer')) {


### PR DESCRIPTION
![2dedbd99-5079-4593-8f2d-228d6b770bbe_text](https://github.com/user-attachments/assets/2a5d14eb-5812-45f8-a8cf-fdb47fecffcf)

## :hammer_and_wrench: Type Of Change

- [x] Refactor

## :book: Jira Ticket

[DLT-3262](https://dialpad.atlassian.net/browse/DLT-3262)

## :book: Description

Replace DtModal's `<dt-lazy-show>` + custom Modal mixin with the native `<dialog>` element.

- `modal.vue` — `<dialog>` with `showModal()`/`close()`, native focus trapping, Escape via `cancel` event
- `modal.less` — Dialog UA resets scoped via `:where(dialog)`, `[open]` selectors alongside `[aria-hidden='false']`
- `modal.test.js` — JSDOM dialog mocks, cancel event test, showModal assertion
- `popover.vue` — One-line z-index query fix to detect `<dialog>` modals

## :bulb: Context

The `<dialog>` element (baseline since 2022) natively provides focus trapping, Escape dismissal, backdrop rendering, and top-layer stacking. This eliminates ~134 LOC of manual focus-trap JS from the Modal mixin.

**Backwards compatible** — the raw HTML CSS pattern (`<div class="d-modal" aria-hidden="false">`) still works unchanged. Dialog-specific CSS is scoped via `:where(dialog).d-modal` so it only applies to `<dialog>` elements. All CSS class names and specificity preserved.

**Non-goals:**
- Pure `<dialog>` implementation (one-element model with `::backdrop`) — blocked by raw HTML backwards compat
- Consolidating focus utilities — deferred to popover migration
- Removing `modal.js` mixin — still used by DtPopover
- Style

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

- Popover migration (DtPopover → Popover API + Floating UI) — separate PR, removes `tippy.js`
- Tooltip migration (DtTooltip → Floating UI) — separate PR
- After both land, `modal.js` mixin and `tippy.js` can be fully removed

[DLT-3262]: https://dialpad.atlassian.net/browse/DLT-3262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ