### PR TITLE
refactor(notice,banner,toast): DLT-3296 decouple CSS and fix specificity violations

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/banner.less
+++ b/packages/dialtone-css/lib/build/less/components/banner.less
@@ -18,6 +18,8 @@
     --banner-line-height: var(--dt-font-line-height-200);
     --banner-dialog-padding-y: var(--dt-spacing-100);
     --banner-dialog-padding-x: var(--dt-spacing-200);
+    --notice-icon-gap: var(--dt-spacing-100);
+    --notice-actions-align: inherit;
 
     position: fixed;
     inset-block-start: 0;
@@ -26,7 +28,7 @@
     max-inline-size: 100%;
     padding: 0;
     line-height: var(--banner-line-height);
-    border-block-end: 1px solid var(--banner-color-border);
+    border-block-end: var(--dt-size-border-100) solid var(--banner-color-border);
     border-radius: 0;
     box-shadow: none;
 
@@ -50,6 +52,11 @@
 //  $   CONTENT CONTAINER
 //  ----------------------------------------------------------------------------
 .d-banner__dialog {
+    --notice-icon-block-offset: var(--dt-spacing-0);
+    --notice-content-direction: row;
+    --notice-content-gap: var(--dt-spacing-75);
+    --notice-content-align: baseline;
+
     position: relative;
     display: flex;
     align-items: center;
@@ -57,20 +64,6 @@
     min-block-size: calc(var(--dt-layout-75) + var(--dt-spacing-25));
     margin: 0 auto;
     padding: var(--banner-dialog-padding-y) var(--banner-dialog-padding-x);
-
-    .d-notice__icon {
-        margin-block-start: var(--dt-spacing-0);
-    }
-
-    .d-notice__content {
-        flex-direction: row;
-        gap: var(--dt-spacing-75);
-        align-items: baseline;
-    }
-
-    .d-notice__message {
-        font: var(--dt-text-body-sm);
-    }
 }
 
 //  ============================================================================

--- a/packages/dialtone-css/lib/build/less/components/notice.less
+++ b/packages/dialtone-css/lib/build/less/components/notice.less
@@ -25,10 +25,8 @@
     --notice-border-radius: var(--dt-size-radius-400);
     --notice-box-shadow: 0 0 0 var(--dt-size-border-100) var(--notice-color-shadow) inset;
 
-    //  Base Styles
+    //  Shared Styles
     //  ------------------------------------------------------------------------
-    display: flex;
-    align-items: start;
     box-sizing: border-box;
     inline-size: 100%;
     max-inline-size: var(--dt-layout-1000);
@@ -41,6 +39,11 @@
     box-shadow: var(--notice-box-shadow);
 }
 
+.d-notice {
+    display: flex;
+    align-items: start;
+}
+
 //  ============================================================================
 //  $   NOTICE AREAS
 //  ============================================================================
@@ -49,9 +52,10 @@
 .d-notice__content {
     display: flex;
     flex: 1 auto;
-    flex-direction: column;
+    flex-direction: var(--notice-content-direction, column);
     margin-inline-end: var(--dt-spacing-200);
-    gap: var(--dt-spacing-100);
+    gap: var(--notice-content-gap, var(--dt-spacing-100));
+    align-items: var(--notice-content-align, normal);
     align-self: center;
 }
 
@@ -62,10 +66,10 @@
     flex: 0 auto;
     gap: var(--dt-spacing-100);
     align-items: center;
-    align-self: start;
+    align-self: var(--notice-actions-align, start);
 
-    .d-banner & {
-        align-self: inherit;
+    :where(button:first-child) {
+        margin-inline-start: var(--notice-actions-button-offset, 0);
     }
 
     .d-btn {
@@ -79,15 +83,11 @@
     display: flex;
     flex: 0 auto;
     color: var(--notice-color-icon);
-    margin-inline-end: var(--dt-spacing-150);
-    margin-block-start: var(--dt-spacing-25);
+    margin-inline-end: var(--notice-icon-gap, var(--dt-spacing-150));
+    margin-block-start: var(--notice-icon-block-offset, var(--dt-spacing-25));
 
     &--has-title {
         margin-block-start: var(--dt-spacing-0);
-    }
-
-    .d-banner & {
-        margin-inline-end: var(--dt-spacing-100);
     }
 }
 
@@ -185,16 +185,14 @@
 
 //  $$  TRUNCATE TEXT
 //  ----------------------------------------------------------------------------
-.d-notice.d-notice--truncate {
-    .d-notice__content {
-        overflow: hidden;
+.d-notice--truncate :where(.d-notice__content) {
+    overflow: hidden;
+}
 
-        .d-notice__title,
-        .d-notice__message {
-            overflow: hidden;
-            white-space: nowrap;
-            text-overflow: ellipsis;
-        }
-    }
+.d-notice--truncate :where(.d-notice__title),
+.d-notice--truncate :where(.d-notice__message) {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 }

--- a/packages/dialtone-css/lib/build/less/components/toast.less
+++ b/packages/dialtone-css/lib/build/less/components/toast.less
@@ -204,7 +204,7 @@
 }
 
 .d-toast-alternate__dialog {
-    --notice-actions-button-offset: var(--dt-spacing-400);
+  --notice-actions-button-offset: var(--dt-spacing-400);
 
   position: relative;
   align-items: center;

--- a/packages/dialtone-css/lib/build/less/components/toast.less
+++ b/packages/dialtone-css/lib/build/less/components/toast.less
@@ -58,13 +58,11 @@
 //  $   CONTENT CONTAINER
 //  ----------------------------------------------------------------------------
 .d-toast__dialog {
+    --notice-actions-button-offset: var(--dt-spacing-400);
+
     position: relative;
     display: flex;
     align-items: start;
-
-    .d-notice__actions :where(button:first-child) {
-        margin-inline-start: var(--dt-spacing-400); // 32
-    }
 }
 
 //  ============================================================================
@@ -206,14 +204,11 @@
 }
 
 .d-toast-alternate__dialog {
+    --notice-actions-button-offset: var(--dt-spacing-400);
+
   position: relative;
   align-items: center;
   inline-size: var(--dt-layout-100-percent);
-
-
-  .d-notice__actions :where(button:first-child) {
-    margin-inline-start: var(--dt-spacing-400); // 32
-  }
 }
 
 .d-toast-alternate__header {


### PR DESCRIPTION
![1_XKKvXatzzuSKf5xZhZjG0w](https://github.com/user-attachments/assets/6afbf29d-9ff1-4df3-babe-0bace6e81b9f)

## :hammer_and_wrench: Type Of Change

- [x] Refactor

## :book: Jira Ticket

[DLT-3296](https://dialpad.atlassian.net/browse/DLT-3296)

## :book: Description

Decouple CSS for notice, banner, and toast. Replace cross-component descendant selectors with CSS custom property inheritance. Fix specificity violations.

**What changed:**
- notice.less no longer references banner or toast (removed `.d-banner &` overrides)
- banner.less and toast.less no longer target `.d-notice__*` children via descendant selectors
- Truncate modifier specificity reduced from (0,4,0) to (0,1,0) via `:where()`
- `display: flex` / `align-items: start` moved from shared rule to `.d-notice` individual rule
- Hardcoded `1px` in banner.less replaced with `var(--dt-size-border-100)`
- Redundant `.d-notice__message` font override in banner.less removed

**What did NOT change:**
- No visual changes
- No breaking changes for CSS-only or Vue consumers
- No class names, HTML structure, or Vue component API changes

## :bulb: Context

notice.less had `.d-banner &` overrides baked into notice child selectors — notice knew about its consumers. banner.less and toast.less reached into notice's children via descendant selectors, inflating specificity to (0,2,0). The truncate modifier hit (0,4,0). Coupling ran in both directions, making all three files fragile to changes in the others.

The fix extends the custom property inheritance pattern already used for colors (e.g. `--notice-color-background`) to also cover spacing, direction, and alignment overrides. Each file now owns only its own styles.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

[DLT-3296]: https://dialpad.atlassian.net/browse/DLT-3296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Refactors CSS for notice, banner, and toast components to decouple styles and eliminate specificity violations. Removes cross-component descendant selectors and replaces direct overrides with CSS custom property inheritance. Consolidates flex layout rules and uses variables for spacing, direction, and alignment. No visual or breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->