### PR TITLE
docs(modal): NO-JIRA fix code examples

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -5,7 +5,6 @@
     :kind="kind"
     :banner-title="bannerTitle"
     :banner-kind="bannerKind"
-    :fixed-header-footer="fixedHeaderFooter"
     :size="size"
     :copy="copy"
     @update:show="isOpen = $event"
@@ -63,11 +62,6 @@ export default {
     bannerTitle: {
       type: String,
       default: '',
-    },
-
-    fixedHeaderFooter: {
-      type: Boolean,
-      default: true,
     },
 
     size: {

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -1,9 +1,4 @@
 <template>
-  <dt-button
-    @click="isOpen = !isOpen"
-  >
-    Click to open
-  </dt-button>
   <dt-modal
     title="Example title"
     :show="isOpen"
@@ -13,7 +8,6 @@
     :fixed-header-footer="fixedHeaderFooter"
     :size="size"
     :copy="copy"
-    modal-class="d-mt0"
     @update:show="isOpen = $event"
   >
     <template
@@ -38,6 +32,12 @@
       </dt-button>
     </template>
   </dt-modal>
+  <dt-button
+    class="d-mt0"
+    @click="isOpen = !isOpen"
+  >
+    Click to open
+  </dt-button>
 </template>
 
 <script>

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -7,13 +7,13 @@
   <dt-modal
     title="Example title"
     :show="isOpen"
-    :append-to="appendTo"
     :kind="kind"
     :banner-title="bannerTitle"
     :banner-kind="bannerKind"
     :fixed-header-footer="fixedHeaderFooter"
     :size="size"
     :copy="copy"
+    modal-class="d-mt0"
     @update:show="isOpen = $event"
   >
     <template
@@ -48,11 +48,6 @@ export default {
     initiallyOpen: {
       type: Boolean,
       default: false,
-    },
-
-    appendTo: {
-      type: String,
-      default: undefined,
     },
 
     kind: {

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -96,6 +96,8 @@ export default {
     };
   },
 
+  // Docs-only behavior: render the modal open once when `initiallyOpen` is true
+  // so we can capture the open state markup for examples, then immediately close it.
   mounted () {
     if (this.initiallyOpen) {
       this.isOpen = false;

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -1,7 +1,14 @@
 <template>
+  <dt-button
+    @click="isOpen = !isOpen"
+  >
+    Click to open
+  </dt-button>
   <dt-modal
     title="Example title"
     :show="isOpen"
+    :append-to="appendTo"
+    :kind="kind"
     :banner-title="bannerTitle"
     :banner-kind="bannerKind"
     :fixed-header-footer="fixedHeaderFooter"
@@ -31,11 +38,6 @@
       </dt-button>
     </template>
   </dt-modal>
-  <dt-button
-    @click="isOpen = !isOpen"
-  >
-    Click to open
-  </dt-button>
 </template>
 
 <script>
@@ -43,6 +45,16 @@ export default {
   name: 'ExampleModal',
 
   props: {
+    initiallyOpen: {
+      type: Boolean,
+      default: false,
+    },
+
+    appendTo: {
+      type: String,
+      default: undefined,
+    },
+
     kind: {
       type: String,
       default: 'default',
@@ -60,7 +72,7 @@ export default {
 
     fixedHeaderFooter: {
       type: Boolean,
-      default: false,
+      default: true,
     },
 
     size: {
@@ -80,8 +92,14 @@ export default {
 
   data () {
     return {
-      isOpen: false,
+      isOpen: this.initiallyOpen,
     };
+  },
+
+  mounted () {
+    if (this.initiallyOpen) {
+      this.isOpen = false;
+    }
   },
 };
 </script>

--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -8,7 +8,7 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-modal--defau
 figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Library--Rebrand-2025-?node-id=4454-10944
 ---
 <code-well-header>
-  <example-modal append-to="body" />
+  <example-modal />
 </code-well-header>
 
 ## Usage
@@ -65,7 +65,7 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
 ### Base Style
 
 <code-well-header>
-  <example-modal append-to="body" />
+  <example-modal />
   <div ref="baseExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0">
     <example-modal initially-open />
   </div>
@@ -112,7 +112,7 @@ vueCode='
 This is the default behavior that adds the scroll automatically in the modal content and leaves the header and footer fixed.
 
 <code-well-header>
-  <example-modal append-to="body" :copy="fixedHeaderFooterCopy" />
+  <example-modal :copy="fixedHeaderFooterCopy" />
   <div ref="fixedExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0">
     <example-modal initially-open :copy="fixedHeaderFooterCopy" />
   </div>
@@ -160,7 +160,7 @@ vueCode='
 A modal style for destructive or irreversible actions.
 
 <code-well-header>
-  <example-modal append-to="body" kind="danger" />
+  <example-modal kind="danger" />
   <div ref="dangerExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0">
     <example-modal initially-open kind="danger" />
   </div>
@@ -209,7 +209,7 @@ vueCode='
 To make this modal take up as much of the screen as possible.
 
 <code-well-header>
-  <example-modal append-to="body" size="full" />
+  <example-modal size="full" />
   <div ref="fullExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0">
     <example-modal initially-open size="full" />
   </div>
@@ -264,7 +264,7 @@ When there is a need of more context information regarding the content of the Mo
       :options="bannerKinds"
       v-model="selectedBannerKind"
     />
-    <example-modal append-to="body" :banner-kind="selectedBannerKind" banner-title="This banner can have different kinds." />
+    <example-modal :banner-kind="selectedBannerKind" banner-title="This banner can have different kinds." />
   </dt-stack>
   <div ref="bannerExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0">
     <example-modal initially-open banner-title="This banner can have different kinds." :banner-kind="selectedBannerKind" />
@@ -325,7 +325,7 @@ In addition to the footer, custom elements can be inserted into the header and b
   </dt-button>
   <dt-modal
     :show="isOpen"
-    append-to="body"
+    modal-class="d-mt0"
     @update:show="updateShow"
   >
     <template #header>

--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -86,7 +86,7 @@ htmlCode='
     </div>
     <footer class="d-modal__footer">
       <button class="d-btn d-btn--primary" type="button">
-        Save changes
+        Confirm
       </button>
       <button class="d-btn" type="button">
         Cancel
@@ -113,24 +113,24 @@ vueCode='
   title="Example title"
   :show="isOpen"
   @update:show="updateShow"
-  copy="Lorem ipsum ..."
+  copy="Sed at orci quis nunc finibus gravida eget vitae est..."
 >
   <template
     #footer
   >
-    <dt-button
-      id="cancel-button"
-      :kind="secondaryButtonKind"
-      importance="clear"
-    >
-      Cancel
-    </dt-button>
     <dt-button
       id="confirm-button"
       importance="primary"
       class="d-ml6"
     >
       Confirm
+    </dt-button>
+    <dt-button
+      id="cancel-button"
+      kind="muted"
+      importance="clear"
+    >
+      Cancel
     </dt-button>
   </template>
 </dt-modal>
@@ -168,7 +168,7 @@ htmlCode='
     </div>
     <footer class="d-modal__footer">
       <button class="d-btn d-btn--primary" type="button">
-        Save changes
+        Confirm
       </button>
       <button class="d-btn" type="button">
         Cancel
@@ -203,18 +203,18 @@ vueCode='
     #footer
   >
     <dt-button
-      id="cancel-button"
-      :kind="secondaryButtonKind"
-      importance="clear"
-    >
-      Cancel
-    </dt-button>
-    <dt-button
       id="confirm-button"
       importance="primary"
       class="d-ml6"
     >
       Confirm
+    </dt-button>
+    <dt-button
+      id="cancel-button"
+      kind="muted"
+      importance="clear"
+    >
+      Cancel
     </dt-button>
   </template>
 </dt-modal>
@@ -252,7 +252,7 @@ htmlCode='
     </div>
     <footer class="d-modal__footer">
       <button class="d-btn d-btn--primary d-btn--danger" type="button">
-        Save changes
+        Confirm
       </button>
       <button class="d-btn d-btn--muted" type="button">
         Cancel
@@ -286,19 +286,19 @@ vueCode='
     #footer
   >
     <dt-button
-      id="cancel-button"
-      :kind="secondaryButtonKind"
-      importance="clear"
-    >
-      Cancel
-    </dt-button>
-    <dt-button
       id="confirm-button"
       kind="danger"
       importance="primary"
       class="d-ml6"
     >
       Confirm
+    </dt-button>
+    <dt-button
+      id="cancel-button"
+      kind="muted"
+      importance="clear"
+    >
+      Cancel
     </dt-button>
   </template>
 </dt-modal>
@@ -336,7 +336,7 @@ htmlCode='
     </div>
     <footer class="d-modal__footer">
       <button class="d-btn d-btn--primary" type="button">
-        Save changes
+        Confirm
       </button>
       <button class="d-btn" type="button">
         Cancel
@@ -370,18 +370,18 @@ vueCode='
     #footer
   >
     <dt-button
-      id="cancel-button"
-      :kind="secondaryButtonKind"
-      importance="clear"
-    >
-      Cancel
-    </dt-button>
-    <dt-button
       id="confirm-button"
       importance="primary"
       class="d-ml6"
     >
       Confirm
+    </dt-button>
+    <dt-button
+      id="cancel-button"
+      kind="muted"
+      importance="clear"
+    >
+      Cancel
     </dt-button>
   </template>
 </dt-modal>
@@ -427,7 +427,7 @@ htmlCode='
     </div>
     <footer class="d-modal__footer">
       <button class="d-btn d-btn--primary" type="button">
-        Save changes
+        Confirm
       </button>
       <button class="d-btn" type="button">
         Cancel
@@ -454,7 +454,7 @@ vueCode='
   title="Example title"
   :show="isOpen"
   banner-title="This banner can have different kinds."
-  :bannerKind="selectedBannerKind"
+  :banner-kind="selectedBannerKind"
   copy="Sed at orci quis nunc finibus gravida eget vitae est..."
   @update:show="updateShow"
 >
@@ -462,18 +462,18 @@ vueCode='
     #footer
   >
     <dt-button
-      id="cancel-button"
-      :kind="secondaryButtonKind"
-      importance="clear"
-    >
-      Cancel
-    </dt-button>
-    <dt-button
       id="confirm-button"
       importance="primary"
       class="d-ml6"
     >
       Confirm
+    </dt-button>
+    <dt-button
+      id="cancel-button"
+      kind="muted"
+      importance="clear"
+    >
+      Cancel
     </dt-button>
   </template>
 </dt-modal>

--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -8,7 +8,7 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-modal--defau
 figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Library--Rebrand-2025-?node-id=4454-10944
 ---
 <code-well-header>
-  <example-modal />
+  <example-modal append-to="body" />
 </code-well-header>
 
 ## Usage
@@ -65,55 +65,23 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
 ### Base Style
 
 <code-well-header>
-  <example-modal />
+  <example-modal append-to="body" />
+  <div ref="baseExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0"><example-modal initially-open /></div>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button type="button" class="base-button__button d-btn d-btn--primary">
-  <span class="d-btn__label base-button__label"> Click to open </span>
-</button>
-<aside id="modal-base" class="d-modal d-m0 d-modal--animate-in" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="false">
-  <div class="d-modal__dialog d-modal__dialog--animate-in" role="document">
-    <h2 class="d-modal__header">
-      Example title
-    </h2>
-    <div class="d-modal__content">
-      <p id="modal-description">
-        Sed at orci quis nunc finibus gravida eget vitae est...
-      </p>
-      <p class="d-mt16"><a href="#" class="d-link">Show me a modal banner</a></p>
-    </div>
-    <footer class="d-modal__footer">
-      <button class="d-btn d-btn--primary" type="button">
-        Confirm
-      </button>
-      <button class="d-btn" type="button">
-        Cancel
-      </button>
-    </footer>
-    <button class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close">
-      <span class="d-btn__icon">
-        <span class="d-icon__wrapper">
-          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
-            <div
-              class="d-skeleton-placeholder d-bar-circle d-skeleton-placeholder--animate"
-              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-            ></div>
-          </div>
-          <svg>...</svg>
-        </span>
-      </span>
-    </button>
-  </div>
-</aside>
-'
+:htmlCode='() => ({ $el: { outerHTML: $refs.baseExample.innerHTML } })'
 vueCode='
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
 <dt-modal
   title="Example title"
   :show="isOpen"
-  @update:show="updateShow"
   copy="Sed at orci quis nunc finibus gravida eget vitae est..."
+  @update:show="updateShow"
 >
   <template
     #footer
@@ -134,70 +102,32 @@ vueCode='
     </dt-button>
   </template>
 </dt-modal>
-<dt-button
-  @click="isOpen = !isOpen"
->
-  Click to open
-</dt-button>
 '
-showHtmlWarning />
+/>
 
 ### Fixed Header and Footer
 
 This is the default behavior that adds the scroll automatically in the modal content and leaves the header and footer fixed.
 
 <code-well-header>
-  <example-modal fixed-header-footer :copy="fixedHeaderFooterCopy" />
+  <example-modal append-to="body" :copy="fixedHeaderFooterCopy" />
+  <div ref="fixedExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0"><example-modal initially-open :copy="fixedHeaderFooterCopy" /></div>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button type="button" class="base-button__button d-btn d-btn--primary">
-  <span class="d-btn__label base-button__label"> Click to open </span>
-</button>
-<aside id="modal-base" class="d-modal d-m0 d-modal--animate-in" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="false">
-  <div class="d-modal__dialog d-modal__dialog--animate-in d-modal__dialog--scrollable d-hmx764" role="document">
-    <h2 class="d-modal__header">
-      Example title
-    </h2>
-    <div class="d-modal__content">
-      <p id="modal-description">
-        Sed at orci quis nunc finibus gravida eget vitae est...
-      </p>
-      <p class="d-mt16"><a href="#" class="d-link">Show me a modal banner</a></p>
-    </div>
-    <footer class="d-modal__footer">
-      <button class="d-btn d-btn--primary" type="button">
-        Confirm
-      </button>
-      <button class="d-btn" type="button">
-        Cancel
-      </button>
-    </footer>
-    <button class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close">
-      <span class="d-btn__icon">
-        <span class="d-icon__wrapper">
-          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
-            <div
-              class="d-skeleton-placeholder d-bar-circle d-skeleton-placeholder--animate"
-              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-            ></div>
-          </div>
-          <svg>...</svg>
-        </span>
-      </span>
-    </button>
-  </div>
-</aside>
-'
+:htmlCode='() => ({ $el: { outerHTML: $refs.fixedExample.innerHTML } })'
 vueCode='
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
 <dt-modal
   title="Example title"
   :show="isOpen"
-  @update:show="updateShow"
-  :showFooter="true"
   :fixed-header-footer="true"
   copy="Sed at orci quis nunc finibus gravida eget vitae est..."
+  @update:show="updateShow"
 >
   <template
     #footer
@@ -218,63 +148,26 @@ vueCode='
     </dt-button>
   </template>
 </dt-modal>
-<dt-button
-  @click="isOpen = !isOpen"
->
-  Click to open
-</dt-button>
 '
-showHtmlWarning />
+/>
 
 ### Danger
 
 A modal style for destructive or irreversible actions.
 
 <code-well-header>
-  <example-modal kind="danger" />
+  <example-modal append-to="body" kind="danger" />
+  <div ref="dangerExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0"><example-modal initially-open kind="danger" /></div>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button type="button" class="base-button__button d-btn d-btn--primary">
-  <span class="d-btn__label base-button__label"> Click to open </span>
-</button>
-<aside id="modal-base" class="d-modal d-m0 d-modal--danger d-modal--animate-in" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="false">
-  <div class="d-modal__dialog d-modal__dialog--animate-in" role="document">
-    <h2 class="d-modal__header">
-      Example title
-    </h2>
-    <div class="d-modal__content">
-      <p id="modal-description">
-        Sed at orci quis nunc finibus gravida eget vitae est...
-      </p>
-      <p class="d-mt16"><a href="#" class="d-link">Show me a modal banner</a></p>
-    </div>
-    <footer class="d-modal__footer">
-      <button class="d-btn d-btn--primary d-btn--danger" type="button">
-        Confirm
-      </button>
-      <button class="d-btn d-btn--muted" type="button">
-        Cancel
-      </button>
-    </footer>
-    <button class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close">
-      <span class="d-btn__icon">
-        <span class="d-icon__wrapper">
-          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
-            <div
-              class="d-skeleton-placeholder d-bar-circle d-skeleton-placeholder--animate"
-              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-            ></div>
-          </div>
-          <svg>...</svg>
-        </span>
-      </span>
-    </button>
-  </div>
-</aside>
-'
+:htmlCode='() => ({ $el: { outerHTML: $refs.dangerExample.innerHTML } })'
 vueCode='
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -302,63 +195,26 @@ vueCode='
     </dt-button>
   </template>
 </dt-modal>
-<dt-button
-  @click="isOpen = !isOpen"
->
-  Click to open
-</dt-button>
 '
-showHtmlWarning />
+/>
 
 ### Full Screen
 
 To make this modal take up as much of the screen as possible.
 
 <code-well-header>
-  <example-modal size="full" />
+  <example-modal append-to="body" size="full" />
+  <div ref="fullExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0"><example-modal initially-open size="full" /></div>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button type="button" class="base-button__button d-btn d-btn--primary">
-  <span class="d-btn__label base-button__label"> Click to open </span>
-</button>
-<aside id="modal-base" class="d-modal d-m0 d-modal--full d-modal--animate-in" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="false">
-  <div class="d-modal__dialog d-modal__dialog--animate-in" role="document">
-    <h2 class="d-modal__header">
-      Example title
-    </h2>
-    <div class="d-modal__content">
-      <p id="modal-description">
-        Sed at orci quis nunc finibus gravida eget vitae est...
-      </p>
-      <p class="d-mt16"><a href="#" class="d-link">Show me a modal banner</a></p>
-    </div>
-    <footer class="d-modal__footer">
-      <button class="d-btn d-btn--primary" type="button">
-        Confirm
-      </button>
-      <button class="d-btn" type="button">
-        Cancel
-      </button>
-    </footer>
-    <button class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close">
-      <span class="d-btn__icon">
-        <span class="d-icon__wrapper">
-          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
-            <div
-              class="d-skeleton-placeholder d-bar-circle d-skeleton-placeholder--animate"
-              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-            ></div>
-          </div>
-          <svg>...</svg>
-        </span>
-      </span>
-    </button>
-  </div>
-</aside>
-'
+:htmlCode='() => ({ $el: { outerHTML: $refs.fullExample.innerHTML } })'
 vueCode='
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -385,13 +241,8 @@ vueCode='
     </dt-button>
   </template>
 </dt-modal>
-<dt-button
-  @click="isOpen = !isOpen"
->
-  Click to open
-</dt-button>
 '
-showHtmlWarning />
+/>
 
 ### Has Banner
 
@@ -405,51 +256,19 @@ When there is a need of more context information regarding the content of the Mo
       :options="bannerKinds"
       v-model="selectedBannerKind"
     />
-    <example-modal kind="default" :banner-kind="selectedBannerKind" banner-title="This banner can have different kinds." />
+    <example-modal append-to="body" :banner-kind="selectedBannerKind" banner-title="This banner can have different kinds." />
   </dt-stack>
+  <div ref="bannerExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0"><example-modal initially-open banner-title="This banner can have different kinds." :banner-kind="selectedBannerKind" /></div>
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<button type="button" class="base-button__button d-btn d-btn--primary">
-  <span class="d-btn__label base-button__label"> Click to open </span>
-</button>
-<aside id="modal-base" class="d-modal d-m0 d-modal--animate-in" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="false">
-  <div class="d-modal__banner d-modal__banner--success">This banner can have different kinds.</div>
-  <div class="d-modal__dialog d-modal__dialog--animate-in" role="document">
-    <h2 class="d-modal__header">
-      Example title
-    </h2>
-    <div class="d-modal__content">
-      <p id="modal-description">
-        Sed at orci quis nunc finibus gravida eget vitae est...
-      </p>
-    </div>
-    <footer class="d-modal__footer">
-      <button class="d-btn d-btn--primary" type="button">
-        Confirm
-      </button>
-      <button class="d-btn" type="button">
-        Cancel
-      </button>
-    </footer>
-    <button class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close">
-      <span class="d-btn__icon">
-        <span class="d-icon__wrapper">
-          <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-300" style="display: none;">
-            <div
-              class="d-skeleton-placeholder d-bar-circle d-skeleton-placeholder--animate"
-              style="animation-delay: 0ms; animation-duration: 1000ms; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-            ></div>
-          </div>
-          <svg>...</svg>
-        </span>
-      </span>
-    </button>
-  </div>
-</aside>
-'
+:htmlCode='() => ({ $el: { outerHTML: $refs.bannerExample.innerHTML } })'
 vueCode='
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -477,13 +296,8 @@ vueCode='
     </dt-button>
   </template>
 </dt-modal>
-<dt-button
-  @click="isOpen = !isOpen"
->
-  Click to open
-</dt-button>
 '
-showHtmlWarning />
+/>
 
 ### Custom Header and Content
 
@@ -494,8 +308,14 @@ In addition to the footer, custom elements can be inserted into the header and b
 **Please note:** supplied header or body slots will take the place of any provided "title" or "copy" text, respectively.
 
 <code-well-header>
+  <dt-button
+    @click="openModal"
+  >
+    Click to open
+  </dt-button>
   <dt-modal
     :show="isOpen"
+    append-to="body"
     @update:show="updateShow"
   >
     <template #header>
@@ -507,11 +327,6 @@ In addition to the footer, custom elements can be inserted into the header and b
       <h2>Custom content</h2>
     </dt-stack>
   </dt-modal>
-  <dt-button
-    @click="openModal"
-  >
-    Click to open
-  </dt-button>
 </code-well-header>
 
 <code-example-tabs

--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -41,7 +41,7 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
 ### Best Practices
 
 - Ideally, users trigger the modal, not the system, and should not be a surprise. Its appearance should reflect user intent to invoke it.  Uninvited modals may surprise the user and result in a quick dismissal of the window.
-- Treat modals as a last resort. Consider whether there’s another component or UI that might be  less disruptive for the user.
+- Treat modals as a last resort. Consider whether there’s another component or UI that might be less disruptive for the user.
 - Limit the number of interactions in a modal. Remove anything that does not support the task.
 - Avoid multiple steps that require navigation within the modal dialog.
 - Avoid complex decision-making that requires additional sources of information unavailable in the modal.
@@ -52,11 +52,11 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
 ## Accessibility
 
 - Opened modals “trap focus,” meaning keyboard navigation controls are constrained to elements within the modal. Tabbing to the modal's last focusable element, and then pressing tab again would loop the focus back to the first element on the page. Focus doesn't return to the underlying page until the user explicitly dismisses the modal, in which case it would return to the place it was before the dialog opened.
-- To ensure maximum compatibility, all `a` tags must have an `href`attribute. Also, any elements which you don't want to be focusable (but might be focusable by default) must have their `tabindex` set to `-1`.
+- To ensure maximum compatibility, all `a` tags must have an `href` attribute. Also, any elements which you don't want to be focusable (but might be focusable by default) must have their `tabindex` set to `-1`.
 - Focus should always begin on the first actionable element within the dialog. This could be an OK button, or the first field in the form. An X button in the top right corner should be last in the tab order even though it may be visually above the other elements.
 - Check out the "Focus management" section of the following [MDN Dialog document](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role#focus_management) if you'd like to know more.
-- Use `aria-labelledby` on its root element to associate a title to the modal to announce its to accessible technology. The value of aria-labelledby is to the `id` value of its heading element (e.g. `h2`).
-- Dismissing Modal returns focus to the originating element that spawned the modal’s display.
+- Use `aria-labelledby` on its root element to associate a title to the modal to announce it to assistive technology. The value of aria-labelledby is to the `id` value of its heading element (e.g. `h2`).
+- Dismissing the modal returns focus to the originating element that spawned the modal’s display.
 
 <component-accessible-table component-name="modal"></component-accessible-table>
 
@@ -66,7 +66,9 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
 
 <code-well-header>
   <example-modal append-to="body" />
-  <div ref="baseExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0"><example-modal initially-open /></div>
+  <div ref="baseExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0">
+    <example-modal initially-open />
+  </div>
 </code-well-header>
 
 <code-example-tabs
@@ -111,7 +113,9 @@ This is the default behavior that adds the scroll automatically in the modal con
 
 <code-well-header>
   <example-modal append-to="body" :copy="fixedHeaderFooterCopy" />
-  <div ref="fixedExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0"><example-modal initially-open :copy="fixedHeaderFooterCopy" /></div>
+  <div ref="fixedExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0">
+    <example-modal initially-open :copy="fixedHeaderFooterCopy" />
+  </div>
 </code-well-header>
 
 <code-example-tabs
@@ -157,7 +161,9 @@ A modal style for destructive or irreversible actions.
 
 <code-well-header>
   <example-modal append-to="body" kind="danger" />
-  <div ref="dangerExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0"><example-modal initially-open kind="danger" /></div>
+  <div ref="dangerExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0">
+    <example-modal initially-open kind="danger" />
+  </div>
 </code-well-header>
 
 <code-example-tabs
@@ -204,7 +210,9 @@ To make this modal take up as much of the screen as possible.
 
 <code-well-header>
   <example-modal append-to="body" size="full" />
-  <div ref="fullExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0"><example-modal initially-open size="full" /></div>
+  <div ref="fullExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0">
+    <example-modal initially-open size="full" />
+  </div>
 </code-well-header>
 
 <code-example-tabs
@@ -258,7 +266,9 @@ When there is a need of more context information regarding the content of the Mo
     />
     <example-modal append-to="body" :banner-kind="selectedBannerKind" banner-title="This banner can have different kinds." />
   </dt-stack>
-  <div ref="bannerExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0"><example-modal initially-open banner-title="This banner can have different kinds." :banner-kind="selectedBannerKind" /></div>
+  <div ref="bannerExample" inert aria-hidden="true" class="d-h0 d-of-hidden d-vi-hidden d-pe-none d-mt0">
+    <example-modal initially-open banner-title="This banner can have different kinds." :banner-kind="selectedBannerKind" />
+  </div>
 </code-well-header>
 
 <code-example-tabs

--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -55,7 +55,7 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
 - To ensure maximum compatibility, all `a` tags must have an `href` attribute. Also, any elements which you don't want to be focusable (but might be focusable by default) must have their `tabindex` set to `-1`.
 - Focus should always begin on the first actionable element within the dialog. This could be an OK button, or the first field in the form. An X button in the top right corner should be last in the tab order even though it may be visually above the other elements.
 - Check out the "Focus management" section of the following [MDN Dialog document](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role#focus_management) if you'd like to know more.
-- Use `aria-labelledby` on its root element to associate a title to the modal to announce it to assistive technology. The value of aria-labelledby is to the `id` value of its heading element (e.g. `h2`).
+- Use `aria-labelledby` on its root element to associate a title to the modal to announce it to assistive technology. The value of `aria-labelledby` should match the `id` of its heading element (e.g. `h2`).
 - Dismissing the modal returns focus to the originating element that spawned the modal’s display.
 
 <component-accessible-table component-name="modal"></component-accessible-table>
@@ -74,11 +74,6 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
 <code-example-tabs
 :htmlCode='() => ({ $el: { outerHTML: $refs.baseExample.innerHTML } })'
 vueCode='
-<dt-button
-  @click="isOpen = !isOpen"
->
-  Click to open
-</dt-button>
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -104,6 +99,11 @@ vueCode='
     </dt-button>
   </template>
 </dt-modal>
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
 '
 />
 
@@ -121,11 +121,6 @@ This is the default behavior that adds the scroll automatically in the modal con
 <code-example-tabs
 :htmlCode='() => ({ $el: { outerHTML: $refs.fixedExample.innerHTML } })'
 vueCode='
-<dt-button
-  @click="isOpen = !isOpen"
->
-  Click to open
-</dt-button>
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -152,6 +147,11 @@ vueCode='
     </dt-button>
   </template>
 </dt-modal>
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
 '
 />
 
@@ -169,11 +169,6 @@ A modal style for destructive or irreversible actions.
 <code-example-tabs
 :htmlCode='() => ({ $el: { outerHTML: $refs.dangerExample.innerHTML } })'
 vueCode='
-<dt-button
-  @click="isOpen = !isOpen"
->
-  Click to open
-</dt-button>
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -201,6 +196,11 @@ vueCode='
     </dt-button>
   </template>
 </dt-modal>
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
 '
 />
 
@@ -218,11 +218,6 @@ To make this modal take up as much of the screen as possible.
 <code-example-tabs
 :htmlCode='() => ({ $el: { outerHTML: $refs.fullExample.innerHTML } })'
 vueCode='
-<dt-button
-  @click="isOpen = !isOpen"
->
-  Click to open
-</dt-button>
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -249,6 +244,11 @@ vueCode='
     </dt-button>
   </template>
 </dt-modal>
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
 '
 />
 
@@ -274,11 +274,6 @@ When there is a need of more context information regarding the content of the Mo
 <code-example-tabs
 :htmlCode='() => ({ $el: { outerHTML: $refs.bannerExample.innerHTML } })'
 vueCode='
-<dt-button
-  @click="isOpen = !isOpen"
->
-  Click to open
-</dt-button>
 <dt-modal
   title="Example title"
   :show="isOpen"
@@ -306,6 +301,11 @@ vueCode='
     </dt-button>
   </template>
 </dt-modal>
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
 '
 />
 
@@ -318,14 +318,8 @@ In addition to the footer, custom elements can be inserted into the header and b
 **Please note:** supplied header or body slots will take the place of any provided "title" or "copy" text, respectively.
 
 <code-well-header>
-  <dt-button
-    @click="openModal"
-  >
-    Click to open
-  </dt-button>
   <dt-modal
     :show="isOpen"
-    modal-class="d-mt0"
     @update:show="updateShow"
   >
     <template #header>
@@ -337,6 +331,12 @@ In addition to the footer, custom elements can be inserted into the header and b
       <h2>Custom content</h2>
     </dt-stack>
   </dt-modal>
+  <dt-button
+    @click="openModal"
+    class="d-mt0"
+  >
+    Click to open
+  </dt-button>
 </code-well-header>
 
 <code-example-tabs
@@ -354,6 +354,11 @@ vueCode='
     <h2>Custom content</h2>
   </dt-stack>
 </dt-modal>
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
 '
 />
 


### PR DESCRIPTION
# docs(modal): NO-JIRA code example update

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExNXM4azl0Z3ZxbzFueDJjOXhrY2hhd2h3ZXVhMmxlaWZkc2l2YnM2MiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3rgXBucGBVpM8MLkvC/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
This PR aligns the code examples on the modal documentation page with UI examples shown on the page. The modal page now also auto-generates the HTML examples to reduce manual updates to that in the future.

### Items addressed

**Button order and text**
- Swapped Confirm and Cancel button order in all code examples to match the live demo (Confirm first)
- Fixed button text in HTML examples from "Save changes" to "Confirm"

**Code example accuracy**
- Replaced all static hardcoded HTML code blocks with auto-generated HTML captured from live Vue component refs, so examples stay accurate as the component changes
- Removed undefined variable `:kind="secondaryButtonKind"` from code examples
- Removed non-existent prop `:showFooter="true"` from the Fixed Header example
- Fixed `:bannerKind` (camelCase) to `banner-kind` (kebab-case) in the Has Banner example
- Fixed `kind` not being forwarded to `<dt-modal>` in ExampleModal (was only passed to the confirm button)

**ExampleModal improvements**
- Added `initiallyOpen` prop and `mounted()` hook to support the HTML capture pattern
- Removed unused `fixedHeaderFooter` prop (DtModal handles its own default)
- Added `class="d-mt0"` to the trigger button to prevent unwanted spacing from the `d-stack8` layout context
- Made modal-first, button-last template order consistent across all examples

**Accessibility and grammar**
- Fixed "announce its to accessible technology" → "announce it to assistive technology"
- Fixed "The value of aria-labelledby is to the `id` value" → "should match the `id` of its heading element"
- Added missing trigger button to the Custom Header `vueCode` example

### Note about revised HTML examples for modal
In order to get the HTML automatically, an extra example modal was added for each entry inside of a hidden `<div>` set to`inert`  to capture the proper HTML markup when the page loads. It renders an `<example-modal initially-open />` so that `DtLazyShow` (which only initializes the modal DOM when show=true) actually renders the full modal markup. The inert attribute prevents that hidden open modal from trapping focus or intercepting keyboard/pointer events on the page. The `d-h0 d-of-hidden d-vi-hidden d-pe-none` classes keep it visually hidden and out of the layout. Not sure if this is overkill, but it does seem to work.
<!--- Describe specifically what the changes are -->

## :bulb: Context
As reported in a Dialtone channel, the code examples provided on the modal documentation page did not match what was actually being displayed -- the buttons were in the wrong order.
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->
There are a few margin fixes in this version because the modal component doesn't append to the body or an ancestor by default. This is something we may want to revisit. In the example of the docs page, it is grouped with a button inside of a stack, and so either the button or the modal end up inheriting a margin.

Another item to consider is whether we should use a stack in the example instead of margins on the buttons. Not sure if that was a purposeful decision.

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

### Before

<img width="1641" height="712" alt="Screenshot 2026-04-16 at 8 25 23 PM" src="https://github.com/user-attachments/assets/e089035f-201c-4695-bdc6-6816a508ac25" />

### After

<img width="1560" height="625" alt="Screenshot 2026-04-16 at 8 27 19 PM" src="https://github.com/user-attachments/assets/e51407de-1eba-422e-9f71-6bae79a52621" />



## :link: Sources

<!--- Add any links to external reference material -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Corrects modal docs: fixes example button order, adds inert wrapper divs and an initiallyOpen prop to render full modal markup without trapping focus, and auto-generates HTML examples from Vue refs to reduce manual updates; also tightens copy and standardizes button styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->