### PR TITLE
fix(components): DLT-3100 remove rootClass references

### DIFF
--- a/packages/combinator/src/components/combinator.vue
+++ b/packages/combinator/src/components/combinator.vue
@@ -89,14 +89,6 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  rootClass: {
-    type: String,
-    default: '',
-  },
-  headerClass: {
-    type: String,
-    default: '',
-  },
 });
 
 const selectedVariant = ref('default');

--- a/packages/dialtone-vue/common/mixins/input.js
+++ b/packages/dialtone-vue/common/mixins/input.js
@@ -105,16 +105,6 @@ export const InputMixin = {
       type: Object,
       default: () => ({}),
     },
-
-    /**
-     * Additional class name for the root element.
-     * Can accept all of: String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
-     */
-    rootClass: {
-      type: [String, Object, Array],
-      default: '',
-    },
   },
 
   data () {

--- a/packages/dialtone-vue/components/breadcrumbs/breadcrumb.test.js
+++ b/packages/dialtone-vue/components/breadcrumbs/breadcrumb.test.js
@@ -122,15 +122,15 @@ describe('DtBreadcrumb Tests', () => {
   });
 
   describe('Extendability Tests', () => {
-    describe('When a rootClass is provided to a breadcrumb item', () => {
+    describe('When a class is provided to a breadcrumb item', () => {
       it('should include the root class', () => {
         mockProps = {
           breadcrumbs: [{
             url: '#',
             label: 'Root',
-            rootClass: MOCK_ROOT_CLASS,
+            class: MOCK_ROOT_CLASS,
           }],
-        }
+        };
 
         updateWrapper();
 

--- a/packages/dialtone-vue/components/breadcrumbs/breadcrumb_item.vue
+++ b/packages/dialtone-vue/components/breadcrumbs/breadcrumb_item.vue
@@ -2,11 +2,11 @@
   <li
     data-qa="dt-breadcrumb-item"
     :class="[
-      rootClass,
       'd-breadcrumbs__item',
       { [BREADCRUMB_ITEM_SELECTED_MODIFIER]: selected },
+      $attrs.class,
     ]"
-    v-bind="addClassStyleAttrs($attrs)"
+    :style="$attrs.style"
   >
     <dt-link
       :kind="linkKind"
@@ -59,16 +59,6 @@ export default {
      */
     label: {
       type: String,
-      default: '',
-    },
-
-    /**
-     * Additional class name for the root element.
-     * Can accept all of: String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
-     */
-    rootClass: {
-      type: [String, Object, Array],
       default: '',
     },
   },

--- a/packages/dialtone-vue/components/breadcrumbs/breadcrumb_item_default.story.vue
+++ b/packages/dialtone-vue/components/breadcrumbs/breadcrumb_item_default.story.vue
@@ -4,7 +4,7 @@
     :selected="$attrs.selected"
     :label="$attrs.label"
     :href="$attrs.href"
-    :root-class="$attrs.rootClass"
+    :class="$attrs.class"
   />
 </template>
 

--- a/packages/dialtone-vue/components/card/card.vue
+++ b/packages/dialtone-vue/components/card/card.vue
@@ -1,9 +1,7 @@
 <template>
   <div
-    :class="[
-      'd-card',
-      containerClass,
-    ]"
+    :class="['d-card', $attrs.class]"
+    :style="$attrs.style"
     data-qa="dt-card"
   >
     <div
@@ -52,6 +50,9 @@ import { hasSlotContent } from '@/common/utils';
 export default {
   compatConfig: { MODE: 3 },
   name: 'DtCard',
+
+  inheritAttrs: false,
+
   props: {
     /**
      * The maximum height of the card content.
@@ -60,14 +61,6 @@ export default {
     maxHeight: {
       type: String,
       default: null,
-    },
-
-    /**
-     * class for card container.
-     */
-    containerClass: {
-      type: [String, Array, Object],
-      default: '',
     },
 
     /**

--- a/packages/dialtone-vue/components/card/card_default.story.vue
+++ b/packages/dialtone-vue/components/card/card_default.story.vue
@@ -1,7 +1,6 @@
 <template>
   <dt-card
-    class="d-w264"
-    :container-class="$attrs.containerClass"
+    :class="['d-w264', $attrs.class]"
     :header-class="$attrs.headerClass"
     :content-class="$attrs.contentClass"
     :footer-class="$attrs.footerClass"

--- a/packages/dialtone-vue/components/checkbox/checkbox.test.js
+++ b/packages/dialtone-vue/components/checkbox/checkbox.test.js
@@ -503,9 +503,9 @@ describe('DtCheckbox Tests', () => {
       });
     });
 
-    describe('When a rootClass is provided', () => {
+    describe('When a class is provided', () => {
       it('should include the root class', () => {
-        mockProps = { rootClass: MOCK_ROOT_CLASS }
+        mockAttrs = { class: MOCK_ROOT_CLASS };
 
         updateWrapper();
 

--- a/packages/dialtone-vue/components/checkbox/checkbox.vue
+++ b/packages/dialtone-vue/components/checkbox/checkbox.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    :class="rootClass"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="$attrs.class"
+    :style="$attrs.style"
   >
     <label :class="['d-checkbox-group', { 'd-checkbox-group--disabled': internalDisabled }]">
       <div class="d-checkbox__input">

--- a/packages/dialtone-vue/components/checkbox/checkbox_default.story.vue
+++ b/packages/dialtone-vue/components/checkbox/checkbox_default.story.vue
@@ -14,7 +14,7 @@
     :description-child-props="$attrs.descriptionChildProps"
     :indeterminate="$attrs.indeterminate"
     :messages="$attrs.messages"
-    :root-class="$attrs.rootClass"
+    :class="$attrs.class"
     @input="$attrs.onInput"
     @focusin="$attrs.onFocusIn"
     @focusout="$attrs.onFocusOut"

--- a/packages/dialtone-vue/components/input/input.test.js
+++ b/packages/dialtone-vue/components/input/input.test.js
@@ -689,9 +689,9 @@ describe('DtInput tests', () => {
       expect(nativeInput.element.disabled).toBe(true);
     });
 
-    describe('When a rootClass is provided', () => {
+    describe('When a class is provided', () => {
       it('should include the root class', () => {
-        mockProps = { rootClass: MOCK_ROOT_CLASS }
+        mockAttrs = { class: MOCK_ROOT_CLASS };
 
         updateWrapper();
 

--- a/packages/dialtone-vue/components/input/input.vue
+++ b/packages/dialtone-vue/components/input/input.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     ref="container"
-    :class="[rootClass, 'd-input__root', { 'd-input--hidden': hidden }]"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="['d-input__root', { 'd-input--hidden': hidden }, $attrs.class]"
+    :style="$attrs.style"
     data-qa="dt-input"
   >
     <label
@@ -243,16 +243,6 @@ export default {
      * same api as Vue's built-in handling of the class attribute.
      */
     inputWrapperClass: {
-      type: [String, Object, Array],
-      default: '',
-    },
-
-    /**
-     * Additional class name for the root element.
-     * Can accept all of: String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
-     */
-    rootClass: {
       type: [String, Object, Array],
       default: '',
     },

--- a/packages/dialtone-vue/components/input/input_default.story.vue
+++ b/packages/dialtone-vue/components/input/input_default.story.vue
@@ -16,7 +16,7 @@
     :input-class="$attrs.inputClass"
     :retain-warning="$attrs.retainWarning"
     :input-wrapper-class="$attrs.inputWrapperClass"
-    :root-class="$attrs.rootClass"
+    :class="$attrs.class"
     :current-length="$attrs.currentLength"
     :validate="validationConfig"
     @blur="$attrs.onBlur"

--- a/packages/dialtone-vue/components/radio/radio.test.js
+++ b/packages/dialtone-vue/components/radio/radio.test.js
@@ -480,9 +480,9 @@ describe('DtRadio Tests', () => {
   });
 
   describe('Extendability Tests', () => {
-    describe('When a rootClass is provided', () => {
+    describe('When a class is provided', () => {
       it('should include the root class', () => {
-        mockProps = { rootClass: MOCK_ROOT_CLASS }
+        mockAttrs = { class: MOCK_ROOT_CLASS };
 
         updateWrapper();
 

--- a/packages/dialtone-vue/components/radio/radio.vue
+++ b/packages/dialtone-vue/components/radio/radio.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    :class="rootClass"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="$attrs.class"
+    :style="$attrs.style"
   >
     <label :class="['d-radio-group', { 'd-radio-group--disabled': internalDisabled }]">
       <div class="d-radio__input">

--- a/packages/dialtone-vue/components/radio/radio_default.story.vue
+++ b/packages/dialtone-vue/components/radio/radio_default.story.vue
@@ -13,7 +13,7 @@
     :label-child-props="$attrs.labelChildProps"
     :description-child-props="$attrs.descriptionChildProps"
     :messages="$attrs.messages"
-    :root-class="$attrs.rootClass"
+    :class="$attrs.class"
     @input="$attrs.onInput"
     @focusin="$attrs.onFocusIn"
     @focusout="$attrs.onFocusOut"

--- a/packages/dialtone-vue/components/select_menu/select_menu.test.js
+++ b/packages/dialtone-vue/components/select_menu/select_menu.test.js
@@ -470,9 +470,9 @@ describe('DtSelectMenu Tests', () => {
       });
     });
 
-    describe('When a rootClass is provided', () => {
+    describe('When a class is provided', () => {
       it('should include the root class', () => {
-        mockProps = { rootClass: MOCK_ROOT_CLASS }
+        mockAttrs = { class: MOCK_ROOT_CLASS };
 
         updateWrapper();
 

--- a/packages/dialtone-vue/components/select_menu/select_menu.vue
+++ b/packages/dialtone-vue/components/select_menu/select_menu.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    :class="rootClass"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="$attrs.class"
+    :style="$attrs.style"
   >
     <label>
       <div
@@ -46,6 +46,7 @@
           :class="[
             'd-select__input',
             SELECT_STATE_MODIFIERS[state],
+            inputClass,
           ]"
           v-bind="removeClassStyleAttrs($attrs)"
           data-qa="dt-select"
@@ -222,11 +223,11 @@ export default {
     },
 
     /**
-     * Additional class name for the root element.
+     * Additional class name for the select input element.
      * Can accept all of: String, Object, and Array, i.e. has the
      * same api as Vue's built-in handling of the class attribute.
      */
-    rootClass: {
+    inputClass: {
       type: [String, Object, Array],
       default: '',
     },

--- a/packages/dialtone-vue/components/select_menu/select_menu_default.story.vue
+++ b/packages/dialtone-vue/components/select_menu/select_menu_default.story.vue
@@ -18,7 +18,8 @@
     :description-child-props="$attrs.descriptionChildProps"
     :option-child-props="$attrs.optionChildProps"
     :messages-child-props="$attrs.messagesChildProps"
-    :root-class="$attrs.rootClass"
+    :input-class="$attrs.inputClass"
+    :class="$attrs.class"
     @input="$attrs.onInput"
     @change="$attrs.onChange"
   >

--- a/packages/dialtone-vue/components/split_button/split_button.test.js
+++ b/packages/dialtone-vue/components/split_button/split_button.test.js
@@ -295,9 +295,9 @@ describe('DtSplitButton Tests', function () {
   });
 
   describe('Extendability Tests', () => {
-    describe('When a rootClass is provided', () => {
+    describe('When a class is provided', () => {
       it('should include the root class', () => {
-        mockProps = { rootClass: MOCK_ROOT_CLASS }
+        mockAttrs = { class: MOCK_ROOT_CLASS };
 
         updateWrapper();
 

--- a/packages/dialtone-vue/components/split_button/split_button.vue
+++ b/packages/dialtone-vue/components/split_button/split_button.vue
@@ -1,8 +1,8 @@
 <template>
   <span
     data-qa="dt-split-button"
-    :class="[rootClass, 'd-split-btn']"
-    :style="{ width }"
+    :class="['d-split-btn', $attrs.class]"
+    :style="[$attrs.style, { width }]"
   >
     <split-button-alpha
       v-bind="alphaButtonProps"
@@ -280,15 +280,6 @@ export default {
       default: null,
     },
 
-    /**
-     * Additional class name for the root element.
-     * Can accept all of: String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
-     */
-    rootClass: {
-      type: [String, Object, Array],
-      default: '',
-    },
   },
 
   emits: [

--- a/packages/dialtone-vue/components/split_button/split_button_default.story.vue
+++ b/packages/dialtone-vue/components/split_button/split_button_default.story.vue
@@ -15,7 +15,7 @@
     :omega-aria-label="$attrs.omegaAriaLabel"
     :omega-id="$attrs.omegaId"
     :omega-tooltip-text="$attrs.omegaTooltipText"
-    :root-class="$attrs.rootClass"
+    :class="$attrs.class"
     :size="$attrs.size"
     :width="$attrs.width"
     @alpha-clicked="$attrs.onAlphaClicked"

--- a/packages/dialtone-vue/components/toggle/toggle.stories.js
+++ b/packages/dialtone-vue/components/toggle/toggle.stories.js
@@ -12,7 +12,7 @@ export const argsData = {
   modelValue: false,
   onChange: action('change'),
   labelClass: 'd-mr6',
-  wrapperClass: '',
+  class: '',
 };
 
 // Prop Controls

--- a/packages/dialtone-vue/components/toggle/toggle.vue
+++ b/packages/dialtone-vue/components/toggle/toggle.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    :class="['d-toggle-wrapper', wrapperClass]"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="['d-toggle-wrapper', $attrs.class]"
+    :style="$attrs.style"
   >
     <label
       v-if="hasSlotContent($slots.default)"
@@ -112,14 +112,6 @@ export default {
     labelClass: {
       type: [String, Array, Object],
       default: '',
-    },
-
-    /**
-     * Additional styling for the wrapper element
-     */
-    wrapperClass: {
-      type: [String, Array, Object],
-      default: undefined,
     },
 
     /**

--- a/packages/dialtone-vue/components/toggle/toggle_default.story.vue
+++ b/packages/dialtone-vue/components/toggle/toggle_default.story.vue
@@ -5,7 +5,7 @@
     :size="$attrs.size"
     :show-icon="$attrs.showIcon"
     :label-class="$attrs.labelClass"
-    :wrapper-class="$attrs.wrapperClass"
+    :class="$attrs.class"
     :label-child-props="$attrs.labelChildProps"
     :toggle-on-click="$attrs.toggleOnClick"
     @change="$attrs.onChange"

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill.stories.js
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill.stories.js
@@ -9,7 +9,7 @@ const iconsList = getIconNames();
 const args = {
   leftIcon: 'video',
   title: 'This meeting has ended',
-  wrapperClass: 'd-w628',
+  class: 'd-w628',
   buttonClass: 'd-bar24',
 };
 

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :class="['d-recipe-feed-item-pill__border', borderClass, wrapperClass]">
+  <div
+    :class="['d-recipe-feed-item-pill__border', borderClass, $attrs.class]"
+    :style="$attrs.style"
+  >
     <div class="d-recipe-feed-item-pill__wrapper">
       <dt-collapsible :open="expanded">
         <template #anchor>
@@ -92,6 +95,8 @@ export default {
 
   components: { DtItemLayout, DtCollapsible },
 
+  inheritAttrs: false,
+
   props: {
     /**
      * Bolded primary text
@@ -99,14 +104,6 @@ export default {
     title: {
       type: String,
       default: () => '',
-    },
-
-    /**
-     * Additional styling around the pill
-     */
-    wrapperClass: {
-      type: [String, Array, Object],
-      default: '',
     },
 
     /**

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill_default.story.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill_default.story.vue
@@ -1,7 +1,7 @@
 <template>
   <dt-recipe-feed-item-pill
     :title="$attrs.title"
-    :wrapper-class="$attrs.wrapperClass"
+    :class="$attrs.class"
     :button-class="$attrs.buttonClass"
     :border-color="$attrs.borderColor"
     :toggleable="$attrs.toggleable"

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill_variants.story.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill_variants.story.vue
@@ -8,7 +8,7 @@
       <dt-recipe-feed-item-pill
         default-toggled
         title="Ben called you"
-        wrapper-class="d-w628"
+        class="d-w628"
         border-color="ai"
       >
         <template
@@ -67,7 +67,7 @@
       <dt-recipe-feed-item-pill
         title="Missed call from Ben"
         border-color="critical"
-        wrapper-class="d-w628"
+        class="d-w628"
         :toggleable="false"
       >
         <template
@@ -102,7 +102,7 @@
       </h3>
       <dt-recipe-feed-item-pill
         title="Voicemail"
-        wrapper-class="d-w628"
+        class="d-w628"
         :toggleable="false"
       >
         <template
@@ -141,7 +141,7 @@
       <dt-recipe-feed-item-pill
         border-color="ai"
         title="Ben called you"
-        wrapper-class="d-w628"
+        class="d-w628"
         :toggleable="false"
       >
         <template
@@ -182,7 +182,7 @@
       <dt-recipe-feed-item-pill
         title="Ben started a meeting"
         button-class="d-bar24"
-        wrapper-class="d-w628"
+        class="d-w628"
         border-color="ai"
         :default-toggled="true"
       >
@@ -246,7 +246,7 @@
         title="Ben started a meeting"
         border-color="ai"
         button-class="d-bar24"
-        wrapper-class="d-w628"
+        class="d-w628"
         :toggleable="false"
       >
         <template

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -233,7 +233,7 @@
               default-toggled
               title="Ben called you"
               icon-name="phone-outgoing"
-              wrapper-class="d-w628"
+              class="d-w628"
               border-color="ai"
             >
               <template #subtitle>


### PR DESCRIPTION
# Fix prop naming inconsistencies

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [X] Fix


## :book: Jira Ticket

This is just the first part of the ticket. 

https://dialpad.atlassian.net/browse/DLT-3100

## :book: Description

Updated `rootClass` to be only `class` on components:


Component | Changes
-- | --
InputMixin | Removed rootClass prop - classes now passed via $attrs
Input | Removed rootClass prop and usage in template
Checkbox | Removed rootClass usage from template (was from mixin)
Radio | Removed rootClass usage from template (was from mixin)
SelectMenu | Removed rootClass, added inputClass for the select element
Toggle | Removed wrapperClass prop, uses class via $attrs
Card | Removed containerClass prop, added inheritAttrs: false, uses class via $attrs
BreadcrumbItem | Removed rootClass prop
SplitButton | Removed rootClass prop, uses class via $attrs
FeedItemPill | Removed wrapperClass prop, added inheritAttrs: false, uses class via $attrs
Combinator | Removed unused rootClass/headerClass props





**Breaking Changes**

- Any consumer code using rootClass, containerClass, or wrapperClass props will silently fail - the props will be ignored and classes won't be applied
- No runtime errors will occur, but styling will break
- This affects: Input, Checkbox, Radio, SelectMenu, Toggle, Card, BreadcrumbItem, SplitButton, FeedItemPill


Component | Removed Prop | Migration
-- | -- | --
Input | rootClass | Use class attribute directly
Checkbox | rootClass | Use class attribute directly
Radio | rootClass | Use class attribute directly
SelectMenu | rootClass | Use class attribute directly
Toggle | wrapperClass | Use class attribute directly
Card | containerClass | Use class attribute directly
BreadcrumbItem | rootClass | Use class attribute directly
SplitButton | rootClass | Use class attribute directly
FeedItemPill | wrapperClass | Use class attribute directly


New Props (not breaking, but worth noting)


Component | New Prop | Purpose
-- | -- | --
SelectMenu | inputClass | Pass classes to the <select> element




------

Before:

```
<dt-input root-class="my-custom-class" />
<dt-toggle wrapper-class="my-toggle-class" />
<dt-card container-class="my-card-class" />
```

After:

```
<dt-input class="my-custom-class" />
<dt-toggle class="my-toggle-class" />
<dt-card class="my-card-class" />
```


-----

Side note: I also removed `addClassStyleAttrs($attrs)` since seems like it is for Vue2 compat mode which is not needed anymore.
It is still present on some `recipes`, if this get approves I will remove it from there too.

There is still `inputWrapperClass` on `input.vue` and `wrapperClass` on `ListItem`
They are for a nested wrapper element, not the root but ... stil confusing..
on `input.vue` we still have `inputClass` and `inputWrapperClass`. At least we don't have `rootClass` anymore. My goodness

