### PR TITLE
feat(workflow): DLT-3290 add plan for review rules sync automation

### DIFF
--- a/docs/plans/2026-04-10-review-rules-sync.md
+++ b/docs/plans/2026-04-10-review-rules-sync.md
@@ -1,0 +1,33 @@
+# DLT-3290: Review Rules Sync
+
+Created: 2026-04-10
+Status: PENDING
+Type: Feature
+
+## Problem
+
+Review rules now live in three places that drift independently:
+
+1. `.claude/rules/code-review.md` (+ `vue-components.md`, `css-utilities.md`, `design-tokens.md`) — source of truth for Claude Code local development
+2. `.coderabbit.yaml` path_instructions — condensed rules for CodeRabbit PR reviews
+3. `.github/workflows/claude-code-review.yml` prompt — condensed rules for Claude CI review
+
+When a rule is added or updated in one place, the others must be updated to match. Currently this is manual and will drift.
+
+## Proposed Solution
+
+Extend the existing doc-sync pattern (edit tracker hook → pre-push guard → enforcer skill) to cover review rule files. When a rule source file is edited, the pre-push guard detects the change and triggers Claude to update the condensed versions in the other two targets.
+
+### Source → Target Mapping
+
+| Source | Targets |
+|--------|---------|
+| `.claude/rules/code-review.md` | `.coderabbit.yaml`, workflow prompt |
+| `.claude/rules/vue-components.md` | `.coderabbit.yaml` Vue section, workflow Vue section |
+| `.claude/rules/css-utilities.md` | `.coderabbit.yaml` CSS section |
+| `.claude/rules/design-tokens.md` | `.coderabbit.yaml` tokens section |
+| `.claude/rules/icons.md` | `.coderabbit.yaml` icons section |
+
+## Status
+
+Awaiting analysis of Claude and CodeRabbit review behavior on this PR before planning implementation.


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3290

## :book: Description

Adds plan document for automating review rules sync across `.claude/rules/`, `.coderabbit.yaml`, and the claude-code-review workflow prompt.

**This PR also serves as a test run** to verify that both Claude Code Review and CodeRabbit work correctly with the new configurations from #1189:
- Claude review should complete without hitting `error_max_turns` (0 permission denials)
- CodeRabbit should apply the Dialtone-specific path instructions from `.coderabbit.yaml`

## :bulb: Context

After merging #1189, review rules live in three places. This ticket tracks building the automation to keep them in sync using the existing doc-sync pattern (edit tracker hook → pre-push guard → enforcer skill).

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

- Observe Claude and CodeRabbit review output on this PR
- Plan and implement the rules sync automation based on observations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a plan document for automating review rules synchronization (DLT-3290). Proposes extending the existing doc-sync mechanism to keep review rules synchronized across `.claude/rules/`, `.coderabbit.yaml`, and the workflow prompt when source files are edited. Includes a mapping table of rule file associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->