### PR TITLE
chore: NO-JIRA fix Storybook dev mode JSX parse error after Vite 8 upgrade

### DIFF
--- a/packages/dialtone-vue/.storybook/main.js
+++ b/packages/dialtone-vue/.storybook/main.js
@@ -2,6 +2,7 @@
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { mergeConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 const require = createRequire(import.meta.url);
 
@@ -28,6 +29,11 @@ const config = {
   async viteFinal (config) {
     // Merge custom configuration into the default config
     return mergeConfig(config, {
+      // @vitejs/plugin-react ensures .jsx files are transformed before
+      // Storybook's external-globals-plugin (which uses es-module-lexer
+      // and cannot parse JSX). Scoped to .jsx only to avoid conflicts
+      // with Vue's SFC compiler.
+      plugins: [react({ include: /\.jsx$/, jsxRuntime: 'classic' })],
       build: {
         sourcemap: true,
       },

--- a/packages/dialtone-vue/package.json
+++ b/packages/dialtone-vue/package.json
@@ -18,7 +18,6 @@
     "@dialpad/dialtone-icons": "workspace:*",
     "@dialpad/i18n": "1.25.0",
     "@tiptap/core": "3.19.0",
-    "@tiptap/static-renderer": "3.19.0",
     "@tiptap/extension-blockquote": "3.19.0",
     "@tiptap/extension-bold": "3.19.0",
     "@tiptap/extension-bubble-menu": "3.19.0",
@@ -47,6 +46,7 @@
     "@tiptap/extension-underline": "3.19.0",
     "@tiptap/extensions": "3.19",
     "@tiptap/pm": "3.19.0",
+    "@tiptap/static-renderer": "3.19.0",
     "@tiptap/suggestion": "3.19.0",
     "@tiptap/vue-3": "3.19.0",
     "date-fns": "4.1.0",
@@ -65,12 +65,13 @@
     "@storybook/addon-links": "10.3.0",
     "@storybook/test-runner": "^0.24.2",
     "@storybook/vue3-vite": "10.3.0",
+    "@vitejs/plugin-react": "6.0.1",
     "@vue/test-utils": "^2.4.0",
     "@vueless/storybook-dark-mode": "^10.0.7",
     "react": "19.2.4",
+    "react-dom": "19.2.4",
     "storybook": "10.3.0",
-    "vue": "^3.3.4",
-    "react-dom": "19.2.4"
+    "vue": "^3.3.4"
   },
   "peerDependencies": {
     "@dialpad/dialtone-css": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,6 +918,9 @@ importers:
       '@storybook/vue3-vite':
         specifier: 10.3.0
         version: 10.3.0(esbuild@0.27.4)(rollup@4.60.1)(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@24.3.1)(esbuild@0.27.4)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))(webpack@5.105.4(@swc/core@1.15.21)(esbuild@0.27.4))
+      '@vitejs/plugin-react':
+        specifier: 6.0.1
+        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@24.3.1)(esbuild@0.27.4)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vue/test-utils':
         specifier: ^2.4.0
         version: 2.4.6
@@ -1378,11 +1381,7 @@ packages:
     resolution: {integrity: sha512-NzGie5sIbfW/AyJwtIRZOumhAiXP6329VNBOrVerXgGrXqbTacTAuXPPVSgprFol5kWdbV34QtAlKN5OY11WEw==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-services/1.11.0/20198484967555617ab62da6ad3c276265ee232d}
     hasBin: true
     peerDependencies:
-      '@vue/composition-api': '*'
       vue: ^2.0.0 || >=3.0.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
 
   '@dialpad/i18n@1.22.3':
     resolution: {integrity: sha512-vIviaCpnXRyd/CegJw4jlcdB9Zbgmml0gmHr9cNXUtJuC+DEOtwadVtq7qpUedggKMltg7VlMkC38U85C6W/yw==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n/1.22.3/fcdcd6ab6ab141035696d71caf35b3554b64c726}
@@ -3630,6 +3629,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.2':
     resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
 
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
   '@rollup/plugin-commonjs@28.0.9':
     resolution: {integrity: sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
@@ -4858,6 +4860,19 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitejs/plugin-vue@6.0.5':
     resolution: {integrity: sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==}
@@ -14501,7 +14516,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -16501,6 +16516,8 @@ snapshots:
       fluent-vue: 3.7.2(@fluent/bundle@0.17.1)(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
       vue-demi: 0.14.10(vue@3.5.31(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   '@dialpad/i18n@1.22.3(vue@3.5.31(typescript@5.9.3))':
     dependencies:
@@ -19144,6 +19161,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.2': {}
 
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
+
   '@rollup/plugin-commonjs@28.0.9(rollup@4.60.1)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
@@ -20489,6 +20508,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@vitejs/plugin-react@6.0.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@24.3.1)(esbuild@0.27.4)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@24.3.1)(esbuild@0.27.4)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitejs/plugin-vue@6.0.5(vite@7.0.8(@types/node@24.3.1)(jiti@1.21.7)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))':
     dependencies:


### PR DESCRIPTION
![30892636f055bbf4a84bed6fd3d23bb3](https://github.com/user-attachments/assets/08955bfd-d6ef-4298-84df-ebac43fd65c0)

## :hammer_and_wrench: Type Of Change

- [x] Build system

## :book: Jira Ticket

NO-JIRA

## :book: Description

Add `@vitejs/plugin-react` to Storybook's Vite config to fix JSX parse errors in dev mode.

After the Vite 8 upgrade (#1136), Storybook local preview failed to work. `storybook dev` fails with `Parse error @:250:28` in `storybook:external-globals-plugin`. 

The root cause: `es-module-lexer` (used by Storybook's external-globals-plugin) cannot parse JSX syntax. In Vite 5-7, esbuild transformed `.jsx` files before this plugin ran. In Vite 8, the OXC transform doesn't pre-process `.jsx` in dev mode for Vue projects, so raw JSX reaches the plugin.

**Fix:** add `@vitejs/plugin-react` with `include: /\.jsx$/` and `jsxRuntime: 'classic'` to ensure JSX files are transformed before the external-globals-plugin sees them. Scoped to `.jsx` files only to avoid conflicts with Vue's SFC compiler.

> [!TIP]
> `storybook build` (CI) was unaffected — the issue is **dev-mode-only**.

## :bulb: Context

Storybook uses React for its docs addon (`preview.jsx`, `DialtoneDocsPage.jsx`) even in Vue projects. Without explicit React JSX handling, these files break in Vite 8 dev mode.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description.
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.