### PR TITLE
feat(css-utilities): DLT-3357 DLT-3358 add ease-in and retune ease-out

### DIFF
--- a/apps/dialtone-documentation/docs/utilities/effects/transition.md
+++ b/apps/dialtone-documentation/docs/utilities/effects/transition.md
@@ -36,6 +36,7 @@ Use `d-ttf-{n}` change an element's `transition-timing-function` (aka easing) fr
 <!-- @wrapper -->
 <dt-stack direction="row" gap="200">
   <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf          ">Ease</dt-button>
+  <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-in       ">Ease In</dt-button>
   <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300                ">Ease In, Ease Out</dt-button>
   <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out      ">Ease Out</dt-button>
   <dt-button kind="unstyled" class="d-p-200 d-bar-400 d-bgc-moderate h:d-bgc-critical h:d-bs-md h:d-fc-critical d-t d-td300 d-ttf-out-quint">Ease Out Quint</dt-button>
@@ -77,7 +78,7 @@ Use `d-tp-{n}` change an what items within an element are transitioned.
         <th scope="row" class="d-code--sm d-docsite-code">.d-{{ i }}{{ d }}</th>
         <td class="d-code--sm">transition-duration: var(--td{{ d }}) !important;</td>
       </tr>
-      <tr v-else-if="i === 'ttf'" v-for="t in ['', 'in-out', 'out', 'out-quint']">
+      <tr v-else-if="i === 'ttf'" v-for="t in ['', 'in', 'in-out', 'out', 'out-quint']">
         <th scope="row" class="d-code--sm d-docsite-code">.d-{{ i }}{{ t ? `-${t}` : '' }}</th>
         <td class="d-code--sm">transition-timing-function: var(--ttf-{{ t || 'ease' }}) !important;</td>
       </tr>

--- a/packages/dialtone-css/lib/build/less/utilities/effects.less
+++ b/packages/dialtone-css/lib/build/less/utilities/effects.less
@@ -190,6 +190,7 @@
 
 //  --  TRANSITION TIMING
 .d-ttf { transition-timing-function: var(--ttf-ease) !important; }
+.d-ttf-in { transition-timing-function: var(--ttf-in) !important; }
 .d-ttf-in-out { transition-timing-function: var(--ttf-in-out) !important; }
 .d-ttf-out { transition-timing-function: var(--ttf-out) !important; }
 .d-ttf-out-quint { transition-timing-function: var(--ttf-out-quint) !important; }

--- a/packages/dialtone-css/lib/build/less/variables/visual-styles.less
+++ b/packages/dialtone-css/lib/build/less/variables/visual-styles.less
@@ -17,8 +17,9 @@
 //  ----------------------------------------------------------------------------
 @transition: {
    ttf-ease:        cubic-bezier(0.25, 0.1, 0.25, 1);
+   ttf-in:          cubic-bezier(0.9, 0, 0.65, 1);
    ttf-in-out:      cubic-bezier(0.645, 0.045, 0.355, 1);
-   ttf-out:         cubic-bezier(0.23, 1, 0.32, 1);
+   ttf-out:         cubic-bezier(0.35, 0, 0.1, 1);
    ttf-out-quint:   cubic-bezier(0.22, 1, 0.36, 1);
    td0:             0s;
    td25:            25ms;


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

- [DLT-3357](https://dialpad.atlassian.net/browse/DLT-3357) — Add `ease-in` CSS Utility
- [DLT-3358](https://dialpad.atlassian.net/browse/DLT-3358) — Update `ease-out` CSS Utility

## :book: Description

- Add `.d-ttf-in` → `var(--ttf-in)` = `cubic-bezier(0.9, 0, 0.65, 1)`
- Retune `--ttf-out` from `cubic-bezier(0.23, 1, 0.32, 1)` to `cubic-bezier(0.35, 0, 0.1, 1)` (point-symmetric mirror of `ttf-in`)
- Add row to Classes table + demo button on `/utilities/effects/transition`

Does not migrate any component. No `dialtone-tokens` changes. No new curves beyond `ttf-in`.

## :bulb: Context

Transition timing utility set was missing ease-in. Mirroring ease-out gives a matched in/out pair.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

[DLT-3357]: https://dialpad.atlassian.net/browse/DLT-3357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DLT-3358]: https://dialpad.atlassian.net/browse/DLT-3358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ