### PR TITLE
feat(css-utilities, eslint-plugin-dialtone): DLT-3329 update border-radius css utilities and associated tooling

### DIFF
--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/utility-class-to-token-stops.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/utility-class-to-token-stops.mjs
@@ -41,13 +41,35 @@ const SPACING_LAYOUT_MAP = {
   96: '150', 128: '200',
 };
 
-// Helper: build regex that matches class names with word boundaries
-// Sorted by descending key length to avoid partial matches (d-h1024 before d-h102)
+// Border-radius: legacy pixel value → new radius token stop
+// MUST STAY IN SYNC with RADIUS_STOPS in dialtone-css/postcss/constants.cjs.
+const RADIUS_MAP = {
+  0: '0', 1: '100', 2: '200', 4: '300', 6: '350',
+  8: '400', 12: '450', 16: '500', 24: '550', 32: '600',
+};
+
+// Border-radius: legacy physical-side prefix → new logical prefix.
+const RADIUS_PAIR_PREFIX_MAP = {
+  btr: 'bbsr', // top    → block-start pair
+  bbr: 'bber', // bottom → block-end pair
+  blr: 'bisr', // left   → inline-start pair
+  brr: 'bier', // right  → inline-end pair
+};
+
+// Class-name boundary: preceded by space, quote, or start; followed by space, quote, or end.
+const CLASS_BOUNDARY_LEFT = `((?:^|["'\\s]))`;
+const CLASS_BOUNDARY_RIGHT = `((?:["'\\s]|$))`;
+
+// Build regex that matches class names ending in any key from `map`, with boundaries.
+// Keys sorted by descending length to avoid partial matches (d-h1024 before d-h102).
 function buildClassRegex (prefix, map) {
   const keys = Object.keys(map).sort((a, b) => b.length - a.length || Number(b) - Number(a));
-  const pattern = keys.join('|');
-  // Match class name boundary: preceded by space, quote, or start; followed by space, quote, or end
-  return new RegExp(`((?:^|["'\\s]))${prefix}(${pattern})((?:["'\\s]|$))`, 'gm');
+  return new RegExp(`${CLASS_BOUNDARY_LEFT}${prefix}(${keys.join('|')})${CLASS_BOUNDARY_RIGHT}`, 'gm');
+}
+
+// Variant for fixed-keyword suffixes (e.g. `-pill`, `-circle`).
+function buildKeywordClassRegex (prefix, keyword) {
+  return new RegExp(`${CLASS_BOUNDARY_LEFT}${prefix}-${keyword}${CLASS_BOUNDARY_RIGHT}`, 'gm');
 }
 
 export default {
@@ -59,6 +81,9 @@ export default {
     '- Padding: d-p8 → d-p-100, d-pt16 → d-pt-200\n' +
     '- Gap: d-g8 → d-g-100, d-rg16 → d-rg-200\n' +
     '- Position: d-t8 → d-t-100, d-tn8 → d-t-n100\n' +
+    '- Border-radius all: d-bar6 → d-bar-350, d-bar24 → d-bar-550\n' +
+    '- Border-radius pair (physical → logical): d-btr6 → d-bbsr-350, d-bbr8 → d-bber-400, d-blr12 → d-bisr-450, d-brr16 → d-bier-500\n' +
+    '- Border-radius pair keyword: d-btr-pill → d-bbsr-pill, d-brr-circle → d-bier-circle\n' +
     '- Old deprecated sizes (d-h72, d-w332, etc.) are left unchanged for manual review.\n',
   patterns: ['**/*.{vue,html,js,ts,jsx,tsx,md,less,css}'],
   globbyConfig: {
@@ -135,5 +160,27 @@ export default {
       from: buildClassRegex(`d-${prefix}n`, NEGATIVE_SPACING_MAP),
       to: (match, pre, px, post) => `${pre}d-${prefix}-n${NEGATIVE_SPACING_MAP[px]}${post}`,
     })),
+
+    // ── Border-radius all-corners numeric: d-bar{px} → d-bar-{stop} ──────
+    {
+      from: buildClassRegex('d-bar', RADIUS_MAP),
+      to: (match, pre, px, post) => `${pre}d-bar-${RADIUS_MAP[px]}${post}`,
+    },
+
+    // ── Border-radius side-pair numeric: d-{legacy}{px} → d-{logical}-{stop}
+    // Physical pair prefixes (btr/bbr/blr/brr) rewrite to their logical siblings (bbsr/bber/bisr/bier).
+    ...Object.entries(RADIUS_PAIR_PREFIX_MAP).map(([legacy, logical]) => ({
+      from: buildClassRegex(`d-${legacy}`, RADIUS_MAP),
+      to: (match, pre, px, post) => `${pre}d-${logical}-${RADIUS_MAP[px]}${post}`,
+    })),
+
+    // ── Border-radius side-pair keyword: d-{legacy}-{pill|circle} → d-{logical}-{pill|circle}
+    // Legacy `.d-bar-pill` / `.d-bar-circle` stay as-is (same name in the new scheme).
+    ...Object.entries(RADIUS_PAIR_PREFIX_MAP).flatMap(([legacy, logical]) =>
+      ['pill', 'circle'].map(keyword => ({
+        from: buildKeywordClassRegex(`d-${legacy}`, keyword),
+        to: (match, pre, post) => `${pre}d-${logical}-${keyword}${post}`,
+      })),
+    ),
   ],
 };

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/utility-class-to-token-stops.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/utility-class-to-token-stops.mjs
@@ -93,6 +93,8 @@ export default {
     dot: true,
     ignore: [
       '**/node_modules/**',
+      // `dot: true` makes dot-dirs globbable; explicitly exclude the git directory.
+      '**/.git/**',
       // Built outputs: regenerated on next build; rewriting selectors in co-selected rules
       // (`.d-bar-350, .d-bar6 { ... }`) would corrupt them since the leading whitespace
       // before the legacy selector looks like a class boundary to the regex.

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/utility-class-to-token-stops.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/utility-class-to-token-stops.mjs
@@ -85,9 +85,36 @@ export default {
     '- Border-radius pair (physical → logical): d-btr6 → d-bbsr-350, d-bbr8 → d-bber-400, d-blr12 → d-bisr-450, d-brr16 → d-bier-500\n' +
     '- Border-radius pair keyword: d-btr-pill → d-bbsr-pill, d-brr-circle → d-bier-circle\n' +
     '- Old deprecated sizes (d-h72, d-w332, etc.) are left unchanged for manual review.\n',
-  patterns: ['**/*.{vue,html,js,ts,jsx,tsx,md,less,css}'],
+  patterns: ['**/*.{vue,html,js,ts,jsx,tsx,md,mdx,less,css}'],
   globbyConfig: {
-    ignore: ['**/dialtone_migration_helper/tests/**', '**/node_modules/**'],
+    // Include dotfiles/dotdirs so tooling directories like `.vuepress/baseComponents/`,
+    // `.storybook/`, and per-repo docs folders are scanned. Dotted build-output caches are
+    // explicitly excluded below.
+    dot: true,
+    ignore: [
+      '**/node_modules/**',
+      // Built outputs: regenerated on next build; rewriting selectors in co-selected rules
+      // (`.d-bar-350, .d-bar6 { ... }`) would corrupt them since the leading whitespace
+      // before the legacy selector looks like a class boundary to the regex.
+      '**/dist/**',
+      '**/build/**',
+      '**/lib/dist/**',
+      // Framework caches
+      '**/.cache/**',
+      '**/.vite/**',
+      '**/.vuepress/.cache/**',
+      '**/.vuepress/.temp/**',
+      '**/.vuepress/dist/**',
+      '**/.next/**',
+      '**/.nuxt/**',
+      '**/.turbo/**',
+      '**/.nx/**',
+      // Migration-helper test fixtures intentionally contain legacy class names.
+      '**/dialtone_migration_helper/tests/**',
+      // ESLint-plugin rules and tests inherently contain legacy class names as regex patterns
+      // and test inputs — they're the tool that detects the legacy classes, don't rewrite them.
+      '**/eslint-plugin-dialtone/**',
+    ],
   },
   expressions: [
     // ── Sizing: d-h{px} → d-h-{layout-stop} ──────────────────────────────

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/utility-class-to-token-stops-radius-examples.vue
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/utility-class-to-token-stops-radius-examples.vue
@@ -1,0 +1,66 @@
+<!--
+  Manual-test fixture for the radius portion of the `utility-class-to-token-stops` migration.
+  Point `pnpm dialtone-migration-helper` at this file to exercise every rewrite in one pass.
+
+  Expected transformations:
+    - d-bar{N}          → d-bar-{stop}
+    - d-btr{N}          → d-bbsr-{stop}
+    - d-bbr{N}          → d-bber-{stop}
+    - d-blr{N}          → d-bisr-{stop}
+    - d-brr{N}          → d-bier-{stop}
+    - d-{btr|bbr|blr|brr}-{pill|circle} → d-{bbsr|bber|bisr|bier}-{pill|circle}
+    - d-bar-pill, d-bar-circle, d-bar-unset: unchanged (canonical)
+-->
+<template>
+  <!-- All-corners: every legacy numeric stop -->
+  <div class="d-bar0">bar0 → bar-0</div>
+  <div class="d-bar1">bar1 → bar-100</div>
+  <div class="d-bar2">bar2 → bar-200</div>
+  <div class="d-bar4">bar4 → bar-300</div>
+  <div class="d-bar6">bar6 → bar-350</div>
+  <div class="d-bar8">bar8 → bar-400</div>
+  <div class="d-bar12">bar12 → bar-450</div>
+  <div class="d-bar16">bar16 → bar-500</div>
+  <div class="d-bar24">bar24 → bar-550 (new token)</div>
+  <div class="d-bar32">bar32 → bar-600</div>
+
+  <!-- Side-pair numeric: physical → logical -->
+  <div class="d-btr6">btr6 → bbsr-350 (top pair)</div>
+  <div class="d-bbr8">bbr8 → bber-400 (bottom pair)</div>
+  <div class="d-blr12">blr12 → bisr-450 (left pair)</div>
+  <div class="d-brr16">brr16 → bier-500 (right pair)</div>
+  <div class="d-btr24">btr24 → bbsr-550</div>
+  <div class="d-bbr32">bbr32 → bber-600</div>
+
+  <!-- Side-pair keyword: physical → logical -->
+  <div class="d-btr-pill">btr-pill → bbsr-pill</div>
+  <div class="d-btr-circle">btr-circle → bbsr-circle</div>
+  <div class="d-bbr-pill">bbr-pill → bber-pill</div>
+  <div class="d-blr-pill">blr-pill → bisr-pill</div>
+  <div class="d-brr-circle">brr-circle → bier-circle</div>
+
+  <!-- Canonical names: unchanged -->
+  <div class="d-bar-pill">bar-pill (unchanged)</div>
+  <div class="d-bar-circle">bar-circle (unchanged)</div>
+  <div class="d-bar-unset">bar-unset (unchanged)</div>
+
+  <!-- Mixed in one class attribute (multi-class rewrite) -->
+  <div class="d-p-200 d-bar6 d-btr8 d-blr-pill d-fc-primary">
+    mixed: bar6+btr8+blr-pill get rewritten; d-p-200 and d-fc-primary untouched
+  </div>
+
+  <!-- Class binding via object syntax (plain strings inside) -->
+  <div :class="{ 'd-bar6': rounded, 'd-btr-pill': pillTop }">
+    object-syntax binding
+  </div>
+
+  <!-- Class binding via template literal -->
+  <div :class="`d-bar${size} d-btr${size}`">
+    template-literal (only matches literal suffixes; dynamic interpolation stays as-is)
+  </div>
+
+  <!-- New logical names (already correct): not touched -->
+  <div class="d-bar-350 d-bbsr-400 d-bier-pill d-bssr-500 d-beer-circle">
+    new logical names stay as-is
+  </div>
+</template>

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/utility-class-to-token-stops.test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/utility-class-to-token-stops.test.mjs
@@ -88,4 +88,83 @@ describe('utility-class-to-token-stops config', () => {
       assert.equal(apply(input), expected);
     });
   });
+
+  // ─── Border-radius migration (DLT-3329) ───────────────────────────────
+
+  describe('border-radius all-corners — legacy pixel-suffix to token stop', () => {
+    const cases = [
+      ['d-bar0', 'd-bar-0'],
+      ['d-bar1', 'd-bar-100'],
+      ['d-bar2', 'd-bar-200'],
+      ['d-bar4', 'd-bar-300'],
+      ['d-bar6', 'd-bar-350'],
+      ['d-bar8', 'd-bar-400'],
+      ['d-bar12', 'd-bar-450'],
+      ['d-bar16', 'd-bar-500'],
+      ['d-bar24', 'd-bar-550'],
+      ['d-bar32', 'd-bar-600'],
+    ];
+    for (const [from, to] of cases) {
+      it(`${from} → ${to}`, () => {
+        assert.equal(apply(`<div class="${from}" />`), `<div class="${to}" />`);
+      });
+    }
+  });
+
+  describe('border-radius side-pair numeric — physical prefix to logical prefix', () => {
+    const cases = [
+      ['d-btr6', 'd-bbsr-350'],     // top    → block-start pair
+      ['d-bbr8', 'd-bber-400'],     // bottom → block-end pair
+      ['d-blr12', 'd-bisr-450'],    // left   → inline-start pair
+      ['d-brr16', 'd-bier-500'],    // right  → inline-end pair
+      ['d-btr24', 'd-bbsr-550'],    // new 550 stop
+      ['d-bbr32', 'd-bber-600'],
+      ['d-blr0', 'd-bisr-0'],
+      ['d-brr1', 'd-bier-100'],
+    ];
+    for (const [from, to] of cases) {
+      it(`${from} → ${to}`, () => {
+        assert.equal(apply(`<div class="${from}" />`), `<div class="${to}" />`);
+      });
+    }
+  });
+
+  describe('border-radius side-pair keyword — pill/circle', () => {
+    const cases = [
+      ['d-btr-pill', 'd-bbsr-pill'],
+      ['d-btr-circle', 'd-bbsr-circle'],
+      ['d-bbr-pill', 'd-bber-pill'],
+      ['d-bbr-circle', 'd-bber-circle'],
+      ['d-blr-pill', 'd-bisr-pill'],
+      ['d-blr-circle', 'd-bisr-circle'],
+      ['d-brr-pill', 'd-bier-pill'],
+      ['d-brr-circle', 'd-bier-circle'],
+    ];
+    for (const [from, to] of cases) {
+      it(`${from} → ${to}`, () => {
+        assert.equal(apply(`<div class="${from}" />`), `<div class="${to}" />`);
+      });
+    }
+  });
+
+  describe('border-radius canonical keyword names — unchanged', () => {
+    const cases = [
+      'd-bar-pill',
+      'd-bar-circle',
+      'd-bar-unset',
+    ];
+    for (const unchanged of cases) {
+      it(`${unchanged} stays as ${unchanged}`, () => {
+        assert.equal(apply(`<div class="${unchanged}" />`), `<div class="${unchanged}" />`);
+      });
+    }
+  });
+
+  describe('border-radius multi-class migration', () => {
+    it('rewrites mixed legacy classes in one string', () => {
+      const input = `<div class="d-bar6 d-btr8 d-blr-pill d-p-200" />`;
+      const expected = `<div class="d-bar-350 d-bbsr-400 d-bisr-pill d-p-200" />`;
+      assert.equal(apply(input), expected);
+    });
+  });
 });

--- a/packages/dialtone-css/lib/build/less/components/box.less
+++ b/packages/dialtone-css/lib/build/less/components/box.less
@@ -185,7 +185,7 @@
 .d-box--bc-positive-subtle { --box-bc: var(--dt-color-border-success-subtle); }
 .d-box--bc-positive-strong { --box-bc: var(--dt-color-border-success-strong); }
 
-@box-border-radius-values: 0, 100, 200, 300, 350, 400, 450, 500, 600;
+@box-border-radius-values: 0, 100, 200, 300, 350, 400, 450, 500, 550, 600;
 
 //  Border width — 7 axes × border-width scale
 .d-box--bw    { ._box-border-width(--box-bw); }

--- a/packages/dialtone-css/lib/build/less/utilities/borders.less
+++ b/packages/dialtone-css/lib/build/less/utilities/borders.less
@@ -107,59 +107,7 @@
 //  ============================================================================
 //  $  BORDER RADIUS
 //  ============================================================================
-//  $$ ALL
-//  ----------------------------------------------------------------------------
-.d-bar-circle { border-radius: var(--dt-size-radius-circle) !important; }
-.d-bar-pill { border-radius: var(--dt-size-radius-pill) !important; }
-.d-bar-unset { border-radius: unset !important; }
-
-//  $$ TOP
-//  ----------------------------------------------------------------------------
-.d-btr-circle {
-    border-start-start-radius: var(--dt-size-radius-circle) !important;
-    border-start-end-radius: var(--dt-size-radius-circle) !important;
-}
-
-.d-btr-pill {
-    border-start-start-radius: var(--dt-size-radius-pill) !important;
-    border-start-end-radius: var(--dt-size-radius-pill) !important;
-}
-
-//  $$ RIGHT
-//  ----------------------------------------------------------------------------
-.d-brr-circle {
-    border-start-end-radius: var(--dt-size-radius-circle) !important;
-    border-end-end-radius: var(--dt-size-radius-circle) !important;
-}
-
-.d-brr-pill {
-    border-start-end-radius: var(--dt-size-radius-pill) !important;
-    border-end-end-radius: var(--dt-size-radius-pill) !important;
-}
-
-//  $$ BOTTOM
-//  ----------------------------------------------------------------------------
-.d-bbr-circle {
-    border-end-end-radius: var(--dt-size-radius-circle) !important;
-     border-end-start-radius: var(--dt-size-radius-circle) !important;
-    }
-
-.d-bbr-pill {
-    border-end-end-radius: var(--dt-size-radius-pill) !important;
-    border-end-start-radius: var(--dt-size-radius-pill) !important;
- }
-
-//  $$ RIGHT
-//  ----------------------------------------------------------------------------
-.d-blr-circle {
-    border-start-start-radius: var(--dt-size-radius-circle) !important;
-    border-end-start-radius: var(--dt-size-radius-circle) !important;
-}
-
-.d-blr-pill {
-    border-start-start-radius: var(--dt-size-radius-pill) !important;
-    border-end-start-radius: var(--dt-size-radius-pill) !important;
-}
+//  Radius utilities are emitted by borderUtilities() in postcss/dialtone-generators.cjs.
 
 
 //  $$ STYLE

--- a/packages/dialtone-css/postcss/constants.cjs
+++ b/packages/dialtone-css/postcss/constants.cjs
@@ -22,18 +22,24 @@ module.exports = {
     0,
   ],
   FLEX_COLUMNS: 12,
-  BORDER_RADIUS_SIZES: {
-    0: 'radius-0',
-    1: 'radius-100',
-    2: 'radius-200',
-    4: 'radius-300',
-    6: 'radius-350',
-    8: 'radius-400',
-    12: 'radius-450',
-    16: 'radius-500',
-    24: '550', // TODO: Remove as it doesn't have a valid token?
-    32: 'radius-600',
-  },
+  // RADIUS_STOPS: drives border-radius utility generation.
+  // Each entry pairs a logical token stop with its legacy t-shirt pixel suffix
+  // so the generator can emit co-selected rules like `.d-bar-350, .d-bar6 { ... }`.
+  // Stops `pill` and `circle` use themselves as the legacy suffix (self-aliased).
+  RADIUS_STOPS: [
+    { stop: '0',      legacyPx: '0' },
+    { stop: '100',    legacyPx: '1' },
+    { stop: '200',    legacyPx: '2' },
+    { stop: '300',    legacyPx: '4' },
+    { stop: '350',    legacyPx: '6' },
+    { stop: '400',    legacyPx: '8' },
+    { stop: '450',    legacyPx: '12' },
+    { stop: '500',    legacyPx: '16' },
+    { stop: '550',    legacyPx: '24' },
+    { stop: '600',    legacyPx: '32' },
+    { stop: 'pill',   legacyPx: 'pill' },
+    { stop: 'circle', legacyPx: 'circle' },
+  ],
   GAP_SPACES: {
     0: '0',
     1: '100',

--- a/packages/dialtone-css/postcss/dialtone-docs.cjs
+++ b/packages/dialtone-css/postcss/dialtone-docs.cjs
@@ -49,6 +49,10 @@ function generateExclusionRegex () {
 const documentation = {};
 const CSSVarRegex = /var\(([^),]+)\)/g;
 
+// Plain class selector (`.d-foo-bar`). Intentionally excludes pseudo-classes, escape sequences,
+// and :where/:is wrappers so pseudo/state variants (`.h\:d-fc-primary:hover`) are skipped.
+const PLAIN_CLASS_SELECTOR = /^\.[\w-]+$/;
+
 /**
  * Metadata rules for utility classes
  * Maps patterns to metadata that should be added to the documentation
@@ -103,6 +107,30 @@ const metadataRules = [
       docs: 'https://dialtone.dialpad.com/utilities/grid/gap.html',
     },
   },
+  // Legacy border-radius all-corners numeric (deprecated per deprecated-radius-utility-classes.js eslint rule)
+  {
+    pattern: /^d-bar(0|1|2|4|6|8|12|16|24|32)$/,
+    metadata: {
+      deprecated: true,
+      discouraged: true,
+      category: 'borders',
+      reason: 'Legacy pixel-suffix border-radius utilities are deprecated. Use token-stop-indexed names instead',
+      alternatives: ['d-bar-{stop}'],
+      docs: 'https://dialtone.dialpad.com/utilities/borders/radius.html',
+    },
+  },
+  // Legacy border-radius physical side-pair numeric and keyword (deprecated)
+  {
+    pattern: /^d-(btr|bbr|brr|blr)(0|1|2|4|6|8|12|16|24|32|-pill|-circle)$/,
+    metadata: {
+      deprecated: true,
+      discouraged: true,
+      category: 'borders',
+      reason: 'Legacy physical-direction border-radius utilities are deprecated. Use logical-named token-stop-indexed equivalents',
+      alternatives: ['d-bbsr-{stop} (was d-btr*)', 'd-bber-{stop} (was d-bbr*)', 'd-bisr-{stop} (was d-blr*)', 'd-bier-{stop} (was d-brr*)'],
+      docs: 'https://dialtone.dialpad.com/utilities/borders/radius.html',
+    },
+  },
 ];
 
 /**
@@ -125,7 +153,16 @@ function getMetadataForClass (className) {
  * @param {import('postcss').Rule} rule
  */
 function generateUtilityClassDocumentation (docs, rule) {
-  const className = rule.selector.split(/(,|\s)/)[0].replace(/^\.(.+)/, '$1');
+  // A rule may have multiple comma-separated class selectors (e.g. logical + legacy co-selection
+  // like `.d-bar-350, .d-bar6`). Catalog each plain class separately so deprecated metadata
+  // attaches to the legacy name while the canonical logical name stays clean.
+  const classNames = rule.selector
+    .split(',')
+    .map(sel => sel.trim().split(/\s+/)[0])
+    .filter(sel => PLAIN_CLASS_SELECTOR.test(sel))
+    .map(sel => sel.slice(1));
+
+  if (classNames.length === 0) return;
 
   const values = rule.nodes.map(node => {
     const _value = node.value;
@@ -145,12 +182,13 @@ function generateUtilityClassDocumentation (docs, rule) {
     return result;
   });
 
-  const metadata = getMetadataForClass(className);
-
-  documentation[className] = {
-    values,
-    ...(metadata && { metadata }),
-  };
+  classNames.forEach(className => {
+    const metadata = getMetadataForClass(className);
+    documentation[className] = {
+      values,
+      ...(metadata && { metadata }),
+    };
+  });
 }
 
 /**

--- a/packages/dialtone-css/postcss/dialtone-generators.cjs
+++ b/packages/dialtone-css/postcss/dialtone-generators.cjs
@@ -8,7 +8,7 @@ const { Rule, AtRule } = require('postcss');
 
 // TODO: Move these constants to the _data directory
 const {
-  BORDER_RADIUS_SIZES,
+  RADIUS_STOPS,
   FLEX_COLUMNS,
   OPACITIES,
   REGEX_OPTIONS,
@@ -49,11 +49,18 @@ const generatedRules = {
   flexColumnEveryChild: [],
   flexColumnNthChild: [],
   flexDirectionColumn: [],
-  borderAllRadius: [],
-  borderTopRadius: [],
-  borderRightRadius: [],
-  borderBottomRadius: [],
-  borderLeftRadius: [],
+  // Border radius: cascade order per PR #1205 (DLT-3321) — all → pairs → single-corners,
+  // so singles win over pairs and pairs win over all. Within pairs: clockwise from top
+  // (block-start, inline-end, block-end, inline-start). Within singles: clockwise from top-left.
+  radiusAll: [],
+  radiusBbsr: [],
+  radiusBier: [],
+  radiusBber: [],
+  radiusBisr: [],
+  radiusBssr: [],
+  radiusBser: [],
+  radiusBeer: [],
+  radiusBesr: [],
   gap: [],
   rowGap: [],
   columnGap: [],
@@ -356,54 +363,70 @@ function flexColumnsUtilities (clonedSource, declaration) {
   }
 }
 
+// Radius scope definitions, ordered by cascade priority (matches generatedRules bucket order).
+// `legacyPrefix: null` means the scope is net-new with no legacy equivalent class.
+// Cascade: all → pairs (clockwise from top) → single corners (clockwise from top-left).
+// See PR #1205 / DLT-3321 for the source-order invariant.
+const RADIUS_SCOPES = [
+  { bucket: 'radiusAll',  logicalPrefix: 'bar',  legacyPrefix: 'bar',  properties: ['border-radius'] },
+  { bucket: 'radiusBbsr', logicalPrefix: 'bbsr', legacyPrefix: 'btr',  properties: ['border-start-start-radius', 'border-start-end-radius'] },
+  { bucket: 'radiusBier', logicalPrefix: 'bier', legacyPrefix: 'brr',  properties: ['border-start-end-radius', 'border-end-end-radius'] },
+  { bucket: 'radiusBber', logicalPrefix: 'bber', legacyPrefix: 'bbr',  properties: ['border-end-start-radius', 'border-end-end-radius'] },
+  { bucket: 'radiusBisr', logicalPrefix: 'bisr', legacyPrefix: 'blr',  properties: ['border-start-start-radius', 'border-end-start-radius'] },
+  { bucket: 'radiusBssr', logicalPrefix: 'bssr', legacyPrefix: null,   properties: ['border-start-start-radius'] },
+  { bucket: 'radiusBser', logicalPrefix: 'bser', legacyPrefix: null,   properties: ['border-start-end-radius'] },
+  { bucket: 'radiusBeer', logicalPrefix: 'beer', legacyPrefix: null,   properties: ['border-end-end-radius'] },
+  { bucket: 'radiusBesr', logicalPrefix: 'besr', legacyPrefix: null,   properties: ['border-end-start-radius'] },
+];
+
 /**
- * Generate border utility classes.
+ * Generate border-radius utility classes. 9 scopes × 12 stops = 108 token-indexed logical
+ * rules, plus `.d-bar-unset`. Legacy t-shirt-named classes (`.d-bar6`, `.d-btr6`, `.d-btr-pill`)
+ * are co-selected on the same rule as their logical replacement.
+ *
+ * Class roots are first-letter compression of the CSS property:
+ *   bar  = border-all-radius           (all four corners)
+ *   bbsr = border-block-start-radius   } synthetic side-pairs (2 longhands each)
+ *   bber = border-block-end-radius     }
+ *   bisr = border-inline-start-radius  }
+ *   bier = border-inline-end-radius    }
+ *   bssr = border-start-start-radius   } single logical corners (no legacy equivalent)
+ *   bser = border-start-end-radius     }
+ *   besr = border-end-start-radius     }
+ *   beer = border-end-end-radius       }
+ *
  * @param { Source } clonedSource
  * @param { Declaration } declaration
  */
 function borderUtilities (clonedSource, declaration) {
-  Object.keys(BORDER_RADIUS_SIZES)
-    .forEach(size => {
-      generatedRules.borderAllRadius.push(new Rule({
-        source: clonedSource,
-        selector: `.d-bar${size}`,
-        nodes: [
-          declaration.clone({ prop: 'border-radius', value: `var(--dt-size-${BORDER_RADIUS_SIZES[size]}) !important` }),
-        ],
-      }));
-      generatedRules.borderTopRadius.push(new Rule({
-        source: clonedSource,
-        selector: `.d-btr${size}`,
-        nodes: [
-          declaration.clone({ prop: 'border-start-start-radius', value: `var(--dt-size-${BORDER_RADIUS_SIZES[size]}) !important` }),
-          declaration.clone({ prop: 'border-start-end-radius', value: `var(--dt-size-${BORDER_RADIUS_SIZES[size]}) !important` }),
-        ],
-      }));
-      generatedRules.borderRightRadius.push(new Rule({
-        source: clonedSource,
-        selector: `.d-brr${size}`,
-        nodes: [
-          declaration.clone({ prop: 'border-start-end-radius', value: `var(--dt-size-${BORDER_RADIUS_SIZES[size]}) !important` }),
-          declaration.clone({ prop: 'border-end-end-radius', value: `var(--dt-size-${BORDER_RADIUS_SIZES[size]}) !important` }),
-        ],
-      }));
-      generatedRules.borderBottomRadius.push(new Rule({
-        source: clonedSource,
-        selector: `.d-bbr${size}`,
-        nodes: [
-          declaration.clone({ prop: 'border-end-start-radius', value: `var(--dt-size-${BORDER_RADIUS_SIZES[size]}) !important` }),
-          declaration.clone({ prop: 'border-end-end-radius', value: `var(--dt-size-${BORDER_RADIUS_SIZES[size]}) !important` }),
-        ],
-      }));
-      generatedRules.borderLeftRadius.push(new Rule({
-        source: clonedSource,
-        selector: `.d-blr${size}`,
-        nodes: [
-          declaration.clone({ prop: 'border-start-start-radius', value: `var(--dt-size-${BORDER_RADIUS_SIZES[size]}) !important` }),
-          declaration.clone({ prop: 'border-end-start-radius', value: `var(--dt-size-${BORDER_RADIUS_SIZES[size]}) !important` }),
-        ],
-      }));
+  RADIUS_STOPS.forEach(({ stop, legacyPx }) => {
+    const value = `var(--dt-size-radius-${stop}) !important`;
+    // Legacy numeric uses concat form (.d-bar6); keyword uses hyphenated form (.d-bar-pill).
+    const legacyInfix = legacyPx === 'pill' || legacyPx === 'circle' ? '-' : '';
+
+    RADIUS_SCOPES.forEach(({ bucket, logicalPrefix, legacyPrefix, properties }) => {
+      const logicalSelector = `.d-${logicalPrefix}-${stop}`;
+      let selector = logicalSelector;
+
+      if (legacyPrefix) {
+        const legacySelector = `.d-${legacyPrefix}${legacyInfix}${legacyPx}`;
+        // Skip redundant co-selection when logical === legacy (all-corners pill/circle).
+        if (legacySelector !== logicalSelector) {
+          selector = `${logicalSelector}, ${legacySelector}`;
+        }
+      }
+
+      const nodes = properties.map(prop => declaration.clone({ prop, value }));
+      generatedRules[bucket].push(new Rule({ source: clonedSource, selector, nodes }));
     });
+  });
+
+  // `.d-bar-unset` reset — emitted last in the all-corners bucket.
+  generatedRules.radiusAll.push(new Rule({
+    source: clonedSource,
+    selector: '.d-bar-unset',
+    nodes: [declaration.clone({ prop: 'border-radius', value: 'unset !important' })],
+  }));
 }
 
 /**

--- a/packages/dialtone-css/postcss/dialtone-generators.cjs
+++ b/packages/dialtone-css/postcss/dialtone-generators.cjs
@@ -49,9 +49,9 @@ const generatedRules = {
   flexColumnEveryChild: [],
   flexColumnNthChild: [],
   flexDirectionColumn: [],
-  // Border radius: cascade order per PR #1205 (DLT-3321) — all → pairs → single-corners,
-  // so singles win over pairs and pairs win over all. Within pairs: clockwise from top
-  // (block-start, inline-end, block-end, inline-start). Within singles: clockwise from top-left.
+  // Border radius cascade order: all → pairs → single-corners, so singles win over pairs
+  // and pairs win over all. Within pairs: clockwise from top (block-start, inline-end,
+  // block-end, inline-start). Within singles: clockwise from top-left.
   radiusAll: [],
   radiusBbsr: [],
   radiusBier: [],
@@ -363,10 +363,8 @@ function flexColumnsUtilities (clonedSource, declaration) {
   }
 }
 
-// Radius scope definitions, ordered by cascade priority (matches generatedRules bucket order).
+// Radius scope definitions, ordered by cascade priority.
 // `legacyPrefix: null` means the scope is net-new with no legacy equivalent class.
-// Cascade: all → pairs (clockwise from top) → single corners (clockwise from top-left).
-// See PR #1205 / DLT-3321 for the source-order invariant.
 const RADIUS_SCOPES = [
   { bucket: 'radiusAll',  logicalPrefix: 'bar',  legacyPrefix: 'bar',  properties: ['border-radius'] },
   { bucket: 'radiusBbsr', logicalPrefix: 'bbsr', legacyPrefix: 'btr',  properties: ['border-start-start-radius', 'border-start-end-radius'] },

--- a/packages/dialtone-tokens/tokens/base/default.json
+++ b/packages/dialtone-tokens/tokens/base/default.json
@@ -2360,6 +2360,10 @@
         "value": "16px",
         "type": "dimension"
       },
+      "550": {
+        "value": "24px",
+        "type": "dimension"
+      },
       "600": {
         "value": "32px",
         "type": "dimension"

--- a/packages/dialtone-vue/components/box/box.vue
+++ b/packages/dialtone-vue/components/box/box.vue
@@ -74,7 +74,7 @@ const props = defineProps({
 
   /**
    * Border radius. Maps to --dt-size-radius-* tokens.
-   * @values 0, 100, 200, 300, 350, 400, 450, 500, 600, pill, circle
+   * @values 0, 100, 200, 300, 350, 400, 450, 500, 550, 600, pill, circle
    */
   borderRadius: { type: String, default: undefined, validator: borderRadiusValidator },
 

--- a/packages/dialtone-vue/components/box/box_constants.js
+++ b/packages/dialtone-vue/components/box/box_constants.js
@@ -48,7 +48,7 @@ export const DT_BOX_BORDER_WIDTH_VALUES = ['0', '50', '100', '150', '200', '300'
  * Border radius values (maps to --dt-size-radius-* tokens).
  * @type {string[]}
  */
-export const DT_BOX_BORDER_RADIUS_VALUES = ['0', '100', '200', '300', '350', '400', '450', '500', '600', 'pill', 'circle'];
+export const DT_BOX_BORDER_RADIUS_VALUES = ['0', '100', '200', '300', '350', '400', '450', '500', '550', '600', 'pill', 'circle'];
 
 /**
  * Shadow values (maps to --dt-shadow-* tokens).

--- a/packages/eslint-plugin-dialtone/docs/rules/deprecated-pixel-utility-classes.md
+++ b/packages/eslint-plugin-dialtone/docs/rules/deprecated-pixel-utility-classes.md
@@ -1,0 +1,55 @@
+# deprecated-pixel-utility-classes
+
+Detects usage of pixel-based utility classes (`d-h16`, `d-p8`, `d-m8`, etc.) and auto-fixes to token-stop-based equivalents (`d-h-25`, `d-p-100`, `d-m-100`).
+
+## Rule Details
+
+Dialtone's sizing, spacing, gap, and position utilities moved from legacy pixel-suffixed names (`d-p8` = 8px) to token-stop-indexed names (`d-p-100` references `--dt-spacing-100`). Mirrors the `utility-class-to-token-stops` migration helper.
+
+This rule flags:
+
+- Sizing: `d-h16` → `d-h-25`, `d-w64` → `d-w-100`, `d-hmn96` → `d-hmn-150`, etc.
+- Margin: `d-m8` → `d-m-100`, `d-mt16` → `d-mt-200`, `d-mtn8` → `d-mt-n100` (negative)
+- Padding: `d-p8` → `d-p-100`, `d-pt16` → `d-pt-200`
+- Gap: `d-g8` → `d-g-100`, `d-rg16` → `d-rg-200`, `d-cg16` → `d-cg-200`
+- Position: `d-t8` → `d-t-100`, `d-tn8` → `d-t-n100` (negative)
+
+Small-value sizing stops fall back to pixel-indexed suffixes (off-scale exceptions from DLT-3330): `d-w1` → `d-w-1px`, `d-h2` → `d-h-2px`, `d-h24` → `d-h-24px`.
+
+This rule does NOT flag:
+
+- New token-stop classes (`d-h-25`, `d-p-100`, etc.)
+- Percentage classes (`d-h100p`, `d-w50p`)
+- Viewport classes (`d-h100vh`, `d-w100vw`, `d-h-dvh`)
+- Keyword classes (`d-h-auto`, `d-w-fit-content`)
+- Character-width classes (`d-w60ch`)
+- Logical property aliases (`d-mis-100`, `d-pbs-200`)
+- Custom non-Dialtone classes (`foo-d-h16`, `my-d-p8` are left alone)
+
+## Options
+
+No options.
+
+## Examples
+
+### Invalid
+
+```vue
+<template>
+  <div class="d-h16 d-w64" />
+  <div class="d-p8 d-mt16" />
+  <div class="d-mtn8" />
+  <div class="d-t8 d-l16" />
+</template>
+```
+
+### Valid (auto-fixed)
+
+```vue
+<template>
+  <div class="d-h-25 d-w-100" />
+  <div class="d-p-100 d-mt-200" />
+  <div class="d-mt-n100" />
+  <div class="d-t-100 d-l-200" />
+</template>
+```

--- a/packages/eslint-plugin-dialtone/docs/rules/deprecated-radius-utility-classes.md
+++ b/packages/eslint-plugin-dialtone/docs/rules/deprecated-radius-utility-classes.md
@@ -1,0 +1,68 @@
+# deprecated-radius-utility-classes
+
+Detects usage of legacy border-radius utility classes (`d-bar6`, `d-btr8`, `d-bbr-pill`, etc.) and auto-fixes them to the new token-stop-indexed logical names (`d-bar-350`, `d-bbsr-400`, `d-bber-pill`).
+
+## Rule Details
+
+Dialtone's border-radius utilities moved from legacy t-shirt-indexed pixel suffixes (`d-bar6` = 6px) to token-stop-indexed logical names (`d-bar-350` references `--dt-size-radius-350`). Physical side prefixes (`btr`/`bbr`/`blr`/`brr`) also moved to logical pair prefixes (`bbsr`/`bber`/`bisr`/`bier`).
+
+This rule flags:
+
+- All-corners numeric: `d-bar6` → `d-bar-350`, `d-bar24` → `d-bar-550`
+- Side-pair numeric: `d-btr6` → `d-bbsr-350`, `d-bbr8` → `d-bber-400`, `d-blr12` → `d-bisr-450`, `d-brr16` → `d-bier-500`
+- Side-pair keyword: `d-btr-pill` → `d-bbsr-pill`, `d-brr-circle` → `d-bier-circle`
+
+This rule does NOT flag:
+
+- New logical classes (`d-bar-350`, `d-bbsr-400`, etc.)
+- Keyword classes (`d-bar-pill`, `d-bar-circle`, `d-bar-unset`)
+- Single-corner logical classes (`d-bssr-*`, `d-bser-*`, `d-beer-*`, `d-besr-*`)
+- Custom non-Dialtone classes that contain legacy-looking substrings (e.g. `foo-d-bar6` is left alone)
+
+## Options
+
+No options.
+
+## Examples
+
+### Invalid
+
+```vue
+<template>
+  <div class="d-bar6 d-btr8" />
+  <div class="d-bbr-pill" />
+</template>
+```
+
+### Valid (auto-fixed)
+
+```vue
+<template>
+  <div class="d-bar-350 d-bbsr-400" />
+  <div class="d-bber-pill" />
+</template>
+```
+
+## Stop Mapping
+
+| Legacy px | Token stop |
+|-----------|------------|
+| 0 | 0 |
+| 1 | 100 |
+| 2 | 200 |
+| 4 | 300 |
+| 6 | 350 |
+| 8 | 400 |
+| 12 | 450 |
+| 16 | 500 |
+| 24 | 550 |
+| 32 | 600 |
+
+## Pair Prefix Mapping
+
+| Physical | Logical | CSS properties |
+|----------|---------|----------------|
+| btr | bbsr | `border-start-start-radius`, `border-start-end-radius` |
+| bbr | bber | `border-end-start-radius`, `border-end-end-radius` |
+| blr | bisr | `border-start-start-radius`, `border-end-start-radius` |
+| brr | bier | `border-start-end-radius`, `border-end-end-radius` |

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-pixel-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-pixel-utility-classes.js
@@ -100,7 +100,9 @@ module.exports = {
           fix (fixer) {
             const rewritten = rewriteClassString(classes);
             if (rewritten === classes) return null;
-            const quote = context.sourceCode.getText(node.value)[0] ?? '"';
+            // Preserve the attribute's quoting style (single, double, or unquoted).
+            const firstChar = sourceCode.getText(node.value)[0];
+            const quote = firstChar === '"' || firstChar === '\'' ? firstChar : '';
             return fixer.replaceText(node.value, `${quote}${rewritten}${quote}`);
           },
         });

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-pixel-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-pixel-utility-classes.js
@@ -1,45 +1,75 @@
 /**
  * @fileoverview Detects usage of pixel-based utility classes (d-h16, d-p8, d-m8, etc.)
  * which should be replaced with token-stop-based equivalents (d-h-25, d-p-100, d-m-100).
+ * Autofixes via `lint-staged` — mirrors the `utility-class-to-token-stops` migration helper.
  * @author Joshua Hynes
  */
 'use strict';
 
-//------------------------------------------------------------------------------
-// Rule Definition
-//------------------------------------------------------------------------------
+// MUST STAY IN SYNC with:
+// - LAYOUT_STOPS, MARGIN_SIZES_SPACING, MARGIN_SIZES_LAYOUT in dialtone-css/postcss/constants.cjs
+// - SIZING_MAP, SPACING_MAP, NEGATIVE_SPACING_MAP, SPACING_LAYOUT_MAP in
+//   dialtone-css/.../migration_helper/configs/utility-class-to-token-stops.mjs
 
-// Pixel values that have token-stop equivalents
-// MUST STAY IN SYNC with LAYOUT_STOPS, MARGIN_SIZES_SPACING, MARGIN_SIZES_LAYOUT,
-// and NEGATIVE_SPACING_MAP in dialtone-css/postcss/constants.cjs
-// Sizing: scale-indexed layout stops (16+) AND off-scale pixel-indexed exceptions
-// from DLT-3330 (1, 2, 8, 20, 24). Ordered by descending string-length then descending
-// value so regex alternation matches longest first (d-w1024 resolves `1024`, not `1`).
+// Ordered by descending string-length then descending value so regex alternation matches
+// longest first (d-w1024 resolves `1024`, not `1`).
 const SIZING_PIXELS = '1024|992|960|928|896|864|832|800|768|736|704|672|640|608|576|544|512|480|448|416|384|352|320|288|256|224|192|160|128|112|96|80|64|48|32|24|20|16|8|2|1';
-// Spacing: spacing stops (0-64px) + layout stops for margin/padding (96, 128)
 const SPACING_PIXELS = '0|1|2|4|6|8|10|12|14|16|20|24|32|48|64|96|128';
-// Negative spacing
 const NEGATIVE_PIXELS = '1|2|4|6|8|10|12|14|16|24|32|48|64';
 
-// Build patterns for each category
-// Sizing: d-h16, d-w64, d-hmn96, d-hmx128, d-wmn32, d-wmx512
-const SIZING_PATTERN = `d-(?:h|w|hmn|hmx|wmn|wmx)(?:${SIZING_PIXELS})\\b`;
-// Margin: d-m8, d-mt16, d-mr8, d-mb8, d-ml8, d-mx8, d-my8
-const MARGIN_PATTERN = `d-m(?:t|r|b|l|x|y)?(?:${SPACING_PIXELS})\\b`;
-// Negative margin: d-mtn8, d-mrn8, d-mbn8, d-mln8, d-mxn8, d-myn8, d-mn8
-const NEGATIVE_MARGIN_PATTERN = `d-m(?:t|r|b|l|x|y)?n(?:${NEGATIVE_PIXELS})\\b`;
-// Padding: d-p8, d-pt16, d-pr8, d-pb8, d-pl8, d-px8, d-py8
-const PADDING_PATTERN = `d-p(?:t|r|b|l|x|y)?(?:${SPACING_PIXELS})\\b`;
-// Gap: d-g8, d-rg8, d-cg8
-const GAP_PATTERN = `d-(?:g|rg|cg)(?:${SPACING_PIXELS})\\b`;
-// Position: d-t8, d-r8, d-b8, d-l8, d-x8, d-y8, d-all8
-const POSITION_PATTERN = `d-(?:t|r|b|l|x|y|all)(?:${SPACING_PIXELS})\\b`;
-// Negative position: d-tn8, d-rn8, d-bn8, d-ln8, d-xn8, d-yn8, d-alln8
-const NEGATIVE_POSITION_PATTERN = `d-(?:t|r|b|l|x|y|all)n(?:${NEGATIVE_PIXELS})\\b`;
+// Sizing autofix: scale-indexed layout stops + off-scale pixel-indexed exceptions (DLT-3330).
+const SIZING_MAP = {
+  1: '1px', 2: '2px', 8: '8px', 20: '20px', 24: '24px',
+  16: '25', 32: '50', 48: '75', 64: '100', 80: '125', 96: '150',
+  112: '175', 128: '200', 160: '250', 192: '300', 224: '350', 256: '400',
+  288: '450', 320: '500', 352: '550', 384: '600', 416: '650', 448: '700',
+  480: '750', 512: '800', 544: '850', 576: '900', 608: '950', 640: '1000',
+  672: '1050', 704: '1100', 736: '1150', 768: '1200', 800: '1250',
+  832: '1300', 864: '1350', 896: '1400', 928: '1450', 960: '1500',
+  992: '1550', 1024: '1600',
+};
 
-const COMBINED_PATTERN = new RegExp(
-  `(?:${SIZING_PATTERN}|${NEGATIVE_MARGIN_PATTERN}|${MARGIN_PATTERN}|${PADDING_PATTERN}|${GAP_PATTERN}|${NEGATIVE_POSITION_PATTERN}|${POSITION_PATTERN})`,
-);
+const SPACING_MAP = {
+  0: '0', 1: '1', 2: '25', 4: '50', 6: '75', 8: '100',
+  10: '125', 12: '150', 14: '175', 16: '200', 20: '250', 24: '300',
+  32: '400', 48: '600', 64: '800',
+};
+
+const NEGATIVE_SPACING_MAP = {
+  1: '1', 2: '25', 4: '50', 6: '75', 8: '100',
+  10: '125', 12: '150', 14: '175', 16: '200', 20: '250', 24: '300',
+  32: '400', 48: '600', 64: '800',
+};
+
+const SPACING_LAYOUT_MAP = { 96: '150', 128: '200' };
+
+// Per-category regexes with capture groups. Negative variants precede positive so `d-mtn8`
+// matches the negative pattern (rule order is load-order in `rewriteClassString`).
+const SIZING_RE          = new RegExp(`\\bd-(h|w|hmn|hmx|wmn|wmx)(${SIZING_PIXELS})\\b`, 'g');
+const NEGATIVE_MARGIN_RE = new RegExp(`\\bd-m(t|r|b|l|x|y)?n(${NEGATIVE_PIXELS})\\b`, 'g');
+const MARGIN_RE          = new RegExp(`\\bd-m(t|r|b|l|x|y)?(${SPACING_PIXELS})\\b`, 'g');
+const PADDING_RE         = new RegExp(`\\bd-p(t|r|b|l|x|y)?(${SPACING_PIXELS})\\b`, 'g');
+const GAP_RE             = new RegExp(`\\bd-(g|rg|cg)(${SPACING_PIXELS})\\b`, 'g');
+const NEGATIVE_POS_RE    = new RegExp(`\\bd-(t|r|b|l|x|y|all)n(${NEGATIVE_PIXELS})\\b`, 'g');
+const POSITION_RE        = new RegExp(`\\bd-(t|r|b|l|x|y|all)(${SPACING_PIXELS})\\b`, 'g');
+
+// Detection-only combined pattern (non-global) for fast early-exit in the visitor.
+const DETECT = new RegExp([SIZING_RE, NEGATIVE_MARGIN_RE, MARGIN_RE, PADDING_RE, GAP_RE, NEGATIVE_POS_RE, POSITION_RE].map(r => r.source).join('|'));
+
+/**
+ * Rewrite a class attribute string from legacy pixel-suffix to token-stop naming.
+ * Returns the input unchanged when no rewrites apply.
+ */
+function rewriteClassString (input) {
+  return input
+    .replace(NEGATIVE_MARGIN_RE, (m, dir, px) => NEGATIVE_SPACING_MAP[px] ? `d-m${dir ?? ''}-n${NEGATIVE_SPACING_MAP[px]}` : m)
+    .replace(NEGATIVE_POS_RE,    (m, dir, px) => NEGATIVE_SPACING_MAP[px] ? `d-${dir}-n${NEGATIVE_SPACING_MAP[px]}` : m)
+    .replace(SIZING_RE,          (m, dir, px) => SIZING_MAP[px] ? `d-${dir}-${SIZING_MAP[px]}` : m)
+    .replace(MARGIN_RE,          (m, dir, px) => { const stop = SPACING_MAP[px] ?? SPACING_LAYOUT_MAP[px]; return stop ? `d-m${dir ?? ''}-${stop}` : m; })
+    .replace(PADDING_RE,         (m, dir, px) => { const stop = SPACING_MAP[px] ?? SPACING_LAYOUT_MAP[px]; return stop ? `d-p${dir ?? ''}-${stop}` : m; })
+    .replace(GAP_RE,             (m, dir, px) => SPACING_MAP[px] ? `d-${dir}-${SPACING_MAP[px]}` : m)
+    .replace(POSITION_RE,        (m, dir, px) => { const stop = SPACING_MAP[px] ?? SPACING_LAYOUT_MAP[px]; return stop ? `d-${dir}-${stop}` : m; });
+}
 
 module.exports = {
   meta: {
@@ -49,10 +79,10 @@ module.exports = {
       recommended: false,
       url: 'https://github.com/dialpad/dialtone/blob/staging/packages/eslint-plugin-dialtone/docs/rules/deprecated-pixel-utility-classes.md',
     },
-    fixable: null,
+    fixable: 'code',
     schema: [],
     messages: {
-      deprecatedPixelClass: `Pixel-based utility classes are deprecated. Use token-stop-based equivalents instead (e.g. d-h16 → d-h-25, d-p8 → d-p-100, d-w1 → d-w-1px). Run the "utility-class-to-token-stops" migration helper to update automatically.`,
+      deprecatedPixelClass: 'Pixel-based utility classes are deprecated. Use token-stop-based equivalents instead (e.g. d-h16 → d-h-25, d-p8 → d-p-100, d-w1 → d-w-1px).',
     },
   },
 
@@ -60,15 +90,20 @@ module.exports = {
     const sourceCode = context.sourceCode ?? context.getSourceCode();
     return sourceCode.parserServices.defineTemplateBodyVisitor({
       VAttribute (node) {
-        if (node.key.name === 'class') {
-          const classes = node.value.value;
-          if (COMBINED_PATTERN.test(classes)) {
-            context.report({
-              node,
-              messageId: 'deprecatedPixelClass',
-            });
-          }
-        }
+        if (node.key.name !== 'class') return;
+        const classes = node.value?.value;
+        if (!classes || !DETECT.test(classes)) return;
+
+        context.report({
+          node,
+          messageId: 'deprecatedPixelClass',
+          fix (fixer) {
+            const rewritten = rewriteClassString(classes);
+            if (rewritten === classes) return null;
+            const quote = context.sourceCode.getText(node.value)[0] ?? '"';
+            return fixer.replaceText(node.value, `${quote}${rewritten}${quote}`);
+          },
+        });
       },
     });
   },

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-pixel-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-pixel-utility-classes.js
@@ -17,7 +17,7 @@ const { START, END, buildDetectRegex, createClassAttributeRule } = require('../u
 // longest first (d-w1024 resolves `1024`, not `1`).
 const SIZING_PIXELS = '1024|992|960|928|896|864|832|800|768|736|704|672|640|608|576|544|512|480|448|416|384|352|320|288|256|224|192|160|128|112|96|80|64|48|32|24|20|16|8|2|1';
 const SPACING_PIXELS = '0|1|2|4|6|8|10|12|14|16|20|24|32|48|64|96|128';
-const NEGATIVE_PIXELS = '1|2|4|6|8|10|12|14|16|24|32|48|64';
+const NEGATIVE_PIXELS = '1|2|4|6|8|10|12|14|16|20|24|32|48|64';
 
 // Sizing autofix: scale-indexed layout stops + off-scale pixel-indexed exceptions (DLT-3330).
 const SIZING_MAP = {

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-pixel-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-pixel-utility-classes.js
@@ -6,6 +6,8 @@
  */
 'use strict';
 
+const { START, END, buildDetectRegex, createClassAttributeRule } = require('../util/class-attribute-rule');
+
 // MUST STAY IN SYNC with:
 // - LAYOUT_STOPS, MARGIN_SIZES_SPACING, MARGIN_SIZES_LAYOUT in dialtone-css/postcss/constants.cjs
 // - SIZING_MAP, SPACING_MAP, NEGATIVE_SPACING_MAP, SPACING_LAYOUT_MAP in
@@ -45,11 +47,6 @@ const SPACING_LAYOUT_MAP = { 96: '150', 128: '200' };
 
 // Per-category regexes with capture groups. Negative variants precede positive so `d-mtn8`
 // matches the negative pattern (rule order is load-order in `rewriteClassString`).
-//
-// Token boundaries: `(?<=^|\s)` / `(?=$|\s)` anchor to start/whitespace rather than `\b`.
-// `\b` treats `-` as a non-word char, so `\bd-h16\b` wrongly matches inside `foo-d-h16`.
-const START = '(?<=^|\\s)';
-const END = '(?=$|\\s)';
 const SIZING_RE          = new RegExp(`${START}d-(h|w|hmn|hmx|wmn|wmx)(${SIZING_PIXELS})${END}`, 'g');
 const NEGATIVE_MARGIN_RE = new RegExp(`${START}d-m(t|r|b|l|x|y)?n(${NEGATIVE_PIXELS})${END}`, 'g');
 const MARGIN_RE          = new RegExp(`${START}d-m(t|r|b|l|x|y)?(${SPACING_PIXELS})${END}`, 'g');
@@ -58,8 +55,7 @@ const GAP_RE             = new RegExp(`${START}d-(g|rg|cg)(${SPACING_PIXELS})${E
 const NEGATIVE_POS_RE    = new RegExp(`${START}d-(t|r|b|l|x|y|all)n(${NEGATIVE_PIXELS})${END}`, 'g');
 const POSITION_RE        = new RegExp(`${START}d-(t|r|b|l|x|y|all)(${SPACING_PIXELS})${END}`, 'g');
 
-// Detection-only combined pattern (non-global) for fast early-exit in the visitor.
-const DETECT = new RegExp([SIZING_RE, NEGATIVE_MARGIN_RE, MARGIN_RE, PADDING_RE, GAP_RE, NEGATIVE_POS_RE, POSITION_RE].map(r => r.source).join('|'));
+const DETECT = buildDetectRegex([SIZING_RE, NEGATIVE_MARGIN_RE, MARGIN_RE, PADDING_RE, GAP_RE, NEGATIVE_POS_RE, POSITION_RE]);
 
 /**
  * Rewrite a class attribute string from legacy pixel-suffix to token-stop naming.
@@ -91,27 +87,9 @@ module.exports = {
     },
   },
 
-  create (context) {
-    const sourceCode = context.sourceCode ?? context.getSourceCode();
-    return sourceCode.parserServices.defineTemplateBodyVisitor({
-      VAttribute (node) {
-        if (node.key.name !== 'class') return;
-        const classes = node.value?.value;
-        if (!classes || !DETECT.test(classes)) return;
-
-        context.report({
-          node,
-          messageId: 'deprecatedPixelClass',
-          fix (fixer) {
-            const rewritten = rewriteClassString(classes);
-            if (rewritten === classes) return null;
-            // Preserve the attribute's quoting style (single, double, or unquoted).
-            const firstChar = sourceCode.getText(node.value)[0];
-            const quote = firstChar === '"' || firstChar === '\'' ? firstChar : '';
-            return fixer.replaceText(node.value, `${quote}${rewritten}${quote}`);
-          },
-        });
-      },
-    });
-  },
+  create: createClassAttributeRule({
+    detect: DETECT,
+    rewrite: rewriteClassString,
+    messageId: 'deprecatedPixelClass',
+  }),
 };

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-pixel-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-pixel-utility-classes.js
@@ -45,13 +45,18 @@ const SPACING_LAYOUT_MAP = { 96: '150', 128: '200' };
 
 // Per-category regexes with capture groups. Negative variants precede positive so `d-mtn8`
 // matches the negative pattern (rule order is load-order in `rewriteClassString`).
-const SIZING_RE          = new RegExp(`\\bd-(h|w|hmn|hmx|wmn|wmx)(${SIZING_PIXELS})\\b`, 'g');
-const NEGATIVE_MARGIN_RE = new RegExp(`\\bd-m(t|r|b|l|x|y)?n(${NEGATIVE_PIXELS})\\b`, 'g');
-const MARGIN_RE          = new RegExp(`\\bd-m(t|r|b|l|x|y)?(${SPACING_PIXELS})\\b`, 'g');
-const PADDING_RE         = new RegExp(`\\bd-p(t|r|b|l|x|y)?(${SPACING_PIXELS})\\b`, 'g');
-const GAP_RE             = new RegExp(`\\bd-(g|rg|cg)(${SPACING_PIXELS})\\b`, 'g');
-const NEGATIVE_POS_RE    = new RegExp(`\\bd-(t|r|b|l|x|y|all)n(${NEGATIVE_PIXELS})\\b`, 'g');
-const POSITION_RE        = new RegExp(`\\bd-(t|r|b|l|x|y|all)(${SPACING_PIXELS})\\b`, 'g');
+//
+// Token boundaries: `(?<=^|\s)` / `(?=$|\s)` anchor to start/whitespace rather than `\b`.
+// `\b` treats `-` as a non-word char, so `\bd-h16\b` wrongly matches inside `foo-d-h16`.
+const START = '(?<=^|\\s)';
+const END = '(?=$|\\s)';
+const SIZING_RE          = new RegExp(`${START}d-(h|w|hmn|hmx|wmn|wmx)(${SIZING_PIXELS})${END}`, 'g');
+const NEGATIVE_MARGIN_RE = new RegExp(`${START}d-m(t|r|b|l|x|y)?n(${NEGATIVE_PIXELS})${END}`, 'g');
+const MARGIN_RE          = new RegExp(`${START}d-m(t|r|b|l|x|y)?(${SPACING_PIXELS})${END}`, 'g');
+const PADDING_RE         = new RegExp(`${START}d-p(t|r|b|l|x|y)?(${SPACING_PIXELS})${END}`, 'g');
+const GAP_RE             = new RegExp(`${START}d-(g|rg|cg)(${SPACING_PIXELS})${END}`, 'g');
+const NEGATIVE_POS_RE    = new RegExp(`${START}d-(t|r|b|l|x|y|all)n(${NEGATIVE_PIXELS})${END}`, 'g');
+const POSITION_RE        = new RegExp(`${START}d-(t|r|b|l|x|y|all)(${SPACING_PIXELS})${END}`, 'g');
 
 // Detection-only combined pattern (non-global) for fast early-exit in the visitor.
 const DETECT = new RegExp([SIZING_RE, NEGATIVE_MARGIN_RE, MARGIN_RE, PADDING_RE, GAP_RE, NEGATIVE_POS_RE, POSITION_RE].map(r => r.source).join('|'));

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-radius-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-radius-utility-classes.js
@@ -26,9 +26,13 @@ const PAIR_PREFIX_MAP = {
 const NUMERIC_SUFFIXES = Object.keys(RADIUS_STOP_MAP).sort((a, b) => b.length - a.length || Number(b) - Number(a)).join('|');
 const PAIR_PREFIXES = Object.keys(PAIR_PREFIX_MAP).join('|');
 
-const ALL_CORNERS_NUMERIC = new RegExp(`\\bd-bar(${NUMERIC_SUFFIXES})\\b`, 'g');
-const PAIR_NUMERIC        = new RegExp(`\\bd-(${PAIR_PREFIXES})(${NUMERIC_SUFFIXES})\\b`, 'g');
-const PAIR_KEYWORD        = new RegExp(`\\bd-(${PAIR_PREFIXES})-(pill|circle)\\b`, 'g');
+// Token boundaries: `(?<=^|\s)` / `(?=$|\s)` anchor to start/whitespace rather than `\b`.
+// `\b` treats `-` as a non-word char, so `\bd-btr6\b` wrongly matches inside `foo-d-btr6`.
+const START = '(?<=^|\\s)';
+const END = '(?=$|\\s)';
+const ALL_CORNERS_NUMERIC = new RegExp(`${START}d-bar(${NUMERIC_SUFFIXES})${END}`, 'g');
+const PAIR_NUMERIC        = new RegExp(`${START}d-(${PAIR_PREFIXES})(${NUMERIC_SUFFIXES})${END}`, 'g');
+const PAIR_KEYWORD        = new RegExp(`${START}d-(${PAIR_PREFIXES})-(pill|circle)${END}`, 'g');
 
 // Non-global detection pattern for fast early-exit.
 const DETECT = new RegExp([ALL_CORNERS_NUMERIC, PAIR_NUMERIC, PAIR_KEYWORD].map(r => r.source).join('|'));

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-radius-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-radius-utility-classes.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+const { START, END, buildDetectRegex, createClassAttributeRule } = require('../util/class-attribute-rule');
+
 // MUST STAY IN SYNC with:
 // - RADIUS_STOPS in dialtone-css/postcss/constants.cjs
 // - RADIUS_MAP / RADIUS_PAIR_PREFIX_MAP in dialtone-css/.../migration_helper/configs/utility-class-to-token-stops.mjs
@@ -26,16 +28,11 @@ const PAIR_PREFIX_MAP = {
 const NUMERIC_SUFFIXES = Object.keys(RADIUS_STOP_MAP).sort((a, b) => b.length - a.length || Number(b) - Number(a)).join('|');
 const PAIR_PREFIXES = Object.keys(PAIR_PREFIX_MAP).join('|');
 
-// Token boundaries: `(?<=^|\s)` / `(?=$|\s)` anchor to start/whitespace rather than `\b`.
-// `\b` treats `-` as a non-word char, so `\bd-btr6\b` wrongly matches inside `foo-d-btr6`.
-const START = '(?<=^|\\s)';
-const END = '(?=$|\\s)';
 const ALL_CORNERS_NUMERIC = new RegExp(`${START}d-bar(${NUMERIC_SUFFIXES})${END}`, 'g');
 const PAIR_NUMERIC        = new RegExp(`${START}d-(${PAIR_PREFIXES})(${NUMERIC_SUFFIXES})${END}`, 'g');
 const PAIR_KEYWORD        = new RegExp(`${START}d-(${PAIR_PREFIXES})-(pill|circle)${END}`, 'g');
 
-// Non-global detection pattern for fast early-exit.
-const DETECT = new RegExp([ALL_CORNERS_NUMERIC, PAIR_NUMERIC, PAIR_KEYWORD].map(r => r.source).join('|'));
+const DETECT = buildDetectRegex([ALL_CORNERS_NUMERIC, PAIR_NUMERIC, PAIR_KEYWORD]);
 
 function rewriteClassString (input) {
   return input
@@ -59,27 +56,9 @@ module.exports = {
     },
   },
 
-  create (context) {
-    const sourceCode = context.sourceCode ?? context.getSourceCode();
-    return sourceCode.parserServices.defineTemplateBodyVisitor({
-      VAttribute (node) {
-        if (node.key.name !== 'class') return;
-        const classes = node.value?.value;
-        if (!classes || !DETECT.test(classes)) return;
-
-        context.report({
-          node,
-          messageId: 'deprecatedRadiusClass',
-          fix (fixer) {
-            const rewritten = rewriteClassString(classes);
-            if (rewritten === classes) return null;
-            // Preserve the attribute's quoting style (single, double, or unquoted).
-            const firstChar = sourceCode.getText(node.value)[0];
-            const quote = firstChar === '"' || firstChar === '\'' ? firstChar : '';
-            return fixer.replaceText(node.value, `${quote}${rewritten}${quote}`);
-          },
-        });
-      },
-    });
-  },
+  create: createClassAttributeRule({
+    detect: DETECT,
+    rewrite: rewriteClassString,
+    messageId: 'deprecatedRadiusClass',
+  }),
 };

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-radius-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-radius-utility-classes.js
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Detects usage of legacy border-radius utility classes (d-bar6, d-btr8, d-bbr-pill,
+ * etc.) and autofixes them to the new token-stop-indexed logical names (d-bar-350, d-bbsr-400,
+ * d-bber-pill).
+ */
+'use strict';
+
+// MUST STAY IN SYNC with:
+// - RADIUS_STOPS in dialtone-css/postcss/constants.cjs
+// - RADIUS_MAP / RADIUS_PAIR_PREFIX_MAP in dialtone-css/.../migration_helper/configs/utility-class-to-token-stops.mjs
+
+const RADIUS_STOP_MAP = {
+  0: '0', 1: '100', 2: '200', 4: '300', 6: '350',
+  8: '400', 12: '450', 16: '500', 24: '550', 32: '600',
+};
+
+const PAIR_PREFIX_MAP = {
+  btr: 'bbsr', // top    → block-start pair
+  bbr: 'bber', // bottom → block-end pair
+  blr: 'bisr', // left   → inline-start pair
+  brr: 'bier', // right  → inline-end pair
+};
+
+// Ordered by descending string length so regex alternation matches longest first
+// (.d-bar32 resolves as `32`, not `3`).
+const NUMERIC_SUFFIXES = Object.keys(RADIUS_STOP_MAP).sort((a, b) => b.length - a.length || Number(b) - Number(a)).join('|');
+const PAIR_PREFIXES = Object.keys(PAIR_PREFIX_MAP).join('|');
+
+const ALL_CORNERS_NUMERIC = new RegExp(`\\bd-bar(${NUMERIC_SUFFIXES})\\b`, 'g');
+const PAIR_NUMERIC        = new RegExp(`\\bd-(${PAIR_PREFIXES})(${NUMERIC_SUFFIXES})\\b`, 'g');
+const PAIR_KEYWORD        = new RegExp(`\\bd-(${PAIR_PREFIXES})-(pill|circle)\\b`, 'g');
+
+// Non-global detection pattern for fast early-exit.
+const DETECT = new RegExp([ALL_CORNERS_NUMERIC, PAIR_NUMERIC, PAIR_KEYWORD].map(r => r.source).join('|'));
+
+function rewriteClassString (input) {
+  return input
+    .replace(ALL_CORNERS_NUMERIC, (_, px) => `d-bar-${RADIUS_STOP_MAP[px]}`)
+    .replace(PAIR_NUMERIC, (_, legacyPrefix, px) => `d-${PAIR_PREFIX_MAP[legacyPrefix]}-${RADIUS_STOP_MAP[px]}`)
+    .replace(PAIR_KEYWORD, (_, legacyPrefix, keyword) => `d-${PAIR_PREFIX_MAP[legacyPrefix]}-${keyword}`);
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Legacy border-radius utility classes (d-bar6, d-btr8, d-bbr-pill) are deprecated. Use token-stop-indexed logical names (d-bar-350, d-bbsr-400, d-bber-pill).',
+      recommended: false,
+      url: 'https://github.com/dialpad/dialtone/blob/staging/packages/eslint-plugin-dialtone/docs/rules/deprecated-radius-utility-classes.md',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      deprecatedRadiusClass: 'Legacy border-radius utility classes are deprecated. Use token-stop-indexed logical names instead (e.g. d-bar6 → d-bar-350, d-btr6 → d-bbsr-350, d-btr-pill → d-bbsr-pill).',
+    },
+  },
+
+  create (context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    return sourceCode.parserServices.defineTemplateBodyVisitor({
+      VAttribute (node) {
+        if (node.key.name !== 'class') return;
+        const classes = node.value?.value;
+        if (!classes || !DETECT.test(classes)) return;
+
+        context.report({
+          node,
+          messageId: 'deprecatedRadiusClass',
+          fix (fixer) {
+            const rewritten = rewriteClassString(classes);
+            if (rewritten === classes) return null;
+            const quote = context.sourceCode.getText(node.value)[0] ?? '"';
+            return fixer.replaceText(node.value, `${quote}${rewritten}${quote}`);
+          },
+        });
+      },
+    });
+  },
+};

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-radius-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-radius-utility-classes.js
@@ -69,7 +69,9 @@ module.exports = {
           fix (fixer) {
             const rewritten = rewriteClassString(classes);
             if (rewritten === classes) return null;
-            const quote = context.sourceCode.getText(node.value)[0] ?? '"';
+            // Preserve the attribute's quoting style (single, double, or unquoted).
+            const firstChar = sourceCode.getText(node.value)[0];
+            const quote = firstChar === '"' || firstChar === '\'' ? firstChar : '';
             return fixer.replaceText(node.value, `${quote}${rewritten}${quote}`);
           },
         });

--- a/packages/eslint-plugin-dialtone/lib/util/class-attribute-rule.js
+++ b/packages/eslint-plugin-dialtone/lib/util/class-attribute-rule.js
@@ -1,0 +1,46 @@
+/**
+ * Helpers for ESLint rules that autofix deprecated CSS utility classes in
+ * Vue template class attributes.
+ */
+'use strict';
+
+// Token-boundary anchors. `\b` treats `-` as a non-word char, so `\bd-h16\b`
+// would match inside `foo-d-h16` — use whitespace/start/end instead.
+const START = '(?<=^|\\s)';
+const END = '(?=$|\\s)';
+
+function buildDetectRegex (regexes) {
+  return new RegExp(regexes.map(r => r.source).join('|'));
+}
+
+/**
+ * Returns a `create` function for a rule that detects and autofixes deprecated
+ * class names in `class` attributes on Vue template nodes. Preserves the
+ * attribute's quoting style (double, single, or unquoted).
+ */
+function createClassAttributeRule ({ detect, rewrite, messageId }) {
+  return (context) => {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    return sourceCode.parserServices.defineTemplateBodyVisitor({
+      VAttribute (node) {
+        if (node.key.name !== 'class') return;
+        const classes = node.value?.value;
+        if (!classes || !detect.test(classes)) return;
+
+        context.report({
+          node,
+          messageId,
+          fix (fixer) {
+            const rewritten = rewrite(classes);
+            if (rewritten === classes) return null;
+            const firstChar = sourceCode.getText(node.value)[0];
+            const quote = firstChar === '"' || firstChar === '\'' ? firstChar : '';
+            return fixer.replaceText(node.value, `${quote}${rewritten}${quote}`);
+          },
+        });
+      },
+    });
+  };
+}
+
+module.exports = { START, END, buildDetectRegex, createClassAttributeRule };

--- a/packages/eslint-plugin-dialtone/lib/util/class-attribute-rule.js
+++ b/packages/eslint-plugin-dialtone/lib/util/class-attribute-rule.js
@@ -21,7 +21,10 @@ function buildDetectRegex (regexes) {
 function createClassAttributeRule ({ detect, rewrite, messageId }) {
   return (context) => {
     const sourceCode = context.sourceCode ?? context.getSourceCode();
-    return sourceCode.parserServices.defineTemplateBodyVisitor({
+    const defineTemplateBodyVisitor = sourceCode.parserServices?.defineTemplateBodyVisitor;
+    if (!defineTemplateBodyVisitor) return {};
+
+    return defineTemplateBodyVisitor({
       VAttribute (node) {
         if (node.key.name !== 'class') return;
         const classes = node.value?.value;

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-pixel-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-pixel-utility-classes.js
@@ -82,6 +82,12 @@ ruleTester.run('deprecated-pixel-utility-classes', rule, {
       output: '<template><div class="d-mt-n100" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
+    // Negative 20 (regression: NEGATIVE_PIXELS must include 20 since NEGATIVE_SPACING_MAP does)
+    {
+      code: '<template><div class="d-mn20 d-tn20" /></template>',
+      output: '<template><div class="d-m-n250 d-t-n250" /></template>',
+      errors: [{ messageId: 'deprecatedPixelClass' }],
+    },
     // Padding
     {
       code: '<template><div class="d-p8 d-pt16" /></template>',

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-pixel-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-pixel-utility-classes.js
@@ -133,5 +133,17 @@ ruleTester.run('deprecated-pixel-utility-classes', rule, {
       output: '<template><div class="d-h-24px d-w-24px" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
+    // Unquoted attribute (HTML5 valid, vue-eslint-parser accepts). Autofix must not add quotes.
+    {
+      code: '<template><div class=d-h16 /></template>',
+      output: '<template><div class=d-h-25 /></template>',
+      errors: [{ messageId: 'deprecatedPixelClass' }],
+    },
+    // Single-quoted attribute — preserves single quotes.
+    {
+      code: '<template><div class=\'d-p8\' /></template>',
+      output: '<template><div class=\'d-p-100\' /></template>',
+      errors: [{ messageId: 'deprecatedPixelClass' }],
+    },
   ],
 });

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-pixel-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-pixel-utility-classes.js
@@ -47,74 +47,90 @@ ruleTester.run('deprecated-pixel-utility-classes', rule, {
     // Sizing
     {
       code: '<template><div class="d-h16" /></template>',
+      output: '<template><div class="d-h-25" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     {
       code: '<template><div class="d-w64" /></template>',
+      output: '<template><div class="d-w-100" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     {
       code: '<template><div class="d-hmn96 d-wmx512" /></template>',
+      output: '<template><div class="d-hmn-150 d-wmx-800" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     // Margin
     {
       code: '<template><div class="d-m8" /></template>',
+      output: '<template><div class="d-m-100" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     {
       code: '<template><div class="d-mt16 d-ml8" /></template>',
+      output: '<template><div class="d-mt-200 d-ml-100" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     // Negative margin
     {
       code: '<template><div class="d-mtn8" /></template>',
+      output: '<template><div class="d-mt-n100" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     // Padding
     {
       code: '<template><div class="d-p8 d-pt16" /></template>',
+      output: '<template><div class="d-p-100 d-pt-200" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     // Gap
     {
       code: '<template><div class="d-g8 d-rg16" /></template>',
+      output: '<template><div class="d-g-100 d-rg-200" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     // Position
     {
       code: '<template><div class="d-t8 d-l16" /></template>',
+      output: '<template><div class="d-t-100 d-l-200" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     // Negative position
     {
       code: '<template><div class="d-tn8" /></template>',
+      output: '<template><div class="d-t-n100" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
-    // Mixed old and new (still reports because old class is present)
+    // Mixed old and new (only old is rewritten)
     {
       code: '<template><div class="d-h-25 d-p8" /></template>',
+      output: '<template><div class="d-h-25 d-p-100" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
-    // Off-scale small-value sizing classes (DLT-3330 targets these for migration to d-*-Npx)
+    // Off-scale small-value sizing classes (DLT-3330 targets these — autofix uses Npx suffix)
     {
       code: '<template><div class="d-w1" /></template>',
+      output: '<template><div class="d-w-1px" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     {
       code: '<template><div class="d-h2" /></template>',
+      output: '<template><div class="d-h-2px" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     {
       code: '<template><div class="d-hmn8" /></template>',
+      output: '<template><div class="d-hmn-8px" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     {
       code: '<template><div class="d-wmx20" /></template>',
+      output: '<template><div class="d-wmx-20px" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
     {
       code: '<template><div class="d-h24 d-w24" /></template>',
+      output: '<template><div class="d-h-24px d-w-24px" /></template>',
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
   ],

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-pixel-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-pixel-utility-classes.js
@@ -41,6 +41,11 @@ ruleTester.run('deprecated-pixel-utility-classes', rule, {
     { code: '<template><div class="d-d-flex d-fc-primary" /></template>' },
     // Logical property aliases
     { code: '<template><div class="d-mis-100 d-pbs-200" /></template>' },
+    // Custom (non-Dialtone) classes that end with a legacy-looking suffix must not match.
+    // `\b` treats `-` as a non-word char, so the previous regex wrongly matched inside these.
+    { code: '<template><div class="foo-d-h16" /></template>' },
+    { code: '<template><div class="my-d-p8 app-d-mt16" /></template>' },
+    { code: '<template><div class="d-h-25 foo-d-h16" /></template>' },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-radius-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-radius-utility-classes.js
@@ -92,5 +92,17 @@ ruleTester.run('deprecated-radius-utility-classes', rule, {
       output: '<template><div class="d-bar-350 d-bbsr-400 d-bisr-pill" /></template>',
       errors: [{ messageId: 'deprecatedRadiusClass' }],
     },
+    // Unquoted attribute — autofix must not add quotes.
+    {
+      code: '<template><div class=d-bar6 /></template>',
+      output: '<template><div class=d-bar-350 /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
+    // Single-quoted attribute — preserves single quotes.
+    {
+      code: '<template><div class=\'d-btr8\' /></template>',
+      output: '<template><div class=\'d-bbsr-400\' /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
   ],
 });

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-radius-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-radius-utility-classes.js
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Tests for deprecated-radius-utility-classes rule.
+ */
+'use strict';
+
+const rule = require('../../../lib/rules/deprecated-radius-utility-classes');
+const { RuleTester } = require('eslint');
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    // eslint-disable-next-line n/no-extraneous-require
+    parser: require('vue-eslint-parser'),
+    parserOptions: { ecmaVersion: 'latest' },
+  },
+});
+
+ruleTester.run('deprecated-radius-utility-classes', rule, {
+  valid: [
+    // New logical token-stop-indexed classes
+    { code: '<template><div class="d-bar-350" /></template>' },
+    { code: '<template><div class="d-bbsr-400 d-bber-200" /></template>' },
+    { code: '<template><div class="d-bisr-450 d-bier-500" /></template>' },
+    { code: '<template><div class="d-bssr-350 d-bser-350 d-besr-350 d-beer-350" /></template>' },
+    { code: '<template><div class="d-bar-550" /></template>' },
+    // Not-deprecated keyword variants
+    { code: '<template><div class="d-bar-pill d-bar-circle d-bar-unset" /></template>' },
+    { code: '<template><div class="d-bbsr-pill d-bier-circle" /></template>' },
+    // Unrelated utilities
+    { code: '<template><div class="d-p-200 d-m-100 d-fc-primary" /></template>' },
+    // Non-radius utility classes that could look similar but aren't matched
+    { code: '<template><div class="d-ba d-baw2 d-bas-dashed" /></template>' },
+  ],
+
+  invalid: [
+    // Legacy all-corners numeric → logical token stop
+    {
+      code: '<template><div class="d-bar6" /></template>',
+      output: '<template><div class="d-bar-350" /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
+    {
+      code: '<template><div class="d-bar0 d-bar1 d-bar2 d-bar4" /></template>',
+      output: '<template><div class="d-bar-0 d-bar-100 d-bar-200 d-bar-300" /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
+    {
+      code: '<template><div class="d-bar24 d-bar32" /></template>',
+      output: '<template><div class="d-bar-550 d-bar-600" /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
+    // Legacy side-pair numeric → logical pair name
+    {
+      code: '<template><div class="d-btr6" /></template>',
+      output: '<template><div class="d-bbsr-350" /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
+    {
+      code: '<template><div class="d-bbr8" /></template>',
+      output: '<template><div class="d-bber-400" /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
+    {
+      code: '<template><div class="d-blr12" /></template>',
+      output: '<template><div class="d-bisr-450" /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
+    {
+      code: '<template><div class="d-brr16" /></template>',
+      output: '<template><div class="d-bier-500" /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
+    // Legacy side-pair keyword → logical pair keyword
+    {
+      code: '<template><div class="d-btr-pill" /></template>',
+      output: '<template><div class="d-bbsr-pill" /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
+    {
+      code: '<template><div class="d-brr-circle" /></template>',
+      output: '<template><div class="d-bier-circle" /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
+    // Mixed classes in one attribute
+    {
+      code: '<template><div class="d-p-200 d-bar6 d-fc-primary" /></template>',
+      output: '<template><div class="d-p-200 d-bar-350 d-fc-primary" /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
+    // Multiple legacy classes rewritten in one pass
+    {
+      code: '<template><div class="d-bar6 d-btr8 d-blr-pill" /></template>',
+      output: '<template><div class="d-bar-350 d-bbsr-400 d-bisr-pill" /></template>',
+      errors: [{ messageId: 'deprecatedRadiusClass' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-radius-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-radius-utility-classes.js
@@ -29,6 +29,11 @@ ruleTester.run('deprecated-radius-utility-classes', rule, {
     { code: '<template><div class="d-p-200 d-m-100 d-fc-primary" /></template>' },
     // Non-radius utility classes that could look similar but aren't matched
     { code: '<template><div class="d-ba d-baw2 d-bas-dashed" /></template>' },
+    // Custom (non-Dialtone) classes that contain a legacy-looking substring must not match.
+    // `\b` treats `-` as a non-word char, so the previous regex wrongly matched inside these.
+    { code: '<template><div class="foo-d-bar6" /></template>' },
+    { code: '<template><div class="my-d-btr8 app-d-brr-pill" /></template>' },
+    { code: '<template><div class="d-bar-350 foo-d-btr6" /></template>' },
   ],
 
   invalid: [


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Feature


## :book: Jira Ticket

[DLT-3329](https://dialpad.atlassian.net/browse/DLT-3329)

## :book: Description

Foundation + tooling for new token-indexed logical border-radius utilities. Last utility family still using legacy t-shirt pixel suffixes (`.d-bar6`, `.d-btr4`, …). Sizing, margin, padding, gap, and position all migrated in PR #1150 — radius catches up here.

**What this PR does:**

- New token `--dt-size-radius-550` (24px). Resolves the pre-existing `.d-bar24` → `var(--dt-size-550)` TODO in `constants.cjs:34`.
- Rewrites `borderUtilities()` in `dialtone-css/postcss/dialtone-generators.cjs`. Emits 108 token-indexed logical classes across 9 scopes.
  - Naming: first-letter compression of CSS property. `bar` (all), `bbsr` / `bber` / `bisr` / `bier` (side pairs), `bssr` / `bser` / `besr` / `beer` (single corners).
  - Single-corner utilities (`.d-bssr-*` etc.) are net-new — Dialtone had no single-corner radius utilities before.
  - Legacy classes co-selected on the same rule (`.d-bar-350, .d-bar6 { ... }`) so nothing breaks.
  - Emission order: all → pairs → single corners, so single wins over pair wins over all in cascade ties. Follows DLT-3321 / PR #1205.
- Deprecation metadata in `dialtone-docs.cjs` flows to `dialtone-docs.json` and the MCP server. Legacy selectors flagged `deprecated: true` with `alternatives` pointing at the logical name.
- New ESLint rule `deprecated-radius-utility-classes` with `fixable: 'code'` autofix. Retrofits `fixable: 'code'` onto the existing `deprecated-pixel-utility-classes` rule too (R6 spillover).
- Extends `utility-class-to-token-stops` migration helper with radius mappings + `RADIUS_PAIR_PREFIX_MAP`.
- Adds `dot: true` and expanded `ignore` list to the migration config (excludes `dist/`, `.cache/`, `.vite/`, `.vuepress/.cache/`, `.next/`, `.nuxt/`, `.turbo/`, `.nx/`, `eslint-plugin-dialtone/`). Consumers running `dt-migrate` in their own repos benefit for margin/padding/gap/sizing/position migrations too — not radius-specific.
- DtBox: adds `550` to `DT_BOX_BORDER_RADIUS_VALUES`, `@values` JSDoc, and the `@box-border-radius-values` Less loop so `<dt-box border-radius="550" />` works end-to-end.

**What this PR does NOT do:**

- Does not migrate any consumer code. `radius.md` still shows legacy demo class names. Stories / recipes / prototypes still use `.d-bar6`, `.d-btr4`, etc. That's [DLT-3337](https://dialpad.atlassian.net/browse/DLT-3337) (stacked follow-up PR).
- No breaking changes. Legacy classes continue to work — each resolves to the same pixel value as before via the co-selection. `.d-bar24` silently changes from `var(--dt-size-550)` to `var(--dt-size-radius-550)` internally; both are 2.4rem / 24px, so no visible difference.

## :bulb: Context

Part of the CSS utility refresh tracked by epic DLT-2975. PR #1150 moved spacing/sizing/position to token-stop-indexed names; radius was the last holdout on the legacy t-shirt-size convention. Also takes the opportunity to add logical single-corner utilities (`border-start-start-radius` and friends) which Dialtone never had.

## :mag: For Reviewers

**Build:**

```bash
pnpm nx run-many --target=build --projects=dialtone-tokens,dialtone-css,eslint-plugin-dialtone,dialtone-mcp-server
```

**Spot-check the generated CSS** (`packages/dialtone-css/lib/dist/dialtone.css`, search):

- `.d-bar-350, .d-bar6 {` — all-corners + legacy co-selected.
- `.d-bbsr-350, .d-btr6 {` — pair logical + legacy co-selected.
- `.d-bssr-350 {` — net-new single-corner, no legacy.
- `.d-bar-550, .d-bar24 {` — the new 24px stop; `.d-bar24` now uses the radius-550 token.

**Cascade order** (the PR #1205 invariant). Apply combinations in any page's DevTools:

| Combo | Expected winner |
|---|---|
| `d-bar-300 d-bbsr-500` | pair wins top |
| `d-bar-300 d-bssr-500` | single wins top-left |
| `d-bbsr-300 d-bssr-500` | single wins over pair |
| `d-btr6 d-bssr-500` | new single wins over legacy pair |

**ESLint autofix:**

```bash
# In any scratch .vue file with `class="d-bar6 d-btr8 d-brr-pill d-h16 d-p8"`
pnpm exec eslint --fix <file>
# Expect: d-bar-350 d-bbsr-400 d-bier-pill d-h-25 d-p-100
```

**DtBox 550:** open Storybook / Combinator for DtBox, set `borderRadius="550"`, confirm 24px rounding applies.

**MCP data:** `packages/dialtone-css/lib/dist/dialtone-docs.json` should flag every `.d-bar{N}`, `.d-btr{N}`, `.d-btr-pill`, etc. as `deprecated: true` with `alternatives` pointing at the logical name.

## :package: Cross-Package Impact

| Package | Changes | Downstream Impact |
|---|---|---|
| dialtone-tokens | New `--dt-size-radius-550` token | dialtone-css consumes it |
| dialtone-css | Rewritten `borderUtilities()`, deprecation metadata, deleted `borders.less` radius block, migration-helper config improvements | dialtone-vue stories/recipes reference new classes (in follow-up PR); MCP data regenerates |
| eslint-plugin-dialtone | New radius rule + pixel-rule autofix retrofit | `lint-staged` in consumer repos autofixes on commit |
| dialtone-vue | DtBox exposes `radius="550"` (constants + JSDoc + component docs JSON) | Combinator + docs Box page can render 24px radius |
| dialtone-mcp-server | Auto-regen from `dialtone-docs.json` | MCP search surfaces deprecation flags |

Dependency flow: **tokens** → **CSS** → **Vue** → docs/MCP.

## :pencil: Checklist

- [x] No private Dialpad links or info in code or PR description.
- [x] Reviewed my changes.
- [x] Added all relevant documentation (generator + rule docblocks).
- [x] Considered performance impact (ESLint autofix hoists regexes to module scope; zero build-time regressions).

For all CSS changes:

- [x] Used design tokens wherever possible.
- [x] Considered behavior on different screen sizes (responsive variants handled by `postcss-responsive-variations`, no change in behavior).
- [x] Visually validated in light mode (dark mode pending — no theme-specific rules added).
- [x] Used `gap` / flexbox over margin where possible (N/A — no new layout).

For all Vue changes:

- [x] Updated unit tests (DtBox test iterates `DT_BOX_BORDER_RADIUS_VALUES`; auto-covers 550).
- [x] Validated with screen reader (N/A — no interactive behavior change).
- [x] Validated keyboard navigation (N/A — same reason).

## :crystal_ball: Next Steps

- [DLT-3337](https://dialpad.atlassian.net/browse/DLT-3337) — follow-up PR stacked on this one. **Merge this PR first**, then DLT-3337 becomes mergeable. It migrates ~1,273 consumer class references across the monorepo and rewrites the radius docs page.
- After this ships, consumer repos (firespotter, web-clients) run `pnpm dt-migrate utility-class-to-token-stops` to pick up the full migration (radius + incidental sizing/spacing/position catch-up from PR #1150).
- Semantic-release on Tuesday will bump `dialtone-css` / `dialtone-tokens` / `dialtone-vue` / `eslint-plugin-dialtone` / `dialtone-mcp-server` to new prerelease versions on the `next` channel.


[DLT-3329]: https://dialpad.atlassian.net/browse/DLT-3329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DLT-3337]: https://dialpad.atlassian.net/browse/DLT-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ