### PR TITLE
fix(css): DLT-3336 register bgo, fco, bco vars as non-inheriting

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/badge.less
+++ b/packages/dialtone-css/lib/build/less/components/badge.less
@@ -13,6 +13,13 @@
 //  • TYPE
 //  • SLOTS
 //
+//  @@  @PROPERTY REGISTRATIONS
+//  ----------------------------------------------------------------------------
+//  `--badge-decorative-color` is set by `.d-badge--decorate-*` modifiers;
+//  register as non-inheriting so a decorated ancestor doesn't bleed into
+//  nested badges.
+@property --badge-decorative-color { syntax: "*"; inherits: false; }
+
 //  ============================================================================
 //  $   BASE STYLE
 //  ----------------------------------------------------------------------------

--- a/packages/dialtone-css/lib/build/less/components/badge.less
+++ b/packages/dialtone-css/lib/build/less/components/badge.less
@@ -13,13 +13,6 @@
 //  • TYPE
 //  • SLOTS
 //
-//  @@  @PROPERTY REGISTRATIONS
-//  ----------------------------------------------------------------------------
-//  `--badge-decorative-color` is set by `.d-badge--decorate-*` modifiers;
-//  register as non-inheriting so a decorated ancestor doesn't bleed into
-//  nested badges.
-@property --badge-decorative-color { syntax: "*"; inherits: false; }
-
 //  ============================================================================
 //  $   BASE STYLE
 //  ----------------------------------------------------------------------------

--- a/packages/dialtone-css/lib/build/less/components/description-list.less
+++ b/packages/dialtone-css/lib/build/less/components/description-list.less
@@ -1,3 +1,7 @@
+//  Register gap modifier var as non-inheriting so nested description lists
+//  don't pick up an ancestor's gap override.
+@property --description-list-gap { syntax: "*"; inherits: false; }
+
 @layer dialtone.components {
 .d-description-list {
   display: flex;

--- a/packages/dialtone-css/lib/build/less/components/progress_circle.less
+++ b/packages/dialtone-css/lib/build/less/components/progress_circle.less
@@ -4,6 +4,14 @@
 //
 //  https://dialtone.dialpad.com/components/progress-circle
 
+//  @@  @PROPERTY REGISTRATIONS
+//  ----------------------------------------------------------------------------
+//  Register size/color modifier vars as non-inheriting so an ancestor
+//  progress-circle (or unrelated setter) doesn't bleed into nested instances.
+@property --progress-size { syntax: "*"; inherits: false; }
+
+@property --progress-color { syntax: "*"; inherits: false; }
+
 @layer dialtone.components {
 .d-progress-circle {
   --progress-size: var(--dt-icon-size-500);

--- a/packages/dialtone-css/lib/build/less/components/progress_circle.less
+++ b/packages/dialtone-css/lib/build/less/components/progress_circle.less
@@ -6,11 +6,11 @@
 
 //  @@  @PROPERTY REGISTRATIONS
 //  ----------------------------------------------------------------------------
-//  Register size/color modifier vars as non-inheriting so an ancestor
-//  progress-circle (or unrelated setter) doesn't bleed into nested instances.
+//  `--progress-size` is only read on `.d-progress-circle` itself, so registering
+//  as non-inheriting is safe. `--progress-color` is NOT registered — it is set
+//  on `.d-progress-circle` and consumed by descendant `.d-progress-circle__shape`
+//  elements via inheritance.
 @property --progress-size { syntax: "*"; inherits: false; }
-
-@property --progress-color { syntax: "*"; inherits: false; }
 
 @layer dialtone.components {
 .d-progress-circle {

--- a/packages/dialtone-css/lib/build/less/utilities/backgrounds.less
+++ b/packages/dialtone-css/lib/build/less/utilities/backgrounds.less
@@ -15,6 +15,18 @@
 //  • GRADIENTS
 //  • PATTERNS
 //
+//  @@  @PROPERTY REGISTRATIONS
+//  ----------------------------------------------------------------------------
+//  Register opacity custom properties as non-inheriting so `--bgo` set on an
+//  ancestor does not bleed into descendants using `.d-bgc-*`. With universal
+//  syntax and no initial-value, `var(--bgo, alpha)` still falls back to the
+//  source color's alpha channel when no opacity utility is applied.
+@property --bgo { syntax: "*"; inherits: false; }
+
+//  `--bgg-size` is consumed by `.d-bgs-var` with fallback `100% 100%`; register
+//  as non-inheriting so a parent setting it doesn't override descendants.
+@property --bgg-size { syntax: "*"; inherits: false; }
+
 //  ============================================================================
 //  $  BACKGROUND ATTACHMENT
 //  ----------------------------------------------------------------------------

--- a/packages/dialtone-css/lib/build/less/utilities/borders.less
+++ b/packages/dialtone-css/lib/build/less/utilities/borders.less
@@ -17,6 +17,16 @@
 //    - VERTICAL DIVIDERS
 //    - HORIZONTAL DIVIDERS
 //
+//  @@  @PROPERTY REGISTRATIONS
+//  ----------------------------------------------------------------------------
+//  Register opacity custom properties as non-inheriting so `--bco` / `--dco`
+//  set on an ancestor do not bleed into descendants using `.d-bc-*` / `.d-divide-*`.
+//  With universal syntax and no initial-value, `var(--bco, alpha)` still falls
+//  back to the source color's alpha channel when no opacity utility is applied.
+@property --bco { syntax: "*"; inherits: false; }
+
+@property --dco { syntax: "*"; inherits: false; }
+
 //  ============================================================================
 //  $  BORDERS
 //  ============================================================================

--- a/packages/dialtone-css/lib/build/less/utilities/colors.less
+++ b/packages/dialtone-css/lib/build/less/utilities/colors.less
@@ -14,6 +14,14 @@
 // TODO: Remove `*-transparent` classes in favor of `*-neutral-transparent` classes.
 //  Both are existing and that's not ok, a migration will be needed on product.
 //
+//  @@  @PROPERTY REGISTRATIONS
+//  ----------------------------------------------------------------------------
+//  Register opacity custom properties as non-inheriting so `--fco` set on an
+//  ancestor does not bleed into descendants using `.d-fc-*`. With universal
+//  syntax and no initial-value, `var(--fco, alpha)` still falls back to the
+//  source color's alpha channel when no opacity utility is applied.
+@property --fco { syntax: "*"; inherits: false; }
+
 //  $$  TEXT COLORS
 //  ----------------------------------------------------------------------------
 @layer dialtone.utilities {

--- a/packages/dialtone-css/lib/build/less/utilities/layout.less
+++ b/packages/dialtone-css/lib/build/less/utilities/layout.less
@@ -15,6 +15,13 @@
 //  • VISIBILITY
 //  • Z-INDEX
 //
+//  @@  @PROPERTY REGISTRATIONS
+//  ----------------------------------------------------------------------------
+//  Register `--fixed-value` as non-inheriting so an ancestor setting it does
+//  not bleed into descendants using `.d-*100p-calc` position utilities.
+//  Universal syntax with no initial-value preserves the `8px` fallback.
+@property --fixed-value { syntax: "*"; inherits: false; }
+
 //  ============================================================================
 //  $   BOX-SIZING
 //  ============================================================================


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

[DLT-3336](https://dialpad.atlassian.net/browse/DLT-3336)

## :book: Description

Register CSS custom properties used by utility classes and same-element component modifiers with `@property { syntax: "*"; inherits: false; }` so their values no longer inherit from ancestors into unintended descendants.

**Utility vars**

- `--fco` (colors.less)
- `--bgo` (backgrounds.less)
- `--bco`, `--dco` (borders.less)
- `--fixed-value` (layout.less)
- `--bgg-size` (backgrounds.less)

**Component modifier vars (same-element read)**

- `--progress-size` (progress_circle.less)
- `--description-list-gap` (description-list.less)

## :bulb: Context

Problem: `.d-bgo90` on a parent sets `--bgo`, which cascades to descendants and overrides the `alpha` fallback in `oklch(from var(--color) l c h / var(--bgo, alpha))` — producing visibly wrong colors on nested `.d-bgc-*`, `.d-fc-*`, `.d-bc-*` elements. Same class of bug applied to the other vars above.

Fix: universal syntax + omitted `initial-value` keeps the `var(--x, alpha)` fallback working when no utility is applied on the element. `inherits: false` is what actually defeats the bleed.

## :crystal_ball: Out of scope / intentionally not registered

- Design tokens (`--dt-*`) — meant to cascade
- Already registered: `--box-*`, `--d-motion-text-mask-pos`
- `--text-tone` — already mitigated; `.d-text` base sets `currentColor`
- `--progress-color` (progress_circle) — set on `.d-progress-circle`, consumed on descendant `.d-progress-circle__shape--track/--fill`; relies on inheritance
- `--badge-decorative-color` (badge) — set on `.d-badge`, consumed on descendant `.d-badge__decorative`; relies on inheritance

## :warning: DevTools warning

Chrome DevTools shows `Invalid property value, expected type "*"` on `--bgo: 50% !important` setters. Cosmetic only — spec says `syntax: "*"` accepts any value, and the fix renders correctly. Likely a Chrome quirk with `!important` on registered custom properties; not blocking.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description.
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :camera: Screenshots

Before / after on `utilities/backgrounds/color.md` — nested `.d-bgc-*` no longer inherit parent `--bgo`.

[DLT-3336]: https://dialpad.atlassian.net/browse/DLT-3336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ