### PR TITLE
fix(ci): NO-JIRA use daily cleanup PR instead of direct push to staging

### DIFF
--- a/.github/workflows/cleanup-plan-docs.yml
+++ b/.github/workflows/cleanup-plan-docs.yml
@@ -64,9 +64,9 @@ jobs:
           BODY="## Automated Plan Cleanup\n\nThis PR removes planning docs that were merged into \`staging\` during development.\n\n### Plans removed\n\n${TABLE}\n---\n\n> **Add highlights here** — anything worth preserving from these plans (key decisions, trade-offs, context for future contributors):\n\n"
 
           {
-            echo 'pr_body<<EOF'
+            echo 'pr_body<<CLEANUP_PR_BODY'
             printf '%b' "$BODY"
-            echo 'EOF'
+            echo 'CLEANUP_PR_BODY'
           } >> "$GITHUB_OUTPUT"
 
           git rm -f PLAN-*.md --ignore-unmatch

--- a/.github/workflows/cleanup-plan-docs.yml
+++ b/.github/workflows/cleanup-plan-docs.yml
@@ -30,10 +30,7 @@ jobs:
         id: check
         run: |
           PLAN_FILES=$(find . -maxdepth 1 -name "PLAN-*.md" 2>/dev/null || true)
-          DOCS_FILES=""
-          if [ -d "./docs/plans" ]; then
-            DOCS_FILES=$(find ./docs/plans -maxdepth 1 -name "*.md" 2>/dev/null || true)
-          fi
+          DOCS_FILES=$(find ./docs/plans -maxdepth 1 -name "*.md" 2>/dev/null || true)
           if [ -z "$PLAN_FILES" ] && [ -z "$DOCS_FILES" ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
           else
@@ -57,9 +54,7 @@ jobs:
           }
 
           scan_plans < <(find . -maxdepth 1 -name "PLAN-*.md" -print0 2>/dev/null || true)
-          if [ -d "./docs/plans" ]; then
-            scan_plans < <(find ./docs/plans -maxdepth 1 -name "*.md" -print0 2>/dev/null || true)
-          fi
+          scan_plans < <(find ./docs/plans -maxdepth 1 -name "*.md" -print0 2>/dev/null || true)
 
           BODY="## Automated Plan Cleanup\n\nThis PR removes planning docs that were merged into \`staging\` during development.\n\n### Plans removed\n\n${TABLE}\n---\n\n> **Add highlights here** — anything worth preserving from these plans (key decisions, trade-offs, context for future contributors):\n\n"
 
@@ -70,9 +65,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           git rm -f PLAN-*.md --ignore-unmatch
-          if [ -d "./docs/plans" ]; then
-            find ./docs/plans -maxdepth 1 -name "*.md" -exec git rm -f {} + 2>/dev/null || true
-          fi
+          find ./docs/plans -maxdepth 1 -name "*.md" -exec git rm -f {} + 2>/dev/null || true
 
       - name: Create cleanup PR
         if: steps.check.outputs.found == 'true'

--- a/.github/workflows/cleanup-plan-docs.yml
+++ b/.github/workflows/cleanup-plan-docs.yml
@@ -1,16 +1,16 @@
 name: Cleanup Plan Docs
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [staging]
+  schedule:
+    - cron: '0 23 * * *'
+  workflow_dispatch:
 
 jobs:
   cleanup:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false
@@ -26,14 +26,58 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Remove planning docs
+      - name: Check for plan files
+        id: check
         run: |
+          PLAN_FILES=$(find . -maxdepth 1 -name "PLAN-*.md" 2>/dev/null)
+          DOCS_FILES=$(find ./docs/plans -maxdepth 1 -name "*.md" 2>/dev/null)
+          if [ -z "$PLAN_FILES" ] && [ -z "$DOCS_FILES" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build PR body and remove plan files
+        id: build_body
+        if: steps.check.outputs.found == 'true'
+        run: |
+          TABLE="| Plan | Status |\n|------|--------|\n"
+
+          while IFS= read -r -d '' FILE; do
+            TITLE=$(grep -m1 "^# " "$FILE" | sed 's/^# //')
+            STATUS=$(grep -m1 "^Status:" "$FILE" | sed 's/^Status: *//' | tr -d '[:space:]')
+            [ -z "$TITLE" ] && TITLE="$(basename "$FILE" .md)"
+            [ -z "$STATUS" ] && STATUS="—"
+            TABLE="${TABLE}| \`$(basename "$FILE")\` — ${TITLE} | ${STATUS} |\n"
+          done < <(find . -maxdepth 1 -name "PLAN-*.md" -print0 2>/dev/null)
+
+          while IFS= read -r -d '' FILE; do
+            TITLE=$(grep -m1 "^# " "$FILE" | sed 's/^# //')
+            STATUS=$(grep -m1 "^Status:" "$FILE" | sed 's/^Status: *//' | tr -d '[:space:]')
+            [ -z "$TITLE" ] && TITLE="$(basename "$FILE" .md)"
+            [ -z "$STATUS" ] && STATUS="—"
+            TABLE="${TABLE}| \`$(basename "$FILE")\` — ${TITLE} | ${STATUS} |\n"
+          done < <(find ./docs/plans -maxdepth 1 -name "*.md" -print0 2>/dev/null)
+
+          BODY="## Automated Plan Cleanup\n\nThis PR removes planning docs that were merged into \`staging\` during development.\n\n### Plans removed\n\n${TABLE}\n---\n\n> **Add highlights here** — anything worth preserving from these plans (key decisions, trade-offs, context for future contributors):\n\n"
+
+          {
+            echo 'pr_body<<EOF'
+            printf '%b' "$BODY"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
           git rm -f PLAN-*.md --ignore-unmatch
           git rm -rf docs/plans/ --ignore-unmatch
 
-      - name: Commit and push if changed
-        run: |
-          if ! git diff --cached --quiet --exit-code; then
-            git commit -m "chore: remove planning docs post-merge [skip ci]"
-            git push origin staging
-          fi
+      - name: Create cleanup PR
+        if: steps.check.outputs.found == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ github.token }}
+          branch: chore/cleanup-plan-docs
+          base: staging
+          commit-message: 'chore: NO-JIRA remove planning docs from staging'
+          title: 'chore: NO-JIRA remove planning docs from staging'
+          body: ${{ steps.build_body.outputs.pr_body }}
+          delete-branch: true

--- a/.github/workflows/cleanup-plan-docs.yml
+++ b/.github/workflows/cleanup-plan-docs.yml
@@ -30,7 +30,10 @@ jobs:
         id: check
         run: |
           PLAN_FILES=$(find . -maxdepth 1 -name "PLAN-*.md" 2>/dev/null || true)
-          DOCS_FILES=$(find ./docs/plans -maxdepth 1 -name "*.md" 2>/dev/null || true)
+          DOCS_FILES=""
+          if [ -d "./docs/plans" ]; then
+            DOCS_FILES=$(find ./docs/plans -maxdepth 1 -name "*.md" 2>/dev/null || true)
+          fi
           if [ -z "$PLAN_FILES" ] && [ -z "$DOCS_FILES" ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
           else
@@ -54,7 +57,9 @@ jobs:
           }
 
           scan_plans < <(find . -maxdepth 1 -name "PLAN-*.md" -print0 2>/dev/null || true)
-          scan_plans < <(find ./docs/plans -maxdepth 1 -name "*.md" -print0 2>/dev/null || true)
+          if [ -d "./docs/plans" ]; then
+            scan_plans < <(find ./docs/plans -maxdepth 1 -name "*.md" -print0 2>/dev/null || true)
+          fi
 
           BODY="## Automated Plan Cleanup\n\nThis PR removes planning docs that were merged into \`staging\` during development.\n\n### Plans removed\n\n${TABLE}\n---\n\n> **Add highlights here** — anything worth preserving from these plans (key decisions, trade-offs, context for future contributors):\n\n"
 
@@ -65,7 +70,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           git rm -f PLAN-*.md --ignore-unmatch
-          find ./docs/plans -maxdepth 1 -name "*.md" -exec git rm -f {} + 2>/dev/null || true
+          if [ -d "./docs/plans" ]; then
+            find ./docs/plans -maxdepth 1 -name "*.md" -exec git rm -f {} + 2>/dev/null || true
+          fi
 
       - name: Create cleanup PR
         if: steps.check.outputs.found == 'true'

--- a/.github/workflows/cleanup-plan-docs.yml
+++ b/.github/workflows/cleanup-plan-docs.yml
@@ -43,21 +43,18 @@ jobs:
         run: |
           TABLE="| Plan | Status |\n|------|--------|\n"
 
-          while IFS= read -r -d '' FILE; do
-            TITLE=$(grep -m1 "^# " "$FILE" | sed 's/^# //')
-            STATUS=$(grep -m1 "^Status:" "$FILE" | sed 's/^Status: *//' | tr -d '[:space:]')
-            [ -z "$TITLE" ] && TITLE="$(basename "$FILE" .md)"
-            [ -z "$STATUS" ] && STATUS="—"
-            TABLE="${TABLE}| \`$(basename "$FILE")\` — ${TITLE} | ${STATUS} |\n"
-          done < <(find . -maxdepth 1 -name "PLAN-*.md" -print0 2>/dev/null)
+          scan_plans() {
+            while IFS= read -r -d '' FILE; do
+              TITLE=$(grep -m1 "^# " "$FILE" | sed 's/^# //')
+              STATUS=$(grep -m1 "^Status:" "$FILE" | sed 's/^Status: *//' | tr -d '[:space:]')
+              [ -z "$TITLE" ] && TITLE="$(basename "$FILE" .md)"
+              [ -z "$STATUS" ] && STATUS="—"
+              TABLE="${TABLE}| \`$(basename "$FILE")\` — ${TITLE} | ${STATUS} |\n"
+            done
+          }
 
-          while IFS= read -r -d '' FILE; do
-            TITLE=$(grep -m1 "^# " "$FILE" | sed 's/^# //')
-            STATUS=$(grep -m1 "^Status:" "$FILE" | sed 's/^Status: *//' | tr -d '[:space:]')
-            [ -z "$TITLE" ] && TITLE="$(basename "$FILE" .md)"
-            [ -z "$STATUS" ] && STATUS="—"
-            TABLE="${TABLE}| \`$(basename "$FILE")\` — ${TITLE} | ${STATUS} |\n"
-          done < <(find ./docs/plans -maxdepth 1 -name "*.md" -print0 2>/dev/null)
+          scan_plans < <(find . -maxdepth 1 -name "PLAN-*.md" -print0 2>/dev/null)
+          scan_plans < <(find ./docs/plans -maxdepth 1 -name "*.md" -print0 2>/dev/null)
 
           BODY="## Automated Plan Cleanup\n\nThis PR removes planning docs that were merged into \`staging\` during development.\n\n### Plans removed\n\n${TABLE}\n---\n\n> **Add highlights here** — anything worth preserving from these plans (key decisions, trade-offs, context for future contributors):\n\n"
 
@@ -68,13 +65,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           git rm -f PLAN-*.md --ignore-unmatch
-          git rm -rf docs/plans/ --ignore-unmatch
+          find ./docs/plans -maxdepth 1 -name "*.md" -exec git rm -f {} + 2>/dev/null || true
 
       - name: Create cleanup PR
         if: steps.check.outputs.found == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ github.token }}
           branch: chore/cleanup-plan-docs
           base: staging
           commit-message: 'chore: NO-JIRA remove planning docs from staging'

--- a/.github/workflows/cleanup-plan-docs.yml
+++ b/.github/workflows/cleanup-plan-docs.yml
@@ -29,8 +29,11 @@ jobs:
       - name: Check for plan files
         id: check
         run: |
-          PLAN_FILES=$(find . -maxdepth 1 -name "PLAN-*.md" 2>/dev/null)
-          DOCS_FILES=$(find ./docs/plans -maxdepth 1 -name "*.md" 2>/dev/null)
+          PLAN_FILES=$(find . -maxdepth 1 -name "PLAN-*.md" 2>/dev/null || true)
+          DOCS_FILES=""
+          if [ -d "./docs/plans" ]; then
+            DOCS_FILES=$(find ./docs/plans -maxdepth 1 -name "*.md" 2>/dev/null || true)
+          fi
           if [ -z "$PLAN_FILES" ] && [ -z "$DOCS_FILES" ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
           else
@@ -53,8 +56,10 @@ jobs:
             done
           }
 
-          scan_plans < <(find . -maxdepth 1 -name "PLAN-*.md" -print0 2>/dev/null)
-          scan_plans < <(find ./docs/plans -maxdepth 1 -name "*.md" -print0 2>/dev/null)
+          scan_plans < <(find . -maxdepth 1 -name "PLAN-*.md" -print0 2>/dev/null || true)
+          if [ -d "./docs/plans" ]; then
+            scan_plans < <(find ./docs/plans -maxdepth 1 -name "*.md" -print0 2>/dev/null || true)
+          fi
 
           BODY="## Automated Plan Cleanup\n\nThis PR removes planning docs that were merged into \`staging\` during development.\n\n### Plans removed\n\n${TABLE}\n---\n\n> **Add highlights here** — anything worth preserving from these plans (key decisions, trade-offs, context for future contributors):\n\n"
 
@@ -65,7 +70,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           git rm -f PLAN-*.md --ignore-unmatch
-          find ./docs/plans -maxdepth 1 -name "*.md" -exec git rm -f {} + 2>/dev/null || true
+          if [ -d "./docs/plans" ]; then
+            find ./docs/plans -maxdepth 1 -name "*.md" -exec git rm -f {} + 2>/dev/null || true
+          fi
 
       - name: Create cleanup PR
         if: steps.check.outputs.found == 'true'


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcjV1OGF5NWZ0dDB5MWt6a3B5MXBqdmp0c3E5eTNyNGN4bXFkZml2aiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oEjHAUOqG3lSS0f1C/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] CI

## :book: Jira Ticket

NO-JIRA

## :book: Description

Rewrites the `cleanup-plan-docs.yml` workflow to fix the protected branch push failure.

**What changed in the workflow file:**
- **Trigger:** Replaced `pull_request: closed` with daily cron (`0 23 * * *`) + `workflow_dispatch`
- **Mechanism:** Replaced direct `git push origin staging` with `peter-evans/create-pull-request@v5`
- **PR body:** Includes a summary table of each plan file being removed (title + status), with a prompt for reviewers to add highlights
- **Branch reuse:** Fixed branch name `chore/cleanup-plan-docs` — if a cleanup PR is already open when the cron runs again, it updates the existing PR instead of creating a duplicate
- **Targeted removal:** Only removes top-level `.md` files in `docs/plans/`, preserving subdirectories like `docs/plans/future/`
- **Resilience:** All `find` commands are guarded with `-d` checks and `|| true` so the workflow succeeds even when `docs/plans/` does not exist (which happens after a cleanup PR merges)

## :bulb: Context

### Problem

The `cleanup-plan-docs.yml` workflow was failing on every PR merge to `staging`:

```
remote: error: GH006: Protected branch update failed for refs/heads/staging.
remote: - Changes must be made through a pull request.
```

**Root cause:** The workflow triggered post-merge and attempted `git push origin staging` directly. Since `staging` is a protected branch requiring PRs, the default `GITHUB_TOKEN` cannot bypass this — the push was always rejected.

### Constraints that shaped the solution

- **Cannot push directly to `staging`** — branch protection requires PRs
- **Cannot clean files pre-merge on every push** — plan files in `docs/plans/` are useful during PR review
- **No native pre-merge trigger in GitHub Actions** — the closest option (on PR approval) risks an approval loop with "dismiss stale reviews" enabled
- **Per-merge cleanup PRs are too noisy** — one cleanup PR per merged PR is overkill
- **`docs/plans/` may not exist** — after a cleanup PR merges, the directory is gone and `find` exits with code 1, which terminates the step under `bash -e`

### Why a daily batch

A single daily cron batches all accumulated plan files into one PR. The `peter-evans/create-pull-request` action with a fixed branch name ensures at most one cleanup PR is open at any time — subsequent runs update it rather than creating duplicates.

### Alternatives considered

| Approach | Why not |
|----------|---------|
| Pre-merge cleanup (on PR approval) | Risk of approval loop with "dismiss stale reviews" |
| Per-merge cleanup PR | Too noisy — one cleanup PR per merged PR |
| Gitignore `docs/plans/` | Loses plan file visibility during PR review |
| Elevated token (PAT/GitHub App) | Security concern, requires admin setup |

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

- After merging, the first cleanup PR will be created at the next 23:00 UTC cron run (or trigger manually via `workflow_dispatch`)
- Monitor the first automated cleanup PR to verify the summary table renders correctly