### PR TITLE
refactor(components): dlt-3283 refactor prop/slots to be consistent

### DIFF
--- a/packages/combinator/src/components/controls/control_number.vue
+++ b/packages/combinator/src/components/controls/control_number.vue
@@ -6,7 +6,7 @@
     :size="100"
     @input="e => emit(VALUE_UPDATE_EVENT, e === '' ? undefined : parseInt(e))"
   >
-    <template #labelSlot>
+    <template #label>
       <dt-text
         kind="label"
         :size="100"

--- a/packages/combinator/src/components/controls/control_slot.vue
+++ b/packages/combinator/src/components/controls/control_slot.vue
@@ -8,7 +8,7 @@
     :size="100"
     @input="updateValue"
   >
-    <template #labelSlot>
+    <template #label>
       <dt-text
         kind="label"
         :size="100"

--- a/packages/combinator/src/components/controls/control_string.vue
+++ b/packages/combinator/src/components/controls/control_string.vue
@@ -6,7 +6,7 @@
     :size="100"
     @input="e => emit(VALUE_UPDATE_EVENT, e)"
   >
-    <template #labelSlot>
+    <template #label>
       <dt-text
         kind="label"
         :size="100"

--- a/packages/dialtone-vue/components/banner/banner.stories.js
+++ b/packages/dialtone-vue/components/banner/banner.stories.js
@@ -16,14 +16,6 @@ export const argsData = {
 
 export const argTypesData = {
   // Slots
-  titleSlot: {
-    table: {
-      type: { summary: 'VNode' },
-    },
-    control: {
-      type: 'text',
-    },
-  },
   icon: {
     options: iconsList,
     table: {

--- a/packages/dialtone-vue/components/banner/banner.stories.js
+++ b/packages/dialtone-vue/components/banner/banner.stories.js
@@ -16,7 +16,7 @@ export const argsData = {
 
 export const argTypesData = {
   // Slots
-  titleOverride: {
+  titleSlot: {
     table: {
       type: { summary: 'VNode' },
     },

--- a/packages/dialtone-vue/components/banner/banner.vue
+++ b/packages/dialtone-vue/components/banner/banner.vue
@@ -15,7 +15,7 @@
       <dt-notice-icon
         v-if="!hideIcon"
         :kind="kind"
-        :class="{ 'd-notice__icon--has-title': title || $slots.titleOverride }"
+        :class="{ 'd-notice__icon--has-title': title || $slots.title }"
       >
         <!-- @slot Slot for custom icon -->
         <slot name="icon" />
@@ -25,10 +25,9 @@
         :content-id="contentId"
         :title="title"
       >
-        <template #titleOverride>
-          <!-- eslint-disable-next-line max-len -->
-          <!-- @slot Allows you to override the title, only use this if you need to override with something other than text. Otherwise use the "title" prop. -->
-          <slot name="titleOverride" />
+        <template #title>
+          <!-- @slot Slot for the title. Can also be used as a slot. -->
+          <slot name="title" />
         </template>
         <!-- @slot the main textual content of the banner -->
         <slot />

--- a/packages/dialtone-vue/components/banner/banner.vue
+++ b/packages/dialtone-vue/components/banner/banner.vue
@@ -26,7 +26,7 @@
         :title="title"
       >
         <template #title>
-          <!-- @slot Slot for the title. Can also be used as a slot. -->
+          <!-- @slot Slot for the title -->
           <slot name="title" />
         </template>
         <!-- @slot the main textual content of the banner -->

--- a/packages/dialtone-vue/components/banner/banner_default.story.vue
+++ b/packages/dialtone-vue/components/banner/banner_default.story.vue
@@ -57,10 +57,10 @@
         <dt-icon :name="$attrs.icon" />
       </template>
       <template
-        v-if="$attrs.titleOverride"
-        #titleOverride
+        v-if="$attrs.titleSlot"
+        #title
       >
-        <span v-html="$attrs.titleOverride" />
+        <span v-html="$attrs.titleSlot" />
       </template>
     </dt-banner>
   </div>

--- a/packages/dialtone-vue/components/banner/banner_default.story.vue
+++ b/packages/dialtone-vue/components/banner/banner_default.story.vue
@@ -57,10 +57,10 @@
         <dt-icon :name="$attrs.icon" />
       </template>
       <template
-        v-if="$attrs.titleSlot"
+        v-if="$attrs.title"
         #title
       >
-        <span v-html="$attrs.titleSlot" />
+        <span v-html="$attrs.title" />
       </template>
     </dt-banner>
   </div>

--- a/packages/dialtone-vue/components/banner/banner_default.story.vue
+++ b/packages/dialtone-vue/components/banner/banner_default.story.vue
@@ -56,12 +56,6 @@
       >
         <dt-icon :name="$attrs.icon" />
       </template>
-      <template
-        v-if="$attrs.title"
-        #title
-      >
-        <span v-html="$attrs.title" />
-      </template>
     </dt-banner>
   </div>
 </template>

--- a/packages/dialtone-vue/components/input/input.stories.js
+++ b/packages/dialtone-vue/components/input/input.stories.js
@@ -69,15 +69,6 @@ export const argTypesData = {
       disable: true,
     },
   },
-  labelSlot: {
-    table: {
-      type: { summary: 'VNode' },
-    },
-    control: {
-      type: 'text',
-    },
-  },
-
   // Props
   modelValue: {
     control: 'text',

--- a/packages/dialtone-vue/components/input/input.vue
+++ b/packages/dialtone-vue/components/input/input.vue
@@ -10,8 +10,8 @@
       :aria-details="$slots.description || description ? descriptionKey : undefined"
       data-qa="dt-input-label-wrapper"
     >
-      <!-- @slot Slot for label, defaults to label prop -->
-      <slot name="labelSlot">
+      <!-- @slot Slot for label, defaults to label prop. Can also be used as a slot. -->
+      <slot name="label">
         <dt-text
           v-if="labelVisible && label"
           ref="label"

--- a/packages/dialtone-vue/components/input/input.vue
+++ b/packages/dialtone-vue/components/input/input.vue
@@ -10,7 +10,7 @@
       :aria-details="$slots.description || description ? descriptionKey : undefined"
       data-qa="dt-input-label-wrapper"
     >
-      <!-- @slot Slot for label, defaults to label prop. Can also be used as a slot. -->
+      <!-- @slot Slot for label, defaults to label prop -->
       <slot name="label">
         <dt-text
           v-if="labelVisible && label"
@@ -213,7 +213,8 @@ export default {
     },
 
     /**
-     * Label for the input
+     * Label for the input.
+     * Can also be used as a slot.
      */
     label: {
       type: String,

--- a/packages/dialtone-vue/components/input/input.vue
+++ b/packages/dialtone-vue/components/input/input.vue
@@ -214,7 +214,7 @@ export default {
 
     /**
      * Label for the input.
-     * Can also be used as a slot.
+     * Can also be overridden with a slot of the same name.
      */
     label: {
       type: String,

--- a/packages/dialtone-vue/components/input/input_default.story.vue
+++ b/packages/dialtone-vue/components/input/input_default.story.vue
@@ -31,10 +31,10 @@
     @update:invalid="$attrs.onUpdateIsInvalid"
   >
     <template
-      v-if="$attrs.labelSlot"
+      v-if="$attrs.label"
       #label
     >
-      <span v-html="$attrs.labelSlot" />
+      <span v-html="$attrs.label" />
     </template>
     <template
       v-if="$attrs.description"

--- a/packages/dialtone-vue/components/input/input_default.story.vue
+++ b/packages/dialtone-vue/components/input/input_default.story.vue
@@ -31,12 +31,6 @@
     @update:invalid="$attrs.onUpdateIsInvalid"
   >
     <template
-      v-if="$attrs.label"
-      #label
-    >
-      <span v-html="$attrs.label" />
-    </template>
-    <template
       v-if="$attrs.description"
       #description
     >

--- a/packages/dialtone-vue/components/input/input_default.story.vue
+++ b/packages/dialtone-vue/components/input/input_default.story.vue
@@ -32,7 +32,7 @@
   >
     <template
       v-if="$attrs.labelSlot"
-      #labelSlot
+      #label
     >
       <span v-html="$attrs.labelSlot" />
     </template>

--- a/packages/dialtone-vue/components/input/input_search_variant.story.vue
+++ b/packages/dialtone-vue/components/input/input_search_variant.story.vue
@@ -29,7 +29,7 @@
   >
     <template
       v-if="$attrs.labelSlot"
-      #labelSlot
+      #label
     >
       <span v-html="$attrs.labelSlot" />
     </template>

--- a/packages/dialtone-vue/components/input/input_search_variant.story.vue
+++ b/packages/dialtone-vue/components/input/input_search_variant.story.vue
@@ -28,12 +28,6 @@
     @update:invalid="$attrs.onUpdateIsInvalid"
   >
     <template
-      v-if="$attrs.label"
-      #label
-    >
-      <span v-html="$attrs.label" />
-    </template>
-    <template
       v-if="$attrs.description"
       #description
     >

--- a/packages/dialtone-vue/components/input/input_search_variant.story.vue
+++ b/packages/dialtone-vue/components/input/input_search_variant.story.vue
@@ -28,10 +28,10 @@
     @update:invalid="$attrs.onUpdateIsInvalid"
   >
     <template
-      v-if="$attrs.labelSlot"
+      v-if="$attrs.label"
       #label
     >
-      <span v-html="$attrs.labelSlot" />
+      <span v-html="$attrs.label" />
     </template>
     <template
       v-if="$attrs.description"

--- a/packages/dialtone-vue/components/list_item_group/list_item_group.stories.js
+++ b/packages/dialtone-vue/components/list_item_group/list_item_group.stories.js
@@ -17,15 +17,6 @@ export const argTypesData = {
       },
     },
   },
-  // Slots
-  headingSlot: {
-    control: 'text',
-    table: {
-      type: {
-        summary: 'VNode',
-      },
-    },
-  },
 };
 
 // Story Collection

--- a/packages/dialtone-vue/components/list_item_group/list_item_group.vue
+++ b/packages/dialtone-vue/components/list_item_group/list_item_group.vue
@@ -13,8 +13,8 @@
       data-qa="dt-dropdown-list-heading"
       :class="['dt-dropdown-list--header', headingClass]"
     >
-      <!-- @slot Slot for heading, will override heading prop. -->
-      <slot name="headingSlot">
+      <!-- @slot Slot for heading, will override heading prop. Can also be used as a slot. -->
+      <slot name="heading">
         {{ heading }}
       </slot>
     </li>

--- a/packages/dialtone-vue/components/list_item_group/list_item_group.vue
+++ b/packages/dialtone-vue/components/list_item_group/list_item_group.vue
@@ -13,7 +13,7 @@
       data-qa="dt-dropdown-list-heading"
       :class="['dt-dropdown-list--header', headingClass]"
     >
-      <!-- @slot Slot for heading, will override heading prop. Can also be used as a slot. -->
+      <!-- @slot Slot for heading, will override heading prop -->
       <slot name="heading">
         {{ heading }}
       </slot>
@@ -42,6 +42,7 @@ export default {
 
     /**
      * List's heading.
+     * Can also be used as a slot.
      */
     heading: {
       type: String,

--- a/packages/dialtone-vue/components/list_item_group/list_item_group.vue
+++ b/packages/dialtone-vue/components/list_item_group/list_item_group.vue
@@ -42,7 +42,7 @@ export default {
 
     /**
      * List's heading.
-     * Can also be used as a slot.
+     * Can also be overridden with a slot of the same name.
      */
     heading: {
       type: String,

--- a/packages/dialtone-vue/components/list_item_group/list_item_group_default.story.vue
+++ b/packages/dialtone-vue/components/list_item_group/list_item_group_default.story.vue
@@ -30,10 +30,10 @@
         item3
       </dt-list-item>
       <template
-        v-if="$attrs.headingSlot"
+        v-if="$attrs.heading"
         #heading
       >
-        <span v-html="$attrs.headingSlot" />
+        <span v-html="$attrs.heading" />
       </template>
     </dt-list-item-group>
   </div>

--- a/packages/dialtone-vue/components/list_item_group/list_item_group_default.story.vue
+++ b/packages/dialtone-vue/components/list_item_group/list_item_group_default.story.vue
@@ -29,12 +29,6 @@
       >
         item3
       </dt-list-item>
-      <template
-        v-if="$attrs.heading"
-        #heading
-      >
-        <span v-html="$attrs.heading" />
-      </template>
     </dt-list-item-group>
   </div>
 </template>

--- a/packages/dialtone-vue/components/list_item_group/list_item_group_default.story.vue
+++ b/packages/dialtone-vue/components/list_item_group/list_item_group_default.story.vue
@@ -31,7 +31,7 @@
       </dt-list-item>
       <template
         v-if="$attrs.headingSlot"
-        #headingSlot
+        #heading
       >
         <span v-html="$attrs.headingSlot" />
       </template>

--- a/packages/dialtone-vue/components/notice/notice.stories.js
+++ b/packages/dialtone-vue/components/notice/notice.stories.js
@@ -24,7 +24,7 @@ const argsDataLongText = {
 
 export const argTypesData = {
   // Slots
-  titleOverride: {
+  titleSlot: {
     table: {
       type: { summary: 'VNode' },
     },

--- a/packages/dialtone-vue/components/notice/notice.stories.js
+++ b/packages/dialtone-vue/components/notice/notice.stories.js
@@ -24,14 +24,6 @@ const argsDataLongText = {
 
 export const argTypesData = {
   // Slots
-  titleSlot: {
-    table: {
-      type: { summary: 'VNode' },
-    },
-    control: {
-      type: 'text',
-    },
-  },
   icon: {
     options: iconsList,
     table: {

--- a/packages/dialtone-vue/components/notice/notice.vue
+++ b/packages/dialtone-vue/components/notice/notice.vue
@@ -6,7 +6,7 @@
     <dt-notice-icon
       v-if="!hideIcon"
       :kind="kind"
-      :class="{ 'd-notice__icon--has-title': title || $slots.titleOverride }"
+      :class="{ 'd-notice__icon--has-title': title || $slots.title }"
     >
       <!-- @slot Slot for custom icon -->
       <slot name="icon" />
@@ -17,10 +17,9 @@
       :title="title"
       :role="role"
     >
-      <template #titleOverride>
-        <!-- @slot Allows you to override the title, only use this if you need
-        to override with something other than text. Otherwise use the "title" prop. -->
-        <slot name="titleOverride" />
+      <template #title>
+        <!-- @slot Slot for the title. Can also be used as a slot. -->
+        <slot name="title" />
       </template>
       <!-- @slot the main textual content of the notice -->
       <slot />

--- a/packages/dialtone-vue/components/notice/notice.vue
+++ b/packages/dialtone-vue/components/notice/notice.vue
@@ -18,7 +18,7 @@
       :role="role"
     >
       <template #title>
-        <!-- @slot Slot for the title. Can also be used as a slot. -->
+        <!-- @slot Slot for the title -->
         <slot name="title" />
       </template>
       <!-- @slot the main textual content of the notice -->

--- a/packages/dialtone-vue/components/notice/notice_content.test.js
+++ b/packages/dialtone-vue/components/notice/notice_content.test.js
@@ -54,14 +54,14 @@ describe('DtNoticeContent tests', () => {
       });
     });
 
-    describe('When title override is true', () => {
+    describe('When title slot is provided', () => {
       beforeEach(() => {
-        slotsData.titleOverride = 'this is an override title';
+        slotsData.title = 'this is a slot title';
         _setWrappers();
       });
 
       it('displays the correct text', () => {
-        expect(title.text()).toBe(slotsData.titleOverride);
+        expect(title.text()).toBe(slotsData.title);
       });
     });
   });

--- a/packages/dialtone-vue/components/notice/notice_content.vue
+++ b/packages/dialtone-vue/components/notice/notice_content.vue
@@ -4,7 +4,7 @@
     data-qa="notice-content"
   >
     <dt-text
-      v-if="title || hasSlotContent($slots.titleOverride)"
+      v-if="title || hasSlotContent($slots.title)"
       :id="titleId"
       kind="headline"
       :size="300"
@@ -13,8 +13,8 @@
       class="d-notice__title"
       data-qa="notice-content-title"
     >
-      <!-- @slot Slot for the title  -->
-      <slot name="titleOverride">
+      <!-- @slot Slot for the title. Can also be used as a slot. -->
+      <slot name="title">
         {{ title }}
       </slot>
     </dt-text>

--- a/packages/dialtone-vue/components/notice/notice_content.vue
+++ b/packages/dialtone-vue/components/notice/notice_content.vue
@@ -46,7 +46,7 @@ export default {
   props: {
     /**
      * Title header of the notice. This can be left blank to remove the title from the notice entirely.
-     * Can also be used as a slot.
+     * Can also be overridden with a slot of the same name.
      */
     title: {
       type: String,

--- a/packages/dialtone-vue/components/notice/notice_content.vue
+++ b/packages/dialtone-vue/components/notice/notice_content.vue
@@ -13,7 +13,7 @@
       class="d-notice__title"
       data-qa="notice-content-title"
     >
-      <!-- @slot Slot for the title. Can also be used as a slot. -->
+      <!-- @slot Slot for the title -->
       <slot name="title">
         {{ title }}
       </slot>
@@ -46,6 +46,7 @@ export default {
   props: {
     /**
      * Title header of the notice. This can be left blank to remove the title from the notice entirely.
+     * Can also be used as a slot.
      */
     title: {
       type: String,

--- a/packages/dialtone-vue/components/notice/notice_default.story.vue
+++ b/packages/dialtone-vue/components/notice/notice_default.story.vue
@@ -45,10 +45,10 @@
       <dt-icon :name="$attrs.icon" />
     </template>
     <template
-      v-if="$attrs.titleSlot"
+      v-if="$attrs.title"
       #title
     >
-      <span v-html="$attrs.titleSlot" />
+      <span v-html="$attrs.title" />
     </template>
   </dt-notice>
 </template>

--- a/packages/dialtone-vue/components/notice/notice_default.story.vue
+++ b/packages/dialtone-vue/components/notice/notice_default.story.vue
@@ -45,10 +45,10 @@
       <dt-icon :name="$attrs.icon" />
     </template>
     <template
-      v-if="$attrs.titleOverride"
-      #titleOverride
+      v-if="$attrs.titleSlot"
+      #title
     >
-      <span v-html="$attrs.titleOverride" />
+      <span v-html="$attrs.titleSlot" />
     </template>
   </dt-notice>
 </template>

--- a/packages/dialtone-vue/components/notice/notice_default.story.vue
+++ b/packages/dialtone-vue/components/notice/notice_default.story.vue
@@ -44,12 +44,6 @@
     >
       <dt-icon :name="$attrs.icon" />
     </template>
-    <template
-      v-if="$attrs.title"
-      #title
-    >
-      <span v-html="$attrs.title" />
-    </template>
   </dt-notice>
 </template>
 

--- a/packages/dialtone-vue/components/select_menu/select_menu.stories.js
+++ b/packages/dialtone-vue/components/select_menu/select_menu.stories.js
@@ -27,28 +27,6 @@ export const argsData = {
 
 export const argTypesData = {
   // Slots
-  labelSlot: {
-    name: 'label',
-    description: 'Slot for label, defaults to label prop',
-    control: 'text',
-    table: {
-      category: 'slots',
-      type: {
-        summary: 'VNode',
-      },
-    },
-  },
-  descriptionSlot: {
-    name: 'description',
-    description: 'Slot for description, defaults to description prop',
-    control: 'text',
-    table: {
-      category: 'slots',
-      type: {
-        summary: 'VNode',
-      },
-    },
-  },
   default: {
     control: 'text',
     table: {

--- a/packages/dialtone-vue/components/select_menu/select_menu.vue
+++ b/packages/dialtone-vue/components/select_menu/select_menu.vue
@@ -120,7 +120,8 @@ export default {
 
   props: {
     /**
-     * Label for the select
+     * Label for the select.
+     * Can also be overridden with a slot of the same name.
      */
     label: {
       type: String,
@@ -137,7 +138,8 @@ export default {
     },
 
     /**
-     * Description for the select
+     * Description for the select.
+     * Can also be overridden with a slot of the same name.
      */
     description: {
       type: String,

--- a/packages/dialtone-vue/components/select_menu/select_menu_default.story.vue
+++ b/packages/dialtone-vue/components/select_menu/select_menu_default.story.vue
@@ -22,18 +22,6 @@
     @input="$attrs.onInput"
     @change="$attrs.onChange"
   >
-    <template
-      v-if="$attrs.labelSlot"
-      #label
-    >
-      <span v-html="$attrs.labelSlot" />
-    </template>
-    <template
-      v-if="$attrs.descriptionSlot"
-      #description
-    >
-      <span v-html="$attrs.descriptionSlot" />
-    </template>
     <html-fragment
       v-if="defaultSlot"
       :html="defaultSlot"

--- a/packages/dialtone-vue/components/toast/layouts/toast_layout_alternate.vue
+++ b/packages/dialtone-vue/components/toast/layouts/toast_layout_alternate.vue
@@ -26,8 +26,8 @@
           :role="role"
           v-bind="toastListeners"
         >
-          <template #titleOverride>
-            <slot name="titleOverride" />
+          <template #title>
+            <slot name="title" />
           </template>
         </dt-notice-content>
 

--- a/packages/dialtone-vue/components/toast/layouts/toast_layout_default.vue
+++ b/packages/dialtone-vue/components/toast/layouts/toast_layout_default.vue
@@ -14,7 +14,7 @@
       <dt-notice-icon
         v-if="!hideIcon"
         :kind="kind"
-        :class="{ 'd-notice__icon--has-title': title || $slots.titleOverride }"
+        :class="{ 'd-notice__icon--has-title': title || $slots.title }"
         v-bind="toastListeners"
       >
         <!-- @slot Slot for custom icon -->
@@ -27,10 +27,9 @@
         :role="role"
         v-bind="toastListeners"
       >
-        <template #titleOverride>
-          <!-- @slot Allows you to override the title, only use this if you need to override
-          with something other than text. Otherwise use the "title" prop. -->
-          <slot name="titleOverride" />
+        <template #title>
+          <!-- @slot Slot for the title. Can also be used as a slot. -->
+          <slot name="title" />
         </template>
         <!-- @slot the main textual content of the toast -->
         <slot>

--- a/packages/dialtone-vue/components/toast/layouts/toast_layout_default.vue
+++ b/packages/dialtone-vue/components/toast/layouts/toast_layout_default.vue
@@ -28,7 +28,7 @@
         v-bind="toastListeners"
       >
         <template #title>
-          <!-- @slot Slot for the title. Can also be used as a slot. -->
+          <!-- @slot Slot for the title -->
           <slot name="title" />
         </template>
         <!-- @slot the main textual content of the toast -->

--- a/packages/dialtone-vue/components/toast/toast.stories.js
+++ b/packages/dialtone-vue/components/toast/toast.stories.js
@@ -15,7 +15,7 @@ export const argsData = {
 
 export const argTypesData = {
   // Slots
-  titleOverride: {
+  titleSlot: {
     table: {
       type: { summary: 'VNode' },
     },

--- a/packages/dialtone-vue/components/toast/toast.stories.js
+++ b/packages/dialtone-vue/components/toast/toast.stories.js
@@ -15,14 +15,6 @@ export const argsData = {
 
 export const argTypesData = {
   // Slots
-  titleSlot: {
-    table: {
-      type: { summary: 'VNode' },
-    },
-    control: {
-      type: 'text',
-    },
-  },
   icon: {
     options: iconsList,
     table: {

--- a/packages/dialtone-vue/components/toast/toast.vue
+++ b/packages/dialtone-vue/components/toast/toast.vue
@@ -19,10 +19,9 @@
     <template #icon>
       <slot name="icon" />
     </template>
-    <template #titleOverride>
-      <!-- @slot Allows you to override the title, only use this if you need to override
-          with something other than text. Otherwise use the "title" prop. -->
-      <slot name="titleOverride" />
+    <template #title>
+      <!-- @slot Slot for the title. Can also be used as a slot. -->
+      <slot name="title" />
     </template>
     <!-- @slot the main textual content of the toast -->
     <slot>

--- a/packages/dialtone-vue/components/toast/toast.vue
+++ b/packages/dialtone-vue/components/toast/toast.vue
@@ -20,7 +20,7 @@
       <slot name="icon" />
     </template>
     <template #title>
-      <!-- @slot Slot for the title. Can also be used as a slot. -->
+      <!-- @slot Slot for the title -->
       <slot name="title" />
     </template>
     <!-- @slot the main textual content of the toast -->

--- a/packages/dialtone-vue/components/toast/toast_default.story.vue
+++ b/packages/dialtone-vue/components/toast/toast_default.story.vue
@@ -56,10 +56,10 @@
           <dt-icon :name="$attrs.icon" />
         </template>
         <template
-          v-if="$attrs.titleOverride"
-          #titleOverride
+          v-if="$attrs.titleSlot"
+          #title
         >
-          <span v-html="$attrs.titleOverride" />
+          <span v-html="$attrs.titleSlot" />
         </template>
       </dt-toast>
     </aside>

--- a/packages/dialtone-vue/components/toast/toast_default.story.vue
+++ b/packages/dialtone-vue/components/toast/toast_default.story.vue
@@ -55,12 +55,6 @@
         >
           <dt-icon :name="$attrs.icon" />
         </template>
-        <template
-          v-if="$attrs.title"
-          #title
-        >
-          <span v-html="$attrs.title" />
-        </template>
       </dt-toast>
     </aside>
   </div>

--- a/packages/dialtone-vue/components/toast/toast_default.story.vue
+++ b/packages/dialtone-vue/components/toast/toast_default.story.vue
@@ -56,10 +56,10 @@
           <dt-icon :name="$attrs.icon" />
         </template>
         <template
-          v-if="$attrs.titleSlot"
+          v-if="$attrs.title"
           #title
         >
-          <span v-html="$attrs.titleSlot" />
+          <span v-html="$attrs.title" />
         </template>
       </dt-toast>
     </aside>


### PR DESCRIPTION
# Refactor prop/slots to be consistent

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3283

## :book: Description

We are refactoring some props/slots names that we had for accomodate storybook. This should not be it anymore and we should appropiate fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Renamed Vue slots for consistency: titleOverride→title, labelSlot→label, headingSlot→heading across Banner, Notice, Toast, Input, ListItemGroup, their stories, and Storybook argTypes. JSDoc, tests, and combinator controls updated. Run a search/replace for #titleOverride→#title, #labelSlot→#label, #headingSlot→#heading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Breaking Changes
These are slot name renames — any consumer passing content via the old slot names will need to update:

1. titleOverride → title slot
Affects: DtBanner, DtNotice, DtToast

```
<!-- Before -->
<dt-banner title="My Title">
  <template #titleOverride>Custom <strong>title</strong></template>
</dt-banner>
 
<!-- After -->
<dt-banner title="My Title">
  <template #title>Custom <strong>title</strong></template>
</dt-banner>
```

2. labelSlot → label slot
Affects: DtInput, DtcControlSlot, DtcControlString, DtcControlNumber

```
<!-- Before -->
<dt-input label="Name">
  <template #labelSlot>Custom <strong>label</strong></template>
</dt-input>
 
<!-- After -->
<dt-input label="Name">
  <template #label>Custom <strong>label</strong></template>
</dt-input>
```

3. headingSlot → heading slot
Affects: DtListItemGroup

```
<!-- Before -->
<dt-list-item-group heading="Group">
  <template #headingSlot>Custom <strong>heading</strong></template>
</dt-list-item-group>
 
<!-- After -->
<dt-list-item-group heading="Group">
  <template #heading>Custom <strong>heading</strong></template>
</dt-list-item-group>
```

4. labelSlot → label slot / descriptionSlot → description slot
Affects: DtSelectMenu

```
<!-- Before -->
<dt-select-menu label="Choose" description="Pick one">
  <template #labelSlot>Custom <strong>label</strong></template>
  <template #descriptionSlot>Custom <strong>description</strong></template>
</dt-select-menu>
 
<!-- After — slots already named correctly, only Storybook references were cleaned up -->
<dt-select-menu label="Choose" description="Pick one">
  <template #label>Custom <strong>label</strong></template>
  <template #description>Custom <strong>description</strong></template>
</dt-select-menu>
```

Migration effort

- Search consuming codebases for #titleOverride, #labelSlot, #headingSlot, #descriptionSlot
- Replace with #title, #label, #heading, #description respectively
- No prop changes — only slot names changed

Packages affected

- dialtone-vue — DtBanner, DtNotice, DtToast, DtInput, DtListItemGroup, DtSelectMenu
- combinator — DtcControlSlot, DtcControlString, DtcControlNumber (consumers of DtInput#label)