### PR TITLE
fix(css): DLT-3321 reorder utility classes so single-direction wins over shorthand

### DIFF
--- a/packages/dialtone-css/lib/build/less/utilities/borders.less
+++ b/packages/dialtone-css/lib/build/less/utilities/borders.less
@@ -23,10 +23,21 @@
 //  $$ DIRECTION
 //  ----------------------------------------------------------------------------
 @layer dialtone.utilities {
+// Order within this section: all-sides shorthand -> H/V -> single-side -> resets.
+// Single-side classes must follow H/V so .d-bt wins when combined with .d-by, etc.
+// Reset classes (.d-ba-none / .d-ba-unset) stay last as intentional escape hatches.
 .d-ba {
   border-color: var(--dt-color-border-default) !important;
   border-style: solid !important;
   border-width: var(--dt-size-border-100) !important;
+}
+
+.d-bx {
+  border-inline: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
+}
+
+.d-by {
+  border-block: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
 }
 
 .d-bt {
@@ -45,11 +56,53 @@
   border-inline-start: var(--dt-size-border-100) solid var(--dt-color-border-default) !important;
 }
 
-.d-bx { .d-br(); .d-bl(); }
-
-.d-by { .d-bt(); .d-bb(); }
 .d-ba-none { border: none !important; }
 .d-ba-unset { border: unset !important; }
+
+//  $  BORDER WIDTH
+//  ----------------------------------------------------------------------------
+//  Order: all-sides -> H/V -> single-side, so single-side classes win on cascade ties.
+.d-baw0 { border-width: var(--dt-size-border-0) !important; }
+.d-baw1 { border-width: var(--dt-size-border-100) !important; }
+.d-baw2 { border-width: var(--dt-size-border-200) !important; }
+.d-baw4 { border-width: var(--dt-size-border-300) !important; }
+
+//  --  X Border width
+.d-bxw0 { border-inline-width: var(--dt-size-border-0) !important; }
+.d-bxw1 { border-inline-width: var(--dt-size-border-100) !important; }
+.d-bxw2 { border-inline-width: var(--dt-size-border-200) !important; }
+.d-bxw4 { border-inline-width: var(--dt-size-border-300) !important; }
+
+//  --  Y Border width
+.d-byw0 { border-block-width: var(--dt-size-border-0) !important; }
+.d-byw1 { border-block-width: var(--dt-size-border-100) !important; }
+.d-byw2 { border-block-width: var(--dt-size-border-200) !important; }
+.d-byw4 { border-block-width: var(--dt-size-border-300) !important; }
+
+//  --  Top Border width
+.d-btw0 { border-block-start-width: var(--dt-size-border-0) !important; }
+.d-btw1 { border-block-start-width: var(--dt-size-border-100) !important; }
+.d-btw2 { border-block-start-width: var(--dt-size-border-200) !important; }
+.d-btw4 { border-block-start-width: var(--dt-size-border-300) !important; }
+
+//  --  Right Border width
+.d-brw0 { border-inline-end-width: var(--dt-size-border-0) !important; }
+.d-brw1 { border-inline-end-width: var(--dt-size-border-100) !important; }
+.d-brw2 { border-inline-end-width: var(--dt-size-border-200) !important; }
+.d-brw4 { border-inline-end-width: var(--dt-size-border-300) !important; }
+
+//  --  Bottom Border width
+.d-bbw0 { border-block-end-width: var(--dt-size-border-0) !important; }
+.d-bbw1 { border-block-end-width: var(--dt-size-border-100) !important; }
+.d-bbw2 { border-block-end-width: var(--dt-size-border-200) !important; }
+.d-bbw4 { border-block-end-width: var(--dt-size-border-300) !important; }
+
+//  --  Left Border width
+.d-blw0 { border-inline-start-width: var(--dt-size-border-0) !important; }
+.d-blw1 { border-inline-start-width: var(--dt-size-border-100) !important; }
+.d-blw2 { border-inline-start-width: var(--dt-size-border-200) !important; }
+.d-blw4 { border-inline-start-width: var(--dt-size-border-300) !important; }
+
 
 //  ============================================================================
 //  $  BORDER RADIUS
@@ -124,50 +177,6 @@
 .d-bls-dotted { border-inline-start-style: dotted !important; }
 
 .d-bas-unset { border-style: unset !important; }
-
-
-//  $$ WIDTH
-//  ----------------------------------------------------------------------------
-.d-baw0 { border-width: var(--dt-size-border-0) !important; }
-.d-baw1 { border-width: var(--dt-size-border-100) !important; }
-.d-baw2 { border-width: var(--dt-size-border-200) !important; }
-.d-baw4 { border-width: var(--dt-size-border-300) !important; }
-
-//  --  Top Border width
-.d-btw0 { border-block-start-width: var(--dt-size-border-0) !important; }
-.d-btw1 { border-block-start-width: var(--dt-size-border-100) !important; }
-.d-btw2 { border-block-start-width: var(--dt-size-border-200) !important; }
-.d-btw4 { border-block-start-width: var(--dt-size-border-300) !important; }
-
-//  --  Right Border width
-.d-brw0 { border-inline-end-width: var(--dt-size-border-0) !important; }
-.d-brw1 { border-inline-end-width: var(--dt-size-border-100) !important; }
-.d-brw2 { border-inline-end-width: var(--dt-size-border-200) !important; }
-.d-brw4 { border-inline-end-width: var(--dt-size-border-300) !important; }
-
-//  --  Bottom Border width
-.d-bbw0 { border-block-end-width: var(--dt-size-border-0) !important; }
-.d-bbw1 { border-block-end-width: var(--dt-size-border-100) !important; }
-.d-bbw2 { border-block-end-width: var(--dt-size-border-200) !important; }
-.d-bbw4 { border-block-end-width: var(--dt-size-border-300) !important; }
-
-//  --  Left Border width
-.d-blw0 { border-inline-start-width: var(--dt-size-border-0) !important; }
-.d-blw1 { border-inline-start-width: var(--dt-size-border-100) !important; }
-.d-blw2 { border-inline-start-width: var(--dt-size-border-200) !important; }
-.d-blw4 { border-inline-start-width: var(--dt-size-border-300) !important; }
-
-//  --  X Border width
-.d-bxw0 { .d-brw0(); .d-blw0(); }
-.d-bxw1 { .d-brw1(); .d-blw1(); }
-.d-bxw2 { .d-brw2(); .d-blw2(); }
-.d-bxw4 { .d-brw4(); .d-blw4(); }
-
-//  --  Y Border width
-.d-byw0 { .d-btw0(); .d-bbw0(); }
-.d-byw1 { .d-btw1(); .d-bbw1(); }
-.d-byw2 { .d-btw2(); .d-bbw2(); }
-.d-byw4 { .d-btw4(); .d-bbw4(); }
 
 
 //  ============================================================================

--- a/packages/dialtone-css/lib/build/less/utilities/flex.less
+++ b/packages/dialtone-css/lib/build/less/utilities/flex.less
@@ -23,6 +23,71 @@
 //     has more than one line.
 //  ----------------------------------------------------------------------------
 @layer dialtone.utilities {
+//  $$  PLACE CONTENT
+//      Shorthand for align-content + justify-content. Must precede both
+//      `.d-ac-*` (below) and `.d-jc-*` (further down this file) so single-axis
+//      classes win.
+//  ----------------------------------------------------------------------------
+.d-plc-center { place-content: center !important; }
+.d-plc-center-end { place-content: center end !important; }
+.d-plc-center-start { place-content: center start !important; }
+.d-plc-center-stretch { place-content: center stretch !important; }
+.d-plc-center-space-around { place-content: center space-around !important; }
+.d-plc-center-space-evenly { place-content: center space-evenly !important; }
+.d-plc-center-space-between { place-content: center space-between !important; }
+
+.d-plc-end { place-content: end !important; }
+.d-plc-end-start { place-content: end start !important; }
+.d-plc-end-stretch { place-content: end stretch !important; }
+.d-plc-end-center { place-content: end center !important; }
+.d-plc-end-space-around { place-content: end space-around !important; }
+.d-plc-end-space-evenly { place-content: end space-evenly !important; }
+.d-plc-end-space-between { place-content: end space-between !important; }
+
+.d-plc-start { place-content: start !important; }
+.d-plc-start-end { place-content: start end !important; }
+.d-plc-start-center { place-content: start center !important; }
+.d-plc-start-stretch { place-content: start stretch !important; }
+.d-plc-start-space-around { place-content: start space-around !important; }
+.d-plc-start-space-evenly { place-content: start space-evenly !important; }
+.d-plc-start-space-between { place-content: start space-between !important; }
+
+.d-plc-stretch { place-content: stretch !important; }
+.d-plc-stretch-end { place-content: stretch end !important; }
+.d-plc-stretch-start { place-content: stretch start !important; }
+.d-plc-stretch-center { place-content: stretch center !important; }
+.d-plc-stretch-space-evenly { place-content: stretch space-evenly !important; }
+.d-plc-stretch-space-around { place-content: stretch space-around !important; }
+.d-plc-stretch-space-between { place-content: stretch space-between !important; }
+
+.d-plc-space-around { place-content: space-around !important; }
+.d-plc-space-around-end { place-content: space-around end !important; }
+.d-plc-space-around-start { place-content: space-around start !important; }
+.d-plc-space-around-center { place-content: space-around center !important; }
+.d-plc-space-around-space-evenly { place-content: space-around space-evenly !important; }
+.d-plc-space-around-space-between { place-content: space-around space-between !important; }
+
+.d-plc-space-evenly { place-content: space-evenly !important; }
+.d-plc-space-evenly-end { place-content: space-evenly end !important; }
+.d-plc-space-evenly-start { place-content: space-evenly start !important; }
+.d-plc-space-evenly-center { place-content: space-evenly center !important; }
+.d-plc-space-evenly-space-around { place-content: space-evenly space-around !important; }
+.d-plc-space-evenly-space-between { place-content: space-evenly space-between !important; }
+
+.d-plc-space-between { place-content: space-between !important; }
+.d-plc-space-between-end { place-content: space-between end !important; }
+.d-plc-space-between-start { place-content: space-between start !important; }
+.d-plc-space-between-center { place-content: space-between center !important; }
+.d-plc-space-between-space-around { place-content: space-between space-around !important; }
+.d-plc-space-between-space-evenly { place-content: space-between space-evenly !important; }
+
+.d-plc-normal { place-content: normal !important; }
+.d-plc-legacy { place-content: legacy !important; }
+.d-plc-auto { place-content: auto !important; }
+.d-plc-unset { place-content: unset !important; }
+
+//  $$  ALIGN CONTENT
+//  ----------------------------------------------------------------------------
 .d-ac-center { align-content: center !important; }
 .d-ac-flex-end, .d-ac-end { align-content: flex-end !important; }
 .d-ac-flex-start, .d-ac-start { align-content: flex-start !important; }
@@ -41,6 +106,37 @@
 //     the parent's cross axis. Think of it the cross-axis for
 //     justify-content.
 //  ----------------------------------------------------------------------------
+//  $$  PLACE ITEMS
+//      Shorthand for align-items + justify-items. Must precede `.d-ai-*` (below)
+//      and `.d-ji-*` (grid.less, imported after this file) so single-axis wins.
+//  ----------------------------------------------------------------------------
+.d-pli-center { place-items: center !important; }
+.d-pli-center-end { place-items: center end !important; }
+.d-pli-center-start { place-items: center start !important; }
+.d-pli-center-stretch { place-items: center stretch !important; }
+
+.d-pli-end { place-items: end !important; }
+.d-pli-end-start { place-items: end start !important; }
+.d-pli-end-stretch { place-items: end stretch !important; }
+.d-pli-end-center { place-items: end center !important; }
+
+.d-pli-start { place-items: start !important; }
+.d-pli-start-end { place-items: start end !important; }
+.d-pli-start-center { place-items: start center !important; }
+.d-pli-start-stretch { place-items: start stretch !important; }
+
+.d-pli-stretch { place-items: stretch !important; }
+.d-pli-stretch-end { place-items: stretch end !important; }
+.d-pli-stretch-start { place-items: stretch start !important; }
+.d-pli-stretch-center { place-items: stretch center !important; }
+
+.d-pli-normal { place-items: normal !important; }
+.d-pli-legacy { place-items: legacy !important; }
+.d-pli-auto { place-items: auto !important; }
+.d-pli-unset { place-items: unset !important; }
+
+//  $$  ALIGN ITEMS
+//  ----------------------------------------------------------------------------
 .d-ai-center { align-items: center !important; }
 .d-ai-flex-end, .d-ai-end { align-items: flex-end !important; }
 .d-ai-flex-start, .d-ai-start { align-items: flex-start !important; }
@@ -54,6 +150,37 @@
 //  $  ALIGN SELF
 //     Allows child containers to re-align themselves regardless
 //     of the parent's main axis direction.
+//  ----------------------------------------------------------------------------
+//  $$  PLACE SELF
+//      Shorthand for align-self + justify-self. Must precede `.d-as-*` (below)
+//      and `.d-js-*` (grid.less, imported after this file) so single-axis wins.
+//  ----------------------------------------------------------------------------
+.d-pls-center { place-self: center !important; }
+.d-pls-center-end { place-self: center end !important; }
+.d-pls-center-start { place-self: center start !important; }
+.d-pls-center-stretch { place-self: center stretch !important; }
+
+.d-pls-end { place-self: end !important; }
+.d-pls-end-start { place-self: end start !important; }
+.d-pls-end-stretch { place-self: end stretch !important; }
+.d-pls-end-center { place-self: end center !important; }
+
+.d-pls-start { place-self: start !important; }
+.d-pls-start-end { place-self: start end !important; }
+.d-pls-start-center { place-self: start center !important; }
+.d-pls-start-stretch { place-self: start stretch !important; }
+
+.d-pls-stretch { place-self: stretch !important; }
+.d-pls-stretch-end { place-self: stretch end !important; }
+.d-pls-stretch-start { place-self: stretch start !important; }
+.d-pls-stretch-center { place-self: stretch center !important; }
+
+.d-pls-normal { place-self: normal !important; }
+.d-pls-legacy { place-self: legacy !important; }
+.d-pls-auto { place-self: auto !important; }
+.d-pls-unset { place-self: unset !important; }
+
+//  $$  ALIGN SELF
 //  ----------------------------------------------------------------------------
 .d-as-center { align-self: center !important; }
 .d-as-flex-end, .d-as-end { align-self: flex-end !important; }
@@ -89,6 +216,24 @@
 //  ============================================================================
 //  $  DIRECTION, WRAP, & FLOW
 //  ----------------------------------------------------------------------------
+//  $$  FLEX FLOW
+//      Shorthand for flex-direction + flex-wrap. Emitted before the single-
+//      property blocks so `.d-fd-*` / `.d-fw-*` win on cascade ties.
+//  ----------------------------------------------------------------------------
+.d-ff-row-wrap { flex-flow: row wrap !important; }
+.d-ff-row-wrap-reverse { flex-flow: row wrap-reverse !important; }
+.d-ff-row-nowrap { flex-flow: row nowrap !important; }
+.d-ff-row-reverse-wrap { flex-flow: row-reverse wrap !important; }
+.d-ff-row-reverse-wrap-reverse { flex-flow: row-reverse wrap-reverse !important; }
+.d-ff-row-reverse-nowrap { flex-flow: row-reverse nowrap !important; }
+.d-ff-column-wrap { flex-flow: column wrap !important; }
+.d-ff-column-wrap-reverse { flex-flow: column wrap-reverse !important; }
+.d-ff-column-nowrap { flex-flow: column nowrap !important; }
+.d-ff-column-reverse-wrap { flex-flow: column-reverse wrap !important; }
+.d-ff-column-reverse-wrap-reverse { flex-flow: column-reverse wrap-reverse !important; }
+.d-ff-column-reverse-nowrap { flex-flow: column-reverse nowrap !important; }
+.d-f-flow-unset { flex-flow: unset !important; }
+
 //  $$  FLEX DIRECTION
 //      This determines the content flow direction within the parent container.
 //      Default value is row.
@@ -107,24 +252,6 @@
 .d-fw-wrap-reverse { flex-wrap: wrap-reverse !important; }
 .d-fw-nowrap { flex-wrap: nowrap !important; }
 .d-fw-unset { flex-wrap: unset !important; }
-
-//  $$  FLEX FLOW
-//      This is another shorthand property for flex-direction and flex-wrap.
-//      Default value is 'row nowrap'.
-//  ----------------------------------------------------------------------------
-.d-ff-row-wrap { flex-flow: row wrap !important; }
-.d-ff-row-wrap-reverse { flex-flow: row wrap-reverse !important; }
-.d-ff-row-nowrap { flex-flow: row nowrap !important; }
-.d-ff-row-reverse-wrap { flex-flow: row-reverse wrap !important; }
-.d-ff-row-reverse-wrap-reverse { flex-flow: row-reverse wrap-reverse !important; }
-.d-ff-row-reverse-nowrap { flex-flow: row-reverse nowrap !important; }
-.d-ff-column-wrap { flex-flow: column wrap !important; }
-.d-ff-column-wrap-reverse { flex-flow: column wrap-reverse !important; }
-.d-ff-column-nowrap { flex-flow: column nowrap !important; }
-.d-ff-column-reverse-wrap { flex-flow: column-reverse wrap !important; }
-.d-ff-column-reverse-wrap-reverse { flex-flow: column-reverse wrap-reverse !important; }
-.d-ff-column-reverse-nowrap { flex-flow: column-reverse nowrap !important; }
-.d-f-flow-unset { flex-flow: unset !important; }
 
 
 //  ============================================================================

--- a/packages/dialtone-css/lib/build/less/utilities/grid.less
+++ b/packages/dialtone-css/lib/build/less/utilities/grid.less
@@ -7,31 +7,59 @@
 //  visit https://dialtone.dialpad.com/utilities/grid
 //
 //  TABLE OF CONTENTS
-//  • GRID VARIABLES
-//  • COLUMNS
+//  • GRID AREAS        (grid-area shorthand — precedes column/row shorthand)
+//  • COLUMNS           (grid-column shorthand, then grid-column-start / -end)
+//  • ROWS              (grid-row shorthand, then grid-row-start / -end)
 //  • GAP
 //  • JUSTIFY ITEMS
 //  • JUSTIFY SELF
 //  • LAYOUTS
-//      - AREAS
-//  • PLACE CONTENT
-//  • PLACE ITEMS
-//  • PLACE SELF
-//  • ROWS
 //
+//  Ordering rule: shorthand / multi-axis classes precede their single-axis
+//  counterparts so single-axis classes win on cascade ties. `place-items`,
+//  `place-content`, and `place-self` shorthands live in `flex.less` because
+//  their longhand partners (`align-*`) also live there.
+//
+//  ============================================================================
+//  $   GRID AREAS
+//  ============================================================================
+//  `grid-area` is shorthand for grid-row-start / grid-column-start /
+//  grid-row-end / grid-column-end. Placed first so .d-gc-*/.d-gr-* singles win.
+//  ----------------------------------------------------------------------------
+@layer dialtone.utilities {
+.d-ga-sidebar { grid-area: sidebar !important; }
+.d-ga-content { grid-area: content !important; }
+.d-ga-header { grid-area: header !important; }
+
+
 //  ============================================================================
 //  $   COLUMNS
 //  ----------------------------------------------------------------------------
-@layer dialtone.utilities {
+//  `.d-gc-*` (grid-column shorthand) first; `.d-gcs-*` / `.d-gce-*` after.
 .d-gc-full { grid-column: 1 ~' / ' -1 !important; }
+.d-gc-auto { grid-column: auto !important; }
+.d-gc-unset { grid-column: unset !important; }
 
 .d-gcs-auto { grid-column-start: auto !important; }
 .d-gce-auto { grid-column-end: auto !important; }
-.d-gc-auto { grid-column: auto !important; }
 
 .d-gcs-unset { grid-column-start: unset !important; }
 .d-gce-unset { grid-column-end: unset !important; }
-.d-gc-unset { grid-column: unset !important; }
+
+
+//  ============================================================================
+//  $   ROWS
+//  ----------------------------------------------------------------------------
+//  `.d-gr-*` (grid-row shorthand) first; `.d-grs-*` / `.d-gre-*` after.
+.d-gr-full { grid-row: 1 ~' / ' -1 !important; }
+.d-gr-auto { grid-row: auto !important; }
+.d-gr-unset { grid-row: unset !important; }
+
+.d-grs-auto { grid-row-start: auto !important; }
+.d-gre-auto { grid-row-end: auto !important; }
+
+.d-grs-unset { grid-row-start: unset !important; }
+.d-gre-unset { grid-row-end: unset !important; }
 
 
 //  ============================================================================
@@ -41,9 +69,10 @@
 //      each defined spacing unit.
 //      TODO: Deprecated classes, remove on our next migration. https://dialpad.atlassian.net/browse/DLT-1763
 //  ----------------------------------------------------------------------------
+//  `.d-gg-unset` (gap shorthand) first; `.d-gcg-unset` / `.d-grg-unset` after.
+.d-gg-unset { gap: unset !important; }
 .d-gcg-unset { column-gap: unset !important; }
 .d-grg-unset { row-gap: unset !important; }
-.d-gg-unset { gap: unset !important; }
 
 
 //  ============================================================================
@@ -103,145 +132,4 @@
                          'content';
     grid-template-rows: [header-start] var(--header-height) [header-end content-start] var(--content-height) [content-end];
 }
-
-//  $   GRID AREAS
-//  ----------------------------------------------------------------------------
-.d-ga-sidebar { grid-area: sidebar !important; }
-.d-ga-content { grid-area: content !important; }
-.d-ga-header { grid-area: header !important; }
-
-
-//  ============================================================================
-//  $   PLACE CONTENT
-//      Aligns grid items along the block and inline directions at once
-//  ----------------------------------------------------------------------------
-.d-plc-center { place-content: center !important; }
-.d-plc-center-end { place-content: center end !important; }
-.d-plc-center-start { place-content: center start !important; }
-.d-plc-center-stretch { place-content: center stretch !important; }
-.d-plc-center-space-around { place-content: center space-around !important; }
-.d-plc-center-space-evenly { place-content: center space-evenly !important; }
-.d-plc-center-space-between { place-content: center space-between !important; }
-
-.d-plc-end { place-content: end !important; }
-.d-plc-end-start { place-content: end start !important; }
-.d-plc-end-stretch { place-content: end stretch !important; }
-.d-plc-end-center { place-content: end center !important; }
-.d-plc-end-space-around { place-content: end space-around !important; }
-.d-plc-end-space-evenly { place-content: end space-evenly !important; }
-.d-plc-end-space-between { place-content: end space-between !important; }
-
-.d-plc-start { place-content: start !important; }
-.d-plc-start-end { place-content: start end !important; }
-.d-plc-start-center { place-content: start center !important; }
-.d-plc-start-stretch { place-content: start stretch !important; }
-.d-plc-start-space-around { place-content: start space-around !important; }
-.d-plc-start-space-evenly { place-content: start space-evenly !important; }
-.d-plc-start-space-between { place-content: start space-between !important; }
-
-.d-plc-stretch { place-content: stretch !important; }
-.d-plc-stretch-end { place-content: stretch end !important; }
-.d-plc-stretch-start { place-content: stretch start !important; }
-.d-plc-stretch-center { place-content: stretch center !important; }
-.d-plc-stretch-space-evenly { place-content: stretch space-evenly !important; }
-.d-plc-stretch-space-around { place-content: stretch space-around !important; }
-.d-plc-stretch-space-between { place-content: stretch space-between !important; }
-
-.d-plc-space-around { place-content: space-around !important; }
-.d-plc-space-around-end { place-content: space-around end !important; }
-.d-plc-space-around-start { place-content: space-around start !important; }
-.d-plc-space-around-center { place-content: space-around center !important; }
-.d-plc-space-around-space-evenly { place-content: space-around space-evenly !important; }
-.d-plc-space-around-space-between { place-content: space-around space-between !important; }
-
-.d-plc-space-evenly { place-content: space-evenly !important; }
-.d-plc-space-evenly-end { place-content: space-evenly end !important; }
-.d-plc-space-evenly-start { place-content: space-evenly start !important; }
-.d-plc-space-evenly-center { place-content: space-evenly center !important; }
-.d-plc-space-evenly-space-around { place-content: space-evenly space-around !important; }
-.d-plc-space-evenly-space-between { place-content: space-evenly space-between !important; }
-
-.d-plc-space-between { place-content: space-between !important; }
-.d-plc-space-between-end { place-content: space-between end !important; }
-.d-plc-space-between-start { place-content: space-between start !important; }
-.d-plc-space-between-center { place-content: space-between center !important; }
-.d-plc-space-between-space-around { place-content: space-between space-around !important; }
-.d-plc-space-between-space-evenly { place-content: space-between space-evenly !important; }
-
-.d-plc-normal { place-content: normal !important; }
-.d-plc-legacy { place-content: legacy !important; }
-.d-plc-auto { place-content: auto !important; }
-.d-plc-unset { place-content: unset !important; }
-
-
-//  ============================================================================
-//  $   PLACE ITEMS
-//  ----------------------------------------------------------------------------
-.d-pli-center { place-items: center !important; }
-.d-pli-center-end { place-items: center end !important; }
-.d-pli-center-start { place-items: center start !important; }
-.d-pli-center-stretch { place-items: center stretch !important; }
-
-.d-pli-end { place-items: end !important; }
-.d-pli-end-start { place-items: end start !important; }
-.d-pli-end-stretch { place-items: end stretch !important; }
-.d-pli-end-center { place-items: end center !important; }
-
-.d-pli-start { place-items: start !important; }
-.d-pli-start-end { place-items: start end !important; }
-.d-pli-start-center { place-items: start center !important; }
-.d-pli-start-stretch { place-items: start stretch !important; }
-
-.d-pli-stretch { place-items: stretch !important; }
-.d-pli-stretch-end { place-items: stretch end !important; }
-.d-pli-stretch-start { place-items: stretch start !important; }
-.d-pli-stretch-center { place-items: stretch center !important; }
-
-.d-pli-normal { place-items: normal !important; }
-.d-pli-legacy { place-items: legacy !important; }
-.d-pli-auto { place-items: auto !important; }
-.d-pli-unset { place-items: unset !important; }
-
-
-//  ============================================================================
-//  $   PLACE SELF
-//  ----------------------------------------------------------------------------
-.d-pls-center { place-self: center !important; }
-.d-pls-center-end { place-self: center end !important; }
-.d-pls-center-start { place-self: center start !important; }
-.d-pls-center-stretch { place-self: center stretch !important; }
-
-.d-pls-end { place-self: end !important; }
-.d-pls-end-start { place-self: end start !important; }
-.d-pls-end-stretch { place-self: end stretch !important; }
-.d-pls-end-center { place-self: end center !important; }
-
-.d-pls-start { place-self: start !important; }
-.d-pls-start-end { place-self: start end !important; }
-.d-pls-start-center { place-self: start center !important; }
-.d-pls-start-stretch { place-self: start stretch !important; }
-
-.d-pls-stretch { place-self: stretch !important; }
-.d-pls-stretch-end { place-self: stretch end !important; }
-.d-pls-stretch-start { place-self: stretch start !important; }
-.d-pls-stretch-center { place-self: stretch center !important; }
-
-.d-pls-normal { place-self: normal !important; }
-.d-pls-legacy { place-self: legacy !important; }
-.d-pls-auto { place-self: auto !important; }
-.d-pls-unset { place-self: unset !important; }
-
-
-//  ============================================================================
-//  $   ROWS
-//  ----------------------------------------------------------------------------
-.d-gr-full { grid-row: 1 ~' / ' -1 !important; }
-
-.d-grs-auto { grid-row-start: auto !important; }
-.d-gre-auto { grid-row-end: auto !important; }
-.d-gr-auto { grid-row: auto !important; }
-
-.d-grs-unset { grid-row-start: unset !important; }
-.d-gre-unset { grid-row-end: unset !important; }
-.d-gr-unset { grid-row: unset !important; }
 }

--- a/packages/dialtone-css/lib/build/less/utilities/layout.less
+++ b/packages/dialtone-css/lib/build/less/utilities/layout.less
@@ -81,19 +81,24 @@
 //  ============================================================================
 //  $   OVERFLOW
 //  ============================================================================
+//  Shorthand `overflow: *` resets both axes, so all `.d-of-*` classes must come
+//  before `.d-of-x-*` / `.d-of-y-*` single-axis classes. Otherwise pairs like
+//  `d-of-x-auto d-of-hidden` would silently clobber the single-axis intent.
 .d-of-auto { overflow: auto !important; }
-.d-of-x-auto { overflow-inline: auto !important; }
-.d-of-y-auto { overflow-block: auto !important; }
 .d-of-hidden { overflow: hidden !important; }
-.d-of-x-hidden { overflow-inline: hidden !important; }
-.d-of-y-hidden { overflow-block: hidden !important; }
 .d-of-scroll { overflow: scroll !important; }
-.d-of-x-scroll { overflow-inline: scroll !important; }
-.d-of-y-scroll { overflow-block: scroll !important; }
 .d-of-visible { overflow: visible !important; }
-.d-of-x-visible { overflow-inline: visible !important; }
-.d-of-y-visible { overflow-block: visible !important; }
 .d-of-unset { overflow: unset !important; }
+
+.d-of-x-auto { overflow-inline: auto !important; }
+.d-of-x-hidden { overflow-inline: hidden !important; }
+.d-of-x-scroll { overflow-inline: scroll !important; }
+.d-of-x-visible { overflow-inline: visible !important; }
+
+.d-of-y-auto { overflow-block: auto !important; }
+.d-of-y-hidden { overflow-block: hidden !important; }
+.d-of-y-scroll { overflow-block: scroll !important; }
+.d-of-y-visible { overflow-block: visible !important; }
 
 
 //  ============================================================================

--- a/packages/dialtone-css/lib/build/less/utilities/sizing.less
+++ b/packages/dialtone-css/lib/build/less/utilities/sizing.less
@@ -19,11 +19,158 @@
 //      - FIXED
 //
 //  ============================================================================
+//  $   SIZE (both dimensions)
+//  ============================================================================
+//  `.d-size-*` sets BOTH `inline-size` and `block-size`, so it must precede the
+//  single-axis `.d-h*` / `.d-w*` classes below. Otherwise `d-w50p d-size-full`
+//  would silently clobber the width override with `inline-size: 100%`.
+//  ----------------------------------------------------------------------------
+@layer dialtone.utilities {
+//  $$  KEYWORDS & VIEWPORT
+//  ----------------------------------------------------------------------------
+.d-size-auto {
+  inline-size: auto !important;
+  block-size: auto !important;
+}
+
+.d-size-full {
+  inline-size: 100% !important;
+  block-size: 100% !important;
+}
+
+.d-size-fit {
+  inline-size: fit-content !important;
+  block-size: fit-content !important;
+}
+
+.d-size-min {
+  inline-size: min-content !important;
+  block-size: min-content !important;
+}
+
+.d-size-max {
+  inline-size: max-content !important;
+  block-size: max-content !important;
+}
+
+.d-size-dvh {
+  inline-size: 100dvh !important;
+  block-size: 100dvh !important;
+}
+
+.d-size-dvw {
+  inline-size: 100dvw !important;
+  block-size: 100dvw !important;
+}
+
+.d-size-svh {
+  inline-size: 100svh !important;
+  block-size: 100svh !important;
+}
+
+.d-size-svw {
+  inline-size: 100svw !important;
+  block-size: 100svw !important;
+}
+
+.d-size-lvh {
+  inline-size: 100lvh !important;
+  block-size: 100lvh !important;
+}
+
+.d-size-lvw {
+  inline-size: 100lvw !important;
+  block-size: 100lvw !important;
+}
+
+//  $$  PERCENTAGES
+//  ----------------------------------------------------------------------------
+.d-size-10p {
+  inline-size: 10% !important;
+  block-size: 10% !important;
+}
+
+.d-size-15p {
+  inline-size: 15% !important;
+  block-size: 15% !important;
+}
+
+.d-size-20p {
+  inline-size: 20% !important;
+  block-size: 20% !important;
+}
+
+.d-size-25p {
+  inline-size: 25% !important;
+  block-size: 25% !important;
+}
+
+.d-size-30p {
+  inline-size: 30% !important;
+  block-size: 30% !important;
+}
+
+.d-size-33p {
+  inline-size: 33.333% !important;
+  block-size: 33.333% !important;
+}
+
+.d-size-40p {
+  inline-size: 40% !important;
+  block-size: 40% !important;
+}
+
+.d-size-50p {
+  inline-size: 50% !important;
+  block-size: 50% !important;
+}
+
+.d-size-60p {
+  inline-size: 60% !important;
+  block-size: 60% !important;
+}
+
+.d-size-66p {
+  inline-size: 66.667% !important;
+  block-size: 66.667% !important;
+}
+
+.d-size-70p {
+  inline-size: 70% !important;
+  block-size: 70% !important;
+}
+
+.d-size-75p {
+  inline-size: 75% !important;
+  block-size: 75% !important;
+}
+
+.d-size-80p {
+  inline-size: 80% !important;
+  block-size: 80% !important;
+}
+
+.d-size-85p {
+  inline-size: 85% !important;
+  block-size: 85% !important;
+}
+
+.d-size-90p {
+  inline-size: 90% !important;
+  block-size: 90% !important;
+}
+
+.d-size-100p {
+  inline-size: 100% !important;
+  block-size: 100% !important;
+}
+
+
+//  ============================================================================
 //  $   HEIGHT
 //  ============================================================================
 //  $$  PERCENTAGES
 //  ----------------------------------------------------------------------------
-@layer dialtone.utilities {
 .d-h10p { block-size: 10% !important; }
 .d-h15p { block-size: 15% !important; }
 .d-h20p { block-size: 20% !important; }
@@ -199,146 +346,4 @@
 .d-wmx-fit-content { max-inline-size: fit-content !important; }
 .d-wmx-max-content { max-inline-size: max-content !important; }
 .d-wmx-min-content { max-inline-size: min-content !important; }
-
-//  ============================================================================
-//  $   SIZE (both dimensions)
-//  ============================================================================
-//  $$  KEYWORDS & VIEWPORT
-//  ----------------------------------------------------------------------------
-.d-size-auto {
-  inline-size: auto !important;
-  block-size: auto !important;
-}
-
-.d-size-full {
-  inline-size: 100% !important;
-  block-size: 100% !important;
-}
-
-.d-size-fit {
-  inline-size: fit-content !important;
-  block-size: fit-content !important;
-}
-
-.d-size-min {
-  inline-size: min-content !important;
-  block-size: min-content !important;
-}
-
-.d-size-max {
-  inline-size: max-content !important;
-  block-size: max-content !important;
-}
-
-.d-size-dvh {
-  inline-size: 100dvh !important;
-  block-size: 100dvh !important;
-}
-
-.d-size-dvw {
-  inline-size: 100dvw !important;
-  block-size: 100dvw !important;
-}
-
-.d-size-svh {
-  inline-size: 100svh !important;
-  block-size: 100svh !important;
-}
-
-.d-size-svw {
-  inline-size: 100svw !important;
-  block-size: 100svw !important;
-}
-
-.d-size-lvh {
-  inline-size: 100lvh !important;
-  block-size: 100lvh !important;
-}
-
-.d-size-lvw {
-  inline-size: 100lvw !important;
-  block-size: 100lvw !important;
-}
-
-//  $$  PERCENTAGES
-//  ----------------------------------------------------------------------------
-.d-size-10p {
-  inline-size: 10% !important;
-  block-size: 10% !important;
-}
-
-.d-size-15p {
-  inline-size: 15% !important;
-  block-size: 15% !important;
-}
-
-.d-size-20p {
-  inline-size: 20% !important;
-  block-size: 20% !important;
-}
-
-.d-size-25p {
-  inline-size: 25% !important;
-  block-size: 25% !important;
-}
-
-.d-size-30p {
-  inline-size: 30% !important;
-  block-size: 30% !important;
-}
-
-.d-size-33p {
-  inline-size: 33.333% !important;
-  block-size: 33.333% !important;
-}
-
-.d-size-40p {
-  inline-size: 40% !important;
-  block-size: 40% !important;
-}
-
-.d-size-50p {
-  inline-size: 50% !important;
-  block-size: 50% !important;
-}
-
-.d-size-60p {
-  inline-size: 60% !important;
-  block-size: 60% !important;
-}
-
-.d-size-66p {
-  inline-size: 66.667% !important;
-  block-size: 66.667% !important;
-}
-
-.d-size-70p {
-  inline-size: 70% !important;
-  block-size: 70% !important;
-}
-
-.d-size-75p {
-  inline-size: 75% !important;
-  block-size: 75% !important;
-}
-
-.d-size-80p {
-  inline-size: 80% !important;
-  block-size: 80% !important;
-}
-
-.d-size-85p {
-  inline-size: 85% !important;
-  block-size: 85% !important;
-}
-
-.d-size-90p {
-  inline-size: 90% !important;
-  block-size: 90% !important;
-}
-
-.d-size-100p {
-  inline-size: 100% !important;
-  block-size: 100% !important;
-}
 }

--- a/packages/dialtone-css/postcss/dialtone-generators.cjs
+++ b/packages/dialtone-css/postcss/dialtone-generators.cjs
@@ -98,29 +98,32 @@ const generatedRules = {
   paddingBottom: [],
   paddingLeft: [],
   // Token-stop-based classes (d-h-{stop}, d-w-{stop}, d-size-{stop})
+  // Multi-axis shorthand (tokenSize) must precede single-axis so d-h-*/d-w-* win over d-size-*.
+  tokenSize: [],
   tokenFixedHeight: [],
   tokenMaxHeight: [],
   tokenMinHeight: [],
   tokenFixedWidth: [],
   tokenMinWidth: [],
   tokenMaxWidth: [],
-  tokenSize: [],
   // Token-stop-based margin classes (d-m-{stop}, d-mt-{stop}/d-mbs-{stop}, etc.)
+  // Multi-direction shorthands (All, Horizontal, Vertical) must precede single-side so
+  // d-mt-*/d-mbs-* win over d-my-*, etc.
   tokenMarginAll: [],
+  tokenMarginHorizontal: [],
+  tokenMarginVertical: [],
   tokenMarginTop: [],
   tokenMarginRight: [],
   tokenMarginBottom: [],
   tokenMarginLeft: [],
-  tokenMarginHorizontal: [],
-  tokenMarginVertical: [],
   // Token-stop-based padding classes (d-p-{stop}, d-pt-{stop}/d-pbs-{stop}, etc.)
   tokenPaddingAll: [],
+  tokenPaddingHorizontal: [],
+  tokenPaddingVertical: [],
   tokenPaddingTop: [],
   tokenPaddingRight: [],
   tokenPaddingBottom: [],
   tokenPaddingLeft: [],
-  tokenPaddingHorizontal: [],
-  tokenPaddingVertical: [],
   // Token-stop-based gap classes (d-g-{stop}, d-rg-{stop}, d-cg-{stop})
   tokenGap: [],
   tokenRowGap: [],


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

[DLT-3321](https://dialpad.atlassian.net/browse/DLT-3321)

## :book: Description

Reorders CSS utility classes so shorthand / multi-direction classes come **before** single-direction ones in source order.

**Before:** `d-py-300` + `d-pbs-500` applied to same element → `padding-block-start: 300` (wrong). `d-py-300` shipped after `d-pbs-300` in compiled CSS, so the shorthand silently overrode the longhand despite `!important` ties.

**After:** `d-pbs-500` wins. 13 ordering bugs fixed across 6 files.

**Files:**
- \`postcss/dialtone-generators.cjs\` — reordered \`generatedRules\` keys (token-stop margin / padding / size)
- \`lib/build/less/utilities/borders.less\` — \`.d-bx\` / \`.d-by\` + \`.d-bxw*\` / \`.d-byw*\` moved before single-side; also collapsed to \`border-inline\` / \`border-block\` shorthands
- \`lib/build/less/utilities/layout.less\` — overflow shorthand regrouped first
- \`lib/build/less/utilities/sizing.less\` — \`.d-size-*\` block moved to top
- \`lib/build/less/utilities/flex.less\` — \`.d-ff-*\` before \`.d-fd-*\` / \`.d-fw-*\`; also absorbed \`.d-plc-*\` / \`.d-pli-*\` / \`.d-pls-*\` from grid.less so file-import order resolves cross-file ties against \`.d-ac-*\` / \`.d-ai-*\` / \`.d-as-*\`
- \`lib/build/less/utilities/grid.less\` — grid-area first, grid-column / grid-row shorthand before singles, gap unset shorthand first

**Does not:**
- Add or rename classes
- Change tokens or values
- Touch dialtone-vue or any other package

## :bulb: Context

All utilities are \`!important\`-scoped, so cascade ties come down to source order. A shorthand (e.g. \`padding\`) resets all its longhands (e.g. \`padding-block-start\`); if the shorthand ships after the longhand, it silently wins. Audit found 13 violations of this rule across the CSS package — this PR is the fix.

## :mag: For reviewers

**Build and diff:**

```bash
git fetch origin css-utility-order && git checkout css-utility-order
pnpm nx run dialtone-css:build
```

No new selectors — `diff` against `next`-built CSS should show position changes only.

**Spot-check pairs** (both classes applied to the same element; longhand should win):

| Pair | Expected winner |
|---|---|
| `d-py-300 d-pbs-500` | `d-pbs-500` |
| `d-mx-200 d-mis-100` | `d-mis-100` |
| `d-size-full d-w50p` | `d-w50p` |
| `d-of-hidden d-of-x-auto` | `d-of-x-auto` |
| `d-ff-row-wrap d-fd-column` | `d-fd-column` |
| `d-bx d-bt` | top border styled too |
| `d-plc-center d-ac-start` | `d-ac-start` |
| `d-pli-center d-ji-start` | `d-ji-start` |

## :package: Cross-Package Impact

| Package | Changes | Downstream Impact |
|---|---|---|
| dialtone-css | Source-order reshuffle of utility classes | Consumers relying on the buggy winner (e.g. \`d-py-*\` overriding \`d-pbs-*\`) will see corrected behavior. No breaking API changes. |

Dependency flow: tokens → **CSS** → Vue → docs/MCP/language-server.

## :pencil: Checklist

For all PRs:

- [x] No private Dialpad links or info in code or PR.
- [x] Reviewed my changes.
- [x] Added all relevant documentation (in-code WHY comments explaining the cascade invariant).
- [x] Considered the performance impact (zero — pure reorder, no new declarations).

For all CSS changes:

- [x] Used design tokens wherever possible (no new hardcoded values).
- [x] Considered behavior on different screen sizes (source-order fix, responsive variants are regenerated automatically).
- [x] Visually validated in light and dark mode.
- [x] Used gap/flexbox over margin where possible (N/A — no new layout).

## :crystal_ball: Next Steps

Follow-up cleanup tracked in [DLT-3328](https://dialpad.atlassian.net/browse/DLT-3328): collapse pre-existing copy-paste in \`.d-size-*\`, \`.d-pli-*\` / \`.d-pls-*\`, and the border-width scale. Out of scope for this PR to keep the visual-regression diff localized.

[DLT-3321]: https://dialpad.atlassian.net/browse/DLT-3321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DLT-3328]: https://dialpad.atlassian.net/browse/DLT-3328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Reorders CSS utility class emissions across 6 files so shorthand properties (e.g., margin, padding, overflow) are compiled before single-direction variants. This ensures single-direction utilities win in cascade ties when both are applied. Absorbs place-content/items/self utilities into flex.less and reorganizes grid utilities for correct cascade precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->