### PR TITLE
docs(tabs, skeleton, rich-text-editor, emoji, avatar): DLT-3347 update doc page code examples

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleTabs.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleTabs.vue
@@ -1,5 +1,6 @@
 <template>
   <dt-tab-group
+    label="Label Example Group"
     :size="size"
     :inverted="inverted"
     :borderless="borderless"
@@ -12,26 +13,19 @@
         panel-id="2"
         selected
       >
-        <p>
-          First tab
-        </p>
+        First tab
       </dt-tab>
       <dt-tab
         id="3"
         panel-id="4"
       >
-        <p>
-          Second tab
-        </p>
+        Second tab
       </dt-tab>
       <dt-tab
         id="5"
         panel-id="6"
-        label="Third Label"
       >
-        <p>
-          Third tab
-        </p>
+        Third tab
       </dt-tab>
     </template>
     <div

--- a/apps/dialtone-documentation/docs/components/avatar.md
+++ b/apps/dialtone-documentation/docs/components/avatar.md
@@ -206,22 +206,22 @@ vueCode='
     <dt-icon-user :size="iconSize" />
   </template>
 </dt-avatar>
-<dt-avatar size="sm" icon-name="user">
+<dt-avatar size="sm">
   <template #icon="{ iconSize }">
     <dt-icon-user :size="iconSize" />
   </template>
 </dt-avatar>
-<dt-avatar size="md" icon-name="user">
+<dt-avatar size="md">
   <template #icon="{ iconSize }">
     <dt-icon-user :size="iconSize" />
   </template>
 </dt-avatar>
-<dt-avatar size="lg" icon-name="user">
+<dt-avatar size="lg">
   <template #icon="{ iconSize }">
     <dt-icon-user :size="iconSize" />
   </template>
 </dt-avatar>
-<dt-avatar size="xl" icon-name="user">
+<dt-avatar size="xl">
   <template #icon="{ iconSize }">
     <dt-icon-user :size="iconSize" />
   </template>

--- a/apps/dialtone-documentation/docs/components/emoji.md
+++ b/apps/dialtone-documentation/docs/components/emoji.md
@@ -23,7 +23,7 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-emoji--defau
 <code-example-tabs
 htmlCode='
 <div>
-  <span class="d-emoji d-icon d-icon--size-500" code=":smile:" size="500">
+  <span class="d-emoji d-icon d-icon--size-500">
     <div aria-busy="true" role="status" aria-label="" class="d-icon d-icon--size-500" style="display: none;">
       <div
         class="d-skeleton-placeholder d-bar-circle d-skeleton-placeholder--animate"
@@ -42,7 +42,7 @@ htmlCode='
 '
 vueCode='
 <dt-emoji
-  code="smile"
+  code=":smile:"
   size="500"
 />
 '

--- a/apps/dialtone-documentation/docs/components/rich-text-editor.md
+++ b/apps/dialtone-documentation/docs/components/rich-text-editor.md
@@ -23,8 +23,7 @@ vueCode='
   v-model="value"
   :editable="true"
   input-aria-label="this is a descriptive label"
-  :input-class="$attrs.inputClass"
-  :output-format="$attrs.outputFormat"
+  output-format="html"
   :auto-focus="false"
   placeholder="Type here..."
   :link="true"
@@ -117,12 +116,11 @@ vueCode='
   v-model="value"
   :editable="true"
   input-aria-label="this is a descriptive label"
-  :input-class="$attrs.inputClass"
-  :output-format="$attrs.outputFormat"
+  output-format="html"
   :auto-focus="false"
   placeholder="Type here..."
   :link="true"
-  :mentionSuggestion="{ items }"
+  :mention-suggestion="{ items }"
 />
 '
 />

--- a/apps/dialtone-documentation/docs/components/skeleton.md
+++ b/apps/dialtone-documentation/docs/components/skeleton.md
@@ -60,14 +60,14 @@ figma: planned
 
 <code-well-header>
   <div class="d-w50p">
-    <dt-skeleton :animate="false" arial-label="Loading" ref="defaultExample" />
+    <dt-skeleton :animate="false" aria-label="Loading" ref="defaultExample" />
   </div>
 </code-well-header>
 
 <code-example-tabs
 :htmlCode="() => $refs.defaultExample"
 vueCode='
-<dt-skeleton :animate="false" arial-label="Loading" />
+<dt-skeleton :animate="false" aria-label="Loading" />
 '
 showHtmlWarning />
 
@@ -75,14 +75,14 @@ showHtmlWarning />
 
 <code-well-header>
   <div class="d-w50p">
-    <dt-skeleton arial-label="Loading" ref="animationExample" />
+    <dt-skeleton aria-label="Loading" ref="animationExample" />
   </div>
 </code-well-header>
 
 <code-example-tabs
 :htmlCode="() => $refs.animationExample"
 vueCode='
-<dt-skeleton arial-label="Loading" />
+<dt-skeleton aria-label="Loading" />
 '
 />
 
@@ -98,7 +98,7 @@ To customize a non-animating Skeleton background color modify the `--placeholder
         style: '--placeholder-from-color: var(--dt-color-blue-400)',
       }"
       ref="customExample"
-      arial-label="Loading"
+      aria-label="Loading"
     />
   </div>
 </code-well-header>
@@ -111,7 +111,7 @@ vueCode='
   :text-option="{
     style: `--placeholder-from-color: var(--dt-color-blue-400)`,
   }"
-  arial-label="Loading"
+  aria-label="Loading"
 />
 '
 showHtmlWarning />
@@ -125,7 +125,7 @@ Customize an animating Skeleton by modifying the `--placeholder-from-color` and 
         style: '--placeholder-from-color: var(--dt-color-blue-400); --placeholder-to-color: var(--dt-color-blue-200);',
       }"
       ref="customAnimateExample"
-      arial-label="Loading"
+      aria-label="Loading"
     />
   </div>
 </code-well-header>
@@ -137,7 +137,7 @@ vueCode='
   :text-option="{
     style: `--placeholder-from-color: var(--dt-color-blue-400); --placeholder-to-color: var(--dt-color-blue-200);`,
   }"
-  arial-label="Loading"
+  aria-label="Loading"
 />
 '
 showHtmlWarning />

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -21,34 +21,43 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
 
 <code-example-tabs
 htmlCode='
-<div class="d-tablist" role="tablist" aria-label="Label Example Group" tabindex="0">
-  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
-  <button id="base-tab-1" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
-  <button id="base-tab-2" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
+<div class="d-tablist" role="tablist" aria-label="Label Example Group">
+  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
+  <button id="dt-tab-3" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
+  <button id="dt-tab-5" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
+</div>
+<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
+  <p>First tab content panel</p>
+</div>
+<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
+  <p>Second tab content panel</p>
+</div>
+<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
+  <p>Third tab content panel</p>
 </div>
 '
 vueCode='
-<dt-tab-group>
+<dt-tab-group label="Label Example Group">
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>
-      First
+      First tab
     </dt-tab>
     <dt-tab id="3" panel-id="4">
-      Second
+      Second tab
     </dt-tab>
     <dt-tab id="5" panel-id="6">
-      Third
+      Third tab
     </dt-tab>
   </template>
   <div>
     <dt-tab-panel id="2" tab-id="1">
-      <p>First Panel</p>
+      <p>First tab content panel</p>
     </dt-tab-panel>
     <dt-tab-panel id="4" tab-id="3">
-      <p>Second Panel</p>
+      <p>Second tab content panel</p>
     </dt-tab-panel>
     <dt-tab-panel id="6" tab-id="5">
-      <p>Third Panel</p>
+      <p>Third tab content panel</p>
     </dt-tab-panel>
   </div>
 </dt-tab-group>
@@ -65,35 +74,44 @@ Add a `d-tablist--no-border` to remove the bottom border of any tablist. Handy f
 
 <code-example-tabs
 htmlCode='
-<div class="d-tablist d-tablist--no-border" role="tablist" aria-label="Label Example Group" tabindex="0">
-  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
-  <button id="base-tab-1" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
-  <button id="base-tab-2" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
+<div class="d-tablist d-tablist--no-border" role="tablist" aria-label="Label Example Group">
+  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
+  <button id="dt-tab-3" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
+  <button id="dt-tab-5" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
+</div>
+<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
+  <p>First tab content panel</p>
+</div>
+<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
+  <p>Second tab content panel</p>
+</div>
+<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
+  <p>Third tab content panel</p>
 </div>
 '
 vueCode='
-<dt-tab-group :borderless="true">
+<dt-tab-group label="Label Example Group" :borderless="true">
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>
-      First
+      First tab
     </dt-tab>
     <dt-tab id="3" panel-id="4">
-      Second
+      Second tab
     </dt-tab>
     <dt-tab id="5" panel-id="6">
-      Third
+      Third tab
     </dt-tab>
   </template>
 
   <div>
     <dt-tab-panel id="2" tab-id="1">
-      <p>First Panel</p>
+      <p>First tab content panel</p>
     </dt-tab-panel>
     <dt-tab-panel id="4" tab-id="3">
-      <p>Second Panel</p>
+      <p>Second tab content panel</p>
     </dt-tab-panel>
     <dt-tab-panel id="6" tab-id="5">
-      <p>Third Panel</p>
+      <p>Third tab content panel</p>
     </dt-tab-panel>
   </div>
 </dt-tab-group>
@@ -110,35 +128,44 @@ Add `d-tablist--inverted` when you want to display tabs on inverted background.
 
 <code-example-tabs
 htmlCode='
-<div class="d-tablist d-tablist--inverted" role="tablist" aria-label="Label Example Group" tabindex="0">
-  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
-  <button id="base-tab-1" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
-  <button id="base-tab-2" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
+<div class="d-tablist d-tablist--inverted" role="tablist" aria-label="Label Example Group">
+  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
+  <button id="dt-tab-3" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
+  <button id="dt-tab-5" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
+</div>
+<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
+  <p>First tab content panel</p>
+</div>
+<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
+  <p>Second tab content panel</p>
+</div>
+<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
+  <p>Third tab content panel</p>
 </div>
 '
 vueCode='
-<dt-tab-group :inverted="true">
+<dt-tab-group label="Label Example Group" :inverted="true">
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>
-      First
+      First tab
     </dt-tab>
     <dt-tab id="3" panel-id="4">
-      Second
+      Second tab
     </dt-tab>
     <dt-tab id="5" panel-id="6">
-      Third
+      Third tab
     </dt-tab>
   </template>
 
   <div>
     <dt-tab-panel id="2" tab-id="1">
-      <p>First Panel</p>
+      <p>First tab content panel</p>
     </dt-tab-panel>
     <dt-tab-panel id="4" tab-id="3">
-      <p>Second Panel</p>
+      <p>Second tab content panel</p>
     </dt-tab-panel>
     <dt-tab-panel id="6" tab-id="5">
-      <p>Third Panel</p>
+      <p>Third tab content panel</p>
     </dt-tab-panel>
   </div>
 </dt-tab-group>
@@ -153,35 +180,44 @@ showHtmlWarning />
 
 <code-example-tabs
 htmlCode='
-<div class="d-tablist" role="tablist" aria-label="Label Example Group" tabindex="0">
-  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" disabled aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
-  <button id="base-tab-1" class="d-tab" role="tab" disabled aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
-  <button id="base-tab-2" class="d-tab" role="tab" disabled aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
+<div class="d-tablist" role="tablist" aria-label="Label Example Group">
+  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" disabled aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
+  <button id="dt-tab-3" class="d-tab" role="tab" disabled aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
+  <button id="dt-tab-5" class="d-tab" role="tab" disabled aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
+</div>
+<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
+  <p>First tab content panel</p>
+</div>
+<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
+  <p>Second tab content panel</p>
+</div>
+<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
+  <p>Third tab content panel</p>
 </div>
 '
 vueCode='
-<dt-tab-group :disabled="true">
+<dt-tab-group label="Label Example Group" :disabled="true">
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>
-      First
+      First tab
     </dt-tab>
-    <dt-tab id="3" panel-id="4" disabled>
-      Second
+    <dt-tab id="3" panel-id="4">
+      Second tab
     </dt-tab>
     <dt-tab id="5" panel-id="6">
-      Third
+      Third tab
     </dt-tab>
   </template>
 
   <div>
     <dt-tab-panel id="2" tab-id="1">
-      <p>First Panel</p>
+      <p>First tab content panel</p>
     </dt-tab-panel>
     <dt-tab-panel id="4" tab-id="3">
-      <p>Second Panel</p>
+      <p>Second tab content panel</p>
     </dt-tab-panel>
     <dt-tab-panel id="6" tab-id="5">
-      <p>Third Panel</p>
+      <p>Third tab content panel</p>
     </dt-tab-panel>
   </div>
 </dt-tab-group>
@@ -198,34 +234,43 @@ vueCode='
 
 <code-example-tabs
 htmlCode='
-<div class="d-tablist" role="tablist" aria-label="Label Example Group" tabindex="0">
-  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
-  <button id="base-tab-1" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
-  <button id="base-tab-2" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
+<div class="d-tablist" role="tablist" aria-label="Label Example Group">
+  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
+  <button id="dt-tab-3" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
+  <button id="dt-tab-5" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
+</div>
+<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
+  <p>First tab content panel</p>
+</div>
+<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
+  <p>Second tab content panel</p>
+</div>
+<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
+  <p>Third tab content panel</p>
 </div>
 '
 vueCode='
-<dt-tab-group>
+<dt-tab-group label="Label Example Group">
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>
-      First
+      First tab
     </dt-tab>
     <dt-tab id="3" panel-id="4">
-      Second
+      Second tab
     </dt-tab>
     <dt-tab id="5" panel-id="6">
-      Third
+      Third tab
     </dt-tab>
   </template>
   <div>
     <dt-tab-panel id="2" tab-id="1">
-      <p>First Panel</p>
+      <p>First tab content panel</p>
     </dt-tab-panel>
     <dt-tab-panel id="4" tab-id="3">
-      <p>Second Panel</p>
+      <p>Second tab content panel</p>
     </dt-tab-panel>
     <dt-tab-panel id="6" tab-id="5">
-      <p>Third Panel</p>
+      <p>Third tab content panel</p>
     </dt-tab-panel>
   </div>
 </dt-tab-group>
@@ -240,34 +285,44 @@ showHtmlWarning />
 
 <code-example-tabs
 htmlCode='
-<div class="d-tablist d-tablist--sm" role="tablist" aria-label="Label Example Group" tabindex="0">
-  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
-  <button id="base-tab-1" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
-  <button id="base-tab-2" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
-</div>'
+<div class="d-tablist d-tablist--sm" role="tablist" aria-label="Label Example Group">
+  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
+  <button id="dt-tab-3" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
+  <button id="dt-tab-5" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
+</div>
+<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
+  <p>First tab content panel</p>
+</div>
+<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
+  <p>Second tab content panel</p>
+</div>
+<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
+  <p>Third tab content panel</p>
+</div>
+'
 vueCode='
-<dt-tab-group size="sm">
+<dt-tab-group label="Label Example Group" size="sm">
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>
-      First
+      First tab
     </dt-tab>
     <dt-tab id="3" panel-id="4">
-      Second
+      Second tab
     </dt-tab>
     <dt-tab id="5" panel-id="6">
-      Third
+      Third tab
     </dt-tab>
   </template>
 
   <div>
     <dt-tab-panel id="2" tab-id="1">
-      <p>First Panel</p>
+      <p>First tab content panel</p>
     </dt-tab-panel>
     <dt-tab-panel id="4" tab-id="3">
-      <p>Second Panel</p>
+      <p>Second tab content panel</p>
     </dt-tab-panel>
     <dt-tab-panel id="6" tab-id="5">
-      <p>Third Panel</p>
+      <p>Third tab content panel</p>
     </dt-tab-panel>
   </div>
 </dt-tab-group>
@@ -286,37 +341,47 @@ If you need to do some validation before changing tabs, you can use the `before-
 
 <code-example-tabs
 htmlCode='
-<div class="d-tablist d-tablist--sm" role="tablist" aria-label="Label Example Group" tabindex="0">
-  <button id="base-tab-0" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="base-panel-0" tabindex="0">First tab </button>
-  <button id="base-tab-1" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-1" tabindex="-1">Second tab </button>
-  <button id="base-tab-2" class="d-tab" role="tab" aria-selected="false" aria-controls="base-panel-2" tabindex="-1">Third tab </button>
-</div>'
+<div class="d-tablist" role="tablist" aria-label="Label Example Group">
+  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
+  <button id="dt-tab-3" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
+  <button id="dt-tab-5" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
+</div>
+<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
+  <p>First tab content panel</p>
+</div>
+<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
+  <p>Second tab content panel</p>
+</div>
+<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
+  <p>Third tab content panel</p>
+</div>
+'
 vueCode='
 <dt-tab-group
-  size="sm"
+  label="Label Example Group"
   @before-change="confirmBeforeLeave"
 >
   <template #tabs>
     <dt-tab id="1" panel-id="2" selected>
-      First
+      First tab
     </dt-tab>
     <dt-tab id="3" panel-id="4">
-      Second
+      Second tab
     </dt-tab>
     <dt-tab id="5" panel-id="6">
-      Third
+      Third tab
     </dt-tab>
   </template>
   <template #default>
     <div>
       <dt-tab-panel id="2" tab-id="1">
-        <p>First Panel</p>
+        <p>First tab content panel</p>
       </dt-tab-panel>
       <dt-tab-panel id="4" tab-id="3">
-        <p>Second Panel</p>
+        <p>Second tab content panel</p>
       </dt-tab-panel>
       <dt-tab-panel id="6" tab-id="5">
-        <p>Third Panel</p>
+        <p>Third tab content panel</p>
       </dt-tab-panel>
     </div>
   </template>

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -267,19 +267,17 @@ vueCode='
       Third tab
     </dt-tab>
   </template>
-  <template #default>
-    <div>
-      <dt-tab-panel id="2" tab-id="1">
-        <p>First tab content panel</p>
-      </dt-tab-panel>
-      <dt-tab-panel id="4" tab-id="3">
-        <p>Second tab content panel</p>
-      </dt-tab-panel>
-      <dt-tab-panel id="6" tab-id="5">
-        <p>Third tab content panel</p>
-      </dt-tab-panel>
-    </div>
-  </template>
+  <div>
+    <dt-tab-panel id="2" tab-id="1">
+      <p>First tab content panel</p>
+    </dt-tab-panel>
+    <dt-tab-panel id="4" tab-id="3">
+      <p>Second tab content panel</p>
+    </dt-tab-panel>
+    <dt-tab-panel id="6" tab-id="5">
+      <p>Third tab content panel</p>
+    </dt-tab-panel>
+  </div>
 </dt-tab-group>
 <script setup>
   function confirmBeforeLeave (event) {

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -16,26 +16,11 @@ figma_url: https://www.figma.com/design/W58r5BkO8qTw3vem9YieJd/DT9-Component-Lib
 ### Default
 
 <code-well-header>
-  <example-tabs />
+  <example-tabs ref="defaultExample" />
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<div class="d-tablist" role="tablist" aria-label="Label Example Group">
-  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
-  <button id="dt-tab-3" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
-  <button id="dt-tab-5" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
-</div>
-<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
-  <p>First tab content panel</p>
-</div>
-<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
-  <p>Second tab content panel</p>
-</div>
-<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
-  <p>Third tab content panel</p>
-</div>
-'
+:htmlCode="() => $refs.defaultExample"
 vueCode='
 <dt-tab-group label="Label Example Group">
   <template #tabs>
@@ -69,26 +54,11 @@ showHtmlWarning />
 Add a `d-tablist--no-border` to remove the bottom border of any tablist. Handy for small tablists and tablists serving as subtabs to a larger menu.
 
 <code-well-header>
-  <example-tabs borderless />
+  <example-tabs borderless ref="borderlessExample" />
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<div class="d-tablist d-tablist--no-border" role="tablist" aria-label="Label Example Group">
-  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
-  <button id="dt-tab-3" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
-  <button id="dt-tab-5" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
-</div>
-<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
-  <p>First tab content panel</p>
-</div>
-<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
-  <p>Second tab content panel</p>
-</div>
-<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
-  <p>Third tab content panel</p>
-</div>
-'
+:htmlCode="() => $refs.borderlessExample"
 vueCode='
 <dt-tab-group label="Label Example Group" :borderless="true">
   <template #tabs>
@@ -123,26 +93,11 @@ showHtmlWarning />
 Add `d-tablist--inverted` when you want to display tabs on inverted background.
 
 <code-well-header bgclass="d-bgc-contrast">
-  <example-tabs inverted />
+  <example-tabs inverted ref="invertedExample" />
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<div class="d-tablist d-tablist--inverted" role="tablist" aria-label="Label Example Group">
-  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
-  <button id="dt-tab-3" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
-  <button id="dt-tab-5" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
-</div>
-<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
-  <p>First tab content panel</p>
-</div>
-<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
-  <p>Second tab content panel</p>
-</div>
-<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
-  <p>Third tab content panel</p>
-</div>
-'
+:htmlCode="() => $refs.invertedExample"
 vueCode='
 <dt-tab-group label="Label Example Group" :inverted="true">
   <template #tabs>
@@ -175,26 +130,11 @@ showHtmlWarning />
 ### Disabled
 
 <code-well-header>
-  <example-tabs disabled />
+  <example-tabs disabled ref="disabledExample" />
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<div class="d-tablist" role="tablist" aria-label="Label Example Group">
-  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" disabled aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
-  <button id="dt-tab-3" class="d-tab" role="tab" disabled aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
-  <button id="dt-tab-5" class="d-tab" role="tab" disabled aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
-</div>
-<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
-  <p>First tab content panel</p>
-</div>
-<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
-  <p>Second tab content panel</p>
-</div>
-<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
-  <p>Third tab content panel</p>
-</div>
-'
+:htmlCode="() => $refs.disabledExample"
 vueCode='
 <dt-tab-group label="Label Example Group" :disabled="true">
   <template #tabs>
@@ -229,26 +169,11 @@ vueCode='
 ### Default
 
 <code-well-header>
-  <example-tabs />
+  <example-tabs ref="defaultSizeExample" />
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<div class="d-tablist" role="tablist" aria-label="Label Example Group">
-  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
-  <button id="dt-tab-3" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
-  <button id="dt-tab-5" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
-</div>
-<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
-  <p>First tab content panel</p>
-</div>
-<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
-  <p>Second tab content panel</p>
-</div>
-<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
-  <p>Third tab content panel</p>
-</div>
-'
+:htmlCode="() => $refs.defaultSizeExample"
 vueCode='
 <dt-tab-group label="Label Example Group">
   <template #tabs>
@@ -280,26 +205,11 @@ showHtmlWarning />
 ### Small
 
 <code-well-header>
-  <example-tabs size="sm" />
+  <example-tabs size="sm" ref="smallExample" />
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<div class="d-tablist d-tablist--sm" role="tablist" aria-label="Label Example Group">
-  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
-  <button id="dt-tab-3" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
-  <button id="dt-tab-5" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
-</div>
-<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
-  <p>First tab content panel</p>
-</div>
-<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
-  <p>Second tab content panel</p>
-</div>
-<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
-  <p>Third tab content panel</p>
-</div>
-'
+:htmlCode="() => $refs.smallExample"
 vueCode='
 <dt-tab-group label="Label Example Group" size="sm">
   <template #tabs>
@@ -336,26 +246,11 @@ showHtmlWarning />
 If you need to do some validation before changing tabs, you can use the `before-change` event. If the event handler is prevented, the tab change will be cancelled.
 
 <code-well-header>
-  <example-tabs validate />
+  <example-tabs validate ref="validationExample" />
 </code-well-header>
 
 <code-example-tabs
-htmlCode='
-<div class="d-tablist" role="tablist" aria-label="Label Example Group">
-  <button id="dt-tab-1" class="d-tab d-tab--selected" role="tab" aria-selected="true" aria-controls="dt-panel-2" tabindex="0">First tab</button>
-  <button id="dt-tab-3" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-4" tabindex="-1">Second tab</button>
-  <button id="dt-tab-5" class="d-tab" role="tab" aria-selected="false" aria-controls="dt-panel-6" tabindex="-1">Third tab</button>
-</div>
-<div id="dt-panel-2" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-1" aria-hidden="false">
-  <p>First tab content panel</p>
-</div>
-<div id="dt-panel-4" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-3" aria-hidden="true" style="display: none;">
-  <p>Second tab content panel</p>
-</div>
-<div id="dt-panel-6" role="tabpanel" tabindex="0" aria-labelledby="dt-tab-5" aria-hidden="true" style="display: none;">
-  <p>Third tab content panel</p>
-</div>
-'
+:htmlCode="() => $refs.validationExample"
 vueCode='
 <dt-tab-group
   label="Label Example Group"


### PR DESCRIPTION
# docs(tabs, skeleton, rich-text-editor, emoji, avatar): DLT-3347 update doc page code examples

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNHhmcW9yMWdhd3lpZzQyZXV2djQ3bTdqeWMwcDh5OHJzYmMzbzhhZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JUh0yTz4h931K/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-3347
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

<!--- Describe specifically what the changes are -->
## docs(tabs, skeleton, emoji, rich-text-editor, avatar): DLT-3347 fix code example inaccuracies

Audited the documentation site for more mismatches between code examples (Vue/HTML) and the actual component implementations. Fixed issues across five component pages.

---

### tabs

- Switched all 7 variant `htmlCode` blocks from hardcoded static strings to dynamic DOM capture (`:htmlCode="() => $refs.xxx"`) — HTML output now reflects live rendered output and stays in sync as the component evolves
- Aligned tab labels and panel content between `ExampleTabs.vue` and all `vueCode` blocks
- Fixed `<template #default>` wrapper in Validation `vueCode` to use implicit default slot (consistent with the rest of the page and the actual implementation)

### skeleton

- Fixed `arial-label` → `aria-label` typo across 8 occurrences (live demo elements and `vueCode` snippets)

### emoji

- Fixed `code="smile"` → `code=":smile:"` in `vueCode` (shortcodes require colon delimiters)
- Removed invalid `code` and `size` raw HTML attributes leaking into the `htmlCode` `<span>` element

### rich-text-editor

- Removed `:input-class="$attrs.inputClass"` from Base Style and With Mentions `vueCode` blocks (`ExampleRichTextEditor.vue` is a transparent `$attrs` pass-through wrapper — these internal bindings are not part of the public API)
- Replaced `:output-format="$attrs.outputFormat"` with the concrete value `output-format="html"`
- Fixed `:mentionSuggestion` → `:mention-suggestion` (Vue kebab-case prop convention)

### avatar

- Removed non-existent `icon-name="user"` prop from the Sizes `vueCode` block (`DtAvatar` has no `icon-name` prop; icons are passed via the `#icon` slot)



## :bulb: Context
This is a follow up to https://github.com/dialpad/dialtone/pull/1213
<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
