### PR TITLE
fix(avatar, presence): NO-JIRA update recipe class override to include uikits version

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -125,7 +125,9 @@
     box-shadow: 0 0 0 var(--dt-size-200) var(--avatar-count-color-shadow);
 
     .d-recipe-leftbar-row--selected &,
-    .d-recipe-leftbar-row__primary:hover & {
+    .d-recipe-leftbar-row__primary:hover &,
+    .dp-general-row--selected &,
+    .dp-general-row__primary:hover & {
       --avatar-count-color-shadow: var(--dt-shell-action-color-background-primary-hover);
     }
 
@@ -295,7 +297,11 @@
   .d-recipe-leftbar-row--selected &,
   .d-recipe-leftbar-row:hover &,
   .d-recipe-leftbar-row:focus-within &,
-  .d-recipe-leftbar-row__primary:hover & {
+  .d-recipe-leftbar-row__primary:hover &,
+  .dp-general-row--selected &,
+  .dp-general-row:hover &,
+  .dp-general-row:focus-within &,
+  .dp-general-row__primary:hover & {
     &--presence {
       .d-presence {
         --presence-color-border-base: var(--dt-color-neutral-transparent);

--- a/packages/dialtone-css/lib/build/less/components/presence.less
+++ b/packages/dialtone-css/lib/build/less/components/presence.less
@@ -23,11 +23,13 @@
   border-width: var(--presence-border-size);
   border-radius: var(--dt-size-radius-circle);
 
-  .d-recipe-leftbar-row--selected & {
+  .d-recipe-leftbar-row--selected &,
+  .dp-general-row--selected & {
     --presence-color-border-base: var(--dt-color-surface-secondary);
   }
 
-  .d-recipe-leftbar-row__primary:hover & {
+  .d-recipe-leftbar-row__primary:hover &,
+  .dp-general-row__primary:hover & {
     --presence-color-border-base: var(--dt-shell-action-color-background-primary-hover);
   }
 


### PR DESCRIPTION
# fix(avatar, presence): NO-JIRA update recipe class override to include uikits version

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExd2NhaGhlenF4ZTlhN25md2drMXJwNG93a213b3BvdDE4cW43dXIyYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/AvMJCeu1EMmhG/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket
NO-JIRA
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

<!--- Describe specifically what the changes are -->
Updated the uses of `d-recipe-leftbar-row` in `avatar.less` and `presence.less` to include the class name that ui-kits uses since the recipes have been migrated to ui-kits.  I tested this locally using `pnpm pack`.

This fixes the immediate issue, but we may also want to make this update in the ui-kits repository for a more permanent fix. These classes were originally left in for some backwards-compatibility I believe, and we may not even need the ones in the presence.less file. However, it is worth considering how these rows will change when the new version of dialtone is introduced and whether that will be a better time to update it fully and remove the old border styles. Open to guidance there.

## :bulb: Context
This should fix the 'selected' left sidebar row state. Currently the border color is slightly off around the presence.

<img width="329" height="118" alt="Screenshot 2026-04-24 at 8 37 14 AM" src="https://github.com/user-attachments/assets/822d640f-d4fc-45b4-9da1-abf390570e30" />


<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->
<img width="916" height="677" alt="Screenshot 2026-04-28 at 10 45 33 AM" src="https://github.com/user-attachments/assets/1c81dbaf-fbf1-4a5e-8c29-6e030bff3df4" />



## :link: Sources

<!--- Add any links to external reference material -->
