### PR TITLE
feat(scripts): DLT-3304 add scripts/docs for migration props changes

### DIFF
--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-23.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-23.md
@@ -18,7 +18,7 @@ excerpt: 'We have made various changes to props and slots in the Design System s
 > - `prevent-typing` → `:allow-typing="false"` on `dt-rich-text-editor` and `dt-recipe-message-input` (inverted).
 > - `dt-popover` `hide-on-click` → `close-on-click` (same semantics, just renamed).
 > - `label-visible` → `show-label` on form inputs and controls.
-> - `title` / `title-id` → `header-text` / `header-id` on `dt-banner`, `dt-notice`, `dt-toast`, `dt-modal`.
+> - `title` / `title-id` → `header-text` / `header-id` on `dt-banner`, `dt-notice`, `dt-toast`. (`dt-modal` only has `title` → `header-text`; it never had `title-id`.)
 > - `banner-title` → `banner-header-text` on `dt-modal`.
 > - `clickable` → `interactive` on `dt-avatar`.
 > - `selectedValues` / `selected-values` → `modelValue` on `dt-checkbox-group`. Use `v-model` directly.
@@ -242,7 +242,7 @@ The `label-visible` prop has been renamed to `show-label` to match the new `show
 
 ## `title` / `title-id` → `header-text` / `header-id`
 
-The `title` prop has been renamed to `header-text` and `title-id` to `header-id` on notice-family components. The old names conflicted with the native HTML `title` attribute, which browsers reserve for tooltips.
+The `title` prop has been renamed to `header-text` on all four components. The `title-id` prop has been renamed to `header-id` on `dt-banner`, `dt-notice`, and `dt-toast` only — `dt-modal` never had a `title-id` prop. The old names conflicted with the native HTML `title` attribute, which browsers reserve for tooltips.
 
 <div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
 <div>

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-23.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-23.md
@@ -10,12 +10,20 @@ excerpt: 'We have made various changes to props and slots in the Design System s
 ## Overview of changes
 
 > - `kind="danger"` and `kind="error"` → `kind="critical"`. `kind="success"` → `kind="positive"`. Same for `validation-state`.
+> - `dt-badge` uses `type` (not `kind`): `type="success"` → `type="positive"`.
+> - `dt-link`: `kind` prop renamed to `tone`; values `danger` → `critical`, `success` → `positive`.
+> - `dt-modal` `bannerKind`/`banner-kind`: `error` → `critical`, `success` → `positive`.
 > - `show` prop → `open` on `dt-modal`, `dt-toast`, `dt-tooltip`. `@update:show` → `@update:open`.
-> - `hide-close`, `hide-icon`, `hide-action`, `hide-clear` → `:show-*="false"` (semantics inverted).
+> - `hide-close`, `hide-icon`, `hide-action`, `hide-clear`, `hide-edges`, `hide-divider`, `hide-actions`, `hide-link-bubble-menu` → `:show-*="false"` (semantics inverted).
+> - `prevent-typing` → `:allow-typing="false"` on `dt-rich-text-editor` and `dt-recipe-message-input` (inverted).
+> - `dt-popover` `hide-on-click` → `close-on-click` (same semantics, just renamed).
 > - `label-visible` → `show-label` on form inputs and controls.
 > - `title` / `title-id` → `header-text` / `header-id` on `dt-banner`, `dt-notice`, `dt-toast`, `dt-modal`.
 > - `banner-title` → `banner-header-text` on `dt-modal`.
 > - `clickable` → `interactive` on `dt-avatar`.
+> - `selectedValues` / `selected-values` → `modelValue` on `dt-checkbox-group`. Use `v-model` directly.
+> - `@input` event removed from `dt-input`, `dt-radio`, `dt-radio-group`, `dt-combobox-multi-select`, `dt-rich-text-editor`, `dt-input-group` → use `@update:model-value`.
+> - `@change` event removed from `dt-toggle` and `dt-select-menu` → use `@update:model-value`.
 > - `rootClass` / `root-class` / `wrapperClass` / `containerClass` **removed** from all components. Apply classes directly on the component element. The script auto-migrates known components; a small number still require manual attention.
 > - Slot renames: `#titleOverride` → `#header`, `#labelSlot` → `#label`, `#headingSlot` → `#heading`.
 
@@ -23,7 +31,7 @@ Run the [migration script](#migration-script) to automate most of these changes.
 
 ---
 
-## `kind` and `validation-state` Value Renames
+## `kind`, `type`, `tone`, and `validation-state` Value Renames
 
 Prop values across the system have been aligned to a single set of semantic names. `danger` and `error` both map to `critical`. `success` maps to `positive`.
 
@@ -34,8 +42,12 @@ Prop values across the system have been aligned to a single set of semantic name
 
 ```vue
 <dt-button kind="danger" />
-<dt-badge kind="error" />
-<dt-badge kind="success" />
+<dt-banner kind="error" />
+<dt-badge type="success" />
+<dt-link kind="danger" />
+<dt-link kind="success" />
+<dt-modal banner-kind="error" />
+<dt-modal banner-kind="success" />
 <dt-input validation-state="error" />
 <dt-checkbox validation-state="success" />
 ```
@@ -47,8 +59,12 @@ Prop values across the system have been aligned to a single set of semantic name
 
 ```vue
 <dt-button kind="critical" />
-<dt-badge kind="critical" />
-<dt-badge kind="positive" />
+<dt-banner kind="critical" />
+<dt-badge type="positive" />
+<dt-link tone="critical" />
+<dt-link tone="positive" />
+<dt-modal banner-kind="critical" />
+<dt-modal banner-kind="positive" />
 <dt-input validation-state="critical" />
 <dt-checkbox validation-state="positive" />
 ```
@@ -56,7 +72,10 @@ Prop values across the system have been aligned to a single set of semantic name
 </div>
 </div>
 
-**Affected components:** [DtBadge](/components/badge.html), [DtBanner](/components/banner.html), [DtButton](/components/button.html), [DtInput](/components/input.html), [DtLink](/components/link.html), [DtModal](/components/modal.html), [DtNotice](/components/notice.html), [DtText](/components/text.html), [DtToast](/components/toast.html), and any component accepting a `kind` or `validation-state` prop.
+> [!INFO] DtLink: `kind` prop renamed to `tone`
+> On `dt-link`, the prop itself is renamed from `kind` to `tone` in addition to the value changes. The migration script handles both in one pass — `kind="danger"` becomes `tone="critical"`. The old `kind` prop is still accepted as a deprecated alias if you prefer to migrate gradually.
+
+**Affected components:** [DtBadge](/components/badge.html), [DtBanner](/components/banner.html), [DtButton](/components/button.html), [DtInput](/components/input.html), [DtLink](/components/link.html), [DtModal](/components/modal.html), [DtNotice](/components/notice.html), [DtText](/components/text.html), [DtToast](/components/toast.html), and any component accepting a `kind`, `type`, `tone`, or `validation-state` prop.
 
 ---
 
@@ -103,9 +122,9 @@ The `show` prop and `update:show` event have been renamed to `open` and `update:
 
 ---
 
-## `hide-*` Props Renamed to `show-*` (Semantics Inverted)
+## `hide-*` and `prevent-*` Props Renamed (Semantics Inverted)
 
-Boolean props prefixed with `hide-` have been replaced with `show-` equivalents with the default value flipped to `true`. A bare `hide-close` (meaning "close button is hidden") becomes `:show-close="false"` (meaning "close button is not shown").
+Boolean props prefixed with `hide-` or `prevent-` have been replaced with `show-` or `allow-` equivalents with the default value flipped to `true`. A bare `hide-close` (meaning "close button is hidden") becomes `:show-close="false"` (meaning "close button is not shown"). Similarly, bare `prevent-typing` becomes `:allow-typing="false"`.
 
 <div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
 <div>
@@ -113,13 +132,18 @@ Boolean props prefixed with `hide-` have been replaced with `show-` equivalents 
 **Before**
 
 ```vue
-<!-- Boolean presence = hide -->
 <dt-banner hide-close hide-icon />
 <dt-chip hide-close />
 <dt-modal hide-close />
 <dt-notice hide-close hide-action />
+<dt-notice-action hide-close hide-action />
 <dt-toast hide-close hide-icon hide-action />
 <dt-filter-pill hide-clear />
+<dt-pagination hide-edges />
+<dt-segmented-control hide-divider />
+<dt-rich-text-editor prevent-typing hide-link-bubble-menu />
+<dt-recipe-message-input prevent-typing />
+<dt-recipe-contact-centers-row hide-actions />
 ```
 
 </div>
@@ -128,13 +152,18 @@ Boolean props prefixed with `hide-` have been replaced with `show-` equivalents 
 **After**
 
 ```vue
-<!-- Explicit false = don't show -->
 <dt-banner :show-close="false" :show-icon="false" />
 <dt-chip :show-close="false" />
 <dt-modal :show-close="false" />
 <dt-notice :show-close="false" :show-action="false" />
+<dt-notice-action :show-close="false" :show-action="false" />
 <dt-toast :show-close="false" :show-icon="false" :show-action="false" />
 <dt-filter-pill :show-clear="false" />
+<dt-pagination :show-edges="false" />
+<dt-segmented-control :show-divider="false" />
+<dt-rich-text-editor :allow-typing="false" :show-link-bubble-menu="false" />
+<dt-recipe-message-input :allow-typing="false" />
+<dt-recipe-contact-centers-row :show-actions="false" />
 ```
 
 </div>
@@ -143,7 +172,38 @@ Boolean props prefixed with `hide-` have been replaced with `show-` equivalents 
 > [!INFO]
 > If you were binding a dynamic expression — e.g., `:hide-close="someCondition"` — the migration script cannot safely invert it and will warn you. Replace manually with `:show-close="!someCondition"`.
 
-**Affected components:** [DtBanner](/components/banner.html), [DtChip](/components/chip.html), [DtFilterPill](/components/filter-pill.html), [DtModal](/components/modal.html), [DtNotice](/components/notice.html), [DtToast](/components/toast.html)
+**Affected components:** [DtBanner](/components/banner.html), [DtChip](/components/chip.html), [DtFilterPill](/components/filter-pill.html), [DtModal](/components/modal.html), [DtNotice](/components/notice.html), [DtNoticeAction](/components/notice.html), [DtPagination](/components/pagination.html), [DtRichTextEditor](/components/rich-text-editor.html), [DtRecipeMessageInput](/components/message-input.html), [DtRecipeContactCentersRow](/components/contact-centers-row.html), [DtSegmentedControl](/components/segmented-control.html), [DtToast](/components/toast.html)
+
+---
+
+## `hideOnClick` → `closeOnClick` on DtPopover
+
+The `hideOnClick` prop on `dt-popover` has been renamed to `closeOnClick`. The behavior is identical — the semantics are the same, only the name changed to better describe what the prop does.
+
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-popover hide-on-click />
+<dt-popover :hide-on-click="false" />
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-popover close-on-click />
+<dt-popover :close-on-click="false" />
+```
+
+</div>
+</div>
+
+**Affected components:** [DtPopover](/components/popover.html)
 
 ---
 
@@ -241,6 +301,92 @@ The `clickable` prop on `dt-avatar` has been renamed to `interactive` to more ac
 
 </div>
 </div>
+
+---
+
+## `selectedValues` → `v-model` on DtCheckboxGroup
+
+The `selectedValues` prop and `update:selectedValues` event on `dt-checkbox-group` have been standardized to the Vue 3 default v-model convention. The prop is now named `modelValue` internally, which means you can drop the `v-model:selectedValues` argument and use a plain `v-model` binding.
+
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-checkbox-group
+  :selected-values="checkedItems"
+  @update:selected-values="checkedItems = $event"
+/>
+
+<dt-checkbox-group v-model:selectedValues="checkedItems" />
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-checkbox-group
+  :model-value="checkedItems"
+  @update:model-value="checkedItems = $event"
+/>
+
+<!-- or simply -->
+<dt-checkbox-group v-model="checkedItems" />
+```
+
+</div>
+</div>
+
+**Affected components:** [DtCheckboxGroup](/components/checkbox-group.html)
+
+---
+
+## `@input` and `@change` Events Replaced by `@update:model-value`
+
+Several form components previously emitted legacy `input` or `change` events alongside (or instead of) the standard `update:modelValue` event. These legacy events have been removed. Use `@update:model-value` (or `v-model`) instead.
+
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-input @input="onValue" />
+<dt-radio @input="onSelect" />
+<dt-radio-group @input="onGroupChange" />
+<dt-toggle @change="onToggle" />
+<dt-select-menu @change="onSelect" />
+<dt-combobox-multi-select @input="onSearch" />
+<dt-rich-text-editor @input="onEdit" />
+<dt-input-group @input="onGroup" />
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-input @update:model-value="onValue" />
+<dt-radio @update:model-value="onSelect" />
+<dt-radio-group @update:model-value="onGroupChange" />
+<dt-toggle @update:model-value="onToggle" />
+<dt-select-menu @update:model-value="onSelect" />
+<dt-combobox-multi-select @update:model-value="onSearch" />
+<dt-rich-text-editor @update:model-value="onEdit" />
+<dt-input-group @update:model-value="onGroup" />
+```
+
+</div>
+</div>
+
+> [!INFO]
+> If you were using `v-model` on any of these components, no change is needed — `v-model` already binds to `update:modelValue` internally.
+
+**Affected components:** [DtComboboxMultiSelect](/components/combobox-multi-select.html), [DtInput](/components/input.html), [DtInputGroup](/components/input-group.html), [DtRadio](/components/radio.html), [DtRadioGroup](/components/radio-group.html), [DtRichTextEditor](/components/rich-text-editor.html), [DtSelectMenu](/components/select-menu.html), [DtToggle](/components/toggle.html)
 
 ---
 
@@ -376,14 +522,23 @@ npx dialtone-migrate-props --cwd ./src --yes
 
 ### What the script handles automatically
 
-- `kind` and `validation-state` value renames (`danger`/`error`/`success`)
+- `kind` and `validation-state` value renames (`danger`/`error`/`success`) on any `dt-*` component
+- `type="success"` → `type="positive"` on `dt-badge`
+- `kind` → `tone` prop rename on `dt-link`, with value renames applied in the same pass
+- `banner-kind` / `bannerKind` value renames on `dt-modal` (`error` → `critical`, `success` → `positive`)
 - `show` → `open`, `@update:show` → `@update:open`, `v-model:show` → `v-model:open`
-- `hide-close`, `hide-icon`, `hide-action`, `hide-clear` → `:show-*="false"`
+- `hide-close`, `hide-icon`, `hide-action`, `hide-clear`, `hide-edges`, `hide-divider`, `hide-actions`, `hide-link-bubble-menu` → `:show-*="false"` on all affected components
+- `prevent-typing` → `:allow-typing="false"` on `dt-rich-text-editor` and `dt-recipe-message-input`
 - `:hide-*="true"` → `:show-*="false"` and `:hide-*="false"` → removed
+- `hide-on-click` → `close-on-click` on `dt-popover` (same semantics)
 - `label-visible` → `show-label`
 - `title` / `title-id` → `header-text` / `header-id`
 - `banner-title` → `banner-header-text`
 - `clickable` → `interactive` on `dt-avatar`
+- `selected-values` / `selectedValues` → `model-value` and `v-model:selectedValues` → `v-model` on `dt-checkbox-group`
+- `@update:selected-values` / `@update:selectedValues` → `@update:model-value` on `dt-checkbox-group`
+- `@input` → `@update:model-value` on `dt-input`, `dt-radio`, `dt-radio-group`, `dt-combobox-multi-select`, `dt-rich-text-editor`, `dt-input-group`
+- `@change` → `@update:model-value` on `dt-toggle`, `dt-select-menu`
 - `root-class` / `rootClass` → `class` on `dt-input`, `dt-checkbox`, `dt-radio`, `dt-select-menu`, `dt-breadcrumb-item`, `dt-split-button`
 - `wrapper-class` / `wrapperClass` → `class` on `dt-toggle`, `dt-feed-item-pill`
 - `container-class` / `containerClass` → `class` on `dt-card`

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-23.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-23.md
@@ -1,0 +1,405 @@
+---
+heading: 'Migrating to consistent prop/slot names'
+author: Brad Paugh
+posted: '2026-4-23'
+excerpt: 'We have made various changes to props and slots in the Design System so they are consistent across all components. These may be migrated to via the script.'
+---
+
+<BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading" :excerpt="$frontmatter.excerpt">
+
+## Overview of changes
+
+> - `kind="danger"` and `kind="error"` → `kind="critical"`. `kind="success"` → `kind="positive"`. Same for `validation-state`.
+> - `show` prop → `open` on `dt-modal`, `dt-toast`, `dt-tooltip`. `@update:show` → `@update:open`.
+> - `hide-close`, `hide-icon`, `hide-action`, `hide-clear` → `:show-*="false"` (semantics inverted).
+> - `label-visible` → `show-label` on form inputs and controls.
+> - `title` / `title-id` → `header-text` / `header-id` on `dt-banner`, `dt-notice`, `dt-toast`, `dt-modal`.
+> - `banner-title` → `banner-header-text` on `dt-modal`.
+> - `clickable` → `interactive` on `dt-avatar`.
+> - `rootClass` / `root-class` / `wrapperClass` / `containerClass` **removed** from all components. Apply classes directly on the component element. The script auto-migrates known components; a small number still require manual attention.
+> - Slot renames: `#titleOverride` → `#header`, `#labelSlot` → `#label`, `#headingSlot` → `#heading`.
+
+Run the [migration script](#migration-script) to automate most of these changes.
+
+---
+
+## `kind` and `validation-state` Value Renames
+
+Prop values across the system have been aligned to a single set of semantic names. `danger` and `error` both map to `critical`. `success` maps to `positive`.
+
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-button kind="danger" />
+<dt-badge kind="error" />
+<dt-badge kind="success" />
+<dt-input validation-state="error" />
+<dt-checkbox validation-state="success" />
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-button kind="critical" />
+<dt-badge kind="critical" />
+<dt-badge kind="positive" />
+<dt-input validation-state="critical" />
+<dt-checkbox validation-state="positive" />
+```
+
+</div>
+</div>
+
+**Affected components:** [DtBadge](/components/badge.html), [DtBanner](/components/banner.html), [DtButton](/components/button.html), [DtInput](/components/input.html), [DtLink](/components/link.html), [DtModal](/components/modal.html), [DtNotice](/components/notice.html), [DtText](/components/text.html), [DtToast](/components/toast.html), and any component accepting a `kind` or `validation-state` prop.
+
+---
+
+## `show` → `open` on Overlay Components
+
+The `show` prop and `update:show` event have been renamed to `open` and `update:open` on overlay components. The new name aligns with the existing `v-model:open` convention used by `dt-popover`, `dt-dropdown`, and `dt-combobox-with-popover`.
+
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-modal
+  :show="isOpen"
+  @update:show="isOpen = $event"
+/>
+
+<dt-toast v-model:show="toastVisible" />
+
+<dt-tooltip :show="hovered" />
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-modal
+  :open="isOpen"
+  @update:open="isOpen = $event"
+/>
+
+<dt-toast v-model:open="toastVisible" />
+
+<dt-tooltip :open="hovered" />
+```
+
+</div>
+</div>
+
+**Affected components:** [DtModal](/components/modal.html), [DtToast](/components/toast.html), [DtTooltip](/components/tooltip.html)
+
+---
+
+## `hide-*` Props Renamed to `show-*` (Semantics Inverted)
+
+Boolean props prefixed with `hide-` have been replaced with `show-` equivalents with the default value flipped to `true`. A bare `hide-close` (meaning "close button is hidden") becomes `:show-close="false"` (meaning "close button is not shown").
+
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<!-- Boolean presence = hide -->
+<dt-banner hide-close hide-icon />
+<dt-chip hide-close />
+<dt-modal hide-close />
+<dt-notice hide-close hide-action />
+<dt-toast hide-close hide-icon hide-action />
+<dt-filter-pill hide-clear />
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<!-- Explicit false = don't show -->
+<dt-banner :show-close="false" :show-icon="false" />
+<dt-chip :show-close="false" />
+<dt-modal :show-close="false" />
+<dt-notice :show-close="false" :show-action="false" />
+<dt-toast :show-close="false" :show-icon="false" :show-action="false" />
+<dt-filter-pill :show-clear="false" />
+```
+
+</div>
+</div>
+
+> [!INFO]
+> If you were binding a dynamic expression — e.g., `:hide-close="someCondition"` — the migration script cannot safely invert it and will warn you. Replace manually with `:show-close="!someCondition"`.
+
+**Affected components:** [DtBanner](/components/banner.html), [DtChip](/components/chip.html), [DtFilterPill](/components/filter-pill.html), [DtModal](/components/modal.html), [DtNotice](/components/notice.html), [DtToast](/components/toast.html)
+
+---
+
+## `label-visible` → `show-label`
+
+The `label-visible` prop has been renamed to `show-label` to match the new `show-*` naming convention. Behavior is identical — setting it to `false` visually hides the label while keeping it accessible to screen readers.
+
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-input label="Name" label-visible="false" />
+<dt-checkbox label="Accept" label-visible="false" />
+<dt-combobox label="Search" :label-visible="showLabels" />
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-input label="Name" show-label="false" />
+<dt-checkbox label="Accept" show-label="false" />
+<dt-combobox label="Search" :show-label="showLabels" />
+```
+
+</div>
+</div>
+
+**Affected components:** [DtCheckbox](/components/checkbox.html), [DtCombobox](/components/combobox.html), [DtComboboxMultiSelect](/components/combobox-multi-select.html), [DtComboboxWithPopover](/components/combobox-with-popover.html), [DtInput](/components/input.html), [DtRadioGroup](/components/radio-group.html), [DtSelectMenu](/components/select-menu.html), [DtToggle](/components/toggle.html)
+
+---
+
+## `title` / `title-id` → `header-text` / `header-id`
+
+The `title` prop has been renamed to `header-text` and `title-id` to `header-id` on notice-family components. The old names conflicted with the native HTML `title` attribute, which browsers reserve for tooltips.
+
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-banner title="Payment failed" title-id="banner-hdr" />
+<dt-notice title="Your session expires soon" />
+<dt-toast title="Changes saved" title-id="toast-hdr" />
+<dt-modal title="Confirm delete" />
+<dt-modal banner-title="Danger zone" />
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-banner header-text="Payment failed" header-id="banner-hdr" />
+<dt-notice header-text="Your session expires soon" />
+<dt-toast header-text="Changes saved" header-id="toast-hdr" />
+<dt-modal header-text="Confirm delete" />
+<dt-modal banner-header-text="Danger zone" />
+```
+
+</div>
+</div>
+
+**Affected components:** [DtBanner](/components/banner.html), [DtModal](/components/modal.html), [DtNotice](/components/notice.html), [DtToast](/components/toast.html)
+
+---
+
+## `clickable` → `interactive` on DtAvatar
+
+The `clickable` prop on `dt-avatar` has been renamed to `interactive` to more accurately describe its effect: the avatar renders as a `<button>`, becomes keyboard-focusable, and participates in the page's tab order.
+
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-avatar full-name="Jane Doe" clickable @click="openProfile" />
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-avatar full-name="Jane Doe" interactive @click="openProfile" />
+```
+
+</div>
+</div>
+
+---
+
+## `rootClass` / `wrapperClass` / `containerClass` Removed
+
+These props have been removed from all components that previously exposed them. They were workarounds for applying classes to a component's root element before Vue 3's `inheritAttrs` approach was adopted. Apply classes directly on the component instead — attributes and classes are now forwarded automatically.
+
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-input root-class="d-w332" label="Email" />
+<dt-toggle wrapper-class="d-mt16" />
+<dt-card container-class="d-mbs-300" />
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-input class="d-w332" label="Email" />
+<dt-toggle class="d-mt16" />
+<dt-card class="d-mbs-300" />
+```
+
+</div>
+</div>
+
+The migration script handles the following components automatically:
+
+| Component | Removed prop |
+| --- | --- |
+| [DtInput](/components/input.html), [DtCheckbox](/components/checkbox.html), [DtRadio](/components/radio.html), [DtSelectMenu](/components/select-menu.html), [DtBreadcrumbItem](/components/breadcrumbs.html), [DtSplitButton](/components/split-button.html) | `rootClass` / `root-class` |
+| [DtToggle](/components/toggle.html), [DtFeedItemPill](/components/feed-item-pill.html) | `wrapperClass` / `wrapper-class` |
+| [DtCard](/components/card.html) | `containerClass` / `container-class` |
+
+> [!WARNING]
+> A small number of components — [DtAvatar](/components/avatar.html), [DtFilterPill](/components/filter-pill.html), [DtModeIsland](/components/mode-island.html), [DtMotionText](/components/motion-text.html) — are not in the auto-migration table. The script will warn for these; move the class to the component tag manually.
+
+> [!WARNING]
+> If you have both `:root-class="expr"` and `:class="…"` on the same component, the script cannot safely merge the two dynamic bindings. It will warn and leave the tag unchanged — merge manually.
+
+**Affected components:** [DtAvatar](/components/avatar.html), [DtBreadcrumbItem](/components/breadcrumbs.html), [DtCard](/components/card.html), [DtCheckbox](/components/checkbox.html), [DtFeedItemPill](/components/feed-item-pill.html), [DtFilterPill](/components/filter-pill.html), [DtInput](/components/input.html), [DtModeIsland](/components/mode-island.html), [DtMotionText](/components/motion-text.html), [DtRadio](/components/radio.html), [DtSelectMenu](/components/select-menu.html), [DtSplitButton](/components/split-button.html), [DtToggle](/components/toggle.html)
+
+---
+
+## Slot Renames
+
+Three slots have been renamed to remove the wordy `Override` and `Slot` suffixes that were artefacts of an older naming convention.
+
+| Old name | New name | Component |
+| --- | --- | --- |
+| `#titleOverride` | `#header` | [DtBanner](/components/banner.html), [DtNotice](/components/notice.html), [DtToast](/components/toast.html) |
+| `#labelSlot` | `#label` | [DtInput](/components/input.html), [DtSelectMenu](/components/select-menu.html) |
+| `#headingSlot` | `#heading` | [DtListItemGroup](/components/list-item-group.html) |
+
+<div class="d-d-grid d-g-200 d-g-cols1 md:d-g-cols2">
+<div>
+
+**Before**
+
+```vue
+<dt-banner kind="critical">
+  <template #titleOverride>
+    <dt-icon name="alert-triangle" /> Payment failed
+  </template>
+</dt-banner>
+
+<dt-input label="Email">
+  <template #labelSlot>
+    Work email <span class="d-fc-critical">*</span>
+  </template>
+</dt-input>
+
+<dt-list-item-group>
+  <template #headingSlot>Recent</template>
+</dt-list-item-group>
+```
+
+</div>
+<div>
+
+**After**
+
+```vue
+<dt-banner kind="critical">
+  <template #header>
+    <dt-icon name="alert-triangle" /> Payment failed
+  </template>
+</dt-banner>
+
+<dt-input label="Email">
+  <template #label>
+    Work email <span class="d-fc-critical">*</span>
+  </template>
+</dt-input>
+
+<dt-list-item-group>
+  <template #heading>Recent</template>
+</dt-list-item-group>
+```
+
+</div>
+</div>
+
+---
+
+## Migration Script
+
+`dialtone-migrate-props` automates the majority of these changes across `.vue`, `.js`, `.ts`, `.html`, `.md`, `.jsx`, and `.tsx` files.
+
+### Dry run (preview changes)
+
+```bash
+npx dialtone-migrate-props --dry-run --cwd ./src
+```
+
+### Apply changes
+
+```bash
+npx dialtone-migrate-props --cwd ./src
+```
+
+### Apply without prompting
+
+```bash
+npx dialtone-migrate-props --cwd ./src --yes
+```
+
+### What the script handles automatically
+
+- `kind` and `validation-state` value renames (`danger`/`error`/`success`)
+- `show` → `open`, `@update:show` → `@update:open`, `v-model:show` → `v-model:open`
+- `hide-close`, `hide-icon`, `hide-action`, `hide-clear` → `:show-*="false"`
+- `:hide-*="true"` → `:show-*="false"` and `:hide-*="false"` → removed
+- `label-visible` → `show-label`
+- `title` / `title-id` → `header-text` / `header-id`
+- `banner-title` → `banner-header-text`
+- `clickable` → `interactive` on `dt-avatar`
+- `root-class` / `rootClass` → `class` on `dt-input`, `dt-checkbox`, `dt-radio`, `dt-select-menu`, `dt-breadcrumb-item`, `dt-split-button`
+- `wrapper-class` / `wrapperClass` → `class` on `dt-toggle`, `dt-feed-item-pill`
+- `container-class` / `containerClass` → `class` on `dt-card`
+- Merges into an existing `class="…"` attribute when one is already present
+- Slot renames: `#titleOverride` → `#header`, `#labelSlot` → `#label`, `#headingSlot` → `#heading`
+- Both kebab-case and camelCase prop variants
+
+### What requires manual review
+
+- **`:hide-*="someExpression"`** — cannot safely invert a dynamic expression. The script warns with the file and prop. Replace with `:show-*="!(someExpression)"`.
+- **`rootClass` on unknown components** — `dt-avatar`, `dt-filter-pill`, `dt-mode-island`, `dt-motion-text` are not in the auto-migration table. The script warns; move the class to the component tag manually.
+- **`:root-class="expr"` + `:class="…"` on the same tag** — the script cannot merge two dynamic bindings. It warns and leaves the tag unchanged; merge manually.
+
+</BlogPost>
+
+<script setup>
+import BlogPost from '@baseComponents/BlogPost.vue';
+import { parse } from 'date-fns';
+</script>

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs
@@ -12,6 +12,7 @@
  *   DLT-3283  slot renames: titleOverride→header, labelSlot→label, headingSlot→heading
  *   DLT-3284  title/titleId → headerText/headerId props (banner, notice, toast, modal)
  *   DLT-3159  label-visible → show-label (checkbox, combobox, input, select-menu, toggle, etc.)
+ *   DLT-3160  checkbox-group: selectedValues → modelValue; @input/@change → @update:model-value on form inputs
  *   DLT-3100  rootClass removed — warns with file locations, cannot auto-migrate
  *
  * Usage:
@@ -87,6 +88,9 @@ const COMPONENT_PROP_RENAMES = {
   'dt-select-menu': { 'label-visible': 'show-label' },
   'dt-toggle': { 'label-visible': 'show-label' },
   'dt-radio-group': { 'label-visible': 'show-label' },
+  'dt-checkbox-group': { 'selected-values': 'model-value' },
+  'dt-link': { kind: 'tone' },
+  'dt-popover': { 'hide-on-click': 'close-on-click' },
 };
 
 // Removed class props per component: old-prop → class attribute directly
@@ -110,15 +114,24 @@ const INVERTED_BOOL_PROPS = {
   'dt-notice': { 'hide-close': 'show-close', 'hide-icon': 'show-icon', 'hide-action': 'show-action' },
   'dt-toast': { 'hide-close': 'show-close', 'hide-icon': 'show-icon', 'hide-action': 'show-action' },
   'dt-filter-pill': { 'hide-clear': 'show-clear' },
+  'dt-notice-action': { 'hide-close': 'show-close', 'hide-action': 'show-action' },
+  'dt-pagination': { 'hide-edges': 'show-edges' },
+  'dt-segmented-control': { 'hide-divider': 'show-divider' },
+  'dt-rich-text-editor': { 'prevent-typing': 'allow-typing', 'hide-link-bubble-menu': 'show-link-bubble-menu' },
+  'dt-recipe-message-input': { 'prevent-typing': 'allow-typing' },
+  'dt-recipe-contact-centers-row': { 'hide-actions': 'show-actions' },
 };
 
-// Prop value renames applied to any dt-* component (kind and validation-state)
+// Prop value renames applied to any dt-* component
 const PROP_VALUE_RENAMES = [
   { prop: 'kind', oldValue: 'danger', newValue: 'critical' },
   { prop: 'kind', oldValue: 'error', newValue: 'critical' },
   { prop: 'kind', oldValue: 'success', newValue: 'positive' },
   { prop: 'validation-state', oldValue: 'error', newValue: 'critical' },
   { prop: 'validation-state', oldValue: 'success', newValue: 'positive' },
+  { prop: 'type', oldValue: 'success', newValue: 'positive' },
+  { prop: 'banner-kind', oldValue: 'error', newValue: 'critical' },
+  { prop: 'banner-kind', oldValue: 'success', newValue: 'positive' },
 ];
 
 // Slot renames — applied globally (names are unique enough across the system)
@@ -127,6 +140,28 @@ const SLOT_RENAMES = [
   { old: 'labelSlot', new: 'label' },
   { old: 'headingSlot', new: 'heading' },
 ];
+
+// v-model arg renames per component (null = drop arg, becomes default v-model)
+const VMODEL_ARG_RENAMES = {
+  'dt-checkbox-group': { 'selected-values': null, selectedValues: null },
+};
+
+// @update:* event renames per component
+const UPDATE_EVENT_RENAMES = {
+  'dt-checkbox-group': { 'selected-values': 'model-value', selectedValues: 'modelValue' },
+};
+
+// Component events removed from emits and replaced by @update:model-value
+const EMIT_EVENT_RENAMES = {
+  'dt-input': { input: 'update:model-value' },
+  'dt-radio': { input: 'update:model-value' },
+  'dt-radio-group': { input: 'update:model-value' },
+  'dt-select-menu': { input: 'update:model-value', change: 'update:model-value' },
+  'dt-toggle': { change: 'update:model-value' },
+  'dt-combobox-multi-select': { input: 'update:model-value' },
+  'dt-rich-text-editor': { input: 'update:model-value' },
+  'dt-input-group': { input: 'update:model-value' },
+};
 
 // Regex matching any Dialtone component opening tag (multi-line safe)
 const DT_TAG_RE = /<(dt-[\w-]+|Dt\w+)\b([\s\S]*?)(?:\/?>)/g;
@@ -344,6 +379,53 @@ function applyRootClassRename (tag, canonical) {
 }
 
 /**
+ * `v-model:oldArg` → `v-model` and `@update:oldEvent` → `@update:newEvent` per component.
+ */
+function applyVModelAndEventRenames (tag, canonical) {
+  const vmodelMap = VMODEL_ARG_RENAMES[canonical];
+  const eventMap = UPDATE_EVENT_RENAMES[canonical];
+  if (!vmodelMap && !eventMap) return { tag, count: 0 };
+
+  let result = tag;
+  let count = 0;
+
+  if (vmodelMap) {
+    for (const [oldArg, newArg] of Object.entries(vmodelMap)) {
+      const before = result;
+      const replacement = newArg ? `v-model:${newArg}` : 'v-model';
+      result = result.replace(new RegExp(`v-model:${escapeRe(oldArg)}\\b`, 'g'), replacement);
+      if (result !== before) count++;
+    }
+  }
+
+  if (eventMap) {
+    for (const [oldEvt, newEvt] of Object.entries(eventMap)) {
+      const before = result;
+      result = result.replace(new RegExp(`@update:${escapeRe(oldEvt)}\\b`, 'g'), `@update:${newEvt}`);
+      if (result !== before) count++;
+    }
+  }
+
+  return { tag: result, count };
+}
+
+/**
+ * Legacy `@input` / `@change` component events → `@update:model-value`.
+ */
+function applyEmitEventRenames (tag, canonical) {
+  const eventMap = EMIT_EVENT_RENAMES[canonical];
+  if (!eventMap) return { tag, count: 0 };
+  let result = tag;
+  let count = 0;
+  for (const [oldEvt, newEvt] of Object.entries(eventMap)) {
+    const before = result;
+    result = result.replace(new RegExp(`@${escapeRe(oldEvt)}\\b`, 'g'), `@${newEvt}`);
+    if (result !== before) count++;
+  }
+  return { tag: result, count };
+}
+
+/**
  * Warn about removed rootClass / root-class prop on components not in ROOT_CLASS_RENAMES.
  */
 function detectRootClass (tag, tagName, canonical) {
@@ -376,22 +458,28 @@ function transformTag (fullTag, tagName) {
   let count = 0;
   const warnings = [];
 
-  const r1 = applyShowToOpen(tag, canonical);
+  const r1 = applyVModelAndEventRenames(tag, canonical);
   tag = r1.tag; count += r1.count;
 
-  const r2 = applyPropRenames(tag, canonical);
+  const r2 = applyShowToOpen(tag, canonical);
   tag = r2.tag; count += r2.count;
 
-  const r3 = applyInvertedBoolProps(tag, canonical);
+  const r3 = applyPropValueRenames(tag);
   tag = r3.tag; count += r3.count;
-  warnings.push(...r3.warnings);
 
-  const r4 = applyPropValueRenames(tag);
+  const r4 = applyPropRenames(tag, canonical);
   tag = r4.tag; count += r4.count;
 
-  const r5 = applyRootClassRename(tag, canonical);
+  const r5 = applyInvertedBoolProps(tag, canonical);
   tag = r5.tag; count += r5.count;
   warnings.push(...r5.warnings);
+
+  const r6 = applyRootClassRename(tag, canonical);
+  tag = r6.tag; count += r6.count;
+  warnings.push(...r6.warnings);
+
+  const r7 = applyEmitEventRenames(tag, canonical);
+  tag = r7.tag; count += r7.count;
 
   warnings.push(...detectRootClass(tag, tagName, canonical));
 
@@ -486,10 +574,15 @@ function printHelp () {
 Usage: npx dialtone-migrate-props [options]
 
 Migrates Dialtone component prop/slot/event breaking changes introduced in
-DLT-3100, DLT-3157, DLT-3159, DLT-3161, DLT-3282, DLT-3283, DLT-3284.
+DLT-3100, DLT-3157, DLT-3159, DLT-3160, DLT-3161, DLT-3282, DLT-3283, DLT-3284.
 
 Migrations applied:
   clickable              → interactive           (dt-avatar)
+  selected-values        → model-value           (dt-checkbox-group)
+  v-model:selected-values → v-model             (dt-checkbox-group)
+  @update:selected-values → @update:model-value (dt-checkbox-group)
+  @input                 → @update:model-value  (dt-input, dt-radio, dt-radio-group, dt-combobox-multi-select, dt-rich-text-editor, dt-input-group)
+  @change                → @update:model-value  (dt-toggle, dt-select-menu)
   show                   → open                  (dt-modal, dt-toast, dt-tooltip)
   @update:show           → @update:open          (dt-modal, dt-toast, dt-tooltip)
   v-model:show           → v-model:open          (dt-modal, dt-toast, dt-tooltip)
@@ -497,16 +590,26 @@ Migrations applied:
   title-id               → header-id             (dt-banner, dt-notice, dt-toast)
   banner-title           → banner-header-text    (dt-modal)
   label-visible          → show-label            (dt-checkbox, dt-combobox, dt-input, etc.)
-  hide-close             → :show-close="false"   (dt-banner, dt-chip, dt-modal, dt-notice, dt-toast)
+  hide-close             → :show-close="false"   (dt-banner, dt-chip, dt-modal, dt-notice, dt-notice-action, dt-toast)
   hide-icon              → :show-icon="false"    (dt-banner, dt-notice, dt-toast)
-  hide-action            → :show-action="false"  (dt-banner, dt-notice, dt-toast)
+  hide-action            → :show-action="false"  (dt-banner, dt-notice, dt-notice-action, dt-toast)
   hide-clear             → :show-clear="false"   (dt-filter-pill)
+  hide-edges             → :show-edges="false"   (dt-pagination)
+  hide-divider           → :show-divider="false" (dt-segmented-control)
+  prevent-typing         → :allow-typing="false" (dt-rich-text-editor, dt-recipe-message-input)
+  hide-link-bubble-menu  → :show-link-bubble-menu="false" (dt-rich-text-editor)
+  hide-actions           → :show-actions="false" (dt-recipe-contact-centers-row)
+  hide-on-click          → close-on-click        (dt-popover, same semantics — not inverted)
   root-class             → class                 (dt-input, dt-checkbox, dt-radio, dt-select-menu, dt-breadcrumb-item, dt-split-button)
   wrapper-class          → class                 (dt-toggle, dt-feed-item-pill)
   container-class        → class                 (dt-card)
   kind="danger"          → kind="critical"       (any dt-* component)
   kind="error"           → kind="critical"       (any dt-* component)
   kind="success"         → kind="positive"       (any dt-* component)
+  type="success"         → type="positive"       (dt-badge)
+  kind                   → tone                  (dt-link, with value renames applied in same pass)
+  banner-kind="error"    → banner-kind="critical" (dt-modal)
+  banner-kind="success"  → banner-kind="positive" (dt-modal)
   validation-state="error"   → validation-state="critical"
   validation-state="success" → validation-state="positive"
   #titleOverride         → #header               (slots)

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs
@@ -417,7 +417,28 @@ function applyVModelAndEventRenames (tag, canonical) {
 }
 
 /**
+ * Remove duplicate `@eventName` bindings within a single tag string, keeping
+ * the first occurrence. This handles the case where multiple source events
+ * (e.g. `@input` and `@change`) both map to the same target event.
+ */
+function deduplicateEventBindings (tag) {
+  const seen = new Set();
+  let removedCount = 0;
+  const cleaned = tag.replace(/ @([\w:.-]+)(?:=(?:"[^"]*"|'[^']*'))?/g, (match, eventName) => {
+    if (seen.has(eventName)) {
+      removedCount++;
+      return '';
+    }
+    seen.add(eventName);
+    return match;
+  });
+  return { tag: cleaned, removedCount };
+}
+
+/**
  * Legacy `@input` / `@change` component events → `@update:model-value`.
+ * When multiple source events map to the same target, the first is kept and
+ * subsequent duplicates are removed.
  */
 function applyEmitEventRenames (tag, canonical) {
   const eventMap = EMIT_EVENT_RENAMES[canonical];
@@ -429,7 +450,8 @@ function applyEmitEventRenames (tag, canonical) {
     result = result.replace(new RegExp(`@${escapeRe(oldEvt)}\\b`, 'g'), `@${newEvt}`);
     if (result !== before) count++;
   }
-  return { tag: result, count };
+  const { tag: deduped, removedCount } = deduplicateEventBindings(result);
+  return { tag: deduped, count: count - removedCount };
 }
 
 /**

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs
@@ -1,0 +1,633 @@
+#!/usr/bin/env node
+/* eslint-disable max-lines */
+
+/**
+ * @fileoverview Migration script for Dialtone component prop/slot/event breaking changes.
+ *
+ * Covers these changes:
+ *   DLT-3161  avatar: clickable → interactive
+ *   DLT-3157  kind/validation-state values: danger→critical, error→critical, success→positive
+ *   DLT-3159  positive boolean props: hide-close→show-close, hide-icon→show-icon, etc.
+ *   DLT-3282  show prop → open (modal, toast, tooltip) + update:show → update:open
+ *   DLT-3283  slot renames: titleOverride→header, labelSlot→label, headingSlot→heading
+ *   DLT-3284  title/titleId → headerText/headerId props (banner, notice, toast, modal)
+ *   DLT-3159  label-visible → show-label (checkbox, combobox, input, select-menu, toggle, etc.)
+ *   DLT-3100  rootClass removed — warns with file locations, cannot auto-migrate
+ *
+ * Usage:
+ *   npx dialtone-migrate-props [options]
+ *
+ * Options:
+ *   --cwd <path>     Working directory (default: current directory)
+ *   --dry-run        Show changes without applying them
+ *   --yes            Apply all changes without prompting
+ *   --help           Show help
+ *
+ * Examples:
+ *   npx dialtone-migrate-props
+ *   npx dialtone-migrate-props --dry-run
+ *   npx dialtone-migrate-props --cwd ./src
+ */
+
+import fs from 'fs/promises';
+import { realpathSync } from 'node:fs';
+import path from 'path';
+import readline from 'readline';
+import { fileURLToPath } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function kebabToCamel (str) {
+  return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+function escapeRe (str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ---------------------------------------------------------------------------
+// Transformation Data
+// ---------------------------------------------------------------------------
+
+// Components where `show` → `open` and `update:show` → `update:open`
+const SHOW_TO_OPEN_COMPONENTS = new Set([
+  'dt-modal', 'DtModal',
+  'dt-toast', 'DtToast',
+  'dt-tooltip', 'DtTooltip',
+]);
+
+// Direct prop renames per component (kebab-case keys; camelCase handled automatically)
+const COMPONENT_PROP_RENAMES = {
+  'dt-avatar': {
+    clickable: 'interactive',
+  },
+  'dt-banner': {
+    title: 'header-text',
+    'title-id': 'header-id',
+  },
+  'dt-notice': {
+    title: 'header-text',
+    'title-id': 'header-id',
+  },
+  'dt-toast': {
+    title: 'header-text',
+    'title-id': 'header-id',
+  },
+  'dt-modal': {
+    title: 'header-text',
+    'banner-title': 'banner-header-text',
+  },
+  'dt-checkbox': { 'label-visible': 'show-label' },
+  'dt-combobox': { 'label-visible': 'show-label' },
+  'dt-combobox-multi-select': { 'label-visible': 'show-label' },
+  'dt-combobox-with-popover': { 'label-visible': 'show-label' },
+  'dt-input': { 'label-visible': 'show-label' },
+  'dt-select-menu': { 'label-visible': 'show-label' },
+  'dt-toggle': { 'label-visible': 'show-label' },
+  'dt-radio-group': { 'label-visible': 'show-label' },
+};
+
+// Removed class props per component: old-prop → class attribute directly
+const ROOT_CLASS_RENAMES = {
+  'dt-input': 'root-class',
+  'dt-checkbox': 'root-class',
+  'dt-radio': 'root-class',
+  'dt-select-menu': 'root-class',
+  'dt-toggle': 'wrapper-class',
+  'dt-card': 'container-class',
+  'dt-breadcrumb-item': 'root-class',
+  'dt-split-button': 'root-class',
+  'dt-feed-item-pill': 'wrapper-class',
+};
+
+// Inverted boolean props per component: `hide-X` → `:show-X="false"`
+const INVERTED_BOOL_PROPS = {
+  'dt-banner': { 'hide-close': 'show-close', 'hide-icon': 'show-icon', 'hide-action': 'show-action' },
+  'dt-chip': { 'hide-close': 'show-close' },
+  'dt-modal': { 'hide-close': 'show-close' },
+  'dt-notice': { 'hide-close': 'show-close', 'hide-icon': 'show-icon', 'hide-action': 'show-action' },
+  'dt-toast': { 'hide-close': 'show-close', 'hide-icon': 'show-icon', 'hide-action': 'show-action' },
+  'dt-filter-pill': { 'hide-clear': 'show-clear' },
+};
+
+// Prop value renames applied to any dt-* component (kind and validation-state)
+const PROP_VALUE_RENAMES = [
+  { prop: 'kind', oldValue: 'danger', newValue: 'critical' },
+  { prop: 'kind', oldValue: 'error', newValue: 'critical' },
+  { prop: 'kind', oldValue: 'success', newValue: 'positive' },
+  { prop: 'validation-state', oldValue: 'error', newValue: 'critical' },
+  { prop: 'validation-state', oldValue: 'success', newValue: 'positive' },
+];
+
+// Slot renames — applied globally (names are unique enough across the system)
+const SLOT_RENAMES = [
+  { old: 'titleOverride', new: 'header' },
+  { old: 'labelSlot', new: 'label' },
+  { old: 'headingSlot', new: 'heading' },
+];
+
+// Regex matching any Dialtone component opening tag (multi-line safe)
+const DT_TAG_RE = /<(dt-[\w-]+|Dt\w+)\b([\s\S]*?)(?:\/?>)/g;
+
+// ---------------------------------------------------------------------------
+// Per-tag Sub-Transformers
+// ---------------------------------------------------------------------------
+
+/**
+ * `show` → `open` plus `@update:show` / `v-model:show` on overlay components.
+ */
+function applyShowToOpen (tag, canonical) {
+  if (!SHOW_TO_OPEN_COMPONENTS.has(canonical)) return { tag, count: 0 };
+  let result = tag;
+  let count = 0;
+
+  // :show="…" or show="…" but NOT show-close / show-icon / show-action etc.
+  result = result.replace(/(\b:?)(show)(?=[=\s/>])/g, (match, colon, _prop, offset, str) => {
+    if (str[offset + match.length] === '-') return match;
+    count++;
+    return `${colon}open`;
+  });
+
+  const updateBefore = result;
+  result = result.replace(/@update:show\b/g, '@update:open');
+  count += (result !== updateBefore) ? 1 : 0;
+
+  const vmodelBefore = result;
+  result = result.replace(/v-model:show\b/g, 'v-model:open');
+  count += (result !== vmodelBefore) ? 1 : 0;
+
+  return { tag: result, count };
+}
+
+/**
+ * Direct 1:1 prop renames for a specific component.
+ */
+function applyPropRenames (tag, canonical) {
+  const renames = COMPONENT_PROP_RENAMES[canonical];
+  if (!renames) return { tag, count: 0 };
+
+  let result = tag;
+  let count = 0;
+
+  for (const [oldProp, newProp] of Object.entries(renames)) {
+    const oldCamel = kebabToCamel(oldProp);
+    const newCamel = kebabToCamel(newProp);
+
+    // Static kebab: `old-prop="…"` or bare boolean
+    const before1 = result;
+    result = result.replace(new RegExp(`(?<!:)\\b${escapeRe(oldProp)}(?=[=\\s/>])`, 'g'), newProp);
+    if (result !== before1) { count++; continue; }
+
+    // Bound kebab: `:old-prop="…"`
+    const before2 = result;
+    result = result.replace(new RegExp(`(?<=:)${escapeRe(oldProp)}(?==)`, 'g'), newProp);
+    if (result !== before2) { count++; continue; }
+
+    // Bound camelCase: `:oldProp="…"`
+    if (oldCamel !== oldProp) {
+      const before3 = result;
+      result = result.replace(new RegExp(`(?<=:)${escapeRe(oldCamel)}(?==)`, 'g'), newCamel);
+      if (result !== before3) count++;
+    }
+  }
+
+  return { tag: result, count };
+}
+
+/**
+ * Apply one inverted-boolean rename: hide-X → :show-X="false".
+ * Returns { tag, count, warning? }
+ */
+function applyOneInvertedProp (tag, oldProp, newProp) {
+  const oldCamel = kebabToCamel(oldProp);
+  const newCamel = kebabToCamel(newProp);
+
+  // `:hide-prop="false"` or `:hideXxx="false"` → remove (default is true)
+  for (const p of [escapeRe(oldProp), escapeRe(oldCamel)]) {
+    const before = tag;
+    tag = tag.replace(new RegExp(`:${p}="false"`, 'g'), '');
+    if (tag !== before) return { tag, count: 1 };
+  }
+
+  // `:hide-prop="true"` → `:show-prop="false"`
+  const trueBefore = tag;
+  tag = tag.replace(new RegExp(`:${escapeRe(oldProp)}="true"`, 'g'), `:${newProp}="false"`);
+  if (tag !== trueBefore) return { tag, count: 1 };
+
+  // `:hideXxx="true"` → `:showXxx="false"`
+  const camelTrueBefore = tag;
+  tag = tag.replace(new RegExp(`:${escapeRe(oldCamel)}="true"`, 'g'), `:${newCamel}="false"`);
+  if (tag !== camelTrueBefore) return { tag, count: 1 };
+
+  // Bare boolean: `hide-prop` → `:show-prop="false"`
+  const bareBefore = tag;
+  tag = tag.replace(new RegExp(`(?<!:)\\b${escapeRe(oldProp)}(?=[\\s/>])`, 'g'), `:${newProp}="false"`);
+  if (tag !== bareBefore) return { tag, count: 1 };
+
+  // Bound expression: cannot auto-invert — emit warning
+  const exprMatch = new RegExp(`:${escapeRe(oldProp)}="([^"]*)"`, 'g').exec(tag);
+  if (exprMatch) {
+    return {
+      tag,
+      count: 0,
+      warning: `Cannot auto-invert :${oldProp}="${exprMatch[1]}" → :${newProp}. ` +
+        `Replace manually with :${newProp}="!(${exprMatch[1]})"`,
+    };
+  }
+
+  return { tag, count: 0 };
+}
+
+/**
+ * Inverted boolean props for a specific component (hide-X → :show-X="false").
+ */
+function applyInvertedBoolProps (tag, canonical) {
+  const invertedMap = INVERTED_BOOL_PROPS[canonical];
+  if (!invertedMap) return { tag, count: 0, warnings: [] };
+
+  let result = tag;
+  let count = 0;
+  const warnings = [];
+
+  for (const [oldProp, newProp] of Object.entries(invertedMap)) {
+    const { tag: updated, count: c, warning } = applyOneInvertedProp(result, oldProp, newProp);
+    result = updated;
+    count += c;
+    if (warning) warnings.push(warning);
+  }
+
+  return { tag: result, count, warnings };
+}
+
+/**
+ * `kind` and `validation-state` value renames on any dt-* component.
+ */
+function applyPropValueRenames (tag) {
+  let result = tag;
+  let count = 0;
+
+  for (const { prop, oldValue, newValue } of PROP_VALUE_RENAMES) {
+    const propCamel = kebabToCamel(prop);
+
+    for (const p of [prop, propCamel]) {
+      // Static: `prop="oldValue"`
+      const before1 = result;
+      result = result.replace(
+        new RegExp(`(?<!:)\\b${escapeRe(p)}="${escapeRe(oldValue)}"`, 'g'),
+        `${p}="${newValue}"`,
+      );
+      if (result !== before1) count++;
+
+      // Bound string literal: `:prop="'oldValue'"`
+      const before2 = result;
+      result = result.replace(
+        new RegExp(`:${escapeRe(p)}="'${escapeRe(oldValue)}'"`, 'g'),
+        `:${p}="'${newValue}'"`,
+      );
+      if (result !== before2) count++;
+    }
+  }
+
+  return { tag: result, count };
+}
+
+/**
+ * Renames a removed class prop (root-class, wrapper-class, container-class) to `class`.
+ * Static values are merged into an existing `class="…"` if present.
+ * Dynamic bindings warn if `:class` already exists (cannot safely merge expressions).
+ */
+function applyRootClassRename (tag, canonical) {
+  const oldProp = ROOT_CLASS_RENAMES[canonical];
+  if (!oldProp) return { tag, count: 0, warnings: [] };
+
+  const oldCamel = kebabToCamel(oldProp);
+  let result = tag;
+  let count = 0;
+  const warnings = [];
+
+  for (const p of [oldProp, oldCamel]) {
+    // Dynamic: `:old-prop="expr"` → `:class="expr"` (warn if :class already exists)
+    const dynRe = new RegExp(`:${escapeRe(p)}="([^"]*)"`);
+    const dynMatch = dynRe.exec(result);
+    if (dynMatch) {
+      if (/:class="/.test(result)) {
+        warnings.push(
+          `Cannot auto-merge :${p}="${dynMatch[1]}" into :class on <${canonical}> — merge manually.`,
+        );
+      } else {
+        result = result.replace(dynMatch[0], `:class="${dynMatch[1]}"`);
+        count++;
+      }
+      break;
+    }
+
+    // Static: `old-prop="value"` → `class="value"` (merge if class already exists)
+    const staticRe = new RegExp(`(?<!:)\\b${escapeRe(p)}="([^"]*)"`);
+    const staticMatch = staticRe.exec(result);
+    if (staticMatch) {
+      const addedVal = staticMatch[1];
+      const existingClassMatch = /(?<![:\w-])class="([^"]*)"/.exec(result);
+      if (existingClassMatch) {
+        result = result.replace(staticMatch[0], '');
+        result = result.replace(existingClassMatch[0], `class="${existingClassMatch[1]} ${addedVal}"`);
+      } else {
+        result = result.replace(staticMatch[0], `class="${addedVal}"`);
+      }
+      count++;
+      break;
+    }
+  }
+
+  return { tag: result, count, warnings };
+}
+
+/**
+ * Warn about removed rootClass / root-class prop on components not in ROOT_CLASS_RENAMES.
+ */
+function detectRootClass (tag, tagName, canonical) {
+  if (ROOT_CLASS_RENAMES[canonical]) return [];
+  const re = /\broot-class(?:=|\b)|\brootClass(?:=|\b)/g;
+  const matches = tag.match(re);
+  if (!matches) return [];
+  return matches.map(() =>
+    `rootClass / root-class has been removed from <${tagName}>` +
+    ' — apply classes directly on the component element or use a wrapper.',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-tag Entry Point
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the canonical kebab-case component name for config lookups.
+ * PascalCase → kebab-case: DtAvatar → dt-avatar
+ */
+function normalizeTagName (tag) {
+  if (tag.startsWith('dt-')) return tag;
+  return tag.replace(/(?<=[a-z])([A-Z])/g, '-$1').toLowerCase();
+}
+
+function transformTag (fullTag, tagName) {
+  const canonical = normalizeTagName(tagName);
+  let tag = fullTag;
+  let count = 0;
+  const warnings = [];
+
+  const r1 = applyShowToOpen(tag, canonical);
+  tag = r1.tag; count += r1.count;
+
+  const r2 = applyPropRenames(tag, canonical);
+  tag = r2.tag; count += r2.count;
+
+  const r3 = applyInvertedBoolProps(tag, canonical);
+  tag = r3.tag; count += r3.count;
+  warnings.push(...r3.warnings);
+
+  const r4 = applyPropValueRenames(tag);
+  tag = r4.tag; count += r4.count;
+
+  const r5 = applyRootClassRename(tag, canonical);
+  tag = r5.tag; count += r5.count;
+  warnings.push(...r5.warnings);
+
+  warnings.push(...detectRootClass(tag, tagName, canonical));
+
+  return { result: tag, count, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Full-file Slot Transforms
+// ---------------------------------------------------------------------------
+
+function transformSlots (content) {
+  let result = content;
+  let count = 0;
+
+  for (const { old: oldName, new: newName } of SLOT_RENAMES) {
+    const patterns = [
+      [new RegExp(`#${escapeRe(oldName)}\\b`, 'g'), `#${newName}`],
+      [new RegExp(`v-slot:${escapeRe(oldName)}\\b`, 'g'), `v-slot:${newName}`],
+      [new RegExp(`slot="${escapeRe(oldName)}"`, 'g'), `slot="${newName}"`],
+    ];
+
+    for (const [re, replacement] of patterns) {
+      const before = result;
+      result = result.replace(re, replacement);
+      if (result !== before) count += (before.match(re) || []).length;
+    }
+  }
+
+  return { result, count };
+}
+
+// ---------------------------------------------------------------------------
+// Main Transform
+// ---------------------------------------------------------------------------
+
+function transformContent (content) {
+  let transformed = content;
+  let totalCount = 0;
+  const allWarnings = [];
+
+  const { result: slotResult, count: slotCount } = transformSlots(transformed);
+  transformed = slotResult;
+  totalCount += slotCount;
+
+  DT_TAG_RE.lastIndex = 0;
+  transformed = transformed.replace(DT_TAG_RE, (fullMatch, tagName) => {
+    const { result, count, warnings } = transformTag(fullMatch, tagName);
+    totalCount += count;
+    if (warnings.length) allWarnings.push(...warnings);
+    return result;
+  });
+
+  return { transformed, count: totalCount, warnings: allWarnings };
+}
+
+export { transformContent };
+
+// ---------------------------------------------------------------------------
+// File Finder
+// ---------------------------------------------------------------------------
+
+async function findFiles (dir, extensions, ignore = []) {
+  const results = [];
+
+  async function walk (currentDir) {
+    try {
+      const entries = await fs.readdir(currentDir, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = path.join(currentDir, entry.name);
+        if (ignore.some(ig => fullPath.includes(ig))) continue;
+        if (entry.isDirectory()) {
+          await walk(fullPath);
+        } else if (entry.isFile() && extensions.some(ext => entry.name.endsWith(ext))) {
+          results.push(fullPath);
+        }
+      }
+    } catch {
+      // skip unreadable dirs
+    }
+  }
+
+  await walk(dir);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function printHelp () {
+  console.log(`
+Usage: npx dialtone-migrate-props [options]
+
+Migrates Dialtone component prop/slot/event breaking changes introduced in
+DLT-3100, DLT-3157, DLT-3159, DLT-3161, DLT-3282, DLT-3283, DLT-3284.
+
+Migrations applied:
+  clickable              → interactive           (dt-avatar)
+  show                   → open                  (dt-modal, dt-toast, dt-tooltip)
+  @update:show           → @update:open          (dt-modal, dt-toast, dt-tooltip)
+  v-model:show           → v-model:open          (dt-modal, dt-toast, dt-tooltip)
+  title                  → header-text           (dt-banner, dt-notice, dt-toast, dt-modal)
+  title-id               → header-id             (dt-banner, dt-notice, dt-toast)
+  banner-title           → banner-header-text    (dt-modal)
+  label-visible          → show-label            (dt-checkbox, dt-combobox, dt-input, etc.)
+  hide-close             → :show-close="false"   (dt-banner, dt-chip, dt-modal, dt-notice, dt-toast)
+  hide-icon              → :show-icon="false"    (dt-banner, dt-notice, dt-toast)
+  hide-action            → :show-action="false"  (dt-banner, dt-notice, dt-toast)
+  hide-clear             → :show-clear="false"   (dt-filter-pill)
+  root-class             → class                 (dt-input, dt-checkbox, dt-radio, dt-select-menu, dt-breadcrumb-item, dt-split-button)
+  wrapper-class          → class                 (dt-toggle, dt-feed-item-pill)
+  container-class        → class                 (dt-card)
+  kind="danger"          → kind="critical"       (any dt-* component)
+  kind="error"           → kind="critical"       (any dt-* component)
+  kind="success"         → kind="positive"       (any dt-* component)
+  validation-state="error"   → validation-state="critical"
+  validation-state="success" → validation-state="positive"
+  #titleOverride         → #header               (slots)
+  #labelSlot             → #label                (slots)
+  #headingSlot           → #heading              (slots)
+  rootClass / root-class → (warns — manual fix required for unknown components)
+
+Options:
+  --cwd <path>     Working directory (default: current directory)
+  --dry-run        Show changes without applying them
+  --yes            Apply all changes without prompting
+  --help           Show help
+`);
+}
+
+async function prompt (question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise(resolve => {
+    rl.question(question, answer => {
+      rl.close();
+      resolve(answer.trim().toLowerCase());
+    });
+  });
+}
+
+function parseArgs (args) {
+  const cwdIndex = args.indexOf('--cwd');
+  return {
+    help: args.includes('--help'),
+    dryRun: args.includes('--dry-run'),
+    autoYes: args.includes('--yes'),
+    cwd: cwdIndex !== -1 && args[cwdIndex + 1]
+      ? path.resolve(args[cwdIndex + 1])
+      : process.cwd(),
+  };
+}
+
+async function scanFiles (cwd) {
+  const extensions = ['.vue', '.md', '.html', '.js', '.ts', '.jsx', '.tsx'];
+  const ignore = ['node_modules', 'dist', '.git', '.vuepress/public'];
+  const files = await findFiles(cwd, extensions, ignore);
+
+  const changes = [];
+  const allWarnings = [];
+
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8');
+    const { transformed, count, warnings } = transformContent(content);
+    if (count > 0) changes.push({ file, content, transformed, count });
+    if (warnings.length) allWarnings.push(...warnings.map(w => `${path.relative(cwd, file)}: ${w}`));
+  }
+
+  return { changes, allWarnings };
+}
+
+async function applyChanges (changes, autoYes) {
+  if (!autoYes) {
+    const answer = await prompt('\nApply changes? (y/N) ');
+    if (answer !== 'y' && answer !== 'yes') {
+      console.log('Cancelled.');
+      return false;
+    }
+  }
+  for (const { file, transformed } of changes) {
+    await fs.writeFile(file, transformed, 'utf8');
+  }
+  return true;
+}
+
+function printWarnings (warnings) {
+  if (!warnings.length) return;
+  console.log('⚠  Manual action required:\n');
+  for (const w of warnings) console.log(`  ${w}`);
+  console.log();
+}
+
+function printChangeSummary (changes, cwd) {
+  const total = changes.reduce((sum, c) => sum + c.count, 0);
+  console.log(`Found ${total} change(s) across ${changes.length} file(s):\n`);
+  for (const { file, count } of changes) {
+    console.log(`  ${path.relative(cwd, file)} (${count} change${count > 1 ? 's' : ''})`);
+  }
+  return total;
+}
+
+async function main () {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) { printHelp(); process.exit(0); }
+
+  console.log(`\nScanning ${opts.cwd} for Dialtone prop/slot/event usage...\n`);
+
+  const { changes, allWarnings } = await scanFiles(opts.cwd);
+  printWarnings(allWarnings);
+
+  if (changes.length === 0) {
+    console.log('No matching usage found. Nothing to migrate.');
+    process.exit(0);
+  }
+
+  const total = printChangeSummary(changes, opts.cwd);
+
+  if (opts.dryRun) {
+    console.log('\n--dry-run: No files were modified.\n');
+    process.exit(0);
+  }
+
+  const applied = await applyChanges(changes, opts.autoYes);
+  if (applied) console.log(`\nMigrated ${total} reference(s) across ${changes.length} file(s).\n`);
+}
+
+const isDirectRun = (() => {
+  try {
+    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectRun) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs
@@ -10,7 +10,7 @@
  *   DLT-3159  positive boolean props: hide-close→show-close, hide-icon→show-icon, etc.
  *   DLT-3282  show prop → open (modal, toast, tooltip) + update:show → update:open
  *   DLT-3283  slot renames: titleOverride→header, labelSlot→label, headingSlot→heading
- *   DLT-3284  title/titleId → headerText/headerId props (banner, notice, toast, modal)
+ *   DLT-3284  title → headerText on banner, notice, toast, modal; title-id → header-id on banner, notice, toast only
  *   DLT-3159  label-visible → show-label (checkbox, combobox, input, select-menu, toggle, etc.)
  *   DLT-3160  checkbox-group: selectedValues → modelValue; @input/@change → @update:model-value on form inputs
  *   DLT-3100  rootClass removed — warns with file locations, cannot auto-migrate
@@ -53,11 +53,7 @@ function escapeRe (str) {
 // ---------------------------------------------------------------------------
 
 // Components where `show` → `open` and `update:show` → `update:open`
-const SHOW_TO_OPEN_COMPONENTS = new Set([
-  'dt-modal', 'DtModal',
-  'dt-toast', 'DtToast',
-  'dt-tooltip', 'DtTooltip',
-]);
+const SHOW_TO_OPEN_COMPONENTS = new Set(['dt-modal', 'dt-toast', 'dt-tooltip']);
 
 // Direct prop renames per component (kebab-case keys; camelCase handled automatically)
 const COMPONENT_PROP_RENAMES = {
@@ -163,8 +159,9 @@ const EMIT_EVENT_RENAMES = {
   'dt-input-group': { input: 'update:model-value' },
 };
 
-// Regex matching any Dialtone component opening tag (multi-line safe)
-const DT_TAG_RE = /<(dt-[\w-]+|Dt\w+)\b([\s\S]*?)(?:\/?>)/g;
+// Regex matching any Dialtone component opening tag, handling > inside quoted attribute values.
+// Alternation `(?:"[^"]*"|'[^']*')` consumes quoted strings before the bare [^>]* can stop at >.
+const DT_TAG_RE = /<(dt-[\w-]+|Dt\w+)\b((?:[^>"']*(?:"[^"]*"|'[^']*'))*[^>]*)(?:\/?>)/g;
 
 // ---------------------------------------------------------------------------
 // Per-tag Sub-Transformers
@@ -220,11 +217,14 @@ function applyPropRenames (tag, canonical) {
     result = result.replace(new RegExp(`(?<=:)${escapeRe(oldProp)}(?==)`, 'g'), newProp);
     if (result !== before2) { count++; continue; }
 
-    // Bound camelCase: `:oldProp="…"`
+    // Bound camelCase: `:oldProp="…"` / Static camelCase: `oldProp="…"` or bare boolean
     if (oldCamel !== oldProp) {
       const before3 = result;
       result = result.replace(new RegExp(`(?<=:)${escapeRe(oldCamel)}(?==)`, 'g'), newCamel);
-      if (result !== before3) count++;
+      if (result !== before3) { count++; continue; }
+      const before4 = result;
+      result = result.replace(new RegExp(`(?<!:)\\b${escapeRe(oldCamel)}(?=[=\\s/>])`, 'g'), newCamel);
+      if (result !== before4) count++;
     }
   }
 
@@ -261,15 +261,17 @@ function applyOneInvertedProp (tag, oldProp, newProp) {
   tag = tag.replace(new RegExp(`(?<!:)\\b${escapeRe(oldProp)}(?=[\\s/>])`, 'g'), `:${newProp}="false"`);
   if (tag !== bareBefore) return { tag, count: 1 };
 
-  // Bound expression: cannot auto-invert — emit warning
-  const exprMatch = new RegExp(`:${escapeRe(oldProp)}="([^"]*)"`, 'g').exec(tag);
-  if (exprMatch) {
-    return {
-      tag,
-      count: 0,
-      warning: `Cannot auto-invert :${oldProp}="${exprMatch[1]}" → :${newProp}. ` +
-        `Replace manually with :${newProp}="!(${exprMatch[1]})"`,
-    };
+  // Bound expression: cannot auto-invert — emit warning (check both kebab and camelCase forms)
+  for (const [attrProp, attrNew] of [[oldProp, newProp], [oldCamel, newCamel]]) {
+    const exprMatch = new RegExp(`:${escapeRe(attrProp)}="([^"]*)"`, 'g').exec(tag);
+    if (exprMatch) {
+      return {
+        tag,
+        count: 0,
+        warning: `Cannot auto-invert :${attrProp}="${exprMatch[1]}" → :${attrNew}. ` +
+          `Replace manually with :${attrNew}="!(${exprMatch[1]})"`,
+      };
+    }
   }
 
   return { tag, count: 0 };
@@ -378,35 +380,40 @@ function applyRootClassRename (tag, canonical) {
   return { tag: result, count, warnings };
 }
 
+function applyVModelArgRenames (tag, canonical) {
+  const vmodelMap = VMODEL_ARG_RENAMES[canonical];
+  if (!vmodelMap) return { tag, count: 0 };
+  let result = tag;
+  let count = 0;
+  for (const [oldArg, newArg] of Object.entries(vmodelMap)) {
+    const before = result;
+    const replacement = newArg ? `v-model:${newArg}` : 'v-model';
+    result = result.replace(new RegExp(`v-model:${escapeRe(oldArg)}\\b`, 'g'), replacement);
+    if (result !== before) count++;
+  }
+  return { tag: result, count };
+}
+
+function applyUpdateEventRenames (tag, canonical) {
+  const eventMap = UPDATE_EVENT_RENAMES[canonical];
+  if (!eventMap) return { tag, count: 0 };
+  let result = tag;
+  let count = 0;
+  for (const [oldEvt, newEvt] of Object.entries(eventMap)) {
+    const before = result;
+    result = result.replace(new RegExp(`@update:${escapeRe(oldEvt)}\\b`, 'g'), `@update:${newEvt}`);
+    if (result !== before) count++;
+  }
+  return { tag: result, count };
+}
+
 /**
  * `v-model:oldArg` → `v-model` and `@update:oldEvent` → `@update:newEvent` per component.
  */
 function applyVModelAndEventRenames (tag, canonical) {
-  const vmodelMap = VMODEL_ARG_RENAMES[canonical];
-  const eventMap = UPDATE_EVENT_RENAMES[canonical];
-  if (!vmodelMap && !eventMap) return { tag, count: 0 };
-
-  let result = tag;
-  let count = 0;
-
-  if (vmodelMap) {
-    for (const [oldArg, newArg] of Object.entries(vmodelMap)) {
-      const before = result;
-      const replacement = newArg ? `v-model:${newArg}` : 'v-model';
-      result = result.replace(new RegExp(`v-model:${escapeRe(oldArg)}\\b`, 'g'), replacement);
-      if (result !== before) count++;
-    }
-  }
-
-  if (eventMap) {
-    for (const [oldEvt, newEvt] of Object.entries(eventMap)) {
-      const before = result;
-      result = result.replace(new RegExp(`@update:${escapeRe(oldEvt)}\\b`, 'g'), `@update:${newEvt}`);
-      if (result !== before) count++;
-    }
-  }
-
-  return { tag: result, count };
+  const r1 = applyVModelArgRenames(tag, canonical);
+  const r2 = applyUpdateEventRenames(r1.tag, canonical);
+  return { tag: r2.tag, count: r1.count + r2.count };
 }
 
 /**
@@ -704,15 +711,21 @@ async function main () {
   const { changes, allWarnings } = await scanFiles(opts.cwd);
   printWarnings(allWarnings);
 
-  if (changes.length === 0) {
+  if (changes.length === 0 && allWarnings.length === 0) {
     console.log('No matching usage found. Nothing to migrate.');
+    process.exit(0);
+  }
+
+  if (changes.length === 0) {
+    console.log('No automated code changes needed. See manual action items above.');
     process.exit(0);
   }
 
   const total = printChangeSummary(changes, opts.cwd);
 
   if (opts.dryRun) {
-    console.log('\n--dry-run: No files were modified.\n');
+    const warnNote = allWarnings.length ? ` ${allWarnings.length} warning(s) require manual action.` : '';
+    console.log(`\n--dry-run: No files were modified.${warnNote}\n`);
     process.exit(0);
   }
 

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_props/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_props/test.mjs
@@ -713,8 +713,8 @@ describe('@change → @update:model-value on toggle and select-menu', () => {
   it('renames both @input and @change on dt-select-menu', () => {
     const input = '<dt-select-menu @input="onInput" @change="onChange" />';
     const { transformed, count } = transformContent(input);
-    assert.equal(transformed, '<dt-select-menu @update:model-value="onInput" @update:model-value="onChange" />');
-    assert.equal(count, 2);
+    assert.equal(transformed, '<dt-select-menu @update:model-value="onInput" />');
+    assert.equal(count, 1);
   });
 
   it('does not rename @change on components not in the map', () => {

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_props/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_props/test.mjs
@@ -214,6 +214,11 @@ describe('hide-close → :show-close="false"', () => {
     assert.ok(warnings.some(w => w.includes('Cannot auto-invert')));
   });
 
+  it('emits a warning for dynamic camelCase :hideClose expressions', () => {
+    const { warnings } = transformContent('<dt-banner :hideClose="someVar" />');
+    assert.ok(warnings.some(w => w.includes('Cannot auto-invert') && w.includes('hideClose')));
+  });
+
   it('converts bare hide-close on a non-self-closing tag', () => {
     const { transformed } = transformContent('<dt-banner hide-close>Content</dt-banner>');
     assert.equal(transformed, '<dt-banner :show-close="false">Content</dt-banner>');
@@ -847,5 +852,16 @@ describe('edge cases', () => {
     const { transformed, count } = transformContent(input);
     assert.equal(transformed, input);
     assert.equal(count, 0);
+  });
+
+  it('handles > inside a quoted attribute value (arrow function)', () => {
+    const { transformed } = transformContent('<dt-modal :show="v => set(v)" />');
+    assert.equal(transformed, '<dt-modal :open="v => set(v)" />');
+  });
+
+  it('renames static camelCase prop (titleId → headerId on dt-banner)', () => {
+    const { transformed, count } = transformContent('<dt-banner titleId="hdr" />');
+    assert.equal(transformed, '<dt-banner headerId="hdr" />');
+    assert.equal(count, 1);
   });
 });

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_props/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_props/test.mjs
@@ -1,0 +1,583 @@
+#!/usr/bin/env node
+
+/**
+ * @fileoverview Tests for dialtone-migrate-props codemod.
+ * Run: node packages/dialtone-css/lib/build/js/dialtone_migrate_props/test.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { transformContent } from './index.mjs';
+
+// ---------------------------------------------------------------------------
+// DLT-3161 — avatar: clickable → interactive
+// ---------------------------------------------------------------------------
+
+describe('clickable → interactive (dt-avatar)', () => {
+  it('renames clickable prop', () => {
+    const input = '<dt-avatar clickable />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, '<dt-avatar interactive />');
+    assert.equal(count, 1);
+  });
+
+  it('renames :clickable binding', () => {
+    const { transformed } = transformContent('<dt-avatar :clickable="true" />');
+    assert.equal(transformed, '<dt-avatar :interactive="true" />');
+  });
+
+  it('does not rename clickable on other components', () => {
+    const input = '<dt-button clickable />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+
+  it('handles PascalCase DtAvatar', () => {
+    const { transformed } = transformContent('<DtAvatar :clickable="isClickable" />');
+    assert.equal(transformed, '<DtAvatar :interactive="isClickable" />');
+  });
+
+  it('renames bare boolean clickable on non-self-closing tag', () => {
+    const { transformed } = transformContent('<dt-avatar clickable>Profile</dt-avatar>');
+    assert.equal(transformed, '<dt-avatar interactive>Profile</dt-avatar>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DLT-3282 — show → open (modal, toast, tooltip)
+// ---------------------------------------------------------------------------
+
+describe('show → open (modal, toast, tooltip)', () => {
+  it('renames :show on dt-modal', () => {
+    const { transformed } = transformContent('<dt-modal :show="isOpen" />');
+    assert.equal(transformed, '<dt-modal :open="isOpen" />');
+  });
+
+  it('renames :show on dt-toast', () => {
+    const { transformed } = transformContent('<dt-toast :show="visible" />');
+    assert.equal(transformed, '<dt-toast :open="visible" />');
+  });
+
+  it('renames :show on dt-tooltip', () => {
+    const { transformed } = transformContent('<dt-tooltip :show="hovered" />');
+    assert.equal(transformed, '<dt-tooltip :open="hovered" />');
+  });
+
+  it('renames @update:show event', () => {
+    const { transformed } = transformContent('<dt-modal :show="open" @update:show="close" />');
+    assert.equal(transformed, '<dt-modal :open="open" @update:open="close" />');
+  });
+
+  it('renames v-model:show', () => {
+    const { transformed } = transformContent('<dt-modal v-model:show="isOpen" />');
+    assert.equal(transformed, '<dt-modal v-model:open="isOpen" />');
+  });
+
+  it('does not rename show on non-overlay components', () => {
+    const input = '<dt-avatar :show="true" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+
+  it('does not rename show-close when renaming show', () => {
+    const input = '<dt-modal :show="isOpen" :show-close="false" />';
+    const { transformed } = transformContent(input);
+    assert.equal(transformed, '<dt-modal :open="isOpen" :show-close="false" />');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DLT-3284 — title/titleId → headerText/headerId (banner, notice, toast, modal)
+// ---------------------------------------------------------------------------
+
+describe('title → header-text (banner, notice, toast, modal)', () => {
+  it('renames title on dt-banner', () => {
+    const { transformed } = transformContent('<dt-banner title="Alert" />');
+    assert.equal(transformed, '<dt-banner header-text="Alert" />');
+  });
+
+  it('renames title-id on dt-banner', () => {
+    const { transformed } = transformContent('<dt-banner title-id="hdr" />');
+    assert.equal(transformed, '<dt-banner header-id="hdr" />');
+  });
+
+  it('renames title on dt-notice', () => {
+    const { transformed } = transformContent('<dt-notice title="Info" />');
+    assert.equal(transformed, '<dt-notice header-text="Info" />');
+  });
+
+  it('renames title-id on dt-notice', () => {
+    const { transformed } = transformContent('<dt-notice title-id="notice-hdr" />');
+    assert.equal(transformed, '<dt-notice header-id="notice-hdr" />');
+  });
+
+  it('renames title on dt-toast', () => {
+    const { transformed } = transformContent('<dt-toast title="Done!" />');
+    assert.equal(transformed, '<dt-toast header-text="Done!" />');
+  });
+
+  it('renames title on dt-modal', () => {
+    const { transformed } = transformContent('<dt-modal title="Confirm" />');
+    assert.equal(transformed, '<dt-modal header-text="Confirm" />');
+  });
+
+  it('renames banner-title on dt-modal', () => {
+    const { transformed } = transformContent('<dt-modal banner-title="Warning" />');
+    assert.equal(transformed, '<dt-modal banner-header-text="Warning" />');
+  });
+
+  it('renames bound :title on dt-banner', () => {
+    const { transformed } = transformContent('<dt-banner :title="alertTitle" />');
+    assert.equal(transformed, '<dt-banner :header-text="alertTitle" />');
+  });
+
+  it('does not rename title on unrelated components', () => {
+    const input = '<dt-avatar title="Profile" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DLT-3159 — label-visible → show-label
+// ---------------------------------------------------------------------------
+
+describe('label-visible → show-label', () => {
+  it('renames on dt-input', () => {
+    const { transformed } = transformContent('<dt-input label-visible="false" />');
+    assert.equal(transformed, '<dt-input show-label="false" />');
+  });
+
+  it('renames on dt-checkbox', () => {
+    const { transformed } = transformContent('<dt-checkbox label-visible="true" />');
+    assert.equal(transformed, '<dt-checkbox show-label="true" />');
+  });
+
+  it('renames on dt-combobox', () => {
+    const { transformed } = transformContent('<dt-combobox :label-visible="showLabel" />');
+    assert.equal(transformed, '<dt-combobox :show-label="showLabel" />');
+  });
+
+  it('renames on dt-toggle', () => {
+    const { transformed } = transformContent('<dt-toggle label-visible="false" />');
+    assert.equal(transformed, '<dt-toggle show-label="false" />');
+  });
+
+  it('renames on dt-select-menu', () => {
+    const { transformed } = transformContent('<dt-select-menu label-visible="false" />');
+    assert.equal(transformed, '<dt-select-menu show-label="false" />');
+  });
+
+  it('does not rename on components without this prop', () => {
+    const input = '<dt-badge label-visible="false" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DLT-3159 — Inverted boolean props (hide-X → :show-X="false")
+// ---------------------------------------------------------------------------
+
+describe('hide-close → :show-close="false"', () => {
+  it('converts bare boolean hide-close on dt-banner', () => {
+    const { transformed } = transformContent('<dt-banner hide-close />');
+    assert.equal(transformed, '<dt-banner :show-close="false" />');
+  });
+
+  it('converts :hide-close="true" on dt-chip', () => {
+    const { transformed } = transformContent('<dt-chip :hide-close="true" />');
+    assert.equal(transformed, '<dt-chip :show-close="false" />');
+  });
+
+  it('removes :hide-close="false" on dt-modal (default is show)', () => {
+    const { transformed } = transformContent('<dt-modal :hide-close="false" />');
+    assert.equal(transformed, '<dt-modal  />');
+  });
+
+  it('converts bare hide-close on dt-notice', () => {
+    const { transformed } = transformContent('<dt-notice hide-close />');
+    assert.equal(transformed, '<dt-notice :show-close="false" />');
+  });
+
+  it('converts bare hide-close on dt-toast', () => {
+    const { transformed } = transformContent('<dt-toast hide-close />');
+    assert.equal(transformed, '<dt-toast :show-close="false" />');
+  });
+
+  it('emits a warning for dynamic :hide-close expressions', () => {
+    const { warnings } = transformContent('<dt-banner :hide-close="someVar" />');
+    assert.ok(warnings.some(w => w.includes('Cannot auto-invert')));
+  });
+
+  it('converts bare hide-close on a non-self-closing tag', () => {
+    const { transformed } = transformContent('<dt-banner hide-close>Content</dt-banner>');
+    assert.equal(transformed, '<dt-banner :show-close="false">Content</dt-banner>');
+  });
+});
+
+describe('hide-icon → :show-icon="false"', () => {
+  it('converts bare hide-icon on dt-banner', () => {
+    const { transformed } = transformContent('<dt-banner hide-icon />');
+    assert.equal(transformed, '<dt-banner :show-icon="false" />');
+  });
+
+  it('converts :hide-icon="true" on dt-notice', () => {
+    const { transformed } = transformContent('<dt-notice :hide-icon="true" />');
+    assert.equal(transformed, '<dt-notice :show-icon="false" />');
+  });
+
+  it('does not apply hide-icon rename to dt-chip (not in map)', () => {
+    const input = '<dt-chip hide-icon />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+});
+
+describe('hide-action → :show-action="false"', () => {
+  it('converts bare hide-action on dt-toast', () => {
+    const { transformed } = transformContent('<dt-toast hide-action />');
+    assert.equal(transformed, '<dt-toast :show-action="false" />');
+  });
+});
+
+describe('hide-clear → :show-clear="false" (dt-filter-pill)', () => {
+  it('converts bare hide-clear', () => {
+    const { transformed } = transformContent('<dt-filter-pill hide-clear />');
+    assert.equal(transformed, '<dt-filter-pill :show-clear="false" />');
+  });
+
+  it('removes :hide-clear="false"', () => {
+    const { transformed } = transformContent('<dt-filter-pill :hide-clear="false" />');
+    assert.equal(transformed, '<dt-filter-pill  />');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DLT-3157 — kind and validation-state value renames
+// ---------------------------------------------------------------------------
+
+describe('kind value renames', () => {
+  it('renames kind="danger" → kind="critical"', () => {
+    const { transformed } = transformContent('<dt-button kind="danger" />');
+    assert.equal(transformed, '<dt-button kind="critical" />');
+  });
+
+  it('renames kind="error" → kind="critical"', () => {
+    const { transformed } = transformContent('<dt-banner kind="error" />');
+    assert.equal(transformed, '<dt-banner kind="critical" />');
+  });
+
+  it('renames kind="success" → kind="positive"', () => {
+    const { transformed } = transformContent('<dt-badge kind="success" />');
+    assert.equal(transformed, '<dt-badge kind="positive" />');
+  });
+
+  it('renames bound :kind="\'danger\'"', () => {
+    const { transformed } = transformContent('<dt-link :kind="\'danger\'" />');
+    assert.equal(transformed, '<dt-link :kind="\'critical\'" />');
+  });
+
+  it('does not alter kind="muted"', () => {
+    const input = '<dt-button kind="muted" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+
+  it('does not alter kind="default"', () => {
+    const input = '<dt-badge kind="default" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+});
+
+describe('validation-state value renames', () => {
+  it('renames validation-state="error" → "critical"', () => {
+    const { transformed } = transformContent('<dt-input validation-state="error" />');
+    assert.equal(transformed, '<dt-input validation-state="critical" />');
+  });
+
+  it('renames validation-state="success" → "positive"', () => {
+    const { transformed } = transformContent('<dt-checkbox validation-state="success" />');
+    assert.equal(transformed, '<dt-checkbox validation-state="positive" />');
+  });
+
+  it('does not alter validation-state="warning"', () => {
+    const input = '<dt-input validation-state="warning" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DLT-3283 — Slot renames
+// ---------------------------------------------------------------------------
+
+describe('slot renames', () => {
+  it('renames #titleOverride → #header', () => {
+    const { transformed } = transformContent('<template #titleOverride>Custom</template>');
+    assert.equal(transformed, '<template #header>Custom</template>');
+  });
+
+  it('renames v-slot:titleOverride → v-slot:header', () => {
+    const { transformed } = transformContent('<template v-slot:titleOverride>Custom</template>');
+    assert.equal(transformed, '<template v-slot:header>Custom</template>');
+  });
+
+  it('renames slot="titleOverride" → slot="header"', () => {
+    const { transformed } = transformContent('<span slot="titleOverride">Custom</span>');
+    assert.equal(transformed, '<span slot="header">Custom</span>');
+  });
+
+  it('renames #labelSlot → #label', () => {
+    const { transformed } = transformContent('<template #labelSlot>Label text</template>');
+    assert.equal(transformed, '<template #label>Label text</template>');
+  });
+
+  it('renames v-slot:labelSlot → v-slot:label', () => {
+    const { transformed } = transformContent('<template v-slot:labelSlot>Label</template>');
+    assert.equal(transformed, '<template v-slot:label>Label</template>');
+  });
+
+  it('renames #headingSlot → #heading', () => {
+    const { transformed } = transformContent('<template #headingSlot>Group name</template>');
+    assert.equal(transformed, '<template #heading>Group name</template>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DLT-3100 — rootClass removal warning
+// ---------------------------------------------------------------------------
+
+describe('rootClass removal warning', () => {
+  it('emits a warning for root-class on dt-avatar', () => {
+    const { warnings } = transformContent('<dt-avatar root-class="d-w300" />');
+    assert.ok(warnings.some(w => w.includes('root-class')));
+    assert.ok(warnings.some(w => w.includes('dt-avatar')));
+  });
+
+  it('auto-migrates :rootClass on dt-input instead of warning', () => {
+    const { transformed, warnings } = transformContent('<dt-input :rootClass="myClass" />');
+    assert.equal(transformed, '<dt-input :class="myClass" />');
+    assert.equal(warnings.filter(w => w.includes('rootClass')).length, 0);
+  });
+
+  it('does not alter the tag content for rootClass', () => {
+    const input = '<dt-avatar root-class="d-w300" />';
+    const { transformed } = transformContent(input);
+    assert.equal(transformed, input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DLT-3100 — rootClass / wrapperClass / containerClass auto-migration
+// ---------------------------------------------------------------------------
+
+describe('root-class auto-migration', () => {
+  it('renames root-class to class on dt-input', () => {
+    const { transformed, count } = transformContent('<dt-input root-class="d-w100p" />');
+    assert.equal(transformed, '<dt-input class="d-w100p" />');
+    assert.equal(count, 1);
+  });
+
+  it('renames rootClass (camelCase) to class on dt-checkbox', () => {
+    const { transformed } = transformContent('<dt-checkbox rootClass="d-ml8" />');
+    assert.equal(transformed, '<dt-checkbox class="d-ml8" />');
+  });
+
+  it('renames :root-class dynamic binding to :class on dt-radio', () => {
+    const { transformed } = transformContent('<dt-radio :root-class="myClass" />');
+    assert.equal(transformed, '<dt-radio :class="myClass" />');
+  });
+
+  it('renames :rootClass camelCase dynamic binding to :class on dt-select-menu', () => {
+    const { transformed } = transformContent('<dt-select-menu :rootClass="myClass" />');
+    assert.equal(transformed, '<dt-select-menu :class="myClass" />');
+  });
+
+  it('merges root-class into existing class on dt-input', () => {
+    const { transformed } = transformContent('<dt-input class="d-mt8" root-class="d-w100p" />');
+    assert.equal(transformed, '<dt-input class="d-mt8 d-w100p"  />');
+  });
+
+  it('warns and leaves tag unchanged when :root-class clashes with existing :class', () => {
+    const input = '<dt-input :class="baseClass" :root-class="extraClass" />';
+    const { transformed, warnings } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.ok(warnings.some(w => w.includes('Cannot auto-merge')));
+  });
+
+  it('renames wrapper-class to class on dt-toggle', () => {
+    const { transformed } = transformContent('<dt-toggle wrapper-class="d-w100p" />');
+    assert.equal(transformed, '<dt-toggle class="d-w100p" />');
+  });
+
+  it('renames wrapper-class to class on dt-feed-item-pill', () => {
+    const { transformed } = transformContent('<dt-feed-item-pill wrapper-class="d-p8" />');
+    assert.equal(transformed, '<dt-feed-item-pill class="d-p8" />');
+  });
+
+  it('renames container-class to class on dt-card', () => {
+    const { transformed } = transformContent('<dt-card container-class="d-bgc-primary" />');
+    assert.equal(transformed, '<dt-card class="d-bgc-primary" />');
+  });
+
+  it('renames root-class on dt-breadcrumb-item', () => {
+    const { transformed } = transformContent('<dt-breadcrumb-item root-class="d-fw-bold" />');
+    assert.equal(transformed, '<dt-breadcrumb-item class="d-fw-bold" />');
+  });
+
+  it('renames root-class on dt-split-button', () => {
+    const { transformed } = transformContent('<dt-split-button root-class="d-mt16" />');
+    assert.equal(transformed, '<dt-split-button class="d-mt16" />');
+  });
+
+  it('still warns for root-class on components not in the migration map', () => {
+    const { warnings } = transformContent('<dt-avatar root-class="d-w300" />');
+    assert.ok(warnings.some(w => w.includes('root-class')));
+    assert.ok(warnings.some(w => w.includes('dt-avatar')));
+  });
+
+  it('handles PascalCase DtInput', () => {
+    const { transformed } = transformContent('<DtInput root-class="d-w100p" />');
+    assert.equal(transformed, '<DtInput class="d-w100p" />');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-Dialtone components are not transformed
+// ---------------------------------------------------------------------------
+
+describe('does not transform non-Dialtone components', () => {
+  it('ignores bare HTML elements', () => {
+    const input = '<div kind="error">text</div>';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+
+  it('ignores components without dt- prefix', () => {
+    const input = '<my-modal :show="open" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+
+  it('ignores app-prefixed components', () => {
+    const input = '<app-banner kind="error" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PascalCase component names
+// ---------------------------------------------------------------------------
+
+describe('PascalCase component names', () => {
+  it('transforms DtModal :show → :open', () => {
+    const { transformed } = transformContent('<DtModal :show="isOpen" />');
+    assert.equal(transformed, '<DtModal :open="isOpen" />');
+  });
+
+  it('transforms DtBanner title → header-text', () => {
+    const { transformed } = transformContent('<DtBanner title="Alert" />');
+    assert.equal(transformed, '<DtBanner header-text="Alert" />');
+  });
+
+  it('transforms DtButton kind="danger"', () => {
+    const { transformed } = transformContent('<DtButton kind="danger" />');
+    assert.equal(transformed, '<DtButton kind="critical" />');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple transforms in one tag / file
+// ---------------------------------------------------------------------------
+
+describe('multiple transforms', () => {
+  it('applies several renames in a single tag', () => {
+    const input = '<dt-banner title="Oops" kind="error" hide-close />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, '<dt-banner header-text="Oops" kind="critical" :show-close="false" />');
+    assert.ok(count >= 3);
+  });
+
+  it('transforms multiple components in one template', () => {
+    const input = `<template>
+  <dt-avatar clickable />
+  <dt-modal :show="open" @update:show="close" />
+  <dt-badge kind="success" />
+</template>`;
+    const expected = `<template>
+  <dt-avatar interactive />
+  <dt-modal :open="open" @update:open="close" />
+  <dt-badge kind="positive" />
+</template>`;
+    const { transformed } = transformContent(input);
+    assert.equal(transformed, expected);
+  });
+
+  it('handles multiline component tags', () => {
+    const input = `<dt-banner
+  title="Alert"
+  kind="error"
+  hide-icon
+/>`;
+    const expected = `<dt-banner
+  header-text="Alert"
+  kind="critical"
+  :show-icon="false"
+/>`;
+    const { transformed } = transformContent(input);
+    assert.equal(transformed, expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('edge cases', () => {
+  it('returns count 0 for content with no matches', () => {
+    const input = '<div><span>No Dialtone here</span></div>';
+    const { count } = transformContent(input);
+    assert.equal(count, 0);
+  });
+
+  it('handles empty string', () => {
+    const { transformed, count } = transformContent('');
+    assert.equal(transformed, '');
+    assert.equal(count, 0);
+  });
+
+  it('does not change already-migrated props', () => {
+    const input = '<dt-modal :open="isOpen" @update:open="close" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+
+  it('does not change already-migrated kind="critical"', () => {
+    const input = '<dt-badge kind="critical" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+
+  it('does not change kind inside text content of a tag', () => {
+    const input = '<dt-text>Use kind="error" on inputs</dt-text>';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+});

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_props/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_props/test.mjs
@@ -246,6 +246,89 @@ describe('hide-action → :show-action="false"', () => {
   });
 });
 
+describe('dt-notice-action hide-close / hide-action (DLT-3159 gap)', () => {
+  it('converts bare hide-close on dt-notice-action', () => {
+    const { transformed } = transformContent('<dt-notice-action hide-close />');
+    assert.equal(transformed, '<dt-notice-action :show-close="false" />');
+  });
+
+  it('converts bare hide-action on dt-notice-action', () => {
+    const { transformed } = transformContent('<dt-notice-action hide-action />');
+    assert.equal(transformed, '<dt-notice-action :show-action="false" />');
+  });
+});
+
+describe('DLT-3159 additional inverted bool props', () => {
+  it('dt-pagination: converts bare hide-edges', () => {
+    const { transformed } = transformContent('<dt-pagination hide-edges />');
+    assert.equal(transformed, '<dt-pagination :show-edges="false" />');
+  });
+
+  it('dt-pagination: removes :hide-edges="false"', () => {
+    const { transformed } = transformContent('<dt-pagination :hide-edges="false" />');
+    assert.equal(transformed, '<dt-pagination  />');
+  });
+
+  it('dt-segmented-control: converts bare hide-divider', () => {
+    const { transformed } = transformContent('<dt-segmented-control hide-divider />');
+    assert.equal(transformed, '<dt-segmented-control :show-divider="false" />');
+  });
+
+  it('dt-rich-text-editor: converts bare prevent-typing', () => {
+    const { transformed } = transformContent('<dt-rich-text-editor prevent-typing />');
+    assert.equal(transformed, '<dt-rich-text-editor :allow-typing="false" />');
+  });
+
+  it('dt-rich-text-editor: converts :prevent-typing="true"', () => {
+    const { transformed } = transformContent('<dt-rich-text-editor :prevent-typing="true" />');
+    assert.equal(transformed, '<dt-rich-text-editor :allow-typing="false" />');
+  });
+
+  it('dt-rich-text-editor: removes :prevent-typing="false"', () => {
+    const { transformed } = transformContent('<dt-rich-text-editor :prevent-typing="false" />');
+    assert.equal(transformed, '<dt-rich-text-editor  />');
+  });
+
+  it('dt-rich-text-editor: converts bare hide-link-bubble-menu', () => {
+    const { transformed } = transformContent('<dt-rich-text-editor hide-link-bubble-menu />');
+    assert.equal(transformed, '<dt-rich-text-editor :show-link-bubble-menu="false" />');
+  });
+
+  it('dt-recipe-message-input: converts bare prevent-typing', () => {
+    const { transformed } = transformContent('<dt-recipe-message-input prevent-typing />');
+    assert.equal(transformed, '<dt-recipe-message-input :allow-typing="false" />');
+  });
+
+  it('dt-recipe-message-input: does not migrate hide-link-bubble-menu (internal data, not a prop)', () => {
+    const input = '<dt-recipe-message-input hide-link-bubble-menu />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+
+  it('dt-recipe-contact-centers-row: converts bare hide-actions', () => {
+    const { transformed } = transformContent('<dt-recipe-contact-centers-row hide-actions />');
+    assert.equal(transformed, '<dt-recipe-contact-centers-row :show-actions="false" />');
+  });
+});
+
+describe('dt-popover hideOnClick → closeOnClick (same semantics, DLT-3159)', () => {
+  it('renames hide-on-click prop', () => {
+    const { transformed } = transformContent('<dt-popover hide-on-click />');
+    assert.equal(transformed, '<dt-popover close-on-click />');
+  });
+
+  it('renames :hideOnClick binding', () => {
+    const { transformed } = transformContent('<dt-popover :hideOnClick="shouldClose" />');
+    assert.equal(transformed, '<dt-popover :closeOnClick="shouldClose" />');
+  });
+
+  it('renames :hide-on-click binding', () => {
+    const { transformed } = transformContent('<dt-popover :hide-on-click="val" />');
+    assert.equal(transformed, '<dt-popover :close-on-click="val" />');
+  });
+});
+
 describe('hide-clear → :show-clear="false" (dt-filter-pill)', () => {
   it('converts bare hide-clear', () => {
     const { transformed } = transformContent('<dt-filter-pill hide-clear />');
@@ -278,9 +361,9 @@ describe('kind value renames', () => {
     assert.equal(transformed, '<dt-badge kind="positive" />');
   });
 
-  it('renames bound :kind="\'danger\'"', () => {
-    const { transformed } = transformContent('<dt-link :kind="\'danger\'" />');
-    assert.equal(transformed, '<dt-link :kind="\'critical\'" />');
+  it('renames bound :kind="\'danger\'" on a non-link component', () => {
+    const { transformed } = transformContent('<dt-button :kind="\'danger\'" />');
+    assert.equal(transformed, '<dt-button :kind="\'critical\'" />');
   });
 
   it('does not alter kind="muted"', () => {
@@ -292,6 +375,79 @@ describe('kind value renames', () => {
 
   it('does not alter kind="default"', () => {
     const input = '<dt-badge kind="default" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+});
+
+describe('DtBadge type value renames (DLT-3157)', () => {
+  it('renames type="success" → type="positive" on dt-badge', () => {
+    const { transformed } = transformContent('<dt-badge type="success" />');
+    assert.equal(transformed, '<dt-badge type="positive" />');
+  });
+
+  it('renames :type="\'success\'" bound value on dt-badge', () => {
+    const { transformed } = transformContent('<dt-badge :type="\'success\'" />');
+    assert.equal(transformed, '<dt-badge :type="\'positive\'" />');
+  });
+
+  it('does not alter type="warning"', () => {
+    const input = '<dt-badge type="warning" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+});
+
+describe('DtLink kind → tone prop rename (DLT-3157)', () => {
+  it('renames kind prop to tone on dt-link', () => {
+    const { transformed } = transformContent('<dt-link kind="muted" />');
+    assert.equal(transformed, '<dt-link tone="muted" />');
+  });
+
+  it('renames kind="danger" and prop to tone="critical"', () => {
+    const { transformed, count } = transformContent('<dt-link kind="danger" />');
+    assert.equal(transformed, '<dt-link tone="critical" />');
+    assert.equal(count, 2);
+  });
+
+  it('renames kind="success" and prop to tone="positive"', () => {
+    const { transformed } = transformContent('<dt-link kind="success" />');
+    assert.equal(transformed, '<dt-link tone="positive" />');
+  });
+
+  it('renames :kind bound binding to :tone', () => {
+    const { transformed } = transformContent('<dt-link :kind="linkTone" />');
+    assert.equal(transformed, '<dt-link :tone="linkTone" />');
+  });
+
+  it('does not rename kind on non-link components', () => {
+    const input = '<dt-button kind="critical" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+});
+
+describe('DtModal banner-kind value renames (DLT-3157)', () => {
+  it('renames banner-kind="error" → banner-kind="critical"', () => {
+    const { transformed } = transformContent('<dt-modal banner-kind="error" />');
+    assert.equal(transformed, '<dt-modal banner-kind="critical" />');
+  });
+
+  it('renames banner-kind="success" → banner-kind="positive"', () => {
+    const { transformed } = transformContent('<dt-modal banner-kind="success" />');
+    assert.equal(transformed, '<dt-modal banner-kind="positive" />');
+  });
+
+  it('renames camelCase bannerKind="error"', () => {
+    const { transformed } = transformContent('<dt-modal bannerKind="error" />');
+    assert.equal(transformed, '<dt-modal bannerKind="critical" />');
+  });
+
+  it('does not alter banner-kind="info"', () => {
+    const input = '<dt-modal banner-kind="info" />';
     const { transformed, count } = transformContent(input);
     assert.equal(transformed, input);
     assert.equal(count, 0);
@@ -449,6 +605,118 @@ describe('root-class auto-migration', () => {
   it('handles PascalCase DtInput', () => {
     const { transformed } = transformContent('<DtInput root-class="d-w100p" />');
     assert.equal(transformed, '<DtInput class="d-w100p" />');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DLT-3160 — dt-checkbox-group: selectedValues → modelValue
+// ---------------------------------------------------------------------------
+
+describe('selectedValues → modelValue (dt-checkbox-group)', () => {
+  it('renames :selected-values binding', () => {
+    const { transformed } = transformContent('<dt-checkbox-group :selected-values="myArr" />');
+    assert.equal(transformed, '<dt-checkbox-group :model-value="myArr" />');
+  });
+
+  it('renames :selectedValues camelCase binding', () => {
+    const { transformed } = transformContent('<dt-checkbox-group :selectedValues="myArr" />');
+    assert.equal(transformed, '<dt-checkbox-group :modelValue="myArr" />');
+  });
+
+  it('converts v-model:selected-values to plain v-model', () => {
+    const { transformed } = transformContent('<dt-checkbox-group v-model:selected-values="myArr" />');
+    assert.equal(transformed, '<dt-checkbox-group v-model="myArr" />');
+  });
+
+  it('converts v-model:selectedValues to plain v-model', () => {
+    const { transformed } = transformContent('<dt-checkbox-group v-model:selectedValues="myArr" />');
+    assert.equal(transformed, '<dt-checkbox-group v-model="myArr" />');
+  });
+
+  it('renames @update:selected-values event', () => {
+    const { transformed } = transformContent('<dt-checkbox-group @update:selected-values="onUpdate" />');
+    assert.equal(transformed, '<dt-checkbox-group @update:model-value="onUpdate" />');
+  });
+
+  it('renames @update:selectedValues event', () => {
+    const { transformed } = transformContent('<dt-checkbox-group @update:selectedValues="onUpdate" />');
+    assert.equal(transformed, '<dt-checkbox-group @update:modelValue="onUpdate" />');
+  });
+
+  it('does not rename selected-values on other components', () => {
+    const input = '<dt-input :selected-values="myArr" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DLT-3160 — @input / @change event renames
+// ---------------------------------------------------------------------------
+
+describe('@input → @update:model-value on form inputs', () => {
+  it('renames @input on dt-input', () => {
+    const { transformed } = transformContent('<dt-input @input="handleInput" />');
+    assert.equal(transformed, '<dt-input @update:model-value="handleInput" />');
+  });
+
+  it('renames @input on dt-radio', () => {
+    const { transformed } = transformContent('<dt-radio @input="onSelect" />');
+    assert.equal(transformed, '<dt-radio @update:model-value="onSelect" />');
+  });
+
+  it('renames @input on dt-radio-group', () => {
+    const { transformed } = transformContent('<dt-radio-group @input="onChange" />');
+    assert.equal(transformed, '<dt-radio-group @update:model-value="onChange" />');
+  });
+
+  it('renames @input on dt-combobox-multi-select', () => {
+    const { transformed } = transformContent('<dt-combobox-multi-select @input="onSearch" />');
+    assert.equal(transformed, '<dt-combobox-multi-select @update:model-value="onSearch" />');
+  });
+
+  it('renames @input on dt-rich-text-editor', () => {
+    const { transformed } = transformContent('<dt-rich-text-editor @input="onEdit" />');
+    assert.equal(transformed, '<dt-rich-text-editor @update:model-value="onEdit" />');
+  });
+
+  it('renames @input on dt-input-group', () => {
+    const { transformed } = transformContent('<dt-input-group @input="onGroup" />');
+    assert.equal(transformed, '<dt-input-group @update:model-value="onGroup" />');
+  });
+
+  it('does not rename @input on components not in the map', () => {
+    const input = '<dt-avatar @input="handler" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+});
+
+describe('@change → @update:model-value on toggle and select-menu', () => {
+  it('renames @change on dt-toggle', () => {
+    const { transformed } = transformContent('<dt-toggle @change="onToggle" />');
+    assert.equal(transformed, '<dt-toggle @update:model-value="onToggle" />');
+  });
+
+  it('renames @change on dt-select-menu', () => {
+    const { transformed } = transformContent('<dt-select-menu @change="onSelect" />');
+    assert.equal(transformed, '<dt-select-menu @update:model-value="onSelect" />');
+  });
+
+  it('renames both @input and @change on dt-select-menu', () => {
+    const input = '<dt-select-menu @input="onInput" @change="onChange" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, '<dt-select-menu @update:model-value="onInput" @update:model-value="onChange" />');
+    assert.equal(count, 2);
+  });
+
+  it('does not rename @change on components not in the map', () => {
+    const input = '<dt-banner @change="handler" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `dialtone-migrate-props` codemod (`packages/dialtone-css/lib/build/js/dialtone_migrate_props/`) to automate Dialtone breaking-change migrations across `.vue`, `.js`, `.ts`, `.html`, `.md`, `.jsx`, `.tsx` files
- Covers DLT-3100, DLT-3157, DLT-3159, DLT-3161, DLT-3282, DLT-3283, DLT-3284
- Adds what's-new post documenting all migrations and script usage

## Migrations handled automatically

- `clickable` → `interactive` (dt-avatar)
- `show` / `@update:show` / `v-model:show` → `open` / `@update:open` / `v-model:open` (dt-modal, dt-toast, dt-tooltip)
- `title` / `title-id` → `header-text` / `header-id` (dt-banner, dt-notice, dt-toast, dt-modal)
- `banner-title` → `banner-header-text` (dt-modal)
- `label-visible` → `show-label` (form inputs and controls)
- `hide-close` / `hide-icon` / `hide-action` / `hide-clear` → `:show-*="false"` (semantics inverted)
- `root-class` → `class` (dt-input, dt-checkbox, dt-radio, dt-select-menu, dt-breadcrumb-item, dt-split-button)
- `wrapper-class` → `class` (dt-toggle, dt-feed-item-pill)
- `container-class` → `class` (dt-card)
- Merges into existing `class="…"` when present; warns on dynamic `:class` clash
- `kind` / `validation-state` value renames (`danger`/`error` → `critical`, `success` → `positive`)
- Slot renames: `#titleOverride` → `#header`, `#labelSlot` → `#label`, `#headingSlot` → `#heading`
- Both kebab-case and camelCase prop variants; PascalCase component names; self-closing and non-self-closing tags

## What still requires manual review

- `:hide-*="someExpression"` — script warns, replace with `:show-*="!(someExpression)"`
- `rootClass` on unknown components (dt-avatar, dt-filter-pill, dt-mode-island, dt-motion-text) — script warns
- `:root-class="expr"` + existing `:class="…"` on same tag — script warns, merge manually

## Test plan

- [ ] `node packages/dialtone-css/lib/build/js/dialtone_migrate_props/test.mjs` — 85 tests, all pass
- [ ] Dry-run against a real consuming repo with `npx dialtone-migrate-props --dry-run --cwd ./src`
- [ ] Verify what's-new post renders correctly in docs