### PR TITLE
fix(popover, collapsible): DP-185811 cancel transitions on unmount

### DIFF
--- a/packages/dialtone-vue/components/collapsible/collapsible.test.js
+++ b/packages/dialtone-vue/components/collapsible/collapsible.test.js
@@ -145,6 +145,22 @@ describe('DtCollapsible Tests', () => {
     });
   });
 
+  describe('When component is unmounting', () => {
+    beforeEach(() => {
+      wrapper.vm._isUnmounting = true;
+    });
+
+    it('does not emit "opened" when leave transition completes', async () => {
+      await wrapper.vm.onLeaveTransitionComplete();
+      expect(wrapper.emitted('opened')).toBeUndefined();
+    });
+
+    it('does not emit "opened" when enter transition completes', async () => {
+      await wrapper.vm.onEnterTransitionComplete();
+      expect(wrapper.emitted('opened')).toBeUndefined();
+    });
+  });
+
   describe('Accessibility Tests', () => {
     describe('Content is expanded', () => {
       beforeEach(async () => {

--- a/packages/dialtone-vue/components/collapsible/collapsible.test.js
+++ b/packages/dialtone-vue/components/collapsible/collapsible.test.js
@@ -159,6 +159,24 @@ describe('DtCollapsible Tests', () => {
       await wrapper.vm.onEnterTransitionComplete();
       expect(wrapper.emitted('opened')).toBeUndefined();
     });
+
+    describe('in controlled mode (open !== null)', () => {
+      beforeEach(async () => {
+        await wrapper.setProps({ open: false });
+      });
+
+      it('does not emit "opened" or "update:open" when leave transition completes', async () => {
+        await wrapper.vm.onLeaveTransitionComplete();
+        expect(wrapper.emitted('opened')).toBeUndefined();
+        expect(wrapper.emitted('update:open')).toBeUndefined();
+      });
+
+      it('does not emit "opened" or "update:open" when enter transition completes', async () => {
+        await wrapper.vm.onEnterTransitionComplete();
+        expect(wrapper.emitted('opened')).toBeUndefined();
+        expect(wrapper.emitted('update:open')).toBeUndefined();
+      });
+    });
   });
 
   describe('Accessibility Tests', () => {

--- a/packages/dialtone-vue/components/collapsible/collapsible.vue
+++ b/packages/dialtone-vue/components/collapsible/collapsible.vue
@@ -249,6 +249,8 @@ export default {
 
   beforeUnmount () {
     this._isUnmounting = true;
+    // Prevent transition callbacks from calling into dead lifecycle methods
+    // after this component is torn down (DP-185811).
   },
 
   methods: {

--- a/packages/dialtone-vue/components/collapsible/collapsible.vue
+++ b/packages/dialtone-vue/components/collapsible/collapsible.vue
@@ -247,8 +247,13 @@ export default {
     this.validateProperAnchor();
   },
 
+  beforeUnmount () {
+    this._isUnmounting = true;
+  },
+
   methods: {
     onLeaveTransitionComplete () {
+      if (this._isUnmounting) return;
       this.$emit('opened', false);
       if (this.open !== null) {
         this.$emit('update:open', false);
@@ -256,6 +261,7 @@ export default {
     },
 
     onEnterTransitionComplete () {
+      if (this._isUnmounting) return;
       this.$emit('opened', true, this.$refs.content);
       if (this.open !== null) {
         this.$emit('update:open', true);

--- a/packages/dialtone-vue/components/popover/popover.test.js
+++ b/packages/dialtone-vue/components/popover/popover.test.js
@@ -305,6 +305,26 @@ describe('DtPopover Tests', () => {
     });
   });
 
+  describe('When component is unmounting', () => {
+    it('sets transition: none on content element to cancel in-flight transitions', () => {
+      const contentEl = wrapper.vm.popoverContentEl;
+      wrapper.unmount();
+      expect(contentEl.style.transition).toBe('none');
+    });
+
+    it('does not emit "opened" when leave transition completes', async () => {
+      wrapper.vm._isUnmounting = true;
+      await wrapper.vm.onLeaveTransitionComplete();
+      expect(wrapper.emitted('opened')).toBeUndefined();
+    });
+
+    it('does not emit "opened" when enter transition completes', async () => {
+      wrapper.vm._isUnmounting = true;
+      await wrapper.vm.onEnterTransitionComplete();
+      expect(wrapper.emitted('opened')).toBeUndefined();
+    });
+  });
+
   describe('When anchor slot content changes', () => {
     it('should attach the tippy instance to the new DOM node', async () => {
       const component = {

--- a/packages/dialtone-vue/components/popover/popover.test.js
+++ b/packages/dialtone-vue/components/popover/popover.test.js
@@ -312,16 +312,26 @@ describe('DtPopover Tests', () => {
       expect(contentEl.style.transition).toBe('none');
     });
 
-    it('does not emit "opened" when leave transition completes', async () => {
+    it('does not emit "opened" when leave transition completes, but does emit when not unmounting', async () => {
       wrapper.vm._isUnmounting = true;
       await wrapper.vm.onLeaveTransitionComplete();
       expect(wrapper.emitted('opened')).toBeUndefined();
+
+      wrapper.vm._isUnmounting = false;
+      await wrapper.vm.onLeaveTransitionComplete();
+      expect(wrapper.emitted('opened')).toBeDefined();
+      expect(wrapper.emitted('opened')[0]).toEqual([false]);
     });
 
-    it('does not emit "opened" when enter transition completes', async () => {
+    it('does not emit "opened" when enter transition completes, but does emit when not unmounting', async () => {
       wrapper.vm._isUnmounting = true;
       await wrapper.vm.onEnterTransitionComplete();
       expect(wrapper.emitted('opened')).toBeUndefined();
+
+      wrapper.vm._isUnmounting = false;
+      await wrapper.vm.onEnterTransitionComplete();
+      expect(wrapper.emitted('opened')).toBeDefined();
+      expect(wrapper.emitted('opened')[0][0]).toBe(true);
     });
   });
 

--- a/packages/dialtone-vue/components/popover/popover.test.js
+++ b/packages/dialtone-vue/components/popover/popover.test.js
@@ -306,32 +306,52 @@ describe('DtPopover Tests', () => {
   });
 
   describe('When component is unmounting', () => {
+    beforeEach(() => {
+      wrapper.vm._isUnmounting = true;
+    });
+
     it('sets transition: none on content element to cancel in-flight transitions', () => {
       const contentEl = wrapper.vm.popoverContentEl;
       wrapper.unmount();
       expect(contentEl.style.transition).toBe('none');
     });
 
-    it('does not emit "opened" when leave transition completes, but does emit when not unmounting', async () => {
-      wrapper.vm._isUnmounting = true;
+    it('does not emit "opened" when leave transition completes', async () => {
       await wrapper.vm.onLeaveTransitionComplete();
       expect(wrapper.emitted('opened')).toBeUndefined();
+    });
 
+    it('emits "opened" and respects open prop when leave transition completes and not unmounting', async () => {
       wrapper.vm._isUnmounting = false;
       await wrapper.vm.onLeaveTransitionComplete();
       expect(wrapper.emitted('opened')).toBeDefined();
       expect(wrapper.emitted('opened')[0]).toEqual([false]);
+      // uncontrolled (open === null): update:open is not emitted
+      expect(wrapper.emitted('update:open')).toBeUndefined();
+      // controlled (open !== null): update:open is emitted
+      await wrapper.setProps({ open: false });
+      await wrapper.vm.onLeaveTransitionComplete();
+      expect(wrapper.emitted('update:open')).toBeDefined();
+      expect(wrapper.emitted('update:open')[0]).toEqual([false]);
     });
 
-    it('does not emit "opened" when enter transition completes, but does emit when not unmounting', async () => {
-      wrapper.vm._isUnmounting = true;
+    it('does not emit "opened" when enter transition completes', async () => {
       await wrapper.vm.onEnterTransitionComplete();
       expect(wrapper.emitted('opened')).toBeUndefined();
+    });
 
+    it('emits "opened" and respects open prop when enter transition completes and not unmounting', async () => {
       wrapper.vm._isUnmounting = false;
       await wrapper.vm.onEnterTransitionComplete();
       expect(wrapper.emitted('opened')).toBeDefined();
       expect(wrapper.emitted('opened')[0][0]).toBe(true);
+      // uncontrolled (open === null): update:open is not emitted
+      expect(wrapper.emitted('update:open')).toBeUndefined();
+      // controlled (open !== null): update:open is emitted
+      await wrapper.setProps({ open: false });
+      await wrapper.vm.onEnterTransitionComplete();
+      expect(wrapper.emitted('update:open')).toBeDefined();
+      expect(wrapper.emitted('update:open')[0]).toEqual([true]);
     });
   });
 

--- a/packages/dialtone-vue/components/popover/popover.vue
+++ b/packages/dialtone-vue/components/popover/popover.vue
@@ -712,6 +712,12 @@ export default {
   },
 
   beforeUnmount () {
+    this._isUnmounting = true;
+    // Cancel any in-progress CSS transitions so transitionend cannot fire
+    // after this component is torn down and call into dead lifecycle methods.
+    if (this.popoverContentEl) {
+      this.popoverContentEl.style.transition = 'none';
+    }
     this.tip?.destroy();
     this.intersectionObserver?.disconnect();
     this.mutationObserver?.disconnect();
@@ -904,6 +910,7 @@ export default {
     },
 
     async onLeaveTransitionComplete () {
+      if (this._isUnmounting) return;
       if (this.modal) {
         await this.focusFirstElement(this.$refs.anchor);
         // await next tick in case the user wants to change focus themselves.
@@ -918,6 +925,7 @@ export default {
     },
 
     async onEnterTransitionComplete () {
+      if (this._isUnmounting) return;
       this.focusInitialElement();
       // await next tick in case the user wants to change focus themselves.
       await this.$nextTick();

--- a/packages/dialtone-vue/components/popover/popover.vue
+++ b/packages/dialtone-vue/components/popover/popover.vue
@@ -913,10 +913,13 @@ export default {
       if (this._isUnmounting) return;
       if (this.modal) {
         await this.focusFirstElement(this.$refs.anchor);
+        if (this._isUnmounting) return;
         // await next tick in case the user wants to change focus themselves.
         await this.$nextTick();
+        if (this._isUnmounting) return;
         this.enableScrolling();
       }
+      if (this._isUnmounting) return;
       this.tip?.unmount();
       this.$emit('opened', false);
       if (this.open !== null) {
@@ -929,6 +932,7 @@ export default {
       this.focusInitialElement();
       // await next tick in case the user wants to change focus themselves.
       await this.$nextTick();
+      if (this._isUnmounting) return;
       this.preventScrolling();
       this.$emit('opened', true, this.$refs.popover__content);
       if (this.open !== null) {


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

[DP-185811](https://dialpad.atlassian.net/browse/DP-185811)

## :book: Description

Fixes a race condition where a CSS leave transition (fade/collapse) could complete after `DtPopover` or `DtCollapsible` was already unmounted, causing Vue to attempt updates on a dead component instance.

## :bulb: Context

Reported from the product side — implementing components were unmounting while a popover/collapsible leave animation was in progress. The `after-leave` hook then fired on the already-torn-down component, producing warnings and potential errors about updating unmounted component instances.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

[DP-185811]: https://dialpad.atlassian.net/browse/DP-185811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ