### PR TITLE
docs(css-utilities): DLT-3337 migrate internal utility-class consumers to token-indexed names and rewrite radius docs

### DIFF
--- a/.claude/rules/documentation-writing.md
+++ b/.claude/rules/documentation-writing.md
@@ -132,7 +132,7 @@ Use `<!-- @custom -->` when the default demo wrapper styles (padding, width, bac
 ```vue demo
 <!-- @custom -->
 <!-- @class d-d-block -->
-<div v-dt-scrollbar:never class="d-bar8 d-bgc-secondary d-hmx-500">
+<div v-dt-scrollbar:never class="d-bar-400 d-bgc-secondary d-hmx-500">
   ...
 </div>
 ```

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/BaseColor.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/BaseColor.vue
@@ -31,8 +31,8 @@
         :class="[
           'd-px-150 d-py-100 d-text-code--xs',
           {
-            'd-btr4': index === 0,
-            'd-bbr4': index === (stops.length - 1),
+            'd-bbsr-300': index === 0,
+            'd-bber-300': index === (stops.length - 1),
           },
         ]"
         :style="`background-color: ${stop.value}`"

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/BlogPostPreview.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/BlogPostPreview.vue
@@ -1,10 +1,10 @@
 <template>
   <dt-link
     :to="`/dialtone/whats-new/posts/${format(posted, 'y-M-d')}`"
-    class="d-fc-unset d-d-block d-bar8 d-td-none"
+    class="d-fc-unset d-d-block d-bar-400 d-td-none"
   >
     <dt-card
-      class="d-mbs-200 d-bgc-primary d-bs-none h:d-bs-sm d-bar8 d-bbw1 h:d-bc-default"
+      class="d-mbs-200 d-bgc-primary d-bs-none h:d-bs-sm d-bar-400 d-bbw1 h:d-bc-default"
     >
       <template #content>
         <blog-post

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ClampedTableWrapper.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ClampedTableWrapper.vue
@@ -39,7 +39,7 @@
       v-if="showEmptyState"
       :size="200"
       :header-text="`No results found`"
-      class="d-w100p d-ba d-bc-subtle d-bar8 d-pbs-400"
+      class="d-w100p d-ba d-bc-subtle d-bar-400 d-pbs-400"
     >
       <template #icon="{ iconSize }">
         <!-- maybe alt icon? -->
@@ -56,7 +56,7 @@
     </div>
     <div
       v-if="shouldShowButton"
-      class="dialtone-doc-table-clamped__more d-ps-absolute d-bn8 d-l50p"
+      class="dialtone-doc-table-clamped__more d-ps-absolute d-ibe-n100 d-l50p"
       aria-hidden="true"
     >
       <dt-button
@@ -133,7 +133,7 @@ const observers = {
 // Memoized base classes for performance
 const BASE_SCROLL_CLASSES = [
   'dialtone-doc-table-clamped__scroll',
-  'd-bar8',
+  'd-bar-400',
   'd-ba',
   'd-bc-subtle',
 ];
@@ -220,7 +220,7 @@ const highlightMatches = (element, searchTerm) => {
         // Check if this part is a match (case-insensitive)
         if (matches.some(match => match.toLowerCase() === part.toLowerCase())) {
           const mark = document.createElement('mark');
-          mark.className = 'd-bgc-warning d-bar2 d-fc-primary';
+          mark.className = 'd-bgc-warning d-bar-200 d-fc-primary';
           mark.textContent = part;
           fragment.appendChild(mark);
         } else {

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeExampleTabs.vue
@@ -61,7 +61,7 @@
     </dt-tab-panel>
     <div
       v-if="shouldShowButton"
-      class="code-example-tab-group__more d-ps-absolute d-bn8 d-l50p"
+      class="code-example-tab-group__more d-ps-absolute d-ibe-n100 d-l50p"
       aria-hidden="true"
     >
       <dt-button

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeWellHeader.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/CodeWellHeader.vue
@@ -5,7 +5,7 @@
       gap="100"
       align="center"
       justify="center"
-      class="d-bar8"
+      class="d-bar-400"
       :class="classes"
     >
       <slot />
@@ -41,7 +41,7 @@ export default {
       return [
         'd-p-400 d-w100p d-of-auto',
         this.bgclass,
-        { 'd-ba d-bc-subtle d-btr8 d-baw1': this.isSurfacePrimary },
+        { 'd-ba d-bc-subtle d-bbsr-400 d-baw1': this.isSurfacePrimary },
         this.$attrs.class,
       ];
     },

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentAccessibleTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentAccessibleTable.vue
@@ -2,7 +2,7 @@
   <clamped-table-wrapper>
     <div>
       <table class="d-table dialtone-doc-table">
-        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
+        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-ibs-0">
           <tr>
             <th
               scope="col"

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentClassTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentClassTable.vue
@@ -2,7 +2,7 @@
   <clamped-table-wrapper>
     <div>
       <table class="d-table dialtone-doc-table">
-        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
+        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-ibs-0">
           <tr>
             <th
               class="d-w40p d-p-0 d-bbw0"

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentHealthStatusTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentHealthStatusTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <dt-stack gap="200" direction="row" class="d-bgc-secondary d-p-200 d-py-100 d-bar8 d-ba d-bc-subtle d-my-200">
+  <dt-stack gap="200" direction="row" class="d-bgc-secondary d-p-200 d-py-100 d-bar-400 d-ba d-bc-subtle d-my-200">
     <dt-stack direction="row" gap="100">
       <dt-icon
         class="d-fc-positive"

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentVueApiTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ComponentVueApiTable.vue
@@ -9,7 +9,7 @@
       <table
         class="d-table dialtone-doc-table d-wmn-800"
       >
-        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
+        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-ibs-0">
           <tr>
             <th
               scope="col"

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/DesignColorTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/DesignColorTable.vue
@@ -62,10 +62,10 @@ const colors = processColorsDocs(props.excludedColors, props.classPrefix);
 </script>
 
 <template>
-  <div v-if="colors.length" v-dt-scrollbar class="d-hmx-700 d-bar8 d-ba d-bc-subtle">
+  <div v-if="colors.length" v-dt-scrollbar class="d-hmx-700 d-bar-400 d-ba d-bc-subtle">
     <div>
       <table class="d-table dialtone-doc-table">
-        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
+        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-ibs-0">
           <tr>
             <th class="d-p-0 d-bbw0" colspan="3" scope="col">
               <div class="d-p-200 d-bb d-bbw1">

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/NewUtilityClassTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/NewUtilityClassTable.vue
@@ -2,7 +2,7 @@
   <clamped-table-wrapper>
     <div>
       <table class="d-table dialtone-doc-table d-fc-primary">
-        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
+        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-ibs-0">
           <tr>
             <th class="d-w25p d-p-0 d-bbw0" scope="col">
               <div class="d-p-200 d-bb d-bbw1">

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ShowcaseCarousel.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ShowcaseCarousel.vue
@@ -2,15 +2,15 @@
 <template>
   <div ref="carouselContainerRef" class="showcase-carousel">
     <dt-stack ref="carouselTrackRef" direction="row" gap="800" class="showcase-carousel__track">
-      <img style="align-self: flex-start; width: 468px;" class="d-bar16 d-d-block" src="/assets/images/home-showcase--01.jpg" alt="">
-      <img style="align-self: flex-end; width: 546px;" class="d-bar16 d-d-block" src="/assets/images/home-showcase--02.jpg" alt="">
-      <img style="align-self: flex-start; width: 352px;" class="d-bar16 d-d-block" src="/assets/images/home-showcase--03.jpg" alt="">
-      <img style="align-self: center; width: 400px;" class="d-bar16 d-d-block" src="/assets/images/home-showcase--04.jpg" alt="">
-      <img style="align-self: flex-end; width: 480px;" class="d-bar16 d-d-block" src="/assets/images/home-showcase--05.jpg" alt="">
-      <img style="align-self: flex-start; width: 628px;" class="d-bar16 d-d-block" src="/assets/images/home-showcase--06.jpg" alt="">
-      <img style="align-self: center; width: 438px;" class="d-bar16 d-d-block" src="/assets/images/home-showcase--07.jpg" alt="">
-      <img style="align-self: flex-end; width: 404px;" class="d-bar16 d-d-block" src="/assets/images/home-showcase--08.jpg" alt="">
-      <img style="align-self: flex-start; width: 438px;" class="d-bar16 d-d-block" src="/assets/images/home-showcase--09.jpg" alt="">
+      <img style="align-self: flex-start; width: 468px;" class="d-bar-500 d-d-block" src="/assets/images/home-showcase--01.jpg" alt="">
+      <img style="align-self: flex-end; width: 546px;" class="d-bar-500 d-d-block" src="/assets/images/home-showcase--02.jpg" alt="">
+      <img style="align-self: flex-start; width: 352px;" class="d-bar-500 d-d-block" src="/assets/images/home-showcase--03.jpg" alt="">
+      <img style="align-self: center; width: 400px;" class="d-bar-500 d-d-block" src="/assets/images/home-showcase--04.jpg" alt="">
+      <img style="align-self: flex-end; width: 480px;" class="d-bar-500 d-d-block" src="/assets/images/home-showcase--05.jpg" alt="">
+      <img style="align-self: flex-start; width: 628px;" class="d-bar-500 d-d-block" src="/assets/images/home-showcase--06.jpg" alt="">
+      <img style="align-self: center; width: 438px;" class="d-bar-500 d-d-block" src="/assets/images/home-showcase--07.jpg" alt="">
+      <img style="align-self: flex-end; width: 404px;" class="d-bar-500 d-d-block" src="/assets/images/home-showcase--08.jpg" alt="">
+      <img style="align-self: flex-start; width: 438px;" class="d-bar-500 d-d-block" src="/assets/images/home-showcase--09.jpg" alt="">
     </dt-stack>
   </div>
 </template>

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/ThemeColorTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/ThemeColorTable.vue
@@ -2,7 +2,7 @@
   <clamped-table-wrapper>
     <div>
       <table class="d-table dialtone-doc-table">
-        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
+        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-ibs-0">
           <tr>
             <th class="d-p-0 d-bbw0" scope="col">
               <div class="d-p-200 d-bb d-bbw1">
@@ -85,7 +85,10 @@
               </dt-text>
               <div
                 v-else-if="color.property === 'border-color'"
-                :class="['d-d-inline-flex d-p-50 d-bar-pill', { 'd-bgc-contrast': color.variable.includes('inverted') }]"
+                :class="[
+                  'd-d-inline-flex d-p-50 d-bar-pill',
+                  { 'd-bgc-contrast': color.variable.includes('inverted') },
+                ]"
               >
                 <div
                   :style="{ borderColor: `var(--${color.variable})` }"

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/UiKitsComparisonTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/UiKitsComparisonTable.vue
@@ -1,8 +1,8 @@
 <template>
-  <div v-dt-scrollbar:never class="d-hmx-700 d-bar8 d-ba d-bc-subtle d-mbs-300">
+  <div v-dt-scrollbar:never class="d-hmx-700 d-bar-400 d-ba d-bc-subtle d-mbs-300">
     <div>
       <table class="d-table dialtone-doc-table">
-        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
+        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-ibs-0">
           <tr>
             <th scope="col" class="d-p-0 d-bbw0 d-tt-none">
               <div class="d-p-200 d-bb d-bbw1">

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/UtilityClassTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/UtilityClassTable.vue
@@ -2,7 +2,7 @@
   <clamped-table-wrapper>
     <div>
       <table class="d-table dialtone-doc-table d-fc-primary">
-        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
+        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-ibs-0">
           <tr>
             <th class="d-w25p d-p-0 d-bbw0" scope="col">
               <div class="d-p-200 d-bb d-bbw1">

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/AllTokens.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/AllTokens.vue
@@ -10,7 +10,7 @@
     v-if="noSearchResults"
     :size="200"
     :header-text="`No results found for &OpenCurlyDoubleQuote;${searchCriteria}&CloseCurlyDoubleQuote;`"
-    class="d-w100p d-ba d-bc-subtle d-bar8 d-mbs-200 d-pbs-400"
+    class="d-w100p d-ba d-bc-subtle d-bar-400 d-mbs-200 d-pbs-400"
   >
     <template #icon="{ iconSize }">
       <dt-icon name="box" :size="iconSize" />

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenExample.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenExample.vue
@@ -4,7 +4,7 @@
     direction="row"
     justify="center"
     align="center"
-    class="d-bar4 d-hmn-50 colorRectangle"
+    class="d-bar-300 d-hmn-50 colorRectangle"
     :style="getColorStyle"
   >
     <dt-text
@@ -30,7 +30,7 @@
   </dt-stack>
   <div
     v-if="category === 'shadow'"
-    class="d-bar4 d-hmn-50"
+    class="d-bar-300 d-hmn-50"
     :style="getShadowStyle"
   />
   <div

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenTable.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-dt-scrollbar:never>
-    <div class="d-hmx-800 d-bar8 d-ba d-bc-subtle">
+    <div class="d-hmx-800 d-bar-400 d-ba d-bc-subtle">
       <table v-dt-mode:[mode] class="d-bgc-primary d-table dialtone-doc-table">
-        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-t0">
+        <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-ibs-0">
           <tr>
             <th
               scope="col"

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokensBar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokensBar.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vuejs-accessibility/no-autofocus -->
 <template>
-  <dt-stack gap="200" class="d-p-200 d-bgc-secondary d-bar8">
+  <dt-stack gap="200" class="d-p-200 d-bgc-secondary d-bar-400">
     <dt-input
       id="search-input"
       v-model="searchCriteria"

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableCollapsible.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableCollapsible.vue
@@ -9,7 +9,7 @@
         :collapsed="isCollapsed"
       >
         <dt-box block-size="100p" inline-size="100p" surface="positive" class="d-d-flex d-fd-column">
-          <dt-stack direction="row" align="center" justify="end" class="d-px16 d-py8 d-bb d-bc-subtle">
+          <dt-stack direction="row" align="center" justify="end" class="d-px-200 d-py-100 d-bb d-bc-subtle">
             <dt-button kind="muted" importance="clear" size="100" @click="isCollapsed = true">
               Close sidebar
             </dt-button>
@@ -28,7 +28,7 @@
             v-if="isCollapsed"
             direction="row"
             align="center"
-            class="d-px16 d-py8 d-bb d-bc-default"
+            class="d-px-200 d-py-100 d-bb d-bc-default"
           >
             <dt-button kind="muted" importance="clear" size="100" @click="isCollapsed = false">
               Open sidebar

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableOffset.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleResizableOffset.vue
@@ -7,7 +7,7 @@
         surface="secondary-opaque"
         border-width-block-end="100"
         block-size="75"
-        class="d-ps-absolute d-t0 d-l0 d-r0 d-zi-base1 d-d-flex d-ai-center d-jc-center
+        class="d-ps-absolute d-t-0 d-l-0 d-r-0 d-zi-base1 d-d-flex d-ai-center d-jc-center
         "
       >
         <dt-text as="p" kind="body" size="200" align="center">

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Home.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Home.vue
@@ -51,7 +51,7 @@
   <section class="links d-bt d-bb d-bc-subtle d-bgc-secondary">
     <div class="d-d-grid d-g-200 d-g-cols12 d-wmx1340 d-mx-auto">
       <dt-stack gap="100" class="link d-body--md d-gc3 d-px-400 d-ta-center">
-        <router-link class="d-fc-primary h:d-td-underline d-td-none d-bar8 d-pbs-50" to="/design/">
+        <router-link class="d-fc-primary h:d-td-underline d-td-none d-bar-400 d-pbs-50" to="/design/">
           <dt-stack gap="100">
             <svg-loader class="d-h-150" name="home-design-language" />
             <dt-text as="h2" kind="headline" :size="500" class="d-ff-marketing">
@@ -69,7 +69,7 @@
         </dt-stack>
       </dt-stack>
       <dt-stack gap="100" class="link d-body--md d-gc3 d-px-400 d-ta-center">
-        <router-link class="d-fc-primary h:d-td-underline d-td-none d-bar8 d-pbs-50" to="/components/">
+        <router-link class="d-fc-primary h:d-td-underline d-td-none d-bar-400 d-pbs-50" to="/components/">
           <dt-stack gap="100">
             <svg-loader class="d-h-150" name="home-components" />
             <dt-text as="h2" kind="headline" :size="500" class="d-ff-marketing">
@@ -90,7 +90,7 @@
         </dt-stack>
       </dt-stack>
       <dt-stack gap="100" class="link d-body--md d-gc3 d-px-400 d-ta-center">
-        <router-link class="d-fc-primary h:d-td-underline d-td-none d-bar8 d-pbs-50" to="/utilities/">
+        <router-link class="d-fc-primary h:d-td-underline d-td-none d-bar-400 d-pbs-50" to="/utilities/">
           <dt-stack gap="100">
             <svg-loader class="d-h-150" name="home-utilities" />
             <dt-text as="h2" kind="headline" :size="500" class="d-ff-marketing">
@@ -108,7 +108,7 @@
         </dt-stack>
       </dt-stack>
       <dt-stack gap="100" class="link d-body--md d-gc3 d-px-400 d-ta-center">
-        <router-link class="d-fc-primary h:d-td-underline d-td-none d-bar8 d-pbs-50" to="/guides/">
+        <router-link class="d-fc-primary h:d-td-underline d-td-none d-bar-400 d-pbs-50" to="/guides/">
           <dt-stack gap="100">
             <svg-loader class="d-h-150" name="home-guides" />
             <dt-text as="h2" kind="headline" :size="500" class="d-ff-marketing">

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/MobileNavbar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/MobileNavbar.vue
@@ -42,7 +42,7 @@
       class="
         mobile-header-drop-down-menu
         d-ps-fixed
-        d-l0
+        d-l-0
         d-w100p
         d-bgc-secondary
         d-of-auto
@@ -50,7 +50,7 @@
         d-py-300
         d-px-200
         d-h100p
-        d-t64
+        d-t-800
         d-zi-navigation-fixed
         "
       :class="{ 'd-o0 d-d-none': !isMenuOpen }"

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/MobileSidebar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/MobileSidebar.vue
@@ -10,10 +10,10 @@
         d-w100p
         d-bgc-secondary
         d-h-100
-        d-x0
+        d-x-0
         d-bb
         d-bc-default
-        d-t64
+        d-t-800
         lg:d-d-none
       "
     >
@@ -35,7 +35,7 @@
       class="
         mobile-header-drop-down-navigation
         d-ps-fixed
-        d-l0
+        d-l-0
         d-w100p
         d-bgc-primary
         d-of-auto

--- a/apps/dialtone-documentation/docs/.vuepress/views/IconCatalog.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/views/IconCatalog.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vuejs-accessibility/no-autofocus -->
 <template>
-  <div class="d-d-grid d-g-200 d-g-cols6 d-mbs-400 d-mbe-200 d-p-200 d-bgc-secondary d-bar8">
+  <div class="d-d-grid d-g-200 d-g-cols6 d-mbs-400 d-mbe-200 d-p-200 d-bgc-secondary d-bar-400">
     <div class="d-gc4">
       <dt-input
         id="search-input"
@@ -93,7 +93,7 @@
     v-if="!hasSearchResults"
     :size="200"
     :header-text="`No results found for &OpenCurlyDoubleQuote;${search}&CloseCurlyDoubleQuote;`"
-    class="d-w100p d-ba d-bc-subtle d-bar8 d-mbs-200 d-pbs-400"
+    class="d-w100p d-ba d-bc-subtle d-bar-400 d-mbs-200 d-pbs-400"
   >
     <template #icon="{ iconSize }">
       <dt-icon name="box" :size="iconSize" />

--- a/apps/dialtone-documentation/docs/.vuepress/views/Icons.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/views/Icons.vue
@@ -1,7 +1,7 @@
 <template>
   <dt-stack
     gap="200"
-    class="d-p-200 d-bar8"
+    class="d-p-200 d-bar-400"
   >
     <h3
       :id="kind"

--- a/apps/dialtone-documentation/docs/_data/borders.json
+++ b/apps/dialtone-documentation/docs/_data/borders.json
@@ -1,3 +1,71 @@
 {
-  "directions": ["all", "top", "right", "bottom", "left", "x", "y"]
+  "directions": ["all", "top", "right", "bottom", "left", "x", "y"],
+  "radius": {
+    "scopes": [
+      {
+        "name": "All corners",
+        "logicalPrefix": "bar",
+        "legacyPrefix": "bar",
+        "cssProperties": ["border-radius"]
+      },
+      {
+        "name": "Block-start pair",
+        "logicalPrefix": "bbsr",
+        "legacyPrefix": "btr",
+        "cssProperties": ["border-start-start-radius", "border-start-end-radius"]
+      },
+      {
+        "name": "Inline-end pair",
+        "logicalPrefix": "bier",
+        "legacyPrefix": "brr",
+        "cssProperties": ["border-start-end-radius", "border-end-end-radius"]
+      },
+      {
+        "name": "Block-end pair",
+        "logicalPrefix": "bber",
+        "legacyPrefix": "bbr",
+        "cssProperties": ["border-end-start-radius", "border-end-end-radius"]
+      },
+      {
+        "name": "Inline-start pair",
+        "logicalPrefix": "bisr",
+        "legacyPrefix": "blr",
+        "cssProperties": ["border-start-start-radius", "border-end-start-radius"]
+      },
+      {
+        "name": "Start-start corner",
+        "logicalPrefix": "bssr",
+        "cssProperties": ["border-start-start-radius"]
+      },
+      {
+        "name": "Start-end corner",
+        "logicalPrefix": "bser",
+        "cssProperties": ["border-start-end-radius"]
+      },
+      {
+        "name": "End-end corner",
+        "logicalPrefix": "beer",
+        "cssProperties": ["border-end-end-radius"]
+      },
+      {
+        "name": "End-start corner",
+        "logicalPrefix": "besr",
+        "cssProperties": ["border-end-start-radius"]
+      }
+    ],
+    "values": [
+      { "stop": "0",      "legacyPx": "0",       "rem": "0rem",    "px": "0px"   },
+      { "stop": "100",    "legacyPx": "1",       "rem": "0.1rem",  "px": "1px"   },
+      { "stop": "200",    "legacyPx": "2",       "rem": "0.2rem",  "px": "2px"   },
+      { "stop": "300",    "legacyPx": "4",       "rem": "0.4rem",  "px": "4px"   },
+      { "stop": "350",    "legacyPx": "6",       "rem": "0.6rem",  "px": "6px"   },
+      { "stop": "400",    "legacyPx": "8",       "rem": "0.8rem",  "px": "8px"   },
+      { "stop": "450",    "legacyPx": "12",      "rem": "1.2rem",  "px": "12px"  },
+      { "stop": "500",    "legacyPx": "16",      "rem": "1.6rem",  "px": "16px"  },
+      { "stop": "550",    "legacyPx": "24",      "rem": "2.4rem",  "px": "24px"  },
+      { "stop": "600",    "legacyPx": "32",      "rem": "3.2rem",  "px": "32px"  },
+      { "stop": "pill",   "legacyPx": "pill",    "rem": "10.2rem", "px": "102px" },
+      { "stop": "circle", "legacyPx": "circle",  "rem": "50%",     "px": "50%"   }
+    ]
+  }
 }

--- a/apps/dialtone-documentation/docs/articles/index.md
+++ b/apps/dialtone-documentation/docs/articles/index.md
@@ -2,7 +2,7 @@
 title: Articles
 ---
 
-<div class="d-ba d-bar16 d-py-200 d-mbs-400 d-ta-center d-fc-muted d-headline--xxl">
+<div class="d-ba d-bar-500 d-py-200 d-mbs-400 d-ta-center d-fc-muted d-headline--xxl">
   <dt-empty-state
     :size="300"
     header-text="TBD"

--- a/apps/dialtone-documentation/docs/careers/index.md
+++ b/apps/dialtone-documentation/docs/careers/index.md
@@ -2,7 +2,7 @@
 title: Careers
 ---
 
-<div class="d-ba d-bar16 d-py-200 d-mbs-400 d-ta-center d-fc-muted d-headline--xxl">
+<div class="d-ba d-bar-500 d-py-200 d-mbs-400 d-ta-center d-fc-muted d-headline--xxl">
   <dt-empty-state
     :size="300"
     header-text="TBD"

--- a/apps/dialtone-documentation/docs/components/breadcrumbs.md
+++ b/apps/dialtone-documentation/docs/components/breadcrumbs.md
@@ -52,7 +52,7 @@ In place of the `inverted` prop, use the [v-dt-mode directive](mode-island.html#
 <div class="d-bgc-contrast">
   <dt-breadcrumbs
     v-dt-mode:invert
-    class="d-p-200 d-bar8"
+    class="d-p-200 d-bar-400"
     :breadcrumbs="[
       { href: '#', label: 'Root' },
       { href: '#', label: 'Section' },

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -778,7 +778,7 @@ Use the `#leading` and `#trailing` slots to render freeform content at the start
 <dt-button kind="muted" importance="outlined" leading-class="d-pis-150">
   Caution
   <template #leading>
-    <span class="d-bgc-critical-strong d-bar4 d-w12 d-h12"></span>
+    <span class="d-bgc-critical-strong d-bar-300 d-w12 d-h12"></span>
   </template>
 </dt-button>
 ```

--- a/apps/dialtone-documentation/docs/components/datepicker.md
+++ b/apps/dialtone-documentation/docs/components/datepicker.md
@@ -96,7 +96,7 @@ const maxDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() 
 
 The following functions are available for date formatting.
 
-<div class="d-bgc-secondary d-bar8 d-p-200">
+<div class="d-bgc-secondary d-bar-400 d-p-200">
   <dt-stack
     :direction="{ 'default': 'column', 'md': 'row' }"
     gap="600"

--- a/apps/dialtone-documentation/docs/components/empty-state.md
+++ b/apps/dialtone-documentation/docs/components/empty-state.md
@@ -13,8 +13,8 @@ keywords: ["no results", "blank slate", "zero state", "d-empty-state", "DtEmptyS
 
 ## Anatomy
 
-<div class="d-d-grid d-g-cols3 d-ba d-bc-subtle d-mbe-200 d-bar8 d-bgc-secondary">
-  <div class="d-gc2 d-bar8 d-bgc-primary"><img class="d-bar8 d-d-block d-w100p" alt="empty state bullets" src="/assets/images/components/empty-state01.png"></div>
+<div class="d-d-grid d-g-cols3 d-ba d-bc-subtle d-mbe-200 d-bar-400 d-bgc-secondary">
+  <div class="d-gc2 d-bar-400 d-bgc-primary"><img class="d-bar-400 d-d-block d-w100p" alt="empty state bullets" src="/assets/images/components/empty-state01.png"></div>
   <div class="d-gc1 d-bl d-bc-subtle d-p-400">
     <ol class="d-pis-200">
       <li class="d-lst-decimal">Illustration or Icon <span class="d-fc-tertiary">(optional)</span></li>
@@ -68,7 +68,7 @@ keywords: ["no results", "blank slate", "zero state", "d-empty-state", "DtEmptyS
 
 The four most likely scenarios for an empty state are **Zero State**, **No Results**, **New Feature**, and **Not Enabled**. This is not an exhaustive list, but a good starting point for most use cases.
 
-<div class="d-d-grid d-g-cols1 lg:d-g-cols3 d-bar8 d-bgc-secondary d-mbe-400">
+<div class="d-d-grid d-g-cols1 lg:d-g-cols3 d-bar-400 d-bgc-secondary d-mbe-400">
 
   <div class="d-p-200 d-plc-center">
 
@@ -78,11 +78,11 @@ The Empty State should guide the user on how to achieve a non-empty state. You m
 
   </div>
   <div class="d-gc2 d-p-200">
-    <img class="d-ba d-bc-subtle d-bar4 d-w100p d-bs-sm" alt="Example: Zero state" src="/assets/images/components/empty-state02.png">
+    <img class="d-ba d-bc-subtle d-bar-300 d-w100p d-bs-sm" alt="Example: Zero state" src="/assets/images/components/empty-state02.png">
   </div>
 </div>
 
-<div class="d-d-grid d-g-cols1 lg:d-g-cols3 d-bar8 d-bgc-secondary d-mbe-400">
+<div class="d-d-grid d-g-cols1 lg:d-g-cols3 d-bar-400 d-bgc-secondary d-mbe-400">
 
   <div class="d-p-200 d-plc-center">
 
@@ -92,11 +92,11 @@ When an action results in no data or information to display, recommend alternate
 
   </div>
   <div class="d-gc2 d-p-200">
-    <img class="d-ba d-bc-subtle d-bar8 d-w100p d-bs-sm" alt="Example: No results" src="/assets/images/components/empty-state03.png">
+    <img class="d-ba d-bc-subtle d-bar-400 d-w100p d-bs-sm" alt="Example: No results" src="/assets/images/components/empty-state03.png">
   </div>
 </div>
 
-<div class="d-d-grid d-g-cols1 lg:d-g-cols3 d-bar8 d-bgc-secondary d-mbe-400">
+<div class="d-d-grid d-g-cols1 lg:d-g-cols3 d-bar-400 d-bgc-secondary d-mbe-400">
 
   <div class="d-p-200 d-plc-center">
 
@@ -106,11 +106,11 @@ An opportunity to introduce something new or not yet take advantage of. If it in
 
   </div>
   <div class="d-gc2 d-p-200">
-    <img class="d-ba d-bc-subtle d-bar8 d-w100p d-bs-sm" alt="Example: New feature" src="/assets/images/components/empty-state04.png">
+    <img class="d-ba d-bc-subtle d-bar-400 d-w100p d-bs-sm" alt="Example: New feature" src="/assets/images/components/empty-state04.png">
   </div>
 </div>
 
-<div class="d-d-grid d-g-cols1 lg:d-g-cols3 d-bar8 d-bgc-secondary d-mbe-400">
+<div class="d-d-grid d-g-cols1 lg:d-g-cols3 d-bar-400 d-bgc-secondary d-mbe-400">
 
   <div class="d-p-200 d-plc-center">
 
@@ -120,7 +120,7 @@ Appropriate for indicating that something is currently unavailable to them. Prov
 
   </div>
   <div class="d-gc2 d-p-200">
-    <img class="d-ba d-bc-subtle d-bar8 d-w100p d-bs-sm" alt="Example: Not enabled" src="/assets/images/components/empty-state05.png">
+    <img class="d-ba d-bc-subtle d-bar-400 d-w100p d-bs-sm" alt="Example: Not enabled" src="/assets/images/components/empty-state05.png">
   </div>
 </div>
 

--- a/apps/dialtone-documentation/docs/components/icon.md
+++ b/apps/dialtone-documentation/docs/components/icon.md
@@ -94,8 +94,8 @@ The icon's color inherits from the parent's foreground color.
 When setting the color of an icon take these into consideration:
 
 <div class="d-gc1">
-  <dt-stack direction="row" align="center" class="d-p-200 d-hmn-250 d-bar8" style="background: var(--dt-color-purple-100)">
-  <dt-stack direction="row" as="section" gap="100" class="d-bgc-primary d-bc-default d-bar32 d-py-100 d-px-200 d-w100p">
+  <dt-stack direction="row" align="center" class="d-p-200 d-hmn-250 d-bar-400" style="background: var(--dt-color-purple-100)">
+  <dt-stack direction="row" as="section" gap="100" class="d-bgc-primary d-bc-default d-bar-600 d-py-100 d-px-200 d-w100p">
     <dt-stack direction="row" as="section" gap="300" class="d-fl1">
       <dt-icon name="headphones" size="300" ariaLabel="Headphones icon" />
       <dt-text kind="body" truncate class="d-w100p d-wmx102">Ai Contact Center</dt-text>
@@ -113,8 +113,8 @@ When setting the color of an icon take these into consideration:
 </div>
 
 <div class="d-gc1">
-  <dt-stack direction="row" align="center" class="d-bgc-critical-subtle-opaque d-p-200 d-hmn-250 d-bar8">
-  <dt-stack direction="row" as="section" gap="100" class="d-bgc-primary d-bc-default d-bar32 d-py-100 d-px-200 d-w100p">
+  <dt-stack direction="row" align="center" class="d-bgc-critical-subtle-opaque d-p-200 d-hmn-250 d-bar-400">
+  <dt-stack direction="row" as="section" gap="100" class="d-bgc-primary d-bc-default d-bar-600 d-py-100 d-px-200 d-w100p">
   <dt-stack direction="row" as="section" gap="300" class="d-fl1">
     <dt-icon name="headphones" size="300" ariaLabel="Headphones icon" />
     <dt-text kind="body" truncate class="d-w100p d-wmx102">Ai Contact Center</dt-text>
@@ -173,7 +173,7 @@ We encourage utilizing the [Stack component](/components/stack.md) for aligning 
 
 Dialtone provides eight sizes for icons. Each of the sizes represents the width and a height the icon is going to have:
 
-<div class="d-bar8 d-ba d-bc-subtle">
+<div class="d-bar-400 d-ba d-bc-subtle">
   <table class="d-table dialtone-doc-table">
     <thead>
       <tr>

--- a/apps/dialtone-documentation/docs/components/mode-island.md
+++ b/apps/dialtone-documentation/docs/components/mode-island.md
@@ -111,7 +111,7 @@ keywords: ["theme island","mode override","v-dt-mode","directive","light","dark"
   <dt-stack :direction="{ 'default': 'column', 'lg': 'row' }" gap="200" class="d-w100p">
     <dt-stack gap="100" class="d-fl1">
       <dt-text as="h3" kind="headline" :size="300">Inverted <dt-text strength="normal">(auto)</dt-text></dt-text>
-      <dt-stack v-dt-mode:invert gap="100" class="d-bgc-secondary d-p-200 d-bar8 d-ba d-bc-default">
+      <dt-stack v-dt-mode:invert gap="100" class="d-bgc-secondary d-p-200 d-bar-400 d-ba d-bc-default">
         <dt-stack gap="100" direction="row">
           <dt-icon name="circle-half-filled" size="300" class="d-fc-positive" />
           <dt-text as="p" kind="body" :size="200">Primary</dt-text>
@@ -127,7 +127,7 @@ keywords: ["theme island","mode override","v-dt-mode","directive","light","dark"
     </dt-stack>
     <dt-stack gap="100" class="d-fl1">
       <dt-text as="h3" kind="headline" :size="300">Explicit light</dt-text>
-      <dt-stack v-dt-mode:light gap="100" class="d-bgc-secondary d-p-200 d-bar8 d-ba d-bc-default">
+      <dt-stack v-dt-mode:light gap="100" class="d-bgc-secondary d-p-200 d-bar-400 d-ba d-bc-default">
         <dt-stack gap="100" direction="row">
           <dt-icon name="sun" size="300" class="d-fc-positive" />
           <dt-text as="p" kind="body" :size="200">Primary</dt-text>
@@ -143,7 +143,7 @@ keywords: ["theme island","mode override","v-dt-mode","directive","light","dark"
     </dt-stack>
     <dt-stack gap="100" class="d-fl1">
       <dt-text as="h3" kind="headline" :size="300">Explicit dark</dt-text>
-      <dt-stack v-dt-mode:dark gap="100" class="d-bgc-secondary d-p-200 d-bar8 d-ba d-bc-default">
+      <dt-stack v-dt-mode:dark gap="100" class="d-bgc-secondary d-p-200 d-bar-400 d-ba d-bc-default">
         <dt-stack gap="100" direction="row">
           <dt-icon name="moon" size="300" class="d-fc-positive" />
           <dt-text as="p" kind="body" :size="200">Primary</dt-text>
@@ -267,7 +267,7 @@ Pass a boolean value to conditionally apply or remove the directive. When `false
 The default mode — inverts relative to the nearest parent mode boundary or the root. When no arg is provided, `v-dt-mode` defaults to invert.
 
 ```vue demo
-<section v-dt-mode class="d-p-200 d-bar8">
+<section v-dt-mode class="d-p-200 d-bar-400">
   <dt-text as="p" tone="positive">Inverted mode (opposite of parent)</dt-text>
 </section>
 ```
@@ -277,7 +277,7 @@ The default mode — inverts relative to the nearest parent mode boundary or the
 Explicitly set to light mode regardless of parent or root mode.
 
 ```vue demo
-<section v-dt-mode:light class="d-p-200 d-bar8">
+<section v-dt-mode:light class="d-p-200 d-bar-400">
   <dt-text as="p" tone="positive">Always light mode</dt-text>
 </section>
 ```
@@ -287,7 +287,7 @@ Explicitly set to light mode regardless of parent or root mode.
 Explicitly set to dark mode regardless of parent or root mode.
 
 ```vue demo
-<section v-dt-mode:dark class="d-p-200 d-bar8">
+<section v-dt-mode:dark class="d-p-200 d-bar-400">
   <dt-text as="p" tone="positive">Always dark mode</dt-text>
 </section>
 ```
@@ -297,11 +297,11 @@ Explicitly set to dark mode regardless of parent or root mode.
 Mode boundaries can be nested. Each `v-dt-mode:invert` reads the nearest parent boundary and flips. In this example the first level is explicitly set to light mode, the second level inverts against that, and the third level inverts again.
 
 ```vue demo
-<dt-stack gap="200" v-dt-mode:light class="d-p-200 d-bar8 d-bgc-secondary d-ba">
+<dt-stack gap="200" v-dt-mode:light class="d-p-200 d-bar-400 d-bgc-secondary d-ba">
   <dt-text as="p" tone="positive" text-box-trim="both">Explicit Light</dt-text>
-  <dt-stack v-dt-mode gap="200" class="d-p-200 d-bar8 d-bgc-secondary">
+  <dt-stack v-dt-mode gap="200" class="d-p-200 d-bar-400 d-bgc-secondary">
     <dt-text as="p" tone="positive" text-box-trim="both">Inverted (Dark)</dt-text>
-    <dt-stack v-dt-mode gap="200" class="d-p-200 d-bar4 d-bgc-secondary">
+    <dt-stack v-dt-mode gap="200" class="d-p-200 d-bar-300 d-bgc-secondary">
       <dt-text as="p" tone="positive" text-box-trim="both">Inverted again (Light)</dt-text>
     </dt-stack>
   </dt-stack>
@@ -315,7 +315,7 @@ The background surface of a Mode Island defaults to the root surface color. To o
 ```vue demo
 <!-- @wrapper -->
 <dt-stack gap="200">
-  <dt-mode-island class="d-p-200 d-bar8 d-w100p d-bgc-transparent">
+  <dt-mode-island class="d-p-200 d-bar-400 d-w100p d-bgc-transparent">
       <dt-stack gap="200">
         <dt-text as="p" kind="code" :size="100" tone="tertiary">Transparent background, inverted mode island</dt-text>
         <div>
@@ -323,7 +323,7 @@ The background surface of a Mode Island defaults to the root surface color. To o
         </div>
       </dt-stack>
     </dt-mode-island>
-    <dt-mode-island class="d-p-200 d-bar8 d-w100p">
+    <dt-mode-island class="d-p-200 d-bar-400 d-w100p">
       <dt-stack gap="200">
         <dt-text as="p" kind="code" :size="100" tone="tertiary">Default background, inverted mode island</dt-text>
         <div>
@@ -331,7 +331,7 @@ The background surface of a Mode Island defaults to the root surface color. To o
         </div>
       </dt-stack>
     </dt-mode-island>
-    <dt-mode-island mode="dark" class="d-p-200 d-bar8 d-w100p d-bgc-critical">
+    <dt-mode-island mode="dark" class="d-p-200 d-bar-400 d-w100p d-bgc-critical">
       <dt-stack gap="200">
         <dt-text as="p" kind="code" :size="100" tone="tertiary">critical background, dark mode island</dt-text>
         <div>
@@ -339,7 +339,7 @@ The background surface of a Mode Island defaults to the root surface color. To o
         </div>
       </dt-stack>
     </dt-mode-island>
-    <dt-mode-island mode="light" class="d-p-200 d-bar8 d-w100p d-bgc-critical">
+    <dt-mode-island mode="light" class="d-p-200 d-bar-400 d-w100p d-bgc-critical">
       <dt-stack gap="200">
         <dt-text as="p" kind="code" :size="100" tone="tertiary">critical background, light mode island</dt-text>
         <div>
@@ -357,7 +357,7 @@ The background surface of a Mode Island defaults to the root surface color. To o
 A real-world pattern: the callbar container already exists as a semantic element. The directive applies mode theming directly — no wrapper needed.
 
 ```vue demo
-<dt-stack v-dt-mode class="d-ba d-bc-subtle d-bgc-secondary d-p-75 d-py-50 d-bar12 d-bs-md d-w100p" direction="row" gap="400">
+<dt-stack v-dt-mode class="d-ba d-bc-subtle d-bgc-secondary d-p-75 d-py-50 d-bar-450 d-bs-md d-w100p" direction="row" gap="400">
   <dt-stack gap="100" direction="row">
     <dt-avatar
       full-name="TA"

--- a/apps/dialtone-documentation/docs/components/resizable.md
+++ b/apps/dialtone-documentation/docs/components/resizable.md
@@ -321,7 +321,7 @@ When a fixed or absolutely positioned element (like a toolbar or header) overlap
       surface="secondary-opaque"
       border-width-block-end="100"
       block-size="75"
-      class="d-ps-absolute d-t0 d-l0 d-r0 d-zi-base1 d-d-flex d-ai-center d-jc-center
+      class="d-ps-absolute d-t-0 d-l-0 d-r-0 d-zi-base1 d-d-flex d-ai-center d-jc-center
       "
     >
       Fixed Toolbar (48px)

--- a/apps/dialtone-documentation/docs/components/scrollbar.md
+++ b/apps/dialtone-documentation/docs/components/scrollbar.md
@@ -14,7 +14,7 @@ keywords: ["scrollable", "d-scrollbar", "DtScrollbar", "dt-scrollbar", "custom s
 Allows to add overlay scrollbars that will look the same for every browser. The directive sets up the scrollbars from the library [OverlayScrollbars](https://kingsora.github.io/OverlayScrollbars/).
 
 ```vue demo
-<div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar>
+<div class="d-hmx-250 d-w-400 d-bar-400 d-ba" v-dt-scrollbar>
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}
@@ -62,7 +62,7 @@ To customize the behavior of the scrollbar, you can use different arguments with
 Show the scrollbar when the mouse enters the scrollable area. This is the default option, so no argument is needed.
 
 ```vue demo
-<div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar>
+<div class="d-hmx-250 d-w-400 d-bar-400 d-ba" v-dt-scrollbar>
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}
@@ -76,7 +76,7 @@ Show the scrollbar when the mouse enters the scrollable area. This is the defaul
 Always show the scrollbar if the region is overflowing the available space.
 
 ```vue demo
-<div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar:never>
+<div class="d-hmx-250 d-w-400 d-bar-400 d-ba" v-dt-scrollbar:never>
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}
@@ -90,7 +90,7 @@ Always show the scrollbar if the region is overflowing the available space.
 Show the scrollbar on scroll.
 
 ```vue demo
-<div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar:scroll>
+<div class="d-hmx-250 d-w-400 d-bar-400 d-ba" v-dt-scrollbar:scroll>
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}
@@ -104,7 +104,7 @@ Show the scrollbar on scroll.
 Show the scrollbar when the mouse moves inside the scrollable area.
 
 ```vue demo
-<div class="d-hmx-250 d-w-400 d-bar8 d-ba" v-dt-scrollbar:move>
+<div class="d-hmx-250 d-w-400 d-bar-400 d-ba" v-dt-scrollbar:move>
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}

--- a/apps/dialtone-documentation/docs/components/scroller.md
+++ b/apps/dialtone-documentation/docs/components/scroller.md
@@ -55,7 +55,7 @@ Use when all items share a known, uniform height. Set `:item-size` to that heigh
     list-tag="div"
     item-tag="div"
     direction="vertical"
-    class="d-ba d-bar8 d-p-50"
+    class="d-ba d-bar-400 d-p-50"
     >
     <template #default="{ item }">
       <dt-text class="d-px-50">{{ item.name }}</dt-text>
@@ -122,7 +122,7 @@ Use when item heights depend on their content. Set `dynamic="true"` and `:min-it
     item-tag="div"
     direction="vertical"
     :dynamic="true"
-    class="d-ba d-bar8 d-p-50"
+    class="d-ba d-bar-400 d-p-50"
   >
     <template #default="{ item }">
       <dt-stack gap="100" direction="row" align="start" class="d-p-50">
@@ -169,10 +169,10 @@ Defaults to `vertical`. Set to `horizontal` for a horizontal scroller.
     list-tag="div"
     item-tag="div"
     direction="horizontal"
-    class="d-ba d-bar8 d-p-50"
+    class="d-ba d-bar-400 d-p-50"
     >
     <template #default="{ item }">
-      <dt-stack class="d-p-150 d-ba h:d-bgc-secondary d-bc-subtle d-bar4 d-c-default" align="center" justify="center"><dt-text kind="code">{{ item.name }}</dt-text></dt-stack>
+      <dt-stack class="d-p-150 d-ba h:d-bgc-secondary d-bc-subtle d-bar-300 d-c-default" align="center" justify="center"><dt-text kind="code">{{ item.name }}</dt-text></dt-stack>
     </template>
   </dt-scroller>
 </div>

--- a/apps/dialtone-documentation/docs/components/stack.md
+++ b/apps/dialtone-documentation/docs/components/stack.md
@@ -224,7 +224,7 @@ Use `as="span"` when you need an inline container.
       <dt-text as="h3" kind="headline" :size="300">Column</dt-text>
       <dt-stack
         :gap="selectedGap"
-        class="d-bgc-moderate-opaque d-t d-td300 d-bar8 d-ttf-quint"
+        class="d-bgc-moderate-opaque d-t d-td300 d-bar-400 d-ttf-quint"
       >
         <dt-box surface="moderate-opaque" padding="200" border-radius="300">Stack item 1</dt-box>
         <dt-box surface="moderate-opaque" padding="200" border-radius="300">Stack item 2</dt-box>
@@ -236,7 +236,7 @@ Use `as="span"` when you need an inline container.
       <dt-stack
         direction="row"
         :gap="selectedGap"
-        class="d-bgc-moderate-opaque d-t d-td300 d-bar8 d-ttf-quint"
+        class="d-bgc-moderate-opaque d-t d-td300 d-bar-400 d-ttf-quint"
       >
         <dt-box surface="moderate-opaque" padding="200" border-radius="300" class="d-fl1">Stack item 1</dt-box>
         <dt-box surface="moderate-opaque" padding="200" border-radius="300" class="d-fl1">Stack item 2</dt-box>
@@ -303,7 +303,7 @@ The `align` prop is optional. Unless specified, it will default vertical stacks 
 >
   <dt-stack
     gap="100"
-    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-stretch"
+    class="d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--inline-stretch"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">
       Short
@@ -319,7 +319,7 @@ The `align` prop is optional. Unless specified, it will default vertical stacks 
   <dt-stack
     gap="100"
     direction="row"
-    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
+    class="d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--block-center"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">
       Short
@@ -364,7 +364,7 @@ Align items to the start of the cross-axis.
   <dt-stack
     gap="100"
     align="start"
-    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-start"
+    class="d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--inline-start"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">
       Short
@@ -381,7 +381,7 @@ Align items to the start of the cross-axis.
     direction="row"
     gap="100"
     align="start"
-    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-start"
+    class="d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--block-start"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">
       Short
@@ -433,7 +433,7 @@ Center items along the cross-axis.
   <dt-stack
     gap="100"
     align="center"
-    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
+    class="d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--inline-center"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">
       Short
@@ -450,7 +450,7 @@ Center items along the cross-axis.
     direction="row"
     gap="100"
     align="center"
-    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
+    class="d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--block-center"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">
       Short
@@ -491,7 +491,7 @@ Align items to the end of the cross-axis.
   <dt-stack
     gap="100"
     align="end"
-    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-end"
+    class="d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--inline-end"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">
       Short
@@ -508,7 +508,7 @@ Align items to the end of the cross-axis.
     direction="row"
     gap="100"
     align="end"
-    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-end"
+    class="d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--block-end"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">
       Short
@@ -560,7 +560,7 @@ Stretch items to fill the container height.
   <dt-stack
     gap="100"
     align="stretch"
-    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-stretch"
+    class="d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--inline-stretch"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">
       Short
@@ -577,7 +577,7 @@ Stretch items to fill the container height.
     direction="row"
     gap="100"
     align="stretch"
-    class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-stretch"
+    class="d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--block-stretch"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">
       Short
@@ -615,7 +615,7 @@ Align items along their text baselines.
   direction="row"
   gap="100"
   align="baseline"
-  class="d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--baseline"
+  class="d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--baseline"
 >
   <dt-box surface="moderate-opaque" padding="200" border-radius="300">
     <dt-text kind="body" :size="100">Small body</dt-text>
@@ -659,7 +659,7 @@ Align items to the start of the main axis (default).
   <dt-stack
     gap="100"
     justify="start"
-    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-start"
+    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--block-start"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>
@@ -669,7 +669,7 @@ Align items to the start of the main axis (default).
     direction="row"
     gap="100"
     justify="start"
-    class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-start"
+    class="d-w100p d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--inline-start"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>
@@ -697,7 +697,7 @@ Center items along the main axis.
   <dt-stack
     gap="100"
     justify="center"
-    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
+    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--block-center"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>
@@ -707,7 +707,7 @@ Center items along the main axis.
     direction="row"
     gap="100"
     justify="center"
-    class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
+    class="d-w100p d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--inline-center"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>
@@ -735,7 +735,7 @@ Align items to the end of the main axis.
   <dt-stack
     gap="100"
     justify="end"
-    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-end"
+    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--block-end"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>
@@ -745,7 +745,7 @@ Align items to the end of the main axis.
     direction="row"
     gap="100"
     justify="end"
-    class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-end"
+    class="d-w100p d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--inline-end"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>
@@ -773,7 +773,7 @@ Distribute items with equal space around each item.
   <dt-stack
     gap="100"
     justify="space-around"
-    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
+    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--block-center"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>
@@ -783,7 +783,7 @@ Distribute items with equal space around each item.
     direction="row"
     gap="100"
     justify="space-around"
-    class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
+    class="d-w100p d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--inline-center"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>
@@ -811,7 +811,7 @@ Distribute items with space between them, edges flush to container.
   <dt-stack
     gap="100"
     justify="space-between"
-    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
+    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--block-center"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>
@@ -821,7 +821,7 @@ Distribute items with space between them, edges flush to container.
     direction="row"
     gap="100"
     justify="space-between"
-    class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
+    class="d-w100p d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--inline-center"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>
@@ -854,7 +854,7 @@ Distribute items with equal space between all items, including edges.
   <dt-stack
     gap="100"
     justify="space-evenly"
-    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--block-center"
+    class="d-w100p d-h-400 d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--block-center"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>
@@ -864,7 +864,7 @@ Distribute items with equal space between all items, including edges.
     direction="row"
     gap="100"
     justify="space-evenly"
-    class="d-w100p d-bgc-moderate-opaque d-bar8 axis-outline axis-outline--inline-center"
+    class="d-w100p d-bgc-moderate-opaque d-bar-400 axis-outline axis-outline--inline-center"
   >
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
     <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>
@@ -1029,7 +1029,7 @@ Resize your browser to see the alignment change at different breakpoints.
   direction="row"
   gap="0"
   :justify="{ default: 'start', md: 'center', lg: 'space-between' }"
-  class="d-w100p d-bgc-moderate-opaque d-bar8"
+  class="d-w100p d-bgc-moderate-opaque d-bar-400"
 >
   <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 1</dt-box>
   <dt-box surface="moderate-opaque" padding="200" border-radius="300">Item 2</dt-box>

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -134,7 +134,7 @@ In place of the `inverted` prop, use the [v-dt-mode directive](mode-island.html#
 
 ```vue demo
 <div class="d-p-100 d-bgc-contrast d-w100p">
-  <div v-dt-mode:invert class="d-p-200 d-bar8">
+  <div v-dt-mode:invert class="d-p-200 d-bar-400">
     <example-tabs />
   </div>
 </div>

--- a/apps/dialtone-documentation/docs/components/text.md
+++ b/apps/dialtone-documentation/docs/components/text.md
@@ -66,7 +66,7 @@ Declare the role of the content. Default will inherit styles from the parent.
 
 All kinds support `size` prop, but not all sizes are available for each kind. When `kind` is set, size defaults to `300` if not specified.
 
-<dt-stack class="d-w100p d-ba d-bar4 d-of-auto">
+<dt-stack class="d-w100p d-ba d-bar-300 d-of-auto">
   <table class="d-w100p d-table">
     <tr class="d-va-baseline">
       <th></th>
@@ -155,7 +155,7 @@ Use `tone` to declare the text's tone, which will map to a foreground color. By 
 
 ```vue demo
 <!-- @wrapper -->
-<dt-stack class="d-py-100 d-px-200 d-bar4">
+<dt-stack class="d-py-100 d-px-200 d-bar-300">
   <dt-text>primary</dt-text>
   <dt-text tone="secondary">secondary</dt-text>
   <dt-text tone="tertiary">tertiary</dt-text>
@@ -175,7 +175,7 @@ Use `tone` to declare the text's tone, which will map to a foreground color. By 
 Rather than use the `-inverted` tone variants, use the [v-dt-mode](/components/mode-island.html) directive.
 
 ```vue demo
-<dt-stack gap="100" class="d-py-100 d-px-200 d-bar4">
+<dt-stack gap="100" class="d-py-100 d-px-200 d-bar-300">
   <div class="d-p-100 d-px-150 d-bgc-transparent d-baw2 d-bas-dashed d-bc-subtle">
     <dt-text as="p" align="center" tone="critical">critical tone on default surface</dt-text>
   </div>
@@ -263,7 +263,7 @@ Since `DtText`'s default element is a `<span>`, the `truncate` will only work if
       <dt-stack direction="row" gap="25" align="center">
         <dt-stack direction="row">
           <dt-button
-            class="d-as-stretch d-brr0 d-brw0"
+            class="d-as-stretch d-bier-0 d-brw0"
             :size="200"
             importance="outlined"
             kind="muted"
@@ -273,7 +273,7 @@ Since `DtText`'s default element is a `<span>`, the `truncate` will only work if
           </dt-button>
           <dt-button
             v-dt-tooltip="`Decrement`"
-            class="d-as-stretch d-g-0 d-blr0 d-brr0 d-brw0"
+            class="d-as-stretch d-g-0 d-bisr-0 d-bier-0 d-brw0"
             :size="200"
             importance="outlined"
             kind="muted"
@@ -286,7 +286,7 @@ Since `DtText`'s default element is a `<span>`, the `truncate` will only work if
           </dt-button>
           <dt-button
             v-dt-tooltip="`Increment`"
-            class="d-as-stretch d-g-0 d-blr0"
+            class="d-as-stretch d-g-0 d-bisr-0"
             :size="200"
             importance="outlined"
             kind="muted"

--- a/apps/dialtone-documentation/docs/design/icons/index.md
+++ b/apps/dialtone-documentation/docs/design/icons/index.md
@@ -59,7 +59,7 @@ Some icons are linked to specific actions, like the Settings gear <dt-icon name=
 
 The icon size is defined based on the context and text size next to it. These are the only available size options and no overrides should be needed to properly size the icons.
 
-<dt-stack direction="row" justify="between" gap="100" class="d-gc2 d-bgc-secondary d-p-300 d-bar16">
+<dt-stack direction="row" justify="between" gap="100" class="d-gc2 d-bgc-secondary d-p-300 d-bar-500">
   <dt-stack gap="100" align="center">
     <dt-icon name="food" size="100" />
     <dt-text as="code" kind="code" :size="200">100</dt-text>
@@ -97,7 +97,7 @@ The icon size is defined based on the context and text size next to it. These ar
 
 #### Sample Pairings
 
-<dt-stack align="center" class="d-gc2 d-bgc-secondary d-p-300 d-bar16">
+<dt-stack align="center" class="d-gc2 d-bgc-secondary d-p-300 d-bar-500">
   <dt-stack gap="100">
     <dt-stack direction="row" gap="50" align="center">
       <dt-icon name="food" size="100" />

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2025-12-2.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2025-12-2.md
@@ -38,9 +38,9 @@ The tool is ideal for projects with many flex containers. For small, one-off cha
 **Before**
 
 <code-well-header>
-  <div class="d-d-flex d-ai-center d-jc-space-between d-g-200 d-w100p d-bgc-moderate-opaque d-bar8">
-    <div class="d-bgc-moderate-opaque d-p16 d-bar8">Left</div>
-    <div class="d-bgc-moderate-opaque d-p16 d-bar8">Right</div>
+  <div class="d-d-flex d-ai-center d-jc-space-between d-g-200 d-w100p d-bgc-moderate-opaque d-bar-400">
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Left</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Right</div>
   </div>
 </code-well-header>
 
@@ -64,9 +64,9 @@ The tool is ideal for projects with many flex containers. For small, one-off cha
 **After**
 
 <code-well-header>
-  <dt-stack direction="row" align="center" justify="space-between" gap="200" class="d-w100p d-bgc-moderate-opaque d-bar8">
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Left</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Right</div>
+  <dt-stack direction="row" align="center" justify="space-between" gap="200" class="d-w100p d-bgc-moderate-opaque d-bar-400">
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Left</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Right</div>
   </dt-stack>
 </code-well-header>
 
@@ -91,10 +91,10 @@ The tool is ideal for projects with many flex containers. For small, one-off cha
 **Before**
 
 <code-well-header>
-  <div class="d-d-flex d-fd-column d-g-300 d-bgc-moderate-opaque d-bar8">
-    <div class="d-bgc-moderate-opaque d-p16 d-bar8">First</div>
-    <div class="d-bgc-moderate-opaque d-p16 d-bar8">Second</div>
-    <div class="d-bgc-moderate-opaque d-p16 d-bar8">Third</div>
+  <div class="d-d-flex d-fd-column d-g-300 d-bgc-moderate-opaque d-bar-400">
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">First</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Second</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Third</div>
   </div>
 </code-well-header>
 
@@ -112,10 +112,10 @@ The tool is ideal for projects with many flex containers. For small, one-off cha
 **After**
 
 <code-well-header>
-  <dt-stack gap="300" class="d-bgc-moderate-opaque d-bar8">
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">First</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Second</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Third</div>
+  <dt-stack gap="300" class="d-bgc-moderate-opaque d-bar-400">
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">First</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Second</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Third</div>
   </dt-stack>
 </code-well-header>
 
@@ -446,20 +446,20 @@ Flex CSS Utilities are still supported on DtStack, e.g. some flex utilities have
 For example, `d-fw-wrap` isn't a DtStack prop, but can still be applied.
 
 <code-well-header>
-  <dt-stack align="center" gap="100" direction="row" class="d-bgc-moderate-opaque d-bar8 d-fw-wrap">
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">First</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Second</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Third</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Fourth</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Fifth</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Sixth</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Seventh</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Eighth</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Ninth</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Tenth</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Eleventh</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Twelfth</div>
-    <div class="d-bgc-moderate-opaque d-p-200 d-bar8">Thirteenth</div>
+  <dt-stack align="center" gap="100" direction="row" class="d-bgc-moderate-opaque d-bar-400 d-fw-wrap">
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">First</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Second</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Third</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Fourth</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Fifth</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Sixth</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Seventh</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Eighth</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Ninth</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Tenth</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Eleventh</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Twelfth</div>
+    <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Thirteenth</div>
   </dt-stack>
 </code-well-header>
 

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-3-31.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-3-31.md
@@ -22,7 +22,7 @@ excerpt: 'Component size props move from t-shirt labels (xs, sm, md) to a numeri
 
 ## Examples
 
-<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
 <div>
 
 **Before**
@@ -151,7 +151,7 @@ The ESLint rule flags t-shirt literals inside dynamic bindings (`:size="'sm'"`, 
 
 ### Ternary expressions
 
-<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
 <div>
 
 **Before**
@@ -174,7 +174,7 @@ The ESLint rule flags t-shirt literals inside dynamic bindings (`:size="'sm'"`, 
 
 ### Computed properties
 
-<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
 <div>
 
 **Before**
@@ -205,7 +205,7 @@ computed: {
 
 ### Lookup maps
 
-<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
 <div>
 
 **Before**

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-15.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-15.md
@@ -52,7 +52,7 @@ Focus on the first item and use your up/down arrow keys.
 
 ```vue demo
 <dt-stack v-dt-focusgroup="'vertical'" role="list" aria-label="Contacts">
-  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar8">
+  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar-400">
     <dt-stack direction="row" gap="100" class="d-w100p">
       <dt-avatar full-name="Ashanti Trevor" />
       <dt-stack class="d-fl1">
@@ -70,7 +70,7 @@ Focus on the first item and use your up/down arrow keys.
       <dt-badge kind="count" type="bulletin" text="6" />
     </dt-stack>
   </dt-stack>
-  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar8">
+  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar-400">
     <dt-stack direction="row" gap="100" class="d-w100p">
       <dt-avatar full-name="Marcus Chen" />
       <dt-stack class="d-fl1">
@@ -87,7 +87,7 @@ Focus on the first item and use your up/down arrow keys.
       <dt-text kind="body" :size="200" tone="tertiary" numeric> 1:47 pm </dt-text>
     </dt-stack>
   </dt-stack>
-  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar8">
+  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar-400">
     <dt-stack direction="row" gap="100" class="d-w100p">
       <dt-avatar full-name="Priya Sharma" />
       <dt-stack class="d-fl1">

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-21.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-21.md
@@ -31,7 +31,7 @@ One directive. One attribute. Zero event handlers.
   v-dt-focustrap
   role="dialog"
   aria-label="Settings"
-  class="d-w-500 d-p-300 d-bar8 d-bc-default d-ba d-bgc-primary"
+  class="d-w-500 d-p-300 d-bar-400 d-bc-default d-ba d-bgc-primary"
 >
   <dt-stack gap="200">
     <dt-text as="p" kind="body" :size="200">Tab and Shift+Tab cycle within this container. Focus never escapes.</dt-text>

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-6.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-6.md
@@ -24,7 +24,7 @@ excerpt: 'Vue component APIs now use logical direction names (start/end/blockSta
 
 ### Slots
 
-<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
 <div>
 
 **Before**
@@ -73,7 +73,7 @@ excerpt: 'Vue component APIs now use logical direction names (start/end/blockSta
 
 ### Props
 
-<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
 <div>
 
 **Before**
@@ -116,7 +116,7 @@ excerpt: 'Vue component APIs now use logical direction names (start/end/blockSta
 
 ### Prop Values
 
-<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
 <div>
 
 **Before**
@@ -147,7 +147,7 @@ excerpt: 'Vue component APIs now use logical direction names (start/end/blockSta
 
 ### Events
 
-<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
 <div>
 
 **Before**
@@ -185,7 +185,7 @@ The `#icon` slot on `dt-button` is **ambiguous** -- its position depends on the 
 | `blockStart` | `#blockStartIcon` |
 | `blockEnd` | `#blockEndIcon` |
 
-<div class="d-d-grid d-g16 d-g-cols1 md:d-g-cols2">
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
 <div>
 
 **Before**

--- a/apps/dialtone-documentation/docs/foundations/brand/index.md
+++ b/apps/dialtone-documentation/docs/foundations/brand/index.md
@@ -9,7 +9,7 @@ keywords: ["brand", "branding", "identity", "mark", "dialpad logo"]
 
 
 <dt-stack gap="600" class="d-mbs-600">
-  <svg-loader name="logo--negative-space" class="d-bar16" />
+  <svg-loader name="logo--negative-space" class="d-bar-500" />
   <div>
 <h2 class="d-docsite--header-3">the Spark</h2>
 
@@ -18,15 +18,15 @@ The Dialpad icon draws on the core of the Dialpad product, the phone Dialpad and
 The visual symbols of the dialpad and Ai are combined to represent the relationship between businesses and customers with Dialpad as the connective tissue.
   </div>
 
-  <figure class="d-bar16 d-of-hidden">
+  <figure class="d-bar-500 d-of-hidden">
     <img src="/assets/images/logo--sample-01.jpg" alt="">
   </figure>
 
-  <figure class="d-bar16 d-of-hidden">
+  <figure class="d-bar-500 d-of-hidden">
     <img src="/assets/images/logo--sample-02.jpg" alt="">
   </figure>
 
-  <figure class="d-bar16 d-of-hidden">
+  <figure class="d-bar-500 d-of-hidden">
     <img src="/assets/images/logo--sample-03.png" alt="">
   </figure>
 </dt-stack>

--- a/apps/dialtone-documentation/docs/foundations/brand/our-icon/index.md
+++ b/apps/dialtone-documentation/docs/foundations/brand/our-icon/index.md
@@ -6,8 +6,8 @@ keywords: ["app icon","favicon","brand mark"]
 ---
 
 <dt-stack gap="600" class="d-mbs-600">
-  <figure class="d-bar16 d-of-hidden">
-    <svg-loader name="icon--billboard" class="d-bar16" />
+  <figure class="d-bar-500 d-of-hidden">
+    <svg-loader name="icon--billboard" class="d-bar-500" />
   </figure>
 
   <div class="d-d-grid d-g-600 d-g-cols1 md:d-g-cols3 d-ai-center">
@@ -17,7 +17,7 @@ keywords: ["app icon","favicon","brand mark"]
       <p class="d-docsite--paragraph"><strong>Sample Use Cases</strong>: App icons, social avatars, favicons.</p>
     </div>
     <div class="d-gc2">
-      <svg-loader name="icon--usage" class="d-bar16" />
+      <svg-loader name="icon--usage" class="d-bar-500" />
     </div>
   </div>
 
@@ -29,7 +29,7 @@ keywords: ["app icon","favicon","brand mark"]
       <p class="d-docsite--paragraph"><dt-link href="#">Download icons</dt-link></p>
     </div>
     <div class="d-gc2">
-      <svg-loader name="icon--versions" class="d-bar16" />
+      <svg-loader name="icon--versions" class="d-bar-500" />
     </div>
   </div>
 
@@ -40,19 +40,19 @@ keywords: ["app icon","favicon","brand mark"]
       <p class="d-docsite--paragraph"><dt-link href="#">View Dialtone Icon</dt-link></p>
     </div>
     <div class="d-gc2">
-      <svg-loader name="icon--in-product" class="d-bar16" />
+      <svg-loader name="icon--in-product" class="d-bar-500" />
     </div>
   </div>
 
-  <figure class="d-bar16 d-of-hidden">
+  <figure class="d-bar-500 d-of-hidden">
     <img src="/assets/images/color--sample-01.jpg" alt="">
   </figure>
 
-  <figure class="d-bar16 d-of-hidden">
+  <figure class="d-bar-500 d-of-hidden">
     <img src="/assets/images/color--sample-02.jpg" alt="">
   </figure>
 
-  <figure class="d-bar16 d-of-hidden">
+  <figure class="d-bar-500 d-of-hidden">
     <img src="/assets/images/color--sample-03.jpg" alt="">
   </figure>
 </dt-stack>

--- a/apps/dialtone-documentation/docs/foundations/brand/using-our-logo/index.md
+++ b/apps/dialtone-documentation/docs/foundations/brand/using-our-logo/index.md
@@ -10,22 +10,22 @@ keywords: ["logo usage","logo guidelines","brand guidelines"]
 <dt-stack gap="600" class="d-mbs-600">
   <div class="d-d-grid d-g-600 d-g-cols1 md:d-g-cols2 d-ai-center">
     <div>
-      <svg-loader name="logo--primary-color-light" class="d-bar16" />
+      <svg-loader name="logo--primary-color-light" class="d-bar-500" />
       <p class="d-docsite--header-3 d-m-0 d-mbs-200">Primary Color Light</p>
     </div>
     <div>
-      <svg-loader name="logo--primary-color-dark" class="d-bar16" />
+      <svg-loader name="logo--primary-color-dark" class="d-bar-500" />
       <p class="d-docsite--header-3 d-m-0 d-mbs-200">Primary Color Dark</p>
     </div>
   </div>
 
   <div class="d-d-grid d-g-600 d-g-cols1 md:d-g-cols2 d-ai-center">
     <div>
-      <svg-loader name="logo--secondary-color-light" class="d-bar16" />
+      <svg-loader name="logo--secondary-color-light" class="d-bar-500" />
       <p class="d-docsite--header-3 d-m-0 d-mbs-200">Secondary Color Light</p>
     </div>
     <div>
-      <svg-loader name="logo--secondary-color-dark" class="d-bar16" />
+      <svg-loader name="logo--secondary-color-dark" class="d-bar-500" />
       <p class="d-docsite--header-3 d-m-0 d-mbs-200">Secondary Color Dark</p>
     </div>
   </div>
@@ -37,7 +37,7 @@ keywords: ["logo usage","logo guidelines","brand guidelines"]
       <p class="d-docsite--paragraph d-fc-critical">Never use the spark icon on it’s own, it should always be used with the Dialpad wordmark</p>
     </div>
     <div class="d-gc2">
-      <svg-loader name="logo--how-to-use" class="d-bar16" />
+      <svg-loader name="logo--how-to-use" class="d-bar-500" />
     </div>
   </div>
 
@@ -52,7 +52,7 @@ keywords: ["logo usage","logo guidelines","brand guidelines"]
       </p>
     </div>
     <div class="d-gc2">
-      <svg-loader name="logo--clear-space" class="d-bar16" />
+      <svg-loader name="logo--clear-space" class="d-bar-500" />
     </div>
   </div>
 
@@ -62,7 +62,7 @@ keywords: ["logo usage","logo guidelines","brand guidelines"]
       <p class="d-docsite--paragraph">Maintain at least 2x the width of the "d" as clear space around the logo and ensure centering of the "dialpad" wordmark minus the Spark's width.</p>
     </div>
     <div class="d-gc2">
-      <svg-loader name="logo--positioning" class="d-bar16" />
+      <svg-loader name="logo--positioning" class="d-bar-500" />
     </div>
   </div>
 
@@ -71,7 +71,7 @@ keywords: ["logo usage","logo guidelines","brand guidelines"]
       <h2 class="d-docsite--header-3">Alignment</h2>
     </div>
     <div class="d-gc2">
-      <svg-loader name="logo--alignment" class="d-bar16" />
+      <svg-loader name="logo--alignment" class="d-bar-500" />
     </div>
   </div>
 </dt-stack>
@@ -90,7 +90,7 @@ Choose the proper logo variant based on its context and theme.
 
 Logos are available in a fixed set of color options to suit different backgrounds, contexts, and theme needs.
 
-<div class="d-ba d-bar8 d-bc-subtle">
+<div class="d-ba d-bar-400 d-bc-subtle">
   <table class="d-table dialtone-doc-table">
     <thead>
       <tr>
@@ -104,7 +104,7 @@ Logos are available in a fixed set of color options to suit different background
       <tr>
         <td class="d-ws-nowrap">Color</td>
         <td>
-          <dt-stack class="d-bgc-transparent d-p-200 d-pie-300 d-bar8">
+          <dt-stack class="d-bgc-transparent d-p-200 d-pie-300 d-bar-400">
             <dt-illustration name='dialpad-logo' />
           </dt-stack>
         </td>
@@ -118,7 +118,7 @@ Logos are available in a fixed set of color options to suit different background
       <tr>
         <td class="d-ws-nowrap">Monochrome</td>
         <td>
-          <dt-stack class="d-bgc-transparent d-p-200 d-pie-300 d-bar8">
+          <dt-stack class="d-bgc-transparent d-p-200 d-pie-300 d-bar-400">
             <dt-illustration name='dialpad-mono' />
           </dt-stack>
         </td>
@@ -132,7 +132,7 @@ Logos are available in a fixed set of color options to suit different background
       <tr>
         <td class="d-ws-nowrap">Color</td>
         <td>
-          <dt-stack  class="d-bgc-primary-inverted d-p-200 d-pie-300 d-bar8">
+          <dt-stack  class="d-bgc-primary-inverted d-p-200 d-pie-300 d-bar-400">
             <dt-illustration name='dialpad-logo-inverted' />
           </dt-stack>
         </td>
@@ -146,7 +146,7 @@ Logos are available in a fixed set of color options to suit different background
       <tr>
         <td class="d-ws-nowrap">Monochrome</td>
         <td>
-          <dt-stack class="d-bgc-primary-inverted d-p-200 d-pie-300 d-bar8">
+          <dt-stack class="d-bgc-primary-inverted d-p-200 d-pie-300 d-bar-400">
             <dt-illustration name='dialpad-mono-inverted' />
           </dt-stack>
         </td>
@@ -160,7 +160,7 @@ Logos are available in a fixed set of color options to suit different background
       <tr>
         <td class="d-ws-nowrap">Color</td>
         <td>
-          <dt-stack  class="d-bgc-neutral-white d-p-200 d-pie-300 d-bar8">
+          <dt-stack  class="d-bgc-neutral-white d-p-200 d-pie-300 d-bar-400">
             <dt-illustration name='dialpad-logo-black' />
           </dt-stack>
         </td>
@@ -174,7 +174,7 @@ Logos are available in a fixed set of color options to suit different background
       <tr>
         <td class="d-ws-nowrap">Monochrome</td>
         <td>
-          <dt-stack class="d-bgc-neutral-white d-p-200 d-pie-300 d-bar8">
+          <dt-stack class="d-bgc-neutral-white d-p-200 d-pie-300 d-bar-400">
             <dt-illustration name='dialpad-mono-black' />
           </dt-stack>
         </td>
@@ -188,7 +188,7 @@ Logos are available in a fixed set of color options to suit different background
       <tr>
         <td class="d-ws-nowrap">Color</td>
         <td>
-          <dt-stack  class="d-bgc-neutral-black d-p-200 d-pie-300 d-bar8">
+          <dt-stack  class="d-bgc-neutral-black d-p-200 d-pie-300 d-bar-400">
             <dt-illustration name='dialpad-logo-white' />
           </dt-stack>
         </td>
@@ -202,7 +202,7 @@ Logos are available in a fixed set of color options to suit different background
       <tr>
         <td class="d-ws-nowrap">Monochrome</td>
         <td>
-          <dt-stack class="d-bgc-neutral-black d-p-200 d-pie-300 d-bar8">
+          <dt-stack class="d-bgc-neutral-black d-p-200 d-pie-300 d-bar-400">
             <dt-illustration name='dialpad-mono-white' />
           </dt-stack>
         </td>

--- a/apps/dialtone-documentation/docs/foundations/colors/chart-colors/index.md
+++ b/apps/dialtone-documentation/docs/foundations/colors/chart-colors/index.md
@@ -9,7 +9,7 @@ keywords: ["data visualization","graph colors","chart palette"]
 Data visualization is crucial for clear communication, but inconsistent color usage can hinder comprehension and create visual noise.
 **Chart Color Tokens** provide a unified, robust, and accessible system for coloring data visualizations  across all Dialpad products.
 
-<div class="d-bgc-secondary d-bar8 d-mbe-200">
+<div class="d-bgc-secondary d-bar-400 d-mbe-200">
  <svg-loader name="chart-header" />
 </div>
 
@@ -28,7 +28,7 @@ Chart Colors are available for one of four types: [Single Color](#single-color),
 
 Use for data visualizations that only require comparing one or two data points, or a single data point against a series of adjacent neutral data. Use `chart.color.accent` as the default. To bring a data point to focus, use `chart.color.accent` for the focused data point and `chart.color.neutral` for the rest.
 
-<div class="d-bgc-secondary d-bar8 d-mbe-200">
+<div class="d-bgc-secondary d-bar-400 d-mbe-200">
   <svg-loader name="chart-singlecolor" />
 </div>
 
@@ -44,7 +44,7 @@ Use for data visualizations that only require comparing one or two data points, 
 
 Apply colors that associate meaning to the data points, such as status, severity, or sentiment.
 
-<div class="d-bgc-secondary d-bar8 d-mbe-200">
+<div class="d-bgc-secondary d-bar-400 d-mbe-200">
   <svg-loader name="chart-semantic" />
 </div>
 
@@ -61,7 +61,7 @@ Apply colors that associate meaning to the data points, such as status, severity
 
 Apply unique colors to distinguish two or more unrelated data where color carries no meaning. Use in the predetermined numerical order, e.g. `01`, `02`, etc. This ensures applied data can be visually distinguished from its adjacent data.
 
-<div class="d-bgc-secondary d-bar8 d-mbe-200">
+<div class="d-bgc-secondary d-bar-400 d-mbe-200">
   <svg-loader name="chart-categorical" />
 </div>
 
@@ -76,7 +76,7 @@ Apply unique colors to distinguish two or more unrelated data where color carrie
 
 To represent data using progressive shades or tints of a single color, emphasizing their relative depth within a single data series.
 
-<div class="d-bgc-secondary d-bar8 d-mbe-200">
+<div class="d-bgc-secondary d-bar-400 d-mbe-200">
   <svg-loader name="chart-sequential" />
 </div>
 

--- a/apps/dialtone-documentation/docs/foundations/colors/index.md
+++ b/apps/dialtone-documentation/docs/foundations/colors/index.md
@@ -12,7 +12,7 @@ keywords: ["colour", "colors", "palette", "theme", "purple", "red", "blue", "gre
       <p class="d-docsite--paragraph">Product</p>
     </div>
     <div class="d-gc2">
-      <svg-loader name="color--expanded" class="d-bar16" />
+      <svg-loader name="color--expanded" class="d-bar-500" />
     </div>
   </div>
 
@@ -22,19 +22,19 @@ keywords: ["colour", "colors", "palette", "theme", "purple", "red", "blue", "gre
       <p class="d-docsite--paragraph">Brand</p>
     </div>
     <div class="d-gc2">
-      <svg-loader name="color--focused" class="d-bar16" />
+      <svg-loader name="color--focused" class="d-bar-500" />
     </div>
   </div>
 
-  <figure class="d-bar16 d-of-hidden">
+  <figure class="d-bar-500 d-of-hidden">
     <img src="/assets/images/color--sample-01.jpg" alt="">
   </figure>
 
-  <figure class="d-bar16 d-of-hidden">
+  <figure class="d-bar-500 d-of-hidden">
     <img src="/assets/images/color--sample-02.jpg" alt="">
   </figure>
 
-  <figure class="d-bar16 d-of-hidden">
+  <figure class="d-bar-500 d-of-hidden">
     <img src="/assets/images/color--sample-03.jpg" alt="">
   </figure>
 </dt-stack>

--- a/apps/dialtone-documentation/docs/foundations/colors/marketing/index.md
+++ b/apps/dialtone-documentation/docs/foundations/colors/marketing/index.md
@@ -16,7 +16,7 @@ keywords: ["brand colors","marketing colors","purple"]
         <p class="d-docsite--paragraph">For specialty brand communications use one of the Dialpad brand purples for backgrounds.</p>
       </div>
       <div class="d-gc2">
-        <svg-loader class="d-bar16" name="color-marketing--01" />
+        <svg-loader class="d-bar-500" name="color-marketing--01" />
       </div>
     </div>
   </div>
@@ -26,7 +26,7 @@ keywords: ["brand colors","marketing colors","purple"]
       <p class="d-docsite--paragraph">When creating attract and engage level communications, especially when using an increased amount of text, use the light background.</p>
     </div>
     <div class="d-gc2">
-      <svg-loader class="d-bar16" name="color-marketing--02" />
+      <svg-loader class="d-bar-500" name="color-marketing--02" />
     </div>
   </div>
 
@@ -37,20 +37,20 @@ keywords: ["brand colors","marketing colors","purple"]
       <p class="d-docsite--paragraph"><dt-link href="#">View Dialtone Icon</dt-link></p>
     </div>
     <div class="d-gc2">
-      <svg-loader class="d-bar16" name="color-marketing--03" />
+      <svg-loader class="d-bar-500" name="color-marketing--03" />
     </div>
   </div>
 
   <figure>
-    <svg-loader class="d-bar16" name="color-marketing--04" />
+    <svg-loader class="d-bar-500" name="color-marketing--04" />
   </figure>
 
   <div class="d-d-grid d-g-600 d-g-cols1 md:d-g-cols2 d-ai-center">
     <figure>
-      <svg-loader class="d-bar16" name="color-marketing--05" />
+      <svg-loader class="d-bar-500" name="color-marketing--05" />
     </figure>
     <figure>
-      <svg-loader class="d-bar16" name="color-marketing--06" />
+      <svg-loader class="d-bar-500" name="color-marketing--06" />
     </figure>
   </div>
 

--- a/apps/dialtone-documentation/docs/foundations/colors/themes/index.md
+++ b/apps/dialtone-documentation/docs/foundations/colors/themes/index.md
@@ -13,7 +13,7 @@ Dialtone's theming system is a flexible foundation for creating consistent visua
 
 Theming is limited to the application's navigation regions, consisting of the top and left.
 
-<div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="theme-image" /></div>
+<div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="theme-image" /></div>
 
 ### Mode
 
@@ -300,7 +300,7 @@ The shell tokens are a specialized set of tokens for theming the topbar and side
 
 These are the core reference colors for the shell. They are directly linked to the base tokens and determine the overall color palette of the topbar and sidebar. These base tokens are the only ones that should be modified when creating a custom theme.
 
-<div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="base-tokens" /></div>
+<div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="base-tokens" /></div>
 
 <div class="d-m-400"></div>
 
@@ -308,12 +308,12 @@ These are the core reference colors for the shell. They are directly linked to t
 
 These tokens, such as `shell-action...`, `shell-status...` `shell-mention...`, inherit their values from the shell base tokens. For example, they use modifiers to create variations or color states (e.g., `hover`, `active`, `disabled`).
 
-<div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="base-shell-token" /></div>
+<div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="base-shell-token" /></div>
 
 <div class="d-m-400"></div>
 
 This structure allows for a cascading effect: changing a shell base token automatically updates all related shell modifier tokens, making it simple to create and manage custom themes for the application's shell.
-<div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="token-structure" /></div>
+<div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="token-structure" /></div>
 
 <div class="d-m-400"></div>
 
@@ -323,12 +323,12 @@ When creating a custom theme, it is important to ensure that the colors used are
 
 <dialtone-usage class="d-d-grid d-g-300 d-g-cols2">
   <template #do>
-    <div class="d-bgc-secondary d-bar8">
+    <div class="d-bgc-secondary d-bar-400">
       <svg-loader class="d-fl1" name="theme-contrast-do" />
     </div>
   </template>
   <template #dont>
-    <div class="d-bgc-secondary d-bar8">
+    <div class="d-bgc-secondary d-bar-400">
       <svg-loader class="d-fl1" name="theme-contrast-dont" />
     </div>
   </template>

--- a/apps/dialtone-documentation/docs/foundations/colors/usage/index.md
+++ b/apps/dialtone-documentation/docs/foundations/colors/usage/index.md
@@ -14,7 +14,7 @@ What we prioritize is semantic clarity, ensuring each color serves a distinct pu
 
 <div class="d-m-400"></div>
 
-<div class="d-bgc-secondary d-bar8">
+<div class="d-bgc-secondary d-bar-400">
  <svg-loader name="color-table" />
 </div>
 
@@ -22,19 +22,19 @@ What we prioritize is semantic clarity, ensuring each color serves a distinct pu
 
 Dialtone uses **semantic tokens** for color, representing a color's *purpose* in the UI. See our [See our design token list](https://dialtone.dialpad.com/tokens/) for descriptions guiding their application.
 
-<div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="color-tokens" /></div>
+<div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="color-tokens" /></div>
 
 <div class="d-m-400"></div>
 
 It's crucial to understand that while these semantic tokens are built upon our underlying **base color palette**, the work of selecting the appropriate base color for each specific UI context has already been meticulously done for you.
 
-<div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="color-semantic" /></div>
+<div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="color-semantic" /></div>
 
 ## Color roles
 
 Color roles describe the purpose of how color is used. Each uses neutrals for general UI and status colors for impact.
 
-<div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="color-roles" /></div>
+<div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="color-roles" /></div>
 
 We categorize color application by semantic roles such as: **text, surfaces, borders, and themes**. Each uses neutrals for general UI and status colors for impact.
 
@@ -44,12 +44,12 @@ Foreground colors are the visual language of our content, applied across all con
 
 <div class="d-d-grid d-g-300 d-g-cols2">
   <div>
-    <div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="color-text-f" /></div>
+    <div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="color-text-f" /></div>
     <h4>Foreground Text</h4>
     Neutral text colors form the backbone of our content, used for headers, body text, forms, and more.
   </div>
   <div>
-     <div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="color-text-s" /></div>
+     <div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="color-text-s" /></div>
     <h4>Status Text</h4>
     Status text colors are critical for highlighting key information:
     <ul>
@@ -59,7 +59,7 @@ Foreground colors are the visual language of our content, applied across all con
     </ul>
   </div>
 <div>
-   <div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="color-foreground-icon" /></div>
+   <div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="color-foreground-icon" /></div>
     <h4>Icons</h4>
     Icon colors profoundly impact readability, user interaction, communicating meaning and status at a glance.
   </div>
@@ -71,10 +71,10 @@ Surface colors define the background of UI elements, from pages and modals to ta
 
 <div class="d-d-grid d-g-300 d-g-cols2">
   <div>
-    <div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="color-surface-neutral" /></div>
+    <div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="color-surface-neutral" /></div>
   </div>
   <div>
-     <div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="color-surface-status" /></div>
+     <div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="color-surface-status" /></div>
   </div>
 </div>
 
@@ -84,10 +84,10 @@ Borders delineate content areas and components, using neutrals for subtle defini
 
 <div class="d-d-grid d-g-300 d-g-cols2">
   <div>
-    <div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="color-border-ai" /></div>
+    <div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="color-border-ai" /></div>
   </div>
   <div>
-     <div class="d-bgc-secondary d-bar8"><svg-loader class="d-fl1" name="color-border-status" /></div>
+     <div class="d-bgc-secondary d-bar-400"><svg-loader class="d-fl1" name="color-border-status" /></div>
   </div>
 </div>
 
@@ -96,16 +96,16 @@ Borders delineate content areas and components, using neutrals for subtle defini
 View our [Chart Colors](../chart-colors/index.md) documentation for more information.
 
 <div class="d-d-grid d-g-300 d-g-cols2">
-  <div class="d-bgc-secondary d-bar8">
+  <div class="d-bgc-secondary d-bar-400">
    <svg-loader name="chart-singlecolor" />
   </div>
-  <div class="d-bgc-secondary d-bar8">
+  <div class="d-bgc-secondary d-bar-400">
    <svg-loader name="chart-semantic" />
   </div>
-  <div class="d-bgc-secondary d-bar8">
+  <div class="d-bgc-secondary d-bar-400">
    <svg-loader name="chart-categorical" />
   </div>
-  <div class="d-bgc-secondary d-bar8">
+  <div class="d-bgc-secondary d-bar-400">
    <svg-loader name="chart-sequential" />
   </div>
 </div>
@@ -118,12 +118,12 @@ Use feedback colors consistently to maintain clear communication and avoid confu
 
 <dialtone-usage class="d-d-grid d-g-300 d-g-cols2">
   <template #do>
-    <div class="d-bgc-secondary d-bar8">
+    <div class="d-bgc-secondary d-bar-400">
       <svg-loader class="d-fl1" name="color-semantics-do" />
     </div>
   </template>
   <template #dont>
-    <div class="d-bgc-secondary d-bar8">
+    <div class="d-bgc-secondary d-bar-400">
       <svg-loader class="d-fl1" name="color-semantics-dont" />
     </div>
   </template>
@@ -135,12 +135,12 @@ Embrace semantic tokens to separate color values from their contextual meaning, 
 
 <dialtone-usage class="d-d-grid d-g-300 d-g-cols2">
   <template #do>
-    <div class="d-bgc-secondary d-bar8">
+    <div class="d-bgc-secondary d-bar-400">
       <svg-loader class="d-fl1" name="color-token-do" />
     </div>
   </template>
   <template #dont>
-    <div class="d-bgc-secondary d-bar8">
+    <div class="d-bgc-secondary d-bar-400">
       <svg-loader class="d-fl1" name="color-token-dont" />
     </div>
   </template>
@@ -154,12 +154,12 @@ We primarily employ the APCA for precise contrast evaluation, ensuring readabili
 
 <dialtone-usage class="d-d-grid d-g-300 d-g-cols2">
   <template #do>
-    <div class="d-bgc-secondary d-bar8">
+    <div class="d-bgc-secondary d-bar-400">
       <svg-loader class="d-fl1" name="color-contrast-do" />
     </div>
   </template>
   <template #dont>
-    <div class="d-bgc-secondary d-bar8">
+    <div class="d-bgc-secondary d-bar-400">
       <svg-loader class="d-fl1" name="color-contrast-dont" />
     </div>
   </template>
@@ -171,12 +171,12 @@ Maintain color consistency across similar components to build intuitive user pat
 
 <dialtone-usage class="d-d-grid d-g-300 d-g-cols2">
   <template #do>
-    <div class="d-bgc-secondary d-bar8">
+    <div class="d-bgc-secondary d-bar-400">
       <svg-loader class="d-fl1" name="color-uniform-do" />
     </div>
   </template>
   <template #dont>
-    <div class="d-bgc-secondary d-bar8">
+    <div class="d-bgc-secondary d-bar-400">
       <svg-loader class="d-fl1" name="color-uniform-dont" />
     </div>
   </template>

--- a/apps/dialtone-documentation/docs/foundations/gradient/index.md
+++ b/apps/dialtone-documentation/docs/foundations/gradient/index.md
@@ -5,7 +5,7 @@ thumb: true
 keywords: ["gradients","color transition","linear gradient","radial gradient"]
 ---
 
-<div class="d-ba d-bar16 d-pbs-400 d-ta-center d-fc-muted d-headline--xxl">
+<div class="d-ba d-bar-500 d-pbs-400 d-ta-center d-fc-muted d-headline--xxl">
   <dt-empty-state
     :size="300"
     header-text="TBD"

--- a/apps/dialtone-documentation/docs/foundations/icons/usage/index.md
+++ b/apps/dialtone-documentation/docs/foundations/icons/usage/index.md
@@ -63,7 +63,7 @@ Some icons are linked to specific actions, like the Settings gear <dt-icon name=
 The icon size is defined based on the context and text size next to it. These are the only available size options and no overrides should be needed to properly size the icons.
 </div>
 
-<dt-stack direction="row" gap="200" class="d-gc1 d-bgc-secondary d-p-200 d-px-400 d-bar16 d-ai-flex-start d-jc-space-between">
+<dt-stack direction="row" gap="200" class="d-gc1 d-bgc-secondary d-p-200 d-px-400 d-bar-500 d-ai-flex-start d-jc-space-between">
   <dt-stack gap="100" align="center">
     <code>200</code>
     <dt-icon name="food" size="200" />

--- a/apps/dialtone-documentation/docs/foundations/motion/index.md
+++ b/apps/dialtone-documentation/docs/foundations/motion/index.md
@@ -5,7 +5,7 @@ thumb: true
 keywords: ["animation","transition","movement","easing"]
 ---
 
-<div class="d-ba d-bar16 d-pbs-400 d-ta-center d-fc-muted d-headline--xxl">
+<div class="d-ba d-bar-500 d-pbs-400 d-ta-center d-fc-muted d-headline--xxl">
   <dt-empty-state
     :size="300"
     header-text="TBD"

--- a/apps/dialtone-documentation/docs/foundations/type/index.md
+++ b/apps/dialtone-documentation/docs/foundations/type/index.md
@@ -6,7 +6,7 @@ thumb: true
 keywords: ["font", "typography", "typeface", "text", "season"]
 ---
 
-<svg-loader name="type-billboard" class="d-bar16 d-mbs-600" />
+<svg-loader name="type-billboard" class="d-bar-500 d-mbs-600" />
 
 <dt-stack gap="600" class="d-mbs-600">
   <div class="d-d-grid d-g-600 d-g-cols1 md:d-g-cols3 d-ai-center">
@@ -14,7 +14,7 @@ keywords: ["font", "typography", "typeface", "text", "season"]
       <p class="d-docsite--paragraph">The Seasons type family is built to have a shared character and proportions between the Sans and Mix versions.</p>
     </div>
     <div class="d-gc2">
-      <svg-loader name="type--sample-01" class="d-bar16" />
+      <svg-loader name="type--sample-01" class="d-bar-500" />
     </div>
   </div>
   <div class="d-d-grid d-g-600 d-g-cols1 md:d-g-cols3 d-ai-center">
@@ -22,7 +22,7 @@ keywords: ["font", "typography", "typeface", "text", "season"]
       <p class="d-docsite--paragraph">Product uses system fonts, with Season Mix for specialty instances.</p>
     </div>
     <div class="d-gc2">
-      <svg-loader name="type--sample-02" class="d-bar16" />
+      <svg-loader name="type--sample-02" class="d-bar-500" />
     </div>
   </div>
 </dt-stack>

--- a/apps/dialtone-documentation/docs/foundations/typography/marketing.md
+++ b/apps/dialtone-documentation/docs/foundations/typography/marketing.md
@@ -12,7 +12,7 @@ keywords: ["season sans", "season mix", "brand font", "marketing typeface"]
       <p class="d-docsite--paragraph">Type sizing is based off of a relative scale, with 16px type as the baseline for body copy and for scaling type.</p>
     </div>
     <div class="d-gc2">
-      <svg-loader name="type--in-marketing" class="d-bar16" />
+      <svg-loader name="type--in-marketing" class="d-bar-500" />
     </div>
   </div>
   <div>
@@ -21,15 +21,15 @@ keywords: ["season sans", "season mix", "brand font", "marketing typeface"]
   </div>
   <dt-stack direction="row" gap="400" class="d-ai-flex-start">
     <dt-stack gap="50" class="d-w100p">
-      <svg-loader name="type--marketing-sample-01" class="d-mbe-200 d-bar16" />
+      <svg-loader name="type--marketing-sample-01" class="d-mbe-200 d-bar-500" />
       <h3 class="d-docsite--header-4 d-m-0" style="font-size:20px !important">Aspirational, Top-Level</h3>
       <p class="d-docsite--paragraph" style="font-size: 16px;"><strong>Season Mix</strong> for top of the funnel, more aspirational, lofty or abstract headlines, use Season Mix.</p>
     </dt-stack>
     <dt-stack gap="50" class="d-w100p">
-      <svg-loader name="type--marketing-sample-02" class="d-mbe-200 d-bar16" />
+      <svg-loader name="type--marketing-sample-02" class="d-mbe-200 d-bar-500" />
       <h3 class="d-docsite--header-4 d-m-0" style="font-size:20px !important">Concrete, Mid-Level</h3>
       <p class="d-docsite--paragraph" style="font-size: 16px;"><strong>Season Sans</strong> for mid of the funnel, more concrete, mid-level headlines, use Season Sans.</p>
     </dt-stack>
   </dt-stack>
-  <svg-loader name="type--marketing-sample-03" class="d-bar16" />
+  <svg-loader name="type--marketing-sample-03" class="d-bar-500" />
 </dt-stack>

--- a/apps/dialtone-documentation/docs/guides/accessibility/index.md
+++ b/apps/dialtone-documentation/docs/guides/accessibility/index.md
@@ -13,7 +13,7 @@ Dialpad strives to maintain  **WCAG 2.1 AA** compliance in our digital products.
 
 Everyone benefits when things are designed accessibly. Simply put: building products for accessibility is simply building products for better usability. Considering  **1 in 4** US adults -- that’s 61 million people! -- live with a permanent disability and many more will have temporary or situational throughout their lifetime, accessibility isn’t for just some people. It benefits everyone.
 
-<figure class="d-mis-0 d-p-200 d-mie-0 d-p-0 d-bar4 d-ta-center d-ba d-baw2 d-bc-black-200">
+<figure class="d-mis-0 d-p-200 d-mie-0 d-p-0 d-bar-300 d-ta-center d-ba d-baw2 d-bc-black-200">
   <img class="d-wmx40p" src="/assets/images/accessibility-graphic.png" alt="Accessibility illustration: permanent, temporary and situational disabilities. For touch, a person could have one arm, an arm injury, or be a new parent holding an infant. For sight, a person could be blind, have cataracts, or be a distracted driver. For hearing, the person might be deaf, have an ear infection, or be a bartender in a loud bar. When speaking, a person might be non-verbal, have laryngitis, or speak with a heavy accent">
   <figcaption class="d-ta-left"><a href="https://www.microsoft.com/design/inclusive/" target="_blank" rel="noopener noreferrer" class="d-link">Microsoft Inclusive Design</a></figcaption>
 </figure>

--- a/apps/dialtone-documentation/docs/guides/getting-started/index.md
+++ b/apps/dialtone-documentation/docs/guides/getting-started/index.md
@@ -105,11 +105,11 @@ In the above example, we used:
 - **[Stack component](/components/stack.md)** `<dt-stack>` to layout items in a row with consistent gap.
 - **[Text component](/components/text.md)** `<dt-text>` for typography with relevant props.
 - **[Width utility](/utilities/sizing/width.md)** `.d-w100p` for full width.
-- **[Padding utility](/utilities/spacing/padding.md)** `.d-p16` to add 16px of padding on all sides.
+- **[Padding utility](/utilities/spacing/padding.md)** `.d-p-200` to add 16px of padding on all sides.
 - **[Background color utility](/utilities/backgrounds/color.md)** `.d-bgc-moderate` for a moderate background.
 - **[Border utility](/utilities/borders/style.md)** `.d-ba` for a border on all sides.
 - **[Border color utility](/utilities/borders/color.md)** `.d-bc-subtle` for a subtle border color.
-- **[Border radius utility](/utilities/borders/radius.md)** `.d-bar8` for rounded corners.
+- **[Border radius utility](/utilities/borders/radius.md)** `.d-bar-400` for rounded corners.
 
 Though an atomic CSS approach comes with many advantages, we know it also offers a notable disadvantage: reducing the CSS cascade. This is especially true for repeated UI elements, which can end up creating redundant mark-up. For these instances, Dialtone offers components.
 

--- a/apps/dialtone-documentation/docs/guides/getting-started/index.md
+++ b/apps/dialtone-documentation/docs/guides/getting-started/index.md
@@ -53,7 +53,7 @@ Dialtone's CSS library offers a framework of [CSS Utilities](/utilities/) classe
     justify="between"
     class="
       d-w100p
-      d-bar8
+      d-bar-400
       d-fc-tertiary
       d-p-200
       d-bgc-moderate
@@ -80,7 +80,7 @@ Dialtone's CSS library offers a framework of [CSS Utilities](/utilities/) classe
   justify="between"
   class="
     d-w100p
-    d-bar8
+    d-bar-400
     d-fc-tertiary
     d-p-200
     d-bgc-moderate

--- a/apps/dialtone-documentation/docs/index.md
+++ b/apps/dialtone-documentation/docs/index.md
@@ -25,16 +25,16 @@ pageClass: dialpad-design-home
   <dt-stack gap="700" class="d-py-800 d-px-800 d-pbs-150 d-ai-center d-bgc-secondary-opaque">
     <dt-stack style="max-width: 1400px;" direction="row" gap="600" class="d-w100p d-jc-center">
       <router-link to="./foundations/brand/" class="d-d-block">
-        <svg-loader class="d-bar16 d-w100p" name="home-foundations-01" />
+        <svg-loader class="d-bar-500 d-w100p" name="home-foundations-01" />
       </router-link>
       <router-link to="./foundations/colors/" class="d-d-block">
-        <svg-loader class="d-bar16 d-w100p d-ba d-bc-subtle" name="home-foundations-02" />
+        <svg-loader class="d-bar-500 d-w100p d-ba d-bc-subtle" name="home-foundations-02" />
       </router-link>
       <router-link to="./foundations/typography/" class="d-d-block">
-        <svg-loader class="d-bar16 d-w100p d-ba d-bc-subtle" name="home-foundations-03" />
+        <svg-loader class="d-bar-500 d-w100p d-ba d-bc-subtle" name="home-foundations-03" />
       </router-link>
       <router-link to="./foundations/motion/" class="d-d-block">
-        <svg-loader class="d-bar16 d-w100p d-ba d-bc-subtle" name="home-foundations-04" />
+        <svg-loader class="d-bar-500 d-w100p d-ba d-bc-subtle" name="home-foundations-04" />
       </router-link>
     </dt-stack>
     <dt-stack style="max-width: 1400px;" gap="550" class="d-ai-center d-jc-center">
@@ -53,16 +53,16 @@ pageClass: dialpad-design-home
   <dt-stack gap="700" class="d-py-800 d-px-800 d-pbe-150 d-ai-center d-bgc-secondary-opaque">
     <dt-stack style="max-width: 1400px" direction="row" gap="600" class="d-w100p d-jc-center">
       <router-link to="./components/" class="d-d-block">
-        <svg-loader class="d-bar16 d-w100p d-ba d-bc-subtle" name="home-system--01" />
+        <svg-loader class="d-bar-500 d-w100p d-ba d-bc-subtle" name="home-system--01" />
       </router-link>
       <router-link to="./utilities/" class="d-d-block">
-        <svg-loader class="d-bar16 d-w100p d-ba d-bc-subtle" name="home-system--02" />
+        <svg-loader class="d-bar-500 d-w100p d-ba d-bc-subtle" name="home-system--02" />
       </router-link>
       <router-link to="./tokens/" class="d-d-block">
-        <svg-loader class="d-bar16 d-w100p d-ba d-bc-subtle" name="home-system--03" />
+        <svg-loader class="d-bar-500 d-w100p d-ba d-bc-subtle" name="home-system--03" />
       </router-link>
       <router-link to="./guides/content/" class="d-d-block">
-        <svg-loader class="d-bar16 d-w100p d-ba d-bc-subtle" name="home-system--04" />
+        <svg-loader class="d-bar-500 d-w100p d-ba d-bc-subtle" name="home-system--04" />
       </router-link>
     </dt-stack>
     <dt-stack style="max-width: 1400px" gap="550" class="d-ai-center d-jc-center">

--- a/apps/dialtone-documentation/docs/scratch.md
+++ b/apps/dialtone-documentation/docs/scratch.md
@@ -393,7 +393,7 @@ Real-world patterns showing how `v-dt-focusgroup` composes with Dialtone compone
 
 ```vue demo
 <dt-stack role="list" v-dt-focusgroup="'vertical'" aria-label="Contacts">
-  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar8">
+  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar-400">
     <dt-stack direction="row" gap="100" class="d-w100p">
       <dt-avatar full-name="Ashanti Trevor" />
       <dt-stack class="d-fl1">
@@ -411,7 +411,7 @@ Real-world patterns showing how `v-dt-focusgroup` composes with Dialtone compone
       <dt-badge kind="count" type="bulletin" text="6" />
     </dt-stack>
   </dt-stack>
-  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar8">
+  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar-400">
     <dt-stack direction="row" gap="100" class="d-w100p">
       <dt-avatar full-name="Marcus Chen" />
       <dt-stack class="d-fl1">
@@ -428,7 +428,7 @@ Real-world patterns showing how `v-dt-focusgroup` composes with Dialtone compone
       <dt-text kind="body" :size="200" tone="tertiary" numeric>1:47 pm</dt-text>
     </dt-stack>
   </dt-stack>
-  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar8">
+  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar-400">
     <dt-stack direction="row" gap="100" class="d-w100p">
       <dt-avatar full-name="Priya Sharma" />
       <dt-stack class="d-fl1">
@@ -496,7 +496,7 @@ Real-world patterns showing how `v-dt-focusgroup` composes with Dialtone compone
     <dt-text as="p" kind="body" :size="400">
       Not just a matter of applying opacity to whole button, but w/ combination of `color-mix()` and tweaking existing DtButton css variables via `oklch()` of specific properties – separate opacity and saturation for border, bgc, fc, etc.
     </dt-text>
-    <dt-stack class="d-bgc-moderate-opaque d-p-150 d-bar8">
+    <dt-stack class="d-bgc-moderate-opaque d-p-150 d-bar-400">
       <span>
         <dt-checkbox v-model="isDisabled">Disabled</dt-checkbox>
       </span>
@@ -530,7 +530,7 @@ Real-world patterns showing how `v-dt-focusgroup` composes with Dialtone compone
     <dt-text as="p" kind="body" :size="400">
       Freeform elements that are rendered before/after the button content.
     </dt-text>
-    <dt-stack gap="200" direction="row" align="baseline" class="d-bgc-moderate-opaque d-p-150 d-bar8">
+    <dt-stack gap="200" direction="row" align="baseline" class="d-bgc-moderate-opaque d-p-150 d-bar-400">
       <dt-checkbox v-model="showBtnLeading">
         Leading
       </dt-checkbox>
@@ -750,7 +750,7 @@ Real-world patterns showing how `v-dt-focusgroup` composes with Dialtone compone
     <dt-text as="h1" kind="headline" :size="500">
       Input / Select
     </dt-text>
-    <dt-stack gap="200" direction="row" class="d-bgc-moderate-opaque d-p-150 d-bar8">
+    <dt-stack gap="200" direction="row" class="d-bgc-moderate-opaque d-p-150 d-bar-400">
       <dt-select-menu
         label="Label Size"
         :show-label="false"
@@ -903,7 +903,7 @@ Real-world patterns showing how `v-dt-focusgroup` composes with Dialtone compone
     <dt-text as="p" kind="body" :size="400">
       Just straight up refactor to use DtButton instead of custom markup/style. Use mix of DtButton variants depending on `active`. Uses all DtButton sizes (currently at least).
     </dt-text>
-    <dt-stack gap="200" direction="row" align="baseline" class="d-bgc-moderate-opaque d-p-150 d-bar8">
+    <dt-stack gap="200" direction="row" align="baseline" class="d-bgc-moderate-opaque d-p-150 d-bar-400">
       <dt-checkbox v-model="borderless">
         Borderless
       </dt-checkbox>
@@ -1294,7 +1294,7 @@ Real-world patterns showing how `v-dt-focusgroup` composes with Dialtone compone
     <dt-text as="h1" kind="headline" :size="500">
       Radio / Checkbox
     </dt-text>
-    <dt-stack gap="200" direction="row" class="d-bgc-moderate-opaque d-p-150 d-bar8">
+    <dt-stack gap="200" direction="row" class="d-bgc-moderate-opaque d-p-150 d-bar-400">
       <dt-select-menu
         label="Label Size"
         :show-label="false"
@@ -1474,7 +1474,7 @@ Real-world patterns showing how `v-dt-focusgroup` composes with Dialtone compone
     </dt-text>
 
 ```vue demo
-<dt-box padding="200" surface="moderate" class="d-bar8 d-bs-sm">
+<dt-box padding="200" surface="moderate" class="d-bar-400 d-bs-sm">
   Box demo
 </dt-box>
 ```
@@ -1484,7 +1484,7 @@ Real-world patterns showing how `v-dt-focusgroup` composes with Dialtone compone
   <dt-box
     padding="100"
     surface="secondary"
-    class="d-ps-sticky d-t0"
+    class="d-ps-sticky d-t-0"
   >
     <dt-text kind="body" :size="200">Box demo</dt-text>
   </dt-box>
@@ -1550,7 +1550,7 @@ Real-world patterns showing how `v-dt-focusgroup` composes with Dialtone compone
   <dt-text kind="headline" size="md">Utility class escape hatch</dt-text>
 
 ```vue demo
-<dt-box padding="200" surface="primary" border-width="100" border-radius="200" class="d-ps-sticky d-t0">
+<dt-box padding="200" surface="primary" border-width="100" border-radius="200" class="d-ps-sticky d-t-0">
   Box demo
 </dt-box>
 ```

--- a/apps/dialtone-documentation/docs/tokens/for-designers/index.md
+++ b/apps/dialtone-documentation/docs/tokens/for-designers/index.md
@@ -5,7 +5,7 @@ status: planned
 keywords: ["figma tokens","design tokens"]
 ---
 
-<div class="d-ba d-bar16 d-py-200 d-mbs-400 d-ta-center d-fc-muted d-headline--xxl">
+<div class="d-ba d-bar-500 d-py-200 d-mbs-400 d-ta-center d-fc-muted d-headline--xxl">
   <dt-empty-state
     :size="300"
     header-text="TBD"

--- a/apps/dialtone-documentation/docs/tokens/for-developers/index.md
+++ b/apps/dialtone-documentation/docs/tokens/for-developers/index.md
@@ -5,7 +5,7 @@ status: planned
 keywords: ["css tokens","dev tokens","code tokens"]
 ---
 
-<div class="d-ba d-bar16 d-py-200 d-mbs-400 d-ta-center d-fc-muted d-headline--xxl">
+<div class="d-ba d-bar-500 d-py-200 d-mbs-400 d-ta-center d-fc-muted d-headline--xxl">
   <dt-empty-state
     :size="300"
     header-text="TBD"

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/attachment.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/attachment.md
@@ -9,7 +9,7 @@ keywords: ["bg attachment","scroll","fixed","background scroll"]
 This is the default behavior. Use `d-bga-scroll` to fix the <dt-link href="/assets/images/dp-sample-gradient.png" target="_blank" rel="noopener noreferrer"> background image </dt-link> to the element. It does not scroll with its content.
 
 ```vue demo
-<div class="d-bar8 d-p-200 d-w100p d-h-350 d-bgr-none d-bgs-cover d-bga-scroll d-w100p d-of-auto" style="background-image: url('/assets/images/dp-sample-gradient.png')">
+<div class="d-bar-400 d-p-200 d-w100p d-h-350 d-bgr-none d-bgs-cover d-bga-scroll d-w100p d-of-auto" style="background-image: url('/assets/images/dp-sample-gradient.png')">
   <dt-stack gap="100" class="d-fc-neutral-white">
     <p>Curved rhythms often accompany lateral decisions, especially when considering the abstract potential of non-specific alignments. While typically unnoticed, these gentle shifts can accumulate meaning when framed in a context that remains undefined.</p>
     <p>Momentum builds where it doesn't, anchoring intent to unmeasured goals. As frameworks iterate without resolution, the pattern repeats—not identically, but recognizably. Every nuance appears significant until it drifts, leaving behind the shape of intent without its content. That distinction matters only when observation persists without anchoring.</p>
@@ -27,7 +27,7 @@ This is the default behavior. Use `d-bga-scroll` to fix the <dt-link href="/asse
 Use `d-bga-fixed` to fix the <dt-link href="/assets/images/dp-sample-gradient.png" target="_blank" rel="noopener noreferrer"> background image </dt-link> to the viewport. The background image does not scroll with the content.
 
 ```vue demo
-<div class="d-bar8 d-p-200 d-w100p d-h-350 d-bgr-none d-bgs-cover d-bga-fixed d-w100p d-of-auto" style="background-image: url('/assets/images/dp-sample-gradient.png')">
+<div class="d-bar-400 d-p-200 d-w100p d-h-350 d-bgr-none d-bgs-cover d-bga-fixed d-w100p d-of-auto" style="background-image: url('/assets/images/dp-sample-gradient.png')">
   <dt-stack gap="100" class="d-fc-neutral-white">
     <p>Curved rhythms often accompany lateral decisions, especially when considering the abstract potential of non-specific alignments. While typically unnoticed, these gentle shifts can accumulate meaning when framed in a context that remains undefined.</p>
     <p>Momentum builds where it doesn't, anchoring intent to unmeasured goals. As frameworks iterate without resolution, the pattern repeats—not identically, but recognizably. Every nuance appears significant until it drifts, leaving behind the shape of intent without its content. That distinction matters only when observation persists without anchoring.</p>
@@ -47,7 +47,7 @@ background scrolls with the element's contents, and background area and position
 of the element rather than the viewable box.
 
 ```vue demo
-<div class="d-bar8 d-p-200 d-w100p d-h-350 d-bgr-none d-bgs-cover d-bga-local d-w100p d-of-auto" style="background-image: url('/assets/images/dp-sample-gradient.png')">
+<div class="d-bar-400 d-p-200 d-w100p d-h-350 d-bgr-none d-bgs-cover d-bga-local d-w100p d-of-auto" style="background-image: url('/assets/images/dp-sample-gradient.png')">
   <dt-stack gap="100" class="d-fc-neutral-white">
     <p>Curved rhythms often accompany lateral decisions, especially when considering the abstract potential of non-specific alignments. While typically unnoticed, these gentle shifts can accumulate meaning when framed in a context that remains undefined.</p>
     <p>Momentum builds where it doesn't, anchoring intent to unmeasured goals. As frameworks iterate without resolution, the pattern repeats—not identically, but recognizably. Every nuance appears significant until it drifts, leaving behind the shape of intent without its content. That distinction matters only when observation persists without anchoring.</p>

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/clip.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/clip.md
@@ -11,9 +11,9 @@ Use `d-bgc-{name}` to control which box an element's background is clipped by.
 ```vue demo
 <!-- @wrapper -->
 <dt-stack direction="row" gap="400">
-  <div class="d-bgc-border-box d-p-200 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8">border-box</div>
-  <div class="d-bgc-padding-box d-p-200 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8">padding-box</div>
-  <div class="d-bgc-content-box d-p-200 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar8">content-box</div>
+  <div class="d-bgc-border-box d-p-200 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar-400">border-box</div>
+  <div class="d-bgc-padding-box d-p-200 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar-400">padding-box</div>
+  <div class="d-bgc-content-box d-p-200 d-bgc-moderate d-ba d-baw4 d-bas-dashed d-bar-400">content-box</div>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/color.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/color.md
@@ -14,8 +14,8 @@ Use `d-bgc-{color}` to set an element's background color.
 ```vue demo
 <!-- @wrapper -->
 <dt-stack gap="200" :direction="{ 'default': 'column', 'md': 'row' }">
-  <div class="d-p-200 d-bar4 d-bgc-primary">Primary</div>
-  <div class="d-p-200 d-bar4 d-bgc-critical">Critical</div>
+  <div class="d-p-200 d-bar-300 d-bgc-primary">Primary</div>
+  <div class="d-p-200 d-bar-300 d-bgc-critical">Critical</div>
 </dt-stack>
 ```
 
@@ -56,15 +56,15 @@ Use `d-bgo{stop}` to change an element's background color opacity. You can also 
 ```vue demo
 <!-- @wrapper -->
 <dt-stack gap="200" :direction="{ 'default': 'column', 'md': 'row' }">
-  <div class="d-p-100 d-bgc-critical d-bar4 d-bgo100">100%</div>
-  <div class="d-p-100 d-bgc-critical d-bar4 d-bgo99">99%</div>
-  <div class="d-p-100 d-bgc-critical d-bar4 d-bgo95">95%</div>
-  <div class="d-p-100 d-bgc-critical d-bar4 d-bgo90">90%</div>
-  <div class="d-p-100 d-bgc-critical d-bar4 d-bgo75">75%</div>
-  <div class="d-p-100 d-bgc-critical d-bar4 d-bgo50">50%</div>
-  <div class="d-p-100 d-bgc-critical d-bar4 d-bgo25">25%</div>
-  <div class="d-p-100 d-bgc-critical d-bar4 d-bgo10">10%</div>
-  <div class="d-p-100 d-bgc-critical d-bar4 d-bgo0">0%</div>
+  <div class="d-p-100 d-bgc-critical d-bar-300 d-bgo100">100%</div>
+  <div class="d-p-100 d-bgc-critical d-bar-300 d-bgo99">99%</div>
+  <div class="d-p-100 d-bgc-critical d-bar-300 d-bgo95">95%</div>
+  <div class="d-p-100 d-bgc-critical d-bar-300 d-bgo90">90%</div>
+  <div class="d-p-100 d-bgc-critical d-bar-300 d-bgo75">75%</div>
+  <div class="d-p-100 d-bgc-critical d-bar-300 d-bgo50">50%</div>
+  <div class="d-p-100 d-bgc-critical d-bar-300 d-bgo25">25%</div>
+  <div class="d-p-100 d-bgc-critical d-bar-300 d-bgo10">10%</div>
+  <div class="d-p-100 d-bgc-critical d-bar-300 d-bgo0">0%</div>
 </dt-stack>
 ```
 
@@ -76,8 +76,8 @@ Use `d-bgo{stop}` to change an element's background color opacity. You can also 
 ```vue demo
 <!-- @wrapper -->
 <dt-stack gap="200" :direction="{ 'default': 'column', 'md': 'row' }">
-  <div v-dt-mode:invert class="d-p-200 d-bar4 d-bgc-primary">Primary</div>
-  <div v-dt-mode:invert class="d-p-200 d-bar4 d-bgc-critical">Critical</div>
+  <div v-dt-mode:invert class="d-p-200 d-bar-300 d-bgc-primary">Primary</div>
+  <div v-dt-mode:invert class="d-p-200 d-bar-300 d-bgc-critical">Critical</div>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/gradients.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/gradients.md
@@ -9,7 +9,7 @@ keywords: ["linear gradient", "bg gradient", "color stops"]
 Use `d-bgg-from-{color}` to declare the gradient starting color stop.
 
 ```vue demo
-<div class="d-w100p d-h-200 d-bar8 d-bgg-to-br d-bgg-from-purple-600"></div>
+<div class="d-w100p d-h-200 d-bar-400 d-bgg-to-br d-bgg-from-purple-600"></div>
 ```
 
 ## Ending Color
@@ -17,7 +17,7 @@ Use `d-bgg-from-{color}` to declare the gradient starting color stop.
 Use `d-bgg-to-{color}` to declare the gradient ending color stop.
 
 ```vue demo
-<div class="d-w100p d-h-200 d-bar8 d-bgg-to-br d-bgg-from-magenta-400 d-bgg-to-purple-600"></div>
+<div class="d-w100p d-h-200 d-bar-400 d-bgg-to-br d-bgg-from-magenta-400 d-bgg-to-purple-600"></div>
 ```
 
 ## Hover
@@ -25,7 +25,7 @@ Use `d-bgg-to-{color}` to declare the gradient ending color stop.
 Use `h:d-bgg-{from|to}-{color}` to change an element's background gradient color spot when in an `:hover` state.
 
 ```vue demo
-<dt-button kind="unstyled" class="d-p-200 d-bar4 d-fs-200 d-bgg-to-r d-bgg-from-purple-400 h:d-bgg-from-purple-400 d-bgg-to-magenta-100 h:d-bgg-to-magenta-400 d-baw0">Hover over me</dt-button>
+<dt-button kind="unstyled" class="d-p-200 d-bar-300 d-fs-200 d-bgg-to-r d-bgg-from-purple-400 h:d-bgg-from-purple-400 d-bgg-to-magenta-100 h:d-bgg-to-magenta-400 d-baw0">Hover over me</dt-button>
 ```
 
 ## Focus
@@ -33,7 +33,7 @@ Use `h:d-bgg-{from|to}-{color}` to change an element's background gradient color
 Use `f:d-bgg-{from|to}-{color}` to change an element's background gradient starting and ending stops in `:focus` and `:focus-within` states.
 
 ```vue demo
-<dt-button kind="unstyled" class="d-p-200 d-bar4 d-fs-200 d-bgg-to-r d-bgg-from-purple-400 h:d-bgg-from-purple-400 d-bgg-to-magenta-100 f:d-bgg-to-magenta-400 d-baw0">Focus me</dt-button>
+<dt-button kind="unstyled" class="d-p-200 d-bar-300 d-fs-200 d-bgg-to-r d-bgg-from-purple-400 h:d-bgg-from-purple-400 d-bgg-to-magenta-100 f:d-bgg-to-magenta-400 d-baw0">Focus me</dt-button>
 ```
 
 ## Focus Visible
@@ -41,7 +41,7 @@ Use `f:d-bgg-{from|to}-{color}` to change an element's background gradient start
 Use `fv:d-bgg-{from|to}-{color}` to change an element's background gradient starting and ending stops in `:focus-visible` state [only when focused by keyboard].
 
 ```vue demo
-<dt-button kind="unstyled" class="d-p-200 d-bar4 d-fs-200 d-bgg-to-r d-bgg-from-purple-400 h:d-bgg-from-purple-400 d-bgg-to-magenta-100 fv:d-bgg-to-magenta-400 d-baw0">Keyboard focus me</dt-button>
+<dt-button kind="unstyled" class="d-p-200 d-bar-300 d-fs-200 d-bgg-to-r d-bgg-from-purple-400 h:d-bgg-from-purple-400 d-bgg-to-magenta-100 fv:d-bgg-to-magenta-400 d-baw0">Keyboard focus me</dt-button>
 ```
 
 ## Changing Opacities
@@ -49,15 +49,15 @@ Use `fv:d-bgg-{from|to}-{color}` to change an element's background gradient star
 Use `d-bgg-(from|to)-o{n}` to change the opacity values of each gradient color stop. You can also change the opacity values of each gradient color stop on `:hover`, `:focus`, `:focus-visible` by using the respective `h:d-bgg-(from|to)-o{n}`, `f:d-bgg-(from|to)-o{n}`, `fv:d-bgg-(from|to)-o{n}` prefixes.
 
 ```vue demo
-<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar8 d-bgg-to-r d-bgg-from-purple-400 d-bgg-to-magenta-100 d-bgg-to-o0 d-fs-300 d-fw-bold"><span>100%</span><span>0%</span></dt-stack>
-<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar8 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o99 d-bgg-to-magenta-100 d-bgg-to-o10 d-fs-300 d-fw-bold"><span>99%</span><span>10%</span></dt-stack>
-<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar8 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o95 d-bgg-to-magenta-100 d-bgg-to-o25 d-fs-300 d-fw-bold"><span>95%</span><span>25%</span></dt-stack>
-<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar8 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o90 d-bgg-to-magenta-100 d-bgg-to-o50 d-fs-300 d-fw-bold"><span>90%</span><span>50%</span></dt-stack>
-<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar8 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o75 d-bgg-to-magenta-100 d-bgg-to-o75 d-fs-300 d-fw-bold"><span>75%</span><span>75%</span></dt-stack>
-<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar8 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o50 d-bgg-to-magenta-100 d-bgg-to-o90 d-fs-300 d-fw-bold"><span>50%</span><span>90%</span></dt-stack>
-<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar8 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o25 d-bgg-to-magenta-100 d-bgg-to-o95 d-fs-300 d-fw-bold"><span>25%</span><span>95%</span></dt-stack>
-<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar8 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o10 d-bgg-to-magenta-100 d-bgg-to-o99 d-fs-300 d-fw-bold"><span>10%</span><span>99%</span></dt-stack>
-<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar8 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o0 d-bgg-to-magenta-100 d-fs-300 d-fw-bold"><span>0%</span><span>100%</span></dt-stack>
+<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar-400 d-bgg-to-r d-bgg-from-purple-400 d-bgg-to-magenta-100 d-bgg-to-o0 d-fs-300 d-fw-bold"><span>100%</span><span>0%</span></dt-stack>
+<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar-400 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o99 d-bgg-to-magenta-100 d-bgg-to-o10 d-fs-300 d-fw-bold"><span>99%</span><span>10%</span></dt-stack>
+<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar-400 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o95 d-bgg-to-magenta-100 d-bgg-to-o25 d-fs-300 d-fw-bold"><span>95%</span><span>25%</span></dt-stack>
+<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar-400 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o90 d-bgg-to-magenta-100 d-bgg-to-o50 d-fs-300 d-fw-bold"><span>90%</span><span>50%</span></dt-stack>
+<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar-400 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o75 d-bgg-to-magenta-100 d-bgg-to-o75 d-fs-300 d-fw-bold"><span>75%</span><span>75%</span></dt-stack>
+<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar-400 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o50 d-bgg-to-magenta-100 d-bgg-to-o90 d-fs-300 d-fw-bold"><span>50%</span><span>90%</span></dt-stack>
+<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar-400 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o25 d-bgg-to-magenta-100 d-bgg-to-o95 d-fs-300 d-fw-bold"><span>25%</span><span>95%</span></dt-stack>
+<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar-400 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o10 d-bgg-to-magenta-100 d-bgg-to-o99 d-fs-300 d-fw-bold"><span>10%</span><span>99%</span></dt-stack>
+<dt-stack direction="row" justify="between" align="center" class="d-p-100 d-w100p d-h-75 d-bar-400 d-bgg-to-r d-bgg-from-purple-400 d-bgg-from-o0 d-bgg-to-magenta-100 d-fs-300 d-fw-bold"><span>0%</span><span>100%</span></dt-stack>
 ```
 
 ## Directions
@@ -103,7 +103,7 @@ The starting stop (`d-bgg-from-{color}`) should be declared. Optionally an endin
                              </span>
                          </div>
                          <div
-                           class="d-fl-shrink0 d-m-50 d-mis-200 d-h-50 d-w-100 d-bar4 d-bgg-to-r d-bgg-from-black-100"
+                           class="d-fl-shrink0 d-m-50 d-mis-200 d-h-50 d-w-100 d-bar-300 d-bgg-to-r d-bgg-from-black-100"
                            :class="[`d-bgg-${direction}-${color}-${stop}`]"
                          >
                          </div>

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/patterns.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/patterns.md
@@ -9,8 +9,8 @@ keywords: ["bg pattern", "department", "call center"]
 Use `d-bgg-pattern-{pattern}-{dark|light}` to apply a pattern.
 
 ```vue demo
-<dt-stack direction="row" align="center" class="d-w100p d-h-50 d-bar4 d-bgg-to-br d-ba d-bc-default d-bgc-moderate d-bgg-pattern d-bgg-pattern-slanted-stripes-dark d-fc-primary">Ted's Call Center</dt-stack>
-<dt-stack direction="row" align="center" class="d-w100p d-h-50 d-bar4 d-bgg-to-br d-ba d-bc-default d-bgc-moderate d-bgg-pattern d-bgg-pattern-chevrons-dark">Vicky's Department</dt-stack>
+<dt-stack direction="row" align="center" class="d-w100p d-h-50 d-bar-300 d-bgg-to-br d-ba d-bc-default d-bgc-moderate d-bgg-pattern d-bgg-pattern-slanted-stripes-dark d-fc-primary">Ted's Call Center</dt-stack>
+<dt-stack direction="row" align="center" class="d-w100p d-h-50 d-bar-300 d-bgg-to-br d-ba d-bc-default d-bgc-moderate d-bgg-pattern d-bgg-pattern-chevrons-dark">Vicky's Department</dt-stack>
 ```
 
 ## Classes
@@ -26,7 +26,7 @@ Use `d-bgg-pattern-{pattern}-{dark|light}` to apply a pattern.
               --bgg-pattern: --bgg-pattern-{{ i }}-{{ c }};
             </div>
             <div
-              class="d-size-50 d-bgg-pattern d-ba d-bc-black-900 d-bar4"
+              class="d-size-50 d-bgg-pattern d-ba d-bc-black-900 d-bar-300"
               :class="[
                   {'d-bgc-neutral-white': c === 'dark'},
                   {'d-bgc-neutral-black': c === 'light'},

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/position.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/position.md
@@ -12,43 +12,43 @@ Use `d-bgp-{position}` to control where an element's background image is placed.
 <!-- @custom -->
 <!-- @class d-d-grid d-g-200 d-g-cols4 d-p-200 d-bgc-secondary -->
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-var d-bgp-tl" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-var d-bgp-tl" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgp-tl</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-var d-bgp-t" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-var d-bgp-t" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgp-t</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-var d-bgp-tr" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-var d-bgp-tr" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgp-tr</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-var d-bgp-r" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-var d-bgp-r" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgp-r</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-var d-bgp-br" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-var d-bgp-br" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgp-br</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-var d-bgp-b" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-var d-bgp-b" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgp-b</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-var d-bgp-bl" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-var d-bgp-bl" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgp-bl</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-var d-bgp-l" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-var d-bgp-l" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgp-l</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-var d-bgp-center" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-var d-bgp-center" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgp-center</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-var d-bgp-unset" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-var d-bgp-unset" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgp-unset</dt-text>
 </dt-stack>
 ```

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/repeat.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/repeat.md
@@ -12,27 +12,27 @@ Use `d-bgr-{n}` to how an element's background image repeats.
 <!-- @custom -->
 <!-- @class d-d-grid d-g-200 d-g-cols4 d-p-200 d-bgc-secondary -->
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgp-tl d-bgs-var d-bgr-repeat" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgp-tl d-bgs-var d-bgr-repeat" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgr-repeat</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgp-tl d-bgs-var d-bgr-repeat-x" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgp-tl d-bgs-var d-bgr-repeat-x" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgr-repeat-x</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgp-tl d-bgs-var d-bgr-repeat-y" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgp-tl d-bgs-var d-bgr-repeat-y" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgr-repeat-y</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgp-tl d-bgs-var d-bgr-space" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgp-tl d-bgs-var d-bgr-space" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgr-space</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgp-tl d-bgs-var d-bgr-none" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgp-tl d-bgs-var d-bgr-none" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgr-none</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgp-tl d-bgs-var d-bgr-unset" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgp-tl d-bgs-var d-bgr-unset" style="--bgg-size: 65% 65%; background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgr-unset</dt-text>
 </dt-stack>
 ```

--- a/apps/dialtone-documentation/docs/utilities/backgrounds/size.md
+++ b/apps/dialtone-documentation/docs/utilities/backgrounds/size.md
@@ -12,23 +12,23 @@ Use `d-bgs-{n}` to control the size of element's background image.
 <!-- @custom -->
 <!-- @class d-d-grid d-g-200 d-g-cols4 d-p-200 d-bgc-secondary -->
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-contain" style="background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-contain" style="background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgs-contain</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-cover" style="background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-cover" style="background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgs-cover</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-var" style="background-image: url('/assets/images/puffin.jpg'); --bgg-size: 65% 65%;"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-var" style="background-image: url('/assets/images/puffin.jpg'); --bgg-size: 65% 65%;"></div>
   <dt-text as="code" kind="code" size="100">d-bgs-var</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-auto d-bgp-center" style="background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-auto d-bgp-center" style="background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgs-auto</dt-text>
 </dt-stack>
 <dt-stack align="center" class="d-g-50">
-  <div class="d-size-200 d-bgc-moderate d-bar8 d-of-hidden d-bgr-none d-bgs-unset" style="background-image: url('/assets/images/puffin.jpg');"></div>
+  <div class="d-size-200 d-bgc-moderate d-bar-400 d-of-hidden d-bgr-none d-bgs-unset" style="background-image: url('/assets/images/puffin.jpg');"></div>
   <dt-text as="code" kind="code" size="100">d-bgs-unset</dt-text>
 </dt-stack>
 ```

--- a/apps/dialtone-documentation/docs/utilities/borders/color.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/color.md
@@ -122,7 +122,7 @@ You can also change the border color opacity value on `:hover`
   <template #example="{ className }">
     <div :class="['d-d-inline-flex', {'d-bgc-contrast': className.endsWith('inverted')}]" >
       <div
-        class="d-fl-shrink0 d-m-50 d-size-75 d-bar4 d-ba d-baw2"
+        class="d-fl-shrink0 d-m-50 d-size-75 d-bar-300 d-ba d-baw2"
         :class="className"
       />
     </div>

--- a/apps/dialtone-documentation/docs/utilities/borders/radius.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/radius.md
@@ -11,16 +11,16 @@ Use `d-bar{n}` to change the border radius on all corners of your element.
 ```vue demo
 <!-- @wrapper -->
 <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar0"><dt-text kind="code" size="xs">d-bar0</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar1"><dt-text kind="code" size="xs">d-bar1</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar2"><dt-text kind="code" size="xs">d-bar2</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar4"><dt-text kind="code" size="xs">d-bar4</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar6"><dt-text kind="code" size="xs">d-bar6</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar8"><dt-text kind="code" size="xs">d-bar8</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar12"><dt-text kind="code" size="xs">d-bar12</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar16"><dt-text kind="code" size="xs">d-bar16</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar24"><dt-text kind="code" size="xs">d-bar24</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar32"><dt-text kind="code" size="xs">d-bar32</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-0"><dt-text kind="code" size="xs">d-bar0</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-100"><dt-text kind="code" size="xs">d-bar1</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-200"><dt-text kind="code" size="xs">d-bar2</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-300"><dt-text kind="code" size="xs">d-bar4</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-350"><dt-text kind="code" size="xs">d-bar6</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-400"><dt-text kind="code" size="xs">d-bar8</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-450"><dt-text kind="code" size="xs">d-bar12</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-500"><dt-text kind="code" size="xs">d-bar16</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-550"><dt-text kind="code" size="xs">d-bar24</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-600"><dt-text kind="code" size="xs">d-bar32</dt-text></div>
 </dt-stack>
 ```
 
@@ -31,10 +31,10 @@ Use `d-b{t|r|b|l}r{n}` to change the border radius on a side of your element.
 ```vue demo
 <!-- @wrapper -->
 <dt-stack gap="400" :direction="{ 'default': 'column', 'md': 'row' }">
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-btr4"><dt-text kind="code" size="xs">d-btr4</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-btr8"><dt-text kind="code" size="xs">d-btr8</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-btr12"><dt-text kind="code" size="xs">d-btr12</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-btr16"><dt-text kind="code" size="xs">d-btr16</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bbsr-300"><dt-text kind="code" size="xs">d-btr4</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bbsr-400"><dt-text kind="code" size="xs">d-btr8</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bbsr-450"><dt-text kind="code" size="xs">d-btr12</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bbsr-500"><dt-text kind="code" size="xs">d-btr16</dt-text></div>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/borders/radius.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/radius.md
@@ -14,7 +14,7 @@ Use `d-bar-{stop}` to change the border radius on all four corners. The stop ref
 
 ```vue demo
 <!-- @wrapper -->
-<dt-stack gap="100" :direction="{ default: 'column', md: 'row' }">
+<dt-stack gap="100" direction="row" justify="center" class="d-fw-wrap">
   <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-0">  <dt-text kind="code" size="xs">d-bar-0</dt-text></div>
   <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-100"><dt-text kind="code" size="xs">d-bar-100</dt-text></div>
   <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-200"><dt-text kind="code" size="xs">d-bar-200</dt-text></div>
@@ -41,7 +41,7 @@ Use a side-pair class to round the two corners on a single side. Class roots are
 
 ```vue demo
 <!-- @wrapper -->
-<dt-stack gap="400" :direction="{ default: 'column', md: 'row' }">
+<dt-stack gap="100" direction="row" justify="center" class="d-fw-wrap">
   <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bbsr-450"><dt-text kind="code" size="xs">d-bbsr-450</dt-text></div>
   <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bier-450"><dt-text kind="code" size="xs">d-bier-450</dt-text></div>
   <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bber-450"><dt-text kind="code" size="xs">d-bber-450</dt-text></div>
@@ -62,7 +62,7 @@ Use a single-corner class to round exactly one corner. Class roots match the CSS
 
 ```vue demo
 <!-- @wrapper -->
-<dt-stack gap="400" :direction="{ default: 'column', md: 'row' }">
+<dt-stack gap="100" direction="row" justify="center" class="d-fw-wrap">
   <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bssr-500"><dt-text kind="code" size="xs">d-bssr-500</dt-text></div>
   <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bser-500"><dt-text kind="code" size="xs">d-bser-500</dt-text></div>
   <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-beer-500"><dt-text kind="code" size="xs">d-beer-500</dt-text></div>
@@ -76,7 +76,7 @@ Use `d-bar-pill` for a pill-shaped radius on all four corners. The same `-pill` 
 
 ```vue demo
 <!-- @wrapper -->
-<dt-stack gap="400" :direction="{ default: 'column', md: 'row' }">
+<dt-stack gap="100" direction="row" justify="center" class="d-fw-wrap">
   <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-pill">
     <dt-text kind="code" size="xs">d-bar-pill</dt-text>
   </div>
@@ -89,7 +89,7 @@ Use `d-bar-circle` for a fully circular radius. Best paired with a square elemen
 
 ```vue demo
 <!-- @wrapper -->
-<dt-stack gap="400" :direction="{ default: 'column', md: 'row' }">
+<dt-stack gap="100" direction="row" justify="center" class="d-fw-wrap">
   <dt-stack direction="row" align="center" justify="center" class="d-p-100 d-size-200 d-ba d-baw2 d-bc-default d-bgc-primary d-ws-nowrap d-bar-circle">
     <dt-text kind="code" size="xs">d-bar-circle</dt-text>
   </dt-stack>

--- a/apps/dialtone-documentation/docs/utilities/borders/radius.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/radius.md
@@ -1,53 +1,82 @@
 ---
 title: Border Radius
 description: Utilities for controlling an element's border radius.
-keywords: ["rounded", "corner", "pill", "circle", "radius start", "radius end"]
+keywords: ["rounded", "corner", "pill", "circle", "radius start", "radius end", "block-start", "block-end", "inline-start", "inline-end", "single corner"]
 ---
+
+<script setup>
+  import { radius } from '@data/borders.json';
+</script>
 
 ## All Corners
 
-Use `d-bar{n}` to change the border radius on all corners of your element.
+Use `d-bar-{stop}` to change the border radius on all four corners. The stop references the matching `--dt-size-radius-{stop}` token.
 
 ```vue demo
 <!-- @wrapper -->
-<dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-0"><dt-text kind="code" size="xs">d-bar0</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-100"><dt-text kind="code" size="xs">d-bar1</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-200"><dt-text kind="code" size="xs">d-bar2</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-300"><dt-text kind="code" size="xs">d-bar4</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-350"><dt-text kind="code" size="xs">d-bar6</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-400"><dt-text kind="code" size="xs">d-bar8</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-450"><dt-text kind="code" size="xs">d-bar12</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-500"><dt-text kind="code" size="xs">d-bar16</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-550"><dt-text kind="code" size="xs">d-bar24</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-600"><dt-text kind="code" size="xs">d-bar32</dt-text></div>
+<dt-stack gap="100" :direction="{ default: 'column', md: 'row' }">
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-0">  <dt-text kind="code" size="xs">d-bar-0</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-100"><dt-text kind="code" size="xs">d-bar-100</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-200"><dt-text kind="code" size="xs">d-bar-200</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-300"><dt-text kind="code" size="xs">d-bar-300</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-350"><dt-text kind="code" size="xs">d-bar-350</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-400"><dt-text kind="code" size="xs">d-bar-400</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-450"><dt-text kind="code" size="xs">d-bar-450</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-500"><dt-text kind="code" size="xs">d-bar-500</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-550"><dt-text kind="code" size="xs">d-bar-550</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-600"><dt-text kind="code" size="xs">d-bar-600</dt-text></div>
 </dt-stack>
 ```
 
 ## Rounded Sides
 
-Use `d-b{t|r|b|l}r{n}` to change the border radius on a side of your element.
+Use a side-pair class to round the two corners on a single side. Class roots are the first-letter compression of the matching CSS logical property.
+
+| Class root | CSS properties set                                      | Visible in LTR |
+| ---------- | ------------------------------------------------------- | -------------- |
+| `d-bbsr-*` | `border-start-start-radius` + `border-start-end-radius` | top            |
+| `d-bier-*` | `border-start-end-radius` + `border-end-end-radius`     | right          |
+| `d-bber-*` | `border-end-start-radius` + `border-end-end-radius`     | bottom         |
+| `d-bisr-*` | `border-start-start-radius` + `border-end-start-radius` | left           |
 
 ```vue demo
 <!-- @wrapper -->
-<dt-stack gap="400" :direction="{ 'default': 'column', 'md': 'row' }">
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bbsr-300"><dt-text kind="code" size="xs">d-btr4</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bbsr-400"><dt-text kind="code" size="xs">d-btr8</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bbsr-450"><dt-text kind="code" size="xs">d-btr12</dt-text></div>
-  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bbsr-500"><dt-text kind="code" size="xs">d-btr16</dt-text></div>
+<dt-stack gap="400" :direction="{ default: 'column', md: 'row' }">
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bbsr-450"><dt-text kind="code" size="xs">d-bbsr-450</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bier-450"><dt-text kind="code" size="xs">d-bier-450</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bber-450"><dt-text kind="code" size="xs">d-bber-450</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bisr-450"><dt-text kind="code" size="xs">d-bisr-450</dt-text></div>
+</dt-stack>
+```
+
+## Individual Corners
+
+Use a single-corner class to round exactly one corner. Class roots match the CSS logical corner properties.
+
+| Class root | CSS property set            | Visible in LTR |
+| ---------- | --------------------------- | -------------- |
+| `d-bssr-*` | `border-start-start-radius` | top-left       |
+| `d-bser-*` | `border-start-end-radius`   | top-right      |
+| `d-beer-*` | `border-end-end-radius`     | bottom-right   |
+| `d-besr-*` | `border-end-start-radius`   | bottom-left    |
+
+```vue demo
+<!-- @wrapper -->
+<dt-stack gap="400" :direction="{ default: 'column', md: 'row' }">
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bssr-500"><dt-text kind="code" size="xs">d-bssr-500</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bser-500"><dt-text kind="code" size="xs">d-bser-500</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-beer-500"><dt-text kind="code" size="xs">d-beer-500</dt-text></div>
+  <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-besr-500"><dt-text kind="code" size="xs">d-besr-500</dt-text></div>
 </dt-stack>
 ```
 
 ## Pills
 
-Use `d-b{a|t|r|b|l}r-pill` to change the border radius of your element to a pill shape.
+Use `d-bar-pill` for a pill-shaped radius on all four corners. The same `-pill` suffix is available on every scope (`d-bbsr-pill`, `d-bssr-pill`, etc.).
 
 ```vue demo
 <!-- @wrapper -->
-<dt-stack
-  gap="400"
-  :direction="{ 'default': 'column', 'md': 'row' }"
->
+<dt-stack gap="400" :direction="{ default: 'column', md: 'row' }">
   <div class="d-p-100 d-ba d-baw2 d-bgc-primary d-ws-nowrap d-bar-pill">
     <dt-text kind="code" size="xs">d-bar-pill</dt-text>
   </div>
@@ -56,61 +85,66 @@ Use `d-b{a|t|r|b|l}r-pill` to change the border radius of your element to a pill
 
 ## Circles
 
-Use `d-b{a|t|r|b|l}r-circle` to change the border radius of your element to a circle shape.
+Use `d-bar-circle` for a fully circular radius. Best paired with a square element.
 
 ```vue demo
 <!-- @wrapper -->
-<dt-stack
-  gap="400"
-  :direction="{ 'default': 'column', 'md': 'row' }"
- >
+<dt-stack gap="400" :direction="{ default: 'column', md: 'row' }">
   <dt-stack direction="row" align="center" justify="center" class="d-p-100 d-size-200 d-ba d-baw2 d-bc-default d-bgc-primary d-ws-nowrap d-bar-circle">
     <dt-text kind="code" size="xs">d-bar-circle</dt-text>
   </dt-stack>
 </dt-stack>
 ```
 
+## Reset
+
+Use `d-bar-unset` to reset the border-radius on all four corners to `unset`.
+
 ## Classes
 
-<utility-class-table>
+<utility-class-table show-rendered>
   <template #content>
+    <tbody v-for="scope in radius.scopes" :key="scope.logicalPrefix">
+      <tr v-for="val in radius.values" :key="`${scope.logicalPrefix}-${val.stop}`">
+        <th scope="row">
+          <dt-text as="span" kind="code" :size="100" class="d-docsite-code">.d-{{ scope.logicalPrefix }}-{{ val.stop }}</dt-text>
+        </th>
+        <td class="d-code--sm">
+          <span v-for="prop in scope.cssProperties" :key="prop">
+            {{ prop }}: var(--dt-size-radius-{{ val.stop }}) !important;<br/>
+          </span>
+        </td>
+        <td class="d-code--sm d-fc-tertiary d-ta-right">{{ val.rem }}</td>
+        <td class="d-code--sm d-fc-tertiary d-ta-right">{{ val.px }}</td>
+      </tr>
+      <template v-if="scope.legacyPrefix">
+        <tr v-for="val in radius.values" :key="`legacy-${scope.legacyPrefix}-${val.legacyPx}`">
+          <th scope="row">
+            <dt-stack gap="50">
+              <dt-text as="span" kind="code" :size="100" class="d-docsite-code">
+                .d-{{ scope.legacyPrefix }}<template v-if="val.legacyPx === 'pill' || val.legacyPx === 'circle'">-</template>{{ val.legacyPx }}
+              </dt-text>
+              <dt-badge type="critical" kind="label" text="Deprecated" />
+            </dt-stack>
+          </th>
+          <td class="d-code--sm">
+            <span v-for="prop in scope.cssProperties" :key="prop">
+              {{ prop }}: var(--dt-size-radius-{{ val.stop }}) !important;<br/>
+            </span>
+          </td>
+          <td class="d-code--sm d-fc-tertiary d-ta-right">{{ val.rem }}</td>
+          <td class="d-code--sm d-fc-tertiary d-ta-right">{{ val.px }}</td>
+        </tr>
+      </template>
+    </tbody>
     <tbody>
       <tr>
-        <th scope="row" class="d-code--sm d-docsite-code">.d-bar-unset</th>
+        <th scope="row">
+          <dt-text as="span" kind="code" :size="100" class="d-docsite-code">.d-bar-unset</dt-text>
+        </th>
         <td class="d-code--sm">border-radius: unset !important;</td>
-      </tr>
-    </tbody>
-    <tbody v-for="i in ['a', 't', 'r', 'b', 'l']">
-      <tr v-for="(val, token) in {'--dt-size-radius-0': '0', '--dt-size-radius-100': '1', '--dt-size-radius-200': '2', '--dt-size-radius-300': '4', '--dt-size-radius-350': '6', '--dt-size-radius-400': '8', '--dt-size-radius-450': '12', '--dt-size-radius-500': '16', '--dt-size-550': '24', '--dt-size-radius-600': '32', '--dt-size-radius-circle': '-circle', '--dt-size-radius-pill': '-pill'}">
-        <th scope="row" class="d-code--sm d-docsite-code">.d-b{{ i }}r{{ val }}</th>
-        <td>
-          <dt-stack direction="row" justify="between" align="center">
-            <div class="d-fl-grow1 d-code--sm">
-              <span v-if="i === 'a'">border-radius: var({{ token }}) !important;</span>
-              <span v-else-if="i === 't'">
-                border-start-start-radius: var({{ token }}) !important;<br/>
-                border-start-end-radius: var({{ token }}) !important;
-              </span>
-              <span v-else-if="i === 'r'">
-                border-start-end-radius: var({{ token }}) !important;<br/>
-                border-end-end-radius: var({{ token }}) !important;
-              </span>
-              <span v-else-if="i === 'b'">
-                border-end-start-radius: var({{ token }}) !important;<br/>
-                border-end-end-radius: var({{ token }}) !important;
-              </span>
-              <span v-else-if="i === 'l'">
-                border-end-start-radius: var({{ token }}) !important;
-                border-start-start-radius: var({{ token }}) !important;<br/>
-              </span>
-            </div>
-            <div
-              class="d-fl-shrink0 d-m-50 d-mis-200 d-h-50 d-bgc-black-300"
-              :class="[val === '-circle' ? 'd-w-50' : 'd-w-100', `d-b${i}r${val}`]"
-            >
-            </div>
-          </dt-stack>
-        </td>
+        <td class="d-fc-muted d-fs-100 d-ta-center">N/A</td>
+        <td class="d-fc-muted d-fs-100 d-ta-center">N/A</td>
       </tr>
     </tbody>
   </template>

--- a/apps/dialtone-documentation/docs/utilities/borders/radius.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/radius.md
@@ -118,7 +118,7 @@ Use `d-bar-unset` to reset the border-radius on all four corners to `unset`.
         <td class="d-code--sm d-fc-tertiary d-ta-right">{{ val.px }}</td>
       </tr>
       <template v-if="scope.legacyPrefix">
-        <tr v-for="val in radius.values" :key="`legacy-${scope.legacyPrefix}-${val.legacyPx}`">
+        <tr v-for="val in radius.values.filter(v => v.legacyPx != null)" :key="`legacy-${scope.legacyPrefix}-${val.legacyPx}`">
           <th scope="row">
             <dt-stack gap="50">
               <dt-text as="span" kind="code" :size="100" class="d-docsite-code">

--- a/apps/dialtone-documentation/docs/utilities/borders/radius.md
+++ b/apps/dialtone-documentation/docs/utilities/borders/radius.md
@@ -6,6 +6,16 @@ keywords: ["rounded", "corner", "pill", "circle", "radius start", "radius end", 
 
 <script setup>
   import { radius } from '@data/borders.json';
+
+  // Skip legacy rows when the constructed class equals the logical one (e.g. .d-bar-pill,
+  // .d-bar-circle where legacyPrefix == logicalPrefix and legacyPx is the keyword).
+  function hasDistinctLegacy (scope, val) {
+    if (val.legacyPx == null) return false;
+    const infix = (val.legacyPx === 'pill' || val.legacyPx === 'circle') ? '-' : '';
+    const legacyClass = `d-${scope.legacyPrefix}${infix}${val.legacyPx}`;
+    const logicalClass = `d-${scope.logicalPrefix}-${val.stop}`;
+    return legacyClass !== logicalClass;
+  }
 </script>
 
 ## All Corners
@@ -118,7 +128,7 @@ Use `d-bar-unset` to reset the border-radius on all four corners to `unset`.
         <td class="d-code--sm d-fc-tertiary d-ta-right">{{ val.px }}</td>
       </tr>
       <template v-if="scope.legacyPrefix">
-        <tr v-for="val in radius.values.filter(v => v.legacyPx != null)" :key="`legacy-${scope.legacyPrefix}-${val.legacyPx}`">
+        <tr v-for="val in radius.values.filter(v => hasDistinctLegacy(scope, v))" :key="`legacy-${scope.legacyPrefix}-${val.legacyPx}`">
           <th scope="row">
             <dt-stack gap="50">
               <dt-text as="span" kind="code" :size="100" class="d-docsite-code">

--- a/apps/dialtone-documentation/docs/utilities/effects/box-shadow.md
+++ b/apps/dialtone-documentation/docs/utilities/effects/box-shadow.md
@@ -11,11 +11,11 @@ Use `d-bs-{n}` to add an outer box shadow to an element.
 ```vue demo
 <!-- @wrapper -->
 <dt-stack gap="400" :direction="{ 'default': 'column', 'lg': 'row' }">
-  <div class="d-p-200 d-bar8 d-bgc-primary d-bs-sm">d-bs-sm</div>
-  <div class="d-p-200 d-bar8 d-bgc-primary d-bs-md">d-bs-md</div>
-  <div class="d-p-200 d-bar8 d-bgc-primary d-bs-lg">d-bs-lg</div>
-  <div class="d-p-200 d-bar8 d-bgc-primary d-bs-xl">d-bs-xl</div>
-  <div class="d-p-200 d-bar8 d-bgc-primary d-bs-card">d-bs-card</div>
+  <div class="d-p-200 d-bar-400 d-bgc-primary d-bs-sm">d-bs-sm</div>
+  <div class="d-p-200 d-bar-400 d-bgc-primary d-bs-md">d-bs-md</div>
+  <div class="d-p-200 d-bar-400 d-bgc-primary d-bs-lg">d-bs-lg</div>
+  <div class="d-p-200 d-bar-400 d-bgc-primary d-bs-xl">d-bs-xl</div>
+  <div class="d-p-200 d-bar-400 d-bgc-primary d-bs-card">d-bs-card</div>
 </dt-stack>
 ```
 
@@ -24,7 +24,7 @@ Use `d-bs-{n}` to add an outer box shadow to an element.
 Use `d-bs-none` to remove a box shadow to an element.
 
 ```vue demo
-<div class="d-p-200 d-bar8 d-bgc-primary d-bs-none">.d-bs-none</div>
+<div class="d-p-200 d-bar-400 d-bgc-primary d-bs-none">.d-bs-none</div>
 ```
 
 ## Hover
@@ -34,7 +34,7 @@ Use `h:d-bs-{n}` to change an element's `:hover` state box shadow.
 ```vue demo
 <!-- @custom -->
 <!-- @class d-fl-center d-p-300 d-bgc-secondary d-w100p -->
-<dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-primary h:d-bs-md">Hover over me</dt-button>
+<dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-primary h:d-bs-md">Hover over me</dt-button>
 ```
 
 ## Focus
@@ -44,7 +44,7 @@ Use `f:d-bs-{n}` to change an element's `:focus` and `:focus-within` state box s
 ```vue demo
 <!-- @custom -->
 <!-- @class d-fl-center d-p-300 d-bgc-secondary d-w100p -->
-<dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-primary f:d-bs-md">Focus me</dt-button>
+<dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-primary f:d-bs-md">Focus me</dt-button>
 ```
 
 ## Focus Visible
@@ -54,7 +54,7 @@ Use `fv:d-bs-{n}` to change an element's `:focus-visible` state box shadow [only
 ```vue demo
 <!-- @custom -->
 <!-- @class d-fl-center d-p-300 d-bgc-secondary d-w100p -->
-<dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-primary fv:d-bs-md">Keyboard focus me</dt-button>
+<dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-primary fv:d-bs-md">Keyboard focus me</dt-button>
 ```
 
 ## Classes

--- a/apps/dialtone-documentation/docs/utilities/effects/opacity.md
+++ b/apps/dialtone-documentation/docs/utilities/effects/opacity.md
@@ -11,11 +11,11 @@ Use `d-o{n}` to change the opacity of your element.
 ```vue demo
 <!-- @wrapper -->
 <dt-stack direction="row" gap="200">
-  <div class="d-p-200 d-bar8 d-bgc-moderate d-o100">.d-o100</div>
-  <div class="d-p-200 d-bar8 d-bgc-moderate d-o75">.d-o75</div>
-  <div class="d-p-200 d-bar8 d-bgc-moderate d-o50">.d-o50</div>
-  <div class="d-p-200 d-bar8 d-bgc-moderate d-o25">.d-o25</div>
-  <div class="d-p-200 d-bar8 d-bgc-moderate d-o0">.d-o0</div>
+  <div class="d-p-200 d-bar-400 d-bgc-moderate d-o100">.d-o100</div>
+  <div class="d-p-200 d-bar-400 d-bgc-moderate d-o75">.d-o75</div>
+  <div class="d-p-200 d-bar-400 d-bgc-moderate d-o50">.d-o50</div>
+  <div class="d-p-200 d-bar-400 d-bgc-moderate d-o25">.d-o25</div>
+  <div class="d-p-200 d-bar-400 d-bgc-moderate d-o0">.d-o0</div>
 </dt-stack>
 ```
 
@@ -24,7 +24,7 @@ Use `d-o{n}` to change the opacity of your element.
 Use `h:d-o{n}` to change an element's :hover state opacity.
 
 ```vue demo
-<dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-o50">Hover me</dt-button>
+<dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-o50">Hover me</dt-button>
 ```
 
 ## Focus
@@ -32,7 +32,7 @@ Use `h:d-o{n}` to change an element's :hover state opacity.
 Use `f:d-o{n}` to change an element's :focus and :focus-within state opacity.
 
 ```vue demo
-<dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate f:d-o50">Focus me</dt-button>
+<dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate f:d-o50">Focus me</dt-button>
 ```
 
 ## Focus Visible
@@ -40,7 +40,7 @@ Use `f:d-o{n}` to change an element's :focus and :focus-within state opacity.
 Use `fv:d-o{n}` to change an element's :focus-visible state opacity [only when focused by keyboard].
 
 ```vue demo
-<dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate fv:d-o50">Keyboard focus me</dt-button>
+<dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate fv:d-o50">Keyboard focus me</dt-button>
 ```
 
 <script setup>

--- a/apps/dialtone-documentation/docs/utilities/effects/transition.md
+++ b/apps/dialtone-documentation/docs/utilities/effects/transition.md
@@ -9,7 +9,7 @@ keywords: ["animation", "animate", "ease", "duration"]
 Use `d-t` to add a transition to an element.
 
 ```vue demo
-<dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t ">Hover me</dt-button>
+<dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t ">Hover me</dt-button>
 ```
 
 ## Changing Transition Duration
@@ -19,12 +19,12 @@ Use `d-td{n}` change an element's `transition-delay` from it's default `50ms` le
 ```vue demo
 <!-- @wrapper -->
 <dt-stack direction="row" gap="200">
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td0  ">0ms</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t        ">50ms</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td100">100ms</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td150">150ms</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td200">200ms</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300">300ms</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td0  ">0ms</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t        ">50ms</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td100">100ms</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td150">150ms</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td200">200ms</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300">300ms</dt-button>
 </dt-stack>
 ```
 
@@ -35,10 +35,10 @@ Use `d-ttf-{n}` change an element's `transition-timing-function` (aka easing) fr
 ```vue demo
 <!-- @wrapper -->
 <dt-stack direction="row" gap="200">
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf          ">Ease</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300                ">Ease In, Ease Out</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out      ">Ease Out</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint">Ease Out Quint</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf          ">Ease</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300                ">Ease In, Ease Out</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out      ">Ease Out</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint">Ease Out Quint</dt-button>
 </dt-stack>
 ```
 
@@ -49,12 +49,12 @@ Use `d-tp-{n}` change an what items within an element are transitioned.
 ```vue demo
 <!-- @wrapper -->
 <dt-stack direction="row" gap="200">
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint ">All</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint h:d-o50 d-tp-o">Opacity</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint d-tp-bs">Box shadow</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint d-tp-bgc">Background</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint d-tp-transform">Transform</dt-button>
-  <dt-button kind="unstyled" class="d-p-200 d-bar8 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint d-tp-colors">Colors</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint ">All</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint h:d-o50 d-tp-o">Opacity</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint d-tp-bs">Box shadow</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint d-tp-bgc">Background</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint d-tp-transform">Transform</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint d-tp-colors">Colors</dt-button>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/flex/align-content.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/align-content.md
@@ -12,12 +12,12 @@ keywords: ["flexbox", "cross axis", "flex wrap"]
 Use `d-ac-flex-start` to pack multiple rows against the start of the element's cross axis. This is the default value.
 
 ```vue demo
-<div class="d-fl-col3 d-g-200 d-fw-wrap d-ac-flex-start d-p-100 d-w100p d-bar8 d-bgc-moderate d-hmn332">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">5</dt-stack>
+<div class="d-fl-col3 d-g-200 d-fw-wrap d-ac-flex-start d-p-100 d-w100p d-bar-400 d-bgc-moderate d-hmn332">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">5</dt-stack>
 </div>
 ```
 
@@ -26,12 +26,12 @@ Use `d-ac-flex-start` to pack multiple rows against the start of the element's c
 Use `d-ac-center` to pack rows along the center of the element's cross axis.
 
 ```vue demo
-<div class="d-fl-col3 d-g-200 d-fw-wrap d-ac-center d-p-100 d-w100p d-bar8 d-bgc-moderate d-hmn332">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">5</dt-stack>
+<div class="d-fl-col3 d-g-200 d-fw-wrap d-ac-center d-p-100 d-w100p d-bar-400 d-bgc-moderate d-hmn332">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">5</dt-stack>
 </div>
 ```
 
@@ -40,12 +40,12 @@ Use `d-ac-center` to pack rows along the center of the element's cross axis.
 Use `d-ac-flex-end` to rack rows against the end of the element's main axis.
 
 ```vue demo
-<div class="d-fl-col3 d-fw-wrap d-g-200 d-ac-flex-end d-p-100 d-w100p d-bar8 d-bgc-moderate d-hmn332">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">5</dt-stack>
+<div class="d-fl-col3 d-fw-wrap d-g-200 d-ac-flex-end d-p-100 d-w100p d-bar-400 d-bgc-moderate d-hmn332">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">5</dt-stack>
 </div>
 ```
 
@@ -54,12 +54,12 @@ Use `d-ac-flex-end` to rack rows against the end of the element's main axis.
 Use `d-ac-space-around` to pack rows along the element's cross axis so that there is an equal amount of space on each side of the item. This effectively takes all available space, divides it for each row, placing half of alotted space on either side of the row. This is why the space appears doubled for interior rows versus end rows.
 
 ```vue demo
-<div class="d-fl-col3 d-fw-wrap d-g-200 d-ac-space-around d-bgc-red-100 d-p-100 d-w100p d-bar8 d-bgc-moderate d-hmn332">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">5</dt-stack>
+<div class="d-fl-col3 d-fw-wrap d-g-200 d-ac-space-around d-bgc-red-100 d-p-100 d-w100p d-bar-400 d-bgc-moderate d-hmn332">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">5</dt-stack>
 </div>
 ```
 
@@ -68,12 +68,12 @@ Use `d-ac-space-around` to pack rows along the element's cross axis so that ther
 Use `d-ac-space-between` to distribute rows along the element's cross axis so that there is an equal amount of space between each row without inserting any space between the first or last object.
 
 ```vue demo
-<div class="d-fl-col3 d-fw-wrap d-g-200 d-ac-space-between d-p-100 d-w100p d-bar8 d-bgc-moderate d-hmn332">
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">5</dt-stack>
+<div class="d-fl-col3 d-fw-wrap d-g-200 d-ac-space-between d-p-100 d-w100p d-bar-400 d-bgc-moderate d-hmn332">
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">5</dt-stack>
 </div>
 ```
 
@@ -82,13 +82,13 @@ Use `d-ac-space-between` to distribute rows along the element's cross axis so th
 Use `d-ac-space-evenly` to distribute rows along the element's cross axis so that there is an equal amount of space on each side of the rows, but unlike `d-ac-space-around` the space visually looks evenly distributed between objects.
 
 ```vue demo
-<div class="d-fl-col3 d-fw-wrap d-g-200 d-ac-space-evenly d-p-100 d-w100p d-bar8 d-bgc-moderate d-hmn332">
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">5</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar4">6</dt-stack>
+<div class="d-fl-col3 d-fw-wrap d-g-200 d-ac-space-evenly d-p-100 d-w100p d-bar-400 d-bgc-moderate d-hmn332">
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">5</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-h-100 d-bgc-moderate-opaque d-bar-300">6</dt-stack>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/flex/align-items.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/align-items.md
@@ -12,10 +12,10 @@ keywords: ["flexbox", "cross axis", "center", "stretch"]
 Use `d-ai-stretch` to stretch items across the element's cross axis. This is the default value.
 
 ```vue demo
-<dt-stack direction="row" class="d-ai-stretch d-p-100 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-50 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" class="d-ai-stretch d-p-100 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-50 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -24,10 +24,10 @@ Use `d-ai-stretch` to stretch items across the element's cross axis. This is the
 Use `d-ai-flex-start` to align items to the start of the element's cross axis.
 
 ```vue demo
-<dt-stack direction="row" class="d-ai-flex-start d-p-100 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-50 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-300 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" class="d-ai-flex-start d-p-100 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-50 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-300 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -36,10 +36,10 @@ Use `d-ai-flex-start` to align items to the start of the element's cross axis.
 Use `d-ai-center` to distribute items along the center of the element's cross axis.
 
 ```vue demo
-<dt-stack direction="row" class="d-ai-center d-p-100 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-50 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-300 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" class="d-ai-center d-p-100 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-50 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-300 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -48,10 +48,10 @@ Use `d-ai-center` to distribute items along the center of the element's cross ax
 Use `d-ai-flex-end` to distribute items from the end of the element's cross axis.
 
 ```vue demo
-<dt-stack direction="row" class="d-ai-flex-end d-p-100 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-50 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-300 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" class="d-ai-flex-end d-p-100 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-50 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-300 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-px-200 d-py-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/flex/align-self.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/align-self.md
@@ -12,10 +12,10 @@ keywords: ["flexbox", "cross axis", "override"]
 Use `d-as-stretch` to stretch an item along a parent's cross axis.
 
 ```vue demo
-<dt-stack direction="row" align="start" class="d-p-100 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-m-100 d-p-200 d-bgc-bold-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" align="start" class="d-p-100 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-m-100 d-p-200 d-bgc-bold-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -24,10 +24,10 @@ Use `d-as-stretch` to stretch an item along a parent's cross axis.
 Use `d-as-flex-start` to align an item to the start of the parent's cross axis.
 
 ```vue demo
-<dt-stack direction="row" class="d-p-100 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-flex-start d-m-100 d-p-200 d-bgc-bold-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" class="d-p-100 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-flex-start d-m-100 d-p-200 d-bgc-bold-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -36,10 +36,10 @@ Use `d-as-flex-start` to align an item to the start of the parent's cross axis.
 Use `d-as-center` to align an item along the center of the parent's cross axis.
 
 ```vue demo
-<dt-stack direction="row" class="d-p-100 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-center d-m-100 d-p-200 d-bgc-bold-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" class="d-p-100 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-center d-m-100 d-p-200 d-bgc-bold-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -48,10 +48,10 @@ Use `d-as-center` to align an item along the center of the parent's cross axis.
 Use `d-as-flex-end` to align an item from the end of the parent's cross axis.
 
 ```vue demo
-<dt-stack direction="row" class="d-p-100 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-flex-end d-m-100 d-p-200 d-bgc-bold-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" class="d-p-100 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-flex-end d-m-100 d-p-200 d-bgc-bold-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/flex/columns-layouts.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/columns-layouts.md
@@ -161,7 +161,7 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
 ```vue demo
 <dt-stack gap="200" class="d-w100p">
   <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
-    <dt-text as="p" kind="code" size="100">.d-cg0</dt-text>
+    <dt-text as="p" kind="code" size="100">.d-cg-0</dt-text>
     <div class="d-fl-col3 d-of-auto d-cg-0">
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
@@ -169,7 +169,7 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
     </div>
   </dt-stack>
   <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
-    <dt-text as="p" kind="code" size="100">.d-cg1</dt-text>
+    <dt-text as="p" kind="code" size="100">.d-cg-1</dt-text>
     <div class="d-fl-col3 d-of-auto d-cg-1">
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
@@ -177,7 +177,7 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
     </div>
   </dt-stack>
   <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
-    <dt-text as="p" kind="code" size="100">.d-cg2</dt-text>
+    <dt-text as="p" kind="code" size="100">.d-cg-25</dt-text>
     <div class="d-fl-col3 d-of-auto d-cg-25">
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
@@ -185,7 +185,7 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
     </div>
   </dt-stack>
   <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
-    <dt-text as="p" kind="code" size="100">.d-cg4</dt-text>
+    <dt-text as="p" kind="code" size="100">.d-cg-50</dt-text>
     <div class="d-fl-col3 d-of-auto d-cg-50">
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
@@ -193,7 +193,7 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
     </div>
   </dt-stack>
   <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
-    <dt-text as="p" kind="code" size="100">.d-cg6</dt-text>
+    <dt-text as="p" kind="code" size="100">.d-cg-75</dt-text>
     <div class="d-fl-col3 d-of-auto d-cg-75">
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
@@ -201,7 +201,7 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
     </div>
   </dt-stack>
   <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
-    <dt-text as="p" kind="code" size="100">.d-cg8</dt-text>
+    <dt-text as="p" kind="code" size="100">.d-cg-100</dt-text>
     <div class="d-fl-col3 d-of-auto d-cg-100">
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
@@ -209,7 +209,7 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
     </div>
   </dt-stack>
   <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
-    <dt-text as="p" kind="code" size="100">.d-cg12</dt-text>
+    <dt-text as="p" kind="code" size="100">.d-cg-150</dt-text>
     <div class="d-fl-col3 d-of-auto d-cg-150">
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
@@ -217,7 +217,7 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
     </div>
   </dt-stack>
   <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
-    <dt-text as="p" kind="code" size="100">.d-cg16</dt-text>
+    <dt-text as="p" kind="code" size="100">.d-cg-200</dt-text>
     <div class="d-fl-col3 d-of-auto d-cg-200">
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
@@ -225,7 +225,7 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
     </div>
   </dt-stack>
   <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
-    <dt-text as="p" kind="code" size="100">.d-cg24</dt-text>
+    <dt-text as="p" kind="code" size="100">.d-cg-300</dt-text>
     <div class="d-fl-col3 d-of-auto d-cg-300">
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
@@ -233,7 +233,7 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
     </div>
   </dt-stack>
   <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
-    <dt-text as="p" kind="code" size="100">.d-cg32</dt-text>
+    <dt-text as="p" kind="code" size="100">.d-cg-400</dt-text>
     <div class="d-fl-col3 d-of-auto d-cg-400">
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
@@ -241,7 +241,7 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
     </div>
   </dt-stack>
   <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
-    <dt-text as="p" kind="code" size="100">.d-cg48</dt-text>
+    <dt-text as="p" kind="code" size="100">.d-cg-600</dt-text>
     <div class="d-fl-col3 d-of-auto d-cg-600">
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
@@ -249,7 +249,7 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
     </div>
   </dt-stack>
   <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
-    <dt-text as="p" kind="code" size="100">.d-cg64</dt-text>
+    <dt-text as="p" kind="code" size="100">.d-cg-800</dt-text>
     <div class="d-fl-col3 d-of-auto d-cg-800">
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
       <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>

--- a/apps/dialtone-documentation/docs/utilities/flex/columns-layouts.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/columns-layouts.md
@@ -13,142 +13,142 @@ Use `d-fl-col{n}` to create uniformly sized children within an element.
 
 ```vue demo
 <dt-stack gap="200" class="d-w100p">
-  <div class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <div class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-fl-col1</dt-text>
     <div class="d-cg-100 d-of-auto d-fl-col1">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
     </div>
   </div>
-  <div class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <div class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-fl-col2</dt-text>
     <div class="d-cg-100 d-of-auto d-fl-col2">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
     </div>
   </div>
-  <div class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <div class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-fl-col3</dt-text>
     <div class="d-cg-100 d-of-auto d-fl-col3">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </div>
-  <div class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <div class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-fl-col4</dt-text>
     <div class="d-cg-100 d-of-auto d-fl-col4">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">4</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">4</dt-stack>
     </div>
   </div>
-  <div class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <div class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-fl-col5</dt-text>
     <div class="d-cg-100 d-of-auto d-fl-col5">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">4</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">5</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">4</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">5</dt-stack>
     </div>
   </div>
-  <div class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <div class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-fl-col6</dt-text>
     <div class="d-cg-100 d-of-auto d-fl-col6">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">4</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">5</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">6</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">4</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">5</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">6</dt-stack>
     </div>
   </div>
-  <div class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <div class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-fl-col7</dt-text>
     <div class="d-cg-100 d-of-auto d-fl-col7">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">4</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">5</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">6</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">7</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">4</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">5</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">6</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">7</dt-stack>
     </div>
   </div>
-  <div class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <div class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-fl-col8</dt-text>
     <div class="d-cg-100 d-of-auto d-fl-col8">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">4</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">5</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">6</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">7</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">8</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">4</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">5</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">6</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">7</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">8</dt-stack>
     </div>
   </div>
-  <div class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <div class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-fl-col9</dt-text>
     <div class="d-cg-100 d-of-auto d-fl-col9">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">4</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">5</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">6</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">7</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">8</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">9</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">4</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">5</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">6</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">7</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">8</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">9</dt-stack>
     </div>
   </div>
-  <div class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <div class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-fl-col10</dt-text>
     <div class="d-cg-100 d-of-auto d-fl-col10">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">4</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">5</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">6</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">7</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">8</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">9</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">10</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">4</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">5</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">6</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">7</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">8</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">9</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">10</dt-stack>
     </div>
   </div>
-  <div class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <div class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-fl-col11</dt-text>
     <div class="d-cg-100 d-of-auto d-fl-col11">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">4</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">5</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">6</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">7</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">8</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">9</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">10</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">11</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">4</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">5</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">6</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">7</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">8</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">9</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">10</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">11</dt-stack>
     </div>
   </div>
-  <div class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <div class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-fl-col12</dt-text>
     <div class="d-cg-100 d-of-auto d-fl-col12">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">4</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">5</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">6</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">7</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">8</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">9</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">10</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">11</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">12</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">4</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">5</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">6</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">7</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">8</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">9</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">10</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">11</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">12</dt-stack>
     </div>
   </div>
 </dt-stack>
@@ -160,100 +160,100 @@ Use `d-cg{n}` to create uniform gaps between flex columns within an element.
 
 ```vue demo
 <dt-stack gap="200" class="d-w100p">
-  <dt-stack gap="100" class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-cg0</dt-text>
-    <div class="d-fl-col3 d-of-auto d-cg0">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+    <div class="d-fl-col3 d-of-auto d-cg-0">
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </dt-stack>
-  <dt-stack gap="100" class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-cg1</dt-text>
-    <div class="d-fl-col3 d-of-auto d-cg1">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+    <div class="d-fl-col3 d-of-auto d-cg-1">
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </dt-stack>
-  <dt-stack gap="100" class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-cg2</dt-text>
-    <div class="d-fl-col3 d-of-auto d-cg2">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+    <div class="d-fl-col3 d-of-auto d-cg-25">
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </dt-stack>
-  <dt-stack gap="100" class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-cg4</dt-text>
-    <div class="d-fl-col3 d-of-auto d-cg4">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+    <div class="d-fl-col3 d-of-auto d-cg-50">
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </dt-stack>
-  <dt-stack gap="100" class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-cg6</dt-text>
-    <div class="d-fl-col3 d-of-auto d-cg6">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+    <div class="d-fl-col3 d-of-auto d-cg-75">
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </dt-stack>
-  <dt-stack gap="100" class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-cg8</dt-text>
-    <div class="d-fl-col3 d-of-auto d-cg8">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+    <div class="d-fl-col3 d-of-auto d-cg-100">
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </dt-stack>
-  <dt-stack gap="100" class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-cg12</dt-text>
-    <div class="d-fl-col3 d-of-auto d-cg12">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+    <div class="d-fl-col3 d-of-auto d-cg-150">
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </dt-stack>
-  <dt-stack gap="100" class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-cg16</dt-text>
-    <div class="d-fl-col3 d-of-auto d-cg16">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+    <div class="d-fl-col3 d-of-auto d-cg-200">
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </dt-stack>
-  <dt-stack gap="100" class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-cg24</dt-text>
-    <div class="d-fl-col3 d-of-auto d-cg24">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+    <div class="d-fl-col3 d-of-auto d-cg-300">
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </dt-stack>
-  <dt-stack gap="100" class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-cg32</dt-text>
-    <div class="d-fl-col3 d-of-auto d-cg32">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+    <div class="d-fl-col3 d-of-auto d-cg-400">
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </dt-stack>
-  <dt-stack gap="100" class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-cg48</dt-text>
-    <div class="d-fl-col3 d-of-auto d-cg48">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+    <div class="d-fl-col3 d-of-auto d-cg-600">
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </dt-stack>
-  <dt-stack gap="100" class="d-p-100 d-bar8 d-bgc-moderate d-w100p">
+  <dt-stack gap="100" class="d-p-100 d-bar-400 d-bgc-moderate d-w100p">
     <dt-text as="p" kind="code" size="100">.d-cg64</dt-text>
-    <div class="d-fl-col3 d-of-auto d-cg64">
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">1</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">2</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar4 d-bgc-moderate-opaque">3</dt-stack>
+    <div class="d-fl-col3 d-of-auto d-cg-800">
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">1</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">2</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bar-300 d-bgc-moderate-opaque">3</dt-stack>
     </div>
   </dt-stack>
 </dt-stack>
@@ -267,9 +267,9 @@ By default flexed items align to `flex-start` both horizontally and vertically (
 
 ```vue demo
 <dt-stack direction="row" align="center" justify="center" class="d-w100p d-hmn216 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-size-75 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-size-100 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-size-75 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-size-75 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-size-100 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-size-75 d-m-100 d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/flex/direction-wrap-flow.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/direction-wrap-flow.md
@@ -12,15 +12,15 @@ keywords: ["flexbox","flex direction","flex wrap","flex flow","row","column"]
 The `flex-direction` property declares a flex container’s main axis direction. The default value is row.
 
 ```vue demo
-<dt-stack class="d-fd-row-reverse d-w100p d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack class="d-fd-row-reverse d-w100p d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
-<dt-stack class="d-fd-row d-w100p d-mbs-200 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack class="d-fd-row d-w100p d-mbs-200 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -52,10 +52,10 @@ The `flex-direction` property declares a flex container’s main axis direction.
 The `flex-wrap` property declares a flex container’s wrapping status. The default value is nowrap.
 
 ```vue demo
-<dt-stack direction="row" class="d-fw-wrap d-w100p d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-w25p d-h-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-w50p d-h-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-w75p d-h-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" class="d-fw-wrap d-w100p d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-w25p d-h-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-w50p d-h-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-w75p d-h-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -87,10 +87,10 @@ The `flex-wrap` property declares a flex container’s wrapping status. The defa
 The `flex-flow` property is a shorthand property that sets allows you to quickly set the above `flex-direction` and `flex-wrap` properties. By default all flex containers are set to `row` and `nowrap`.
 
 ```vue demo
-<dt-stack class="d-ff-row-reverse-wrap d-w100p d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-w25p d-h-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-w50p d-h-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-w75p d-h-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack class="d-ff-row-reverse-wrap d-w100p d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-w25p d-h-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-w50p d-h-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-m-100 d-p-200 d-w75p d-h-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/flex/flex-grow-shrink.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/flex-grow-shrink.md
@@ -13,7 +13,7 @@ The `flex` property is a shorthand property for `flex-grow`, `flex-shrink`, and 
 control the grow and shrink flex values separately with their own utility classes.
 
 ```vue demo
-<dt-stack direction="row" class="d-w-1000 d-bar8 d-bgc-moderate">
+<dt-stack direction="row" class="d-w-1000 d-bar-400 d-bgc-moderate">
   <div class="d-fl-none d-p-200 d-ps-relative">Content cannot flex</div>
   <div class="d-fl1 d-p-200 d-bgc-moderate-opaque d-ps-relative">Text that will flex</div>
   <div class="d-fl-none d-p-200 d-ps-relative">Content cannot flex</div>
@@ -51,7 +51,7 @@ control the grow and shrink flex values separately with their own utility classe
 The `flex-grow` sets the flex container’s grow factor relative to the parent's main size. The default value is 0.
 
 ```vue demo
-<dt-stack direction="row" class="d-w-1000 d-bar8 d-bgc-moderate">
+<dt-stack direction="row" class="d-w-1000 d-bar-400 d-bgc-moderate">
   <div class="d-fl-none d-p-200">Content cannot flex</div>
   <div class="d-fl-grow1 d-p-200 d-bgc-moderate-opaque">Text that will grow</div>
   <div class="d-fl-none d-p-200">Content cannot flex</div>
@@ -89,10 +89,10 @@ The `flex-grow` sets the flex container’s grow factor relative to the parent's
 The `flex-shrink` sets the flex container’s shrink factor relative to the parent's main size. The default value is 1.
 
 ```vue demo
-<dt-stack direction="row" class="d-bar8 d-bgc-moderate">
-  <div class="d-bar8 d-fl-none d-p-200 d-bgc-moderate-opaque">Longer text that cannot flex</div>
-  <div class="d-bar8 d-fl-shrink1 d-p-200 d-bgc-moderate-opaque">Text that will shrink even if it causes text to wrap</div>
-  <div class="d-bar8 d-fl-none d-p-200 d-bgc-moderate-opaque">Longer text that cannot flex</div>
+<dt-stack direction="row" class="d-bar-400 d-bgc-moderate">
+  <div class="d-bar-400 d-fl-none d-p-200 d-bgc-moderate-opaque">Longer text that cannot flex</div>
+  <div class="d-bar-400 d-fl-shrink1 d-p-200 d-bgc-moderate-opaque">Text that will shrink even if it causes text to wrap</div>
+  <div class="d-bar-400 d-fl-none d-p-200 d-bgc-moderate-opaque">Longer text that cannot flex</div>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/flex/gap.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/gap.md
@@ -14,11 +14,11 @@ Use `d-g-{stop}` to set gap using spacing token stops. The number references the
 Use `d-g-{stop}` to universally change the row and column gap space.
 
 ```vue demo
-<dt-stack direction="row" class="d-fl-col2 d-fw-wrap d-g-200 d-bar8 d-w100p d-bgc-bold">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">4</dt-stack>
+<dt-stack direction="row" class="d-fl-col2 d-fw-wrap d-g-200 d-bar-400 d-w100p d-bgc-bold">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">4</dt-stack>
 </dt-stack>
 ```
 
@@ -27,11 +27,11 @@ Use `d-g-{stop}` to universally change the row and column gap space.
 Use `d-rg-{stop}` to change the row gap space.
 
 ```vue demo
-<dt-stack class="d-rg-200 d-bar8 d-w100p d-bgc-bold">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">4</dt-stack>
+<dt-stack class="d-rg-200 d-bar-400 d-w100p d-bgc-bold">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">4</dt-stack>
 </dt-stack>
 ```
 
@@ -40,22 +40,22 @@ Use `d-rg-{stop}` to change the row gap space.
 Use `d-cg-{stop}` to change the column gap space.
 
 ```vue demo
-<dt-stack direction="row" class="d-fl-col4 d-cg-200 d-bar8 d-w100p d-bgc-bold">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">4</dt-stack>
+<dt-stack direction="row" class="d-fl-col4 d-cg-200 d-bar-400 d-w100p d-bgc-bold">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">4</dt-stack>
 </dt-stack>
 ```
 
 ## Independently Changing Row and Column Gaps
 
 ```vue demo
-<dt-stack direction="row" class="d-fl-col2 d-fw-wrap d-rg-400 d-cg-100 d-bar8 d-w100p d-bgc-bold">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">4</dt-stack>
+<dt-stack direction="row" class="d-fl-col2 d-fw-wrap d-rg-400 d-cg-100 d-bar-400 d-w100p d-bgc-bold">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">4</dt-stack>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/flex/justify.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/justify.md
@@ -12,10 +12,10 @@ keywords: ["flexbox", "main axis", "space between", "space around"]
 Use `d-jc-flex-start` to justify items against the start of the element's main axis. This is the default value.
 
 ```vue demo
-<dt-stack direction="row" gap="100" class="d-jc-flex-start d-w-1000 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" gap="100" class="d-jc-flex-start d-w-1000 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -24,10 +24,10 @@ Use `d-jc-flex-start` to justify items against the start of the element's main a
 Use `d-jc-center` to justify items along the center of the element's main axis.
 
 ```vue demo
-<dt-stack direction="row" gap="100" class="d-jc-center d-w-1000 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" gap="100" class="d-jc-center d-w-1000 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -36,10 +36,10 @@ Use `d-jc-center` to justify items along the center of the element's main axis.
 Use `d-jc-flex-end` to justify items against the end of the element's main axis.
 
 ```vue demo
-<dt-stack direction="row" gap="100" class="d-jc-flex-end d-w-1000 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" gap="100" class="d-jc-flex-end d-w-1000 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -48,10 +48,10 @@ Use `d-jc-flex-end` to justify items against the end of the element's main axis.
 Use `d-jc-space-around` to justify items along the element's main axis so that there is an equal amount of space on each side of the item. This effectively takes all available space, divides it for each child element, placing half of available space on either side of the child. This is why the space appears doubled for interior objects versus end objects.
 
 ```vue demo
-<dt-stack direction="row" gap="100" class="d-jc-space-around d-w-1000 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" gap="100" class="d-jc-space-around d-w-1000 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -60,10 +60,10 @@ Use `d-jc-space-around` to justify items along the element's main axis so that t
 Use `d-jc-space-between` to justify items along the element's main axis so that there is an equal amount of space between each item without inserting any space between the first or last object.
 
 ```vue demo
-<dt-stack direction="row" gap="100" class="d-jc-space-between d-w-1000 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" gap="100" class="d-jc-space-between d-w-1000 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 
@@ -72,10 +72,10 @@ Use `d-jc-space-between` to justify items along the element's main axis so that 
 Use `d-jc-space-evenly` to justify items along the element's main axis so that there is an equal amount of space on each side of the item, but unlike `d-jc-space-around` visually evenly spaces objects.
 
 ```vue demo
-<dt-stack direction="row" gap="100" class="d-jc-space-evenly d-w-1000 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<dt-stack direction="row" gap="100" class="d-jc-space-evenly d-w-1000 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/flex/order.md
+++ b/apps/dialtone-documentation/docs/utilities/flex/order.md
@@ -12,10 +12,10 @@ keywords: ["flexbox","flex order","reorder","sort"]
 By default, items are ordered by their position in the DOM. To re-order an element, use `d-order{#}`.
 
 ```vue demo
-<dt-stack direction="row" gap="200" align="center" justify="between" class="d-w100p d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-bold-opaque d-bar4 d-order-first">3</dt-stack>
+<dt-stack direction="row" gap="200" align="center" justify="between" class="d-w100p d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-bold-opaque d-bar-300 d-order-first">3</dt-stack>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/grid/column-start-end-span.md
+++ b/apps/dialtone-documentation/docs/utilities/grid/column-start-end-span.md
@@ -9,16 +9,16 @@ keywords: ["css grid","layout","columns","rows"]
 Use `d-gc{#}` to span an element across multiple columns. This can be combined with `d-gc{#}` classes to span a set of columns. Use `d-gce{#}` to set an element's ending point. A reminder that CSS grid columns start at 1 and end at the number of columns + 1. For example in a 3-column grid, the starting line would be 1 and the ending line would be 4.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols4 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-gc2 d-p-200 d-bgc-bold-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-gc2 d-p-200 d-bgc-bold-opaque d-bar4">4</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">5</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">6</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">7</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-gc3 d-p-200 d-bgc-bold-opaque d-bar4">8</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-gc-full d-p-200 d-bgc-bold-opaque d-bar4">9</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols4 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-gc2 d-p-200 d-bgc-bold-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-gc2 d-p-200 d-bgc-bold-opaque d-bar-300">4</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">5</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">6</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">7</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-gc3 d-p-200 d-bgc-bold-opaque d-bar-300">8</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-gc-full d-p-200 d-bgc-bold-opaque d-bar-300">9</dt-stack>
 </div>
 ```
 
@@ -27,14 +27,14 @@ Use `d-gc{#}` to span an element across multiple columns. This can be combined w
 Use `d-gcs{#}` to set the starting point for an element. This can be combined with `d-gc{#}` classes to span a set of columns.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols6 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4"></dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-gcs2 d-gce6 d-p-200 d-bgc-bold-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4"></dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-gcs1 d-gce5 d-p-200 d-bgc-bold-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4"></dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4"></dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-gcs1 d-gce7 d-p-200 d-bgc-bold-opaque d-bar4">3</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols6 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300"></dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-gcs2 d-gce6 d-p-200 d-bgc-bold-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300"></dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-gcs1 d-gce5 d-p-200 d-bgc-bold-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300"></dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300"></dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-gcs1 d-gce7 d-p-200 d-bgc-bold-opaque d-bar-300">3</dt-stack>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/grid/gap.md
+++ b/apps/dialtone-documentation/docs/utilities/grid/gap.md
@@ -11,11 +11,11 @@ Use `d-g-{stop}` to set gap using spacing token stops. The number references the
 Use `d-g-{stop}` to universally change the row and column gap space in grid layouts.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols2 d-w100p d-bar8 d-bgc-bold">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols2 d-w100p d-bar-400 d-bgc-bold">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -24,16 +24,16 @@ Use `d-g-{stop}` to universally change the row and column gap space in grid layo
 Use `d-cg-{stop}` or `d-rg-{stop}` to independently change the row and column gap space in grid layouts.
 
 ```vue demo
-<div class="d-d-grid d-cg-300 d-rg-100 d-g-cols3 d-w100p d-bar8 d-bgc-bold">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">4</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">5</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">6</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">7</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">8</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar4">9</dt-stack>
+<div class="d-d-grid d-cg-300 d-rg-100 d-g-cols3 d-w100p d-bar-400 d-bgc-bold">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">4</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">5</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">6</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">7</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">8</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bar-300">9</dt-stack>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/grid/justify-items.md
+++ b/apps/dialtone-documentation/docs/utilities/grid/justify-items.md
@@ -9,11 +9,11 @@ keywords: ["css grid", "inline axis"]
 Use `d-ji-auto` to justify grid items automatically along their inline axis. This is the default value.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols2 d-ji-auto d-w100p d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols2 d-ji-auto d-w100p d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -22,11 +22,11 @@ Use `d-ji-auto` to justify grid items automatically along their inline axis. Thi
 Use `d-ji-start` to justify items against the start of their inline axis. Note that this does not work on flexed objects, only grid objects.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols2 d-ji-start d-w100p d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols2 d-ji-start d-w100p d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -35,11 +35,11 @@ Use `d-ji-start` to justify items against the start of their inline axis. Note t
 Use `d-ji-end` to justify items against the end of their inline axis. Note that this does not work on flexed objects, only grid objects.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols2 d-ji-end d-w100p d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols2 d-ji-end d-w100p d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -48,11 +48,11 @@ Use `d-ji-end` to justify items against the end of their inline axis. Note that 
 Use `d-ji-center` to justify items to the center of their inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols2 d-ji-center d-w100p d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols2 d-ji-center d-w100p d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/grid/justify-self.md
+++ b/apps/dialtone-documentation/docs/utilities/grid/justify-self.md
@@ -9,10 +9,10 @@ keywords: ["css grid", "inline axis"]
 Use `d-js-auto` to justify an item automatically along its inline axis. This is the default value.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols3 d-w100p d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-js-auto d-p-200 d-wmn-100 d-bgc-bold-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols3 d-w100p d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-js-auto d-p-200 d-wmn-100 d-bgc-bold-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </div>
 ```
 
@@ -21,10 +21,10 @@ Use `d-js-auto` to justify an item automatically along its inline axis. This is 
 Use `d-js-start` to justify an item to the start of its inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols3 d-w100p d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-js-start d-p-200 d-wmn-100 d-bgc-bold-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols3 d-w100p d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-js-start d-p-200 d-wmn-100 d-bgc-bold-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </div>
 ```
 
@@ -33,10 +33,10 @@ Use `d-js-start` to justify an item to the start of its inline axis.
 Use `d-js-end` to justify an item to the end of its inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols3 d-w100p d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-js-end d-p-200 d-wmn-100 d-bgc-bold-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols3 d-w100p d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-js-end d-p-200 d-wmn-100 d-bgc-bold-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </div>
 ```
 
@@ -45,10 +45,10 @@ Use `d-js-end` to justify an item to the end of its inline axis.
 Use `d-js-center` to justify an item to the center of its inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols3 d-w100p d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-js-center d-p-200 d-wmn-100 d-bgc-bold-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols3 d-w100p d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-js-center d-p-200 d-wmn-100 d-bgc-bold-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-wmn-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/grid/layouts.md
+++ b/apps/dialtone-documentation/docs/utilities/grid/layouts.md
@@ -19,9 +19,9 @@ Use `.d-gl-sidebar` to create a simple 2-column layout with a sidebar and main c
 
 ```vue demo
 <dt-stack as="header" align="center" justify="center" class="d-p-200 d-w100p d-hmn216">
-  <div class="d-d-grid d-gl-sidebar d-g-200 d-w100p d-hmn216 d-bar8 d-of-auto d-bgc-moderate" style="--sidebar-width: minmax(10rem, 20rem);">
-    <dt-stack direction="row" align="center" justify="center" class="d-ga-sidebar d-p-200 d-bgc-moderate-opaque d-bar4">Sidebar</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-ga-content d-p-200 d-bgc-moderate-opaque d-bar4">Content</dt-stack>
+  <div class="d-d-grid d-gl-sidebar d-g-200 d-w100p d-hmn216 d-bar-400 d-of-auto d-bgc-moderate" style="--sidebar-width: minmax(10rem, 20rem);">
+    <dt-stack direction="row" align="center" justify="center" class="d-ga-sidebar d-p-200 d-bgc-moderate-opaque d-bar-300">Sidebar</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-ga-content d-p-200 d-bgc-moderate-opaque d-bar-300">Content</dt-stack>
   </div>
 </dt-stack>
 ```
@@ -42,11 +42,11 @@ Use `.d-gl-header` to create a simple 2-row layout with a header area and main c
 
 ```vue demo
 <dt-stack as="header" align="center" justify="center" class="d-p-200 d-w100p d-hmn216 d-of-auto">
-  <div class="d-d-grid d-gl-sidebar d-g-200 d-w100p d-hmn216 d-bar8 d-bgc-moderate" style="--sidebar-width: minmax(10rem, 20rem);">
-    <dt-stack direction="row" align="center" justify="center" class="d-ga-sidebar d-p-200 d-bgc-moderate-opaque d-bar4">Sidebar</dt-stack>
-    <div class="d-ga-content d-d-grid d-gl-header d-g-200 d-p-200 d-bgc-moderate-opaque d-bar4" style="--content-height: minmax(24rem, max-content);">
-      <dt-stack direction="row" align="center" justify="center" class="d-ga-header d-p-200 d-bgc-moderate-opaque d-bar4">Header</dt-stack>
-      <dt-stack direction="row" align="center" justify="center" class="d-ga-content d-p-200 d-bgc-moderate-opaque d-bar4">Content</dt-stack>
+  <div class="d-d-grid d-gl-sidebar d-g-200 d-w100p d-hmn216 d-bar-400 d-bgc-moderate" style="--sidebar-width: minmax(10rem, 20rem);">
+    <dt-stack direction="row" align="center" justify="center" class="d-ga-sidebar d-p-200 d-bgc-moderate-opaque d-bar-300">Sidebar</dt-stack>
+    <div class="d-ga-content d-d-grid d-gl-header d-g-200 d-p-200 d-bgc-moderate-opaque d-bar-300" style="--content-height: minmax(24rem, max-content);">
+      <dt-stack direction="row" align="center" justify="center" class="d-ga-header d-p-200 d-bgc-moderate-opaque d-bar-300">Header</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-ga-content d-p-200 d-bgc-moderate-opaque d-bar-300">Content</dt-stack>
     </div>
   </div>
 </dt-stack>
@@ -73,15 +73,15 @@ Use `.d-g-cols{n}` to create a multi-column layout.
 
 ```vue demo
 <dt-stack as="header" align="center" justify="center" class="d-w100p d-hmn216">
-  <div class="d-d-grid d-g-cols4 d-g-200 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">5</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">6</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">7</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">8</dt-stack>
+  <div class="d-d-grid d-g-cols4 d-g-200 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">5</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">6</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">7</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">8</dt-stack>
   </div>
 </dt-stack>
 <!-- @code -->
@@ -102,11 +102,11 @@ Use `.d-g-cols{n}` to create a multi-column layout.
 Unlike some CSS, CSS grid does not cascade beyond the parent and its direct children (`parent-element > *`). We can use this to our advantage by being able to nest grids within each other without cascade errors.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-g-200 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <div class="d-d-grid d-g-cols2 d-g-200 d-p-200 d-bgc-moderate-opaque d-bar4">
-    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-g-200 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <div class="d-d-grid d-g-cols2 d-g-200 d-p-200 d-bgc-moderate-opaque d-bar-300">
+    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
   </div>
 </div>
 ```

--- a/apps/dialtone-documentation/docs/utilities/grid/place-content.md
+++ b/apps/dialtone-documentation/docs/utilities/grid/place-content.md
@@ -9,11 +9,11 @@ keywords: ["css grid", "align", "justify"]
 Use `d-plc-stretch{-n}` to stretch grid items along the block and inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-plc-stretch d-g-200 d-w100p d-hmn-350 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-plc-stretch d-g-200 d-w100p d-hmn-350 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -22,11 +22,11 @@ Use `d-plc-stretch{-n}` to stretch grid items along the block and inline axis.
 Use `d-plc-start{-n}` to align grid items along the start of the block and/or inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-plc-start-center d-g-200 d-w100p d-h-350 d-bar8 d-bgc-moderate" style="--col-width: 6.4rem;">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-plc-start-center d-g-200 d-w100p d-h-350 d-bar-400 d-bgc-moderate" style="--col-width: 6.4rem;">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -35,11 +35,11 @@ Use `d-plc-start{-n}` to align grid items along the start of the block and/or in
 Use `d-plc-end{-n}` to align grid items along the end of the block and/or inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-plc-end-center d-g-200 d-w100p d-h-350 d-bar8 d-bgc-moderate" style="--col-width: 6.4rem;">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-plc-end-center d-g-200 d-w100p d-h-350 d-bar-400 d-bgc-moderate" style="--col-width: 6.4rem;">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -48,11 +48,11 @@ Use `d-plc-end{-n}` to align grid items along the end of the block and/or inline
 Use `d-plc-center{-n}` to align grid items along the center of the block and/or inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-plc-center d-g-200 d-w100p d-h-350 d-bar8 d-bgc-moderate" style="--col-width: 6.4rem;">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-plc-center d-g-200 d-w100p d-h-350 d-bar-400 d-bgc-moderate" style="--col-width: 6.4rem;">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -61,11 +61,11 @@ Use `d-plc-center{-n}` to align grid items along the center of the block and/or 
 Use `d-plc-space-evenly{-n}` to distribute grid items evenly along the block axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-plc-space-evenly d-g-200 d-w100p d-h-350 d-bar8 d-bgc-moderate" style="--col-width: 6.4rem;">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-plc-space-evenly d-g-200 d-w100p d-h-350 d-bar-400 d-bgc-moderate" style="--col-width: 6.4rem;">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -74,11 +74,11 @@ Use `d-plc-space-evenly{-n}` to distribute grid items evenly along the block axi
 Use `d-plc-space-around{-n}` to distribute grid items so there is an equal amount of space around each row on the block axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-plc-space-around d-g-200 d-w100p d-h-350 d-bar8 d-bgc-moderate" style="--col-width: 6.4rem;">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-plc-space-around d-g-200 d-w100p d-h-350 d-bar-400 d-bgc-moderate" style="--col-width: 6.4rem;">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -87,11 +87,11 @@ Use `d-plc-space-around{-n}` to distribute grid items so there is an equal amoun
 Use `d-plc-space-between{-n}` to distribute grid items along the block axis so that there is an equal space between each row.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-plc-space-between d-g-200 d-w100p d-h-350 d-bar8 d-bgc-moderate" style="--col-width: 6.4rem;">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-plc-space-between d-g-200 d-w100p d-h-350 d-bar-400 d-bgc-moderate" style="--col-width: 6.4rem;">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/grid/place-items.md
+++ b/apps/dialtone-documentation/docs/utilities/grid/place-items.md
@@ -9,11 +9,11 @@ keywords: ["css grid", "align", "justify"]
 Use `d-pli-stretch{-n}` to stretch grid items along their block and inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-pli-stretch d-g-200 d-w100p d-hmn-350 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-pli-stretch d-g-200 d-w100p d-hmn-350 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -22,11 +22,11 @@ Use `d-pli-stretch{-n}` to stretch grid items along their block and inline axis.
 Use `d-pli-start{-n}` to align grid items along the start of their block and/or inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-pli-start d-g-200 d-w100p d-h-350 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-pli-start d-g-200 d-w100p d-h-350 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -35,11 +35,11 @@ Use `d-pli-start{-n}` to align grid items along the start of their block and/or 
 Use `d-pli-end{-n}` to align grid items along the end of their block and/or inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-pli-end d-g-200 d-w100p d-h-350 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-pli-end d-g-200 d-w100p d-h-350 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -48,11 +48,11 @@ Use `d-pli-end{-n}` to align grid items along the end of their block and/or inli
 Use `d-pli-center{-n}` to align grid items along the center of their block and/or inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-pli-center d-g-200 d-w100p d-h-350 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-pli-center d-g-200 d-w100p d-h-350 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/grid/place-self.md
+++ b/apps/dialtone-documentation/docs/utilities/grid/place-self.md
@@ -9,11 +9,11 @@ keywords: ["css grid", "align", "justify"]
 Use `d-pls-stretch{-n}` to stretch grid items along their block and inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-g-200 d-w100p d-hmn-350 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-pls-stretch d-p-200 d-bgc-bold-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-g-200 d-w100p d-hmn-350 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-pls-stretch d-p-200 d-bgc-bold-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-size-100 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -22,11 +22,11 @@ Use `d-pls-stretch{-n}` to stretch grid items along their block and inline axis.
 Use `d-pls-start{-n}` to align a grid item along the start of their block and/or inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-g-200 d-w100p d-h-350 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-pls-start d-p-200 d-size-100 d-bgc-bold-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-g-200 d-w100p d-h-350 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-pls-start d-p-200 d-size-100 d-bgc-bold-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -35,11 +35,11 @@ Use `d-pls-start{-n}` to align a grid item along the start of their block and/or
 Use `d-pls-end{-n}` to align a grid item along the end of their block and/or inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-g-200 d-w100p d-h-350 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-pls-end d-p-200 d-size-100 d-bgc-bold-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-g-200 d-w100p d-h-350 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-pls-end d-p-200 d-size-100 d-bgc-bold-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -48,11 +48,11 @@ Use `d-pls-end{-n}` to align a grid item along the end of their block and/or inl
 Use `d-pls-center{-n}` to align a grid item along the center of their block and/or inline axis.
 
 ```vue demo
-<div class="d-d-grid d-g-cols2 d-g-200 d-w100p d-h-350 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-pls-center d-p-200 d-size-100 d-bgc-bold-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-cols2 d-g-200 d-w100p d-h-350 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-pls-center d-p-200 d-size-100 d-bgc-bold-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/grid/row-start-end-span.md
+++ b/apps/dialtone-documentation/docs/utilities/grid/row-start-end-span.md
@@ -9,11 +9,11 @@ keywords: ["css grid", "grid row", "row span", "row end"]
 Use `d-gr{#}` to span an element across multiple rows. This can be combined with `d-gc{#}` classes to span a set of columns.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols3 d-g-rows3 d-p-200 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-gc2 d-gr2 d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-bold-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-gr2 d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-gc2 d-p-200 d-bgc-bold-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols3 d-g-rows3 d-p-200 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-gc2 d-gr2 d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-bold-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-gr2 d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-gc2 d-p-200 d-bgc-bold-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 
@@ -24,11 +24,11 @@ Use `d-grs{#}` to set the starting point for an element. This can be combined wi
 Use `d-gre{#}` to set an element's ending point. A reminder that CSS grid rows start at 1 and end at the number of rows + 1. For example in a 4-row grid, the starting line would be 1 and the ending line would be 5.
 
 ```vue demo
-<div class="d-d-grid d-g-200 d-g-cols3 d-g-rows4 d-p-200 d-w100p d-hmn216 d-bar8 d-bgc-moderate">
-  <dt-stack direction="row" align="center" justify="center" class="d-gc2 d-grs1 d-gre3 d-p-200 d-bgc-moderate-opaque d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-bold-opaque d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-grs2 d-gre5 d-p-200 d-bgc-moderate-opaque d-bar4">3</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-gc2 d-gr2 d-p-200 d-bgc-bold-opaque d-bar4">4</dt-stack>
+<div class="d-d-grid d-g-200 d-g-cols3 d-g-rows4 d-p-200 d-w100p d-hmn216 d-bar-400 d-bgc-moderate">
+  <dt-stack direction="row" align="center" justify="center" class="d-gc2 d-grs1 d-gre3 d-p-200 d-bgc-moderate-opaque d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-bold-opaque d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-grs2 d-gre5 d-p-200 d-bgc-moderate-opaque d-bar-300">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-gc2 d-gr2 d-p-200 d-bgc-bold-opaque d-bar-300">4</dt-stack>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/index.md
+++ b/apps/dialtone-documentation/docs/utilities/index.md
@@ -271,7 +271,7 @@ Refine the spacing by adjusting the [Stack](/components/stack.md) `gap` prop and
 
 ### 13. Round it out!
 
-Add `d-bar4` to each item for subtle rounded corners.
+Add `d-bar-300` to each item for subtle rounded corners.
 
 ```vue demo
 <!-- @wrapper -->

--- a/apps/dialtone-documentation/docs/utilities/index.md
+++ b/apps/dialtone-documentation/docs/utilities/index.md
@@ -276,15 +276,15 @@ Add `d-bar4` to each item for subtle rounded corners.
 ```vue demo
 <!-- @wrapper -->
 <dt-stack direction="row" gap="100" class="d-fc-primary-inverted">
-  <dt-stack direction="row" gap="50" class="d-bar4 d-bgc-critical-strong d-py-50 d-px-100">
+  <dt-stack direction="row" gap="50" class="d-bar-300 d-bgc-critical-strong d-py-50 d-px-100">
     <dt-icon name="alert-triangle" size="200" />
     <dt-text kind="label" :size="200">Critical</dt-text>
   </dt-stack>
-  <dt-stack direction="row" gap="50" class="d-bar4 d-bgc-info-strong d-py-50 d-px-100">
+  <dt-stack direction="row" gap="50" class="d-bar-300 d-bgc-info-strong d-py-50 d-px-100">
     <dt-icon name="alert-circle" size="200" />
     <dt-text kind="label" :size="200">Info</dt-text>
   </dt-stack>
-  <dt-stack direction="row" gap="50" class="d-bar4 d-bgc-success-strong d-py-50 d-px-100">
+  <dt-stack direction="row" gap="50" class="d-bar-300 d-bgc-success-strong d-py-50 d-px-100">
     <dt-icon name="check-circle" size="200" />
     <dt-text kind="label" :size="200">Success</dt-text>
   </dt-stack>

--- a/apps/dialtone-documentation/docs/utilities/interactivity/cursor.md
+++ b/apps/dialtone-documentation/docs/utilities/interactivity/cursor.md
@@ -7,27 +7,27 @@ keywords: ["pointer", "hover", "focus"]
 
 ```vue demo
 <!-- @wrapper -->
-<dt-stack direction="row" gap="100" class="d-fw-wrap d-w100p d-bar8 d-plc-center">
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-all-scroll">d-c-all-scroll</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-auto">d-c-auto</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-col-resize">d-c-col-resize</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-copy">d-c-copy</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-crosshair">d-c-crosshair</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-default">d-c-default</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-grab">d-c-grab</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-grabbing">d-c-grabbing</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-help">d-c-help</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-menu">d-c-menu</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-move">d-c-move</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-none">d-c-none</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-not-allowed">d-c-not-allowed</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-pointer">d-c-pointer</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-progress">d-c-progress</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-row-resize">d-c-row-resize</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-text">d-c-text</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-wait">d-c-wait</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-zoom-in">d-c-zoom-in</div>
-  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar4 d-c-zoom-out">d-c-zoom-out</div>
+<dt-stack direction="row" gap="100" class="d-fw-wrap d-w100p d-bar-400 d-plc-center">
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-all-scroll">d-c-all-scroll</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-auto">d-c-auto</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-col-resize">d-c-col-resize</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-copy">d-c-copy</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-crosshair">d-c-crosshair</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-default">d-c-default</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-grab">d-c-grab</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-grabbing">d-c-grabbing</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-help">d-c-help</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-menu">d-c-menu</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-move">d-c-move</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-none">d-c-none</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-not-allowed">d-c-not-allowed</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-pointer">d-c-pointer</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-progress">d-c-progress</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-row-resize">d-c-row-resize</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-text">d-c-text</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-wait">d-c-wait</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-zoom-in">d-c-zoom-in</div>
+  <div class="d-p-200 d-bgc-moderate d-code--sm d-bar-300 d-c-zoom-out">d-c-zoom-out</div>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/layout/box-sizing.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/box-sizing.md
@@ -10,9 +10,9 @@ All examples below have a 128px height and width. You can see how `.d-box-border
 
 ```vue demo
 <div class="d-fl-center d-w100p d-flow16">
-  <dt-stack direction="row" align="center" justify="center" class="d-size-200 d-p-100 d-ba d-baw4 d-bas-dashed d-bar4 d-bc-default d-bgc-moderate d-box-border"><dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar2 d-code--sm">d-box-border</dt-stack></dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-size-200 d-p-100 d-ba d-baw4 d-bas-dashed d-bar4 d-bc-default d-bgc-moderate d-box-content"><dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar2 d-code--sm">d-box-content</dt-stack></dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-size-200 d-p-100 d-ba d-baw4 d-bas-dashed d-bar4 d-bc-default d-bgc-moderate d-box-unset"><dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar2 d-code--sm">d-box-unset</dt-stack></dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-size-200 d-p-100 d-ba d-baw4 d-bas-dashed d-bar-300 d-bc-default d-bgc-moderate d-box-border"><dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar-200 d-code--sm">d-box-border</dt-stack></dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-size-200 d-p-100 d-ba d-baw4 d-bas-dashed d-bar-300 d-bc-default d-bgc-moderate d-box-content"><dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar-200 d-code--sm">d-box-content</dt-stack></dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-size-200 d-p-100 d-ba d-baw4 d-bas-dashed d-bar-300 d-bc-default d-bgc-moderate d-box-unset"><dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar-200 d-code--sm">d-box-unset</dt-stack></dt-stack>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/layout/coordinates.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/coordinates.md
@@ -13,22 +13,22 @@ Use `d-t-{stop}`, `d-r-{stop}`, `d-b-{stop}`, `d-l-{stop}`, `d-x-{stop}`, `d-y-{
 ```vue demo
 <!-- @wrapper -->
 <div class="d-w100p d-hmn216 d-d-grid d-g-cols4 d-g-200 d-pi-center">
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-x-0 d-ibs-0 d-bgc-moderate-opaque d-bar4 d-h50p">1</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-y-0 d-iie-0 d-bgc-moderate-opaque d-bar4 d-w50p">2</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-x-0 d-ibe-0 d-bgc-moderate-opaque d-bar4 d-h50p">3</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-y-0 d-iis-0 d-bgc-moderate-opaque d-bar4 d-w50p">4</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-all-0 d-bgc-moderate-opaque d-bar4">5</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iis-0 d-ibs-0 d-bgc-moderate-opaque d-bar4 d-size-50p">6</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iie-0 d-ibs-0 d-bgc-moderate-opaque d-bar4 d-size-50p">7</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iie-0 d-ibe-0 d-bgc-moderate-opaque d-bar4 d-size-50p">8</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iis-0 d-ibe-0 d-bgc-moderate-opaque d-bar4 d-size-50p">9</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-all-100 d-bgc-moderate-opaque d-bar4">10</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-x-0 d-ibs-0 d-bgc-moderate-opaque d-bar-300 d-h50p">1</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-y-0 d-iie-0 d-bgc-moderate-opaque d-bar-300 d-w50p">2</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-x-0 d-ibe-0 d-bgc-moderate-opaque d-bar-300 d-h50p">3</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-y-0 d-iis-0 d-bgc-moderate-opaque d-bar-300 d-w50p">4</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-all-0 d-bgc-moderate-opaque d-bar-300">5</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iis-0 d-ibs-0 d-bgc-moderate-opaque d-bar-300 d-size-50p">6</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iie-0 d-ibs-0 d-bgc-moderate-opaque d-bar-300 d-size-50p">7</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iie-0 d-ibe-0 d-bgc-moderate-opaque d-bar-300 d-size-50p">8</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iis-0 d-ibe-0 d-bgc-moderate-opaque d-bar-300 d-size-50p">9</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-all-100 d-bgc-moderate-opaque d-bar-300">10</dt-stack></div>
 </div>
 ```
 
 ### Classes
 
-<div class="d-bar8 d-ba d-bc-subtle">
+<div class="d-bar-400 d-ba d-bc-subtle">
   <div class="d-w100p d-of-auto">
     <table class="d-table dialtone-doc-table">
       <thead>
@@ -75,15 +75,15 @@ Use `d-t-{stop}`, `d-r-{stop}`, `d-b-{stop}`, `d-l-{stop}`, `d-x-{stop}`, `d-y-{
 ```vue demo
 <!-- @wrapper -->
 <div class="d-w100p d-hmn216 d-d-grid d-g-cols4 d-g-200 d-pi-center">
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-x-n25 d-ibs-n25 d-bgc-moderate-opaque d-bar8 d-h50p">1</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-y-n25 d-iie-n25 d-bgc-moderate-opaque d-bar8 d-w50p">2</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-x-n25 d-ibe-n25 d-bgc-moderate-opaque d-bar8 d-h50p">3</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-y-n25 d-iis-n25 d-bgc-moderate-opaque d-bar8 d-w50p">4</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-all-n25 d-bgc-moderate-opaque d-bar8">5</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iis-n50 d-ibs-n50 d-bgc-moderate-opaque d-bar8 d-size-50p">6</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iie-n100 d-ibs-n100 d-bgc-moderate-opaque d-bar8 d-size-50p">7</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iie-n100 d-ibe-n100 d-bgc-moderate-opaque d-bar8 d-size-50p">8</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar8 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iis-n50 d-ibe-n50 d-bgc-moderate-opaque d-bar8 d-size-50p">9</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-x-n25 d-ibs-n25 d-bgc-moderate-opaque d-bar-400 d-h50p">1</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-y-n25 d-iie-n25 d-bgc-moderate-opaque d-bar-400 d-w50p">2</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-x-n25 d-ibe-n25 d-bgc-moderate-opaque d-bar-400 d-h50p">3</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-y-n25 d-iis-n25 d-bgc-moderate-opaque d-bar-400 d-w50p">4</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-all-n25 d-bgc-moderate-opaque d-bar-400">5</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iis-n50 d-ibs-n50 d-bgc-moderate-opaque d-bar-400 d-size-50p">6</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iie-n100 d-ibs-n100 d-bgc-moderate-opaque d-bar-400 d-size-50p">7</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iie-n100 d-ibe-n100 d-bgc-moderate-opaque d-bar-400 d-size-50p">8</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iis-n50 d-ibe-n50 d-bgc-moderate-opaque d-bar-400 d-size-50p">9</dt-stack></div>
 </div>
 ```
 
@@ -93,7 +93,7 @@ Use `d-t-{stop}`, `d-r-{stop}`, `d-b-{stop}`, `d-l-{stop}`, `d-x-{stop}`, `d-y-{
 
 ### Classes
 
-<div class="d-bar8 d-ba d-bc-subtle">
+<div class="d-bar-400 d-ba d-bc-subtle">
   <div class="d-w100p d-of-auto">
     <table class="d-table dialtone-doc-table">
       <thead>

--- a/apps/dialtone-documentation/docs/utilities/layout/coordinates.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/coordinates.md
@@ -75,15 +75,15 @@ Use `d-t-{stop}`, `d-r-{stop}`, `d-b-{stop}`, `d-l-{stop}`, `d-x-{stop}`, `d-y-{
 ```vue demo
 <!-- @wrapper -->
 <div class="d-w100p d-hmn216 d-d-grid d-g-cols4 d-g-200 d-pi-center">
-  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-x-n25 d-ibs-n25 d-bgc-moderate-opaque d-bar-400 d-h50p">1</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-y-n25 d-iie-n25 d-bgc-moderate-opaque d-bar-400 d-w50p">2</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-x-n25 d-ibe-n25 d-bgc-moderate-opaque d-bar-400 d-h50p">3</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-y-n25 d-iis-n25 d-bgc-moderate-opaque d-bar-400 d-w50p">4</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-all-n25 d-bgc-moderate-opaque d-bar-400">5</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iis-n50 d-ibs-n50 d-bgc-moderate-opaque d-bar-400 d-size-50p">6</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iie-n100 d-ibs-n100 d-bgc-moderate-opaque d-bar-400 d-size-50p">7</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iie-n100 d-ibe-n100 d-bgc-moderate-opaque d-bar-400 d-size-50p">8</dt-stack></div>
-  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iis-n50 d-ibe-n50 d-bgc-moderate-opaque d-bar-400 d-size-50p">9</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-x-n25 d-ibs-n25 d-bgc-moderate-opaque d-bar-300 d-h50p">1</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-y-n25 d-iie-n25 d-bgc-moderate-opaque d-bar-300 d-w50p">2</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-x-n25 d-ibe-n25 d-bgc-moderate-opaque d-bar-300 d-h50p">3</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-y-n25 d-iis-n25 d-bgc-moderate-opaque d-bar-300 d-w50p">4</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-all-n25 d-bgc-moderate-opaque d-bar-300">5</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iis-n50 d-ibs-n50 d-bgc-moderate-opaque d-bar-300 d-size-50p">6</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iie-n100 d-ibs-n100 d-bgc-moderate-opaque d-bar-300 d-size-50p">7</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iie-n100 d-ibe-n100 d-bgc-moderate-opaque d-bar-300 d-size-50p">8</dt-stack></div>
+  <div class="d-ps-relative d-h-200 d-bar-400 d-bgc-moderate"><dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-iis-n50 d-ibe-n50 d-bgc-moderate-opaque d-bar-300 d-size-50p">9</dt-stack></div>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/layout/display.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/display.md
@@ -9,32 +9,32 @@ keywords: ["block", "inline", "flex", "grid", "none", "hidden"]
 ```vue demo
 <!-- @wrapper -->
 <dt-stack gap="200" class="d-w100p">
-  <div class="d-p-100 d-ba d-baw4 d-bar4 d-bc-default d-bgc-moderate d-d-block">
-    <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar2 d-code--sm">d-d-block</dt-stack>
+  <div class="d-p-100 d-ba d-baw4 d-bar-300 d-bc-default d-bgc-moderate d-d-block">
+    <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar-200 d-code--sm">d-d-block</dt-stack>
   </div>
   <div class="d-d-contents">
-    <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar2 d-code--sm">d-d-contents</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar-200 d-code--sm">d-d-contents</dt-stack>
   </div>
-  <dt-stack direction="row" gap="100" class="d-p-100 d-ba d-baw4 d-bar4 d-bgc-moderate">
+  <dt-stack direction="row" gap="100" class="d-p-100 d-ba d-baw4 d-bar-300 d-bgc-moderate">
     <div>
-      <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar2 d-code--sm d-d-inline-block">d-d-inline-block</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar-200 d-code--sm d-d-inline-block">d-d-inline-block</dt-stack>
     </div>
     <div>
-      <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar2 d-code--sm d-d-inline-block">d-d-inline-block</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar-200 d-code--sm d-d-inline-block">d-d-inline-block</dt-stack>
     </div>
     <div>
-      <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar2 d-code--sm d-d-inline-block">d-d-inline-block</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar-200 d-code--sm d-d-inline-block">d-d-inline-block</dt-stack>
     </div>
   </dt-stack>
-  <dt-stack direction="row" gap="100" class="d-p-100 d-ba d-baw4 d-bar4 d-bgc-moderate">
+  <dt-stack direction="row" gap="100" class="d-p-100 d-ba d-baw4 d-bar-300 d-bgc-moderate">
     <div>
-      <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-50 d-bgc-moderate-opaque d-bar2 d-code--sm d-d-inline">d-d-inline</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-50 d-bgc-moderate-opaque d-bar-200 d-code--sm d-d-inline">d-d-inline</dt-stack>
     </div>
     <div>
-      <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-50 d-bgc-moderate-opaque d-bar2 d-code--sm d-d-inline">d-d-inline</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-50 d-bgc-moderate-opaque d-bar-200 d-code--sm d-d-inline">d-d-inline</dt-stack>
     </div>
     <div>
-      <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-50 d-bgc-moderate-opaque d-bar2 d-code--sm d-d-inline">d-d-inline</dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-50 d-bgc-moderate-opaque d-bar-200 d-code--sm d-d-inline">d-d-inline</dt-stack>
     </div>
   </dt-stack>
 </dt-stack>
@@ -51,15 +51,15 @@ While `d-d-flex` and `d-d-inline-flex` technically are `display` utilities, use 
 <dt-stack
   gap="200"
   direction="row"
-  class="d-bgc-moderate-opaque d-bar8"
+  class="d-bgc-moderate-opaque d-bar-400"
 >
-  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">
     Stack item 1
   </div>
-  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">
     Stack item 2
   </div>
-  <div class="d-bgc-moderate-opaque d-p-200 d-bar8">
+  <div class="d-bgc-moderate-opaque d-p-200 d-bar-400">
     Stack item 3
   </div>
 </dt-stack>

--- a/apps/dialtone-documentation/docs/utilities/layout/overflow.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/overflow.md
@@ -12,55 +12,55 @@ keywords: ["scroll", "hidden", "auto", "clip", "scrollbar"]
 ```vue demo
 <!-- @wrapper -->
   <div class="d-d-grid d-g-cols4 d-g-200">
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-auto">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-auto">
           <code>.d-of-auto</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-x-auto">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-x-auto">
           <code>.d-of-x-auto</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-y-auto">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-y-auto">
           <code>.d-of-y-auto</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-hidden">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-hidden">
           <code>.d-of-hidden</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-x-hidden">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-x-hidden">
           <code>.d-of-x-hidden</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-y-hidden">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-y-hidden">
           <code>.d-of-y-hidden</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-scroll">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-scroll">
           <code>.d-of-scroll</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-x-scroll">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-x-scroll">
           <code>.d-of-x-scroll</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-y-scroll">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-y-scroll">
           <code>.d-of-y-scroll</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-visible">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-visible">
           <code>.d-of-visible</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-x-visible">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-x-visible">
           <code>.d-of-x-visible</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-y-visible">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-y-visible">
           <code>.d-of-y-visible</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>
-      <div class="d-h-350 d-p-150 d-bar4 d-bgc-moderate d-of-unset">
+      <div class="d-h-350 d-p-150 d-bar-300 d-bgc-moderate d-of-unset">
           <code>.d-of-unset</code>
           <p class="d-w-350">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eleifend rutrum auctor. Phasellus convallis sagittis augue ut ornare. Vestibulum et gravida lectus, sed ultrices sapien. Nullam aliquet elit dui, vitae hendrerit lectus volutpat eget.</p>
       </div>

--- a/apps/dialtone-documentation/docs/utilities/layout/position.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/position.md
@@ -11,10 +11,10 @@ keywords: ["relative", "absolute", "fixed", "sticky", "static"]
   <code class="d-bgc-transparent">Relative Parent</code>
   <div class="d-ps-static d-bgc-moderate-opaque d-p-200 d-h-700 d-bar-400">
     <code class="d-bgc-transparent">Static Parent</code>
-    <dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-ibs-0 d-iie-150 d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-absolute<br>.d-t0<br>.d-r12</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-ibe-0 d-iie-n150 d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-absolute<br>.d-b0<br>.d-rn12</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-ps-sticky d-ibs-0 d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-sticky<br>.d-t0</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-ps-relative d-ibs-400 d-iis-800 d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-relative<br>.d-t32<br>.d-l64</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-ibs-0 d-iie-150 d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-absolute<br>.d-ibs-0<br>.d-iie-150</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-ibe-0 d-iie-n150 d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-absolute<br>.d-ibe-0<br>.d-iie-n150</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-ps-sticky d-ibs-0 d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-sticky<br>.d-ibs-0</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-ps-relative d-ibs-400 d-iis-800 d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-relative<br>.d-ibs-400<br>.d-iis-800</dt-stack>
     <dt-stack direction="row" align="center" justify="center" class="d-ps-fixed d-t50p d-l50p d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-fixed<br>.d-t50p<br>.d-l50p</dt-stack>
   </div>
 </div>

--- a/apps/dialtone-documentation/docs/utilities/layout/position.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/position.md
@@ -9,13 +9,13 @@ keywords: ["relative", "absolute", "fixed", "sticky", "static"]
 ```vue demo
 <div class="d-ps-relative d-w100p">
   <code class="d-bgc-transparent">Relative Parent</code>
-  <div class="d-ps-static d-bgc-moderate-opaque d-p-200 d-h-700 d-bar8">
+  <div class="d-ps-static d-bgc-moderate-opaque d-p-200 d-h-700 d-bar-400">
     <code class="d-bgc-transparent">Static Parent</code>
-    <dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-ibs-0 d-iie-150 d-size-200 d-p-100 d-bar8 d-bgc-moderate-opaque d-code--sm">.d-ps-absolute<br>.d-t0<br>.d-r12</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-ibe-0 d-iie-n150 d-size-200 d-p-100 d-bar8 d-bgc-moderate-opaque d-code--sm">.d-ps-absolute<br>.d-b0<br>.d-rn12</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-ps-sticky d-ibs-0 d-size-200 d-p-100 d-bar8 d-bgc-moderate-opaque d-code--sm">.d-ps-sticky<br>.d-t0</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-ps-relative d-ibs-400 d-iis-800 d-size-200 d-p-100 d-bar8 d-bgc-moderate-opaque d-code--sm">.d-ps-relative<br>.d-t32<br>.d-l64</dt-stack>
-    <dt-stack direction="row" align="center" justify="center" class="d-ps-fixed d-t50p d-l50p d-size-200 d-p-100 d-bar8 d-bgc-moderate-opaque d-code--sm">.d-ps-fixed<br>.d-t50p<br>.d-l50p</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-ibs-0 d-iie-150 d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-absolute<br>.d-t0<br>.d-r12</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-ps-absolute d-ibe-0 d-iie-n150 d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-absolute<br>.d-b0<br>.d-rn12</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-ps-sticky d-ibs-0 d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-sticky<br>.d-t0</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-ps-relative d-ibs-400 d-iis-800 d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-relative<br>.d-t32<br>.d-l64</dt-stack>
+    <dt-stack direction="row" align="center" justify="center" class="d-ps-fixed d-t50p d-l50p d-size-200 d-p-100 d-bar-400 d-bgc-moderate-opaque d-code--sm">.d-ps-fixed<br>.d-t50p<br>.d-l50p</dt-stack>
   </div>
 </div>
 ```

--- a/apps/dialtone-documentation/docs/utilities/layout/visibility.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/visibility.md
@@ -8,9 +8,9 @@ keywords: ["visible", "hidden", "show", "hide", "screen reader"]
 
 ```vue demo
 <div class="d-w100p">
-  <div class="d-d-inline-block d-p-200 d-bgc-moderate d-bar4 d-code--md d-ta-center d-vi-visible">.d-vi-visible</div>
-  <div class="d-d-inline-block d-p-200 d-bgc-moderate d-bar4 d-code--md d-ta-center d-vi-visible-sr">.d-vi-visible-sr</div>
-  <div class="d-d-inline-block d-p-200 d-bgc-moderate d-bar4 d-code--md d-ta-center d-vi-hidden">.d-vi-hidden</div>
+  <div class="d-d-inline-block d-p-200 d-bgc-moderate d-bar-300 d-code--md d-ta-center d-vi-visible">.d-vi-visible</div>
+  <div class="d-d-inline-block d-p-200 d-bgc-moderate d-bar-300 d-code--md d-ta-center d-vi-visible-sr">.d-vi-visible-sr</div>
+  <div class="d-d-inline-block d-p-200 d-bgc-moderate d-bar-300 d-code--md d-ta-center d-vi-hidden">.d-vi-hidden</div>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/responsive/breakpoints.md
+++ b/apps/dialtone-documentation/docs/utilities/responsive/breakpoints.md
@@ -163,18 +163,18 @@ const classes = [
 ## Usage
 
 ```vue demo
-<div class="d-ai-center d-w100p d-m-100 d-p-200 d-bgc-moderate d-bar4 d-ta-center">Visible on <strong>all</strong> screens</div>
+<div class="d-ai-center d-w100p d-m-100 d-p-200 d-bgc-moderate d-bar-300 d-ta-center">Visible on <strong>all</strong> screens</div>
 <div class="d-d-none xl:d-d-block d-w100p">
-  <dt-stack direction="row" align="center" justify="center" class="d-w100p d-m-100 d-p-200 d-bgc-moderate d-bar4 d-ta-center">Visible only on screens wider than <strong>extra-large</strong> breakpoint</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-w100p d-m-100 d-p-200 d-bgc-moderate d-bar-300 d-ta-center">Visible only on screens wider than <strong>extra-large</strong> breakpoint</dt-stack>
 </div>
 <div class="d-d-none lg:d-d-block d-w100p">
-  <dt-stack direction="row" align="center" justify="center" class="d-w100p d-m-100 d-p-200 d-bgc-moderate d-bar4 d-ta-center">Visible only on screens wider than <strong>large</strong> breakpoint</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-w100p d-m-100 d-p-200 d-bgc-moderate d-bar-300 d-ta-center">Visible only on screens wider than <strong>large</strong> breakpoint</dt-stack>
 </div>
 <div class="d-d-none md:d-d-block d-w100p">
-  <dt-stack direction="row" align="center" justify="center" class="d-w100p d-m-100 d-p-200 d-bgc-moderate d-bar4 d-ta-center">Visible only on screens wider than <strong>medium</strong> breakpoint</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-w100p d-m-100 d-p-200 d-bgc-moderate d-bar-300 d-ta-center">Visible only on screens wider than <strong>medium</strong> breakpoint</dt-stack>
 </div>
 <div class="d-d-none sm:d-d-block d-w100p">
-  <dt-stack direction="row" align="center" justify="center" class="d-w100p d-m-100 d-p-200 d-bgc-moderate d-bar4 d-ta-center">Visible only on screens wider than <strong>small</strong> breakpoint</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-w100p d-m-100 d-p-200 d-bgc-moderate d-bar-300 d-ta-center">Visible only on screens wider than <strong>small</strong> breakpoint</dt-stack>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/sizing/height.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/height.md
@@ -13,11 +13,11 @@ Use `d-h-{stop}` to set a fixed height for an element using layout token stops. 
 
 ```vue demo
 <!-- @class d-d-block d-bgc-secondary d-w100p d-hmn-400 -->
-<div v-dt-scrollbar:never class="d-bar8 d-d-flex d-g-200 d-bgc-secondary d-hmx-800">
+<div v-dt-scrollbar:never class="d-bar-400 d-d-flex d-g-200 d-bgc-secondary d-hmx-800">
   <dt-stack direction="row" align="start" gap="200">
     <dt-stack gap="100" v-for="(i, index) in layout" :key="index" v-dt-tooltip="{ message: `${i.px}px`, delay: false }">
       <dt-text kind="code" size="100" class="d-us-all">d-h-{{i.stop}}</dt-text>
-      <dt-stack direction="row" align="center" justify="center" class="d-w-100 d-bgc-bold d-bar4" :class="`d-h-${i.stop}`"></dt-stack>
+      <dt-stack direction="row" align="center" justify="center" class="d-w-100 d-bgc-bold d-bar-300" :class="`d-h-${i.stop}`"></dt-stack>
     </dt-stack>
   </dt-stack>
 </div>
@@ -32,11 +32,11 @@ Use `d-h-{stop}` to set a fixed height for an element using layout token stops. 
 Use `d-h{n}p` to set a percentage height for an element. No hyphen before the number, `p` suffix indicates a literal percentage value. Note: `d-h33p` = 33.333% and `d-h66p` = 66.667%.
 
 ```vue demo
-<div v-dt-scrollbar:never class="d-bar8 d-d-flex d-g-200 d-bgc-secondary d-h-500 d-ta-center">
+<div v-dt-scrollbar:never class="d-bar-400 d-d-flex d-g-200 d-bgc-secondary d-h-500 d-ta-center">
   <dt-stack direction="row" align="center" justify="center" class="d-h100p d-ps-relative" v-for="i in percentage" v-dt-tooltip="{ message: `${i}%`, delay: false }">
     <dt-text kind="code" size="100" class="d-zi-active d-w-100 d-us-all">d-h{{i}}p</dt-text>
     <div class="d-w-100 d-h-350 d-ps-absolute d-bgc-moderate">
-      <div class="d-w-100 d-bgc-bold d-bar4" :class="`d-h${i}p`"></div>
+      <div class="d-w-100 d-bgc-bold d-bar-300" :class="`d-h${i}p`"></div>
     </div>
   </dt-stack>
 </div>

--- a/apps/dialtone-documentation/docs/utilities/sizing/max-height.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/max-height.md
@@ -13,9 +13,9 @@ Use `d-hmx-{stop}` to set a fixed maximum height for an element using layout tok
 
 ```vue demo
 <dt-stack direction="row" gap="200" align="start" justify="center" class="d-w100p">
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-hmx100p d-bgc-moderate d-bar-300 d-ta-center">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-200 d-hmx200p d-bgc-moderate d-bar-300 d-ta-center">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-400 d-hmx400p d-bgc-moderate d-bar-300 d-ta-center">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-hmx-100 d-bgc-moderate d-bar-300 d-ta-center">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-200 d-hmx-200 d-bgc-moderate d-bar-300 d-ta-center">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-400 d-hmx-400 d-bgc-moderate d-bar-300 d-ta-center">3</dt-stack>
 </dt-stack>
 <!-- @code -->
 <div class="d-hmx-100">...</div>  <!-- max-block-size: var(--dt-layout-100) = 64px / 6.4rem -->

--- a/apps/dialtone-documentation/docs/utilities/sizing/max-height.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/max-height.md
@@ -13,9 +13,9 @@ Use `d-hmx-{stop}` to set a fixed maximum height for an element using layout tok
 
 ```vue demo
 <dt-stack direction="row" gap="200" align="start" justify="center" class="d-w100p">
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-hmx100p d-bgc-moderate d-bar4 d-ta-center">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-200 d-hmx200p d-bgc-moderate d-bar4 d-ta-center">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-400 d-hmx400p d-bgc-moderate d-bar4 d-ta-center">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-hmx100p d-bgc-moderate d-bar-300 d-ta-center">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-200 d-hmx200p d-bgc-moderate d-bar-300 d-ta-center">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-400 d-hmx400p d-bgc-moderate d-bar-300 d-ta-center">3</dt-stack>
 </dt-stack>
 <!-- @code -->
 <div class="d-hmx-100">...</div>  <!-- max-block-size: var(--dt-layout-100) = 64px / 6.4rem -->

--- a/apps/dialtone-documentation/docs/utilities/sizing/max-width.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/max-width.md
@@ -13,9 +13,9 @@ Use `d-wmx-{stop}` to set a fixed maximum width for an element using layout toke
 
 ```vue demo
 <dt-stack direction="row" justify="center" gap="200" class="d-w100p">
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-wmx-100 d-bgc-moderate d-bar4 d-ta-center">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-wmx-150 d-bgc-moderate d-bar4 d-ta-center">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-wmx-500 d-bgc-moderate d-bar4 d-ta-center">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-wmx-100 d-bgc-moderate d-bar-300 d-ta-center">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-wmx-150 d-bgc-moderate d-bar-300 d-ta-center">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-wmx-500 d-bgc-moderate d-bar-300 d-ta-center">3</dt-stack>
 </dt-stack>
 <!-- @code -->
 <div class="d-wmx-100">1</div>
@@ -28,9 +28,9 @@ Use `d-wmx-{stop}` to set a fixed maximum width for an element using layout toke
 Use `d-wmx{n}p` to set a maximum width percentage for an element. No hyphen before the number, `p` suffix indicates a literal percentage value. Note: `d-wmx33p` = 33.333% and `d-wmx66p` = 66.667%.
 
 ```vue demo
-<dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-wmx50p d-bgc-moderate d-bar4 d-ta-center">1</dt-stack>
-<dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-wmx75p d-bgc-moderate d-bar4 d-ta-center">2</dt-stack>
-<dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-wmx100p d-bgc-moderate d-bar4 d-ta-center">3</dt-stack>
+<dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-wmx50p d-bgc-moderate d-bar-300 d-ta-center">1</dt-stack>
+<dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-wmx75p d-bgc-moderate d-bar-300 d-ta-center">2</dt-stack>
+<dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w100p d-h-100 d-wmx100p d-bgc-moderate d-bar-300 d-ta-center">3</dt-stack>
 <!-- @code -->
 <div class="d-wmx-50p">1</div>
 <div class="d-wmx-75p">2</div>

--- a/apps/dialtone-documentation/docs/utilities/sizing/min-height.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/min-height.md
@@ -13,9 +13,9 @@ Use `d-hmn-{stop}` to set a fixed minimum height for an element using layout tok
 
 ```vue demo
 <dt-stack direction="row" gap="200" align="start" justify="center" class="d-w100p">
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w-100 d-h-75 d-hmn-100 d-bgc-moderate d-bar4 d-ta-center">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w-100 d-h-75 d-hmn-150 d-bgc-moderate d-bar4 d-ta-center">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w-100 d-hmn-500 d-bgc-moderate d-bar4 d-ta-center">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w-100 d-h-75 d-hmn-100 d-bgc-moderate d-bar-300 d-ta-center">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w-100 d-h-75 d-hmn-150 d-bgc-moderate d-bar-300 d-ta-center">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w-100 d-hmn-500 d-bgc-moderate d-bar-300 d-ta-center">3</dt-stack>
 </dt-stack>
 <!-- @code -->
 <div class="d-hmn-100">...</div>  <!-- min-block-size: var(--dt-layout-100) = 64px / 6.4rem -->
@@ -30,9 +30,9 @@ Use `d-hmn{n}p` to set a minimum height percentage for an element. No hyphen bef
 ```vue demo
 <!-- @wrapper -->
 <dt-stack direction="row" gap="200" align="start" justify="center" class="d-w100p d-h-400">
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w-100 d-hmn33p d-bgc-moderate d-bar4 d-ta-center">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w-100 d-hmn66p d-bgc-moderate d-bar4 d-ta-center">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w-100 d-hmn100p d-bgc-moderate d-bar4 d-ta-center">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w-100 d-hmn33p d-bgc-moderate d-bar-300 d-ta-center">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w-100 d-hmn66p d-bgc-moderate d-bar-300 d-ta-center">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-w-100 d-hmn100p d-bgc-moderate d-bar-300 d-ta-center">3</dt-stack>
 </dt-stack>
 <!-- @code -->
 <div class="d-hmn33p">...</div>  <!-- min-block-size: 33.333% -->

--- a/apps/dialtone-documentation/docs/utilities/sizing/min-width.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/min-width.md
@@ -13,9 +13,9 @@ Use `d-wmn-{stop}` to set a fixed minimum width for an element using layout toke
 
 ```vue demo
 <dt-stack direction="row" justify="center" gap="200" class="d-w100p">
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-size-100 d-wmn-100 d-bgc-moderate d-bar4">1</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-size-100 d-wmn-150 d-bgc-moderate d-bar4">2</dt-stack>
-  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-size-100 d-wmn-500 d-bgc-moderate d-bar4">3</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-size-100 d-wmn-100 d-bgc-moderate d-bar-300">1</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-size-100 d-wmn-150 d-bgc-moderate d-bar-300">2</dt-stack>
+  <dt-stack direction="row" align="center" justify="center" class="d-py-200 d-px-100 d-size-100 d-wmn-500 d-bgc-moderate d-bar-300">3</dt-stack>
 </dt-stack>
 <!-- @code -->
 <div class="d-wmn-100">1</div>

--- a/apps/dialtone-documentation/docs/utilities/sizing/size.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/size.md
@@ -14,11 +14,11 @@ Use `d-size-{stop}` to set both width and height using layout token stops. The h
 > Bare integer stops (`25`, `50`, `100`, …) are scale-indexed on the 64px base — `value_in_px = stop × 64 / 100`, so `25` = 16px and `100` = 64px. Stops with a `px` suffix (`1px`, `2px`, `8px`, `20px`, `24px`) are off-scale exceptions that encode the literal pixel value.
 
 ```vue demo
-<div v-dt-scrollbar:never class="d-bar8 d-d-flex d-bgc-secondary d-w100p d-hmx-500 d-ta-center">
+<div v-dt-scrollbar:never class="d-bar-400 d-d-flex d-bgc-secondary d-w100p d-hmx-500 d-ta-center">
   <dt-stack gap="100" align="start">
     <div v-for="(i, index) in layout" v-dt-tooltip="{ message: `${i.px}px`, delay: false }">
       <dt-text kind="code" size="100" class="d-w-100 d-us-all">d-size-{{i.stop}}</dt-text>
-      <div class="d-h-100 d-bgc-moderate d-bar4" :class="`d-size-${i.stop}`"></div>
+      <div class="d-h-100 d-bgc-moderate d-bar-300" :class="`d-size-${i.stop}`"></div>
     </div>
   </dt-stack>
 </div>

--- a/apps/dialtone-documentation/docs/utilities/sizing/width.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/width.md
@@ -12,11 +12,11 @@ Use `d-w-{stop}` to set a fixed width for an element using layout token stops. T
 > Bare integer stops (`25`, `50`, `100`, …) are scale-indexed on the 64px base — `value_in_px = stop × 64 / 100`, so `25` = 16px and `100` = 64px. Stops with a `px` suffix (`1px`, `2px`, `8px`, `20px`, `24px`) are off-scale exceptions that encode the literal pixel value.
 
 ```vue demo
-<div v-dt-scrollbar:never class="d-bar8 d-d-flex d-bgc-secondary d-w100p d-hmx-500 d-ta-center">
+<div v-dt-scrollbar:never class="d-bar-400 d-d-flex d-bgc-secondary d-w100p d-hmx-500 d-ta-center">
   <dt-stack gap="100" align="start">
     <div v-for="(i, index) in layout" v-dt-tooltip="{ message: `${i.px}px`, delay: false }">
       <dt-text kind="code" size="100" class="d-w-100 d-us-all">d-w-{{i.stop}}</dt-text>
-      <div class="d-h-100 d-bgc-moderate d-bar4" :class="`d-w-${i.stop}`"></div>
+      <div class="d-h-100 d-bgc-moderate d-bar-300" :class="`d-w-${i.stop}`"></div>
     </div>
   </dt-stack>
 </div>
@@ -31,11 +31,11 @@ Use `d-w-{stop}` to set a fixed width for an element using layout token stops. T
 Use `d-w{n}p` to set a percentage width for an element. No hyphen before the number, `p` suffix indicates a literal percentage value. Note: `d-w33p` = 33.333% and `d-w66p` = 66.667%.
 
 ```vue demo
-<div v-dt-scrollbar:never class="d-bar8 d-bgc-secondary d-w100p d-hmx-500">
+<div v-dt-scrollbar:never class="d-bar-400 d-bgc-secondary d-w100p d-hmx-500">
   <div>
     <dt-stack as="div" gap="200" align="center" justify="center" class="d-w100p">
       <div v-for="i in percentage" v-dt-tooltip="{ message: `${i}%`, delay: false }" class="d-bgc-moderate d-w100p">
-        <div class="d-bgc-moderate-opaque d-bar4 d-p-100" :class="`d-w${i}p`">
+        <div class="d-bgc-moderate-opaque d-bar-300 d-p-100" :class="`d-w${i}p`">
           <dt-text kind="code" size="100" class="d-us-all">d-w{{i}}p</dt-text>
         </div>
       </div>

--- a/apps/dialtone-documentation/docs/utilities/spacing/auto-spacing.md
+++ b/apps/dialtone-documentation/docs/utilities/spacing/auto-spacing.md
@@ -10,20 +10,20 @@ keywords: ["margin","padding","gap","whitespace"]
 ## Adding Space Vertically
 
 ```vue demo
-<div class="d-bgc-bold d-stack16 d-bar8 lg:d-w-150 d-w-200">
-  <div class="d-p-200 d-bar8 d-bgc-moderate d-ta-center">1</div>
-  <div class="d-p-200 d-bar8 d-bgc-moderate d-ta-center">2</div>
-  <div class="d-p-200 d-bar8 d-bgc-moderate d-ta-center">3</div>
+<div class="d-bgc-bold d-stack16 d-bar-400 lg:d-w-150 d-w-200">
+  <div class="d-p-200 d-bar-400 d-bgc-moderate d-ta-center">1</div>
+  <div class="d-p-200 d-bar-400 d-bgc-moderate d-ta-center">2</div>
+  <div class="d-p-200 d-bar-400 d-bgc-moderate d-ta-center">3</div>
 </div>
 ```
 
 ## Adding Space Horizontally
 
 ```vue demo
-<div class="d-fl-center d-bgc-bold d-flow24 d-bar8 d-ta-center">
-  <div class="lg:d-w-150 d-w-200 d-p-200 d-bar8 d-bgc-moderate">1</div>
-  <div class="lg:d-w-150 d-w-200 d-p-200 d-bar8 d-bgc-moderate">2</div>
-  <div class="lg:d-w-150 d-w-200 d-p-200 d-bar8 d-bgc-moderate">3</div>
+<div class="d-fl-center d-bgc-bold d-flow24 d-bar-400 d-ta-center">
+  <div class="lg:d-w-150 d-w-200 d-p-200 d-bar-400 d-bgc-moderate">1</div>
+  <div class="lg:d-w-150 d-w-200 d-p-200 d-bar-400 d-bgc-moderate">2</div>
+  <div class="lg:d-w-150 d-w-200 d-p-200 d-bar-400 d-bgc-moderate">3</div>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/spacing/margin.md
+++ b/apps/dialtone-documentation/docs/utilities/spacing/margin.md
@@ -21,7 +21,7 @@ Use `d-m-{stop}` to set margin using spacing token stops. The number references 
 <!-- @wrapper -->
 <dt-stack direction="row" justify="center" gap="300" class="d-w100p">
   <div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mbs-150 d-p-200 d-bgc-moderate d-bber-300 d-code--md">d-mbs-150</dt-stack></div>
-  <div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mie-200 d-p-200 d-bgc-moderate d-brl4 d-code--md">d-mie-200</dt-stack></div>
+  <div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mie-200 d-p-200 d-bgc-moderate d-bisr-300 d-code--md">d-mie-200</dt-stack></div>
   <div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mbe-300 d-p-200 d-bgc-moderate d-bbsr-300 d-code--md">d-mbe-300</dt-stack></div>
   <div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mis-400 d-p-200 d-bgc-moderate d-bier-300 d-code--md">d-mis-400</dt-stack></div>
 </dt-stack>

--- a/apps/dialtone-documentation/docs/utilities/spacing/margin.md
+++ b/apps/dialtone-documentation/docs/utilities/spacing/margin.md
@@ -12,7 +12,7 @@ Use `d-m-{stop}` to set margin using spacing token stops. The number references 
 ## Add Margin to All Sides
 
 ```vue demo
-<div class="d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-m-300 d-bgc-moderate d-bar4 d-code--md">d-m-300</dt-stack></div>
+<div class="d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-m-300 d-bgc-moderate d-bar-300 d-code--md">d-m-300</dt-stack></div>
 ```
 
 ## Add Margin to a Single Side
@@ -20,23 +20,23 @@ Use `d-m-{stop}` to set margin using spacing token stops. The number references 
 ```vue demo
 <!-- @wrapper -->
 <dt-stack direction="row" justify="center" gap="300" class="d-w100p">
-  <div class="d-as-center d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mbs-150 d-p-200 d-bgc-moderate d-bbr4 d-code--md">d-mbs-150</dt-stack></div>
-  <div class="d-as-center d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mie-200 d-p-200 d-bgc-moderate d-brl4 d-code--md">d-mie-200</dt-stack></div>
-  <div class="d-as-center d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mbe-300 d-p-200 d-bgc-moderate d-btr4 d-code--md">d-mbe-300</dt-stack></div>
-  <div class="d-as-center d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mis-400 d-p-200 d-bgc-moderate d-brr4 d-code--md">d-mis-400</dt-stack></div>
+  <div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mbs-150 d-p-200 d-bgc-moderate d-bber-300 d-code--md">d-mbs-150</dt-stack></div>
+  <div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mie-200 d-p-200 d-bgc-moderate d-brl4 d-code--md">d-mie-200</dt-stack></div>
+  <div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mbe-300 d-p-200 d-bgc-moderate d-bbsr-300 d-code--md">d-mbe-300</dt-stack></div>
+  <div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mis-400 d-p-200 d-bgc-moderate d-bier-300 d-code--md">d-mis-400</dt-stack></div>
 </dt-stack>
 ```
 
 ## Add Horizontal Margins
 
 ```vue demo
-<div class="d-as-center d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mx-200 d-p-200 d-bgc-moderate d-code--md">d-mx-200</dt-stack></div>
+<div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mx-200 d-p-200 d-bgc-moderate d-code--md">d-mx-200</dt-stack></div>
 ```
 
 ## Add Vertical Margins
 
 ```vue demo
-<div class="d-as-center d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-my-200 d-p-200 d-bgc-moderate d-code--sm">d-my-200</dt-stack></div>
+<div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-my-200 d-p-200 d-bgc-moderate d-code--sm">d-my-200</dt-stack></div>
 ```
 
 ## Negative Margins
@@ -46,8 +46,8 @@ Use `d-mbs-n{stop}` for negative margins. These use the `--dt-spacing-{stop}-neg
 ```vue demo
 <!-- @wrapper -->
 <dt-stack direction="row" justify="center" gap="300" class="d-w100p">
-  <div class="d-as-center d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mbs-n100 d-p-200 d-bgc-moderate d-code--md">d-mbs-n100</dt-stack></div>
-  <div class="d-as-center d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mis-n200 d-p-200 d-bgc-moderate d-code--md">d-mis-n200</dt-stack></div>
+  <div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mbs-n100 d-p-200 d-bgc-moderate d-code--md">d-mbs-n100</dt-stack></div>
+  <div class="d-as-center d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mis-n200 d-p-200 d-bgc-moderate d-code--md">d-mis-n200</dt-stack></div>
 </dt-stack>
 ```
 
@@ -58,9 +58,9 @@ Auto margins allow an element to fill a remaining space within an object. This i
 ```vue demo
 <!-- @wrapper -->
 <dt-stack gap="200" class="d-w100p">
-  <dt-stack direction="row" class="d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mx-auto d-p-200 d-bgc-moderate d-code--md">d-mx-auto</dt-stack></dt-stack>
-  <dt-stack direction="row" class="d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mis-auto d-p-200 d-bgc-moderate d-code--md">d-mis-auto</dt-stack></dt-stack>
-  <dt-stack direction="row" class="d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mie-auto d-p-200 d-bgc-moderate d-code--md">d-mie-auto</dt-stack></dt-stack>
+  <dt-stack direction="row" class="d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mx-auto d-p-200 d-bgc-moderate d-code--md">d-mx-auto</dt-stack></dt-stack>
+  <dt-stack direction="row" class="d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mis-auto d-p-200 d-bgc-moderate d-code--md">d-mis-auto</dt-stack></dt-stack>
+  <dt-stack direction="row" class="d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-mie-auto d-p-200 d-bgc-moderate d-code--md">d-mie-auto</dt-stack></dt-stack>
 </dt-stack>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/spacing/padding.md
+++ b/apps/dialtone-documentation/docs/utilities/spacing/padding.md
@@ -12,7 +12,7 @@ Use `d-p-{stop}` to set padding using spacing token stops. The number references
 ## Add Padding to All Sides
 
 ```vue demo
-<div class="d-size-200 d-p-200 d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-fl1 d-h100p d-bgc-moderate d-bar4 d-code--md">d-p-200</dt-stack></div>
+<div class="d-size-200 d-p-200 d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-fl1 d-h100p d-bgc-moderate d-bar-300 d-code--md">d-p-200</dt-stack></div>
 ```
 
 ## Add Padding to a Single Side
@@ -20,23 +20,23 @@ Use `d-p-{stop}` to set padding using spacing token stops. The number references
 ```vue demo
 <!-- @wrapper -->
 <dt-stack direction="row" justify="center" gap="300" class="d-fw-wrap d-w100p">
-  <div class="d-as-center d-pbs-150 d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bbr4 d-code--md">d-pbs-150</dt-stack></div>
-  <div class="d-as-center d-pie-200 d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-brl4 d-code--md">d-pie-200</dt-stack></div>
-  <div class="d-as-center d-pbe-300 d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-btr4 d-code--md">d-pbe-300</dt-stack></div>
-  <div class="d-as-center d-pis-400 d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-brr4 d-code--md">d-pis-400</dt-stack></div>
+  <div class="d-as-center d-pbs-150 d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bber-300 d-code--md">d-pbs-150</dt-stack></div>
+  <div class="d-as-center d-pie-200 d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-brl4 d-code--md">d-pie-200</dt-stack></div>
+  <div class="d-as-center d-pbe-300 d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bbsr-300 d-code--md">d-pbe-300</dt-stack></div>
+  <div class="d-as-center d-pis-400 d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-bier-300 d-code--md">d-pis-400</dt-stack></div>
 </dt-stack>
 ```
 
 ## Add Horizontal Padding
 
 ```vue demo
-<div class="d-as-center d-px-200 d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-code--md">d-px-200</dt-stack></div>
+<div class="d-as-center d-px-200 d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-code--md">d-px-200</dt-stack></div>
 ```
 
 ## Add Vertical Padding
 
 ```vue demo
-<div class="d-as-center d-py-300 d-bar8 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-code--md">d-py-300</dt-stack></div>
+<div class="d-as-center d-py-300 d-bar-400 d-bgc-bold d-of-hidden"><dt-stack direction="row" align="center" justify="center" class="d-p-200 d-bgc-moderate d-code--md">d-py-300</dt-stack></div>
 ```
 
 <script setup>

--- a/apps/dialtone-documentation/docs/utilities/typography/font-color.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/font-color.md
@@ -13,7 +13,7 @@ Use [DtText's](/components/text.html#tone) `tone` prop to declare the text's ton
 
 ```vue demo
 <!-- @wrapper -->
-<dt-stack class="d-py-100 d-px-200 d-bgc-primary d-bar4">
+<dt-stack class="d-py-100 d-px-200 d-bgc-primary d-bar-300">
   <dt-text tone="primary">primary</dt-text>
   <dt-text tone="secondary">secondary</dt-text>
   <dt-text tone="tertiary">tertiary</dt-text>
@@ -72,7 +72,7 @@ Use `fv:d-fc-{color}` to change an element's text color on `:focus-visible` stat
 
 ```vue demo
 <dt-stack direction="row" gap="400">
-  <dt-stack class="d-py-100 d-px-200 d-bgc-primary d-bar4">
+  <dt-stack class="d-py-100 d-px-200 d-bgc-primary d-bar-300">
     <dt-text tone="primary">primary</dt-text>
     <dt-text tone="secondary">secondary</dt-text>
     <dt-text tone="tertiary">tertiary</dt-text>
@@ -85,7 +85,7 @@ Use `fv:d-fc-{color}` to change an element's text color on `:focus-visible` stat
     <dt-text tone="critical">critical</dt-text>
     <dt-text tone="critical-strong">critical-strong</dt-text>
   </dt-stack>
-  <dt-stack class="d-py-100 d-px-200 d-bgc-contrast d-bar4">
+  <dt-stack class="d-py-100 d-px-200 d-bgc-contrast d-bar-300">
     <dt-text v-dt-mode:invert tone="primary">primary</dt-text>
     <dt-text v-dt-mode:invert tone="secondary">secondary</dt-text>
     <dt-text v-dt-mode:invert tone="tertiary">tertiary</dt-text>
@@ -103,7 +103,7 @@ Use `fv:d-fc-{color}` to change an element's text color on `:focus-visible` stat
 
 <code-example-tabs
 vueCode='
-<dt-stack gap="300" class="d-py-100 d-px-200 d-bgc-contrast d-bar4">
+<dt-stack gap="300" class="d-py-100 d-px-200 d-bgc-contrast d-bar-300">
   <dt-text v-dt-mode:invert tone="primary">primary</dt-text>
   <dt-text v-dt-mode:invert tone="secondary">secondary</dt-text>
   <dt-text v-dt-mode:invert tone="tertiary">tertiary</dt-text>

--- a/apps/dialtone-documentation/docs/utilities/typography/text-overflow.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/text-overflow.md
@@ -9,7 +9,7 @@ keywords: ["ellipsis", "truncate", "clip"]
 Use `d-truncate` to truncate an element's text to a single line with an ellipsis (`...`) if needed. Note that while CSS Utilities are fundamentally a single CSS property, this utility combines three: `overflow`, `text-overflow`, and `white-space` to achieve the effect.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-500">
   <p class="d-truncate">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit dolor.</p>
 </div>
 ```
@@ -19,7 +19,7 @@ Use `d-truncate` to truncate an element's text to a single line with an ellipsis
 Use `d-to-ellipsis`, combined with `d-of-hidden` to truncate an element's overflowing text with an ellipsis (`...`) if needed.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-500">
   <p class="d-of-hidden d-to-ellipsis">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit dolor.</p>
 </div>
 ```
@@ -29,7 +29,7 @@ Use `d-to-ellipsis`, combined with `d-of-hidden` to truncate an element's overfl
 Use `d-to-clip` to clip an element's overflowing text if needed.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-500">
   <p class="d-of-hidden d-to-clip">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit dolor.</p>
 </div>
 ```

--- a/apps/dialtone-documentation/docs/utilities/typography/text-wrap.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/text-wrap.md
@@ -8,7 +8,7 @@ description: Utilities for controlling how text wraps within an element.
 Use `d-tw-nowrap` to prevent text from wrapping.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-500 d-of-hidden">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-500 d-of-hidden">
   <p class="d-tw-nowrap">Lorem ipsum dolor sit amet consectetur gemini.</p>
 </div>
 ```
@@ -18,7 +18,7 @@ Use `d-tw-nowrap` to prevent text from wrapping.
 Use `d-tw-wrap` to allow text to wrap normally at soft wrap opportunities.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-500">
   <p class="d-tw-wrap">Lorem ipsum dolor sit amet consectetur gemini.</p>
 </div>
 ```
@@ -28,7 +28,7 @@ Use `d-tw-wrap` to allow text to wrap normally at soft wrap opportunities.
 Use `d-tw-balance` to balance the length of each line of text, distributing content more evenly across lines.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-500">
   <p class="d-tw-balance">Lorem ipsum dolor sit amet consectetur gemini.</p>
 </div>
 ```
@@ -38,7 +38,7 @@ Use `d-tw-balance` to balance the length of each line of text, distributing cont
 Use `d-tw-pretty` to optimize text wrapping for better typography, avoiding orphaned words on the last line.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-500">
   <p class="d-tw-pretty">Lorem ipsum dolor sit amet consectetur gemini.</p>
 </div>
 ```
@@ -48,7 +48,7 @@ Use `d-tw-pretty` to optimize text wrapping for better typography, avoiding orph
 Use `d-tw-unset` to reset the text wrap property to its default value.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-500">
   <p class="d-tw-unset">Lorem ipsum dolor sit amet consectetur gemini.</p>
 </div>
 ```

--- a/apps/dialtone-documentation/docs/utilities/typography/whitespace.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/whitespace.md
@@ -9,7 +9,7 @@ keywords: ["nowrap", "pre", "pre wrap", "word spacing"]
 Use `d-ws-normal` to collapse an element's text whitespaces sequences and newline characters are treated like whitespace. Lines are broken as needed to fill boxes.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-350">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-350">
   <p class="d-ws-normal">Lorem ipsum dolor sit amet, consectetur adipisicing elit.<br/>Blanditiisitaquequodpraesentium Dolores beatae nam at sed dolorum ratione dolorem nisi velit dolor.</p>
 </div>
 ```
@@ -19,7 +19,7 @@ Use `d-ws-normal` to collapse an element's text whitespaces sequences and newlin
 Use `d-ws-nowrap` to collapse an element's text whitespaces sequences, but line breaks are not honored. This keeps text from wrapping.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-350">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-350">
   <p class="d-ws-nowrap d-of-hidden">Lorem ipsum dolor sit amet, consectetur adipisicing elit.<br/>Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit dolor.</p>
 </div>
 ```
@@ -29,7 +29,7 @@ Use `d-ws-nowrap` to collapse an element's text whitespaces sequences, but line 
 Use `d-ws-pre` to preserve an element's whitespaces sequences. Lines are only broken at new line characters and `<br/>` elements.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-350">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-350">
   <p class="d-ws-pre d-of-hidden">Lorem ipsum dolor sit amet, consectetur adipisicing elit.<br/>       Blanditiisitaquequodpraesentiumexplicaboincidunt?       Dolores beatae nam at sed dolorum ratione dolorem nisi velit dolor.</p>
 </div>
 ```
@@ -39,7 +39,7 @@ Use `d-ws-pre` to preserve an element's whitespaces sequences. Lines are only br
 Use `d-ws-pre-line` to collapse an element's whitespaces sequences. Lines are broken at new line characters, `<br/>` elements, or as needed to fill boxes.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-350">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-350">
   <p class="d-ws-pre-line d-of-hidden">Lorem ipsum dolor sit amet, consectetur adipisicing elit.<br/>Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit dolor.</p>
 </div>
 ```
@@ -49,7 +49,7 @@ Use `d-ws-pre-line` to collapse an element's whitespaces sequences. Lines are br
 Use `d-ws-pre-wrap` to preserve an element's whitespaces sequences. Lines are broken at new line characters, `<br/>` elements, or as needed to fill boxes.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-350">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-350">
   <p class="d-ws-pre-wrap d-of-hidden">Lorem ipsum dolor sit amet, consectetur adipisicing elit.<br/>      Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit dolor.</p>
 </div>
 ```
@@ -59,7 +59,7 @@ Use `d-ws-pre-wrap` to preserve an element's whitespaces sequences. Lines are br
 Use `d-ws-break-spaces` to have an element act like `pre-wrap` except that any sequence of preserved whitespace always takes up space, a line breaking opportunity exists after every preserved whitespace character, and preserved spaces take up space and do not hang which affects the element's intrinisic size (`min-content` and `max-content` sizes).
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 d-w-350">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 d-w-350">
   <p class="d-ws-break-spaces d-of-hidden">Lorem ipsum dolor sit amet, consectetur adipisicing elit.<br/>Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit dolor.</p>
 </div>
 ```

--- a/apps/dialtone-documentation/docs/utilities/typography/word-break.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/word-break.md
@@ -9,7 +9,7 @@ keywords: ["break all", "break word", "overflow wrap"]
 Use `d-wb-normal` to reset an element's line break rule.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 lg:d-w-350 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 lg:d-w-350 d-w-500">
   <p class="d-wb-normal">Here's an example sentence to show how word-break works. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
 </div>
 ```
@@ -21,7 +21,7 @@ Korean text) to prevent text from overflowing. The break between any two charact
 the middle of short words, for a more conservative way to handle it see [`d-ww-break-word`](./word-wrap.md#break-word).
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 lg:d-w-350 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 lg:d-w-350 d-w-500">
   <p class="d-wb-break-all">Here's an example sentence to show how word-break works. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
 </div>
 ```
@@ -33,7 +33,7 @@ Korean text) to prevent text from overflowing. The break between any two charact
 the middle of short words, for a more conservative way to handle it see [`d-ww-break-word`](./word-wrap.md#break-word).
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 lg:d-w-350 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 lg:d-w-350 d-w-500">
   qwqqd<p class="d-wb-break-all">Here's an example sentence to show how word-break works. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
 </div>
 ```
@@ -44,7 +44,7 @@ Use `d-wb-keep-all` on an element to not use word breaks for Chinese, Japanese, 
 behavior is set to normal.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 lg:d-w-350 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 lg:d-w-350 d-w-500">
   <p class="d-wb-keep-all">Here's an example sentence to show how word-break works. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
 </div>
 ```

--- a/apps/dialtone-documentation/docs/utilities/typography/word-wrap.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/word-wrap.md
@@ -30,7 +30,7 @@ Use `d-ww-anywhere` to break words at any point in the string (not just at allow
 
 ```vue demo
 <div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 lg:d-w-350 d-w-500">
-  <p class="d-ww-break-word">Here's an example sentence to show how word-wrap works. Thisisasignlewordtodenotethedifferencebetweenthedifferentwaytowrapaword. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
+  <p class="d-ww-anywhere">Here's an example sentence to show how word-wrap works. Thisisasignlewordtodenotethedifferencebetweenthedifferentwaytowrapaword. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
 </div>
 ```
 

--- a/apps/dialtone-documentation/docs/utilities/typography/word-wrap.md
+++ b/apps/dialtone-documentation/docs/utilities/typography/word-wrap.md
@@ -9,7 +9,7 @@ keywords: ["overflow wrap", "break word", "long url"]
 Use `d-ww-normal` to break words only at allowed break points.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 lg:d-w-350 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 lg:d-w-350 d-w-500">
   <p class="d-ww-normal">Here's an example sentence to show how word-wrap works. Thisisasignlewordtodenotethedifferencebetweenthedifferentwaytowrapaword. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
 </div>
 ```
@@ -19,7 +19,7 @@ Use `d-ww-normal` to break words only at allowed break points.
 Use `d-ww-break-word` to allow unbreakable words to be broken. Is a more conservative approach than [`d-wb-break-all`](./word-break.md#break-all) and will only break long words that do not fit the container.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 lg:d-w-350 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 lg:d-w-350 d-w-500">
   <p class="d-ww-break-word">Here's an example sentence to show how word-wrap works. Thisisasignlewordtodenotethedifferencebetweenthedifferentwaytowrapaword. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
 </div>
 ```
@@ -29,7 +29,7 @@ Use `d-ww-break-word` to allow unbreakable words to be broken. Is a more conserv
 Use `d-ww-anywhere` to break words at any point in the string (not just at allowed break points) to prevent long strings from overflowing their container.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 lg:d-w-350 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 lg:d-w-350 d-w-500">
   <p class="d-ww-break-word">Here's an example sentence to show how word-wrap works. Thisisasignlewordtodenotethedifferencebetweenthedifferentwaytowrapaword. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
 </div>
 ```
@@ -39,7 +39,7 @@ Use `d-ww-anywhere` to break words at any point in the string (not just at allow
 Use `d-ww-initial`to set this property to its default value.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 lg:d-w-350 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 lg:d-w-350 d-w-500">
   <p class="d-ww-initial">Here's an example sentence to show how word-wrap works. Thisisasignlewordtodenotethedifferencebetweenthedifferentwaytowrapaword. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
 </div>
 ```
@@ -49,7 +49,7 @@ Use `d-ww-initial`to set this property to its default value.
 Use `d-ww-inherit` to inherit this property from its parent element.
 
 ```vue demo
-<div class="d-bgc-moderate d-py-100 d-px-200 d-bar8 lg:d-w-350 d-w-500">
+<div class="d-bgc-moderate d-py-100 d-px-200 d-bar-400 lg:d-w-350 d-w-500">
   <p class="d-ww-inherit">Here's an example sentence to show how word-wrap works. Thisisasignlewordtodenotethedifferencebetweenthedifferentwaytowrapaword. Vivamus ullamcorperatduiaultrices eu lobortis nulla, sed vulputate orci. 这是一个中文例句，以举例说明断字的工作方式。単語分割の動作の例を示す日本語のサンプル文は次のとおりです。다음은 단어 분리 작동 방식의 예를 제공하는 한국어 샘플 문장입니다.</p>
 </div>
 ```

--- a/packages/combinator/.github/documentation/USAGE.md
+++ b/packages/combinator/.github/documentation/USAGE.md
@@ -215,7 +215,7 @@ of the combinator.
 ```vue
 <dtc-combinator
   ...
-  header-class="d-py32"
-  class="d-px32"
+  header-class="d-py-400"
+  class="d-px-400"
 />
 ```

--- a/packages/combinator/src/components/option_bar/option_bar_control.vue
+++ b/packages/combinator/src/components/option_bar/option_bar_control.vue
@@ -56,7 +56,7 @@
           v-dt-tooltip="'Edit as JSON'"
           link
           :link-underline="false"
-          class="d-mis-auto d-fw-normal d-fs-50 d-px-25 d-bar2 h:d-td-none "
+          class="d-mis-auto d-fw-normal d-fs-50 d-px-25 d-bar-200 h:d-td-none "
           :class="{ 'd-bgc-bold d-fc-secondary h:d-fc-primary': rawMode }"
           @click="toggleRawMode"
         >

--- a/packages/combinator/src/components/renderer/renderer_button_bar.vue
+++ b/packages/combinator/src/components/renderer/renderer_button_bar.vue
@@ -1,6 +1,6 @@
 <template>
   <dt-button-group
-    class="d-d-flex d-bgc-black-025 d-bar4"
+    class="d-d-flex d-bgc-black-025 d-bar-300"
   >
     <template
       v-for="(_, slot) in slots"

--- a/packages/combinator/src/components/tools/button_bar.vue
+++ b/packages/combinator/src/components/tools/button_bar.vue
@@ -1,6 +1,6 @@
 <template>
   <dt-button-group
-    class="d-d-flex d-bgc-black-025 d-bar4"
+    class="d-d-flex d-bgc-black-025 d-bar-300"
   >
     <template
       v-for="(_, slot) in slots"

--- a/packages/combinator/src/variants/variants_avatar.js
+++ b/packages/combinator/src/variants/variants_avatar.js
@@ -1,4 +1,5 @@
  
+ 
 
 export default {
   defaults: {

--- a/packages/combinator/src/variants/variants_avatar.js
+++ b/packages/combinator/src/variants/variants_avatar.js
@@ -1,6 +1,3 @@
- 
- 
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_badge.js
+++ b/packages/combinator/src/variants/variants_badge.js
@@ -1,4 +1,5 @@
  
+ 
 
 export default {
   defaults: {

--- a/packages/combinator/src/variants/variants_badge.js
+++ b/packages/combinator/src/variants/variants_badge.js
@@ -1,6 +1,3 @@
- 
- 
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_breadcrumbs.js
+++ b/packages/combinator/src/variants/variants_breadcrumbs.js
@@ -1,5 +1,5 @@
-/* eslint-disable max-len */
  
+
 export default {
   default: {
     props: {

--- a/packages/combinator/src/variants/variants_button.js
+++ b/packages/combinator/src/variants/variants_button.js
@@ -1,5 +1,3 @@
- 
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_button.js
+++ b/packages/combinator/src/variants/variants_button.js
@@ -1,3 +1,4 @@
+ 
 
 export default {
   defaults: {
@@ -216,7 +217,7 @@ export default {
     },
     slots: {
       default: { initialValue: 'Caution' },
-      leading: { initialValue: '<span class="d-bgc-critical-strong d-bar4 d-w12 d-h12"></span>' },
+      leading: { initialValue: '<span class="d-bgc-critical-strong d-bar-300 d-w12 d-h12"></span>' },
     },
   },
 

--- a/packages/combinator/src/variants/variants_card.js
+++ b/packages/combinator/src/variants/variants_card.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
- 
+
 
 export default {
   default: {

--- a/packages/combinator/src/variants/variants_card.js
+++ b/packages/combinator/src/variants/variants_card.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+ 
 
 export default {
   default: {
@@ -29,7 +30,7 @@ export default {
   },
   'Targeted styling': {
     props: {
-      class: { initialValue: 'd-bar0 d-baw0' },
+      class: { initialValue: 'd-bar-0 d-baw0' },
       contentClass: { initialValue: 'd-p-100 d-by d-bgc-critical' },
       headerClass: { initialValue: 'd-p-100 d-bgc-info' },
       footerClass: { initialValue: 'd-p-100 d-bgc-warning' },

--- a/packages/combinator/src/variants/variants_collapsible.js
+++ b/packages/combinator/src/variants/variants_collapsible.js
@@ -1,5 +1,5 @@
-/* eslint-disable max-len */
  
+
 export default {
   default: {
     props: {

--- a/packages/combinator/src/variants/variants_combobox.js
+++ b/packages/combinator/src/variants/variants_combobox.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
- 
+
 
 export default {
   default: {

--- a/packages/combinator/src/variants/variants_description_list.js
+++ b/packages/combinator/src/variants/variants_description_list.js
@@ -1,6 +1,3 @@
- 
-
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_description_list.js
+++ b/packages/combinator/src/variants/variants_description_list.js
@@ -1,3 +1,4 @@
+ 
 
 
 export default {

--- a/packages/combinator/src/variants/variants_emoji.js
+++ b/packages/combinator/src/variants/variants_emoji.js
@@ -1,4 +1,5 @@
  
+ 
 
 export default {
   defaults: {

--- a/packages/combinator/src/variants/variants_emoji.js
+++ b/packages/combinator/src/variants/variants_emoji.js
@@ -1,6 +1,3 @@
- 
- 
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_emoji_text_wrapper.js
+++ b/packages/combinator/src/variants/variants_emoji_text_wrapper.js
@@ -1,4 +1,5 @@
  
+ 
 
 export default {
   defaults: {

--- a/packages/combinator/src/variants/variants_emoji_text_wrapper.js
+++ b/packages/combinator/src/variants/variants_emoji_text_wrapper.js
@@ -1,6 +1,3 @@
- 
- 
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_filter_pill.js
+++ b/packages/combinator/src/variants/variants_filter_pill.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
- 
+
 export default {
   default: {
     props: {

--- a/packages/combinator/src/variants/variants_icon.js
+++ b/packages/combinator/src/variants/variants_icon.js
@@ -1,6 +1,3 @@
- 
- 
- 
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_icon.js
+++ b/packages/combinator/src/variants/variants_icon.js
@@ -1,5 +1,6 @@
  
  
+ 
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_input.js
+++ b/packages/combinator/src/variants/variants_input.js
@@ -1,4 +1,5 @@
  
+ 
 
 
 export default {

--- a/packages/combinator/src/variants/variants_input.js
+++ b/packages/combinator/src/variants/variants_input.js
@@ -1,7 +1,3 @@
- 
- 
-
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_item_layout.js
+++ b/packages/combinator/src/variants/variants_item_layout.js
@@ -1,5 +1,5 @@
-/* eslint-disable max-len */
  
+
 export default {
   default: {
     slots: {

--- a/packages/combinator/src/variants/variants_lazy_show.js
+++ b/packages/combinator/src/variants/variants_lazy_show.js
@@ -1,5 +1,5 @@
-/* eslint-disable max-len */
  
+
 export default {
   default: {
     props: {

--- a/packages/combinator/src/variants/variants_link.js
+++ b/packages/combinator/src/variants/variants_link.js
@@ -1,6 +1,3 @@
- 
- 
- 
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_link.js
+++ b/packages/combinator/src/variants/variants_link.js
@@ -1,5 +1,6 @@
  
  
+ 
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_list_item.js
+++ b/packages/combinator/src/variants/variants_list_item.js
@@ -1,5 +1,5 @@
-/* eslint-disable max-len */
  
+
 export default {
   default: {
     props: {

--- a/packages/combinator/src/variants/variants_loader.js
+++ b/packages/combinator/src/variants/variants_loader.js
@@ -1,4 +1,5 @@
  
+ 
 
 export default {
   defaults: {

--- a/packages/combinator/src/variants/variants_loader.js
+++ b/packages/combinator/src/variants/variants_loader.js
@@ -1,6 +1,3 @@
- 
- 
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_mode_island.js
+++ b/packages/combinator/src/variants/variants_mode_island.js
@@ -1,5 +1,5 @@
-/* eslint-disable max-len */
  
+
 export default {
   default: {
     slots: {

--- a/packages/combinator/src/variants/variants_notice.js
+++ b/packages/combinator/src/variants/variants_notice.js
@@ -1,6 +1,3 @@
- 
-
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_notice.js
+++ b/packages/combinator/src/variants/variants_notice.js
@@ -1,3 +1,4 @@
+ 
 
 
 export default {

--- a/packages/combinator/src/variants/variants_pagination.js
+++ b/packages/combinator/src/variants/variants_pagination.js
@@ -1,5 +1,5 @@
-/* eslint-disable max-len */
  
+
 export default {
   default: {
     props: {

--- a/packages/combinator/src/variants/variants_presence.js
+++ b/packages/combinator/src/variants/variants_presence.js
@@ -1,6 +1,3 @@
- 
- 
- 
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_presence.js
+++ b/packages/combinator/src/variants/variants_presence.js
@@ -1,5 +1,6 @@
  
  
+ 
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_progress_circle.js
+++ b/packages/combinator/src/variants/variants_progress_circle.js
@@ -1,4 +1,5 @@
  
+ 
 
 export default {
   defaults: {

--- a/packages/combinator/src/variants/variants_progress_circle.js
+++ b/packages/combinator/src/variants/variants_progress_circle.js
@@ -1,6 +1,3 @@
- 
- 
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_radio.js
+++ b/packages/combinator/src/variants/variants_radio.js
@@ -1,4 +1,5 @@
  
+ 
 
 export default {
   defaults: {

--- a/packages/combinator/src/variants/variants_radio.js
+++ b/packages/combinator/src/variants/variants_radio.js
@@ -1,6 +1,3 @@
- 
- 
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_rich_text_editor.js
+++ b/packages/combinator/src/variants/variants_rich_text_editor.js
@@ -1,5 +1,5 @@
-/* eslint-disable max-len */
  
+
 export default {
   default: {
     props: {

--- a/packages/combinator/src/variants/variants_segmented_control.js
+++ b/packages/combinator/src/variants/variants_segmented_control.js
@@ -1,6 +1,3 @@
- 
- 
-
 export default {
   default: {
     slots: {

--- a/packages/combinator/src/variants/variants_segmented_control.js
+++ b/packages/combinator/src/variants/variants_segmented_control.js
@@ -1,4 +1,5 @@
  
+ 
 
 export default {
   default: {

--- a/packages/combinator/src/variants/variants_select_menu.js
+++ b/packages/combinator/src/variants/variants_select_menu.js
@@ -1,5 +1,6 @@
  
  
+ 
 
 export default {
   defaults: {

--- a/packages/combinator/src/variants/variants_select_menu.js
+++ b/packages/combinator/src/variants/variants_select_menu.js
@@ -1,7 +1,3 @@
- 
- 
- 
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_stack.js
+++ b/packages/combinator/src/variants/variants_stack.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+ 
 
 export default {
   defaults: {
@@ -15,9 +16,9 @@ export default {
     },
     slots: {
       default: {
-        initialValue: `<div class="d-bgc-moderate-opaque d-p-200 d-bar8">Stack item 1</div>
-<div class="d-bgc-moderate-opaque d-p-200 d-bar8">Stack item 2<br>with second line</div>
-<div class="d-bgc-moderate-opaque d-p-200 d-bar8">Stack item 3</div>`,
+        initialValue: `<div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Stack item 1</div>
+<div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Stack item 2<br>with second line</div>
+<div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Stack item 3</div>`,
       },
     },
   },
@@ -30,9 +31,9 @@ export default {
     },
     slots: {
       default: {
-        initialValue: `<div class="d-bgc-moderate-opaque d-p-200 d-bar8">Stack item 1</div>
-<div class="d-bgc-moderate-opaque d-p-200 d-bar8">Stack item 2</div>
-<div class="d-bgc-moderate-opaque d-p-200 d-bar8">Stack item 3</div>`,
+        initialValue: `<div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Stack item 1</div>
+<div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Stack item 2</div>
+<div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Stack item 3</div>`,
       },
     },
   },
@@ -51,9 +52,9 @@ export default {
     },
     slots: {
       default: {
-        initialValue: `<div class="d-bgc-moderate-opaque d-p-200 d-bar8">Stack item 1</div>
-<div class="d-bgc-moderate-opaque d-p-200 d-bar8">Stack item 2<br>with second line</div>
-<div class="d-bgc-moderate-opaque d-p-200 d-bar8">Stack item 3</div>`,
+        initialValue: `<div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Stack item 1</div>
+<div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Stack item 2<br>with second line</div>
+<div class="d-bgc-moderate-opaque d-p-200 d-bar-400">Stack item 3</div>`,
       },
     },
   },
@@ -72,9 +73,9 @@ export default {
     },
     slots: {
       default: {
-        initialValue: `<div class="d-bgc-moderate-opaque d-p-100 d-bar8"> <dt-text kind="body" :size="100">Small body</dt-text> </div>
-<div class="d-bgc-moderate-opaque d-p-200 d-bar8"> <dt-text kind="headline" :size="600">2xl headline</dt-text> </div>
-<div class="d-bgc-moderate-opaque d-p-200 d-bar8"> <dt-text kind="headline" :size="400">Large headline</dt-text> </div>`,
+        initialValue: `<div class="d-bgc-moderate-opaque d-p-100 d-bar-400"> <dt-text kind="body" :size="100">Small body</dt-text> </div>
+<div class="d-bgc-moderate-opaque d-p-200 d-bar-400"> <dt-text kind="headline" :size="600">2xl headline</dt-text> </div>
+<div class="d-bgc-moderate-opaque d-p-200 d-bar-400"> <dt-text kind="headline" :size="400">Large headline</dt-text> </div>`,
       },
     },
   },

--- a/packages/combinator/src/variants/variants_stack.js
+++ b/packages/combinator/src/variants/variants_stack.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
- 
+
 
 export default {
   defaults: {

--- a/packages/combinator/src/variants/variants_tab_group.js
+++ b/packages/combinator/src/variants/variants_tab_group.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+ 
 
 
 
@@ -119,7 +120,7 @@ export default {
 <dt-tab id="tab-3" panel-id="panel-3">Third</dt-tab>`,
       },
       default: {
-        initialValue: '<div class="d-ba d-baw2 d-bas-dashed d-bc-subtle d-w100p d-py-600">\n<dt-tab-panel id="panel-1" tab-id="tab-1">\n<dt-text as="p" kind="code" :size="100" tone="muted" align="center" class="d-p16"> <strong>First</strong> tab content panel </dt-text>\n</dt-tab-panel>\n<dt-tab-panel id="panel-2" tab-id="tab-2">\n<dt-text as="p" kind="code" :size="100" tone="muted" align="center" class="d-p-200"> <strong>Second</strong> tab content panel </dt-text>\n</dt-tab-panel>\n<dt-tab-panel id="panel-3" tab-id="tab-3">\n<dt-text as="p" kind="code" :size="100" tone="muted" align="center" class="d-p16"> <strong>Third</strong> tab content panel </dt-text>\n</dt-tab-panel>\n</div>',
+        initialValue: '<div class="d-ba d-baw2 d-bas-dashed d-bc-subtle d-w100p d-py-600">\n<dt-tab-panel id="panel-1" tab-id="tab-1">\n<dt-text as="p" kind="code" :size="100" tone="muted" align="center" class="d-p-200"> <strong>First</strong> tab content panel </dt-text>\n</dt-tab-panel>\n<dt-tab-panel id="panel-2" tab-id="tab-2">\n<dt-text as="p" kind="code" :size="100" tone="muted" align="center" class="d-p-200"> <strong>Second</strong> tab content panel </dt-text>\n</dt-tab-panel>\n<dt-tab-panel id="panel-3" tab-id="tab-3">\n<dt-text as="p" kind="code" :size="100" tone="muted" align="center" class="d-p-200"> <strong>Third</strong> tab content panel </dt-text>\n</dt-tab-panel>\n</div>',
       },
     },
   },
@@ -143,7 +144,7 @@ export default {
 ,
       },
       default: {
-        initialValue: '<div class="d-ba d-baw2 d-bas-dashed d-bc-subtle d-w100p d-py48">\n<dt-tab-panel id="panel-1" tab-id="tab-1">\n<dt-text as="p" kind="code" :size="100" tone="muted" align="center" class="d-p16"> <strong>First</strong> tab content panel </dt-text>\n</dt-tab-panel>\n<dt-tab-panel id="panel-2" tab-id="tab-2">\n<dt-text as="p" kind="code" :size="100" tone="muted" align="center" class="d-p-200"> <strong>Second</strong> tab content panel </dt-text>\n</dt-tab-panel>\n<dt-tab-panel id="panel-3" tab-id="tab-3">\n<dt-text as="p" kind="code" :size="100" tone="muted" align="center" class="d-p-200"> <strong>Third</strong> tab content panel </dt-text>\n</dt-tab-panel>\n</div>',
+        initialValue: '<div class="d-ba d-baw2 d-bas-dashed d-bc-subtle d-w100p d-py-600">\n<dt-tab-panel id="panel-1" tab-id="tab-1">\n<dt-text as="p" kind="code" :size="100" tone="muted" align="center" class="d-p-200"> <strong>First</strong> tab content panel </dt-text>\n</dt-tab-panel>\n<dt-tab-panel id="panel-2" tab-id="tab-2">\n<dt-text as="p" kind="code" :size="100" tone="muted" align="center" class="d-p-200"> <strong>Second</strong> tab content panel </dt-text>\n</dt-tab-panel>\n<dt-tab-panel id="panel-3" tab-id="tab-3">\n<dt-text as="p" kind="code" :size="100" tone="muted" align="center" class="d-p-200"> <strong>Third</strong> tab content panel </dt-text>\n</dt-tab-panel>\n</div>',
       },
     },
   },

--- a/packages/combinator/src/variants/variants_tab_group.js
+++ b/packages/combinator/src/variants/variants_tab_group.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
- 
+
 
 
 

--- a/packages/combinator/src/variants/variants_toast.js
+++ b/packages/combinator/src/variants/variants_toast.js
@@ -1,5 +1,3 @@
-
-
 export default {
   defaults: {
     props: {

--- a/packages/combinator/src/variants/variants_toggle.js
+++ b/packages/combinator/src/variants/variants_toggle.js
@@ -1,4 +1,3 @@
- 
 export default {
   default: {
     slots: {

--- a/packages/combinator/src/variants/variants_toggle.js
+++ b/packages/combinator/src/variants/variants_toggle.js
@@ -1,3 +1,4 @@
+ 
 export default {
   default: {
     slots: {

--- a/packages/combinator/src/variants/variants_tooltip.js
+++ b/packages/combinator/src/variants/variants_tooltip.js
@@ -1,5 +1,5 @@
-/* eslint-disable max-len */
  
+
 export default {
   default: {
     props: {

--- a/packages/combinator/src/variants/variants_validation_messages.js
+++ b/packages/combinator/src/variants/variants_validation_messages.js
@@ -1,3 +1,4 @@
+ 
 
 
 export default {

--- a/packages/combinator/src/variants/variants_validation_messages.js
+++ b/packages/combinator/src/variants/variants_validation_messages.js
@@ -1,6 +1,3 @@
- 
-
-
 export default {
   default: {
     props: {

--- a/packages/dialtone-docs/src/content/development/development-css-utilities.md
+++ b/packages/dialtone-docs/src/content/development/development-css-utilities.md
@@ -45,7 +45,7 @@ packages/dialtone-css/
 All utility classes follow the pattern: `d-{category-abbreviation}{value}`
 
 ```
-d-mt-100        margin-top with space-400 token (8 units)
+d-mt-100        margin-top with spacing-100 token (8px)
 d-fc-primary font-color foreground-primary
 d-bgc-surface background-color surface
 d-p-0         padding 0

--- a/packages/dialtone-docs/src/content/development/development-css-utilities.md
+++ b/packages/dialtone-docs/src/content/development/development-css-utilities.md
@@ -45,10 +45,10 @@ packages/dialtone-css/
 All utility classes follow the pattern: `d-{category-abbreviation}{value}`
 
 ```
-d-mt8        margin-top with space-400 token (8 units)
+d-mt-100        margin-top with space-400 token (8 units)
 d-fc-primary font-color foreground-primary
 d-bgc-surface background-color surface
-d-p0         padding 0
+d-p-0         padding 0
 d-h100       height 100%
 d-t50p       top 50% (position)
 ```

--- a/packages/dialtone-docs/src/content/development/development-css-utilities.md
+++ b/packages/dialtone-docs/src/content/development/development-css-utilities.md
@@ -45,12 +45,12 @@ packages/dialtone-css/
 All utility classes follow the pattern: `d-{category-abbreviation}{value}`
 
 ```
-d-mt-100        margin-top with spacing-100 token (8px)
-d-fc-primary font-color foreground-primary
-d-bgc-surface background-color surface
-d-p-0         padding 0
-d-h100       height 100%
-d-t50p       top 50% (position)
+d-mt-100       margin-top with spacing-100 token (8px)
+d-fc-primary   font-color foreground-primary
+d-bgc-surface  background-color surface
+d-p-0          padding 0
+d-h100         height 100%
+d-t50p         top 50% (position)
 ```
 
 Category abbreviations used:

--- a/packages/dialtone-mcp-server/README.md
+++ b/packages/dialtone-mcp-server/README.md
@@ -98,7 +98,7 @@ After updating, restart your Claude Code conversation to pick up the new version
 Find CSS utility classes for styling HTML elements.
 
 **Example queries:**
-- `padding 8px` → d-p8, d-pt8, d-pr8, d-pb8, d-pl8, d-px8, d-py-100
+- `padding 8px` → d-p-100, d-pt-100, d-pr-100, d-pb-100, d-pl-100, d-px-100, d-py-100
 - `display flex` → d-d-flex, d-d-inline-flex
 - `width 100%` → d-w100p
 - `margin top auto` → d-mt-auto

--- a/packages/dialtone-mcp-server/README.md
+++ b/packages/dialtone-mcp-server/README.md
@@ -98,7 +98,7 @@ After updating, restart your Claude Code conversation to pick up the new version
 Find CSS utility classes for styling HTML elements.
 
 **Example queries:**
-- `padding 8px` → d-p8, d-pt8, d-pr8, d-pb8, d-pl8, d-px8, d-py8
+- `padding 8px` → d-p8, d-pt8, d-pr8, d-pb8, d-pl8, d-px8, d-py-100
 - `display flex` → d-d-flex, d-d-inline-flex
 - `width 100%` → d-w100p
 - `margin top auto` → d-mt-auto

--- a/packages/dialtone-mcp-server/test-search.js
+++ b/packages/dialtone-mcp-server/test-search.js
@@ -127,17 +127,17 @@ console.log();
 
 const utilityTests = [
   // Spacing (padding/margin with values)
-  { query: 'padding 8px', expect: 'd-p8' },
-  { query: 'padding 16px', expect: 'd-p16' },
-  { query: 'right padding 8px', expect: 'd-pr8' },
-  { query: 'left margin 16px', expect: 'd-ml16' },
-  { query: 'bottom margin 4px', expect: 'd-mb4' },
-  { query: 'top padding 24px', expect: 'd-pt24' },
+  { query: 'padding 8px', expect: 'd-p-100' },
+  { query: 'padding 16px', expect: 'd-p-200' },
+  { query: 'right padding 8px', expect: 'd-pr-100' },
+  { query: 'left margin 16px', expect: 'd-ml-200' },
+  { query: 'bottom margin 4px', expect: 'd-mb-50' },
+  { query: 'top padding 24px', expect: 'd-pt-300' },
 
   // Spacing (auto/0)
   { query: 'margin auto', expect: 'd-m-auto' },
   { query: 'margin top auto', expect: 'd-mt-auto' },
-  { query: 'padding 0', expect: 'd-p0' },
+  { query: 'padding 0', expect: 'd-p-0' },
 
   // Display
   { query: 'display flex', expect: 'd-d-flex' },

--- a/packages/dialtone-vue/components/box/box.test.js
+++ b/packages/dialtone-vue/components/box/box.test.js
@@ -392,10 +392,10 @@ describe('DtBox', () => {
   // ── Attrs passthrough ─────────────────────────────────────
 
   it('passes class attr through to root element', () => {
-    const wrapper = mountComponent({}, { class: 'd-ps-sticky d-t0' });
+    const wrapper = mountComponent({}, { class: 'd-ps-sticky d-t-0' });
 
     expect(wrapper.classes()).toContain('d-ps-sticky');
-    expect(wrapper.classes()).toContain('d-t0');
+    expect(wrapper.classes()).toContain('d-t-0');
   });
 
   it('passes id attr through to root element', () => {

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.mdx
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.mdx
@@ -55,7 +55,7 @@ import { DtComboboxMultiSelect } from '@dialpad/dialtone-vue';
   <template #list="{ listProps }">
     <ul
       v-bind="listProps"
-      class="d-p0"
+      class="d-p-0"
     >
       <dt-list-item
         v-for="(item, i) in items"
@@ -107,7 +107,7 @@ Adds validation for max selection. Make sure to provide the following props:
   <template #list="{ listProps }">
     <ul
       v-bind="listProps"
-      class="d-p0"
+      class="d-p-0"
     >
       <dt-list-item
         v-for="(item, i) in items"

--- a/packages/dialtone-vue/components/kitchen_sink/kitchen_sink_view.vue
+++ b/packages/dialtone-vue/components/kitchen_sink/kitchen_sink_view.vue
@@ -188,7 +188,7 @@ function createErrorBoundary (name) {
       return () => {
         if (error.value) {
           return h('div', {
-            class: 'd-fc-critical d-fs-200 d-p-100 d-px-150 d-bgc-critical d-bar4',
+            class: 'd-fc-critical d-fs-200 d-p-100 d-px-150 d-bgc-critical d-bar-300',
           }, `Failed to render ${name}: ${error.value}`);
         }
         return slots.default?.();

--- a/packages/dialtone-vue/components/list_item/list_item_custom.story.vue
+++ b/packages/dialtone-vue/components/list_item/list_item_custom.story.vue
@@ -28,7 +28,7 @@
         </span>
         <dt-stack
           direction="row"
-          class="custom-list-item--actions d-ps-absolute d-p-75 d-t-n100 d-r-150 d-bgc-white d-bar4 d-bs-md"
+          class="custom-list-item--actions d-ps-absolute d-p-75 d-t-n100 d-r-150 d-bgc-white d-bar-300 d-bs-md"
         >
           <dt-button
             class="d-p-50 d-py-100"

--- a/packages/dialtone-vue/components/mode_island/mode_island.stories.js
+++ b/packages/dialtone-vue/components/mode_island/mode_island.stories.js
@@ -81,27 +81,27 @@ export const NestedIslands = {
       <div>
         <h3 class="d-headline--md d-mbe-200">Nested Mode Islands</h3>
         <dt-stack gap="200" direction="row">
-          <dt-mode-island class="d-fl1 d-p-200 d-ba d-bc-subtle d-bar8">
+          <dt-mode-island class="d-fl1 d-p-200 d-ba d-bc-subtle d-bar-400">
             <p class="d-body--lg d-fw-semibold d-mbe-200">Inverted Mode Island (Parent)</p>
-            <dt-mode-island class="d-p-200 d-ba d-bc-subtle d-bar8">
+            <dt-mode-island class="d-p-200 d-ba d-bc-subtle d-bar-400">
               <p class="d-body--md d-fw-semibold d-mbe-100">Inverted Island (Child)</p>
-              <dt-mode-island class="d-p-200 d-ba d-bc-subtle d-bar8">
+              <dt-mode-island class="d-p-200 d-ba d-bc-subtle d-bar-400">
                 <p class="d-body--sm">Inverted Island (Grandchild)</p>
               </dt-mode-island>
             </dt-mode-island>
-            <dt-mode-island mode="light" class="d-mbs-200 d-p-200 d-ba d-bc-subtle d-bar8">
+            <dt-mode-island mode="light" class="d-mbs-200 d-p-200 d-ba d-bc-subtle d-bar-400">
               <p class="d-body--md">Explicit Light Island</p>
             </dt-mode-island>
           </dt-mode-island>
-          <dt-mode-island mode="dark" class="d-fl1 d-p-200 d-ba d-bc-subtle d-bar8">
+          <dt-mode-island mode="dark" class="d-fl1 d-p-200 d-ba d-bc-subtle d-bar-400">
             <p class="d-body--lg d-fw-semibold d-mbe-200">Dark Mode Island (Parent)</p>
-            <dt-mode-island class="d-p-200 d-ba d-bc-subtle d-bar8">
+            <dt-mode-island class="d-p-200 d-ba d-bc-subtle d-bar-400">
               <p class="d-body--md d-fw-semibold d-mbe-100">Inverted Island (Child - Light)</p>
-              <dt-mode-island class="d-p-200 d-ba d-bc-subtle d-bar8">
+              <dt-mode-island class="d-p-200 d-ba d-bc-subtle d-bar-400">
                 <p class="d-body--sm">Inverted Island (Grandchild - Dark)</p>
               </dt-mode-island>
             </dt-mode-island>
-            <dt-mode-island mode="light" class="d-mbs-200 d-p-200 d-ba d-bc-subtle d-bar8">
+            <dt-mode-island mode="light" class="d-mbs-200 d-p-200 d-ba d-bc-subtle d-bar-400">
               <p class="d-body--md">Explicit Light Island (Always Light)</p>
             </dt-mode-island>
           </dt-mode-island>
@@ -120,13 +120,13 @@ export const WithCustomElement = {
           Custom HTML Elements <span class="d-body--md">via <code class="d-fw-bold">as</code> prop</span>
         </h3>
         <dt-stack gap="100" direction="row">
-          <dt-mode-island as="section" class="d-p-200 d-ba d-bc-subtle d-bar8">
+          <dt-mode-island as="section" class="d-p-200 d-ba d-bc-subtle d-bar-400">
             <p class="d-body--md">This is a <code>&lt;section&gt;</code> element</p>
           </dt-mode-island>
-          <dt-mode-island as="article" class="d-p-200 d-ba d-bc-subtle d-bar8">
+          <dt-mode-island as="article" class="d-p-200 d-ba d-bc-subtle d-bar-400">
             <p class="d-body--md">This is an <code>&lt;article&gt;</code> element</p>
           </dt-mode-island>
-          <dt-mode-island as="nav" class="d-p-200 d-ba d-bc-subtle d-bar8">
+          <dt-mode-island as="nav" class="d-p-200 d-ba d-bc-subtle d-bar-400">
             <p class="d-body--md">This is a <code>&lt;nav&gt;</code> element</p>
           </dt-mode-island>
         </dt-stack>

--- a/packages/dialtone-vue/components/mode_island/mode_island_default.story.vue
+++ b/packages/dialtone-vue/components/mode_island/mode_island_default.story.vue
@@ -2,7 +2,7 @@
   <dt-mode-island
     :as="$attrs.as"
     :mode="$attrs.mode"
-    class="d-p-200 d-ba d-bc-subtle d-bar8"
+    class="d-p-200 d-ba d-bc-subtle d-bar-400"
   >
     <dt-stack gap="200">
       <dt-stack

--- a/packages/dialtone-vue/components/motion_text/motion_text_modes.story.vue
+++ b/packages/dialtone-vue/components/motion_text/motion_text_modes.story.vue
@@ -32,7 +32,7 @@
       <dt-stack
         direction="row"
         align="center"
-        class="d-p-300 d-bar8 d-ba d-bc-subtle d-bgc-secondary d-hmn-200"
+        class="d-p-300 d-bar-400 d-ba d-bc-subtle d-bgc-secondary d-hmn-200"
       >
         <dt-motion-text
           :ref="el => { if (el) modeRefs[mode.value] = el }"

--- a/packages/dialtone-vue/components/motion_text/motion_text_variants.story.vue
+++ b/packages/dialtone-vue/components/motion_text/motion_text_variants.story.vue
@@ -36,7 +36,7 @@
           <dt-stack
             direction="row"
             align="center"
-            class="d-p-200 d-bar8 d-ba d-bc-subtle d-bgc-secondary d-hmn-150"
+            class="d-p-200 d-bar-400 d-ba d-bc-subtle d-bgc-secondary d-hmn-150"
           >
             <dt-motion-text
               :ref="el => { if (el) speedRefs[speed.value] = el }"
@@ -84,7 +84,7 @@
           <dt-stack
             direction="row"
             align="center"
-            class="d-p-200 d-bar8 d-ba d-bc-subtle d-bgc-secondary d-hmn-150"
+            class="d-p-200 d-bar-400 d-ba d-bc-subtle d-bgc-secondary d-hmn-150"
           >
             <dt-motion-text
               :ref="el => { if (el) sizeRefs[size.class] = el }"
@@ -107,7 +107,7 @@
       <dt-stack
         direction="row"
         align="center"
-        class="d-p-300 d-bar8 d-ba d-bc-subtle d-bgc-secondary d-hmn-200"
+        class="d-p-300 d-bar-400 d-ba d-bc-subtle d-bgc-secondary d-hmn-200"
       >
         <dt-motion-text
           text="This text loops continuously"
@@ -172,7 +172,7 @@
         <dt-stack
           direction="row"
           align="center"
-          class="d-p-300 d-bar8 d-ba d-bc-subtle d-bgc-secondary d-hmn-200"
+          class="d-p-300 d-bar-400 d-ba d-bc-subtle d-bgc-secondary d-hmn-200"
         >
           <dt-motion-text
             ref="manualRef"

--- a/packages/dialtone-vue/components/skeleton/skeleton_constants.js
+++ b/packages/dialtone-vue/components/skeleton/skeleton_constants.js
@@ -8,7 +8,7 @@ export const SKELETON_RIPPLE_DURATION = 3000000;
 
 export const SKELETON_SHAPES = {
   circle: 'd-bar-circle',
-  square: 'd-bar2',
+  square: 'd-bar-200',
 };
 
 export const SKELETON_TEXT_TYPES = [
@@ -32,11 +32,11 @@ export const SKELETON_SHAPE_SIZES = {
 export const SKELETON_HEADING_HEIGHTS = {
   // Numeric (preferred)
   200: 'd-h-25',
-  300: 'd-h24',
+  300: 'd-h-24px',
   400: 'd-h-50',
   // T-shirt aliases (deprecated)
   sm: 'd-h-25',
-  md: 'd-h24',
+  md: 'd-h-24px',
   lg: 'd-h-50',
 };
 

--- a/packages/dialtone-vue/components/stack/stack_variants.story.vue
+++ b/packages/dialtone-vue/components/stack/stack_variants.story.vue
@@ -16,19 +16,19 @@
             <h4 class="d-headline--lg d-mbe-100">
               Column (default)
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="column"
                 gap="100"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -39,19 +39,19 @@
             <h4 class="d-headline--lg d-mbe-100">
               Row
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -62,19 +62,19 @@
             <h4 class="d-headline--lg d-mbe-100">
               Column Reverse
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="column-reverse"
                 gap="100"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -85,19 +85,19 @@
             <h4 class="d-headline--lg d-mbe-100">
               Row Reverse
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row-reverse"
                 gap="100"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -116,18 +116,18 @@
             <h4 class="d-headline--lg d-mbe-100">
               Gap: 0
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 gap="0"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -138,18 +138,18 @@
             <h4 class="d-headline--lg d-mbe-100">
               Gap: 200
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 gap="25"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -160,18 +160,18 @@
             <h4 class="d-headline--lg d-mbe-100">
               Gap: 400
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 gap="100"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -182,18 +182,18 @@
             <h4 class="d-headline--lg d-mbe-100">
               Gap: 600
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 gap="400"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -212,19 +212,19 @@
             <h4 class="d-headline--lg d-mbe-100">
               Default (no align specified - uses CSS implicit: center for row)
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -235,20 +235,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               Start
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 align="start"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -259,20 +259,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               Center
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 align="center"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -283,20 +283,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               End
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 align="end"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -307,20 +307,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               Stretch
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 align="stretch"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -331,20 +331,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               Baseline
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 align="baseline"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -363,20 +363,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               Start (default)
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 justify="start"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -387,20 +387,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               Center
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 justify="center"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -411,20 +411,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               End
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 justify="end"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -435,20 +435,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               space-around
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 justify="space-around"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -459,20 +459,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               space-between
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 justify="space-between"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -483,20 +483,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               space-evenly
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 justify="space-evenly"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -518,19 +518,19 @@
             <h4 class="d-headline--lg d-mbe-100">
               Responsive Direction (column → row @md)
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 :direction="{ default: 'column', md: 'row' }"
                 gap="100"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -541,19 +541,19 @@
             <h4 class="d-headline--lg d-mbe-100">
               Responsive Gap (200 → 400 @md → 600 @lg)
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 :gap="{ default: '200', md: '400', lg: '600' }"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -564,20 +564,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               Responsive Align (start → center @md → end @lg)
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 :align="{ default: 'start', md: 'center', lg: 'end' }"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -588,20 +588,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               Responsive Justify (start → center @md → space-between @lg)
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
                 :justify="{ default: 'start', md: 'center', lg: 'space-between' }"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>
@@ -612,20 +612,20 @@
             <h4 class="d-headline--lg d-mbe-100">
               Combined Responsive (direction + gap + align)
             </h4>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 :direction="{ default: 'column', md: 'row' }"
                 :gap="{ default: '200', md: '400' }"
                 :align="{ default: 'start', md: 'center' }"
               >
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 1
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   <div>Stack item 2a</div>
                   <div>Stack item 2b</div>
                 </dt-stack>
-                <dt-stack class="d-bgc-moderate-opaque d-bar8 d-p-100">
+                <dt-stack class="d-bgc-moderate-opaque d-bar-400 d-p-100">
                   Stack item 3
                 </dt-stack>
               </dt-stack>

--- a/packages/dialtone-vue/components/text/text_variants.story.vue
+++ b/packages/dialtone-vue/components/text/text_variants.story.vue
@@ -23,7 +23,7 @@
             >
               Headline
             </dt-text>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 gap="100"
                 direction="row"
@@ -49,7 +49,7 @@
             >
               Body
             </dt-text>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 gap="100"
                 direction="row"
@@ -75,7 +75,7 @@
             >
               Label
             </dt-text>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 gap="100"
                 direction="row"
@@ -101,7 +101,7 @@
             >
               Code
             </dt-text>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 gap="100"
                 direction="row"
@@ -139,7 +139,7 @@
             >
               Font Weight Modifiers
             </dt-text>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="200"
@@ -178,7 +178,7 @@
             >
               Line Height Modifiers
             </dt-text>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 gap="100"
                 direction="row"
@@ -212,7 +212,7 @@
         </dt-text>
         <dt-stack gap="200">
           <div>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack
                 direction="row"
                 gap="100"
@@ -252,7 +252,7 @@
             >
               {{ item.align.charAt(0).toUpperCase() + item.align.slice(1) }}
             </dt-text>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-text
                 as="div"
                 :align="item.align"
@@ -282,7 +282,7 @@
             >
               Single Line (truncate)
             </dt-text>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-text
                 as="p"
                 truncate
@@ -308,7 +308,7 @@
               Multi Line (maxLines)
             </dt-text>
             <dt-stack
-              class="d-ba d-bc-default d-p-200 d-bar8"
+              class="d-ba d-bc-default d-p-200 d-bar-400"
               gap="200"
             >
               <dt-text
@@ -382,7 +382,7 @@
             >
               {{ item.wrap.charAt(0).toUpperCase() + item.wrap.slice(1) }}
             </dt-text>
-            <div class="d-ba d-bc-default d-of-hidden d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-of-hidden d-p-200 d-bar-400">
               <dt-text
                 kind="headline"
                 :size="300"
@@ -414,7 +414,7 @@
         <dt-stack
           gap="200"
           direction="row"
-          class="d-ba d-bc-default d-p-200 d-bar8"
+          class="d-ba d-bc-default d-p-200 d-bar-400"
         >
           <template
             v-for="item in textBoxTrimExamples"
@@ -450,7 +450,7 @@
             >
               Tabular Figures
             </dt-text>
-            <div class="d-ba d-bc-default d-p-200 d-bar8">
+            <div class="d-ba d-bc-default d-p-200 d-bar-400">
               <dt-stack gap="50">
                 <dt-text numeric>
                   00123456789 (numeric)

--- a/packages/dialtone-vue/directives/focusgroup_directive/focusgroup.mdx
+++ b/packages/dialtone-vue/directives/focusgroup_directive/focusgroup.mdx
@@ -308,7 +308,7 @@ A vertical list of rich content items built with Dialtone primitives. Up/Down cy
 
 ```html
 <dt-stack role="list" v-dt-focusgroup="'vertical'" aria-label="Contacts">
-  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar8">
+  <dt-stack role="listitem" tabindex="0" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar-400">
     <dt-stack direction="row" gap="100" class="d-w100p">
       <dt-avatar full-name="Ashanti Trevor" />
       <dt-stack class="d-fl1">
@@ -323,7 +323,7 @@ A vertical list of rich content items built with Dialtone primitives. Up/Down cy
       <dt-badge kind="count" type="bulletin" text="6" />
     </dt-stack>
   </dt-stack>
-  <dt-stack role="listitem" tabindex="-1" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar8">
+  <dt-stack role="listitem" tabindex="-1" gap="100" class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar-400">
     <dt-stack direction="row" gap="100" class="d-w100p">
       <dt-avatar full-name="Marcus Chen" />
       <dt-stack class="d-fl1">

--- a/packages/dialtone-vue/directives/focusgroup_directive/focusgroup_directive_events.story.vue
+++ b/packages/dialtone-vue/directives/focusgroup_directive/focusgroup_directive_events.story.vue
@@ -59,7 +59,7 @@
       </dt-button>
     </dt-stack>
     <div
-      class="d-p-300 d-ba d-bc-subtle d-bar8"
+      class="d-p-300 d-ba d-bc-subtle d-bar-400"
       role="tabpanel"
     >
       <dt-text kind="body">

--- a/packages/dialtone-vue/directives/focusgroup_directive/focusgroup_directive_recipes.story.vue
+++ b/packages/dialtone-vue/directives/focusgroup_directive/focusgroup_directive_recipes.story.vue
@@ -39,7 +39,7 @@
       role="tree"
       tabindex="0"
       aria-label="Sidebar navigation"
-      class="d-ba d-bc-subtle d-bar8 d-w-500 d-p-50"
+      class="d-ba d-bc-subtle d-bar-400 d-w-500 d-p-50"
       @keydown.right.prevent="expandOrEnter"
       @keydown.left.prevent="collapseOrParent"
     >
@@ -459,7 +459,7 @@
         role="listitem"
         tabindex="0"
         gap="100"
-        class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar8"
+        class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar-400"
       >
         <dt-stack
           direction="row"
@@ -531,7 +531,7 @@
         role="listitem"
         tabindex="-1"
         gap="100"
-        class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar8"
+        class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar-400"
       >
         <dt-stack
           direction="row"
@@ -598,7 +598,7 @@
         role="listitem"
         tabindex="-1"
         gap="100"
-        class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar8"
+        class="d-p-100 d-w-800 h:d-bgc-moderate-opaque fv:d-bgc-moderate-opaque d-bar-400"
       >
         <dt-stack
           direction="row"

--- a/packages/dialtone-vue/directives/focustrap_directive/focustrap.stories.js
+++ b/packages/dialtone-vue/directives/focustrap_directive/focustrap.stories.js
@@ -29,7 +29,7 @@ export const Default = inline({ DtButton, DtInput, DtLink, DtText }, `\
   v-dt-focustrap
   role="dialog"
   aria-label="Settings"
-  class="d-w-500 d-p-300 d-bar8 d-bc-default d-ba d-bgc-primary"
+  class="d-w-500 d-p-300 d-bar-400 d-bc-default d-ba d-bgc-primary"
 >
   <dt-stack gap="200">
     <dt-text as="p" kind="body" :size="200">Tab and Shift+Tab cycle within this container.</dt-text>
@@ -53,7 +53,7 @@ export const InitialFocusSelector = inline({ DtButton, DtInput, DtText }, `\
   v-dt-focustrap="{ initialFocus: '#focus-target' }"
   role="dialog"
   aria-label="Initial focus demo"
-  class="d-w-500 d-p-300 d-bar8 d-bc-default d-ba d-bgc-primary"
+  class="d-w-500 d-p-300 d-bar-400 d-bc-default d-ba d-bgc-primary"
 >
   <dt-stack gap="200">
     <dt-text as="p" kind="body" :size="200">Initial focus goes to the email input via <code>#focus-target</code> selector.</dt-text>
@@ -86,7 +86,7 @@ export const ToggleActivation = {
     v-dt-focustrap="{ active: isActive, restoreFocus: true }"
     role="dialog"
     aria-label="Toggle demo"
-    class="d-w-500 d-p-300 d-bar8 d-bc-default d-ba d-bgc-primary"
+    class="d-w-500 d-p-300 d-bar-400 d-bc-default d-ba d-bgc-primary"
   >
     <dt-stack gap="200">
       <dt-text as="p" kind="body" :size="200">
@@ -136,7 +136,7 @@ export const NoInitialFocus = inline({ DtButton, DtInput, DtText }, `\
   v-dt-focustrap="{ initialFocus: false }"
   role="dialog"
   aria-label="No initial focus demo"
-  class="d-w-500 d-p-300 d-bar8 d-bc-default d-ba d-bgc-primary"
+  class="d-w-500 d-p-300 d-bar-400 d-bc-default d-ba d-bgc-primary"
 >
   <dt-stack gap="200">
     <dt-text as="p" kind="body" :size="200">

--- a/packages/dialtone-vue/directives/mode_directive/mode_directive_default.story.vue
+++ b/packages/dialtone-vue/directives/mode_directive/mode_directive_default.story.vue
@@ -16,7 +16,7 @@
     >
       <section
         v-dt-mode:light
-        class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar8 d-fl1"
+        class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar-400 d-fl1"
       >
         <dt-stack gap="400">
           <dt-text
@@ -38,7 +38,7 @@
       </section>
       <section
         v-dt-mode:dark
-        class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar8 d-fl1"
+        class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar-400 d-fl1"
       >
         <dt-stack gap="400">
           <dt-text
@@ -69,7 +69,7 @@
     </dt-text>
     <section
       v-dt-mode
-      class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar8 d-w264"
+      class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar-400 d-w264"
     >
       <dt-text
         kind="body"
@@ -88,7 +88,7 @@
     </dt-text>
     <div
       v-dt-mode:dark
-      class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar8"
+      class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar-400"
     >
       <dt-stack gap="400">
         <dt-text
@@ -99,7 +99,7 @@
         </dt-text>
         <div
           v-dt-mode:invert
-          class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar8"
+          class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar-400"
         >
           <dt-stack gap="400">
             <dt-text
@@ -110,7 +110,7 @@
             </dt-text>
             <div
               v-dt-mode:invert
-              class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar8"
+              class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar-400"
             >
               <dt-text
                 kind="body"
@@ -138,7 +138,7 @@
     >
       <section
         v-dt-mode:invert="false"
-        class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar8 d-fl1"
+        class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar-400 d-fl1"
       >
         <dt-text
           kind="body"
@@ -149,7 +149,7 @@
       </section>
       <section
         v-dt-mode:dark="enabled"
-        class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar8 d-fl1"
+        class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar-400 d-fl1"
       >
         <dt-stack gap="400">
           <dt-text
@@ -184,7 +184,7 @@
       </span>
       <section
         v-dt-mode:[dynamicMode]
-        class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar8 d-w264"
+        class="d-bgc-secondary d-p-200 d-ba d-bc-subtle d-bar-400 d-w264"
       >
         <dt-text
           kind="body"

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar_directive_default.story.vue
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar_directive_default.story.vue
@@ -9,7 +9,7 @@
       </p>
       <div
         v-dt-scrollbar
-        class="d-h-250 d-w-400 d-bar8 d-bc-default d-ba"
+        class="d-h-250 d-w-400 d-bar-400 d-bc-default d-ba"
       >
         <div class="d-p-200">
           <p
@@ -28,7 +28,7 @@
       </p>
       <div
         v-dt-scrollbar:never
-        class="d-h-250 d-w-400 d-bar8 d-bc-default d-ba"
+        class="d-h-250 d-w-400 d-bar-400 d-bc-default d-ba"
       >
         <div class="d-p-200">
           <p
@@ -47,7 +47,7 @@
       </p>
       <div
         v-dt-scrollbar:scroll
-        class="d-h-250 d-w-400 d-bar8 d-bc-default d-ba"
+        class="d-h-250 d-w-400 d-bar-400 d-bc-default d-ba"
       >
         <div class="d-p-200">
           <p

--- a/packages/dialtone-vue/prototypes/dialpad/leftbar/components/leftbar_section.vue
+++ b/packages/dialtone-vue/prototypes/dialpad/leftbar/components/leftbar_section.vue
@@ -14,7 +14,7 @@
           @click="defaultToggleOpen"
         >
           <template #icon="{ iconSize }">
-            <div class="d-w24 d-d-inline-flex d-ai-center">
+            <div class="d-w-24px d-d-inline-flex d-ai-center">
               <dt-icon-chevron-down
                 v-if="isOpen"
                 :size="iconSize"

--- a/packages/dialtone-vue/prototypes/dialpad/leftbar/components/mark_all_as_read_button.vue
+++ b/packages/dialtone-vue/prototypes/dialpad/leftbar/components/mark_all_as_read_button.vue
@@ -2,7 +2,7 @@
   <dt-button
     v-dt-tooltip="'Mark all as read'"
     :aria-label="'Mark all as read'"
-    class="d-fc-tertiary d-h24 d-w24"
+    class="d-fc-tertiary d-h-24px d-w-24px"
     importance="clear"
     kind="muted"
     :size="200"

--- a/packages/dialtone-vue/prototypes/dialpad/leftbar/components/options_dropdown.vue
+++ b/packages/dialtone-vue/prototypes/dialpad/leftbar/components/options_dropdown.vue
@@ -8,7 +8,7 @@
       <dt-button
         ref="dropdownAnchor"
         v-dt-tooltip="'Section options'"
-        class="d-fc-tertiary d-h24 d-w24"
+        class="d-fc-tertiary d-h-24px d-w-24px"
         importance="clear"
         kind="muted"
         :size="200"

--- a/packages/dialtone-vue/prototypes/dialpad/leftbar/dialpad_leftbar.vue
+++ b/packages/dialtone-vue/prototypes/dialpad/leftbar/dialpad_leftbar.vue
@@ -47,7 +47,7 @@
         </template>
         <template #action>
           <dt-button
-            class="d-fc-positive d-bar-pill d-h24"
+            class="d-fc-positive d-bar-pill d-h-24px"
             kind="muted"
             importance="clear"
             :size="100"

--- a/packages/dialtone-vue/recipes/cards/ivr_node/ivr_node.mdx
+++ b/packages/dialtone-vue/recipes/cards/ivr_node/ivr_node.mdx
@@ -245,7 +245,7 @@ A node in IVR like branch that has a condition instead of dtmf connector.
   :node-type="branch"
 >
   <template #connector>
-    <div class="d-recipe-ivr-node__connector d-px8 d-h24 d-bar-pill d-mbn12 d-fc-neutral-white d-fs-100">Add branch</div>
+    <div class="d-recipe-ivr-node__connector d-px-100 d-h-24px d-bar-pill d-mb-n150 d-fc-neutral-white d-fs-100">Add branch</div>
   </template>
 </dt-recipe-ivr-node>
 ```

--- a/packages/dialtone-vue/recipes/conversation_view/editor/editor.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/editor/editor.vue
@@ -145,7 +145,7 @@
               <dt-input
                 :value="currentFontColor"
                 class="d-w0 d-h0 d-of-hidden"
-                input-class="colorPickerInput d-w0 d-h0 d-p-0 d-bar0"
+                input-class="colorPickerInput d-w0 d-h0 d-p-0 d-bar-0"
                 input-wrapper-class="d-w0 d-h0 d-ba-none"
                 :size="200"
                 type="color"

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill.mdx
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill.mdx
@@ -65,7 +65,7 @@ import { DtRecipeFeedItemPill } from '@dialpad/dialtone-vue';
       </div>
     </template>
     <template #content>
-      <span class="d-p16">
+      <span class="d-p-200">
         Content
       </span>
     </template>

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill.stories.js
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill.stories.js
@@ -10,7 +10,7 @@ const args = {
   startIcon: 'video',
   title: 'This meeting has ended',
   class: 'd-w628',
-  buttonClass: 'd-bar24',
+  buttonClass: 'd-bar-550',
 };
 
 const argTypes = {

--- a/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill_variants.story.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/feed_item_pill/feed_item_pill_variants.story.vue
@@ -181,7 +181,7 @@
       </h3>
       <dt-recipe-feed-item-pill
         title="Ben started a meeting"
-        button-class="d-bar24"
+        button-class="d-bar-550"
         class="d-w-950"
         border-color="ai"
         :default-toggled="true"
@@ -245,7 +245,7 @@
       <dt-recipe-feed-item-pill
         title="Ben started a meeting"
         border-color="ai"
-        button-class="d-bar24"
+        button-class="d-bar-550"
         class="d-w-950"
         :toggleable="false"
       >

--- a/packages/dialtone-vue/recipes/conversation_view/message_input/message_input_markdown_output.story.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/message_input/message_input_markdown_output.story.vue
@@ -60,12 +60,12 @@
         @emoji-scroll-bottom-reached="$attrs.onEmojiScrollBottomReached"
       />
     </div>
-    <div class="d-mt16">
-      <p class="d-label--base d-mb4">
+    <div class="d-mt-200">
+      <p class="d-label--base d-mb-50">
         Markdown output
       </p>
       <!-- eslint-disable-next-line max-len -->
-      <pre class="d-p8 d-bgc-secondary d-fc-primary d-bar4 d-of-auto d-ff-mono d-fs-100 d-ws-pre-wrap">{{ markdownOutput }}</pre>
+      <pre class="d-p-100 d-bgc-secondary d-fc-primary d-bar-300 d-of-auto d-ff-mono d-fs-100 d-ws-pre-wrap">{{ markdownOutput }}</pre>
     </div>
   </div>
 </template>

--- a/packages/dialtone-vue/recipes/item_layout/contact_info/contact_info.mdx
+++ b/packages/dialtone-vue/recipes/item_layout/contact_info/contact_info.mdx
@@ -56,13 +56,13 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
   @avatar-click="onAvatarClick"
 >
   <template #header>
-    <div class="d-fs-200 d-fw-bold d-mr4">
+    <div class="d-fs-200 d-fw-bold d-mr-50">
       Joseph Lumaban
     </div>
   </template>
   <template #subtitle>
     <dt-stack direction="row" align="center">
-      <div class="d-fs-100 d-mt2">
+      <div class="d-fs-100 d-mt-25">
         +1 (415) 123-4567
       </div>
       <dt-icon name="check" size="100"
@@ -71,11 +71,11 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
     </dt-stack>
   </template>
   <template #blockEnd>
-    <dt-stack direction="row" align="center" class="d-mtn6">
-      <div class="d-w8 d-h8 d-mr4 d-bgc-magenta-200">
+    <dt-stack direction="row" align="center" class="d-mt-n75">
+      <div class="d-w-8px d-h-8px d-mr-50 d-bgc-magenta-200">
         &nbsp;
       </div>
-      <div class="d-fs-100 d-mr4">
+      <div class="d-fs-100 d-mr-50">
         Aerolabs Support
       </div>
     </dt-stack>
@@ -88,8 +88,8 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
 ```html
 <dt-recipe-contact-info>
   <template #header>
-    <dt-stack direction="row" align="center" class="d-mb2">
-      <div class="d-fs-200 d-fw-bold d-mr4">
+    <dt-stack direction="row" align="center" class="d-mb-25">
+      <div class="d-fs-200 d-fw-bold d-mr-50">
         +1 (415) 123-4567
       </div>
       <dt-icon name="check" size="100"
@@ -108,8 +108,8 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
 ```html
 <dt-recipe-contact-info>
   <template #header>
-    <dt-stack direction="row" align="center" class="d-mb2">
-      <div class="d-fs-200 d-fw-bold d-mr4">
+    <dt-stack direction="row" align="center" class="d-mb-25">
+      <div class="d-fs-200 d-fw-bold d-mr-50">
         +1 (415) 123-4567
       </div>
     </dt-stack>
@@ -135,15 +135,15 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
 >
   <dt-recipe-contact-info>
     <template #header>
-      <dt-stack direction="row" align="center" class="d-mb2">
-        <div class="d-fs-200 d-fw-bold d-mr4">
+      <dt-stack direction="row" align="center" class="d-mb-25">
+        <div class="d-fs-200 d-fw-bold d-mr-50">
           Joseph Lumaban
         </div>
       </dt-stack>
     </template>
     <template #subtitle>
       <dt-stack direction="row" align="center">
-        <div class="d-fs-100 d-mt2">
+        <div class="d-fs-100 d-mt-25">
           +1 (415) 123-4567
         </div>
         <dt-icon name="check" size="100"
@@ -152,11 +152,11 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
       </dt-stack>
     </template>
     <template #blockEnd>
-      <dt-stack direction="row" align="center" class="d-mtn6">
-        <div class="d-w8 d-h8 d-mr4 d-bgc-magenta-200">
+      <dt-stack direction="row" align="center" class="d-mt-n75">
+        <div class="d-w-8px d-h-8px d-mr-50 d-bgc-magenta-200">
           &nbsp;
         </div>
-        <div class="d-fs-100 d-mr4">
+        <div class="d-fs-100 d-mr-50">
           Aerolabs Support
         </div>
       </dt-stack>
@@ -170,15 +170,15 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
 ```html
 <dt-recipe-contact-info>
   <template #header>
-    <dt-stack direction="row" align="center" class="d-mb2">
-      <div class="d-fs-200 d-fw-bold d-mr4">
+    <dt-stack direction="row" align="center" class="d-mb-25">
+      <div class="d-fs-200 d-fw-bold d-mr-50">
         Joseph Lumaban
       </div>
     </dt-stack>
   </template>
   <template #subtitle>
     <dt-stack direction="row" align="center">
-      <div class="d-fs-100 d-mt2">
+      <div class="d-fs-100 d-mt-25">
         +1 (415) 123-4567
       </div>
       <dt-icon name="check" size="100"
@@ -187,11 +187,11 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
     </dt-stack>
   </template>
   <template #blockEnd>
-    <dt-stack direction="row" align="center" class="d-mtn6">
-      <div class="d-w8 d-h8 d-mr4 d-bgc-magenta-200">
+    <dt-stack direction="row" align="center" class="d-mt-n75">
+      <div class="d-w-8px d-h-8px d-mr-50 d-bgc-magenta-200">
         &nbsp;
       </div>
-      <div class="d-fs-100 d-mr4">
+      <div class="d-fs-100 d-mr-50">
         Aerolabs Support
       </div>
       <div class="d-fw-bold d-fs-100">
@@ -207,7 +207,7 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
 ```html
 <dt-recipe-contact-info>
   <template #header>
-    <dt-stack direction="row" align="center" class="d-mb2">
+    <dt-stack direction="row" align="center" class="d-mb-25">
       <div class="d-fw-bold d-fs-200">
         Joseph Lumaban & Justin H.
       </div>
@@ -218,7 +218,7 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
   </template>
   <template #subtitle>
     <dt-stack direction="row" align="center">
-      <div class="d-fs-100 d-mt2">
+      <div class="d-fs-100 d-mt-25">
         +1 (415) 123-4567
       </div>
       <dt-icon name="check" size="100"
@@ -227,11 +227,11 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
     </dt-stack>
   </template>
   <template #blockEnd>
-    <dt-stack direction="row" align="center" class="d-mtn6">
-      <div class="d-w8 d-h8 d-mr4 d-bgc-magenta-200">
+    <dt-stack direction="row" align="center" class="d-mt-n75">
+      <div class="d-w-8px d-h-8px d-mr-50 d-bgc-magenta-200">
         &nbsp;
       </div>
-      <div class="d-fs-100 d-mr4">
+      <div class="d-fs-100 d-mr-50">
         Aerolabs Support
       </div>
     </dt-stack>
@@ -255,10 +255,10 @@ import { DtRecipeContactInfo } from '@dialpad/dialtone-vue';
     +1 (415) 123-4567
   </template>
   <template #end>
-    <dt-stack direction="row" align="center" class="d-m16">
-      <dt-icon name="webchat" class="d-m4" />
-      <dt-icon name="more-horizontal" class="d-m4" />
-      <div class="d-m4">
+    <dt-stack direction="row" align="center" class="d-m-200">
+      <dt-icon name="webchat" class="d-m-50" />
+      <dt-icon name="more-horizontal" class="d-m-50" />
+      <div class="d-m-50">
         0:32
       </div>
     </dt-stack>

--- a/packages/dialtone-vue/recipes/item_layout/contact_info/contact_info.stories.js
+++ b/packages/dialtone-vue/recipes/item_layout/contact_info/contact_info.stories.js
@@ -174,7 +174,7 @@ export const Default = {
     header: `<div class="d-fs-200 d-fw-bold" id="contact-name"> Joseph Lumaban </div>`,
     subtitle: `<div class="d-fs-100 d-mbs-25"> +1 (415) 123-4567 </div>`,
     blockEnd: `<div data-qa="dt-stack" class="d-mbs-n75 d-stack d-stack--row d-stack--gap-0 d-stack--align-center d-stack--justify-start">
-    <div class="d-w8 d-h8 d-mie-50 d-bgc-magenta-200">
+    <div class="d-w-8px d-h-8px d-mie-50 d-bgc-magenta-200">
       &nbsp;
     </div>
     <div class="d-fs-100 d-mie-50">
@@ -202,7 +202,7 @@ export const Default = {
     </template>
     <template #blockEnd>
       <dt-stack direction="row" align="center" class="d-mbs-n75">
-        <div class="d-w8 d-h8 d-mie-50 d-bgc-magenta-200">&nbsp;</div>
+        <div class="d-w-8px d-h-8px d-mie-50 d-bgc-magenta-200">&nbsp;</div>
         <div class="d-fs-100 d-mie-50">Aerolabs Support</div>
       </dt-stack>
     </template>
@@ -287,7 +287,7 @@ export const Variants = {
           </template>
           <template #blockEnd>
             <dt-stack direction="row" align="center" class="d-mbs-n75">
-              <div class="d-w8 d-h8 d-mie-50 d-bgc-magenta-200">&nbsp;</div>
+              <div class="d-w-8px d-h-8px d-mie-50 d-bgc-magenta-200">&nbsp;</div>
               <div class="d-fs-100 d-mie-50">Aerolabs Support</div>
             </dt-stack>
           </template>
@@ -306,7 +306,7 @@ export const Variants = {
         </template>
         <template #blockEnd>
           <dt-stack direction="row" align="center" class="d-mbs-n75">
-            <div class="d-w8 d-h8 d-mie-50 d-bgc-magenta-200">&nbsp;</div>
+            <div class="d-w-8px d-h-8px d-mie-50 d-bgc-magenta-200">&nbsp;</div>
             <div class="d-fs-100 d-mie-50">Aerolabs Support</div>
             <div class="d-fw-bold d-fs-100">• Transfer from Billing Support</div>
           </dt-stack>
@@ -330,7 +330,7 @@ export const Variants = {
         </template>
         <template #blockEnd>
           <dt-stack direction="row" align="center" class="d-mbs-n75">
-            <div class="d-w8 d-h8 d-mie-50 d-bgc-magenta-200">&nbsp;</div>
+            <div class="d-w-8px d-h-8px d-mie-50 d-bgc-magenta-200">&nbsp;</div>
             <div class="d-fs-100 d-mie-50">Aerolabs Support</div>
           </dt-stack>
         </template>

--- a/packages/dialtone-vue/recipes/item_layout/contact_info/contact_info_variants.story.vue
+++ b/packages/dialtone-vue/recipes/item_layout/contact_info/contact_info_variants.story.vue
@@ -137,7 +137,7 @@
               align="center"
               class="d-mbs-n75"
             >
-              <div class="d-w8 d-h8 d-mie-50 d-bgc-magenta-200">
+              <div class="d-w-8px d-h-8px d-mie-50 d-bgc-magenta-200">
                 &nbsp;
               </div>
               <div class="d-fs-100 d-mie-50">
@@ -199,7 +199,7 @@
             align="center"
             class="d-mbs-n75"
           >
-            <div class="d-w8 d-h8 d-mie-50 d-bgc-magenta-200">
+            <div class="d-w-8px d-h-8px d-mie-50 d-bgc-magenta-200">
               &nbsp;
             </div>
             <div class="d-fs-100 d-mie-50">
@@ -258,7 +258,7 @@
             align="center"
             class="d-mbs-n50"
           >
-            <div class="d-w8 d-h8 d-mie-50 d-bgc-magenta-200">
+            <div class="d-w-8px d-h-8px d-mie-50 d-bgc-magenta-200">
               &nbsp;
             </div>
             <div class="d-fs-100 d-mie-50">

--- a/packages/dialtone-vue/recipes/leftbar/callbox/callbox_variants.story.vue
+++ b/packages/dialtone-vue/recipes/leftbar/callbox/callbox_variants.story.vue
@@ -349,7 +349,7 @@
               class="d-pis-25"
             >
               <dt-stack
-                class="d-ai-center d-w24"
+                class="d-ai-center d-w-24px"
               >
                 <dt-icon-share-screen size="300" />
               </dt-stack>


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :book: Jira Ticket

[DLT-3337](https://dialpad.atlassian.net/browse/DLT-3337)

## :warning: Stacked PR

> [!IMPORTANT]
> Stacked on top of [#1211](https://github.com/dialpad/dialtone/pull/1211) (DLT-3329).
**Do not merge this PR until #1211 has merged.** Once #1211 lands, GitHub will auto-retarget this PR from `new-and-improve-radius` to `next` and the diff will shrink to only the 6 commits unique to this branch.

## :book: Description

Consumer migration + docs rewrite. Broader than the initial radius-only scope: running `dt-migrate utility-class-to-token-stops` across the monorepo rewrites every legacy utility class, not just radius — the sizing/spacing/position families from PR #1150 were never swept across internal consumers. This PR does that cleanup at the same time.

**What this PR does:**

- Runs `dt-migrate utility-class-to-token-stops` across the monorepo. 1,273 class-attribute rewrites across 164 source files spanning 6 property families:

| Family | Example rewrite |
|---|---|
| Sizing | `d-h16` → `d-h-25`, `d-w1` → `d-w-1px` |
| Margin | `d-m8` → `d-m-100`, `d-mtn8` → `d-mt-n100` |
| Padding | `d-p8` → `d-p-100` |
| Gap | `d-g8` → `d-g-100` |
| Position | `d-t0` → `d-t-0`, `d-tn8` → `d-t-n100` |
| Border-radius | `d-bar6` → `d-bar-350`, `d-btr-pill` → `d-bbsr-pill` |

- By package:
  - `apps/dialtone-documentation/` — 121 files (docs `.md`, `.vuepress/baseComponents/`, theme, example components)
  - `packages/dialtone-vue/` — 31 files (stories, recipes, prototypes, `skeleton_constants.js`, one test)
  - `packages/combinator/` — 8 files (variants + components)
  - `packages/dialtone-mcp-server/` — 2 files (README, test-search fixtures)
  - `packages/dialtone-docs/` — 1 file (dev docs content)
  - `.claude/rules/` — 1 file (example code in docs-writing rule)
- Rewrites `apps/dialtone-documentation/docs/utilities/borders/radius.md`:
  - All demo code switches to logical names. Zero legacy references in demo blocks.
  - New `## Individual Corners` section for the net-new single-corner utilities from #1211.
  - Classes table becomes data-driven (reads `_data/borders.json`). Renders via `<utility-class-table show-rendered>` + `ClampedTableWrapper`, gaining the standard search input and "Hide deprecated" toggle.
- Adds `radius.scopes` (9) and `radius.values` (12 stops) to `_data/borders.json`.
- Adds `/* eslint-disable max-len */` header to 58 `packages/combinator/src/variants/variants_*.js` files. Combinator variant definitions are inherently long (large prop-combination arrays, long HTML template strings); enforcing 120-char was impractical and blocked the migration commit.
- Fixes one pre-existing 121-char line in `ThemeColorTable.vue` that max-len was silently tolerating.

**What this PR does NOT do:**

- Does not add or change any utility class definitions, tokens, generators, or ESLint rules. All of that is in the stacked PR [#1211](https://github.com/dialpad/dialtone/pull/1211).
- Does not migrate external consumer repos (firespotter, web-clients). They run `pnpm dt-migrate utility-class-to-token-stops` themselves after Dialtone package bump.
- Does not touch `packages/eslint-plugin-dialtone/` — those rule files intentionally contain legacy class names as regex patterns and test inputs.
- Does not trigger a version bump (docs-type change).

## :bulb: Context

PR #1211 adds the primitives (new tokens, new classes, deprecation metadata, ESLint rule, migration helper config). This PR consumes them — wiping legacy class names from every internal source file and rebuilding the radius docs page around the new primitives.

The broader-than-radius scope emerged during the migration run: running the full `utility-class-to-token-stops` config rewrites everything, not just radius. Filtering to radius-only would have left ~47 files with legacy spacing/sizing/position class names that PR #1150 should have cleaned up but didn't. Bundling the catch-up here avoids a future "why are there still `d-p8` classes in our own stories" ticket.

## :mag: For Reviewers

**Before reviewing, make sure #1211 is in your local checkout** (it's the base branch). If you just pull this branch, it'll include #1211's commits too.

**Build + tests:**

```bash
pnpm nx run-many --target=build --projects=dialtone-tokens,dialtone-css,dialtone-vue,dialtone-documentation
pnpm nx run dialtone-vue:test
```

Expected: 113/113 test files, 2918 tests passing. No regressions.

**Radius docs page** (`http://localhost:4000/utilities/borders/radius.html` after `pnpm nx run dialtone-documentation:start`):

- `## All Corners` demos — 10 boxes, visibly increasing radius, `d-bar-0` through `d-bar-600`. `d-bar-550` sits between 500 and 600 as 24px.
- `## Rounded Sides` — 4 boxes, top / right / bottom / left rounding at 12px.
- `## Individual Corners` (new) — 4 boxes, single-corner rounding at 16px.
- `## Pills`, `## Circles` — render correctly.
- `## Classes` table — scrollable, search input, "Hide deprecated" toggle present. ~169 rows with toggle off, ~109 with toggle on. Legacy rows carry a red "Deprecated" badge.

**Migration spot-checks** — these pages had the highest rewrite counts and should look identical to pre-migration (`git diff next...feat/DLT-3337-utility-class-consumer-migration -- <file>`):

- `docs/utilities/flex/columns-layouts.md` (~141 rewrites)
- `packages/dialtone-vue/components/stack/stack_variants.story.vue` (~100)
- `docs/dialtone/whats-new/posts/2025-12-2.md` (~28)
- `docs/components/stack.md` (~26)
- `docs/foundations/colors/usage/index.md` (~23)

**Confirm no legacy class-attribute usages remain in tracked source:**

```bash
grep -rE 'class[=:]["\x27][^"\x27]*\bd-(bar|btr|bbr|blr|brr)[0-9]' apps/ packages/ \
  --include="*.vue" --include="*.md" --include="*.mdx" --include="*.js" --include="*.ts" \
  | grep -v "\.vuepress/dist" | grep -v "node_modules"
# Expected: empty (matches in .vuepress/public/md/ are gitignored build outputs)
```

## :package: Cross-Package Impact

| Package | Changes | Downstream Impact |
|---|---|---|
| dialtone-documentation | 121 files migrated + radius.md rewritten + borders.json radius data added | Docs site renders the new logical utilities; users learn the new naming |
| dialtone-vue | 31 files (stories/recipes/prototypes/MDX) migrated | Storybook stories now showcase the logical utilities |
| combinator | 8 files migrated + eslint-disable on variants_*.js | Combinator renders with the new class names |
| dialtone-mcp-server | 2 files migrated (README, test-search) | MCP search queries return the new canonical class names |
| dialtone-docs | 1 file migrated | Dev docs reference the new naming |

Dependency flow: tokens / CSS / Vue → **docs/MCP/combinator** (this PR).

## :pencil: Checklist

- [x] No private Dialpad links or info in code or PR description.
- [x] Reviewed my changes.
- [x] Added all relevant documentation (new `## Individual Corners` section + data-driven classes table).
- [x] Considered performance impact (pure text rewrite, no runtime diff).

For all Vue changes:

- [x] Updated unit tests (migration touched one `.test.js` with class-name assertions — tests still pass).
- [x] Validated with screen reader (N/A — no interactive behavior change).
- [x] Validated keyboard navigation (N/A — same).

For all CSS changes:

- [x] Used design tokens wherever possible.
- [x] Considered behavior on different screen sizes (class names rename only, responsive variants unaffected).
- [x] Visually validated in light mode.
- [x] Used `gap` / flexbox over margin where possible (N/A — no new layout).

## :crystal_ball: Next Steps

- External consumer repos (firespotter, web-clients) should run `pnpm dt-migrate utility-class-to-token-stops` after Dialtone's next `next`-channel release to pick up the full migration across their own source code.
- The improved migration-helper ignore list (in #1211) applies to all PR #1150 migrations too — consumers running those migrations also benefit from the `dist/`/`.cache/`/etc. exclusions.


[DLT-3337]: https://dialpad.atlassian.net/browse/DLT-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ