### PR TITLE
feat(design-tokens, text, link, box, css): DLT-3338 add info semantic tokens and consumers

### DIFF
--- a/apps/dialtone-documentation/docs/components/link.md
+++ b/apps/dialtone-documentation/docs/components/link.md
@@ -52,6 +52,7 @@ keywords: ["anchor", "hyperlink", "url", "d-link", "DtLink", "dt-link", "text li
   <dt-link href="#link" tone="muted">Muted link</dt-link>
   <dt-link href="#link" tone="positive">Positive link</dt-link>
   <dt-link href="#link" tone="warning">Warning link</dt-link>
+  <dt-link href="#link" tone="info">Info link</dt-link>
   <dt-link href="#link" tone="mention">Mention link</dt-link>
 </DtStack>
 ```
@@ -77,6 +78,7 @@ In place of the `inverted` prop, use the [v-dt-mode directive](mode-island.html#
   <dt-link v-dt-mode:invert href="#link" tone="critical">Critical link</dt-link>
   <dt-link v-dt-mode:invert href="#link" tone="positive">Positive link</dt-link>
   <dt-link v-dt-mode:invert href="#link" tone="warning">Warning link</dt-link>
+  <dt-link v-dt-mode:invert href="#link" tone="info">Info link</dt-link>
   <dt-link v-dt-mode:invert href="#link" tone="muted">Muted link</dt-link>
   <dt-link v-dt-mode:invert href="#link" tone="mention">Mention link</dt-link>
 </DtStack>

--- a/apps/dialtone-documentation/docs/components/text.md
+++ b/apps/dialtone-documentation/docs/components/text.md
@@ -167,6 +167,8 @@ Use `tone` to declare the text's tone, which will map to a foreground color. By 
   <dt-text tone="warning">warning</dt-text>
   <dt-text tone="critical">critical</dt-text>
   <dt-text tone="critical-strong">critical-strong</dt-text>
+  <dt-text tone="info">info</dt-text>
+  <dt-text tone="info-strong">info-strong</dt-text>
 </dt-stack>
 ```
 

--- a/packages/dialtone-css/lib/build/less/components/box.less
+++ b/packages/dialtone-css/lib/build/less/components/box.less
@@ -110,7 +110,7 @@
 //  `positive*` moves into these lists and the alias blocks can be dropped.
 @box-surface-values: primary, secondary, moderate, bold, strong, contrast, backdrop, brand, info, warning, critical, brand-subtle, brand-strong, info-subtle, info-strong, warning-subtle, warning-strong, critical-subtle, critical-strong, primary-opaque, secondary-opaque, moderate-opaque, bold-opaque, strong-opaque, contrast-opaque, brand-opaque, brand-subtle-opaque, info-opaque, info-subtle-opaque, warning-opaque, warning-subtle-opaque, critical-opaque, critical-subtle-opaque;
 
-@box-border-color-values: subtle, default, moderate, bold, accent, focus, brand, warning, critical, brand-subtle, brand-strong, warning-subtle, warning-strong, critical-subtle, critical-strong;
+@box-border-color-values: subtle, default, moderate, bold, accent, focus, brand, warning, critical, info, brand-subtle, brand-strong, warning-subtle, warning-strong, critical-subtle, critical-strong, info-subtle, info-strong;
 
 @box-border-width-values: 0, 50, 100, 150, 200, 300, 400;
 @box-layout-percent-values: 10, 20, 25, 30, 33, 40, 50, 60, 66, 70, 75, 80, 90, 95, 100;

--- a/packages/dialtone-css/lib/build/less/components/link.less
+++ b/packages/dialtone-css/lib/build/less/components/link.less
@@ -99,6 +99,13 @@
         --link-color-default-hover: var(--dt-color-link-success-hover);
     }
 
+    //  $$  INFO
+    //  ----------------------------------------------------------------------------
+    &--info {
+        --link-color-default: var(--dt-color-link-info);
+        --link-color-default-hover: var(--dt-color-link-info-hover);
+    }
+
     //  $$  MUTED
     //  ----------------------------------------------------------------------------
     &--muted {
@@ -163,6 +170,13 @@
     &--inverted-warning {
         --link-color-default: var(--dt-color-link-warning-inverted);
         --link-color-default-hover: var(--dt-color-link-warning-inverted-hover);
+    }
+
+    //  $$  INVERTED INFO
+    //  ----------------------------------------------------------------------------
+    &--inverted-info {
+        --link-color-default: var(--dt-color-link-info-inverted);
+        --link-color-default-hover: var(--dt-color-link-info-inverted-hover);
     }
 
     //  $$  INVERTED MUTED

--- a/packages/dialtone-css/lib/build/less/components/notice.less
+++ b/packages/dialtone-css/lib/build/less/components/notice.less
@@ -144,7 +144,7 @@
 .d-banner--info,
 .d-toast--info {
     --notice-color-background: var(--dt-color-surface-info);
-    --notice-color-icon: var(--dt-color-blue-800);
+    --notice-color-icon: var(--dt-color-foreground-info);
 
     &.d-notice--important,
     &.d-banner--important,

--- a/packages/dialtone-css/lib/build/less/components/progress_circle.less
+++ b/packages/dialtone-css/lib/build/less/components/progress_circle.less
@@ -29,7 +29,7 @@
   // AI fill gradient is an SVG <linearGradient> applied in the Vue component;
   // the track intentionally keeps the default border color.
   &--ai { --progress-color: var(--dt-color-border-bold); }
-  &--info { --progress-color: var(--dt-color-blue-600); } // TODO: I still have to create "info" design tokens
+  &--info { --progress-color: var(--dt-color-border-info); }
 }
 
 .d-progress-circle__bar {

--- a/packages/dialtone-css/lib/build/less/components/text.less
+++ b/packages/dialtone-css/lib/build/less/components/text.less
@@ -232,6 +232,8 @@
   &--tone-positive        { --text-tone: var(--dt-color-foreground-positive); }
   &--tone-positive-strong { --text-tone: var(--dt-color-foreground-positive-strong); }
   &--tone-warning         { --text-tone: var(--dt-color-foreground-warning); }
+  &--tone-info            { --text-tone: var(--dt-color-foreground-info); }
+  &--tone-info-strong     { --text-tone: var(--dt-color-foreground-info-strong); }
   &--tone-neutral-black   { --text-tone: var(--dt-color-neutral-black); }
   &--tone-neutral-white   { --text-tone: var(--dt-color-neutral-white); }
 }

--- a/packages/dialtone-css/lib/build/less/recipes/settings_menu_button.less
+++ b/packages/dialtone-css/lib/build/less/recipes/settings_menu_button.less
@@ -19,7 +19,7 @@
 .d-recipe-settings-menu-button-update {
   block-size: var(--dt-layout-50);
   padding-inline-start: var(--dt-spacing-150);
-  color: var(--dt-color-blue-800); // TODO
+  color: var(--dt-color-foreground-info);
   background-color: var(--dt-color-surface-info);
   border-color: var(--dt-color-border-default);
   border-radius: var(--dt-size-radius-pill);

--- a/packages/dialtone-tokens/tokens/theme/dp/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/dark.json
@@ -30,6 +30,14 @@
         "value": "{color.gold.700}",
         "type": "color"
       },
+      "info": {
+        "value": "{color.blue.700}",
+        "type": "color"
+      },
+      "info-strong": {
+        "value": "{color.blue.800}",
+        "type": "color"
+      },
       "positive": {
         "value": "{color.green.600}",
         "type": "color"
@@ -589,6 +597,10 @@
         "value": "{color.gold.800}",
         "type": "color"
       },
+      "info": {
+        "value": "{color.blue.800}",
+        "type": "color"
+      },
       "success": {
         "value": "{color.green.600}",
         "type": "color"
@@ -603,6 +615,10 @@
       },
       "warning-subtle": {
         "value": "{color.gold.600}",
+        "type": "color"
+      },
+      "info-subtle": {
+        "value": "{color.blue.300}",
         "type": "color"
       },
       "success-subtle": {
@@ -623,6 +639,10 @@
       },
       "warning-strong": {
         "value": "{color.gold.900}",
+        "type": "color"
+      },
+      "info-strong": {
+        "value": "{color.blue.400}",
         "type": "color"
       },
       "brand-strong": {

--- a/packages/dialtone-tokens/tokens/theme/dp/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/dark.json
@@ -642,7 +642,7 @@
         "type": "color"
       },
       "info-strong": {
-        "value": "{color.blue.400}",
+        "value": "{color.blue.900}",
         "type": "color"
       },
       "brand-strong": {

--- a/packages/dialtone-tokens/tokens/theme/dp/default.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/default.json
@@ -76,6 +76,16 @@
         "type": "color",
         "description": "Indicates information that requires user\u2019s attention and further action may be necessary."
       },
+      "info": {
+        "value": "{color.blue.800}",
+        "type": "color",
+        "description": "Indicates a generally informational state."
+      },
+      "info-strong": {
+        "value": "{color.blue.900}",
+        "type": "color",
+        "description": "Indicates a generally informational state on surfaces that require a stronger contrast."
+      },
       "primary-inverted": {
         "value": "{color.black.100}",
         "type": "color",
@@ -151,6 +161,16 @@
         "value": "{color.gold.500}",
         "type": "color",
         "description": "Warning text that sits on high-contrast surfaces or backgrounds"
+      },
+      "info-inverted": {
+        "value": "{color.blue.300}",
+        "type": "color",
+        "description": "Info text that sits on high-contrast surfaces or backgrounds."
+      },
+      "info-strong-inverted": {
+        "value": "{color.blue.200}",
+        "type": "color",
+        "description": "Info strong text that sits on high-contrast surfaces or backgrounds."
       }
     },
     "link": {
@@ -185,6 +205,14 @@
       },
       "warning-hover": {
         "value": "{color.gold.900}",
+        "type": "color"
+      },
+      "info": {
+        "value": "{color.foreground.info}",
+        "type": "color"
+      },
+      "info-hover": {
+        "value": "{color.foreground.info-strong}",
         "type": "color"
       },
       "muted": {
@@ -233,6 +261,14 @@
       },
       "warning-inverted-hover": {
         "value": "{color.gold.300}",
+        "type": "color"
+      },
+      "info-inverted": {
+        "value": "{color.foreground.info-inverted}",
+        "type": "color"
+      },
+      "info-inverted-hover": {
+        "value": "{color.foreground.info-strong-inverted}",
         "type": "color"
       },
       "muted-inverted": {
@@ -995,6 +1031,10 @@
         "value": "{color.gold.500}",
         "type": "color"
       },
+      "info": {
+        "value": "{color.blue.600}",
+        "type": "color"
+      },
       "brand": {
         "value": "{color.brand.purple}",
         "type": "color"
@@ -1011,6 +1051,10 @@
         "value": "{color.gold.300}",
         "type": "color"
       },
+      "info-subtle": {
+        "value": "{color.blue.300}",
+        "type": "color"
+      },
       "brand-subtle": {
         "value": "{color.purple.300}",
         "type": "color"
@@ -1025,6 +1069,10 @@
       },
       "warning-strong": {
         "value": "{color.gold.700}",
+        "type": "color"
+      },
+      "info-strong": {
+        "value": "{color.blue.800}",
         "type": "color"
       },
       "brand-strong": {
@@ -1095,6 +1143,10 @@
         "value": "{color.gold.500}",
         "type": "color"
       },
+      "info-inverted": {
+        "value": "{color.blue.300}",
+        "type": "color"
+      },
       "brand-inverted": {
         "value": "{color.purple.400}",
         "type": "color"
@@ -1111,6 +1163,10 @@
         "value": "{color.gold.800}",
         "type": "color"
       },
+      "info-subtle-inverted": {
+        "value": "{color.blue.900}",
+        "type": "color"
+      },
       "brand-subtle-inverted": {
         "value": "{color.purple.600}",
         "type": "color"
@@ -1125,6 +1181,10 @@
       },
       "warning-strong-inverted": {
         "value": "{color.gold.300}",
+        "type": "color"
+      },
+      "info-strong-inverted": {
+        "value": "{color.blue.200}",
         "type": "color"
       },
       "brand-strong-inverted": {

--- a/packages/dialtone-vue/components/box/box.vue
+++ b/packages/dialtone-vue/components/box/box.vue
@@ -68,7 +68,7 @@ const props = defineProps({
   /**
    * Border color. Maps to --dt-color-border-* tokens.
    * Defaults to 'default'. Visible when any border-width prop is set.
-   * @values transparent, subtle, default, moderate, bold, positive, positive-subtle, positive-strong, warning, warning-subtle, warning-strong, critical, critical-subtle, critical-strong, focus, brand, brand-subtle, brand-strong
+   * @values transparent, subtle, default, moderate, bold, positive, positive-subtle, positive-strong, warning, warning-subtle, warning-strong, critical, critical-subtle, critical-strong, info, info-subtle, info-strong, focus, brand, brand-subtle, brand-strong
    */
   borderColor: { type: String, default: 'default', validator: borderColorValidator },
 

--- a/packages/dialtone-vue/components/box/box_constants.js
+++ b/packages/dialtone-vue/components/box/box_constants.js
@@ -33,9 +33,10 @@ export const DT_BOX_SURFACE_VALUES = [
  */
 export const DT_BOX_BORDER_COLOR_VALUES = [
   'transparent', 'subtle', 'default', 'moderate', 'bold', 'accent', 'focus',
-  'brand', 'positive', 'warning', 'critical',
+  'brand', 'positive', 'warning', 'critical', 'info',
   'brand-subtle', 'brand-strong', 'positive-subtle', 'positive-strong',
   'warning-subtle', 'warning-strong', 'critical-subtle', 'critical-strong',
+  'info-subtle', 'info-strong',
 ];
 
 /**

--- a/packages/dialtone-vue/components/link/link.test.js
+++ b/packages/dialtone-vue/components/link/link.test.js
@@ -2,12 +2,11 @@ import { mount } from '@vue/test-utils';
 import DtLink from './link.vue';
 import {
   LINK_KIND_MODIFIERS,
-  CRITICAL,
-  POSITIVE,
-  WARNING,
-  MUTED,
+  LINK_VARIANTS,
   getLinkKindModifier,
 } from './link_constants';
+
+const TONE_VALUES = LINK_VARIANTS.filter(v => v !== '');
 
 const baseProps = {
   href: '#',
@@ -62,48 +61,8 @@ describe('DtLink tests', () => {
       });
     });
 
-    describe('When tone is critical', () => {
-      it('should have correct class', () => {
-        mockProps = { tone: CRITICAL };
-
-        updateWrapper();
-
-        expect(nativeLink.classes(LINK_KIND_MODIFIERS[CRITICAL])).toBe(true);
-      });
-    });
-
-    describe('When tone is positive', () => {
-      it('should have correct class', () => {
-        mockProps = { tone: POSITIVE };
-
-        updateWrapper();
-
-        expect(nativeLink.classes(LINK_KIND_MODIFIERS[POSITIVE])).toBe(true);
-      });
-    });
-
-    describe('When tone is warning', () => {
-      it('should have correct class', async () => {
-        mockProps = { tone: WARNING };
-
-        updateWrapper();
-
-        expect(nativeLink.classes(LINK_KIND_MODIFIERS[WARNING])).toBe(true);
-      });
-    });
-
-    describe('When tone is muted', () => {
-      it('should have correct class', async () => {
-        mockProps = { tone: MUTED };
-
-        updateWrapper();
-
-        expect(nativeLink.classes(LINK_KIND_MODIFIERS[MUTED])).toBe(true);
-      });
-    });
-
     describe('When inverted is true', () => {
-      it('should have correct class', async () => {
+      it('should have correct class', () => {
         mockProps = { inverted: true };
 
         updateWrapper();
@@ -112,44 +71,20 @@ describe('DtLink tests', () => {
       });
     });
 
-    describe('When tone is critical and inverted is true', () => {
-      it('should have correct class', async () => {
-        mockProps = { tone: CRITICAL, inverted: true };
+    it.each(TONE_VALUES)('applies tone modifier class for %s', (tone) => {
+      mockProps = { tone };
 
-        updateWrapper();
+      updateWrapper();
 
-        expect(nativeLink.classes(getLinkKindModifier(CRITICAL, true))).toBe(true);
-      });
+      expect(nativeLink.classes(LINK_KIND_MODIFIERS[tone])).toBe(true);
     });
 
-    describe('When tone is positive and inverted is true', () => {
-      it('should have correct class', async () => {
-        mockProps = { tone: POSITIVE, inverted: true };
+    it.each(TONE_VALUES)('applies inverted tone modifier class for %s', (tone) => {
+      mockProps = { tone, inverted: true };
 
-        updateWrapper();
+      updateWrapper();
 
-        expect(nativeLink.classes(getLinkKindModifier(POSITIVE, true))).toBe(true);
-      });
-    });
-
-    describe('When tone is warning and inverted is true', () => {
-      it('should have correct class', async () => {
-        mockProps = { tone: WARNING, inverted: true };
-
-        updateWrapper();
-
-        expect(nativeLink.classes(getLinkKindModifier(WARNING, true))).toBe(true);
-      });
-    });
-
-    describe('When tone is muted and inverted is true', () => {
-      it('should have correct class', async () => {
-        mockProps = { tone: MUTED, inverted: true };
-
-        updateWrapper();
-
-        expect(nativeLink.classes(getLinkKindModifier(MUTED, true))).toBe(true);
-      });
+      expect(nativeLink.classes(getLinkKindModifier(tone, true))).toBe(true);
     });
 
     describe('When underline is false', () => {
@@ -279,7 +214,7 @@ describe('DtLink tests', () => {
       };
 
       it('should apply link classes to the router-link', () => {
-        mockProps = { to: '/components/', tone: MUTED };
+        mockProps = { to: '/components/', tone: 'muted' };
         mockGlobal = {
           stubs: { RouterLink: RouterLinkStub },
         };
@@ -289,7 +224,7 @@ describe('DtLink tests', () => {
         const routerLink = wrapper.findComponent(RouterLinkStub);
         expect(routerLink.exists()).toBe(true);
         expect(wrapper.find('[data-qa="dt-link"]').classes()).toContain('d-link');
-        expect(wrapper.find('[data-qa="dt-link"]').classes()).toContain(LINK_KIND_MODIFIERS[MUTED]);
+        expect(wrapper.find('[data-qa="dt-link"]').classes()).toContain(LINK_KIND_MODIFIERS.muted);
       });
     });
   });

--- a/packages/dialtone-vue/components/link/link.vue
+++ b/packages/dialtone-vue/components/link/link.vue
@@ -26,7 +26,7 @@ export default {
   props: {
     /**
      * Applies the link variant styles
-     * @values null, critical, warning, positive, muted, mention
+     * @values null, critical, warning, positive, info, muted, mention
      */
     tone: {
       type: String,

--- a/packages/dialtone-vue/components/link/link_constants.js
+++ b/packages/dialtone-vue/components/link/link_constants.js
@@ -1,15 +1,17 @@
 export const CRITICAL = 'critical';
 export const POSITIVE = 'positive';
 export const WARNING = 'warning';
+export const INFO = 'info';
 export const MUTED = 'muted';
 export const MENTION = 'mention';
-export const LINK_VARIANTS = ['', CRITICAL, WARNING, POSITIVE, MUTED, MENTION];
+export const LINK_VARIANTS = ['', CRITICAL, WARNING, POSITIVE, INFO, MUTED, MENTION];
 
 export const LINK_KIND_MODIFIERS = {
   default: '',
   critical: 'd-link--critical',
   warning: 'd-link--warning',
   positive: 'd-link--positive',
+  info: 'd-link--info',
   muted: 'd-link--muted',
   mention: 'd-link--mention',
 };
@@ -19,6 +21,7 @@ const LINK_KIND_MODIFIERS_INVERTED = {
   critical: 'd-link--inverted-critical',
   warning: 'd-link--inverted-warning',
   positive: 'd-link--inverted-positive',
+  info: 'd-link--inverted-info',
   muted: 'd-link--inverted-muted',
   mention: 'd-link--inverted-mention',
 };

--- a/packages/dialtone-vue/components/text/text.vue
+++ b/packages/dialtone-vue/components/text/text.vue
@@ -80,7 +80,7 @@ export default {
 
     /**
      * Semantic foreground color.
-     * @values primary, secondary, tertiary, muted, disabled, placeholder, critical, critical-strong, positive, positive-strong, warning, neutral-black, neutral-white
+     * @values primary, secondary, tertiary, muted, disabled, placeholder, critical, critical-strong, positive, positive-strong, warning, info, info-strong, neutral-black, neutral-white
      */
     tone: {
       type: String,

--- a/packages/dialtone-vue/components/text/text_constants.js
+++ b/packages/dialtone-vue/components/text/text_constants.js
@@ -38,6 +38,8 @@ export const TEXT_TONE_MODIFIERS = {
   'positive': 'd-text--tone-positive',
   'positive-strong': 'd-text--tone-positive-strong',
   'warning': 'd-text--tone-warning',
+  'info': 'd-text--tone-info',
+  'info-strong': 'd-text--tone-info-strong',
   'neutral-black': 'd-text--tone-neutral-black',
   'neutral-white': 'd-text--tone-neutral-white',
 };

--- a/packages/dialtone-vue/components/text/text_variants.story.vue
+++ b/packages/dialtone-vue/components/text/text_variants.story.vue
@@ -520,6 +520,8 @@ export default {
         { key: 'positive', props: { kind: 'body', tone: 'positive' }, copy: 'Positive tone' },
         { key: 'warning', props: { kind: 'body', tone: 'warning' }, copy: 'Warning tone' },
         { key: 'critical', props: { kind: 'body', tone: 'critical' }, copy: 'Critical tone' },
+        { key: 'info', props: { kind: 'body', tone: 'info' }, copy: 'Info tone' },
+        { key: 'info-strong', props: { kind: 'body', tone: 'info-strong' }, copy: 'Info strong tone' },
       ];
     },
 


### PR DESCRIPTION
<img width="248" height="157" alt="image" src="https://github.com/user-attachments/assets/21818157-fbc8-492c-aee6-0490d84d34ca" />

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3338

## :book: Description

Closes the `info` parity gap. Today `info` only lives in `color.surface.*` and `color.chart.*`; consumers needing info-flavored text / borders / links must reach into raw `blue-*` palette. This PR adds the missing semantic tokens and wires them through three components.

**What this does:**

1. **New semantic tokens** in `dp` theme (`default.json` + `dark.json`):
   - `color.foreground.info` / `-strong` + inverted pair
   - `color.border.info` / `-subtle` / `-strong` + inverted trio
   - `color.link.info` / `-hover` + inverted pair
   - 19 new tokens total. Non-`dp` themes inherit automatically.

2. **Migrates 3 existing consumers** from raw `--dt-color-blue-*` to new semantic tokens:
   - `DtNotice` / `DtBanner` / `DtToast` info icon → `foreground-info`
   - `DtProgressCircle` info variant → `border-info`
   - Settings menu button recipe → `foreground-info`
   - Clears two pre-existing `// TODO` comments that were blocked on these tokens.

3. **Expands component APIs** to accept `info`:
   - `DtText` `tone` gets `info` + `info-strong`
   - `DtLink` `tone` gets `info` (+ inverted wiring)
   - `DtBox` `borderColor` gets `info` / `info-subtle` / `info-strong`

Bonus: refactors `DtLink`'s 8 per-tone unit tests into `it.each(LINK_VARIANTS)` — eliminates pre-existing redundancy, auto-covers future tone additions.

**What this does NOT do** (deliberate, not gaps):

- `DtModal` main `kind` — critical-only by convention
- `DtButton` `kind` — no info-button pattern
- Validation `critical` on input / radio / checkbox — binary state, info N/A

## :bulb: Context

Before: critical / warning / positive all have foreground + border + link token coverage; `info` only had surface + chart. Consumers built info-flavored UI by reaching into the raw blue palette, which breaks theming and contrast guarantees.

After: `info` reaches parity with its sibling statuses. Semantic token usage is now internally consistent across notice / progress / text / link / box / recipes.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description.
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader. _(color-only additions, no new interactive semantics)_
- [x] I have validated components keyboard navigation. _(same as above)_

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## 📷 Screenshots / GIFs

<img width="311" height="878" alt="image" src="https://github.com/user-attachments/assets/98103ba5-dcb6-420a-8b74-65eb12bd236d" />


