### PR TITLE
feat(eslint-plugin-dialtone): DLT-3314 add deprecated-dialtone-component rule

### DIFF
--- a/packages/eslint-plugin-dialtone/docs/rules/deprecated-dialtone-component.md
+++ b/packages/eslint-plugin-dialtone/docs/rules/deprecated-dialtone-component.md
@@ -1,0 +1,76 @@
+# Finds deprecated Dialtone components that should be replaced by newer alternatives
+
+## Rule Details
+
+This informs developers of deprecated Dialtone components and suggests what to use instead.
+
+### DtIcon
+
+`DtIcon` is a generic wrapper component that renders an icon by `name` prop. Import specific icon components directly from `@dialpad/dialtone-icons/vue3` instead — this avoids loading the entire icon registry and makes icon usage statically analyzable.
+
+### DtRecipe* components
+
+All `DtRecipe*` components have been moved to standalone UI-Kit packages and will no longer receive updates in Dialtone.
+They will remain available until the next major Dialtone release.
+See the [migration guide](https://dialtone.dialpad.com/about/whats-new/) for details.
+
+| Deprecated | Replacement | Package |
+| --- | --- | --- |
+| `DtIcon` | e.g. `DtIconPhoneHangUp` | `@dialpad/dialtone-icons/vue3` |
+| `DtRecipeComboboxMultiSelect` | `DtComboboxMultiSelect` | `@dialpad/dialtone` |
+| `DtRecipeComboboxWithPopover` | `DtComboboxWithPopover` | `@dialpad/dialtone` |
+| `DtRecipeMotionText` | `DtMotionText` | `@dialpad/dialtone` |
+| `DtRecipeCallbarButton` | `DpCallbarButton` | `@dialpad/callbarkit` |
+| `DtRecipeCallbarButtonWithPopover` | `DpCallbarButtonWithPopover` | `@dialpad/callbarkit` |
+| `DtRecipeCallbarButtonWithDropdown` | `DpCallbarButtonWithDropdown` | `@dialpad/callbarkit` |
+| `DtRecipeGroupedChip` | `DpGroupedChip` | `@dialpad/callbarkit` |
+| `DtRecipeTopBannerInfo` | `DpTopBannerInfo` | `@dialpad/callbarkit` |
+| `DtRecipeAttachmentCarousel` | `DpAttachmentCarousel` | `@dialpad/chatkit` |
+| `DtRecipeMessageInput` | `DpMessageInput` | `@dialpad/chatkit` |
+| `DtRecipeContactInfo` | `DpContactInfo` | `@dialpad/chatkit` |
+| `DtRecipeEditor` | `DpEditor` | `@dialpad/chatkit` |
+| `DtRecipeEmojiRow` | `DpEmojiRow` | `@dialpad/chatkit` |
+| `DtRecipeFeedItemPill` | `DpFeedItemPill` | `@dialpad/chatkit` |
+| `DtRecipeFeedItemRow` | `DpFeedItemRow` | `@dialpad/chatkit` |
+| `DtRecipeContactCentersRow` | `DpContactCentersRow` | `@dialpad/navigationkit` |
+| `DtRecipeContactRow` | `DpContactRow` | `@dialpad/navigationkit` |
+| `DtRecipeGeneralRow` | `DpGeneralRow` | `@dialpad/navigationkit` |
+| `DtRecipeGroupRow` | `DpGroupRow` | `@dialpad/navigationkit` |
+| `DtRecipeUnreadPill` | `DpUnreadPill` | `@dialpad/navigationkit` |
+| `DtRecipeCallbox` | `DpCallbox` | `@dialpad/navigationkit` |
+| `DtRecipeSettingsMenuButton` | `DpSettingsMenuButton` | `@dialpad/navigationkit` |
+| `DtRecipeIvrNode` | `DpIvrNode` | `@dialpad/workflowkit` |
+
+Examples of **incorrect** code for this rule:
+
+**using the generic DtIcon wrapper**:
+
+```js
+import { DtIcon } from '@dialpad/dialtone-vue';
+```
+
+**import of a deprecated DtRecipe component**:
+
+```js
+import { DtRecipeCallbarButton } from '@dialpad/dialtone-vue';
+```
+
+Examples of **correct** code for this rule:
+
+**direct icon component import**:
+
+```js
+import { DtIconPhoneHangUp } from '@dialpad/dialtone-icons/vue3';
+```
+
+**import of the replacement UI-Kit component**:
+
+```js
+import { DpCallbarButton } from '@dialpad/callbarkit';
+```
+
+**import of a non-deprecated Dialtone component**:
+
+```js
+import { DtButton } from '@dialpad/dialtone-vue';
+```

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-dialtone-component.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-dialtone-component.js
@@ -62,7 +62,8 @@ module.exports = {
       ImportDeclaration(node) {
         const importPath = node.source.value;
 
-        if (!importPath.includes('@dialpad/dialtone-vue') && !importPath.includes('@dialpad/dialtone')) {
+        const isDialtoneSource = /^@dialpad\/dialtone(?:-vue)?(?:$|\/)/.test(importPath);
+        if (!isDialtoneSource) {
           return;
         }
 

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-dialtone-component.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-dialtone-component.js
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview Detects usages of deprecated Dialtone components that should be replaced by newer alternatives.
+ * @author Brad Paugh
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'suggestion', // `problem`, `suggestion`, or `layout`
+    docs: {
+      description: "Detects usages of deprecated Dialtone components that should be replaced by newer alternatives",
+      recommended: false,
+      url: 'https://github.com/dialpad/dialtone/blob/staging/packages/eslint-plugin-dialtone/docs/rules/deprecated-dialtone-component.md',
+    },
+    fixable: null, // Or `code` or `whitespace`
+    schema: [], // Add a schema if the rule has options
+    messages: {
+      deprecatedDialtoneComponent: '{{ componentName }} is deprecated. Replace with {{ replacement }} from {{ package }}.',
+      deprecatedDtIcon: 'DtIcon is deprecated. Import icon components directly instead, for example: import { DtIconPhoneHangUp } from \'@dialpad/dialtone-icons/vue3\'.',
+    }
+  },
+
+  create(context) {
+    const deprecatedIconComponent = 'DtIcon';
+
+    const deprecatedComponents = [
+      { componentName: 'DtRecipeComboboxMultiSelect', replacement: 'DtComboboxMultiSelect', package: '@dialpad/dialtone' },
+      { componentName: 'DtRecipeComboboxWithPopover', replacement: 'DtComboboxWithPopover', package: '@dialpad/dialtone' },
+      { componentName: 'DtRecipeMotionText', replacement: 'DtMotionText', package: '@dialpad/dialtone' },
+      { componentName: 'DtRecipeCallbarButton', replacement: 'DpCallbarButton', package: '@dialpad/callbarkit' },
+      { componentName: 'DtRecipeCallbarButtonWithPopover', replacement: 'DpCallbarButtonWithPopover', package: '@dialpad/callbarkit' },
+      { componentName: 'DtRecipeCallbarButtonWithDropdown', replacement: 'DpCallbarButtonWithDropdown', package: '@dialpad/callbarkit' },
+      { componentName: 'DtRecipeGroupedChip', replacement: 'DpGroupedChip', package: '@dialpad/callbarkit' },
+      { componentName: 'DtRecipeTopBannerInfo', replacement: 'DpTopBannerInfo', package: '@dialpad/callbarkit' },
+      { componentName: 'DtRecipeAttachmentCarousel', replacement: 'DpAttachmentCarousel', package: '@dialpad/chatkit' },
+      { componentName: 'DtRecipeMessageInput', replacement: 'DpMessageInput', package: '@dialpad/chatkit' },
+      { componentName: 'DtRecipeContactInfo', replacement: 'DpContactInfo', package: '@dialpad/chatkit' },
+      { componentName: 'DtRecipeEditor', replacement: 'DpEditor', package: '@dialpad/chatkit' },
+      { componentName: 'DtRecipeEmojiRow', replacement: 'DpEmojiRow', package: '@dialpad/chatkit' },
+      { componentName: 'DtRecipeFeedItemPill', replacement: 'DpFeedItemPill', package: '@dialpad/chatkit' },
+      { componentName: 'DtRecipeFeedItemRow', replacement: 'DpFeedItemRow', package: '@dialpad/chatkit' },
+      { componentName: 'DtRecipeContactCentersRow', replacement: 'DpContactCentersRow', package: '@dialpad/navigationkit' },
+      { componentName: 'DtRecipeContactRow', replacement: 'DpContactRow', package: '@dialpad/navigationkit' },
+      { componentName: 'DtRecipeGeneralRow', replacement: 'DpGeneralRow', package: '@dialpad/navigationkit' },
+      { componentName: 'DtRecipeGroupRow', replacement: 'DpGroupRow', package: '@dialpad/navigationkit' },
+      { componentName: 'DtRecipeUnreadPill', replacement: 'DpUnreadPill', package: '@dialpad/navigationkit' },
+      { componentName: 'DtRecipeCallbox', replacement: 'DpCallbox', package: '@dialpad/navigationkit' },
+      { componentName: 'DtRecipeSettingsMenuButton', replacement: 'DpSettingsMenuButton', package: '@dialpad/navigationkit' },
+      { componentName: 'DtRecipeIvrNode', replacement: 'DpIvrNode', package: '@dialpad/workflowkit' },
+    ];
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      ImportDeclaration(node) {
+        const importPath = node.source.value;
+
+        if (!importPath.includes('@dialpad/dialtone-vue') && !importPath.includes('@dialpad/dialtone')) {
+          return;
+        }
+
+        node.specifiers.forEach(specifier => {
+          if (specifier.type !== 'ImportSpecifier') return;
+
+          const importedName = specifier.imported.name;
+
+          if (importedName === deprecatedIconComponent) {
+            context.report({
+              node: specifier,
+              messageId: 'deprecatedDtIcon',
+            });
+            return;
+          }
+
+          const found = deprecatedComponents.find(item => item.componentName === importedName);
+
+          if (found) {
+            context.report({
+              node: specifier,
+              messageId: 'deprecatedDialtoneComponent',
+              data: {
+                componentName: found.componentName,
+                replacement: found.replacement,
+                package: found.package,
+              }
+            });
+          }
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-dialtone-component.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-dialtone-component.js
@@ -1,0 +1,188 @@
+/**
+ * @fileoverview Detects usages of deprecated Dialtone components that should be replaced by newer alternatives.
+ * @author Brad Paugh
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/deprecated-dialtone-component"), RuleTester = require("eslint").RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({parserOptions: {sourceType: 'module', ecmaVersion: 'latest'}});
+ruleTester.run("deprecated-dialtone-component", rule, {
+    valid: [
+        {
+            name: 'Non-deprecated Dialtone component import',
+            code: "import { DtButton } from '@dialpad/dialtone-vue';",
+        },
+        {
+            name: 'Direct icon component import (not DtIcon)',
+            code: "import { DtIconPhoneHangUp } from '@dialpad/dialtone-icons/vue3';",
+        },
+        {
+            name: 'Non-deprecated Dialtone component import from dialtone',
+            code: "import { DtComboboxWithPopover } from '@dialpad/dialtone';",
+        },
+        {
+            name: 'Import from a non-Dialtone package',
+            code: "import { DtRecipeCallbarButton } from 'some-other-package';",
+        },
+        {
+            name: 'Default import from Dialtone',
+            code: "import Dialtone from '@dialpad/dialtone-vue';",
+        },
+    ],
+
+    invalid: [
+        {
+            name: 'Deprecated DtRecipeComboboxMultiSelect from dialtone-vue',
+            code: "import { DtRecipeComboboxMultiSelect } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeComboboxWithPopover from dialtone',
+            code: "import { DtRecipeComboboxWithPopover } from '@dialpad/dialtone';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeMotionText',
+            code: "import { DtRecipeMotionText } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeCallbarButton',
+            code: "import { DtRecipeCallbarButton } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeCallbarButtonWithPopover',
+            code: "import { DtRecipeCallbarButtonWithPopover } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeCallbarButtonWithDropdown',
+            code: "import { DtRecipeCallbarButtonWithDropdown } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeGroupedChip',
+            code: "import { DtRecipeGroupedChip } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeTopBannerInfo',
+            code: "import { DtRecipeTopBannerInfo } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeAttachmentCarousel',
+            code: "import { DtRecipeAttachmentCarousel } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeMessageInput',
+            code: "import { DtRecipeMessageInput } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeContactInfo',
+            code: "import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeEditor',
+            code: "import { DtRecipeEditor } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeEmojiRow',
+            code: "import { DtRecipeEmojiRow } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeFeedItemPill',
+            code: "import { DtRecipeFeedItemPill } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeFeedItemRow',
+            code: "import { DtRecipeFeedItemRow } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeContactCentersRow',
+            code: "import { DtRecipeContactCentersRow } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeContactRow',
+            code: "import { DtRecipeContactRow } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeGeneralRow',
+            code: "import { DtRecipeGeneralRow } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeGroupRow',
+            code: "import { DtRecipeGroupRow } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeUnreadPill',
+            code: "import { DtRecipeUnreadPill } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeCallbox',
+            code: "import { DtRecipeCallbox } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeSettingsMenuButton',
+            code: "import { DtRecipeSettingsMenuButton } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtRecipeIvrNode',
+            code: "import { DtRecipeIvrNode } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Multiple deprecated imports in one statement',
+            code: "import { DtRecipeCallbarButton, DtRecipeEditor } from '@dialpad/dialtone-vue';",
+            errors: [
+                { messageId: 'deprecatedDialtoneComponent' },
+                { messageId: 'deprecatedDialtoneComponent' },
+            ],
+        },
+        {
+            name: 'Mixed deprecated and valid imports in one statement',
+            code: "import { DtButton, DtRecipeMotionText } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDialtoneComponent' }],
+        },
+        {
+            name: 'Deprecated DtIcon from dialtone-vue',
+            code: "import { DtIcon } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDtIcon' }],
+        },
+        {
+            name: 'Deprecated DtIcon from dialtone',
+            code: "import { DtIcon } from '@dialpad/dialtone';",
+            errors: [{ messageId: 'deprecatedDtIcon' }],
+        },
+        {
+            name: 'DtIcon mixed with other valid imports',
+            code: "import { DtButton, DtIcon } from '@dialpad/dialtone-vue';",
+            errors: [{ messageId: 'deprecatedDtIcon' }],
+        },
+    ],
+});


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbXpuYXVvbGp6NnFkb3ZkZjlnZDR3dmllbGVqeGZlM2Nob3k0cGdieCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oriO0OEd9QIDdllqo/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-3314](https://dialpad.atlassian.net/browse/DLT-3314)

## :book: Description

Adds a new ESLint rule `deprecated-dialtone-component` to `eslint-plugin-dialtone` that detects imports of deprecated Dialtone components and reports the correct replacement.

Two categories of deprecations are covered:

- **`DtIcon`** — the generic icon wrapper component. Should be replaced with a direct named icon import (e.g. `DtIconPhoneHangUp`) from `@dialpad/dialtone-icons/vue3`.
- **`DtRecipe*` components** — all recipe components that have been moved to standalone UI-Kit packages (`@dialpad/callbarkit`, `@dialpad/chatkit`, `@dialpad/navigationkit`, `@dialpad/workflowkit`) or promoted to core Dialtone (`@dialpad/dialtone`).

The rule operates on named `ImportSpecifier` nodes (not file paths), so it correctly flags only the deprecated name within a multi-import statement without flagging the whole import.

## :bulb: Context

`DtRecipe*` components were deprecated in favour of UI-Kit packages (see the [March 2026 release note](https://dialtone.dialpad.com/about/whats-new/)). `DtIcon` is being deprecated in favour of direct icon imports for better tree-shaking and static analysability. This rule helps consumers of `@dialpad/dialtone-vue` catch usages that need to be migrated.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

[DLT-3314]: https://dialpad.atlassian.net/browse/DLT-3314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds an ESLint rule `deprecated-dialtone-component` that detects deprecated `DtIcon` and `DtRecipe*` imports, reports replacements, and includes implementation, documentation, and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->