### PR TITLE
fix(rich-text-editor): DP-185735 fix arrow key navigation broken near links

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/rich-text-editor.less
+++ b/packages/dialtone-css/lib/build/less/components/rich-text-editor.less
@@ -17,6 +17,13 @@
   > .ProseMirror {
     box-shadow: none;
 
+    // inline-flex/inline-block create atomic boxes that break arrow-key cursor navigation
+    // in contenteditable — ArrowDown jumps to link start, ArrowUp freezes inside links.
+    // Resetting to inline restores correct caret positioning without affecting visual output.
+    :where(a) {
+      display: inline;
+    }
+
     p.is-editor-empty:first-child::before {
       float: left;
       height: 0;


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change
- [x] Bug fix

## :book: Jira Ticket
[DP-185735](https://dialpad.atlassian.net/browse/DP-185735)

## :book: Description
Arrow key navigation (ArrowUp / ArrowDown) was broken when the cursor was near or inside a link in the Rich Text Editor.

**Root cause:** `.d-link` sets `display: inline-flex`, which makes `<a>` elements inside ProseMirror's contenteditable behave as atomic inline-level boxes. Browsers treat `inline-flex`/`inline-block` elements as single glyphs when computing caret positions, causing:
- **ArrowDown** from the preceding line to snap to the start of the link boundary instead of moving to the horizontally-aligned character below
- **ArrowUp** inside a link to do nothing (the caret cannot exit the inline-flex box upward)

**Fix:** Added a scoped CSS override in `rich-text-editor.less` that resets `display` to `inline` for anchor tags inside `.d-rich-text-editor > .ProseMirror`. Uses `:where(a)` to keep specificity at (0,1,0) and avoid bleeding into other contexts. Links in the RTE don't use icons, so there is no visual regression from losing `inline-flex`.

## :page_facing_up: Documentation Artifacts

| Artifact | Status | Notes |
|---|---|---|
| CSS (`rich-text-editor.less`) | ✅ Updated | Scoped fix added |
| Vue source | N/A | No component logic changes |
| Tests | N/A | CSS-only fix |

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

[DP-185735]: https://dialpad.atlassian.net/browse/DP-185735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ