### PR TITLE
fix(rich-text-editor): DP-179947 use URL as display text when inserting link without text

### DIFF
--- a/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.test.js
@@ -1643,24 +1643,13 @@ describe('DtRichTextEditor tests', () => {
         wrapper.vm.editor.commands.focus();
       });
 
-      describe('When display text is provided', () => {
-        it('should insert the display text as a link', async () => {
-          wrapper.vm.setLink('https://example.com', 'Example', linkOptions, supportedProtocols, defaultPrefix);
-          await wrapper.vm.$nextTick();
-          const output = wrapper.vm.getOutput();
-          expect(output).toContain('href="https://example.com"');
-          expect(output).toContain('Example');
-        });
-      });
-
-      describe('When display text is empty', () => {
-        it('should use the URL as the display text', async () => {
-          wrapper.vm.setLink('https://example.com', '', linkOptions, supportedProtocols, defaultPrefix);
-          await wrapper.vm.$nextTick();
-          const output = wrapper.vm.getOutput();
-          expect(output).toContain('href="https://example.com"');
-          expect(output).toContain('https://example.com');
-        });
+      it.each([
+        ['https://example.com', 'Example', 'Example'],
+        ['https://example.com', '', 'https://example.com'],
+      ])('should render link correctly (url=%s, displayText=%s)', async (url, displayText, expectedSubstring) => {
+        wrapper.vm.setLink(url, displayText, linkOptions, supportedProtocols, defaultPrefix);
+        await wrapper.vm.$nextTick();
+        expect(wrapper.vm.getOutput()).toContain(expectedSubstring);
       });
     });
 

--- a/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.test.js
@@ -1633,6 +1633,37 @@ describe('DtRichTextEditor tests', () => {
       });
     });
 
+    describe('setLink method', () => {
+      const linkOptions = { class: 'd-link' };
+      const supportedProtocols = [/^https?:\/\//, /^ftp?:\/\//, /mailto:/];
+      const defaultPrefix = 'https://';
+
+      beforeEach(async () => {
+        await wrapper.setProps({ link: true, outputFormat: 'html' });
+        wrapper.vm.editor.commands.focus();
+      });
+
+      describe('When display text is provided', () => {
+        it('should insert the display text as a link', async () => {
+          wrapper.vm.setLink('https://example.com', 'Example', linkOptions, supportedProtocols, defaultPrefix);
+          await wrapper.vm.$nextTick();
+          const output = wrapper.vm.getOutput();
+          expect(output).toContain('href="https://example.com"');
+          expect(output).toContain('Example');
+        });
+      });
+
+      describe('When display text is empty', () => {
+        it('should use the URL as the display text', async () => {
+          wrapper.vm.setLink('https://example.com', '', linkOptions, supportedProtocols, defaultPrefix);
+          await wrapper.vm.$nextTick();
+          const output = wrapper.vm.getOutput();
+          expect(output).toContain('href="https://example.com"');
+          expect(output).toContain('https://example.com');
+        });
+      });
+    });
+
     describe('Link keyboard shortcut functionality', () => {
       describe('When Mod+K is pressed and link is enabled', () => {
         it('should emit edit-link event', async () => {

--- a/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.vue
@@ -974,12 +974,13 @@ export default {
         .run();
 
       const selection = this.editor?.view?.state?.selection;
+      const displayText = linkText || linkInput;
 
       this.editor
         .chain()
         .focus()
-        .insertContent(linkText)
-        .setTextSelection({ from: selection.from, to: selection.from + linkText.length })
+        .insertContent(displayText)
+        .setTextSelection({ from: selection.from, to: selection.from + displayText.length })
         .setLink({ href: linkInput, class: linkOptions.class })
         .run();
     },


### PR DESCRIPTION
## Description

JIRA Link: https://dialpad.atlassian.net/browse/DP-179947

When a user inserts a link in the rich text editor without providing display text, the link is now visible in the editor using the URL itself as the display text.

## Summary of changes requested

- Fix `setLink` in `DtRichTextEditor` to fall back to the URL when display text is empty
- Add tests covering both the display-text-provided and display-text-empty cases

## Technical Details

**Root cause:** `setLink(linkInput, linkText, ...)` called `insertContent(linkText)` followed by `setTextSelection({ from, to: from + linkText.length })`. When `linkText` was `""`, this inserted nothing and created a zero-width selection, so the subsequent `setLink()` mark command had no range to apply to — leaving the editor with no visible link node.

**Fix:** `packages/dialtone-vue/components/rich_text_editor/rich_text_editor.vue` — introduce `const displayText = linkText || linkInput` and use it for both `insertContent` and `setTextSelection`, so the URL is used as the visible text when no display text is provided.

**Tests:** Added two cases to `rich_text_editor.test.js` under a new `setLink method` describe block — one for when display text is provided, one for when it is empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Use the URL as visible link text when no display text is provided to prevent zero-width selections. setLink now derives displayText = linkText || linkInput and uses it for insertContent and selection. Added tests covering both non-empty and empty display-text link insertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->