### PR TITLE
docs(css-utilities): DLT-3295 DLT-3280 mark physical utilities as deprecated

### DIFF
--- a/apps/dialtone-documentation/docs/_data/flex.json
+++ b/apps/dialtone-documentation/docs/_data/flex.json
@@ -123,6 +123,31 @@
       "class": "jc-unset",
       "output": "justify-content: unset",
       "description": "Resets the justify-content to its initial value."
+    },
+    {
+      "class": "jc-start",
+      "output": "justify-content: flex-start",
+      "deprecated": true
+    },
+    {
+      "class": "jc-end",
+      "output": "justify-content: flex-end",
+      "deprecated": true
+    },
+    {
+      "class": "jc-around",
+      "output": "justify-content: space-around",
+      "deprecated": true
+    },
+    {
+      "class": "jc-between",
+      "output": "justify-content: space-between",
+      "deprecated": true
+    },
+    {
+      "class": "jc-evenly",
+      "output": "justify-content: space-evenly",
+      "deprecated": true
     }
   ],
   "alignContent": [
@@ -175,6 +200,16 @@
       "class": "ac-unset",
       "output": "align-content: unset",
       "description": "Resets the align-content to its initial value."
+    },
+    {
+      "class": "ac-start",
+      "output": "align-content: flex-start",
+      "deprecated": true
+    },
+    {
+      "class": "ac-end",
+      "output": "align-content: flex-end",
+      "deprecated": true
     }
   ],
   "alignItems": [
@@ -212,6 +247,16 @@
       "class": "ai-unset",
       "output": "align-items: unset",
       "description": "Resets the align-items to its initial value."
+    },
+    {
+      "class": "ai-start",
+      "output": "align-items: flex-start",
+      "deprecated": true
+    },
+    {
+      "class": "ai-end",
+      "output": "align-items: flex-end",
+      "deprecated": true
     }
   ],
   "alignSelf": [
@@ -254,6 +299,16 @@
       "class": "as-unset",
       "output": "align-self: unset",
       "description": "Resets the align-self to its initial value."
+    },
+    {
+      "class": "as-start",
+      "output": "align-self: flex-start",
+      "deprecated": true
+    },
+    {
+      "class": "as-end",
+      "output": "align-self: flex-end",
+      "deprecated": true
     }
   ],
   "direction": [

--- a/apps/dialtone-documentation/docs/_data/interactivity.json
+++ b/apps/dialtone-documentation/docs/_data/interactivity.json
@@ -127,16 +127,26 @@
       "output": "resize: both !important;"
     },
     {
-      "class": "d-r-horizontal",
-      "output": "resize: horizontal !important;"
+      "class": "d-r-inline",
+      "output": "resize: inline !important;"
     },
     {
-      "class": "d-r-vertical",
-      "output": "resize: vertical !important;"
+      "class": "d-r-block",
+      "output": "resize: block !important;"
     },
     {
       "class": "d-r-none",
       "output": "resize: none !important;"
+    },
+    {
+      "class": "d-r-horizontal",
+      "output": "resize: horizontal !important;",
+      "deprecated": true
+    },
+    {
+      "class": "d-r-vertical",
+      "output": "resize: vertical !important;",
+      "deprecated": true
     }
   ]
 }

--- a/apps/dialtone-documentation/docs/_data/type.json
+++ b/apps/dialtone-documentation/docs/_data/type.json
@@ -497,11 +497,13 @@
     "unset"
   ],
   "align": [
-    { "class": "left", "value": "start" },
-    { "class": "right", "value": "end" },
+    { "class": "start", "value": "start" },
+    { "class": "end", "value": "end" },
     { "class": "center", "value": "center" },
     { "class": "justify", "value": "justify" },
-    { "class": "unset", "value": "unset" }
+    { "class": "unset", "value": "unset" },
+    { "class": "left", "value": "start", "deprecated": true },
+    { "class": "right", "value": "end", "deprecated": true }
   ],
   "lineClamp": [
     "1",

--- a/apps/dialtone-documentation/docs/utilities/flex/align-content.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/align-content.md
@@ -101,8 +101,8 @@ import { alignContent } from '@data/flex.json';
 <utility-class-table>
  <template #content>
     <tbody>
-      <tr v-for="{ class: className, output } in alignContent">
-        <th scope="row" class="d-code--sm d-docsite-code">.d-{{ className }}</th>
+      <tr v-for="{ class: className, output, deprecated } in alignContent" >
+        <th scope="row" class="d-code--sm d-docsite-code">.d-{{ className }} <dt-badge v-if="deprecated" type="critical" class="d-ff-sans">Deprecated</dt-badge></th>
         <td class="d-code--sm">{{ output }}</td>
       </tr>
     </tbody>

--- a/apps/dialtone-documentation/docs/utilities/flex/align-items.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/align-items.md
@@ -64,8 +64,8 @@ Use `d-ai-flex-end` to distribute items from the end of the element's cross axis
 <utility-class-table>
  <template #content>
     <tbody>
-      <tr v-for="{ class: className, output } in alignItems">
-        <th scope="row" class="d-code--sm d-docsite-code">.d-{{ className }}</th>
+      <tr v-for="{ class: className, output, deprecated } in alignItems" >
+        <th scope="row" class="d-code--sm d-docsite-code">.d-{{ className }} <dt-badge v-if="deprecated" type="critical" class="d-ff-sans">Deprecated</dt-badge></th>
         <td class="d-code--sm">{{ output }}</td>
       </tr>
     </tbody>

--- a/apps/dialtone-documentation/docs/utilities/flex/align-self.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/align-self.md
@@ -64,8 +64,8 @@ Use `d-as-flex-end` to align an item from the end of the parent's cross axis.
 <utility-class-table>
   <template #content>
     <tbody>
-      <tr v-for=" { class: className, output } in alignSelf">
-        <th scope="row" class="d-code--sm d-docsite-code">.d-{{ className }}</th>
+      <tr v-for="{ class: className, output, deprecated } in alignSelf" >
+        <th scope="row" class="d-code--sm d-docsite-code">.d-{{ className }} <dt-badge v-if="deprecated" type="critical" class="d-ff-sans">Deprecated</dt-badge></th>
         <td class="d-code--sm">{{ output }}</td>
       </tr>
     </tbody>

--- a/apps/dialtone-documentation/docs/utilities/flex/justify.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/justify.md
@@ -84,8 +84,8 @@ Use `d-jc-space-evenly` to justify items along the element's main axis so that t
 <utility-class-table>
   <template #content>
     <tbody>
-      <tr v-for="{ class: className, output } in justifyContent">
-        <th scope="row" class="d-code--sm d-docsite-code">.d-{{ className }}</th>
+      <tr v-for="{ class: className, output, deprecated } in justifyContent" >
+        <th scope="row" class="d-code--sm d-docsite-code">.d-{{ className }} <dt-badge v-if="deprecated" type="critical" class="d-ff-sans">Deprecated</dt-badge></th>
         <td class="d-code--sm">{{ output }}</td>
       </tr>
     </tbody>

--- a/apps/dialtone-documentation/docs/utilities/grid/justify-items.md
+++ b/apps/dialtone-documentation/docs/utilities/grid/justify-items.md
@@ -61,9 +61,25 @@ Use `d-ji-center` to justify items to the center of their inline axis.
 <utility-class-table>
   <template #content>
     <tbody>
-      <tr v-for="i in ['center', 'end', 'start', 'left', 'right', 'baseline', 'first-baseline', 'last-baseline', 'stretch', 'safe', 'unsafe', 'normal', 'legacy', 'auto', 'unset']">
-        <th scope="row" class="d-code--sm d-docsite-code">.d-ji-{{ i }}</th>
-        <td class="d-code--sm">justify-items: {{ i }} !important;</td>
+      <tr v-for="{ class: cls, deprecated } in [
+        { class: 'center' },
+        { class: 'end' },
+        { class: 'start' },
+        { class: 'left', deprecated: true },
+        { class: 'right', deprecated: true },
+        { class: 'baseline' },
+        { class: 'first-baseline' },
+        { class: 'last-baseline' },
+        { class: 'stretch' },
+        { class: 'safe' },
+        { class: 'unsafe' },
+        { class: 'normal' },
+        { class: 'legacy' },
+        { class: 'auto' },
+        { class: 'unset' },
+      ]">
+        <th scope="row" class="d-code--sm d-docsite-code">.d-ji-{{ cls }} <dt-badge v-if="deprecated" type="critical" class="d-ff-sans">Deprecated</dt-badge></th>
+        <td class="d-code--sm">justify-items: {{ cls }} !important;</td>
       </tr>
     </tbody>
   </template>

--- a/apps/dialtone-documentation/docs/utilities/grid/justify-self.md
+++ b/apps/dialtone-documentation/docs/utilities/grid/justify-self.md
@@ -57,9 +57,25 @@ Use `d-js-center` to justify an item to the center of its inline axis.
 <utility-class-table>
   <template #content>
     <tbody>
-      <tr v-for="i in ['center', 'end', 'start', 'left', 'right', 'baseline', 'first-baseline', 'last-baseline', 'stretch', 'safe', 'unsafe', 'normal', 'legacy', 'auto', 'unset']">
-        <th scope="row" class="d-code--sm d-docsite-code">.d-js-{{ i }}</th>
-        <td class="d-code--sm">justify-self: {{ i }} !important;</td>
+      <tr v-for="{ class: cls, deprecated } in [
+        { class: 'center' },
+        { class: 'end' },
+        { class: 'start' },
+        { class: 'left', deprecated: true },
+        { class: 'right', deprecated: true },
+        { class: 'baseline' },
+        { class: 'first-baseline' },
+        { class: 'last-baseline' },
+        { class: 'stretch' },
+        { class: 'safe' },
+        { class: 'unsafe' },
+        { class: 'normal' },
+        { class: 'legacy' },
+        { class: 'auto' },
+        { class: 'unset' },
+      ]">
+        <th scope="row" class="d-code--sm d-docsite-code">.d-js-{{ cls }} <dt-badge v-if="deprecated" type="critical" class="d-ff-sans">Deprecated</dt-badge></th>
+        <td class="d-code--sm">justify-self: {{ cls }} !important;</td>
       </tr>
     </tbody>
   </template>

--- a/apps/dialtone-documentation/docs/utilities/interactivity/resize.md
+++ b/apps/dialtone-documentation/docs/utilities/interactivity/resize.md
@@ -10,8 +10,8 @@ keywords: ["resizable", "drag to resize"]
 <!-- @wrapper -->
 <dt-stack gap="400" class="d-w50p">
   <div class="d-of-auto d-p-200 d-ba d-r-both">.d-r-both</div>
-  <div class="d-of-auto d-p-200 d-ba d-r-horizontal">.d-r-horizontal</div>
-  <div class="d-of-auto d-p-200 d-ba d-r-vertical">.d-r-vertical</div>
+  <div class="d-of-auto d-p-200 d-ba d-r-inline">.d-r-inline</div>
+  <div class="d-of-auto d-p-200 d-ba d-r-block">.d-r-block</div>
   <div class="d-of-auto d-p-200 d-ba d-r-none">.d-r-none</div>
 </dt-stack>
 ```
@@ -25,8 +25,8 @@ keywords: ["resizable", "drag to resize"]
 <utility-class-table>
   <template #content>
     <tbody>
-      <tr v-for="{ class: className, output } in resize">
-        <th scope="row" class="d-code--sm d-docsite-code">.{{ className }}</th>
+      <tr v-for="{ class: className, output, deprecated } in resize">
+        <th scope="row" class="d-code--sm d-docsite-code">.{{ className }} <dt-badge v-if="deprecated" type="critical" class="d-ff-sans">Deprecated</dt-badge></th>
         <td class="d-code--sm">{{ output }}</td>
       </tr>
     </tbody>

--- a/apps/dialtone-documentation/docs/utilities/typography/text-align.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/text-align.md
@@ -1,7 +1,7 @@
 ---
 title: Text Align
 description: Utilities for controlling an element's text alignment.
-keywords: ["left", "center", "right", "justify"]
+keywords: ["start", "end", "left", "center", "right", "justify"]
 ---
 
 > [!WARNING] Use DtText over CSS Utilities
@@ -14,12 +14,12 @@ Use `d-ta-{n}` to change an element's text alignment.
 ```vue demo
 <!-- @wrapper -->
 <div class="d-w100p d-d-grid d-g-200 d-ai-center lg:d-fs-100" style="grid-template-columns: auto 1fr">
-  <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-ta-left</div>
-  <div><p class="d-bgc-moderate d-ta-left">The quick brown fox jumps over the lazy dog.</p></div>
+  <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-ta-start</div>
+  <div><p class="d-bgc-moderate d-ta-start">The quick brown fox jumps over the lazy dog.</p></div>
   <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-ta-center</div>
   <div><p class="d-bgc-moderate d-ta-center">The quick brown fox jumps over the lazy dog.</p></div>
-  <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-ta-right</div>
-  <div><p class="d-bgc-moderate d-ta-right">The quick brown fox jumps over the lazy dog.</p></div>
+  <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-ta-end</div>
+  <div><p class="d-bgc-moderate d-ta-end">The quick brown fox jumps over the lazy dog.</p></div>
   <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-ta-justify</div>
   <div><p class="d-bgc-moderate d-ta-justify d-w-500">The quick brown fox jumps over the lazy dog. This needs a width applied to it to work.</p></div>
   <div class="d-code--sm d-docsite-code d-ws-nowrap">.d-ta-unset</div>
@@ -37,7 +37,10 @@ Use `d-ta-{n}` to change an element's text alignment.
   <template #content>
     <tbody>
       <tr v-for="i in align">
-        <th class="d-code--sm d-docsite-code">.d-ta-{{ i.class }}</th>
+        <th class="d-code--sm d-docsite-code">
+          .d-ta-{{ i.class }}
+          <dt-badge v-if="i.deprecated" type="critical" class="d-ff-sans">Deprecated</dt-badge>
+        </th>
         <td class="d-code--sm">text-align: {{ i.value }} !important;</td>
       </tr>
     </tbody>

--- a/packages/dialtone-css/lib/build/less/utilities/typography.less
+++ b/packages/dialtone-css/lib/build/less/utilities/typography.less
@@ -354,8 +354,8 @@ ul {
 //  ============================================================================
 //  $$  TEXT ALIGN
 //  ----------------------------------------------------------------------------
-.d-ta-left { text-align: start !important; }
-.d-ta-right { text-align: end !important; }
+.d-ta-start, .d-ta-left { text-align: start !important; }
+.d-ta-end, .d-ta-right { text-align: end !important; }
 .d-ta-center { text-align: center !important; }
 .d-ta-justify { text-align: justify !important; }
 .d-ta-unset { text-align: unset !important; }


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :book: Jira Ticket

- [DLT-3280](https://dialpad.atlassian.net/browse/DLT-3280)
- [DLT-3295](https://dialpad.atlassian.net/browse/DLT-3295)

## :book: Description

Mark deprecated physical-direction CSS utility classes in documentation with `deprecated` badges. Add `d-ta-start` / `d-ta-end` logical aliases for text-align.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

📷 Screenshots / GIFs

<img width="956" height="515" alt="image" src="https://github.com/user-attachments/assets/1b43bd30-35e5-4dbf-a251-96a86d5855da" />

[DLT-3280]: https://dialpad.atlassian.net/browse/DLT-3280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DLT-3295]: https://dialpad.atlassian.net/browse/DLT-3295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Marks physical-direction CSS utility classes as deprecated with visual badges across documentation. Introduces logical alternatives like `d-ta-start` and `d-ta-end` for text-align. Updates JSON data files and LESS styles to support both deprecated and new logical utilities while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->