### PR TITLE
docs(tabs, popover, dropdown, button-group): DLT-3342 fix code example inaccuracies

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExamplePopover.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExamplePopover.vue
@@ -28,15 +28,15 @@
         This is the footer
       </div>
     </template>
-    <template #content>
+    <template #content="{ close }">
       <slot name="content">
         <div class="d-mb8">
           This is content rendered within the popover.
         </div>
       </slot>
-      <button class="d-btn d-btn--primary">
+      <dt-button @click="close">
         Button
-      </button>
+      </dt-button>
     </template>
   </dt-popover>
 </template>

--- a/apps/dialtone-documentation/docs/components/button-group.md
+++ b/apps/dialtone-documentation/docs/components/button-group.md
@@ -78,18 +78,18 @@ When aligned to `end`, the `primary` button is on the **right** side of the grou
 <code-example-tabs
 htmlCode='
 <div role="group" class="d-btn-group d-btn-group--end">
-  <button type="button" class="base-button__button d-btn d-btn--primary">
-    <span class="d-btn__label base-button__label"> Confirm </span>
-  </button>
   <button data-qa="dt-button" type="button" class="base-button__button d-btn d-btn--outlined">
     <span class="d-btn__label base-button__label"> Cancel </span>
+  </button>
+  <button type="button" class="base-button__button d-btn d-btn--primary">
+    <span class="d-btn__label base-button__label"> Confirm </span>
   </button>
 </div>
 '
 vueCode='
 <dt-button-group alignment="end">
-  <dt-button importance="primary">Confirm</dt-button>
   <dt-button importance="outlined">Cancel</dt-button>
+  <dt-button importance="primary">Confirm</dt-button>
 </dt-button-group>
 '
 showHtmlWarning />

--- a/apps/dialtone-documentation/docs/components/dropdown.md
+++ b/apps/dialtone-documentation/docs/components/dropdown.md
@@ -78,7 +78,7 @@ Use the Dropdown component when you have a list of links or actions that can be 
         v-for="(item) in items"
         :key="item.id"
         role="menuitem"
-        :navigation-type="arrow-keys"
+        navigation-type="arrow-keys"
         @click="close"
       >
         {{ item.name }}
@@ -127,7 +127,7 @@ vueCode='
       v-for="(item) in items"
       :key="item.id"
       role="menuitem"
-      :navigation-type="arrow-keys"
+      navigation-type="arrow-keys"
       @click="close"
     >
       {{ item.name }}
@@ -304,7 +304,7 @@ Set `openOnContext=true` to open the menu on right-click (context menu) and disa
         v-for="(item) in items"
         :key="item.id"
         role="menuitem"
-        :navigation-type="arrow-keys"
+        navigation-type="arrow-keys"
         @click="close"
       >
         {{ item.name }}
@@ -329,7 +329,7 @@ vueCode='
       v-for="(item) in items"
       :key="item.id"
       role="menuitem"
-      :navigation-type="arrow-keys"
+      navigation-type="arrow-keys"
       @click="close"
     >
       {{ item.name }}

--- a/apps/dialtone-documentation/docs/components/popover.md
+++ b/apps/dialtone-documentation/docs/components/popover.md
@@ -90,8 +90,8 @@ htmlCode='
 '
 vueCode='
 <dt-popover>
-  <template #anchor>
-    <dt-button>
+  <template #anchor="{ attrs }">
+    <dt-button v-bind="attrs">
        View Popover
     </dt-button>
   </template>
@@ -145,8 +145,8 @@ vueCode='
 <dt-popover
   :modal="false"
 >
-  <template #anchor>
-    <dt-button>
+  <template #anchor="{ attrs }">
+    <dt-button v-bind="attrs">
       View Popover
     </dt-button>
   </template>
@@ -218,8 +218,8 @@ htmlCode='
 '
 vueCode='
 <dt-popover>
-  <template #anchor>
-    <dt-button>
+  <template #anchor="{ attrs }">
+    <dt-button v-bind="attrs">
       View Popover
     </dt-button>
   </template>
@@ -296,8 +296,8 @@ htmlCode='
 '
 vueCode='
 <dt-popover>
-  <template #anchor>
-    <dt-button>
+  <template #anchor="{ attrs }">
+    <dt-button v-bind="attrs">
       View Popover
     </dt-button>
   </template>
@@ -340,8 +340,8 @@ vueCode='
 <dt-popover
   :fallback-placements="[`top`]"
 >
-  <template #anchor>
-    <dt-button>
+  <template #anchor="{ attrs }">
+    <dt-button v-bind="attrs">
        fallback placement: top
     </dt-button>
   </template>
@@ -376,8 +376,8 @@ vueCode='
 <dt-popover
   padding="small"
 >
-  <template #anchor>
-    <dt-button>
+  <template #anchor="{ attrs }">
+    <dt-button v-bind="attrs">
        View Popover
     </dt-button>
   </template>

--- a/apps/dialtone-documentation/docs/components/popover.md
+++ b/apps/dialtone-documentation/docs/components/popover.md
@@ -89,9 +89,7 @@ htmlCode='
 </div>
 '
 vueCode='
-<dt-popover
-  :open="onOpen"
->
+<dt-popover>
   <template #anchor>
     <dt-button>
        View Popover
@@ -145,7 +143,6 @@ htmlCode='
 '
 vueCode='
 <dt-popover
-  :open="onOpen"
   :modal="false"
 >
   <template #anchor>
@@ -220,9 +217,7 @@ htmlCode='
 </div>
 '
 vueCode='
-<dt-popover
-  :open="onOpen"
->
+<dt-popover>
   <template #anchor>
     <dt-button>
       View Popover
@@ -300,9 +295,7 @@ htmlCode='
 </div>
 '
 vueCode='
-<dt-popover
-  :open="onOpen"
->
+<dt-popover>
   <template #anchor>
     <dt-button>
       View Popover
@@ -345,7 +338,6 @@ manually specify which position it will move to in what order you can do so via 
 <code-example-tabs
 vueCode='
 <dt-popover
-  :open="onOpen"
   :fallback-placements="[`top`]"
 >
   <template #anchor>
@@ -382,7 +374,6 @@ Padding options for the popover content are provided via size classes "small", "
 <code-example-tabs
 vueCode='
 <dt-popover
-  :open="onOpen"
   padding="small"
 >
   <template #anchor>

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -36,7 +36,7 @@ vueCode='
     <dt-tab id="3" panel-id="4">
       Second
     </dt-tab>
-    <dt-tab id="5`" panel-id="6">
+    <dt-tab id="5" panel-id="6">
       Third
     </dt-tab>
   </template>
@@ -80,7 +80,7 @@ vueCode='
     <dt-tab id="3" panel-id="4">
       Second
     </dt-tab>
-    <dt-tab id="5`" panel-id="6">
+    <dt-tab id="5" panel-id="6">
       Third
     </dt-tab>
   </template>
@@ -125,7 +125,7 @@ vueCode='
     <dt-tab id="3" panel-id="4">
       Second
     </dt-tab>
-    <dt-tab id="5`" panel-id="6">
+    <dt-tab id="5" panel-id="6">
       Third
     </dt-tab>
   </template>
@@ -168,7 +168,7 @@ vueCode='
     <dt-tab id="3" panel-id="4" disabled>
       Second
     </dt-tab>
-    <dt-tab id="5`" panel-id="6">
+    <dt-tab id="5" panel-id="6">
       Third
     </dt-tab>
   </template>
@@ -213,7 +213,7 @@ vueCode='
     <dt-tab id="3" panel-id="4">
       Second
     </dt-tab>
-    <dt-tab id="5`" panel-id="6">
+    <dt-tab id="5" panel-id="6">
       Third
     </dt-tab>
   </template>
@@ -254,7 +254,7 @@ vueCode='
     <dt-tab id="3" panel-id="4">
       Second
     </dt-tab>
-    <dt-tab id="5`" panel-id="6">
+    <dt-tab id="5" panel-id="6">
       Third
     </dt-tab>
   </template>
@@ -303,7 +303,7 @@ vueCode='
     <dt-tab id="3" panel-id="4">
       Second
     </dt-tab>
-    <dt-tab id="5`" panel-id="6">
+    <dt-tab id="5" panel-id="6">
       Third
     </dt-tab>
   </template>


### PR DESCRIPTION
# docs(tabs, popover, dropdown, button-group): DLT-3342 fix code example inaccuracies

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExanJtZXVyeWxwcDkxZnppcDczdWx2NnRiNm93dXNxZzQ5ZWR2MGh5YiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/oO8Io8e7uHu8gJQYbg/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3342

<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

<!--- Describe specifically what the changes are -->

Claude-assisted cleanup as a follow up to the modal code examples work last week.

### Summary

- Fixed stray backtick syntax error (`id="5`"`) in all 7 tab variant vueCode examples
- Fixed incorrect `:navigation-type="arrow-keys"` binding syntax (should be a plain string attribute) in dropdown Default and Context Menu examples — live demos and vueCode
- Fixed button order mismatch in button-group End variant — vueCode and htmlCode now match the live demo (Cancel first, Confirm second)
- Removed undefined `:open="onOpen"` prop binding from all 6 popover vueCode examples — `DtPopover` manages its own open state by default
- Added missing `#anchor="{ attrs }"` + `v-bind="attrs"` to all 6 popover vueCode examples to match actual accessible usage (consistent with `ExamplePopover.vue` and the page's own accessibility guidance)
- Fixed `ExamplePopover.vue` live demo: the "Button" inside the popover content was not wired to close the popover — now uses slot scope `{ close }` and `@click="close"`

### Test plan

- [ ] Tabs page: Vue tab in each code example shows `id="5"` with no backtick
- [ ] Dropdown page: Default and Context Menu dropdowns open/close correctly; Vue tab shows `navigation-type="arrow-keys"` without colon
- [ ] Button Group page: End variant Vue and HTML tabs show Cancel before Confirm
- [ ] Popover page: All Vue tabs show `#anchor="{ attrs }"` with `v-bind="attrs"`; clicking "Button" inside any open popover closes it


## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

- All changes are docs-only; no component source, tests, or build pipeline is affected
- Follows the same pattern established in PR #1207 (modal docs cleanup)
- Toast (`closeEvent`) and combobox-with-popover (`onEscape`, `onHighlight`) were audited and confirmed as intentional placeholder handler names — no changes needed

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->
In reviewing this, there appear to be some more opportunities for updates on the Tabs page specifically, so I'll plan to make a follow-up PR to address those.

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

### Tabs

<img width="1251" height="579" alt="Screenshot 2026-04-20 at 9 07 32 AM" src="https://github.com/user-attachments/assets/444c04bb-4faf-4d43-bc2d-9023002b8ad9" />

### Popover

<img width="1249" height="574" alt="Screenshot 2026-04-20 at 9 08 02 AM" src="https://github.com/user-attachments/assets/2af44c26-5bc2-44ef-af18-95bd607c4a19" />

### Button Group

<img width="865" height="333" alt="Screenshot 2026-04-20 at 9 08 36 AM" src="https://github.com/user-attachments/assets/5f244acd-fac6-43b8-ac9c-88f8c655f135" />


## :link: Sources

<!--- Add any links to external reference material -->
