### PR TITLE
refactor(box): DLT-3333 rename percent prop values to p-suffix

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizable.vue
@@ -1,19 +1,23 @@
 <template>
-  <div class="d-w100p" style="height: 300px;">
+  <dt-box block-size="400" inline-size="100p">
     <dt-resizable>
       <dt-resizable-panel id="ex-sidebar" initial-size="25p" user-min-size="825">
-        <dt-stack align="center" justify="center" class="d-w100p d-h100p d-bgc-purple-100">
-          <span class="d-fs-200 d-fw-bold d-fc-purple-600">Sidebar</span>
-        </dt-stack>
+        <dt-box block-size="100p" inline-size="100p" surface="positive" class="d-plc-center">
+          <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="muted">
+            Sidebar
+          </dt-text>
+        </dt-box>
       </dt-resizable-panel>
       <dt-resizable-handle />
       <dt-resizable-panel id="ex-content">
-        <dt-stack align="center" justify="center" class="d-w100p d-h100p d-bgc-gold-100">
-          <span class="d-fs-200 d-fw-bold d-fc-gold-500">Content</span>
-        </dt-stack>
+        <dt-box block-size="100p" inline-size="100p" surface="warning-subtle" class="d-plc-center">
+          <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="muted">
+            Content
+          </dt-text>
+        </dt-box>
       </dt-resizable-panel>
     </dt-resizable>
-  </div>
+  </dt-box>
 </template>
 
 <script>

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableCollapsible.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableCollapsible.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-w100p" style="height: 300px;">
+  <dt-box block-size="400" inline-size="100p">
     <dt-resizable @panel-collapse="onPanelCollapse">
       <dt-resizable-panel
         id="exc-sidebar"
@@ -8,37 +8,41 @@
         collapsible
         :collapsed="isCollapsed"
       >
-        <dt-stack class="d-w100p d-h100p d-bgc-purple-100">
-          <dt-stack direction="row" align="center" justify="end" class="d-px16 d-py8 d-bb d-bc-default">
-            <button class="d-btn d-btn--sm" @click="isCollapsed = true">
+        <dt-box block-size="100p" inline-size="100p" surface="positive" class="d-d-flex d-fd-column">
+          <dt-stack direction="row" align="center" justify="end" class="d-px16 d-py8 d-bb d-bc-subtle">
+            <dt-button kind="muted" importance="clear" size="100" @click="isCollapsed = true">
               Close sidebar
-            </button>
+            </dt-button>
           </dt-stack>
           <dt-stack align="center" justify="center" class="d-fl1">
-            <span class="d-fs-200 d-fw-bold d-fc-purple-600">Sidebar</span>
+            <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="muted">
+              Sidebar
+            </dt-text>
           </dt-stack>
-        </dt-stack>
+        </dt-box>
       </dt-resizable-panel>
       <dt-resizable-handle />
       <dt-resizable-panel id="exc-content">
-        <dt-stack class="d-w100p d-h100p d-bgc-gold-100">
+        <dt-box block-size="100p" inline-size="100p" surface="warning-subtle" class="d-d-flex d-fd-column">
           <dt-stack
             v-if="isCollapsed"
             direction="row"
             align="center"
             class="d-px16 d-py8 d-bb d-bc-default"
           >
-            <button class="d-btn d-btn--sm" @click="isCollapsed = false">
+            <dt-button kind="muted" importance="clear" size="100" @click="isCollapsed = false">
               Open sidebar
-            </button>
+            </dt-button>
           </dt-stack>
           <dt-stack align="center" justify="center" class="d-fl1">
-            <span class="d-fs-200 d-fw-bold d-fc-gold-500">Content</span>
+            <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="muted">
+              Content
+            </dt-text>
           </dt-stack>
-        </dt-stack>
+        </dt-box>
       </dt-resizable-panel>
     </dt-resizable>
-  </div>
+  </dt-box>
 </template>
 
 <script>

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableNested.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableNested.vue
@@ -1,0 +1,37 @@
+<template>
+  <dt-box block-size="400" inline-size="100p">
+    <dt-resizable>
+      <dt-resizable-panel id="ex-sidebar" initial-size="25p" user-min-size="825" user-max-size="50p">
+        <dt-box block-size="100p" inline-size="100p" surface="positive" class="d-plc-center">
+          <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="muted">
+            Sidebar
+          </dt-text>
+        </dt-box>
+      </dt-resizable-panel>
+      <dt-resizable-handle />
+      <dt-resizable-panel id="content">
+        <dt-resizable direction="column">
+          <dt-resizable-panel id="editor" initial-size="25p">
+            <dt-box block-size="100p" inline-size="100p" surface="info" class="d-plc-center">
+              <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="muted">
+                Content Start
+              </dt-text>
+            </dt-box>
+          </dt-resizable-panel>
+          <dt-resizable-handle />
+          <dt-resizable-panel id="terminal">
+            <dt-box block-size="100p" inline-size="100p" surface="warning-subtle" class="d-plc-center">
+              <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="muted">
+                Content End
+              </dt-text>
+            </dt-box>
+          </dt-resizable-panel>
+        </dt-resizable>
+      </dt-resizable-panel>
+    </dt-resizable>
+  </dt-box>
+</template>
+
+<script>
+export default { name: 'ExampleResizableNested' };
+</script>

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableOffset.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableOffset.vue
@@ -1,23 +1,36 @@
 <template>
-  <div class="d-w100p" style="height: 300px;">
+  <dt-box block-size="400" inline-size="100p">
     <dt-resizable offset-element="#doc-demo-toolbar">
-      <div
+      <dt-box
         id="doc-demo-toolbar"
-        class="d-ps-absolute d-t0 d-l0 d-r0 d-zi-base1 d-d-flex d-ai-center
-          d-px16 d-bgc-secondary d-bb d-bc-default d-bgo50"
-        style="height: 48px;"
+        padding-inline="200"
+        surface="secondary-opaque"
+        border-width-block-end="100"
+        block-size="75"
+        class="d-ps-absolute d-t0 d-l0 d-r0 d-zi-base1 d-d-flex d-ai-center d-jc-center
+        "
       >
-        <span class="d-fs-100">Fixed Toolbar (48px)</span>
-      </div>
-      <dt-resizable-panel id="exo-left" initial-size="50p" class="d-bgc-purple-100">
-        <span class="d-fs-200 d-fw-bold d-fc-purple-600">Left Panel</span>
+        <dt-text as="p" kind="body" size="200" align="center">
+          Fixed Toolbar (48px)
+        </dt-text>
+      </dt-box>
+      <dt-resizable-panel id="exo-left" initial-size="50p" class="d-bgc-success">
+        <dt-box block-size="100p" inline-size="100p" class="d-plc-center">
+          <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="positive" class="d-fco80">
+            Left Panel
+          </dt-text>
+        </dt-box>
       </dt-resizable-panel>
       <dt-resizable-handle />
-      <dt-resizable-panel id="exo-right" initial-size="50p" class="d-bgc-gold-100">
-        <span class="d-fs-200 d-fw-bold d-fc-gold-500">Right Panel</span>
+      <dt-resizable-panel id="exo-right" initial-size="50p" class="d-bgc-warning-subtle">
+        <dt-box block-size="100p" inline-size="100p" class="d-plc-center">
+          <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="warning" class="d-fco80">
+            Right Panel
+          </dt-text>
+        </dt-box>
       </dt-resizable-panel>
     </dt-resizable>
-  </div>
+  </dt-box>
 </template>
 
 <script>

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableThreePanel.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableThreePanel.vue
@@ -1,25 +1,31 @@
 <template>
-  <div class="d-w100p" style="height: 300px;">
+  <dt-box block-size="400" inline-size="100p">
     <dt-resizable>
       <dt-resizable-panel id="ex3-sidebar" initial-size="20p" user-min-size="825">
-        <dt-stack align="center" justify="center" class="d-w100p d-h100p d-bgc-purple-100">
-          <span class="d-fs-200 d-fw-bold d-fc-purple-600">Sidebar</span>
-        </dt-stack>
+        <dt-box block-size="100p" inline-size="100p" surface="positive" class="d-plc-center">
+          <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="muted">
+            Sidebar
+          </dt-text>
+        </dt-box>
       </dt-resizable-panel>
       <dt-resizable-handle />
       <dt-resizable-panel id="ex3-content">
-        <dt-stack align="center" justify="center" class="d-w100p d-h100p d-bgc-gold-100">
-          <span class="d-fs-200 d-fw-bold d-fc-gold-500">Content</span>
-        </dt-stack>
+        <dt-box block-size="100p" inline-size="100p" surface="warning-subtle" class="d-plc-center">
+          <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="muted">
+            Content
+          </dt-text>
+        </dt-box>
       </dt-resizable-panel>
       <dt-resizable-handle />
       <dt-resizable-panel id="ex3-details" initial-size="25p" user-min-size="825">
-        <dt-stack align="center" justify="center" class="d-w100p d-h100p d-bgc-green-100">
-          <span class="d-fs-200 d-fw-bold d-fc-green-500">Details</span>
-        </dt-stack>
+        <dt-box block-size="100p" inline-size="100p" surface="info" class="d-plc-center">
+          <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="muted">
+            Details
+          </dt-text>
+        </dt-box>
       </dt-resizable-panel>
     </dt-resizable>
-  </div>
+  </dt-box>
 </template>
 
 <script>

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableVertical.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableVertical.vue
@@ -1,19 +1,23 @@
 <template>
-  <div class="d-w100p" style="height: 300px;">
+  <dt-box block-size="400" inline-size="100p">
     <dt-resizable direction="column">
       <dt-resizable-panel id="exv-top" initial-size="40p">
-        <dt-stack align="center" justify="center" class="d-w100p d-h100p d-bgc-purple-100">
-          <span class="d-fs-200 d-fw-bold d-fc-purple-600">Top Panel</span>
-        </dt-stack>
+        <dt-box block-size="100p" inline-size="100p" surface="positive" class="d-plc-center">
+          <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="muted">
+            Top Panel
+          </dt-text>
+        </dt-box>
       </dt-resizable-panel>
       <dt-resizable-handle />
       <dt-resizable-panel id="exv-bottom">
-        <dt-stack align="center" justify="center" class="d-w100p d-h100p d-bgc-gold-100">
-          <span class="d-fs-200 d-fw-bold d-fc-gold-500">Bottom Panel</span>
-        </dt-stack>
+        <dt-box block-size="100p" inline-size="100p" surface="warning-subtle" class="d-plc-center">
+          <dt-text as="p" align="center" kind="label" size="200" strength="bold" tone="muted">
+            Bottom Panel
+          </dt-text>
+        </dt-box>
       </dt-resizable-panel>
     </dt-resizable>
-  </div>
+  </dt-box>
 </template>
 
 <script>

--- a/apps/dialtone-documentation/docs/components/box.md
+++ b/apps/dialtone-documentation/docs/components/box.md
@@ -183,7 +183,7 @@ Maps to Dialtone's **layout token scale** (`--dt-layout-*`). Supports both fixed
 <dt-stack direction="row" gap="200">
   <dt-box padding="200" surface="moderate" border-radius="300" inline-size="300">300 (192px)</dt-box>
   <dt-box padding="200" surface="moderate" border-radius="300" inline-size="500">500 (320px)</dt-box>
-  <dt-box padding="200" surface="moderate" border-radius="300" inline-size="50-percent">50-percent</dt-box>
+  <dt-box padding="200" surface="moderate" border-radius="300" inline-size="50p">50p</dt-box>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/components/resizable.md
+++ b/apps/dialtone-documentation/docs/components/resizable.md
@@ -6,99 +6,107 @@ thumb: true
 storybook: https://dialtone.dialpad.com/vue/?path=/story/components-resizable--default
 ---
 
-<code-well-header custom class="d-p24 d-bgc-secondary d-bar8">
-  <example-resizable />
-</code-well-header>
-
 ## Usage
 
 The resizable component splits a container into adjustable panels separated by draggable handles. It works well for sidebar layouts, split-view editors, and any interface where users should control how space is distributed.
 
-### Examples
-
-#### Two panels
-
-<code-well-header custom class="d-p24 d-bgc-secondary d-bar8" ref="twoPanelExample">
-  <example-resizable />
-</code-well-header>
-
-```vue
+```vue code-only
 <dt-resizable>
-  <dt-resizable-panel id="sidebar" initial-size="25p">
-    Sidebar
-  </dt-resizable-panel>
+  <dt-resizable-panel> ... </dt-resizable-panel>
   <dt-resizable-handle />
-  <dt-resizable-panel id="content">
-    Main content
-  </dt-resizable-panel>
+  <dt-resizable-panel> ... </dt-resizable-panel>
 </dt-resizable>
 ```
 
-#### Three panels
+## Examples
 
-<code-well-header custom class="d-p24 d-bgc-secondary d-bar8" ref="threePanelExample">
-  <example-resizable-three-panel />
-</code-well-header>
+### Two panels
 
-```vue
-<dt-resizable>
-  <dt-resizable-panel id="sidebar" initial-size="20p">
-    Sidebar
-  </dt-resizable-panel>
-  <dt-resizable-handle />
-  <dt-resizable-panel id="content">
-    Content
-  </dt-resizable-panel>
-  <dt-resizable-handle />
-  <dt-resizable-panel id="details" initial-size="25p">
-    Details
-  </dt-resizable-panel>
-</dt-resizable>
+```vue demo
+<example-resizable />
+<!-- @code -->
+<dt-box block-size="400" inline-size="100p">
+  <dt-resizable>
+    <dt-resizable-panel id="sidebar" initial-size="25p">
+      Sidebar
+    </dt-resizable-panel>
+    <dt-resizable-handle />
+    <dt-resizable-panel id="content">
+      Main content
+    </dt-resizable-panel>
+  </dt-resizable>
+</dt-box>
 ```
 
-#### Vertical
+### Three panels
 
-<code-well-header custom class="d-p24 d-bgc-secondary d-bar8" ref="verticalExample">
-  <example-resizable-vertical />
-</code-well-header>
-
-```vue
-<dt-resizable direction="column">
-  <dt-resizable-panel id="top" initial-size="40p">
-    Top
-  </dt-resizable-panel>
-  <dt-resizable-handle />
-  <dt-resizable-panel id="bottom">
-    Bottom
-  </dt-resizable-panel>
-</dt-resizable>
+```vue demo
+<example-resizable-three-panel />
+<!-- @code -->
+<dt-box block-size="400" inline-size="100p">
+  <dt-resizable>
+    <dt-resizable-panel id="ex3-sidebar" initial-size="20p" user-min-size="825">
+      Sidebar
+    </dt-resizable-panel>
+    <dt-resizable-handle />
+    <dt-resizable-panel id="ex3-content">
+      Content
+    </dt-resizable-panel>
+    <dt-resizable-handle />
+    <dt-resizable-panel id="ex3-details" initial-size="25p" user-min-size="825">
+      Details
+    </dt-resizable-panel>
+  </dt-resizable>
+</dt-box>
 ```
 
-#### Nested layouts
+### Vertical
+
+```vue demo
+<example-resizable-vertical />
+<!-- @code -->
+<dt-box block-size="400" inline-size="100p">
+  <dt-resizable direction="column">
+    <dt-resizable-panel id="exv-top" initial-size="40p">
+      Top Panel
+    </dt-resizable-panel>
+    <dt-resizable-handle />
+    <dt-resizable-panel id="exv-bottom">
+      Bottom Panel
+    </dt-resizable-panel>
+  </dt-resizable>
+</dt-box>
+```
+
+### Nested layouts
 
 Resizable groups can be nested. For example, a horizontal sidebar + content layout where the content area is itself a vertical split:
 
-```vue
-<dt-resizable>
-  <dt-resizable-panel id="sidebar" initial-size="25p">
-    Sidebar
-  </dt-resizable-panel>
-  <dt-resizable-handle />
-  <dt-resizable-panel id="content">
-    <dt-resizable direction="column">
-      <dt-resizable-panel id="editor" initial-size="60p">
-        Editor
-      </dt-resizable-panel>
-      <dt-resizable-handle />
-      <dt-resizable-panel id="terminal">
-        Terminal
-      </dt-resizable-panel>
-    </dt-resizable>
-  </dt-resizable-panel>
-</dt-resizable>
+```vue demo
+<example-resizable-nested />
+<!-- @code -->
+<dt-box block-size="400" inline-size="100p">
+  <dt-resizable>
+    <dt-resizable-panel id="ex-sidebar" initial-size="25p" user-min-size="825" user-max-size="50p">
+      Sidebar
+    </dt-resizable-panel>
+    <dt-resizable-handle />
+    <dt-resizable-panel id="content">
+      <dt-resizable direction="column">
+        <dt-resizable-panel id="editor" initial-size="25p">
+          Content Start
+        </dt-resizable-panel>
+        <dt-resizable-handle />
+        <dt-resizable-panel id="terminal">
+          Content End
+        </dt-resizable-panel>
+      </dt-resizable>
+    </dt-resizable-panel>
+  </dt-resizable>
+</dt-box>
 ```
 
-### Best practices
+## Best practices
 
 <dialtone-usage>
 <template #do>
@@ -118,28 +126,30 @@ Resizable groups can be nested. For example, a horizontal sidebar + content layo
 
 </dialtone-usage>
 
-### Constraints
+## Constraints
 
 All size props accept two formats: percentage tokens (e.g., `"25p"` for 25% of the container) and Dialtone size tokens (e.g., `"925"` which resolves to 332px). Raw pixel values are not accepted — the component resolves token values from Dialtone's CSS custom properties at runtime.
 
 `initial-size` defines where a panel starts. For panels whose size should flex with the available space (like a main content area), omit `initial-size` and the panel will fill whatever space remains.
 
-#### User constraints
+### User constraints
 
 `user-min-size` and `user-max-size` set hard limits on how small or large a user can drag a panel. These are enforced during drag interactions.
 
-```vue
-<dt-resizable-panel
-  id="sidebar"
-  initial-size="30p"
-  user-min-size="20p"
-  user-max-size="50p"
->
-  Sidebar (min 20%, max 50%)
-</dt-resizable-panel>
+```vue code-only
+<dt-box block-size="400" inline-size="100p">
+  <dt-resizable-panel
+    id="sidebar"
+    initial-size="30p"
+    user-min-size="20p"
+    user-max-size="50p"
+  >
+    Sidebar (min 20%, max 50%)
+  </dt-resizable-panel>
+</dt-box>
 ```
 
-#### System constraints
+### System constraints
 
 `system-min-size` and `system-max-size` define the range the layout engine uses when redistributing space during viewport resizes. These default to the user constraints when not specified. System min must be >= user min, and system max must be <= user max.
 
@@ -147,47 +157,53 @@ All size props accept two formats: percentage tokens (e.g., `"25p"` for 25% of t
 
 Set `:resizable="false"` to fix a panel at its `initial-size`. Fixed panels cannot be dragged, and no handle is rendered between a fixed panel and its neighbor. The layout engine subtracts fixed panel widths first, then distributes the remaining space among resizable panels.
 
-```vue
-<dt-resizable>
-  <dt-resizable-panel id="nav" initial-size="700" :resizable="false">
-    Navigation (64px, fixed)
-  </dt-resizable-panel>
-  <dt-resizable-panel id="content">
-    Content (fills remaining space)
-  </dt-resizable-panel>
-</dt-resizable>
+```vue code-only
+<dt-box block-size="400" inline-size="100p">
+  <dt-resizable>
+    <dt-resizable-panel id="nav" initial-size="700" :resizable="false">
+      Navigation (64px, fixed)
+    </dt-resizable-panel>
+    <dt-resizable-panel id="content">
+      Content (fills remaining space)
+    </dt-resizable-panel>
+  </dt-resizable>
+</dt-box>
 ```
 
-### Collapsing panels
+## Collapsing panels
 
-<code-well-header custom class="d-p24 d-bgc-secondary d-bar8" ref="collapsibleExample">
-  <example-resizable-collapsible />
-</code-well-header>
+```vue demo-only
+<example-resizable-collapsible />
+```
 
 Mark a panel as `collapsible` to let it collapse to zero width. Use the `collapsed` prop for the initial state, or call `collapsePanel()` from a template ref.
 
-```vue
-<dt-resizable @panel-collapse="onPanelCollapse">
-  <dt-resizable-panel
-    id="sidebar"
-    initial-size="25p"
-    user-min-size="825"
-    collapsible
-    :collapsed="isSidebarCollapsed"
-  >
-    Sidebar
-  </dt-resizable-panel>
-  <dt-resizable-handle />
-  <dt-resizable-panel id="content">
-    <header>
-      <button @click="isSidebarCollapsed = !isSidebarCollapsed">
-        Toggle sidebar
-      </button>
-    </header>
-    Content
-  </dt-resizable-panel>
-</dt-resizable>
+```vue code-only
+<dt-box block-size="400" inline-size="100p">
+  <dt-resizable @panel-collapse="onPanelCollapse">
+    <dt-resizable-panel
+      id="sidebar"
+      initial-size="25p"
+      user-min-size="825"
+      collapsible
+      :collapsed="isSidebarCollapsed"
+    >
+      Sidebar
+    </dt-resizable-panel>
+    <dt-resizable-handle />
+    <dt-resizable-panel id="content">
+      <header>
+        <button @click="isSidebarCollapsed = !isSidebarCollapsed">
+          Toggle sidebar
+        </button>
+      </header>
+      Content
+    </dt-resizable-panel>
+  </dt-resizable>
+</dt-box>
+```
 
+```js
 <script setup>
 import { ref } from 'vue';
 
@@ -199,55 +215,62 @@ function onPanelCollapse (panelId, collapsed) {
   }
 }
 </script>
+
 ```
 
 Listen to `@panel-collapse` to keep your local state in sync — the panel can also be collapsed by the system (auto-collapse rules, viewport resize). Always provide a visible control in a sibling panel to restore a collapsed panel.
 
-#### Dynamic constraints on collapse
+### Dynamic constraints on collapse
 
 For layouts where a panel starts hidden (e.g., a detail pane that opens when an item is selected), bind `initial-size` to a computed value that changes based on collapsed state:
 
-```vue
-<dt-resizable-panel
-  id="list"
-  :initial-size="isDetailOpen ? '30p' : '100p'"
->
-  List
-</dt-resizable-panel>
-<dt-resizable-handle />
-<dt-resizable-panel
-  id="detail"
-  :initial-size="isDetailOpen ? '70p' : '0p'"
-  collapsible
-  :collapsed="!isDetailOpen"
->
-  Detail
-</dt-resizable-panel>
+```vue code-only
+<dt-box block-size="400" inline-size="100p">
+  <dt-resizable-panel
+    id="list"
+    :initial-size="isDetailOpen ? '30p' : '100p'"
+  >
+    List
+  </dt-resizable-panel>
+  <dt-resizable-handle />
+  <dt-resizable-panel
+    id="detail"
+    :initial-size="isDetailOpen ? '70p' : '0p'"
+    collapsible
+    :collapsed="!isDetailOpen"
+  >
+    Detail
+  </dt-resizable-panel>
+</dt-box>
 ```
 
-#### Auto-collapse rules
+### Auto-collapse rules
 
 Use `collapse-rules` to define which panels collapse first when space gets tight. Lower priority numbers collapse first.
 
-```vue
-<dt-resizable
-  :collapse-rules="[
-    { panelId: 'details', priority: 1 },
-    { panelId: 'sidebar', priority: 2 },
-  ]"
->
-  ...
-</dt-resizable>
+```vue code-only
+<dt-box block-size="400" inline-size="100p">
+  <dt-resizable
+    :collapse-rules="[
+      { panelId: 'details', priority: 1 },
+      { panelId: 'sidebar', priority: 2 },
+    ]"
+  >
+    ...
+  </dt-resizable>
+</dt-box>
 ```
 
-### Persisting panel sizes
+## Persisting panel sizes
 
 Add a `storage-key` to save panel sizes to localStorage automatically. Users resize once, and the layout restores on their next visit.
 
-```vue
-<dt-resizable storage-key="my-layout">
-  ...
-</dt-resizable>
+```vue code-only
+<dt-box block-size="400" inline-size="100p">
+  <dt-resizable storage-key="my-layout">
+    ...
+  </dt-resizable>
+</dt-box>
 ```
 
 For state management integration (Pinia, Vuex, or an API), implement the `ResizableStorageAdapter` interface and pass it via `:storage`:
@@ -260,15 +283,17 @@ const piniaAdapter = {
 };
 ```
 
-```vue
-<dt-resizable :storage="piniaAdapter">
-  ...
-</dt-resizable>
+```vue code-only
+<dt-box block-size="400" inline-size="100p">
+  <dt-resizable :storage="piniaAdapter">
+    ...
+  </dt-resizable>
+</dt-box>
 ```
 
 When both `storage-key` and `:storage` are provided, the custom adapter takes precedence.
 
-### Space allocation strategies
+## Space allocation strategies
 
 When a panel opens or closes, the remaining panels need to redistribute space. The `space-allocation-strategy` prop controls how:
 
@@ -277,25 +302,27 @@ When a panel opens or closes, the remaining panels need to redistribute space. T
 
 ### Offset from fixed elements
 
-<code-well-header custom class="d-p24 d-bgc-secondary d-bar8">
-  <example-resizable-offset />
-</code-well-header>
+```vue demo-only
+<example-resizable-offset />
+```
 
 When a fixed or absolutely positioned element (like a toolbar or header) overlaps the resizable area, set `offset-element` on `DtResizable` to automatically offset all handles and panel content below it.
 
-```vue
-<dt-resizable offset-element="#toolbar">
-  <div id="toolbar" style="position: absolute; top: 0; left: 0; right: 0; height: 48px; z-index: 10;">
-    Toolbar
-  </div>
-  <dt-resizable-panel id="left" initial-size="50p">
-    Left
-  </dt-resizable-panel>
-  <dt-resizable-handle />
-  <dt-resizable-panel id="right" initial-size="50p">
-    Right
-  </dt-resizable-panel>
-</dt-resizable>
+```vue code-only
+<dt-box block-size="400" inline-size="100p">
+  <dt-resizable offset-element="#toolbar">
+    <div id="toolbar" style="position: absolute; top: 0; left: 0; right: 0; height: 48px; z-index: 10;">
+      Toolbar
+    </div>
+    <dt-resizable-panel id="left" initial-size="50p">
+      Left
+    </dt-resizable-panel>
+    <dt-resizable-handle />
+    <dt-resizable-panel id="right" initial-size="50p">
+      Right
+    </dt-resizable-panel>
+  </dt-resizable>
+</dt-box>
 ```
 
 Alternatively, use `offset-amount` for an explicit pixel value without measuring an element. If both are provided, `offset-amount` takes precedence.
@@ -369,6 +396,7 @@ Double-clicking a handle resets the two adjacent panels to their initial size pr
 
 <script setup>
 import ExampleResizable from '@exampleComponents/ExampleResizable.vue';
+import ExampleResizableNested from '@exampleComponents/ExampleResizableNested.vue';
 import ExampleResizableThreePanel from '@exampleComponents/ExampleResizableThreePanel.vue';
 import ExampleResizableVertical from '@exampleComponents/ExampleResizableVertical.vue';
 import ExampleResizableCollapsible from '@exampleComponents/ExampleResizableCollapsible.vue';

--- a/apps/dialtone-documentation/docs/components/resizable.md
+++ b/apps/dialtone-documentation/docs/components/resizable.md
@@ -310,27 +310,27 @@ When a fixed or absolutely positioned element (like a toolbar or header) overlap
 
 ```vue code-only
 <dt-box block-size="400" inline-size="100p">
-    <dt-resizable offset-element="#doc-demo-toolbar">
-      <dt-box
-        id="doc-demo-toolbar"
-        padding-inline="200"
-        surface="secondary-opaque"
-        border-width-block-end="100"
-        block-size="75"
-        class="d-ps-absolute d-t0 d-l0 d-r0 d-zi-base1 d-d-flex d-ai-center d-jc-center
-        "
-      >
-        Fixed Toolbar (48px)
-      </dt-box>
-      <dt-resizable-panel id="exo-left" initial-size="50p" class="d-bgc-success">
-        Left Panel
-      </dt-resizable-panel>
-      <dt-resizable-handle />
-      <dt-resizable-panel id="exo-right" initial-size="50p" class="d-bgc-warning-subtle">
-        Right Panel
-      </dt-resizable-panel>
-    </dt-resizable>
-  </dt-box>
+  <dt-resizable offset-element="#doc-demo-toolbar">
+    <dt-box
+      id="doc-demo-toolbar"
+      padding-inline="200"
+      surface="secondary-opaque"
+      border-width-block-end="100"
+      block-size="75"
+      class="d-ps-absolute d-t0 d-l0 d-r0 d-zi-base1 d-d-flex d-ai-center d-jc-center
+      "
+    >
+      Fixed Toolbar (48px)
+    </dt-box>
+    <dt-resizable-panel id="exo-left" initial-size="50p" class="d-bgc-success">
+      Left Panel
+    </dt-resizable-panel>
+    <dt-resizable-handle />
+    <dt-resizable-panel id="exo-right" initial-size="50p" class="d-bgc-warning-subtle">
+      Right Panel
+    </dt-resizable-panel>
+  </dt-resizable>
+</dt-box>
 ```
 
 Alternatively, use `offset-amount` for an explicit pixel value without measuring an element. If both are provided, `offset-amount` takes precedence.

--- a/apps/dialtone-documentation/docs/components/resizable.md
+++ b/apps/dialtone-documentation/docs/components/resizable.md
@@ -138,14 +138,16 @@ All size props accept two formats: percentage tokens (e.g., `"25p"` for 25% of t
 
 ```vue code-only
 <dt-box block-size="400" inline-size="100p">
-  <dt-resizable-panel
-    id="sidebar"
-    initial-size="30p"
-    user-min-size="20p"
-    user-max-size="50p"
-  >
-    Sidebar (min 20%, max 50%)
-  </dt-resizable-panel>
+  <dt-resizable>
+    <dt-resizable-panel
+      id="sidebar"
+      initial-size="30p"
+      user-min-size="20p"
+      user-max-size="50p"
+    >
+      Sidebar (min 20%, max 50%)
+    </dt-resizable-panel>
+  </dt-resizable>
 </dt-box>
 ```
 
@@ -226,21 +228,23 @@ For layouts where a panel starts hidden (e.g., a detail pane that opens when an 
 
 ```vue code-only
 <dt-box block-size="400" inline-size="100p">
-  <dt-resizable-panel
-    id="list"
-    :initial-size="isDetailOpen ? '30p' : '100p'"
-  >
-    List
-  </dt-resizable-panel>
-  <dt-resizable-handle />
-  <dt-resizable-panel
-    id="detail"
-    :initial-size="isDetailOpen ? '70p' : '0p'"
-    collapsible
-    :collapsed="!isDetailOpen"
-  >
-    Detail
-  </dt-resizable-panel>
+  <dt-resizable>
+    <dt-resizable-panel
+      id="list"
+      :initial-size="isDetailOpen ? '30p' : '100p'"
+    >
+      List
+    </dt-resizable-panel>
+    <dt-resizable-handle />
+    <dt-resizable-panel
+      id="detail"
+      :initial-size="isDetailOpen ? '70p' : '0p'"
+      collapsible
+      :collapsed="!isDetailOpen"
+    >
+      Detail
+    </dt-resizable-panel>
+  </dt-resizable>
 </dt-box>
 ```
 

--- a/apps/dialtone-documentation/docs/components/resizable.md
+++ b/apps/dialtone-documentation/docs/components/resizable.md
@@ -310,19 +310,27 @@ When a fixed or absolutely positioned element (like a toolbar or header) overlap
 
 ```vue code-only
 <dt-box block-size="400" inline-size="100p">
-  <dt-resizable offset-element="#toolbar">
-    <div id="toolbar" style="position: absolute; top: 0; left: 0; right: 0; height: 48px; z-index: 10;">
-      Toolbar
-    </div>
-    <dt-resizable-panel id="left" initial-size="50p">
-      Left
-    </dt-resizable-panel>
-    <dt-resizable-handle />
-    <dt-resizable-panel id="right" initial-size="50p">
-      Right
-    </dt-resizable-panel>
-  </dt-resizable>
-</dt-box>
+    <dt-resizable offset-element="#doc-demo-toolbar">
+      <dt-box
+        id="doc-demo-toolbar"
+        padding-inline="200"
+        surface="secondary-opaque"
+        border-width-block-end="100"
+        block-size="75"
+        class="d-ps-absolute d-t0 d-l0 d-r0 d-zi-base1 d-d-flex d-ai-center d-jc-center
+        "
+      >
+        Fixed Toolbar (48px)
+      </dt-box>
+      <dt-resizable-panel id="exo-left" initial-size="50p" class="d-bgc-success">
+        Left Panel
+      </dt-resizable-panel>
+      <dt-resizable-handle />
+      <dt-resizable-panel id="exo-right" initial-size="50p" class="d-bgc-warning-subtle">
+        Right Panel
+      </dt-resizable-panel>
+    </dt-resizable>
+  </dt-box>
 ```
 
 Alternatively, use `offset-amount` for an explicit pixel value without measuring an element. If both are provided, `offset-amount` takes precedence.

--- a/packages/combinator/src/lib/tokens.js
+++ b/packages/combinator/src/lib/tokens.js
@@ -8,13 +8,15 @@ const TEXT_SIZE_TO_CSS_SUFFIX = {
   700: '3xl',
 };
 
+const LAYOUT_PERCENT_VALUE = /^(\d+)p$/;
+
 const cache = new Map();
 
 let measureEl = null;
 
 /**
  * Clears the token resolution cache. Call on theme change so resolved
- * values (which depend on live CSS custom properties) are re-read.
+ * values (most of which depend on live CSS custom properties) are re-read.
  */
 export function clearTokenCache () {
   cache.clear();
@@ -196,12 +198,11 @@ function resolveBorderRadius (value) {
 }
 
 function resolveLayout (value) {
-  // Percent values ('50-percent') resolve to raw strings like
-  // '50%' — read directly,don't run through width measurement.
-  if (String(value).endsWith('-percent')) {
-    const raw = getComputedStyle(document.documentElement).getPropertyValue(`--dt-layout-${value}`).trim();
-    return raw || null;
-  }
+  // Percent props ('33p', '66p') display as the integer percentage, matching
+  // the prop name — avoids float drift from tokens like --dt-layout-33-percent
+  // which resolves to 33.333%.
+  const percentMatch = String(value).match(LAYOUT_PERCENT_VALUE);
+  if (percentMatch) return `${percentMatch[1]}%`;
   const px = resolveCssVar(`--dt-layout-${value}`);
   return px ? formatPx(px) : null;
 }

--- a/packages/dialtone-css/lib/build/less/components/box.less
+++ b/packages/dialtone-css/lib/build/less/components/box.less
@@ -70,7 +70,7 @@
   });
   // Percentage tokens
   each(@box-layout-percent-values, {
-    &-@{value}-percent { @{prop}: ~"var(--dt-layout-@{value}-percent)"; }
+    &-@{value}p { @{prop}: ~"var(--dt-layout-@{value}-percent)"; }
   });
 }
 

--- a/packages/dialtone-vue/components/box/box.test.js
+++ b/packages/dialtone-vue/components/box/box.test.js
@@ -304,6 +304,18 @@ describe('DtBox', () => {
     expect(wrapper.classes()).toContain('d-box--bls-500');
   });
 
+  it('applies inlineSize modifier class for percent layout token', () => {
+    const wrapper = mountComponent({ inlineSize: '100p' });
+
+    expect(wrapper.classes()).toContain('d-box--is-100p');
+  });
+
+  it('applies blockSize modifier class for percent layout token', () => {
+    const wrapper = mountComponent({ blockSize: '50p' });
+
+    expect(wrapper.classes()).toContain('d-box--bls-50p');
+  });
+
   it('applies maxInlineSize modifier class for layout token', () => {
     const wrapper = mountComponent({ maxInlineSize: '800' });
 

--- a/packages/dialtone-vue/components/box/box.vue
+++ b/packages/dialtone-vue/components/box/box.vue
@@ -176,37 +176,37 @@ const props = defineProps({
 
   /**
    * Block size (height in horizontal writing mode). Maps to --dt-layout-* tokens.
-   * @values 0, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 10-percent, 20-percent, 25-percent, 30-percent, 33-percent, 40-percent, 50-percent, 60-percent, 66-percent, 70-percent, 75-percent, 80-percent, 90-percent, 95-percent, 100-percent
+   * @values 0, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 10p, 20p, 25p, 30p, 33p, 40p, 50p, 60p, 66p, 70p, 75p, 80p, 90p, 95p, 100p
    */
   blockSize: { type: String, default: undefined, validator: layoutValidator },
 
   /**
    * Inline size (width in horizontal writing mode). Maps to --dt-layout-* tokens.
-   * @values 0, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 10-percent, 20-percent, 25-percent, 30-percent, 33-percent, 40-percent, 50-percent, 60-percent, 66-percent, 70-percent, 75-percent, 80-percent, 90-percent, 95-percent, 100-percent
+   * @values 0, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 10p, 20p, 25p, 30p, 33p, 40p, 50p, 60p, 66p, 70p, 75p, 80p, 90p, 95p, 100p
    */
   inlineSize: { type: String, default: undefined, validator: layoutValidator },
 
   /**
    * Maximum block size. Maps to --dt-layout-* tokens.
-   * @values 0, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 10-percent, 20-percent, 25-percent, 30-percent, 33-percent, 40-percent, 50-percent, 60-percent, 66-percent, 70-percent, 75-percent, 80-percent, 90-percent, 95-percent, 100-percent
+   * @values 0, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 10p, 20p, 25p, 30p, 33p, 40p, 50p, 60p, 66p, 70p, 75p, 80p, 90p, 95p, 100p
    */
   maxBlockSize: { type: String, default: undefined, validator: layoutValidator },
 
   /**
    * Minimum block size. Maps to --dt-layout-* tokens.
-   * @values 0, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 10-percent, 20-percent, 25-percent, 30-percent, 33-percent, 40-percent, 50-percent, 60-percent, 66-percent, 70-percent, 75-percent, 80-percent, 90-percent, 95-percent, 100-percent
+   * @values 0, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 10p, 20p, 25p, 30p, 33p, 40p, 50p, 60p, 66p, 70p, 75p, 80p, 90p, 95p, 100p
    */
   minBlockSize: { type: String, default: undefined, validator: layoutValidator },
 
   /**
    * Maximum inline size. Maps to --dt-layout-* tokens.
-   * @values 0, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 10-percent, 20-percent, 25-percent, 30-percent, 33-percent, 40-percent, 50-percent, 60-percent, 66-percent, 70-percent, 75-percent, 80-percent, 90-percent, 95-percent, 100-percent
+   * @values 0, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 10p, 20p, 25p, 30p, 33p, 40p, 50p, 60p, 66p, 70p, 75p, 80p, 90p, 95p, 100p
    */
   maxInlineSize: { type: String, default: undefined, validator: layoutValidator },
 
   /**
    * Minimum inline size. Maps to --dt-layout-* tokens.
-   * @values 0, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 10-percent, 20-percent, 25-percent, 30-percent, 33-percent, 40-percent, 50-percent, 60-percent, 66-percent, 70-percent, 75-percent, 80-percent, 90-percent, 95-percent, 100-percent
+   * @values 0, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 10p, 20p, 25p, 30p, 33p, 40p, 50p, 60p, 66p, 70p, 75p, 80p, 90p, 95p, 100p
    */
   minInlineSize: { type: String, default: undefined, validator: layoutValidator },
 

--- a/packages/dialtone-vue/components/box/box_constants.js
+++ b/packages/dialtone-vue/components/box/box_constants.js
@@ -62,8 +62,8 @@ export const DT_BOX_SHADOW_VALUES = ['small', 'medium', 'large', 'extra-large', 
  */
 export const DT_BOX_LAYOUT_VALUES = [
   '0', '25', '50', '75', '100', '200', '300', '400', '500', '600', '700', '800', '900', '1000', '1100', '1200', '1300', '1400', '1500', '1600',
-  '10-percent', '20-percent', '25-percent', '30-percent', '33-percent', '40-percent', '50-percent',
-  '60-percent', '66-percent', '70-percent', '75-percent', '80-percent', '90-percent', '95-percent', '100-percent',
+  '10p', '20p', '25p', '30p', '33p', '40p', '50p',
+  '60p', '66p', '70p', '75p', '80p', '90p', '95p', '100p',
 ];
 
 /**


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Refactor

## :book: Jira Ticket

[DLT-3333](https://dialpad.atlassian.net/browse/DLT-3333)

## :book: Description

Rename DtBox sizing-prop percent values from `{n}-percent` → `{n}p`.

```
<dt-box block-size="100-percent">   →   <dt-box block-size="100p">
```

Affected sizing props: `blockSize`, `inlineSize`, `minBlockSize`, `maxBlockSize`, `minInlineSize`, `maxInlineSize`.

## :bulb: Context

- Aligns DtBox prop API with DtResizable (`initial-size="50p"`) and the sizing/layout utility classes (`d-w100p`, `d-h100p`, `d-t100p`).
- Ships as a hard rename — no deprecation/aliases. DtBox shipped <2 days ago (DLT-3315), no external adopters.
- Combinator `resolveLayout` updated to display the new values as integer percentages (`33p → 33%`, `66p → 66%` — avoids float drift from `--dt-layout-33-percent = 33.333%`).
- Peer `ExampleResizable*.vue` files migrated from `dt-stack` + palette utilities (`d-bgc-purple-100`, etc.) to DtBox + DtText — uses the new `{n}p` values throughout. New `ExampleResizableNested.vue` added.
- `resizable.md` reworked to document sizing conventions and add nested example.

## :no_entry: Out of Scope

- `--dt-layout-*-percent` design token names — **unchanged**. External consumers (incl. Figma Tokens Studio) depend on these.
- `var(--dt-layout-*-percent)` callsites in `dialtone-css` recipes and `hovercard_*.story.vue` — unrelated to DtBox API surface.
- Backward-compat aliases, deprecation warnings, stylelint rules — hard cutover.

## :package: Cross-Package Impact

| Package | Changes |
| --- | --- |
| `dialtone-vue` | DtBox prop values + validator; 2 new percent tests |
| `dialtone-css` | `_box-layout` mixin emits `.d-box--{prefix}-{n}p` classes (token refs unchanged) |
| `combinator` | `resolveLayout` in `src/lib/tokens.js` recognizes `{n}p` and returns integer `%` |
| `dialtone-documentation` | `box.md` demo + `resizable.md` overhaul + 5 migrated `ExampleResizable*.vue` + 1 new |

Dependency flow: tokens → **CSS** → **Vue** → **docs** / MCP

## :page_facing_up: Documentation Artifacts

| Artifact | Status |
| --- | --- |
| Vue source | Updated |
| Tests | Updated (2 new percent tests) |
| Storybook stories | N/A (stories don't reference percent values) |
| Component docs JSON | Regenerated |
| VuePress docs | Updated (box.md + resizable.md) |
| MCP server data | Rebuilt |

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description.
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

- Flag: DtResizable uses `--dt-size-*` tokens while DtBox uses `--dt-layout-*` — same numeric labels, wildly different pixel values (e.g. `700` = 64px in size scale, 448px in layout scale). Worth a separate Jira to align or at minimum document.

[DLT-3333]: https://dialpad.atlassian.net/browse/DLT-3333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ