### PR TITLE
refactor(components): DLT-3100 remove rootClass references

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ClampedTableWrapper.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ClampedTableWrapper.vue
@@ -6,7 +6,7 @@
         aria-label="Search table"
         placeholder="Search table"
         type="search"
-        root-class="d-w-500"
+        class="d-w-500"
         @keydown.escape="handleEscapeKey"
       >
         <template #startIcon="{ iconSize }">
@@ -29,7 +29,7 @@
           </dt-stack>
         </template>
       </dt-input>
-      <dt-toggle v-if="hasDeprecatedRows" v-model="hideDeprecated" wrapper-class="d-g-100" size="sm">
+      <dt-toggle v-if="hasDeprecatedRows" v-model="hideDeprecated" class="d-g-100" size="sm">
         <dt-text kind="label" size="xs" strength="normal">
           Hide deprecated
         </dt-text>

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -118,7 +118,7 @@ This style's use should be rare. When in doubt, use the [default button style](#
 
 ```vue demo
 <dt-stack gap="100">
-  <dt-toggle v-model="isDisabled" :size="200" wrapperClass="d-g-100 d-m-auto d-pbe-100">Disabled</dt-toggle>
+  <dt-toggle v-model="isDisabled" :size="200" class="d-g-100 d-m-auto d-pbe-100">Disabled</dt-toggle>
   <dt-stack gap="100">
     <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
       <dt-button :disabled="isDisabled"> Place Call </dt-button>
@@ -232,7 +232,7 @@ Use the [v-dt-mode directive](mode-island.html#inverting) in place of `kind="inv
 
 ```vue demo
 <dt-stack gap="100">
-  <dt-toggle v-model="isInverted" :size="200" wrapperClass="d-g-100 d-m-auto d-pbe-100">Inverted</dt-toggle>
+  <dt-toggle v-model="isInverted" :size="200" class="d-g-100 d-m-auto d-pbe-100">Inverted</dt-toggle>
   <dt-stack gap="100">
     <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
       <dt-button v-dt-mode:invert="isInverted"> Place Call </dt-button>
@@ -657,7 +657,7 @@ The width of the button remains determined by the length of the label, which is 
 
 ```vue demo
 <dt-stack gap="200" align="center">
-  <dt-toggle :size="200" v-model="loading" wrapperClass="d-g-100">
+  <dt-toggle :size="200" v-model="loading" class="d-g-100">
     Loading
   </dt-toggle>
   <dt-stack

--- a/apps/dialtone-documentation/docs/components/toggle.md
+++ b/apps/dialtone-documentation/docs/components/toggle.md
@@ -43,13 +43,13 @@ The Toggle component acts as a way to allow the User to switch between two mutua
 
 ```vue demo
 <dt-stack as="fieldset" gap="100">
-  <dt-toggle wrapper-class="d-g-200">Unchecked Toggle</dt-toggle>
-  <dt-toggle :model-value="true" wrapper-class="d-g-200">Checked Toggle</dt-toggle>
-  <dt-toggle disabled wrapper-class="d-g-200">Unchecked Disabled</dt-toggle>
-  <dt-toggle :model-value="true" disabled wrapper-class="d-g-200">Checked Disabled</dt-toggle>
-  <dt-toggle :model-value="mixed" wrapper-class="d-g-200">Indeterminate Toggle</dt-toggle>
-  <dt-toggle :model-value="mixed" wrapper-class="d-g-200" disabled>Indeterminate Disabled</dt-toggle>
-  <dt-toggle wrapper-class="d-g-200" :show-icon="false">Without icon</dt-toggle>
+  <dt-toggle class="d-g-200">Unchecked Toggle</dt-toggle>
+  <dt-toggle :model-value="true" class="d-g-200">Checked Toggle</dt-toggle>
+  <dt-toggle disabled class="d-g-200">Unchecked Disabled</dt-toggle>
+  <dt-toggle :model-value="true" disabled class="d-g-200">Checked Disabled</dt-toggle>
+  <dt-toggle :model-value="mixed" class="d-g-200">Indeterminate Toggle</dt-toggle>
+  <dt-toggle :model-value="mixed" class="d-g-200" disabled>Indeterminate Disabled</dt-toggle>
+  <dt-toggle class="d-g-200" :show-icon="false">Without icon</dt-toggle>
 </dt-stack>
 ```
 
@@ -57,15 +57,15 @@ The Toggle component acts as a way to allow the User to switch between two mutua
 
 ```vue demo
 <dt-stack as="fieldset" gap="100">
-  <dt-toggle :size="200" wrapper-class="d-g-200">Small size</dt-toggle>
-  <dt-toggle wrapper-class="d-g-200">Default size</dt-toggle>
+  <dt-toggle :size="200" class="d-g-200">Small size</dt-toggle>
+  <dt-toggle class="d-g-200">Default size</dt-toggle>
 </dt-stack>
 ```
 
 ### With v-model
 
 ```vue demo
-<dt-toggle v-model="checked" wrapper-class="d-g-200">Toggle</dt-toggle>
+<dt-toggle v-model="checked" class="d-g-200">Toggle</dt-toggle>
 ```
 
 ## Vue API

--- a/packages/combinator/.github/documentation/USAGE.md
+++ b/packages/combinator/.github/documentation/USAGE.md
@@ -216,6 +216,6 @@ of the combinator.
 <dtc-combinator
   ...
   header-class="d-py32"
-  root-class="d-px32"
+  class="d-px32"
 />
 ```

--- a/packages/combinator/src/components/combinator.vue
+++ b/packages/combinator/src/components/combinator.vue
@@ -217,14 +217,6 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  rootClass: {
-    type: String,
-    default: '',
-  },
-  headerClass: {
-    type: String,
-    default: '',
-  },
   devMode: {
     type: Boolean,
     default: false,

--- a/packages/combinator/src/components/controls/control_boolean.vue
+++ b/packages/combinator/src/components/controls/control_boolean.vue
@@ -5,7 +5,7 @@
       :disabled="disabled"
       label-class="d-label--sm d-fc-secondary"
       :size="200"
-      wrapper-class="d-jc-space-between"
+      class="d-jc-space-between"
       data-qa="dtc-control-boolean-input"
       @change="e => emit(VALUE_UPDATE_EVENT, e)"
     >

--- a/packages/combinator/src/components/option_bar/option_bar.vue
+++ b/packages/combinator/src/components/option_bar/option_bar.vue
@@ -46,7 +46,7 @@
           type="search"
           placeholder="Search"
           :size="100"
-          root-class="d-w100p d-mbs-25"
+          class="d-w100p d-mbs-25"
         >
           <template #startIcon="{ iconSize }">
             <dt-icon

--- a/packages/combinator/src/components/option_bar/option_bar_control.vue
+++ b/packages/combinator/src/components/option_bar/option_bar_control.vue
@@ -69,7 +69,7 @@
         type="textarea"
         :size="100"
         spellcheck="false"
-        root-class="d-mbs-75"
+        class="d-mbs-75"
       />
     </component>
   </div>

--- a/packages/combinator/src/variants/variants_card.js
+++ b/packages/combinator/src/variants/variants_card.js
@@ -29,7 +29,7 @@ export default {
   },
   'Targeted styling': {
     props: {
-      containerClass: { initialValue: 'd-bar0 d-baw0' },
+      class: { initialValue: 'd-bar0 d-baw0' },
       contentClass: { initialValue: 'd-p-100 d-by d-bgc-critical' },
       headerClass: { initialValue: 'd-p-100 d-bgc-info' },
       footerClass: { initialValue: 'd-p-100 d-bgc-warning' },

--- a/packages/combinator/src/variants/variants_toggle.js
+++ b/packages/combinator/src/variants/variants_toggle.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-len */
-
 export default {
   default: {
     slots: {
@@ -8,7 +6,7 @@ export default {
       },
     },
     props: {
-      wrapperClass: { initialValue: 'd-g-200' },
+      class: { initialValue: 'd-g-200' },
     },
   },
 
@@ -23,7 +21,7 @@ export default {
 
   'with space between': {
     props: {
-      wrapperClass: { initialValue: 'd-g-200 d-w-200 d-jc-space-between' },
+      class: { initialValue: 'd-g-200 d-w-200 d-jc-space-between' },
     },
     slots: {
       default: { initialValue: 'Label' },

--- a/packages/dialtone-vue/common/mixins/input.js
+++ b/packages/dialtone-vue/common/mixins/input.js
@@ -105,16 +105,6 @@ export const InputMixin = {
       type: Object,
       default: () => ({}),
     },
-
-    /**
-     * Additional class name for the root element.
-     * Can accept all of: String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
-     */
-    rootClass: {
-      type: [String, Object, Array],
-      default: '',
-    },
   },
 
   data () {

--- a/packages/dialtone-vue/common/utils/index.js
+++ b/packages/dialtone-vue/common/utils/index.js
@@ -4,9 +4,6 @@ import {
   VALIDATION_MESSAGE_TYPES,
 } from '../constants/index.js';
 import {
-  configVue2StyleClassAttrs,
-} from '../config';
-import {
   h,
   Comment,
   Text,
@@ -250,18 +247,6 @@ export function removeClassStyleAttrs (attrs) {
   return Object.fromEntries(listeners);
 }
 
-/**
-  This should be applied to the root element on components using inheritAttrs: false.
-  This will add the class and style attributes back to the root element if configVue2StyleClassAttrs
-  is enabled.
-*/
-export function addClassStyleAttrs (attrs) {
-  if (!configVue2StyleClassAttrs) return {};
-  return {
-    class: attrs.class,
-    style: attrs.style,
-  };
-}
 
 /*
 * Set's a global timer to debounce the execution of a function.
@@ -532,7 +517,6 @@ export default {
   extractVueListeners,
   extractNonListeners,
   removeClassStyleAttrs,
-  addClassStyleAttrs,
   returnFirstEl,
   debounce,
   isOutOfViewPort,

--- a/packages/dialtone-vue/common/utils/index.js
+++ b/packages/dialtone-vue/common/utils/index.js
@@ -239,20 +239,12 @@ export const returnFirstEl = (el) => {
 };
 
 /**
-  Only will apply changes if the config option configVue2StyleClassAttrs is set to true. It is false by default.
-
-  Removes the class and style attributes from the $attrs. This is useful for vue 2 to vue 3 migration
-  purposes so we don't cause breaking changes due to INSTANCE_ATTRS_CLASS_STYLE
-  https://v3-migration.vuejs.org/breaking-changes/attrs-includes-class-style
-
-  Remove the class and style attributes from the v-bind like so so v-bind="removeClassStyleAttrs($attrs)",
-  and then apply them to the root element manually via:
-
-  :class="$attrs.class"
-  :style="$attrs.style"
+  In Vue 3, $attrs includes class and style attributes, but when using inheritAttrs: false
+  and manually binding :class="$attrs.class" and :style="$attrs.style" to the root element,
+  we need to prevent class/style from being passed to inner elements via v-bind="removeClassStyleAttrs($attrs)".
+  This function removes class and style attributes from the attrs object.
 */
 export function removeClassStyleAttrs (attrs) {
-  if (!configVue2StyleClassAttrs) return attrs;
   const listeners = Object.entries(attrs)
     .filter(([key]) => !['class', 'style'].includes(key));
   return Object.fromEntries(listeners);

--- a/packages/dialtone-vue/components/avatar/avatar.vue
+++ b/packages/dialtone-vue/components/avatar/avatar.vue
@@ -109,8 +109,6 @@ export default {
   name: 'DtAvatar',
   components: { DtPresence },
 
-  inheritAttrs: false,
-
   props: {
     /**
      * Id of the avatar content wrapper element
@@ -397,7 +395,6 @@ export default {
     avatarClasses () {
       return [
         'd-avatar',
-        this.$attrs.class,
         AVATAR_SIZE_MODIFIERS[this.validatedSize],
         this.avatarClass,
         {
@@ -416,9 +413,7 @@ export default {
      * Compute inline styles for fallback color in browsers that don't support oklch()
      */
     avatarStyles () {
-      // $attrs.style can be object, string, or array — normalize to an array for merging
-      const attrStyle = this.$attrs.style;
-      const baseStyles = attrStyle != null ? [].concat(attrStyle) : [];
+      const baseStyles = [];
 
       // Only compute hex fallback for browsers that don't support oklch()
       if (!supportsOklch && !this.isIconType && this.computedFamily && this.computedVariant !== undefined) {

--- a/packages/dialtone-vue/components/breadcrumbs/breadcrumb.test.js
+++ b/packages/dialtone-vue/components/breadcrumbs/breadcrumb.test.js
@@ -122,13 +122,13 @@ describe('DtBreadcrumb Tests', () => {
   });
 
   describe('Extendability Tests', () => {
-    describe('When a rootClass is provided to a breadcrumb item', () => {
-      it('should include the root class', () => {
+    describe('When a class is provided to a breadcrumb item', () => {
+      it('should include the class', () => {
         mockProps = {
           breadcrumbs: [{
             url: '#',
             label: 'Root',
-            rootClass: MOCK_ROOT_CLASS,
+            class: MOCK_ROOT_CLASS,
           }],
         }
 

--- a/packages/dialtone-vue/components/breadcrumbs/breadcrumb_item.vue
+++ b/packages/dialtone-vue/components/breadcrumbs/breadcrumb_item.vue
@@ -2,11 +2,11 @@
   <li
     data-qa="dt-breadcrumb-item"
     :class="[
-      rootClass,
       'd-breadcrumbs__item',
       { [BREADCRUMB_ITEM_SELECTED_MODIFIER]: selected },
+      $attrs.class,
     ]"
-    v-bind="addClassStyleAttrs($attrs)"
+    :style="$attrs.style"
   >
     <dt-link
       :kind="linkKind"
@@ -27,7 +27,7 @@
 
 <script>
 import { BREADCRUMB_ITEM_SELECTED_MODIFIER } from './breadcrumbs_constants';
-import { removeClassStyleAttrs, addClassStyleAttrs } from '@/common/utils';
+import { removeClassStyleAttrs } from '@/common/utils';
 import { DtLink, MUTED } from '@/components/link';
 
 export default {
@@ -65,16 +65,6 @@ export default {
       type: String,
       default: '',
     },
-
-    /**
-     * Additional class name for the root element.
-     * Can accept all of: String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
-     */
-    rootClass: {
-      type: [String, Object, Array],
-      default: '',
-    },
   },
 
   data () {
@@ -100,7 +90,6 @@ export default {
 
   methods: {
     removeClassStyleAttrs,
-    addClassStyleAttrs,
   },
 };
 </script>

--- a/packages/dialtone-vue/components/breadcrumbs/breadcrumb_item_default.story.vue
+++ b/packages/dialtone-vue/components/breadcrumbs/breadcrumb_item_default.story.vue
@@ -4,7 +4,7 @@
     :selected="$attrs.selected"
     :label="$attrs.label"
     :href="$attrs.href"
-    :root-class="$attrs.rootClass"
+    :class="$attrs.class"
   />
 </template>
 

--- a/packages/dialtone-vue/components/card/card.vue
+++ b/packages/dialtone-vue/components/card/card.vue
@@ -1,7 +1,6 @@
 <template>
   <div
-    :class="['d-card', $attrs.class]"
-    :style="$attrs.style"
+    class="d-card"
     data-qa="dt-card"
   >
     <div
@@ -51,7 +50,6 @@ export default {
   compatConfig: { MODE: 3 },
   name: 'DtCard',
 
-  inheritAttrs: false,
 
   props: {
     /**

--- a/packages/dialtone-vue/components/card/card.vue
+++ b/packages/dialtone-vue/components/card/card.vue
@@ -1,9 +1,7 @@
 <template>
   <div
-    :class="[
-      'd-card',
-      containerClass,
-    ]"
+    :class="['d-card', $attrs.class]"
+    :style="$attrs.style"
     data-qa="dt-card"
   >
     <div
@@ -52,6 +50,9 @@ import { hasSlotContent } from '@/common/utils';
 export default {
   compatConfig: { MODE: 3 },
   name: 'DtCard',
+
+  inheritAttrs: false,
+
   props: {
     /**
      * The maximum height of the card content.
@@ -60,14 +61,6 @@ export default {
     maxHeight: {
       type: String,
       default: null,
-    },
-
-    /**
-     * class for card container.
-     */
-    containerClass: {
-      type: [String, Array, Object],
-      default: '',
     },
 
     /**

--- a/packages/dialtone-vue/components/card/card_default.story.vue
+++ b/packages/dialtone-vue/components/card/card_default.story.vue
@@ -1,7 +1,6 @@
 <template>
   <dt-card
-    class="d-w-400"
-    :container-class="$attrs.containerClass"
+    :class="['d-w264', $attrs.class]"
     :header-class="$attrs.headerClass"
     :content-class="$attrs.contentClass"
     :footer-class="$attrs.footerClass"

--- a/packages/dialtone-vue/components/checkbox/checkbox.test.js
+++ b/packages/dialtone-vue/components/checkbox/checkbox.test.js
@@ -580,9 +580,9 @@ describe('DtCheckbox Tests', () => {
       });
     });
 
-    describe('When a rootClass is provided', () => {
-      it('should include the root class', () => {
-        mockProps = { rootClass: MOCK_ROOT_CLASS }
+    describe('When a class is provided', () => {
+      it('should include the class', () => {
+        mockAttrs = { class: MOCK_ROOT_CLASS }
 
         updateWrapper();
 

--- a/packages/dialtone-vue/components/checkbox/checkbox.vue
+++ b/packages/dialtone-vue/components/checkbox/checkbox.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    :class="rootClass"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="$attrs.class"
+    :style="$attrs.style"
   >
     <label :class="['d-checkbox-group', { 'd-checkbox-group--disabled': internalDisabled }]">
       <div class="d-checkbox__input">
@@ -72,7 +72,7 @@ import {
   GroupableMixin,
   MessagesMixin,
 } from '@/common/mixins/input';
-import { removeClassStyleAttrs, addClassStyleAttrs } from '@/common/utils';
+import { removeClassStyleAttrs } from '@/common/utils';
 import { CHECKBOX_INPUT_VALIDATION_CLASSES } from './checkbox_constants';
 import { DtValidationMessages } from '../validation_messages';
 import { DtText, TEXT_SIZE_MODIFIERS, TEXT_STRENGTH_MODIFIERS } from '@/components/text';
@@ -214,7 +214,6 @@ export default {
 
   methods: {
     removeClassStyleAttrs,
-    addClassStyleAttrs,
 
     emitValue (target) {
       let { value, checked } = target;

--- a/packages/dialtone-vue/components/checkbox/checkbox_default.story.vue
+++ b/packages/dialtone-vue/components/checkbox/checkbox_default.story.vue
@@ -14,7 +14,7 @@
     :description-child-props="$attrs.descriptionChildProps"
     :indeterminate="$attrs.indeterminate"
     :messages="$attrs.messages"
-    :root-class="$attrs.rootClass"
+    :class="$attrs.class"
     @input="$attrs.onInput"
     @focusin="$attrs.onFocusIn"
     @focusout="$attrs.onFocusOut"

--- a/packages/dialtone-vue/components/filter_pill/filter_pill.vue
+++ b/packages/dialtone-vue/components/filter_pill/filter_pill.vue
@@ -231,8 +231,6 @@ export default {
     DtStack,
   },
 
-  inheritAttrs: false,
-
   props: {
     /**
      * When true, uses DtDropdown instead of DtPopover as the overlay.

--- a/packages/dialtone-vue/components/input/input.stories.js
+++ b/packages/dialtone-vue/components/input/input.stories.js
@@ -146,9 +146,6 @@ export const argTypesData = {
   inputWrapperClass: {
     control: 'text',
   },
-  rootClass: {
-    control: 'text',
-  },
 
   // HTML attributes
   placeholder: {

--- a/packages/dialtone-vue/components/input/input.test.js
+++ b/packages/dialtone-vue/components/input/input.test.js
@@ -844,9 +844,9 @@ describe('DtInput tests', () => {
       expect(nativeInput.element.disabled).toBe(true);
     });
 
-    describe('When a rootClass is provided', () => {
-      it('should include the root class', () => {
-        mockProps = { rootClass: MOCK_ROOT_CLASS }
+    describe('When a class is provided', () => {
+      it('should include the class', () => {
+        mockAttrs = { class: MOCK_ROOT_CLASS }
 
         updateWrapper();
 

--- a/packages/dialtone-vue/components/input/input.vue
+++ b/packages/dialtone-vue/components/input/input.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     ref="container"
-    :class="[rootClass, 'd-input__root', { 'd-input--hidden': hidden }]"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="['d-input__root', { 'd-input--hidden': hidden }, $attrs.class]"
+    :style="$attrs.style"
     data-qa="dt-input"
   >
     <label
@@ -152,7 +152,6 @@ import {
   getValidationState,
   hasSlotContent,
   removeClassStyleAttrs,
-  addClassStyleAttrs,
 } from '@/common/utils';
 import { DtValidationMessages } from '@/components/validation_messages';
 import { DtText, TEXT_SIZE_MODIFIERS, TEXT_STRENGTH_MODIFIERS } from '@/components/text';
@@ -272,16 +271,6 @@ export default {
      * same api as Vue's built-in handling of the class attribute.
      */
     inputWrapperClass: {
-      type: [String, Object, Array],
-      default: '',
-    },
-
-    /**
-     * Additional class name for the root element.
-     * Can accept all of: String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
-     */
-    rootClass: {
       type: [String, Object, Array],
       default: '',
     },
@@ -651,7 +640,6 @@ export default {
 
   methods: {
     removeClassStyleAttrs,
-    addClassStyleAttrs,
     inputClasses () {
       return [
         'd-input__input',

--- a/packages/dialtone-vue/components/input/input_default.story.vue
+++ b/packages/dialtone-vue/components/input/input_default.story.vue
@@ -16,7 +16,7 @@
     :input-class="$attrs.inputClass"
     :retain-warning="$attrs.retainWarning"
     :input-wrapper-class="$attrs.inputWrapperClass"
-    :root-class="$attrs.rootClass"
+    :class="$attrs.class"
     :current-length="$attrs.currentLength"
     :label-visible="$attrs.labelVisible"
     :hidden="$attrs.hidden"

--- a/packages/dialtone-vue/components/mode_island/mode_island.vue
+++ b/packages/dialtone-vue/components/mode_island/mode_island.vue
@@ -2,7 +2,6 @@
   <component
     :is="as"
     class="d-mode-island"
-    v-bind="$attrs"
     :data-dt-mode="computedMode"
     :data-mode-island-inverted="invertedAttribute"
     :data-dt-contrast="currentContrast"
@@ -38,8 +37,6 @@ export default {
       default: null,
     },
   },
-
-  inheritAttrs: false,
 
   props: {
     /**

--- a/packages/dialtone-vue/components/motion_text/motion_text.vue
+++ b/packages/dialtone-vue/components/motion_text/motion_text.vue
@@ -80,8 +80,6 @@ export default {
   compatConfig: { MODE: 3 },
   name: 'DtMotionText',
 
-  inheritAttrs: false,
-
   props: {
     /**
      * The text content to animate.
@@ -235,7 +233,6 @@ export default {
           'd-motion-text--paused': this.isPaused,
           'd-motion-text--looped': this.isLooped,
         },
-        this.$attrs.class,
       ];
     },
   },

--- a/packages/dialtone-vue/components/radio/radio.test.js
+++ b/packages/dialtone-vue/components/radio/radio.test.js
@@ -557,9 +557,9 @@ describe('DtRadio Tests', () => {
   });
 
   describe('Extendability Tests', () => {
-    describe('When a rootClass is provided', () => {
-      it('should include the root class', () => {
-        mockProps = { rootClass: MOCK_ROOT_CLASS }
+    describe('When a class is provided', () => {
+      it('should include the class', () => {
+        mockAttrs = { class: MOCK_ROOT_CLASS }
 
         updateWrapper();
 

--- a/packages/dialtone-vue/components/radio/radio.vue
+++ b/packages/dialtone-vue/components/radio/radio.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    :class="rootClass"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="$attrs.class"
+    :style="$attrs.style"
   >
     <label :class="['d-radio-group', { 'd-radio-group--disabled': internalDisabled }]">
       <div class="d-radio__input">
@@ -73,7 +73,7 @@ import {
 import { RADIO_INPUT_VALIDATION_CLASSES } from './radio_constants';
 import { DtValidationMessages } from '../validation_messages';
 import { DtText, TEXT_SIZE_MODIFIERS, TEXT_STRENGTH_MODIFIERS } from '@/components/text';
-import { hasSlotContent, removeClassStyleAttrs, addClassStyleAttrs } from '@/common/utils';
+import { hasSlotContent, removeClassStyleAttrs } from '@/common/utils';
 
 /**
  * Radios are control elements that allow the user to make a single selection.
@@ -234,7 +234,6 @@ export default {
 
   methods: {
     removeClassStyleAttrs,
-    addClassStyleAttrs,
 
     runValidations () {
       if (!this.hasLabelContent && !this.$attrs['aria-label']) {

--- a/packages/dialtone-vue/components/radio/radio_default.story.vue
+++ b/packages/dialtone-vue/components/radio/radio_default.story.vue
@@ -13,7 +13,7 @@
     :label-child-props="$attrs.labelChildProps"
     :description-child-props="$attrs.descriptionChildProps"
     :messages="$attrs.messages"
-    :root-class="$attrs.rootClass"
+    :class="$attrs.class"
     @input="$attrs.onInput"
     @focusin="$attrs.onFocusIn"
     @focusout="$attrs.onFocusOut"

--- a/packages/dialtone-vue/components/rich_text_editor/extensions/variable/VariableComponent.vue
+++ b/packages/dialtone-vue/components/rich_text_editor/extensions/variable/VariableComponent.vue
@@ -94,7 +94,7 @@ export default {
       <template #content="{ close }">
         <dt-input
           v-model="altText"
-          root-class="d-p-100 d-w332"
+          class="d-p-100 d-w332"
           :label="i18n.$t('DIALTONE_EDITOR_VARIABLE_LABEL')"
           :placeholder="placeholderText"
           :validate="{

--- a/packages/dialtone-vue/components/select_menu/select_menu.test.js
+++ b/packages/dialtone-vue/components/select_menu/select_menu.test.js
@@ -549,9 +549,9 @@ describe('DtSelectMenu Tests', () => {
       });
     });
 
-    describe('When a rootClass is provided', () => {
-      it('should include the root class', () => {
-        mockProps = { rootClass: MOCK_ROOT_CLASS }
+    describe('When a class is provided', () => {
+      it('should include the class', () => {
+        mockAttrs = { class: MOCK_ROOT_CLASS }
 
         updateWrapper();
 

--- a/packages/dialtone-vue/components/select_menu/select_menu.vue
+++ b/packages/dialtone-vue/components/select_menu/select_menu.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    :class="rootClass"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="$attrs.class"
+    :style="$attrs.style"
   >
     <label>
       <dt-text
@@ -231,16 +231,6 @@ export default {
     disabled: {
       type: Boolean,
       default: false,
-    },
-
-    /**
-     * Additional class name for the root element.
-     * Can accept all of: String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
-     */
-    rootClass: {
-      type: [String, Object, Array],
-      default: '',
     },
 
     /**

--- a/packages/dialtone-vue/components/select_menu/select_menu.vue
+++ b/packages/dialtone-vue/components/select_menu/select_menu.vue
@@ -96,7 +96,6 @@ import {
   getValidationState,
   hasSlotContent,
   removeClassStyleAttrs,
-  addClassStyleAttrs,
 } from '@/common/utils';
 import { MessagesMixin } from '@/common/mixins/input';
 import { optionsValidator } from './select_menu_validators.js';
@@ -363,7 +362,6 @@ export default {
 
   methods: {
     removeClassStyleAttrs,
-    addClassStyleAttrs,
     emitValue (value, event) {
       this.$emit('update:modelValue', value, event);
       this.$emit('input', value, event);

--- a/packages/dialtone-vue/components/select_menu/select_menu_default.story.vue
+++ b/packages/dialtone-vue/components/select_menu/select_menu_default.story.vue
@@ -18,7 +18,7 @@
     :description-child-props="$attrs.descriptionChildProps"
     :option-child-props="$attrs.optionChildProps"
     :messages-child-props="$attrs.messagesChildProps"
-    :root-class="$attrs.rootClass"
+    :class="$attrs.class"
     @input="$attrs.onInput"
     @change="$attrs.onChange"
   >

--- a/packages/dialtone-vue/components/split_button/split_button.test.js
+++ b/packages/dialtone-vue/components/split_button/split_button.test.js
@@ -657,9 +657,9 @@ describe('DtSplitButton Tests', function () {
   });
 
   describe('Extendability Tests', () => {
-    describe('When a rootClass is provided', () => {
-      it('should include the root class', () => {
-        mockProps = { rootClass: MOCK_ROOT_CLASS }
+    describe('When a class is provided', () => {
+      it('should include the class', () => {
+        mockAttrs = { class: MOCK_ROOT_CLASS }
 
         updateWrapper();
 

--- a/packages/dialtone-vue/components/split_button/split_button.vue
+++ b/packages/dialtone-vue/components/split_button/split_button.vue
@@ -1,8 +1,8 @@
 <template>
   <span
     data-qa="dt-split-button"
-    :class="[rootClass, 'd-split-btn', { 'd-split-btn--no-divider': !showDivider && importance === 'clear' }]"
-    :style="{ width }"
+    :class="['d-split-btn', { 'd-split-btn--no-divider': !showDivider && importance === 'clear' }, $attrs.class]"
+    :style="[$attrs.style, { width }]"
   >
     <split-button-start
       v-bind="startButtonProps"
@@ -497,16 +497,6 @@ export default {
     showDivider: {
       type: Boolean,
       default: true,
-    },
-
-    /**
-     * Additional class name for the root element.
-     * Can accept all of: String, Object, and Array, i.e. has the
-     * same api as Vue's built-in handling of the class attribute.
-     */
-    rootClass: {
-      type: [String, Object, Array],
-      default: '',
     },
 
     /**

--- a/packages/dialtone-vue/components/split_button/split_button_default.story.vue
+++ b/packages/dialtone-vue/components/split_button/split_button_default.story.vue
@@ -15,7 +15,7 @@
     :end-aria-label="$attrs.endAriaLabel"
     :end-id="$attrs.endId"
     :end-tooltip-text="$attrs.endTooltipText"
-    :root-class="$attrs.rootClass"
+    :class="$attrs.class"
     :size="$attrs.size"
     :start-to="$attrs.startTo"
     :start-replace="$attrs.startReplace"

--- a/packages/dialtone-vue/components/toggle/toggle.stories.js
+++ b/packages/dialtone-vue/components/toggle/toggle.stories.js
@@ -12,7 +12,7 @@ export const argsData = {
   modelValue: false,
   onChange: action('change'),
   labelClass: 'd-mie-75',
-  wrapperClass: '',
+  class: '',
 };
 
 // Prop Controls

--- a/packages/dialtone-vue/components/toggle/toggle.vue
+++ b/packages/dialtone-vue/components/toggle/toggle.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    :class="['d-toggle-wrapper', wrapperClass]"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="['d-toggle-wrapper', $attrs.class]"
+    :style="$attrs.style"
   >
     <label
       v-if="labelVisible && hasSlotContent($slots.default)"
@@ -32,7 +32,7 @@
 </template>
 
 <script>
-import { getUniqueString, hasSlotContent, removeClassStyleAttrs, addClassStyleAttrs } from '@/common/utils';
+import { getUniqueString, hasSlotContent, removeClassStyleAttrs } from '@/common/utils';
 import { TOGGLE_CHECKED_VALUES, TOGGLE_SIZE_MODIFIERS } from '@/components/toggle/toggle_constants';
 
 /**
@@ -123,14 +123,6 @@ export default {
     },
 
     /**
-     * Additional styling for the wrapper element
-     */
-    wrapperClass: {
-      type: [String, Array, Object],
-      default: undefined,
-    },
-
-    /**
      * A set of props that are passed into the label container
      */
     labelChildProps: {
@@ -206,7 +198,6 @@ export default {
   },
 
   methods: {
-    addClassStyleAttrs,
     toggleCheckedValue () {
       this.$emit('update:modelValue', !this.internalChecked);
       this.$emit('change', !this.internalChecked);

--- a/packages/dialtone-vue/components/toggle/toggle_default.story.vue
+++ b/packages/dialtone-vue/components/toggle/toggle_default.story.vue
@@ -5,7 +5,7 @@
     :size="$attrs.size"
     :show-icon="$attrs.showIcon"
     :label-class="$attrs.labelClass"
-    :wrapper-class="$attrs.wrapperClass"
+    :class="$attrs.class"
     :label-child-props="$attrs.labelChildProps"
     :toggle-on-click="$attrs.toggleOnClick"
     @change="$attrs.onChange"

--- a/packages/dialtone-vue/recipes/buttons/callbar_button/callbar_button.vue
+++ b/packages/dialtone-vue/recipes/buttons/callbar_button/callbar_button.vue
@@ -2,7 +2,8 @@
   <dt-tooltip
     :id="id"
     :inverted="invertedTooltip"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="$attrs.class"
+    :style="$attrs.style"
     :delay="tooltipDelay"
     :show="showTooltip"
     :offset="[0, 24]"
@@ -48,7 +49,7 @@
 import { CALLBAR_BUTTON_VALID_WIDTH_SIZE } from './callbar_button_constants';
 import { DtButton } from '@/components/button';
 import { DtTooltip } from '@/components/tooltip';
-import utils, { extractVueListeners, removeClassStyleAttrs, addClassStyleAttrs } from '@/common/utils';
+import utils, { extractVueListeners, removeClassStyleAttrs } from '@/common/utils';
 
 export default {
   compatConfig: { MODE: 3 },
@@ -251,7 +252,6 @@ export default {
 
   methods: {
     removeClassStyleAttrs,
-    addClassStyleAttrs,
   },
 };
 </script>

--- a/packages/dialtone-vue/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
+++ b/packages/dialtone-vue/recipes/buttons/callbar_button_with_dropdown/callbar_button_with_dropdown.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    class="dt-recipe--callbar-button-with-dropdown"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="['dt-recipe--callbar-button-with-dropdown', $attrs.class]"
+    :style="$attrs.style"
   >
     <dt-recipe-callbar-button
       :active="active"
@@ -83,7 +83,7 @@ import { DtButton } from '@/components/button';
 import { DtDropdown } from '@/components/dropdown';
 import { DtIconChevronUp } from '@dialpad/dialtone-icons/vue';
 import { DtRecipeCallbarButton, CALLBAR_BUTTON_VALID_WIDTH_SIZE } from '../callbar_button';
-import utils, { warnIfUnmounted, removeClassStyleAttrs, addClassStyleAttrs, returnFirstEl } from '@/common/utils';
+import utils, { warnIfUnmounted, removeClassStyleAttrs, returnFirstEl } from '@/common/utils';
 import { DialtoneLocalization } from '@/localization';
 
 export default {
@@ -199,7 +199,7 @@ export default {
      * we actually have a click handler or not.
      * We're hacking it by adding an onClick prop: https://github.com/vuejs/core/issues/5220
      */
-     
+
     onClick: {
       type: Function,
       default: null,
@@ -314,7 +314,6 @@ export default {
 
   methods: {
     removeClassStyleAttrs,
-    addClassStyleAttrs,
     arrowClick (ev) {
       this.$emit('arrow-click', ev);
       return this.toggleOpen();

--- a/packages/dialtone-vue/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
+++ b/packages/dialtone-vue/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    class="d-recipe-callbar-button-with-popover"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="['d-recipe-callbar-button-with-popover', $attrs.class]"
+    :style="$attrs.style"
   >
     <dt-recipe-callbar-button
       :aria-label="ariaLabel"
@@ -90,7 +90,7 @@ import { DtButton } from '@/components/button';
 import { DtPopover } from '@/components/popover';
 import { DtIconChevronUp } from '@dialpad/dialtone-icons/vue';
 import { DtRecipeCallbarButton, CALLBAR_BUTTON_VALID_WIDTH_SIZE } from '../callbar_button';
-import utils, { warnIfUnmounted, removeClassStyleAttrs, addClassStyleAttrs, returnFirstEl } from '@/common/utils';
+import utils, { warnIfUnmounted, removeClassStyleAttrs, returnFirstEl } from '@/common/utils';
 import { DialtoneLocalization } from '@/localization';
 
 export default {
@@ -226,7 +226,7 @@ export default {
      * we actually have a click handler or not.
      * We're hacking it by adding an onClick prop: https://github.com/vuejs/core/issues/5220
     */
-     
+
     onClick: {
       type: Function,
       default: null,
@@ -366,7 +366,6 @@ export default {
 
   methods: {
     removeClassStyleAttrs,
-    addClassStyleAttrs,
     arrowClick (ev) {
       this.$emit('arrow-click', ev);
       return this.toggleOpen();

--- a/packages/dialtone-vue/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/editor/editor.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     ref="editorRoot"
-    class="d-recipe-editor"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="['d-recipe-editor', $attrs.class]"
+    :style="$attrs.style"
     data-qa="dt-recipe-editor"
     role="presentation"
     @click="$refs.richTextEditor.focusEditor()"
@@ -120,7 +120,7 @@
             v-dt-tooltip="{
               message: button.tooltipMessage,
               placement: 'top',
-              externalAnchorElement: $refs[getButtonRef(buttonGroup.key, button.selector)]?.$el, 
+              externalAnchorElement: $refs[getButtonRef(buttonGroup.key, button.selector)]?.$el,
             }"
             kind="muted"
             importance="clear"
@@ -393,7 +393,7 @@ import {
   EDITOR_DEFAULT_LINK_PREFIX,
   EDITOR_DEFAULT_FONT_COLOR,
 } from './editor_constants.js';
-import { removeClassStyleAttrs, addClassStyleAttrs } from '@/common/utils';
+import { removeClassStyleAttrs } from '@/common/utils';
 import { DtButton } from '@/components/button';
 import { DtPopover } from '@/components/popover';
 import { DtStack } from '@/components/stack';
@@ -1174,7 +1174,6 @@ export default {
 
   methods: {
     removeClassStyleAttrs,
-    addClassStyleAttrs,
 
     focusEditor () {
       this.$refs.richTextEditor?.editor?.commands.focus();

--- a/packages/dialtone-vue/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/editor/editor.vue
@@ -43,10 +43,11 @@
                 @escape="close()"
               >
                 <template #input="{ inputProps }">
+                  <!-- eslint-disable vue/no-restricted-class -->
                   <dt-input
                     v-bind="inputProps"
                     v-model="fontStyleSearch"
-                    root-class="d-p-100 d-pbe-50 d-w216"
+                    class="d-p-100 d-pbe-50 d-w216"
                     type="search"
                     :placeholder="i18n.$t('DIALTONE_EDITOR_FONT_STYLE_SEARCH_PLACEHOLDER')"
                     :size="200"
@@ -56,6 +57,7 @@
                       <dt-icon-search :size="iconSize" />
                     </template>
                   </dt-input>
+                  <!-- eslint-enable vue/no-restricted-class -->
                 </template>
                 <template #list="{ listProps }">
                   <ul
@@ -139,9 +141,10 @@
                 size="200"
                 :style="!isDefaultFontColor ? { color: currentFontColor } : {}"
               />
+              <!-- eslint-disable vue/no-restricted-class -->
               <dt-input
                 :value="currentFontColor"
-                root-class="d-w0 d-h0 d-of-hidden"
+                class="d-w0 d-h0 d-of-hidden"
                 input-class="colorPickerInput d-w0 d-h0 d-p-0 d-bar0"
                 input-wrapper-class="d-w0 d-h0 d-ba-none"
                 :size="200"
@@ -149,6 +152,7 @@
                 @input="onColorPickerInput"
                 @click.stop
               />
+              <!-- eslint-enable vue/no-restricted-class -->
             </template>
           </dt-button>
 
@@ -175,10 +179,11 @@
                 @escape="close()"
               >
                 <template #input="{ inputProps }">
+                  <!-- eslint-disable vue/no-restricted-class -->
                   <dt-input
                     v-bind="inputProps"
                     v-model="variableSearchValue"
-                    root-class="d-p-100 d-pbe-50 d-w264"
+                    class="d-p-100 d-pbe-50 d-w264"
                     type="search"
                     :placeholder="i18n.$t('DIALTONE_EDITOR_VARIABLE_POPOVER_SEARCH_PLACEHOLDER')"
                     :size="300"
@@ -188,6 +193,7 @@
                       <dt-icon-search :size="iconSize" />
                     </template>
                   </dt-input>
+                  <!-- eslint-enable vue/no-restricted-class -->
                 </template>
                 <template #list="{ listProps }">
                   <div v-bind="listProps">

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill.stories.js
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill.stories.js
@@ -9,7 +9,7 @@ const iconsList = getIconNames();
 const args = {
   startIcon: 'video',
   title: 'This meeting has ended',
-  wrapperClass: 'd-w628',
+  class: 'd-w628',
   buttonClass: 'd-bar24',
 };
 

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :class="['d-recipe-feed-item-pill__border', borderClass, wrapperClass]">
+  <div
+    :class="['d-recipe-feed-item-pill__border', borderClass, $attrs.class]"
+    :style="$attrs.style"
+  >
     <div class="d-recipe-feed-item-pill__wrapper">
       <dt-collapsible :open="expanded">
         <template #anchor>
@@ -123,14 +126,6 @@ export default {
     title: {
       type: String,
       default: () => '',
-    },
-
-    /**
-     * Additional styling around the pill
-     */
-    wrapperClass: {
-      type: [String, Array, Object],
-      default: '',
     },
 
     /**

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill_default.story.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill_default.story.vue
@@ -1,7 +1,7 @@
 <template>
   <dt-recipe-feed-item-pill
     :title="$attrs.title"
-    :wrapper-class="$attrs.wrapperClass"
+    :class="$attrs.class"
     :button-class="$attrs.buttonClass"
     :border-color="$attrs.borderColor"
     :toggleable="$attrs.toggleable"

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill_variants.story.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill_variants.story.vue
@@ -8,7 +8,7 @@
       <dt-recipe-feed-item-pill
         default-toggled
         title="Ben called you"
-        wrapper-class="d-w-950"
+        class="d-w-950"
         border-color="ai"
       >
         <template
@@ -67,7 +67,7 @@
       <dt-recipe-feed-item-pill
         title="Missed call from Ben"
         border-color="critical"
-        wrapper-class="d-w-950"
+        class="d-w-950"
         :toggleable="false"
       >
         <template
@@ -102,7 +102,7 @@
       </h3>
       <dt-recipe-feed-item-pill
         title="Voicemail"
-        wrapper-class="d-w-950"
+        class="d-w-950"
         :toggleable="false"
       >
         <template
@@ -141,7 +141,7 @@
       <dt-recipe-feed-item-pill
         border-color="ai"
         title="Ben called you"
-        wrapper-class="d-w-950"
+        class="d-w-950"
         :toggleable="false"
       >
         <template
@@ -182,7 +182,7 @@
       <dt-recipe-feed-item-pill
         title="Ben started a meeting"
         button-class="d-bar24"
-        wrapper-class="d-w-950"
+        class="d-w-950"
         border-color="ai"
         :default-toggled="true"
       >
@@ -246,7 +246,7 @@
         title="Ben started a meeting"
         border-color="ai"
         button-class="d-bar24"
-        wrapper-class="d-w-950"
+        class="d-w-950"
         :toggleable="false"
       >
         <template

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_row/feed_item_row_variants.story.vue
@@ -233,7 +233,7 @@
               default-toggled
               title="Ben called you"
               icon-name="phone-outgoing"
-              wrapper-class="d-w-950"
+              class="d-w-950"
               border-color="ai"
             >
               <template #subtitle>

--- a/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.vue
@@ -3,8 +3,8 @@
   <div
     data-qa="dt-recipe-message-input"
     role="presentation"
-    class="d-recipe-message-input"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="['d-recipe-message-input', $attrs.class]"
+    :style="$attrs.style"
     @dragover.prevent
     @drop.prevent="onDrop"
     @paste="onPaste"
@@ -286,7 +286,7 @@ import {
   RICH_TEXT_EDITOR_AUTOFOCUS_TYPES,
 } from '@/components/rich_text_editor';
 import lastActiveNodes from './last_active_nodes';
-import { removeClassStyleAttrs, returnFirstEl, addClassStyleAttrs } from '@/common/utils';
+import { removeClassStyleAttrs, returnFirstEl } from '@/common/utils';
 import MeetingPill from './extensions/meeting_pill/meeting_pill';
 import { DtButton } from '@/components/button';
 import { DtEmojiPicker } from '@/components/emoji_picker';
@@ -899,7 +899,6 @@ export default {
 
   methods: {
     removeClassStyleAttrs,
-    addClassStyleAttrs,
 
     linkDialogOpened (value) {
       this.linkDialogOpen = value;

--- a/packages/dialtone-vue/recipes/leftbar/contact_centers_row/contact_centers_row.vue
+++ b/packages/dialtone-vue/recipes/leftbar/contact_centers_row/contact_centers_row.vue
@@ -3,8 +3,9 @@
     :class="[
       'd-recipe-leftbar-row__container',
       { 'd-recipe-leftbar-row__container--off-duty': $slots.timer },
+      $attrs.class,
     ]"
-    v-bind="addClassStyleAttrs($attrs)"
+    :style="$attrs.style"
   >
     <div
       :class="leftbarContactCentersRowClasses"
@@ -87,7 +88,7 @@
 </template>
 
 <script>
-import { extractVueListeners, safeConcatStrings, removeClassStyleAttrs, returnFirstEl, addClassStyleAttrs } from '@/common/utils';
+import { extractVueListeners, safeConcatStrings, removeClassStyleAttrs, returnFirstEl } from '@/common/utils';
 import { DtBadge } from '@/components/badge';
 import { DtButton } from '@/components/button';
 import { DtEmojiTextWrapper } from '@/components/emoji_text_wrapper';
@@ -236,7 +237,6 @@ export default {
 
   methods: {
     removeClassStyleAttrs,
-    addClassStyleAttrs,
 
     adjustLabelWidth () {
       const labelWidth = returnFirstEl(this.$el)?.querySelector('.d-recipe-leftbar-row__primary')?.clientWidth || 0;

--- a/packages/dialtone-vue/recipes/leftbar/general_row/general_row.vue
+++ b/packages/dialtone-vue/recipes/leftbar/general_row/general_row.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    :class="leftbarGeneralRowClasses"
-    v-bind="addClassStyleAttrs($attrs)"
+    :class="[leftbarGeneralRowClasses, $attrs.class]"
+    :style="$attrs.style"
     data-qa="dt-recipe-leftbar-row"
   >
     <a
@@ -204,7 +204,7 @@ import { DtTooltip } from '@/components/tooltip';
 import { DtEmojiTextWrapper } from '@/components/emoji_text_wrapper';
 import { DtAvatar } from '@/components/avatar';
 import DtRecipeLeftbarGeneralRowIcon from './leftbar_general_row_icon.vue';
-import { extractVueListeners, safeConcatStrings, removeClassStyleAttrs, returnFirstEl, addClassStyleAttrs } from '@/common/utils';
+import { extractVueListeners, safeConcatStrings, removeClassStyleAttrs, returnFirstEl } from '@/common/utils';
 import { DialtoneLocalization } from '@/localization';
 
 const TYPE_TO_ICON = new Map([
@@ -559,7 +559,6 @@ export default {
 
   methods: {
     removeClassStyleAttrs,
-    addClassStyleAttrs,
 
     validateProps () {
       if (this.type === LEFTBAR_GENERAL_ROW_TYPES.CONTACT_CENTER &&


### PR DESCRIPTION
# Remove rootClass references

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [X] Refactor


## :book: Jira Ticket

**This is just the first part of the ticket.** 

https://dialpad.atlassian.net/browse/DLT-3100

## :book: Description

Updated `rootClass` to be only `class` on components:


Component | Changes
-- | --
InputMixin | Removed rootClass prop - classes now passed via $attrs
Input | Removed rootClass prop and usage in template
Checkbox | Removed rootClass usage from template (was from mixin)
Radio | Removed rootClass usage from template (was from mixin)
SelectMenu | Removed rootClass, added inputClass for the select element
Toggle | Removed wrapperClass prop, uses class via $attrs
Card | Removed containerClass prop, added inheritAttrs: false, uses class via $attrs
BreadcrumbItem | Removed rootClass prop
SplitButton | Removed rootClass prop, uses class via $attrs
FeedItemPill | Removed wrapperClass prop, added inheritAttrs: false, uses class via $attrs
Combinator | Removed unused rootClass/headerClass props





**Breaking Changes**

- Any consumer code using rootClass, containerClass, or wrapperClass props will silently fail - the props will be ignored and classes won't be applied
- No runtime errors will occur, but styling will break
- This affects: Input, Checkbox, Radio, SelectMenu, Toggle, Card, BreadcrumbItem, SplitButton, FeedItemPill


Component | Removed Prop | Migration
-- | -- | --
Input | rootClass | Use class attribute directly
Checkbox | rootClass | Use class attribute directly
Radio | rootClass | Use class attribute directly
SelectMenu | rootClass | Use class attribute directly
Toggle | wrapperClass | Use class attribute directly
Card | containerClass | Use class attribute directly
BreadcrumbItem | rootClass | Use class attribute directly
SplitButton | rootClass | Use class attribute directly
FeedItemPill | wrapperClass | Use class attribute directly


New Props (not breaking, but worth noting)


Component | New Prop | Purpose
-- | -- | --
SelectMenu | inputClass | Pass classes to the <select> element




------

Before:

```
<dt-input root-class="my-custom-class" />
<dt-toggle wrapper-class="my-toggle-class" />
<dt-card container-class="my-card-class" />
```

After:

```
<dt-input class="my-custom-class" />
<dt-toggle class="my-toggle-class" />
<dt-card class="my-card-class" />
```


-----

Side note: I also removed `addClassStyleAttrs($attrs)` since seems like it is for Vue2 compat mode which is not needed anymore.
It is still present on some `recipes`, if this get approves I will remove it from there too.

There is still `inputWrapperClass` on `input.vue` and `wrapperClass` on `ListItem`
They are for a nested wrapper element, not the root but ... stil confusing..
on `input.vue` we still have `inputClass` and `inputWrapperClass`. At least we don't have `rootClass` anymore. My goodness



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Refactors Vue components to remove custom class props (rootClass/containerClass/wrapperClass) in favor of standard class/$attrs; removes addClassStyleAttrs, updates removeClassStyleAttrs, and adjusts templates, tests, stories, and variants across many components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->