### PR TITLE
feat(focustrap): DLT-3297 add v-dt-focustrap directive for declarative focus trapping

### DIFF
--- a/apps/dialtone-documentation/docs/_data/vue-utilities.json
+++ b/apps/dialtone-documentation/docs/_data/vue-utilities.json
@@ -6,6 +6,11 @@
       "storybook": "https://dialtone.dialpad.com/vue/next/?path=/docs/directives-focusgroup--docs"
     },
     {
+      "name": "v-dt-focustrap",
+      "description": "Trap Tab/Shift+Tab within a container — initial focus, boundary wrapping, and focus restoration for dialogs and overlays",
+      "storybook": "https://dialtone.dialpad.com/vue/next/?path=/docs/directives-focustrap--docs"
+    },
+    {
       "name": "v-dt-mode",
       "description": "Scope descendant design tokens to a light, dark, or inverted color palette",
       "storybook": "https://dialtone.dialpad.com/vue/next/?path=/docs/directives-mode--docs"

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-21.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-21.md
@@ -77,7 +77,7 @@ Tab cycles through the inputs and buttons. Shift+Tab wraps backward. Focus never
 ## Options
 
 | Option | Type | Default | Description |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `active` | `boolean` | `true` | Whether the trap is active. Reactive. |
 | `initialFocus` | `'auto' \| string \| HTMLElement \| false` | `'auto'` | Where to place focus on activation. `'auto'` = first focusable. CSS selector = `el.querySelector()`. `false` = don't move focus. |
 | `restoreFocus` | `boolean` | `true` | Restore focus to the previously-focused element on deactivation. |
@@ -87,12 +87,12 @@ Tab cycles through the inputs and buttons. Shift+Tab wraps backward. Focus never
 These directives solve different problems. Use both when a widget needs both behaviors.
 
 | | `v-dt-focustrap` | `v-dt-focusgroup` |
-|---|---|---|
+| --- | --- | --- |
 | **Purpose** | Prevent focus from *leaving* a container | Move focus *within* a container via arrow keys |
 | **Key handled** | `Tab` / `Shift+Tab` | Arrow keys, `Home`, `End` |
 | **Typical use** | Dialogs, modals, popovers, drawers | Toolbars, tab lists, menus, listboxes |
 | **Tab behavior** | Cycles Tab at container boundaries | Single Tab stop — Tab exits the group |
-| **Composable?** | Yes — a dialog can use `v-dt-focustrap` on the dialog and `v-dt-focusgroup` on a toolbar inside it |
+| **Composable?** | Yes — use on the dialog container | Yes — use on a toolbar or menu inside the dialog |
 
 ## What It Does NOT Do
 

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-21.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-21.md
@@ -1,0 +1,125 @@
+---
+heading: 'Introducing v-dt-focustrap: Declarative Focus Trapping'
+author: Francis Rupert
+posted: '2026-4-21'
+excerpt: 'New Vue directive for focus trapping. Trap Tab/Shift+Tab within dialogs, popovers, and overlays with a single attribute — configurable initial focus, boundary wrapping, and focus restoration built in.'
+---
+
+<BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading" :excerpt="$frontmatter.excerpt">
+
+## TLDR
+
+- New directive `v-dt-focustrap` traps Tab/Shift+Tab within a container element.
+- Configurable initial focus: auto (first focusable), CSS selector, element ref, or disabled.
+- Focus restoration on deactivation — returns focus to the element that triggered the overlay.
+- Reactive — bind to your open/close state and the directive handles the full lifecycle.
+- Companion to `v-dt-focusgroup` — they solve different problems and compose together.
+- [Storybook docs](https://dialtone.dialpad.com/vue/next/?path=/docs/directives-focustrap--docs)
+
+## The Motivation
+
+When a dialog, popover, or drawer opens, Tab must not escape the container. Users who rely on keyboard navigation will Tab past the overlay into page content behind it — confusing, disorienting, and a WCAG 2.4.3 failure.
+
+Focus trapping in Dialtone has been handled by the Modal mixin, which 5+ components wire up differently. Some call `focusFirstElement()` on mount, some on transition-end, some conditionally. Some restore focus, some don't. There's no shared primitive for new components — every team re-implements the same logic with subtle differences.
+
+## The Solution
+
+One directive. One attribute. Zero event handlers.
+
+```vue demo
+<div
+  v-dt-focustrap
+  role="dialog"
+  aria-label="Settings"
+  class="d-w-500 d-p-300 d-bar8 d-bc-default d-ba d-bgc-primary"
+>
+  <dt-stack gap="200">
+    <dt-text as="p" kind="body" :size="200">Tab and Shift+Tab cycle within this container. Focus never escapes.</dt-text>
+    <dt-input label="Name" placeholder="Jane Doe" />
+    <dt-input label="Email" placeholder="jane@example.com" />
+    <dt-stack direction="row" gap="100">
+      <dt-button>Save</dt-button>
+      <dt-button kind="muted" importance="clear">Cancel</dt-button>
+    </dt-stack>
+  </dt-stack>
+</div>
+```
+
+Tab cycles through the inputs and buttons. Shift+Tab wraps backward. Focus never leaves the container. That's it.
+
+## Who Benefits
+
+- **Keyboard users** stay inside the overlay without escaping into page content behind it
+- **Screen reader users** get the expected dialog focus behavior — no silent focus loss
+- **Product teams** ship accessible overlays without writing focus management logic
+- **Dialtone** has one implementation to test, maintain, and improve
+
+## Configuration
+
+### Boolean binding — activate when truthy
+
+```html
+<div v-dt-focustrap="isOpen" role="dialog" aria-label="Settings">
+```
+
+### Object binding — full configuration
+
+```html
+<div v-dt-focustrap="{ active: isOpen, initialFocus: '#name-input', restoreFocus: true }" role="dialog">
+```
+
+### Always active
+
+```html
+<div v-dt-focustrap role="alertdialog" aria-label="Confirm">
+```
+
+## Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `active` | `boolean` | `true` | Whether the trap is active. Reactive. |
+| `initialFocus` | `'auto' \| string \| HTMLElement \| false` | `'auto'` | Where to place focus on activation. `'auto'` = first focusable. CSS selector = `el.querySelector()`. `false` = don't move focus. |
+| `restoreFocus` | `boolean` | `true` | Restore focus to the previously-focused element on deactivation. |
+
+## Focustrap vs. Focusgroup
+
+These directives solve different problems. Use both when a widget needs both behaviors.
+
+| | `v-dt-focustrap` | `v-dt-focusgroup` |
+|---|---|---|
+| **Purpose** | Prevent focus from *leaving* a container | Move focus *within* a container via arrow keys |
+| **Key handled** | `Tab` / `Shift+Tab` | Arrow keys, `Home`, `End` |
+| **Typical use** | Dialogs, modals, popovers, drawers | Toolbars, tab lists, menus, listboxes |
+| **Tab behavior** | Cycles Tab at container boundaries | Single Tab stop — Tab exits the group |
+| **Composable?** | Yes — a dialog can use `v-dt-focustrap` on the dialog and `v-dt-focusgroup` on a toolbar inside it |
+
+## What It Does NOT Do
+
+- **Escape key.** Not handled. Add your own `@keydown.escape` handler.
+- **Click outside.** Not handled. Use a click-outside directive or manual listener.
+- **`aria-modal` or `role`.** Not set. You must provide the appropriate ARIA semantics yourself.
+- **Scroll lock.** Not managed. Use CSS `overflow: hidden` on `<body>` if needed.
+
+These boundaries are intentional. A focused tool that does one thing well is more trustworthy than one that tries to manage the full overlay lifecycle.
+
+## Replacing a Custom Focus Trap
+
+If your product feature has its own focus trap logic, you can replace it:
+
+```html
+<!-- Before: manual focus trap -->
+<div ref="dialog" @keydown.tab="trapFocus" role="dialog">
+
+<!-- After: directive handles everything -->
+<div v-dt-focustrap="isOpen" role="dialog">
+```
+
+Remove your `@keydown.tab` handler, your `querySelectorAll` calls for Tab trapping, and your `previousActiveElement` save/restore logic. Keep your Escape and click-outside handlers — those are yours to own.
+
+</BlogPost>
+
+<script setup>
+import BlogPost from '@baseComponents/BlogPost.vue';
+import { parse } from 'date-fns';
+</script>

--- a/packages/dialtone-vue/.storybook/preview.jsx
+++ b/packages/dialtone-vue/.storybook/preview.jsx
@@ -50,6 +50,7 @@ import { DtTooltipDirective } from '@/directives/tooltip_directive';
 import { DtScrollbarDirective } from '@/directives/scrollbar_directive';
 import { DtModeDirective } from '@/directives/mode_directive';
 import { DtFocusgroupDirective } from '@/directives/focusgroup_directive';
+import { DtFocustrapDirective } from '@/directives/focustrap_directive';
 import { DtStack } from '@/components/stack';
 import { faker } from '@faker-js/faker';
 
@@ -137,6 +138,7 @@ setup((app) => {
   app.use(DtScrollbarDirective);
   app.use(DtModeDirective);
   app.use(DtFocusgroupDirective);
+  app.use(DtFocustrapDirective);
   app.component('DtStack', DtStack);
   // global seed, to make sure results are reproducible on percy and don't change on every reload too.
   faker.seed(6687422389464139);

--- a/packages/dialtone-vue/directives/focustrap_directive/focustrap.js
+++ b/packages/dialtone-vue/directives/focustrap_directive/focustrap.js
@@ -1,0 +1,205 @@
+import { getTabbableElements, getFirstFocusCandidate } from './focustrap_utils.js';
+import { FOCUSTRAP_DEFAULTS, FOCUSTRAP_STATE_KEY } from './focustrap_constants.js';
+
+/**
+ * v-dt-focustrap directive — trap Tab/Shift+Tab within a container element.
+ *
+ * Manages initial focus, Tab boundary wrapping, and focus restoration.
+ * Does NOT handle Escape or click-outside — that's the component's responsibility.
+ *
+ * @example
+ * // Boolean binding — activate when truthy
+ * <div role="dialog" v-dt-focustrap="isOpen" aria-label="Settings">
+ *
+ * // Object binding — full configuration
+ * <div role="dialog" v-dt-focustrap="{ active: isOpen, initialFocus: '#name-input' }">
+ *
+ * // Always active (no binding value)
+ * <div role="alertdialog" v-dt-focustrap aria-label="Confirm">
+ *
+ * @see https://dialtone.dialpad.com/vue/next/?path=/docs/directives-focustrap--docs
+ */
+export const DtFocustrapDirective = {
+  name: 'dt-focustrap-directive',
+
+  install (app) {
+    app.directive('dt-focustrap', {
+      mounted (el, binding) {
+        const config = resolveConfig(binding.value);
+        el[FOCUSTRAP_STATE_KEY] = createState();
+
+        if (config.active) {
+          activate(el, config);
+        }
+      },
+
+      updated (el, binding) {
+        const prev = resolveConfig(binding.oldValue);
+        const next = resolveConfig(binding.value);
+        const state = el[FOCUSTRAP_STATE_KEY];
+
+        if (!state) return;
+
+        if (!prev.active && next.active) {
+          activate(el, next);
+        } else if (prev.active && !next.active) {
+          deactivate(el);
+        }
+      },
+
+      unmounted (el) {
+        const state = el[FOCUSTRAP_STATE_KEY];
+        if (state?.active) {
+          deactivate(el);
+        }
+        cleanup(el);
+        delete el[FOCUSTRAP_STATE_KEY];
+      },
+    });
+  },
+};
+
+// ── Config resolution ───────────────────────────────────────
+
+function resolveConfig (value) {
+  if (value == null || value === true) {
+    return { ...FOCUSTRAP_DEFAULTS, active: true };
+  }
+  if (value === false) {
+    return { ...FOCUSTRAP_DEFAULTS, active: false };
+  }
+  if (typeof value === 'object') {
+    return { ...FOCUSTRAP_DEFAULTS, ...value };
+  }
+  return { ...FOCUSTRAP_DEFAULTS, active: Boolean(value) };
+}
+
+// ── State management ────────────────────────────────────────
+
+function createState () {
+  return {
+    active: false,
+    onKeydown: null,
+    previousActiveElement: null,
+    restoreFocus: true,
+    addedTabindex: false,
+  };
+}
+
+// ── Activate / Deactivate ───────────────────────────────────
+
+function activate (el, config) {
+  const state = el[FOCUSTRAP_STATE_KEY];
+  if (!state || state.active) return;
+
+  state.active = true;
+  state.restoreFocus = config.restoreFocus;
+  state.previousActiveElement = document.activeElement;
+
+  // Bind Tab keydown handler
+  state.onKeydown = (event) => handleKeydown(event, el);
+  el.addEventListener('keydown', state.onKeydown);
+
+  // Set initial focus
+  setInitialFocus(el, config);
+}
+
+function deactivate (el) {
+  const state = el[FOCUSTRAP_STATE_KEY];
+  if (!state || !state.active) return;
+
+  state.active = false;
+  cleanup(el);
+
+  // Restore focus using the config captured at activation time
+  if (state.restoreFocus && state.previousActiveElement) {
+    try {
+      state.previousActiveElement.focus({ preventScroll: true });
+    } catch {
+      // Element no longer in DOM or not focusable
+    }
+  }
+  state.previousActiveElement = null;
+}
+
+function cleanup (el) {
+  const state = el[FOCUSTRAP_STATE_KEY];
+  if (!state) return;
+  if (state.onKeydown) {
+    el.removeEventListener('keydown', state.onKeydown);
+    state.onKeydown = null;
+  }
+  if (state.addedTabindex) {
+    el.removeAttribute('tabindex');
+    state.addedTabindex = false;
+  }
+}
+
+// ── Initial focus ───────────────────────────────────────────
+
+function resolveInitialFocusTarget (el, initialFocus) {
+  if (initialFocus === 'auto' || initialFocus == null) {
+    const elements = getTabbableElements(el, { includeNegativeTabIndex: true });
+    return getFirstFocusCandidate(elements);
+  }
+  if (typeof initialFocus === 'string') return el.querySelector(initialFocus);
+  if (initialFocus instanceof HTMLElement) return initialFocus;
+  return null;
+}
+
+function focusOrFallback (el, target) {
+  if (target) {
+    target.focus({ preventScroll: true });
+    return;
+  }
+  if (!el.hasAttribute('tabindex')) {
+    el.setAttribute('tabindex', '-1');
+    const state = el[FOCUSTRAP_STATE_KEY];
+    if (state) state.addedTabindex = true;
+  }
+  el.focus({ preventScroll: true });
+}
+
+function setInitialFocus (el, config) {
+  if (config.initialFocus === false) return;
+
+  // Delay to next microtask to avoid breaking transitions and unwanted scrolling
+  Promise.resolve().then(() => {
+    const state = el[FOCUSTRAP_STATE_KEY];
+    if (!state?.active) return;
+    focusOrFallback(el, resolveInitialFocusTarget(el, config.initialFocus));
+  });
+}
+
+// ── Tab trapping ────────────────────────────────────────────
+
+function handleKeydown (event, el) {
+  if (event.key !== 'Tab') return;
+
+  const elements = getTabbableElements(el);
+
+  if (!elements.length) {
+    event.preventDefault();
+    return;
+  }
+
+  // Tab boundaries use DOM order (elements[0] / elements[last]),
+  // NOT getFirstFocusCandidate() — the radio-preference logic is for
+  // initial focus only, not for Tab wrapping.
+  const first = elements[0];
+  const last = elements[elements.length - 1];
+
+  if (event.shiftKey) {
+    if (document.activeElement === first) {
+      last.focus({ preventScroll: true });
+      event.preventDefault();
+    }
+  } else {
+    if (document.activeElement === last) {
+      first.focus({ preventScroll: true });
+      event.preventDefault();
+    }
+  }
+}
+
+export default DtFocustrapDirective;

--- a/packages/dialtone-vue/directives/focustrap_directive/focustrap.mdx
+++ b/packages/dialtone-vue/directives/focustrap_directive/focustrap.mdx
@@ -1,0 +1,258 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as FocustrapDirectiveStories from './focustrap.stories.js';
+
+<Meta of={FocustrapDirectiveStories}/>
+
+# Focustrap directive
+
+Traps Tab and Shift+Tab focus within a container element. Manages initial focus
+placement, Tab boundary wrapping, and focus restoration on deactivation.
+
+Use this directive for dialogs, popovers, drawers, and any overlay where focus
+must not escape the container while it is open.
+
+The directive handles **Tab trapping only**. Escape-to-close, click-outside
+dismissal, and `aria-modal` management remain the consumer's responsibility.
+
+## Usage
+
+Import and install the directive:
+
+```js
+import { DtFocustrapDirective } from "@dialpad/dialtone-vue";
+app.use(DtFocustrapDirective);
+```
+
+### Boolean binding -- activate when truthy
+
+```html
+<div v-dt-focustrap="isOpen" role="dialog" aria-label="Settings">
+  ...
+</div>
+```
+
+### Object binding -- full configuration
+
+```html
+<div
+  v-dt-focustrap="{ active: isOpen, initialFocus: '#name-input', restoreFocus: true }"
+  role="dialog"
+  aria-label="Settings"
+>
+  <input id="name-input" />
+  ...
+</div>
+```
+
+### No binding -- always active
+
+```html
+<div v-dt-focustrap role="alertdialog" aria-label="Confirm">
+  ...
+</div>
+```
+
+## Examples
+
+### Default (always active)
+
+A dialog container with buttons, inputs, and a link. Tab and Shift+Tab cycle
+within the container and never escape.
+
+<Canvas of={FocustrapDirectiveStories.Default} />
+
+### Initial focus via CSS selector
+
+Use `initialFocus` with a CSS selector string to direct focus to a specific
+element when the trap activates.
+
+<Canvas of={FocustrapDirectiveStories.InitialFocusSelector} />
+
+### Toggle activation
+
+Bind `active` to a reactive boolean. When the trap deactivates with
+`restoreFocus: true`, focus returns to the element that was focused before
+activation.
+
+<Canvas of={FocustrapDirectiveStories.ToggleActivation} sourceState="none" />
+
+### No initial focus
+
+Set `initialFocus: false` to prevent the directive from moving focus on
+activation. Focus stays where it was, but Tab still cycles within the container.
+
+<Canvas of={FocustrapDirectiveStories.NoInitialFocus} />
+
+## Options
+
+<table>
+  <thead>
+    <tr><th>Property</th><th>Type</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>active</code></td>
+      <td><code>boolean</code></td>
+      <td><code>true</code></td>
+      <td>Whether the trap is currently active. Reactive -- changing this activates or deactivates the trap.</td>
+    </tr>
+    <tr>
+      <td><code>initialFocus</code></td>
+      <td><code>'auto' | string | HTMLElement | false</code></td>
+      <td><code>'auto'</code></td>
+      <td>
+        Where to place focus when the trap activates.<br/>
+        <code>'auto'</code> -- first tabbable element (including <code>tabindex="-1"</code>).<br/>
+        <strong>CSS selector</strong> -- e.g. <code>'#my-input'</code>, resolved via <code>el.querySelector()</code>.<br/>
+        <strong>HTMLElement</strong> -- a direct DOM reference.<br/>
+        <code>false</code> -- do not move focus.
+      </td>
+    </tr>
+    <tr>
+      <td><code>restoreFocus</code></td>
+      <td><code>boolean</code></td>
+      <td><code>true</code></td>
+      <td>Restore focus to the previously focused element when the trap deactivates.</td>
+    </tr>
+  </tbody>
+</table>
+
+## How it works
+
+### Keydown interception
+
+The directive listens for `keydown` events on the container element and
+intercepts the `Tab` key. All other keys pass through unmodified.
+
+### Tab wrapping
+
+When Tab is pressed on the **last** tabbable element, focus wraps to the
+**first** tabbable element. When Shift+Tab is pressed on the **first** tabbable
+element, focus wraps to the **last**. The tabbable element list is re-queried on
+every Tab press, so dynamically added or removed elements are handled correctly.
+
+### Initial focus resolution
+
+When the trap activates, focus is placed according to the `initialFocus` option:
+
+1. **`'auto'`** (default) -- focuses the first tabbable element inside the
+   container, including elements with `tabindex="-1"`. For radio buttons, prefers
+   the checked radio over the first in the group.
+2. **CSS selector string** -- runs `el.querySelector()` against the container.
+3. **HTMLElement reference** -- focuses the element directly.
+4. **`false`** -- no initial focus movement.
+5. **Fallback** -- if no tabbable element is found, the container itself is made
+   focusable (`tabindex="-1"`) and focused.
+
+Initial focus is set asynchronously (microtask) to avoid breaking CSS transitions
+and unwanted scrolling.
+
+### Focus restoration
+
+When the trap deactivates with `restoreFocus: true`, the element that held focus
+before activation is refocused. If that element has been removed from the DOM,
+the restore is silently skipped.
+
+## Focustrap vs. Focusgroup
+
+These directives solve different problems. Use both when a widget needs both behaviors.
+
+<table>
+  <thead>
+    <tr><th></th><th><code>v-dt-focustrap</code></th><th><code>v-dt-focusgroup</code></th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Purpose</strong></td>
+      <td>Prevent focus from <em>leaving</em> a container</td>
+      <td>Move focus <em>within</em> a container via arrow keys</td>
+    </tr>
+    <tr>
+      <td><strong>Key handled</strong></td>
+      <td><code>Tab</code> / <code>Shift+Tab</code></td>
+      <td>Arrow keys, <code>Home</code>, <code>End</code></td>
+    </tr>
+    <tr>
+      <td><strong>Typical use</strong></td>
+      <td>Dialogs, modals, popovers, hovercards, drawers</td>
+      <td>Toolbars, tab lists, menus, listboxes, radio groups</td>
+    </tr>
+    <tr>
+      <td><strong>Tab behavior</strong></td>
+      <td>Cycles Tab at container boundaries</td>
+      <td>Single Tab stop — Tab exits the group</td>
+    </tr>
+    <tr>
+      <td><strong>Focus management</strong></td>
+      <td>Initial focus + focus restoration</td>
+      <td>Roving tabindex + memory</td>
+    </tr>
+    <tr>
+      <td><strong>Composable?</strong></td>
+      <td colspan="2">Yes — a dialog can use <code>v-dt-focustrap</code> on the dialog element and <code>v-dt-focusgroup</code> on a toolbar inside it.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Why use this instead of a custom implementation?
+
+**Consistent behavior.** Every focus trap in the product works the same way — same
+focusable-element detection, same Tab wrapping, same initial focus logic, same
+focus restoration. No per-team divergence.
+
+**Battle-tested discovery logic.** The focusable-element selectors and filters are
+extracted from the Modal mixin that has been stable in production across DtModal,
+DtBanner, DtPopover, and DtImageViewer for years. Radio button handling, visibility
+filtering, disabled-state filtering — all handled.
+
+**Zero boilerplate.** One attribute replaces: a mixin import, a keydown handler, a
+`focusFirstElement()` call, a `previousActiveElement` ref, and a manual
+`focus()` restore in your close handler.
+
+**Reactive.** Bind to your open/close state and the directive handles the full
+lifecycle. No manual activate/deactivate calls.
+
+## Migrating a custom focus trap in product code
+
+If your product feature has its own focus trap logic (manual Tab keydown listeners,
+`querySelectorAll('button, [href], input...')`, etc.), you can replace it with one line:
+
+```html
+<!-- Before: manual focus trap -->
+<div ref="dialog" @keydown.tab="trapFocus" role="dialog">
+
+<!-- After: directive handles everything -->
+<div v-dt-focustrap="isOpen" role="dialog">
+```
+
+**Steps:**
+
+1. Remove any `@keydown.tab` handler that implements Tab wrapping
+2. Remove any `focusableElements` / `querySelectorAll` calls for Tab trapping
+3. Remove any `previousActiveElement` save/restore logic
+4. Add `v-dt-focustrap="yourOpenState"` to the container
+5. If you need focus on a specific element, add `initialFocus: '#your-element'`
+6. Keep your existing Escape and click-outside handlers — those are yours to own
+
+## What it does NOT do
+
+- **Escape key** -- not handled. Add your own `@keydown.escape` handler.
+- **Click outside** -- not handled. Use a click-outside directive or manual listener.
+- **`aria-modal`** -- not set. Add `aria-modal="true"` to your dialog element yourself.
+- **`role="dialog"`** -- not set. You must provide the appropriate ARIA role and label.
+- **Scroll lock** -- not managed. Use CSS `overflow: hidden` on `<body>` if needed.
+- **Portal / teleport** -- the directive works on the element it is bound to,
+  regardless of where it sits in the DOM. Works fine with Vue `<Teleport>`.
+
+## Migration from Modal mixin
+
+Components that currently use `modal.js` mixin for focus trapping can adopt
+`v-dt-focustrap` incrementally:
+
+1. Add `v-dt-focustrap="isOpen"` to the container element.
+2. Remove the mixin's `focusTrap()` / `releaseFocusTrap()` calls.
+3. The directive handles tabbable element discovery, Tab wrapping, initial focus,
+   and focus restoration automatically.
+
+The directive uses the same focusable-element selectors as the mixin, so behavior
+is consistent.

--- a/packages/dialtone-vue/directives/focustrap_directive/focustrap.stories.js
+++ b/packages/dialtone-vue/directives/focustrap_directive/focustrap.stories.js
@@ -1,0 +1,154 @@
+import DtButton from '@/components/button/button.vue';
+import DtInput from '@/components/input/input.vue';
+import DtLink from '@/components/link/link.vue';
+import { DtText } from '@/components/text';
+
+export const argsData = {};
+export const argTypesData = {};
+
+export default {
+  title: 'Directives/Focustrap',
+  args: argsData,
+  argTypes: argTypesData,
+  excludeStories: /.*Data$/,
+};
+
+// -- Helper: inline story with single source of truth --------
+const inline = (components, template) => ({
+  render: () => ({ components, template }),
+  parameters: {
+    options: { showPanel: false },
+    controls: { disable: true },
+    docs: { source: { code: template, language: 'html' } },
+  },
+});
+
+// -- Default: always-active trap with buttons and input ------
+export const Default = inline({ DtButton, DtInput, DtLink, DtText }, `\
+<div
+  v-dt-focustrap
+  role="dialog"
+  aria-label="Settings"
+  class="d-w-500 d-p-300 d-bar8 d-bc-default d-ba d-bgc-primary"
+>
+  <dt-stack gap="200">
+    <dt-text as="p" kind="body" :size="200">Tab and Shift+Tab cycle within this container.</dt-text>
+    <dt-stack gap="200">
+      <dt-input label="Name" placeholder="Jane Doe" />
+      <dt-input label="Email" placeholder="jane@example.com" />
+      <dt-stack direction="row" gap="100">
+        <dt-button>Save</dt-button>
+        <dt-button kind="muted" importance="clear">Cancel</dt-button>
+      </dt-stack>
+      <dt-text as="p">
+        <dt-link href="#">Terms and conditions</dt-link>
+      </dt-text>
+    </dt-stack>
+  </dt-stack>
+</div>`);
+
+// -- Initial focus via CSS selector -------------------------
+export const InitialFocusSelector = inline({ DtButton, DtInput, DtText }, `\
+<div
+  v-dt-focustrap="{ initialFocus: '#focus-target' }"
+  role="dialog"
+  aria-label="Initial focus demo"
+  class="d-w-500 d-p-300 d-bar8 d-bc-default d-ba d-bgc-primary"
+>
+  <dt-stack gap="200">
+    <dt-text as="p" kind="body" :size="200">Initial focus goes to the email input via <code>#focus-target</code> selector.</dt-text>
+    <dt-stack gap="200">
+      <dt-input label="Name" placeholder="Jane Doe" />
+      <dt-input id="focus-target" label="Email (initially focused)" placeholder="jane@example.com" />
+      <dt-stack direction="row" gap="100">
+        <dt-button>Submit</dt-button>
+        <dt-button kind="muted" importance="clear">Cancel</dt-button>
+      </dt-stack>
+    </dt-stack>
+  </dt-stack>
+</div>`);
+
+// -- Toggle activation with focus restoration ----------------
+export const ToggleActivation = {
+  render: () => ({
+    components: { DtButton, DtInput, DtText },
+    data () {
+      return { isActive: false };
+    },
+    template: `\
+<dt-stack gap="200">
+  <dt-text as="p">
+    <dt-button @click="isActive = !isActive" kind="muted" importance="outlined">
+      {{ isActive ? 'Deactivate trap' : 'Activate trap' }}
+    </dt-button>
+  </dt-text>
+  <div
+    v-dt-focustrap="{ active: isActive, restoreFocus: true }"
+    role="dialog"
+    aria-label="Toggle demo"
+    class="d-w-500 d-p-300 d-bar8 d-bc-default d-ba d-bgc-primary"
+  >
+    <dt-stack gap="200">
+      <dt-text as="p" kind="body" :size="200">
+        Trap is <strong>{{ isActive ? 'active' : 'inactive' }}</strong>.
+        When deactivated, focus returns to the toggle button.
+      </dt-text>
+      <dt-stack gap="200">
+        <dt-input label="First name" placeholder="Jane" />
+        <dt-input label="Last name" placeholder="Doe" />
+        <dt-stack direction="row" gap="100">
+          <dt-button>Save</dt-button>
+          <dt-button kind="muted" importance="outlined" @click="isActive = false">Cancel</dt-button>
+        </dt-stack>
+      </dt-stack>
+    </dt-stack>
+  </div>
+</dt-stack>`,
+  }),
+  parameters: {
+    options: { showPanel: false },
+    controls: { disable: true },
+    docs: {
+      source: {
+        code: `\
+<dt-button @click="isActive = !isActive">
+  {{ isActive ? 'Deactivate trap' : 'Activate trap' }}
+</dt-button>
+<div
+  v-dt-focustrap="{ active: isActive, restoreFocus: true }"
+  role="dialog"
+  aria-label="Toggle demo"
+>
+  <dt-input label="First name" />
+  <dt-input label="Last name" />
+  <dt-button>Save</dt-button>
+  <dt-button @click="isActive = false">Cancel</dt-button>
+</div>`,
+        language: 'html',
+      },
+    },
+  },
+};
+
+// -- No initial focus — focus stays where it was -------------
+export const NoInitialFocus = inline({ DtButton, DtInput, DtText }, `\
+<div
+  v-dt-focustrap="{ initialFocus: false }"
+  role="dialog"
+  aria-label="No initial focus demo"
+  class="d-w-500 d-p-300 d-bar8 d-bc-default d-ba d-bgc-primary"
+>
+  <dt-stack gap="200">
+    <dt-text as="p" kind="body" :size="200">
+      <code>initialFocus: false</code> &mdash; focus stays where it was before the trap activated.
+      Tab still cycles within the container.
+    </dt-text>
+    <dt-stack gap="200">
+      <dt-input label="Search" placeholder="Type to search..." />
+      <dt-stack direction="row" gap="100">
+        <dt-button>Apply</dt-button>
+        <dt-button kind="muted" importance="outlined">Reset</dt-button>
+      </dt-stack>
+    </dt-stack>
+  </dt-stack>
+</div>`);

--- a/packages/dialtone-vue/directives/focustrap_directive/focustrap.test.js
+++ b/packages/dialtone-vue/directives/focustrap_directive/focustrap.test.js
@@ -1,19 +1,11 @@
 import { mount } from '@vue/test-utils';
 import { DtFocustrapDirective } from './focustrap.js';
 import { FOCUSTRAP_DEFAULTS, FOCUSTRAP_STATE_KEY } from './focustrap_constants.js';
+import { flushPromises } from '@/common/utils';
 
 // ── Helpers ─────────────────────────────────────────────────
 
 const PLUGINS = [DtFocustrapDirective];
-
-/**
- * Flush the microtask queue so that Promise.resolve().then(...)
- * used by setInitialFocus has a chance to run.
- */
-async function flushMicrotasks (wrapper) {
-  await wrapper.vm.$nextTick();
-  await new Promise(resolve => setTimeout(resolve, 0));
-}
 
 function mountDialog (config = true, options = {}) {
   return mount({
@@ -56,14 +48,14 @@ describe('DtFocustrapDirective', () => {
   describe('Default rendering', () => {
     it('should mount without errors', async () => {
       wrapper = mountDialog();
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(wrapper.find('[data-qa="trap"]').exists()).toBe(true);
     });
 
     it('should store state on the container element', async () => {
       wrapper = mountDialog();
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       expect(el[FOCUSTRAP_STATE_KEY]).toBeDefined();
@@ -71,7 +63,7 @@ describe('DtFocustrapDirective', () => {
 
     it('should activate the trap on mount', async () => {
       wrapper = mountDialog();
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       expect(el[FOCUSTRAP_STATE_KEY].active).toBe(true);
@@ -79,7 +71,7 @@ describe('DtFocustrapDirective', () => {
 
     it('should register a keydown listener on the container', async () => {
       wrapper = mountDialog();
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       expect(el[FOCUSTRAP_STATE_KEY].onKeydown).toBeTypeOf('function');
@@ -91,7 +83,7 @@ describe('DtFocustrapDirective', () => {
   describe('Tab wrapping', () => {
     it('should wrap focus from last element to first on Tab', async () => {
       wrapper = mountDialog();
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       wrapper.find('[data-qa="third"]').element.focus();
       await wrapper.find('[data-qa="trap"]').trigger('keydown', { key: 'Tab' });
@@ -101,7 +93,7 @@ describe('DtFocustrapDirective', () => {
 
     it('should wrap focus from first element to last on Shift+Tab', async () => {
       wrapper = mountDialog();
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       wrapper.find('[data-qa="first"]').element.focus();
       await wrapper.find('[data-qa="trap"]').trigger('keydown', { key: 'Tab', shiftKey: true });
@@ -111,12 +103,11 @@ describe('DtFocustrapDirective', () => {
 
     it('should not interfere with Tab between middle elements', async () => {
       wrapper = mountDialog();
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       wrapper.find('[data-qa="second"]').element.focus();
       await wrapper.find('[data-qa="trap"]').trigger('keydown', { key: 'Tab' });
 
-      // Focus should remain on second since the handler only traps at boundaries
       expect(document.activeElement).toBe(wrapper.find('[data-qa="second"]').element);
     });
   });
@@ -126,21 +117,7 @@ describe('DtFocustrapDirective', () => {
   describe('Initial focus: auto', () => {
     it('should focus the first focusable element on activation', async () => {
       wrapper = mountDialog();
-      await flushMicrotasks(wrapper);
-
-      expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
-    });
-
-    it('should focus first focusable element when config is bare true', async () => {
-      wrapper = mountDialog(true);
-      await flushMicrotasks(wrapper);
-
-      expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
-    });
-
-    it('should focus first focusable element when config is { active: true }', async () => {
-      wrapper = mountDialog({ active: true });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
     });
@@ -151,16 +128,15 @@ describe('DtFocustrapDirective', () => {
   describe('Initial focus: CSS selector', () => {
     it('should focus the element matching the selector', async () => {
       wrapper = mountDialog({ active: true, initialFocus: '[data-qa="second"]' });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(document.activeElement).toBe(wrapper.find('[data-qa="second"]').element);
     });
 
     it('should fall back to container if selector matches nothing', async () => {
       wrapper = mountDialog({ active: true, initialFocus: '[data-qa="nonexistent"]' });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
-      // Container should be focused as fallback
       expect(document.activeElement).toBe(wrapper.find('[data-qa="trap"]').element);
     });
   });
@@ -169,14 +145,13 @@ describe('DtFocustrapDirective', () => {
 
   describe('Initial focus: false', () => {
     it('should not move focus when initialFocus is false', async () => {
-      // Focus something outside the trap first
       const outsideBtn = document.createElement('button');
       outsideBtn.setAttribute('data-qa', 'outside');
       document.body.appendChild(outsideBtn);
       outsideBtn.focus();
 
       wrapper = mountDialog({ active: true, initialFocus: false });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(document.activeElement).toBe(outsideBtn);
 
@@ -195,7 +170,7 @@ describe('DtFocustrapDirective', () => {
           <input type="radio" name="choice" value="c" data-qa="radio-c" />
         </div>
       `);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(document.activeElement).toBe(wrapper.find('[data-qa="radio-b"]').element);
     });
@@ -207,7 +182,7 @@ describe('DtFocustrapDirective', () => {
           <input type="radio" name="choice" value="b" data-qa="radio-b" />
         </div>
       `);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(document.activeElement).toBe(wrapper.find('[data-qa="radio-a"]').element);
     });
@@ -216,40 +191,36 @@ describe('DtFocustrapDirective', () => {
   // ── Focus restoration ──────────────────────────────────
 
   describe('Focus restoration', () => {
-    it('should restore focus to previously focused element on deactivation', async () => {
-      const outsideBtn = document.createElement('button');
+    let outsideBtn;
+
+    beforeEach(() => {
+      outsideBtn = document.createElement('button');
       outsideBtn.setAttribute('data-qa', 'outside');
       document.body.appendChild(outsideBtn);
       outsideBtn.focus();
+    });
 
+    afterEach(() => {
+      outsideBtn.remove();
+    });
+
+    it('should restore focus to previously focused element on deactivation', async () => {
       wrapper = mountWithTemplate(true, `
         <div>
           <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Test dialog">
             <button data-qa="first">First</button>
-            <button data-qa="second">Second</button>
           </div>
         </div>
       `);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       await wrapper.setData({ config: false });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(document.activeElement).toBe(outsideBtn);
-
-      outsideBtn.remove();
     });
-  });
 
-  // ── Focus restoration: disabled ────────────────────────
-
-  describe('Focus restoration: disabled', () => {
     it('should not restore focus when restoreFocus is false', async () => {
-      const outsideBtn = document.createElement('button');
-      outsideBtn.setAttribute('data-qa', 'outside');
-      document.body.appendChild(outsideBtn);
-      outsideBtn.focus();
-
       wrapper = mountWithTemplate({ active: true, restoreFocus: false }, `
         <div>
           <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Test dialog">
@@ -257,14 +228,12 @@ describe('DtFocustrapDirective', () => {
           </div>
         </div>
       `);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       await wrapper.setData({ config: { active: false, restoreFocus: false } });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(document.activeElement).not.toBe(outsideBtn);
-
-      outsideBtn.remove();
     });
   });
 
@@ -273,10 +242,10 @@ describe('DtFocustrapDirective', () => {
   describe('Reactive activation', () => {
     it('should set active state when binding changes from false to true', async () => {
       wrapper = mountDialog(false);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       await wrapper.setData({ config: true });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       expect(el[FOCUSTRAP_STATE_KEY].active).toBe(true);
@@ -284,20 +253,20 @@ describe('DtFocustrapDirective', () => {
 
     it('should focus first element when binding changes from false to true', async () => {
       wrapper = mountDialog(false);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       await wrapper.setData({ config: true });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
     });
 
     it('should activate with object binding change', async () => {
       wrapper = mountDialog({ active: false });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       await wrapper.setData({ config: { active: true } });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
     });
@@ -308,10 +277,10 @@ describe('DtFocustrapDirective', () => {
   describe('Reactive deactivation', () => {
     it('should set active state to false when binding changes from true to false', async () => {
       wrapper = mountDialog(true);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       await wrapper.setData({ config: false });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       expect(el[FOCUSTRAP_STATE_KEY].active).toBe(false);
@@ -324,10 +293,10 @@ describe('DtFocustrapDirective', () => {
       outsideBtn.focus();
 
       wrapper = mountDialog(true);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       await wrapper.setData({ config: false });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(document.activeElement).toBe(outsideBtn);
 
@@ -336,13 +305,13 @@ describe('DtFocustrapDirective', () => {
 
     it('should remove keydown listener on deactivation', async () => {
       wrapper = mountDialog(true);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       expect(el[FOCUSTRAP_STATE_KEY].onKeydown).toBeTypeOf('function');
 
       await wrapper.setData({ config: false });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(el[FOCUSTRAP_STATE_KEY].onKeydown).toBeNull();
     });
@@ -353,7 +322,7 @@ describe('DtFocustrapDirective', () => {
   describe('Boolean binding', () => {
     it('should activate the trap when bound to true', async () => {
       wrapper = mountDialog(true);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       expect(el[FOCUSTRAP_STATE_KEY].active).toBe(true);
@@ -361,14 +330,14 @@ describe('DtFocustrapDirective', () => {
 
     it('should focus first element when bound to true', async () => {
       wrapper = mountDialog(true);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
     });
 
     it('should treat false as { active: false }', async () => {
       wrapper = mountDialog(false);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       expect(el[FOCUSTRAP_STATE_KEY].active).toBe(false);
@@ -384,10 +353,9 @@ describe('DtFocustrapDirective', () => {
           <p>No focusable elements here</p>
         </div>
       `);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const trap = wrapper.find('[data-qa="trap"]');
-      // Should not throw
       await trap.trigger('keydown', { key: 'Tab' });
     });
 
@@ -397,7 +365,7 @@ describe('DtFocustrapDirective', () => {
           <p>No focusable elements here</p>
         </div>
       `);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
       const spy = vi.spyOn(event, 'preventDefault');
@@ -410,25 +378,28 @@ describe('DtFocustrapDirective', () => {
   // ── Dynamic content ────────────────────────────────────
 
   describe('Dynamic content', () => {
+    const DYNAMIC_TEMPLATE = `
+      <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Dynamic dialog">
+        <button data-qa="first">First</button>
+        <button v-if="showMiddle" data-qa="middle">Middle</button>
+        <button data-qa="last">Last</button>
+      </div>
+    `;
+
     it('should include newly added elements in Tab wrapping', async () => {
       wrapper = mount({
-        data () { return { config: true, showExtra: false }; },
-        template: `
-          <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Dynamic dialog">
-            <button data-qa="first">First</button>
-            <button v-if="showExtra" data-qa="extra">Extra</button>
-          </div>
-        `,
+        data () { return { config: true, showMiddle: false }; },
+        template: DYNAMIC_TEMPLATE,
       }, {
         global: { plugins: PLUGINS },
         attachTo: document.body,
       });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
-      await wrapper.setData({ showExtra: true });
-      await flushMicrotasks(wrapper);
+      await wrapper.setData({ showMiddle: true });
+      await flushPromises();
 
-      wrapper.find('[data-qa="extra"]').element.focus();
+      wrapper.find('[data-qa="last"]').element.focus();
       await wrapper.find('[data-qa="trap"]').trigger('keydown', { key: 'Tab' });
       expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
     });
@@ -436,29 +407,20 @@ describe('DtFocustrapDirective', () => {
     it('should handle removed focusable elements', async () => {
       wrapper = mount({
         data () { return { config: true, showMiddle: true }; },
-        template: `
-          <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Dynamic dialog">
-            <button data-qa="first">First</button>
-            <button v-if="showMiddle" data-qa="middle">Middle</button>
-            <button data-qa="last">Last</button>
-          </div>
-        `,
+        template: DYNAMIC_TEMPLATE,
       }, {
         global: { plugins: PLUGINS },
         attachTo: document.body,
       });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
-      // Remove the middle button
       await wrapper.setData({ showMiddle: false });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
-      // Tab on last should wrap to first
       wrapper.find('[data-qa="last"]').element.focus();
       await wrapper.find('[data-qa="trap"]').trigger('keydown', { key: 'Tab' });
       expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
 
-      // Shift+Tab on first should wrap to last
       wrapper.find('[data-qa="first"]').element.focus();
       await wrapper.find('[data-qa="trap"]').trigger('keydown', { key: 'Tab', shiftKey: true });
       expect(document.activeElement).toBe(wrapper.find('[data-qa="last"]').element);
@@ -478,7 +440,7 @@ describe('DtFocustrapDirective', () => {
       ' ',
     ])('should not interfere with %s key', async (key) => {
       wrapper = mountDialog();
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       wrapper.find('[data-qa="first"]').element.focus();
       const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
@@ -494,7 +456,7 @@ describe('DtFocustrapDirective', () => {
   describe('Unmount cleanup', () => {
     it('should remove keydown listener on unmount', async () => {
       wrapper = mountDialog();
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       const spy = vi.spyOn(el, 'removeEventListener');
@@ -503,7 +465,6 @@ describe('DtFocustrapDirective', () => {
 
       expect(spy).toHaveBeenCalledWith('keydown', expect.any(Function));
 
-      // Prevent double-unmount in afterEach
       wrapper = null;
     });
 
@@ -514,7 +475,7 @@ describe('DtFocustrapDirective', () => {
       outsideBtn.focus();
 
       wrapper = mountDialog(true);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       wrapper.unmount();
 
@@ -526,7 +487,7 @@ describe('DtFocustrapDirective', () => {
 
     it('should clear state key from element on unmount', async () => {
       wrapper = mountDialog();
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       expect(el[FOCUSTRAP_STATE_KEY]).toBeDefined();
@@ -549,13 +510,13 @@ describe('DtFocustrapDirective', () => {
           </div>
         </div>
       `);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       expect(el.getAttribute('tabindex')).toBe('-1');
 
       await wrapper.setData({ config: false });
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       expect(el.hasAttribute('tabindex')).toBe(false);
     });
@@ -566,7 +527,7 @@ describe('DtFocustrapDirective', () => {
           <p>Are you sure?</p>
         </div>
       `);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       expect(el.getAttribute('tabindex')).toBe('-1');
@@ -578,7 +539,7 @@ describe('DtFocustrapDirective', () => {
           <p>Are you sure?</p>
         </div>
       `);
-      await flushMicrotasks(wrapper);
+      await flushPromises();
 
       const el = wrapper.find('[data-qa="trap"]').element;
       expect(document.activeElement).toBe(el);

--- a/packages/dialtone-vue/directives/focustrap_directive/focustrap.test.js
+++ b/packages/dialtone-vue/directives/focustrap_directive/focustrap.test.js
@@ -1,0 +1,603 @@
+import { mount } from '@vue/test-utils';
+import { DtFocustrapDirective } from './focustrap.js';
+import { FOCUSTRAP_DEFAULTS, FOCUSTRAP_STATE_KEY } from './focustrap_constants.js';
+
+// ── Helpers ─────────────────────────────────────────────────
+
+const PLUGINS = [DtFocustrapDirective];
+
+/**
+ * Flush the microtask queue so that Promise.resolve().then(...)
+ * used by setInitialFocus has a chance to run.
+ */
+async function flushMicrotasks (wrapper) {
+  await wrapper.vm.$nextTick();
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function mountDialog (config = true, options = {}) {
+  return mount({
+    data () { return { config }; },
+    template: `
+      <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Test dialog">
+        <button data-qa="first">First</button>
+        <input data-qa="second" />
+        <a href="#" data-qa="third">Third</a>
+      </div>
+    `,
+    ...options,
+  }, {
+    global: { plugins: PLUGINS },
+    attachTo: document.body,
+  });
+}
+
+function mountWithTemplate (config, template) {
+  return mount({
+    data () { return { config }; },
+    template,
+  }, {
+    global: { plugins: PLUGINS },
+    attachTo: document.body,
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe('DtFocustrapDirective', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  // ── Default rendering ──────────────────────────────────
+
+  describe('Default rendering', () => {
+    it('should mount without errors', async () => {
+      wrapper = mountDialog();
+      await flushMicrotasks(wrapper);
+
+      expect(wrapper.find('[data-qa="trap"]').exists()).toBe(true);
+    });
+
+    it('should store state on the container element', async () => {
+      wrapper = mountDialog();
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      expect(el[FOCUSTRAP_STATE_KEY]).toBeDefined();
+    });
+
+    it('should activate the trap on mount', async () => {
+      wrapper = mountDialog();
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      expect(el[FOCUSTRAP_STATE_KEY].active).toBe(true);
+    });
+
+    it('should register a keydown listener on the container', async () => {
+      wrapper = mountDialog();
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      expect(el[FOCUSTRAP_STATE_KEY].onKeydown).toBeTypeOf('function');
+    });
+  });
+
+  // ── Tab wrapping ───────────────────────────────────────
+
+  describe('Tab wrapping', () => {
+    it('should wrap focus from last element to first on Tab', async () => {
+      wrapper = mountDialog();
+      await flushMicrotasks(wrapper);
+
+      wrapper.find('[data-qa="third"]').element.focus();
+      await wrapper.find('[data-qa="trap"]').trigger('keydown', { key: 'Tab' });
+
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
+    });
+
+    it('should wrap focus from first element to last on Shift+Tab', async () => {
+      wrapper = mountDialog();
+      await flushMicrotasks(wrapper);
+
+      wrapper.find('[data-qa="first"]').element.focus();
+      await wrapper.find('[data-qa="trap"]').trigger('keydown', { key: 'Tab', shiftKey: true });
+
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="third"]').element);
+    });
+
+    it('should not interfere with Tab between middle elements', async () => {
+      wrapper = mountDialog();
+      await flushMicrotasks(wrapper);
+
+      wrapper.find('[data-qa="second"]').element.focus();
+      await wrapper.find('[data-qa="trap"]').trigger('keydown', { key: 'Tab' });
+
+      // Focus should remain on second since the handler only traps at boundaries
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="second"]').element);
+    });
+  });
+
+  // ── Initial focus: auto ────────────────────────────────
+
+  describe('Initial focus: auto', () => {
+    it('should focus the first focusable element on activation', async () => {
+      wrapper = mountDialog();
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
+    });
+
+    it('should focus first focusable element when config is bare true', async () => {
+      wrapper = mountDialog(true);
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
+    });
+
+    it('should focus first focusable element when config is { active: true }', async () => {
+      wrapper = mountDialog({ active: true });
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
+    });
+  });
+
+  // ── Initial focus: CSS selector ────────────────────────
+
+  describe('Initial focus: CSS selector', () => {
+    it('should focus the element matching the selector', async () => {
+      wrapper = mountDialog({ active: true, initialFocus: '[data-qa="second"]' });
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="second"]').element);
+    });
+
+    it('should fall back to container if selector matches nothing', async () => {
+      wrapper = mountDialog({ active: true, initialFocus: '[data-qa="nonexistent"]' });
+      await flushMicrotasks(wrapper);
+
+      // Container should be focused as fallback
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="trap"]').element);
+    });
+  });
+
+  // ── Initial focus: false ───────────────────────────────
+
+  describe('Initial focus: false', () => {
+    it('should not move focus when initialFocus is false', async () => {
+      // Focus something outside the trap first
+      const outsideBtn = document.createElement('button');
+      outsideBtn.setAttribute('data-qa', 'outside');
+      document.body.appendChild(outsideBtn);
+      outsideBtn.focus();
+
+      wrapper = mountDialog({ active: true, initialFocus: false });
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).toBe(outsideBtn);
+
+      outsideBtn.remove();
+    });
+  });
+
+  // ── Initial focus: radio button ────────────────────────
+
+  describe('Initial focus: radio button', () => {
+    it('should prefer checked radio over first unchecked radio', async () => {
+      wrapper = mountWithTemplate({ active: true }, `
+        <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Radio dialog">
+          <input type="radio" name="choice" value="a" data-qa="radio-a" />
+          <input type="radio" name="choice" value="b" data-qa="radio-b" checked />
+          <input type="radio" name="choice" value="c" data-qa="radio-c" />
+        </div>
+      `);
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="radio-b"]').element);
+    });
+
+    it('should focus first radio when none is checked', async () => {
+      wrapper = mountWithTemplate({ active: true }, `
+        <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Radio dialog">
+          <input type="radio" name="choice" value="a" data-qa="radio-a" />
+          <input type="radio" name="choice" value="b" data-qa="radio-b" />
+        </div>
+      `);
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="radio-a"]').element);
+    });
+  });
+
+  // ── Focus restoration ──────────────────────────────────
+
+  describe('Focus restoration', () => {
+    it('should restore focus to previously focused element on deactivation', async () => {
+      const outsideBtn = document.createElement('button');
+      outsideBtn.setAttribute('data-qa', 'outside');
+      document.body.appendChild(outsideBtn);
+      outsideBtn.focus();
+
+      wrapper = mountWithTemplate(true, `
+        <div>
+          <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Test dialog">
+            <button data-qa="first">First</button>
+            <button data-qa="second">Second</button>
+          </div>
+        </div>
+      `);
+      await flushMicrotasks(wrapper);
+
+      await wrapper.setData({ config: false });
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).toBe(outsideBtn);
+
+      outsideBtn.remove();
+    });
+  });
+
+  // ── Focus restoration: disabled ────────────────────────
+
+  describe('Focus restoration: disabled', () => {
+    it('should not restore focus when restoreFocus is false', async () => {
+      const outsideBtn = document.createElement('button');
+      outsideBtn.setAttribute('data-qa', 'outside');
+      document.body.appendChild(outsideBtn);
+      outsideBtn.focus();
+
+      wrapper = mountWithTemplate({ active: true, restoreFocus: false }, `
+        <div>
+          <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Test dialog">
+            <button data-qa="first">First</button>
+          </div>
+        </div>
+      `);
+      await flushMicrotasks(wrapper);
+
+      await wrapper.setData({ config: { active: false, restoreFocus: false } });
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).not.toBe(outsideBtn);
+
+      outsideBtn.remove();
+    });
+  });
+
+  // ── Reactive activation ────────────────────────────────
+
+  describe('Reactive activation', () => {
+    it('should set active state when binding changes from false to true', async () => {
+      wrapper = mountDialog(false);
+      await flushMicrotasks(wrapper);
+
+      await wrapper.setData({ config: true });
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      expect(el[FOCUSTRAP_STATE_KEY].active).toBe(true);
+    });
+
+    it('should focus first element when binding changes from false to true', async () => {
+      wrapper = mountDialog(false);
+      await flushMicrotasks(wrapper);
+
+      await wrapper.setData({ config: true });
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
+    });
+
+    it('should activate with object binding change', async () => {
+      wrapper = mountDialog({ active: false });
+      await flushMicrotasks(wrapper);
+
+      await wrapper.setData({ config: { active: true } });
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
+    });
+  });
+
+  // ── Reactive deactivation ──────────────────────────────
+
+  describe('Reactive deactivation', () => {
+    it('should set active state to false when binding changes from true to false', async () => {
+      wrapper = mountDialog(true);
+      await flushMicrotasks(wrapper);
+
+      await wrapper.setData({ config: false });
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      expect(el[FOCUSTRAP_STATE_KEY].active).toBe(false);
+    });
+
+    it('should restore focus when binding changes from true to false', async () => {
+      const outsideBtn = document.createElement('button');
+      outsideBtn.setAttribute('data-qa', 'outside');
+      document.body.appendChild(outsideBtn);
+      outsideBtn.focus();
+
+      wrapper = mountDialog(true);
+      await flushMicrotasks(wrapper);
+
+      await wrapper.setData({ config: false });
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).toBe(outsideBtn);
+
+      outsideBtn.remove();
+    });
+
+    it('should remove keydown listener on deactivation', async () => {
+      wrapper = mountDialog(true);
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      expect(el[FOCUSTRAP_STATE_KEY].onKeydown).toBeTypeOf('function');
+
+      await wrapper.setData({ config: false });
+      await flushMicrotasks(wrapper);
+
+      expect(el[FOCUSTRAP_STATE_KEY].onKeydown).toBeNull();
+    });
+  });
+
+  // ── Boolean binding ────────────────────────────────────
+
+  describe('Boolean binding', () => {
+    it('should activate the trap when bound to true', async () => {
+      wrapper = mountDialog(true);
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      expect(el[FOCUSTRAP_STATE_KEY].active).toBe(true);
+    });
+
+    it('should focus first element when bound to true', async () => {
+      wrapper = mountDialog(true);
+      await flushMicrotasks(wrapper);
+
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
+    });
+
+    it('should treat false as { active: false }', async () => {
+      wrapper = mountDialog(false);
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      expect(el[FOCUSTRAP_STATE_KEY].active).toBe(false);
+    });
+  });
+
+  // ── Zero focusable elements ────────────────────────────
+
+  describe('Zero focusable elements', () => {
+    it('should prevent Tab without errors when no focusable elements exist', async () => {
+      wrapper = mountWithTemplate(true, `
+        <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Empty dialog">
+          <p>No focusable elements here</p>
+        </div>
+      `);
+      await flushMicrotasks(wrapper);
+
+      const trap = wrapper.find('[data-qa="trap"]');
+      // Should not throw
+      await trap.trigger('keydown', { key: 'Tab' });
+    });
+
+    it('should call preventDefault on Tab when no focusable elements exist', async () => {
+      wrapper = mountWithTemplate(true, `
+        <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Empty dialog">
+          <p>No focusable elements here</p>
+        </div>
+      `);
+      await flushMicrotasks(wrapper);
+
+      const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+      const spy = vi.spyOn(event, 'preventDefault');
+      wrapper.find('[data-qa="trap"]').element.dispatchEvent(event);
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  // ── Dynamic content ────────────────────────────────────
+
+  describe('Dynamic content', () => {
+    it('should include newly added elements in Tab wrapping', async () => {
+      wrapper = mount({
+        data () { return { config: true, showExtra: false }; },
+        template: `
+          <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Dynamic dialog">
+            <button data-qa="first">First</button>
+            <button v-if="showExtra" data-qa="extra">Extra</button>
+          </div>
+        `,
+      }, {
+        global: { plugins: PLUGINS },
+        attachTo: document.body,
+      });
+      await flushMicrotasks(wrapper);
+
+      await wrapper.setData({ showExtra: true });
+      await flushMicrotasks(wrapper);
+
+      wrapper.find('[data-qa="extra"]').element.focus();
+      await wrapper.find('[data-qa="trap"]').trigger('keydown', { key: 'Tab' });
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
+    });
+
+    it('should handle removed focusable elements', async () => {
+      wrapper = mount({
+        data () { return { config: true, showMiddle: true }; },
+        template: `
+          <div role="dialog" v-dt-focustrap="config" data-qa="trap" aria-label="Dynamic dialog">
+            <button data-qa="first">First</button>
+            <button v-if="showMiddle" data-qa="middle">Middle</button>
+            <button data-qa="last">Last</button>
+          </div>
+        `,
+      }, {
+        global: { plugins: PLUGINS },
+        attachTo: document.body,
+      });
+      await flushMicrotasks(wrapper);
+
+      // Remove the middle button
+      await wrapper.setData({ showMiddle: false });
+      await flushMicrotasks(wrapper);
+
+      // Tab on last should wrap to first
+      wrapper.find('[data-qa="last"]').element.focus();
+      await wrapper.find('[data-qa="trap"]').trigger('keydown', { key: 'Tab' });
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="first"]').element);
+
+      // Shift+Tab on first should wrap to last
+      wrapper.find('[data-qa="first"]').element.focus();
+      await wrapper.find('[data-qa="trap"]').trigger('keydown', { key: 'Tab', shiftKey: true });
+      expect(document.activeElement).toBe(wrapper.find('[data-qa="last"]').element);
+    });
+  });
+
+  // ── Non-Tab keys ignored ───────────────────────────────
+
+  describe('Non-Tab keys ignored', () => {
+    it.each([
+      'ArrowRight',
+      'ArrowLeft',
+      'ArrowDown',
+      'ArrowUp',
+      'Enter',
+      'Escape',
+      ' ',
+    ])('should not interfere with %s key', async (key) => {
+      wrapper = mountDialog();
+      await flushMicrotasks(wrapper);
+
+      wrapper.find('[data-qa="first"]').element.focus();
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      const spy = vi.spyOn(event, 'preventDefault');
+      wrapper.find('[data-qa="trap"]').element.dispatchEvent(event);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Unmount cleanup ────────────────────────────────────
+
+  describe('Unmount cleanup', () => {
+    it('should remove keydown listener on unmount', async () => {
+      wrapper = mountDialog();
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      const spy = vi.spyOn(el, 'removeEventListener');
+
+      wrapper.unmount();
+
+      expect(spy).toHaveBeenCalledWith('keydown', expect.any(Function));
+
+      // Prevent double-unmount in afterEach
+      wrapper = null;
+    });
+
+    it('should restore focus on unmount when trap was active', async () => {
+      const outsideBtn = document.createElement('button');
+      outsideBtn.setAttribute('data-qa', 'outside');
+      document.body.appendChild(outsideBtn);
+      outsideBtn.focus();
+
+      wrapper = mountDialog(true);
+      await flushMicrotasks(wrapper);
+
+      wrapper.unmount();
+
+      expect(document.activeElement).toBe(outsideBtn);
+
+      outsideBtn.remove();
+      wrapper = null;
+    });
+
+    it('should clear state key from element on unmount', async () => {
+      wrapper = mountDialog();
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      expect(el[FOCUSTRAP_STATE_KEY]).toBeDefined();
+
+      wrapper.unmount();
+
+      expect(el[FOCUSTRAP_STATE_KEY]).toBeUndefined();
+      wrapper = null;
+    });
+  });
+
+  // ── Fallback: container focused ────────────────────────
+
+  describe('Fallback focus', () => {
+    it('should remove synthetic tabindex on deactivation', async () => {
+      wrapper = mountWithTemplate(true, `
+        <div>
+          <div role="alertdialog" v-dt-focustrap="config" data-qa="trap" aria-label="Alert">
+            <p>Are you sure?</p>
+          </div>
+        </div>
+      `);
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      expect(el.getAttribute('tabindex')).toBe('-1');
+
+      await wrapper.setData({ config: false });
+      await flushMicrotasks(wrapper);
+
+      expect(el.hasAttribute('tabindex')).toBe(false);
+    });
+
+    it('should add tabindex to container when no focusable children exist', async () => {
+      wrapper = mountWithTemplate(true, `
+        <div role="alertdialog" v-dt-focustrap="config" data-qa="trap" aria-label="Alert">
+          <p>Are you sure?</p>
+        </div>
+      `);
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      expect(el.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('should focus container when no focusable children exist', async () => {
+      wrapper = mountWithTemplate(true, `
+        <div role="alertdialog" v-dt-focustrap="config" data-qa="trap" aria-label="Alert">
+          <p>Are you sure?</p>
+        </div>
+      `);
+      await flushMicrotasks(wrapper);
+
+      const el = wrapper.find('[data-qa="trap"]').element;
+      expect(document.activeElement).toBe(el);
+    });
+  });
+
+  // ── Constants ──────────────────────────────────────────
+
+  describe('FOCUSTRAP_DEFAULTS', () => {
+    it('should have expected default values', () => {
+      expect(FOCUSTRAP_DEFAULTS).toEqual({
+        active: true,
+        initialFocus: 'auto',
+        restoreFocus: true,
+      });
+    });
+
+    it('should be frozen', () => {
+      expect(Object.isFrozen(FOCUSTRAP_DEFAULTS)).toBe(true);
+    });
+  });
+});

--- a/packages/dialtone-vue/directives/focustrap_directive/focustrap_constants.js
+++ b/packages/dialtone-vue/directives/focustrap_directive/focustrap_constants.js
@@ -1,0 +1,14 @@
+/**
+ * Default configuration for v-dt-focustrap directive.
+ */
+export const FOCUSTRAP_DEFAULTS = Object.freeze({
+  active: true,
+  initialFocus: 'auto',
+  restoreFocus: true,
+});
+
+/**
+ * Key used to store directive state on the host element.
+ * @type {symbol}
+ */
+export const FOCUSTRAP_STATE_KEY = Symbol('dtFocustrap');

--- a/packages/dialtone-vue/directives/focustrap_directive/focustrap_utils.js
+++ b/packages/dialtone-vue/directives/focustrap_directive/focustrap_utils.js
@@ -44,7 +44,7 @@ export function getTabbableElements (container, { includeNegativeTabIndex = fals
 export function getFirstFocusCandidate (elements) {
   if (!elements.length) return undefined;
   const first = elements[0];
-  if (first.matches('[type="radio"]:not(:checked)')) {
+  if (first.matches('[type="radio"]:not(:checked)') && first.name) {
     return elements.find(el => el.checked && el.name === first.name) || first;
   }
   return first;

--- a/packages/dialtone-vue/directives/focustrap_directive/focustrap_utils.js
+++ b/packages/dialtone-vue/directives/focustrap_directive/focustrap_utils.js
@@ -1,0 +1,51 @@
+/**
+ * Focusable element discovery utilities for the v-dt-focustrap directive.
+ *
+ * Extracted from common/mixins/modal.js — the selectors and filtering logic
+ * are battle-tested across DtModal, DtBanner, DtPopover, and DtImageViewer.
+ */
+
+const FOCUSABLE_ATTRS = ':not(:disabled):not([aria-disabled="true"]):not([role="presentation"])';
+const TABBABLE_ATTRS = `${FOCUSABLE_ATTRS}:not([tabindex="-1"])`;
+const FOCUSABLE_ELEMENTS = 'button,[href],input,select,textarea,details,[tabindex]';
+
+/**
+ * Returns all tabbable elements within a container, filtered by visibility and state.
+ *
+ * "Tabbable" means the element is focusable AND reachable via sequential Tab navigation
+ * (excludes tabindex="-1"). Elements hidden via display:none or visibility:hidden are excluded.
+ *
+ * @param {HTMLElement} container - DOM element to search within
+ * @param {object} [options]
+ * @param {boolean} [options.includeNegativeTabIndex=false] - Include tabindex="-1" elements
+ * @returns {HTMLElement[]}
+ */
+export function getTabbableElements (container, { includeNegativeTabIndex = false } = {}) {
+  if (!container) return [];
+  const candidates = [...container.querySelectorAll(FOCUSABLE_ELEMENTS)];
+  const attrs = includeNegativeTabIndex ? FOCUSABLE_ATTRS : TABBABLE_ATTRS;
+  return candidates.filter((el) => {
+    const style = window.getComputedStyle(el);
+    return style.getPropertyValue('display') !== 'none' &&
+      style.getPropertyValue('visibility') !== 'hidden' &&
+      el.matches(attrs);
+  });
+}
+
+/**
+ * Returns the best candidate for initial focus within a list of focusable elements.
+ *
+ * For radio buttons: if the first element is an unchecked radio, prefers
+ * the checked radio with the same name (if one exists).
+ *
+ * @param {HTMLElement[]} elements - List of focusable elements
+ * @returns {HTMLElement|undefined}
+ */
+export function getFirstFocusCandidate (elements) {
+  if (!elements.length) return undefined;
+  const first = elements[0];
+  if (first.matches('[type="radio"]:not(:checked)')) {
+    return elements.find(el => el.checked && el.name === first.name) || first;
+  }
+  return first;
+}

--- a/packages/dialtone-vue/directives/focustrap_directive/index.js
+++ b/packages/dialtone-vue/directives/focustrap_directive/index.js
@@ -1,0 +1,1 @@
+export { default as DtFocustrapDirective } from './focustrap.js';

--- a/packages/dialtone-vue/index.js
+++ b/packages/dialtone-vue/index.js
@@ -72,6 +72,7 @@ export * from './directives/tooltip_directive';
 export * from './directives/scrollbar_directive';
 export * from './directives/mode_directive';
 export * from './directives/focusgroup_directive';
+export * from './directives/focustrap_directive';
 
 /// Recipes
 export * from './recipes/buttons/callbar_button';


### PR DESCRIPTION
![undoubtedly-its-a-trap-ovlpnki9ajlr2unq](https://github.com/user-attachments/assets/9b7b12ef-332a-4143-b651-b9279ec04cc0)


## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-3297](https://dialpad.atlassian.net/browse/DLT-3297)

## :book: Description

New `v-dt-focustrap` directive. Traps Tab/Shift+Tab within a container element. Configurable initial focus (auto, CSS selector, element ref, or disabled), Tab boundary wrapping, and focus restoration on deactivation. Reactive — bind to open/close state.

Replaces the need to manually wire the Modal mixin for focus trapping. Follows the same directive pattern as `v-dt-focusgroup`.

**Does NOT:** handle Escape, click-outside, `aria-modal`, scroll lock, or migrate existing components (separate follow-up tickets).

## :bulb: Context

Focus trapping is scattered across 5+ components via the Modal mixin, each wiring it differently. No shared primitive for new components like Hovercard (DLT-2845). This directive provides one consistent implementation.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

- Migrate existing components to use `v-dt-focustrap`: Modal, Banner, Popover, ImageViewer, Hovercard (DLT-2845), FeedItemRow (separate tickets per component)

## :camera: Screenshots / GIFs / Video

<img width="1463" height="1077" alt="image" src="https://github.com/user-attachments/assets/48029b06-9be1-42b0-8ca2-427c6022c1f7" />

https://github.com/user-attachments/assets/c7134548-91ac-412a-9a6b-a6c4f739ba5a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds v-dt-focustrap Vue directive to trap Tab/Shift+Tab inside a container with configurable initial focus (auto, selector, element, or disabled), optional focus restoration, boundary wrapping, reactive activation, plus utilities, Storybook docs, tests, and a blog post.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[DLT-3297]: https://dialpad.atlassian.net/browse/DLT-3297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ