### PR TITLE
fix: correct types paths in package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,22 +57,22 @@
       "require": "./dist/tokens/postcss/*.cjs"
     },
     "./vue": {
-      "types": "./dist/vue3/types/index.d.ts",
+      "types": "./dist/vue3/index.d.ts",
       "import": "./dist/vue3/dialtone-vue.js",
       "require": "./dist/vue3/dialtone-vue.cjs"
     },
     "./vue/lib/*": {
-      "types": "./dist/vue3/types/index.d.ts",
+      "types": "./dist/vue3/index.d.ts",
       "import": "./dist/vue3/lib/*/index.js",
       "require": "./dist/vue3/lib/*/index.cjs"
     },
     "./vue3": {
-      "types": "./dist/vue3/types/index.d.ts",
+      "types": "./dist/vue3/index.d.ts",
       "import": "./dist/vue3/dialtone-vue.js",
       "require": "./dist/vue3/dialtone-vue.cjs"
     },
     "./vue3/lib/*": {
-      "types": "./dist/vue3/types/index.d.ts",
+      "types": "./dist/vue3/index.d.ts",
       "import": "./dist/vue3/lib/*/index.js",
       "require": "./dist/vue3/lib/*/index.cjs"
     },


### PR DESCRIPTION
The `exports` map pointed all Vue component type definitions to `./dist/vue3/types/index.d.ts` which doesn't exist in the build output.

### Changes

Fixed 4 export entries to point to the barrel `./dist/vue3/index.d.ts` which re-exports all component types:

| Export | Before (broken) | After (fixed) |
|--------|-----------------|---------------|
| `./vue` | `./dist/vue3/types/index.d.ts` | `./dist/vue3/index.d.ts` |
| `./vue/lib/*` | `./dist/vue3/types/index.d.ts` | `./dist/vue3/index.d.ts` |
| `./vue3` | `./dist/vue3/types/index.d.ts` | `./dist/vue3/index.d.ts` |
| `./vue3/lib/*` | `./dist/vue3/types/index.d.ts` | `./dist/vue3/index.d.ts` |

> **Note:** Per-component types (`./dist/vue3/components/*/index.d.ts`) can't be used for `lib/*` subpaths because `lib/` uses hyphens (e.g. `button-group`) while `components/` uses underscores (`button_group`). The barrel file works for all cases since it re-exports everything.

### Impact

Without this fix, TypeScript consumers using subpath imports like `@dialpad/dialtone/vue3/lib/button` get `Cannot find type definition file` errors. Barrel imports (`@dialpad/dialtone/vue`) worked around it via fallback resolution but subpath imports were broken.

Check error in https://github.com/dialpad/web-clients/actions/runs/25132738800/job/73663040484?pr=1627