### PR TITLE
docs: DLT-3345 migrate d-stack*/d-flow* wrappers to DtStack

### DIFF
--- a/apps/dialtone-documentation/docs/utilities/layout/box-sizing.md
+++ b/apps/dialtone-documentation/docs/utilities/layout/box-sizing.md
@@ -9,11 +9,12 @@ keywords: ["border box", "content box"]
 All examples below have a 128px height and width. You can see how `.d-box-border` elements includes the padding and border into the overall box's height and width.
 
 ```vue demo
-<div class="d-fl-center d-w100p d-flow16">
+<!-- @wrapper -->
+<dt-stack direction="row" gap="200" class="d-fl-center d-w100p">
   <dt-stack direction="row" align="center" justify="center" class="d-size-200 d-p-100 d-ba d-baw4 d-bas-dashed d-bar-300 d-bc-default d-bgc-moderate d-box-border"><dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar-200 d-code--sm">d-box-border</dt-stack></dt-stack>
   <dt-stack direction="row" align="center" justify="center" class="d-size-200 d-p-100 d-ba d-baw4 d-bas-dashed d-bar-300 d-bc-default d-bgc-moderate d-box-content"><dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar-200 d-code--sm">d-box-content</dt-stack></dt-stack>
   <dt-stack direction="row" align="center" justify="center" class="d-size-200 d-p-100 d-ba d-baw4 d-bas-dashed d-bar-300 d-bc-default d-bgc-moderate d-box-unset"><dt-stack direction="row" align="center" justify="center" class="d-fl1 d-as-stretch d-p-100 d-bgc-moderate-opaque d-bar-200 d-code--sm">d-box-unset</dt-stack></dt-stack>
-</div>
+</dt-stack>
 ```
 
 ## Classes

--- a/packages/dialtone-vue/components/avatar/avatar_variants.story.vue
+++ b/packages/dialtone-vue/components/avatar/avatar_variants.story.vue
@@ -1,8 +1,12 @@
 <template>
-  <div class="d-stack16">
+  <dt-stack gap="200">
     <div>
       <h2>Image</h2>
-      <div class="d-flow16 d-d-flex d-ai-center">
+      <dt-stack
+        direction="row"
+        gap="200"
+        align="center"
+      >
         <dt-avatar
           v-for="size in avatarSizes"
           :key="`image-${size}`"
@@ -12,11 +16,15 @@
           :image-src="$attrs.imageSrc"
           :image-alt="$attrs.imageAlt"
         />
-      </div>
+      </dt-stack>
     </div>
     <div>
       <h2>Initials</h2>
-      <div class="d-flow16 d-d-flex d-ai-center">
+      <dt-stack
+        direction="row"
+        gap="200"
+        align="center"
+      >
         <dt-avatar
           v-for="size in avatarSizes"
           :key="`initials-${size}`"
@@ -24,11 +32,15 @@
           :size="size"
           full-name="Avatar Icon"
         />
-      </div>
+      </dt-stack>
     </div>
     <div>
       <h2>Icon</h2>
-      <div class="d-flow16 d-d-flex d-ai-center">
+      <dt-stack
+        direction="row"
+        gap="200"
+        align="center"
+      >
         <dt-avatar
           v-for="size in avatarSizes"
           :key="`icon-${size}`"
@@ -40,11 +52,15 @@
             <dt-icon-user />
           </template>
         </dt-avatar>
-      </div>
+      </dt-stack>
     </div>
     <div>
       <h2>Icon Only (Transparent Background)</h2>
-      <div class="d-flow16 d-d-flex d-ai-center">
+      <dt-stack
+        direction="row"
+        gap="200"
+        align="center"
+      >
         <dt-avatar
           icon-only
           size="300"
@@ -93,11 +109,15 @@
             <dt-icon-contacts />
           </template>
         </dt-avatar>
-      </div>
+      </dt-stack>
     </div>
     <div>
       <h2>Deactivated</h2>
-      <div class="d-flow16 d-d-flex d-ai-center">
+      <dt-stack
+        direction="row"
+        gap="200"
+        align="center"
+      >
         <dt-avatar
           :seed="$attrs.seed"
           size="300"
@@ -121,11 +141,15 @@
             <dt-icon-user />
           </template>
         </dt-avatar>
-      </div>
+      </dt-stack>
     </div>
     <div>
       <h2>Presence</h2>
-      <div class="d-flow16 d-d-flex d-ai-center">
+      <dt-stack
+        direction="row"
+        gap="200"
+        align="center"
+      >
         <dt-avatar
           v-for="state in AVATAR_PRESENCE_STATES"
           :key="`presence-${state}`"
@@ -136,11 +160,14 @@
           :image-alt="$attrs.imageAlt"
           :presence="state"
         />
-      </div>
+      </dt-stack>
     </div>
     <div>
       <h2>Overlay</h2>
-      <div class="d-flow16 d-d-flex">
+      <dt-stack
+        direction="row"
+        gap="200"
+      >
         <dt-avatar
           :seed="$attrs.seed"
           :size="500"
@@ -161,11 +188,14 @@
           :image-alt="$attrs.imageAlt"
           overlay-text="+3"
         />
-      </div>
+      </dt-stack>
     </div>
     <div>
       <h2>Clickable</h2>
-      <div class="d-flow16 d-d-flex">
+      <dt-stack
+        direction="row"
+        gap="200"
+      >
         <dt-avatar
           :seed="$attrs.seed"
           full-name="Person avatar"
@@ -187,11 +217,15 @@
           :image-alt="$attrs.imageAlt"
           clickable
         />
-      </div>
+      </dt-stack>
     </div>
     <div>
       <h2>Group (Single Digit)</h2>
-      <div class="d-flow16 d-d-flex d-ai-center">
+      <dt-stack
+        direction="row"
+        gap="200"
+        align="center"
+      >
         <dt-avatar
           v-for="size in groupSizes"
           :key="`group-${size}`"
@@ -202,8 +236,13 @@
           :image-alt="$attrs.imageAlt"
           :group="3"
         />
-      </div>
-      <div class="d-flow16 d-d-flex d-ai-center d-mbs-100">
+      </dt-stack>
+      <dt-stack
+        direction="row"
+        gap="200"
+        align="center"
+        class="d-mbs-100"
+      >
         <dt-avatar
           v-for="size in groupSizes"
           :key="`group-initials-${size}`"
@@ -212,11 +251,15 @@
           full-name="Person avatar"
           :group="5"
         />
-      </div>
+      </dt-stack>
     </div>
     <div>
       <h2>Group (Double Digit)</h2>
-      <div class="d-flow16 d-d-flex d-ai-center">
+      <dt-stack
+        direction="row"
+        gap="200"
+        align="center"
+      >
         <dt-avatar
           v-for="size in groupSizes"
           :key="`group-double-${size}`"
@@ -227,8 +270,13 @@
           :image-alt="$attrs.imageAlt"
           :group="12"
         />
-      </div>
-      <div class="d-flow16 d-d-flex d-ai-center d-mbs-100">
+      </dt-stack>
+      <dt-stack
+        direction="row"
+        gap="200"
+        align="center"
+        class="d-mbs-100"
+      >
         <dt-avatar
           v-for="size in groupSizes"
           :key="`group-double-initials-${size}`"
@@ -237,11 +285,15 @@
           full-name="Person avatar"
           :group="12"
         />
-      </div>
+      </dt-stack>
     </div>
     <div>
       <h2>Group (Triple Digit)</h2>
-      <div class="d-flow16 d-d-flex d-ai-center">
+      <dt-stack
+        direction="row"
+        gap="200"
+        align="center"
+      >
         <dt-avatar
           v-for="size in groupSizes"
           :key="`group-triple-${size}`"
@@ -252,8 +304,13 @@
           :image-alt="$attrs.imageAlt"
           :group="120"
         />
-      </div>
-      <div class="d-flow16 d-d-flex d-ai-center d-mbs-100">
+      </dt-stack>
+      <dt-stack
+        direction="row"
+        gap="200"
+        align="center"
+        class="d-mbs-100"
+      >
         <dt-avatar
           v-for="size in groupSizes"
           :key="`group-triple-initials-${size}`"
@@ -262,9 +319,9 @@
           full-name="Person avatar"
           :group="120"
         />
-      </div>
+      </dt-stack>
     </div>
-  </div>
+  </dt-stack>
 </template>
 
 <script>
@@ -279,12 +336,14 @@ import {
   DtIconContacts,
 } from '@dialpad/dialtone-icons/vue';
 import DtAvatar from './avatar.vue';
+import { DtStack } from '@/components/stack';
 import { AVATAR_PRESENCE_STATES, AVATAR_SIZE_MODIFIERS } from './avatar_constants.js';
 
 export default {
   name: 'DtAvatarVariants',
   components: {
     DtAvatar,
+    DtStack,
     DtIconUser,
     DtIconHear,
     DtIconHash,

--- a/packages/dialtone-vue/components/badge/badge_examples.story.vue
+++ b/packages/dialtone-vue/components/badge/badge_examples.story.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-fd-column d-p-300 d-w100p d-of-auto d-stack8">
+  <dt-stack gap="100">
     <h2>Kind: Label</h2>
     <dt-stack
       direction="row"
@@ -187,7 +187,7 @@
         type="bulletin"
       />
     </dt-stack>
-  </div>
+  </dt-stack>
 </template>
 
 <script>

--- a/packages/dialtone-vue/components/badge/badge_variants.story.vue
+++ b/packages/dialtone-vue/components/badge/badge_variants.story.vue
@@ -1,35 +1,33 @@
 <template>
-  <div class="d-fd-column d-of-auto d-stack8">
-    <dt-stack
-      id="components-badge--variants-container"
-      direction="row"
-      gap="100"
-      align="center"
-      class="d-ff-row-wrap"
-    >
-      <dt-badge
-        v-for="type in types"
-        :key="type.value"
-        :text="type.display"
-        :type="type.value"
-      />
-      <dt-badge
-        v-for="type in types.slice(0, types.length - 1)"
-        :key="`${type.value}-count`"
-        text="1"
-        :type="type.value"
-        kind="count"
-      />
-      <dt-badge
-        v-for="decoration in Object.keys(BADGE_DECORATION_MODIFIERS)"
-        :key="decoration"
-        :decoration="decoration"
-        :text="getDecorationText(decoration)"
-        type="default"
-        kind="label"
-      />
-    </dt-stack>
-  </div>
+  <dt-stack
+    id="components-badge--variants-container"
+    direction="row"
+    gap="100"
+    align="center"
+    class="d-ff-row-wrap"
+  >
+    <dt-badge
+      v-for="type in types"
+      :key="type.value"
+      :text="type.display"
+      :type="type.value"
+    />
+    <dt-badge
+      v-for="type in types.slice(0, types.length - 1)"
+      :key="`${type.value}-count`"
+      text="1"
+      :type="type.value"
+      kind="count"
+    />
+    <dt-badge
+      v-for="decoration in Object.keys(BADGE_DECORATION_MODIFIERS)"
+      :key="decoration"
+      :decoration="decoration"
+      :text="getDecorationText(decoration)"
+      type="default"
+      kind="label"
+    />
+  </dt-stack>
 </template>
 
 <script>

--- a/packages/dialtone-vue/components/button/button_variants.story.vue
+++ b/packages/dialtone-vue/components/button/button_variants.story.vue
@@ -164,12 +164,15 @@
         Icon Bottom
       </dt-button>
     </dt-stack>
-    <div class="d-flow8">
+    <dt-stack
+      direction="row"
+      gap="100"
+    >
       <!-- Loading -->
       <dt-button loading>
         Button
       </dt-button>
-    </div>
+    </dt-stack>
 
     <!-- Link -->
     <h2>Link</h2>

--- a/packages/dialtone-vue/components/chip/chip_variants.story.vue
+++ b/packages/dialtone-vue/components/chip/chip_variants.story.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/no-v-text-v-html-on-component -->
 <template>
-  <div class="d-d-flex d-fd-column d-stack8">
+  <dt-stack gap="100">
     <div>
       <h4>With Icon</h4>
       <dt-chip>
@@ -40,16 +40,17 @@
         </template>
       </dt-chip>
     </div>
-  </div>
+  </dt-stack>
 </template>
 
 <script>
 import DtChip from './chip.vue';
 import { DtIcon } from '@/components/icon';
 import { DtAvatar } from '@/components/avatar';
+import { DtStack } from '@/components/stack';
 
 export default {
   name: 'DtChipVariants',
-  components: { DtAvatar, DtChip, DtIcon },
+  components: { DtAvatar, DtChip, DtIcon, DtStack },
 };
 </script>

--- a/packages/dialtone-vue/components/codeblock/codeblock_variants.story.vue
+++ b/packages/dialtone-vue/components/codeblock/codeblock_variants.story.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-d-flex d-fd-column d-stack8">
+  <dt-stack gap="100">
     <div>
       <h4>Default (sm)</h4>
       <dt-codeblock :text="text" />
@@ -32,15 +32,16 @@
         bordered
       />
     </div>
-  </div>
+  </dt-stack>
 </template>
 
 <script>
 import DtCodeblock from './codeblock.vue';
+import { DtStack } from '@/components/stack';
 
 export default {
   name: 'DtCodeblockVariants',
-  components: { DtCodeblock },
+  components: { DtCodeblock, DtStack },
 
   data () {
     return {

--- a/packages/dialtone-vue/components/image_viewer/image_viewer_variants.story.vue
+++ b/packages/dialtone-vue/components/image_viewer/image_viewer_variants.story.vue
@@ -1,6 +1,6 @@
 <!-- Use this template story to allow the user control the component's props and slots -->
 <template>
-  <div class="d-stack16">
+  <dt-stack gap="200">
     <dt-image-viewer
       :image-src="test"
       image-alt="Alt Text"
@@ -14,17 +14,18 @@
       image-button-class="d-wmn-100 d-hmn-100 d-wmx-500 d-hmx-500"
       aria-label="Click to open image"
     />
-  </div>
+  </dt-stack>
 </template>
 
 <script>
 import DtImageViewer from './image_viewer.vue';
+import { DtStack } from '@/components/stack';
 import test from '@/common/assets/test.jpg?url';
 import fry from '@/common/assets/fry.gif?url';
 
 export default {
   name: 'DtImageViewerVariants',
-  components: { DtImageViewer },
+  components: { DtImageViewer, DtStack },
   data () {
     return {
       test,

--- a/packages/dialtone-vue/components/popover/popover_variants.story.vue
+++ b/packages/dialtone-vue/components/popover/popover_variants.story.vue
@@ -183,7 +183,7 @@
         </div>
       </template>
       <template #content>
-        <div class="d-stack8">
+        <dt-stack gap="100">
           <p>
             {{ sampleText }}
           </p>
@@ -193,7 +193,7 @@
           <p>
             {{ sampleText }}
           </p>
-        </div>
+        </dt-stack>
       </template>
     </dt-popover>
 
@@ -216,7 +216,7 @@
         </dt-button>
       </template>
       <template #content>
-        <div class="d-stack8">
+        <dt-stack gap="100">
           <p>
             {{ sampleText }}
           </p>
@@ -226,7 +226,7 @@
           <p>
             {{ sampleText }}
           </p>
-        </div>
+        </dt-stack>
       </template>
     </dt-popover>
 
@@ -251,7 +251,7 @@
         <div>This is a footer</div>
       </template>
       <template #content>
-        <div class="d-stack8">
+        <dt-stack gap="100">
           <p>
             {{ sampleText }}
           </p>
@@ -261,7 +261,7 @@
           <p>
             {{ sampleText }}
           </p>
-        </div>
+        </dt-stack>
       </template>
     </dt-popover>
 
@@ -284,7 +284,7 @@
         </dt-button>
       </template>
       <template #content>
-        <div class="d-stack8">
+        <dt-stack gap="100">
           <p>
             {{ sampleText }}
           </p>
@@ -350,7 +350,7 @@
               </dt-list-item>
             </template>
           </dt-dropdown>
-        </div>
+        </dt-stack>
       </template>
     </dt-popover>
 
@@ -373,7 +373,7 @@
         </dt-button>
       </template>
       <template #content>
-        <div class="d-stack8">
+        <dt-stack gap="100">
           <p>
             {{ sampleText }}
           </p>
@@ -385,7 +385,7 @@
             </template>
             This is the tooltip content
           </dt-tooltip>
-        </div>
+        </dt-stack>
       </template>
     </dt-popover>
 
@@ -458,6 +458,7 @@ import { DtDropdown } from '@/components/dropdown';
 import { DtListItem } from '@/components/list_item';
 import { DtTooltip } from '@/components/tooltip';
 import { DtIcon } from '@/components/icon';
+import { DtStack } from '@/components/stack';
 
 export default {
   name: 'PopoverVariantsStory',
@@ -469,6 +470,7 @@ export default {
     DtTooltip,
     DtIcon,
     DtListItem,
+    DtStack,
   },
 
   data () {

--- a/packages/dialtone-vue/components/tab/tabs_variants.story.vue
+++ b/packages/dialtone-vue/components/tab/tabs_variants.story.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-stack32">
+  <dt-stack gap="100">
     <div
       v-for="(variant, i) in variantsTabs"
       :key="i"
@@ -56,17 +56,18 @@
         </div>
       </dt-tab-group>
     </div>
-  </div>
+  </dt-stack>
 </template>
 
 <script>
 import DtTabGroup from './tab_group.vue';
 import DtTab from './tab.vue';
 import DtTabPanel from './tab_panel.vue';
+import { DtStack } from '@/components/stack';
 
 export default {
   name: 'DtTabsVariants',
-  components: { DtTabGroup, DtTab, DtTabPanel },
+  components: { DtTabGroup, DtTab, DtTabPanel, DtStack },
   data () {
     return {
       variantsTabs: [

--- a/packages/dialtone-vue/recipes/buttons/callbar_button/callbar_button_callbar.story.vue
+++ b/packages/dialtone-vue/recipes/buttons/callbar_button/callbar_button_callbar.story.vue
@@ -1,9 +1,13 @@
 <!-- eslint-disable vue/no-unregistered-components -->
 <template>
-  <div class="d-stack16">
+  <dt-stack gap="200">
     <h3>Normal</h3>
-    <div class="d-d-flex d-flow16 d-fw-wrap d-stack16">
-      <dt-recipe-callbar-button class="d-mbs-200">
+    <dt-stack
+      direction="row"
+      gap="100"
+      class="d-fw-wrap"
+    >
+      <dt-recipe-callbar-button>
         Screenshare
         <template #icon>
           <dt-icon name="share-screen" />
@@ -92,14 +96,17 @@
           More options
         </template>
       </dt-recipe-callbar-button>
-    </div>
+    </dt-stack>
 
     <h3>Active</h3>
-    <div class="d-d-flex d-flow16 d-fw-wrap d-stack16">
+    <dt-stack
+      direction="row"
+      gap="100"
+      class="d-fw-wrap"
+    >
       <dt-recipe-callbar-button
         active
         danger
-        class="d-mbs-200"
       >
         Stop
         <template #icon>
@@ -201,19 +208,21 @@
           More options
         </template>
       </dt-recipe-callbar-button>
-    </div>
-  </div>
+    </dt-stack>
+  </dt-stack>
 </template>
 
 <script>
 import DtRecipeCallbarButton from './callbar_button.vue';
 import { DtIcon } from '@/components/icon';
+import { DtStack } from '@/components/stack';
 
 export default {
   name: 'DtRecipeCallbarButtonCallbar',
   components: {
     DtRecipeCallbarButton,
     DtIcon,
+    DtStack,
   },
 };
 </script>

--- a/packages/dialtone-vue/recipes/buttons/callbar_button/callbar_button_variants.story.vue
+++ b/packages/dialtone-vue/recipes/buttons/callbar_button/callbar_button_variants.story.vue
@@ -28,9 +28,6 @@
         <template #tooltip>
           Tooltip
         </template>
-        <template #icon>
-          <dt-icon name="box-select" />
-        </template>
       </dt-recipe-callbar-button>
       <dt-recipe-callbar-button aria-label="mic on">
         <template #icon>
@@ -81,9 +78,6 @@
         Label only
         <template #tooltip>
           Tooltip
-        </template>
-        <template #icon>
-          <dt-icon name="box-select" />
         </template>
       </dt-recipe-callbar-button>
 
@@ -145,9 +139,6 @@
         Label only
         <template #tooltip>
           Tooltip
-        </template>
-        <template #icon>
-          <dt-icon name="box-select" />
         </template>
       </dt-recipe-callbar-button>
 
@@ -215,9 +206,6 @@
         Label only
         <template #tooltip>
           Tooltip
-        </template>
-        <template #icon>
-          <dt-icon name="box-select" />
         </template>
       </dt-recipe-callbar-button>
 

--- a/packages/dialtone-vue/recipes/buttons/callbar_button/callbar_button_variants.story.vue
+++ b/packages/dialtone-vue/recipes/buttons/callbar_button/callbar_button_variants.story.vue
@@ -1,9 +1,12 @@
 <template>
-  <div class="d-stack16">
+  <dt-stack gap="200">
     <h3>
       Call Bar Buttons
     </h3>
-    <div class="d-d-flex d-flow16 d-fw-wrap">
+    <dt-stack
+      direction="row"
+      gap="200"
+    >
       <dt-recipe-callbar-button>
         Button
         <template #icon>
@@ -20,14 +23,15 @@
           <dt-icon name="accessibility" />
         </template>
       </dt-recipe-callbar-button>
-
       <dt-recipe-callbar-button>
         Label only
         <template #tooltip>
           Tooltip
         </template>
+        <template #icon>
+          <dt-icon name="box-select" />
+        </template>
       </dt-recipe-callbar-button>
-
       <dt-recipe-callbar-button aria-label="mic on">
         <template #icon>
           <dt-icon name="mic" />
@@ -46,12 +50,16 @@
           Tooltip
         </template>
       </dt-recipe-callbar-button>
-    </div>
+    </dt-stack>
 
     <h3>
       Active Call Bar Buttons
     </h3>
-    <div class="d-d-flex d-flow16 d-fw-wrap">
+    <dt-stack
+      direction="row"
+      gap="200"
+      class="d-fw-wrap"
+    >
       <dt-recipe-callbar-button active>
         Button
         <template #icon>
@@ -73,6 +81,9 @@
         Label only
         <template #tooltip>
           Tooltip
+        </template>
+        <template #icon>
+          <dt-icon name="box-select" />
         </template>
       </dt-recipe-callbar-button>
 
@@ -100,7 +111,7 @@
           Tooltip
         </template>
       </dt-recipe-callbar-button>
-    </div>
+    </dt-stack>
 
     <h3>
       Danger Call Bar Buttons
@@ -108,7 +119,11 @@
     <div class="d-fs12">
       Danger Call Bar Buttons look the same as regular buttons; they only differ on their active state.
     </div>
-    <div class="d-d-flex d-flow16 d-fw-wrap">
+    <dt-stack
+      direction="row"
+      gap="200"
+      class="d-fw-wrap"
+    >
       <dt-recipe-callbar-button danger>
         Button
         <template #icon>
@@ -130,6 +145,9 @@
         Label only
         <template #tooltip>
           Tooltip
+        </template>
+        <template #icon>
+          <dt-icon name="box-select" />
         </template>
       </dt-recipe-callbar-button>
 
@@ -157,12 +175,16 @@
           Tooltip
         </template>
       </dt-recipe-callbar-button>
-    </div>
+    </dt-stack>
 
     <h3>
       Danger Active Call Bar Buttons
     </h3>
-    <div class="d-d-flex d-flow16 d-fw-wrap">
+    <dt-stack
+      direction="row"
+      gap="200"
+      class="d-fw-wrap"
+    >
       <dt-recipe-callbar-button
         active
         danger
@@ -194,6 +216,9 @@
         <template #tooltip>
           Tooltip
         </template>
+        <template #icon>
+          <dt-icon name="box-select" />
+        </template>
       </dt-recipe-callbar-button>
 
       <dt-recipe-callbar-button
@@ -222,12 +247,16 @@
           Tooltip
         </template>
       </dt-recipe-callbar-button>
-    </div>
+    </dt-stack>
 
     <h3>
       Rounded
     </h3>
-    <div class="d-d-flex d-flow16 d-fw-wrap">
+    <dt-stack
+      direction="row"
+      gap="200"
+      class="d-fw-wrap"
+    >
       <dt-recipe-callbar-button
         circle
         aria-label="recording"
@@ -292,19 +321,21 @@
           Rounded button
         </template>
       </dt-recipe-callbar-button>
-    </div>
-  </div>
+    </dt-stack>
+  </dt-stack>
 </template>
 
 <script>
 import DtRecipeCallbarButton from './callbar_button.vue';
 import { DtIcon } from '@/components/icon';
+import { DtStack } from '@/components/stack';
 
 export default {
   name: 'DtRecipeCallbarButtonVariants',
   components: {
     DtRecipeCallbarButton,
     DtIcon,
+    DtStack,
   },
 };
 </script>

--- a/packages/dialtone-vue/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_variants.story.vue
+++ b/packages/dialtone-vue/recipes/buttons/callbar_button_with_popover/callbar_button_with_popover_variants.story.vue
@@ -1,9 +1,13 @@
 <template>
-  <div class="d-stack16">
+  <dt-stack gap="200">
     <h3>
       Call Bar Buttons
     </h3>
-    <div class="d-d-flex d-flow16 d-fw-wrap">
+    <dt-stack
+      direction="row"
+      gap="200"
+      class="d-fw-wrap"
+    >
       <dt-recipe-callbar-button-with-popover
         disabled
         arrow-button-label="Open popover"
@@ -58,12 +62,16 @@
           Header Content
         </template>
       </dt-recipe-callbar-button-with-popover>
-    </div>
+    </dt-stack>
 
     <h3>
       Active Call Bar Buttons
     </h3>
-    <div class="d-d-flex d-flow16 d-fw-wrap">
+    <dt-stack
+      direction="row"
+      gap="200"
+      class="d-fw-wrap"
+    >
       <dt-recipe-callbar-button-with-popover
         active
         disabled
@@ -122,19 +130,21 @@
           Header Content
         </template>
       </dt-recipe-callbar-button-with-popover>
-    </div>
-  </div>
+    </dt-stack>
+  </dt-stack>
 </template>
 
 <script>
 import DtRecipeCallbarButtonWithPopover from './callbar_button_with_popover.vue';
 import { DtIcon } from '@/components/icon';
+import { DtStack } from '@/components/stack';
 
 export default {
   name: 'DtRecipeCallbarButtonWithPopoverVariants',
   components: {
     DtRecipeCallbarButtonWithPopover,
     DtIcon,
+    DtStack,
   },
 };
 </script>

--- a/packages/dialtone-vue/recipes/leftbar/callbox/callbox_variants.story.vue
+++ b/packages/dialtone-vue/recipes/leftbar/callbox/callbox_variants.story.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable max-lines -->
 <template>
-  <div class="d-stack16">
+  <dt-stack gap="200">
     <dt-recipe-callbox
       avatar-full-name="Jaqueline Nackos"
       avatar-seed="Jaqueline Nackos"
@@ -401,7 +401,7 @@
         </dt-button>
       </template>
     </dt-recipe-callbox>
-  </div>
+  </dt-stack>
 </template>
 
 <script>

--- a/packages/dialtone-vue/recipes/leftbar/unread_pill/unread_pill_variants.story.vue
+++ b/packages/dialtone-vue/recipes/leftbar/unread_pill/unread_pill_variants.story.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-stack16">
+  <dt-stack gap="200">
     <dt-recipe-unread-pill
       direction="up"
       kind="mentions"
@@ -16,14 +16,15 @@
       direction="down"
       kind="messages"
     />
-  </div>
+  </dt-stack>
 </template>
 
 <script>
 import DtRecipeUnreadPill from './unread_pill.vue';
+import { DtStack } from '@/components/stack';
 
 export default {
   name: 'DtRecipeUnreadPillVariants',
-  components: { DtRecipeUnreadPill },
+  components: { DtRecipeUnreadPill, DtStack },
 };
 </script>


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3345

## :book: Description

Swap deprecated `d-stack*` / `d-flow*` CSS utility classes for `<dt-stack>`.

15 files, 37 usages:
- 14 storybook stories (component + recipe)
- 1 doc page: `box-sizing.md`

Mapping applied:
- `d-stack{n}` → `<dt-stack gap="...">`
- `d-flow{n}` → `<dt-stack direction="row" gap="...">`
- `d-d-flex` dropped (implicit in `<dt-stack>`)
- `d-ai-*` / `d-jc-*` → `align` / `justify` props
- `d-fw-wrap` kept as class (no prop equivalent)

## :bulb: Context

Deprecated classes use the adjacent-sibling margin hack. `<dt-stack>` uses flexbox `gap` and is already the doc writing standard. Cleans up story wrappers plus one demo wrapper PR #1167 missed.

## :warning: Out of Scope

- `dropdown_list.vue` (production `<ul>` internals)
- `combobox_multi_select_default.story.vue` (forwards `d-stack2` via `listClass` into `dropdown_list.vue`)
- `auto-spacing.md` (kept; documents the utilities)

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description.
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

[DLT-3346](https://dialpad.atlassian.net/browse/DLT-3346): extend `prefer-stack-over-flex` ESLint rule to flag `d-stack*` / `d-flow*` so regressions can't land silently.

## :camera: Screenshots / GIFs

Deploy preview handles visual verification of `box-sizing.md` and storybook stories.

## :link: Sources

N/A

[DLT-3346]: https://dialpad.atlassian.net/browse/DLT-3346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ