### PR TITLE
feat(colors, link, tokens): DLT-3360 retune blue/gold/purple/black/red palette, add mention semantic tokens, migrate success to positive

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -66,9 +66,13 @@ reviews:
         - Token naming: camelCase with category prefix (dtColor*, dtSpace*,
           dtFontSize*, dtFontWeight*, dtShadow*, dtRadius*, dtSize*).
 
-        - New tokens must have dark mode overrides in dark.json.
+        - New tokens may inherit from default.json when the same value is correct
+          in dark mode. Add a dark.json override only when the dark theme value
+          must differ from the default.
 
-        - Component tokens must reference semantic tokens, not base palette.
+        - Prefer semantic tokens when a suitable mapping exists, but direct
+          base-palette references are valid when they are the correct source of
+          truth (e.g., a token tied to a specific palette stop).
 
         - Flag any circular references or references to non-existent tokens.
 

--- a/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-syntax.less
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/assets/less/dialtone-syntax.less
@@ -40,6 +40,15 @@ div[class*="language-"] {
   }
 }
 
+code:not(.d-code--md, .d-code--sm, .d-prose *) {
+	padding: var(--dt-size-200) var(--dt-size-300);
+	color: var(--dt-color-foreground-info);
+	background-color: var(--dt-color-surface-info-subtle);
+	border-radius: var(--dt-size-radius-200);
+	user-select: all;
+}
+
+
 code[class*="language-"],
 pre[class*="language-"] {
 	margin: 0;

--- a/apps/dialtone-documentation/docs/guides/mcp-server/index.md
+++ b/apps/dialtone-documentation/docs/guides/mcp-server/index.md
@@ -117,7 +117,7 @@ Find CSS utility classes to style HTML elements. Use when your query mentions CS
 
 **Tool:** `search_tokens`
 
-Find design tokens (CSS variables) from Dialtone's design system. Use when your query mentions token categories (color, space, font, size) or semantic names (primary, success, foreground, background).
+Find design tokens (CSS variables) from Dialtone's design system. Use when your query mentions token categories (color, space, font, size) or semantic names (primary, positive, foreground, background).
 
 **Example queries:**
 

--- a/apps/dialtone-documentation/docs/scratch-color.md
+++ b/apps/dialtone-documentation/docs/scratch-color.md
@@ -1,0 +1,462 @@
+---
+layout: Blank
+---
+
+<dt-box class="d-ps-fixed d-ibs-100 d-iie-200" surface="primary">
+  <dt-stack direction="row" gap="100">
+    <dt-dropdown
+      navigation-type="arrow-keys"
+    >
+      <template #anchor>
+        <dt-button
+          importance="outlined"
+          kind="muted"
+          :size="200"
+        >
+          <dt-stack gap="100" direction="row">
+            <span>
+              <dt-text strength="bold">Mode:</dt-text>
+              <dt-text tone="tertiary">{{ capitalize(currentMode) }}</dt-text>
+            </span>
+            <span>
+              <dt-text strength="bold">Contrast:</dt-text>
+              <dt-text tone="tertiary">{{ capitalize(currentContrast) }}</dt-text>
+            </span>
+          </dt-stack>
+          <template #startIcon="{ iconSize }">
+            <dt-icon
+              :size="iconSize"
+              :name="currentModeIconName"
+            />
+          </template>
+          <template #endIcon="{ iconSize }">
+            <dt-icon
+              :size="iconSize"
+              name="chevron-down"
+            />
+          </template>
+        </dt-button>
+      </template>
+      <template #list>
+        <dt-list-item-group
+          heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
+          heading="Mode"
+        >
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setMode('system')"
+          >
+            System
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentMode !== 'system' }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setMode('light')"
+          >
+            Light
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentMode !== 'light' }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setMode('dark')"
+          >
+            Dark
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentMode !== 'dark' }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+        </dt-list-item-group>
+        <dt-dropdown-separator />
+        <dt-list-item-group
+          heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
+          heading="Contrast"
+        >
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setContrast('default')"
+          >
+            Default
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentContrast !== 'default' }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setContrast('high')"
+          >
+            High
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentContrast !== 'high' }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+        </dt-list-item-group>
+      </template>
+    </dt-dropdown>
+    <dt-dropdown
+      navigation-type="arrow-keys"
+      max-height="33vh"
+    >
+      <template #anchor>
+        <dt-button
+          v-dt-tooltip:bottom="`Theme: ${capitalize(currentTheme)}`"
+          class="theme-toggle-button dialtone-shell-btn"
+          importance="outlined"
+          kind="muted"
+          :size="200"
+        >
+          <dt-stack direction="row" gap="50">
+            Theme: {{ currentTheme }}
+          </dt-stack>
+          <template #endIcon>
+            <dt-icon name="chevron-down" size="200" />
+          </template>
+        </dt-button>
+      </template>
+      <template #list>
+        <dt-list-item-group
+          heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
+          heading="Base Theme"
+        >
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setTheme('dp')"
+          >
+            Dialpad (DP)
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentTheme !== 'dp' }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+        </dt-list-item-group>
+        <dt-dropdown-separator />
+        <dt-list-item-group
+          heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
+          heading="Partner Themes"
+        >
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setTheme('tmo')"
+          >
+            T-Mobile (TMO)
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentTheme !== 'tmo' }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+        </dt-list-item-group>
+        <dt-dropdown-separator />
+        <dt-list-item-group
+          heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
+          heading="Accessibility"
+        >
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setTheme('prota-deuter')"
+          >
+            Prota-Deuter
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentTheme !== 'prota-deuter' }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+          <dt-list-item
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setTheme('trita')"
+          >
+            Trita
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentTheme !== 'trita' }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+        </dt-list-item-group>
+        <dt-dropdown-separator />
+        <dt-list-item-group
+          heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
+          heading="Named Themes"
+        >
+          <dt-list-item
+            v-for="themeName in namedThemes"
+            :key="themeName"
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setTheme(themeName)"
+          >
+            {{ formatThemeName(themeName) }}
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentTheme !== themeName }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+        </dt-list-item-group>
+        <dt-dropdown-separator />
+        <dt-list-item-group
+          heading-class="d-py-50 d-px-100 d-c-default d-fc-tertiary d-label--sm"
+          heading="Experimental (37 themes)"
+        >
+          <dt-list-item
+            v-for="themeNum in numberedThemes"
+            :key="themeNum"
+            role="menuitem"
+            navigation-type="arrow-keys"
+            @click="setTheme(themeNum)"
+          >
+            Theme {{ themeNum }}
+            <template #end>
+              <dt-icon :class="{ 'd-o0': currentTheme !== themeNum }" name="check" size="200" />
+            </template>
+          </dt-list-item>
+        </dt-list-item-group>
+      </template>
+    </dt-dropdown>
+  </dt-stack>
+</dt-box>
+<dt-box surface="primary" padding="400">
+  <dt-stack gap="400">
+    <dt-stack gap="200">
+      <dt-text as="h3" kind="label" size="200" strength="bold" tone="primary">Surfaces</dt-text>
+      <dt-stack direction="row" align="start">
+        <dt-stack
+          v-for="surfaceItem in primarySurfaces"
+          :key="surfaceItem.name"
+        >
+          <dt-box padding="300" :surface="surfaceItem.name">
+            <dt-text v-if="surfaceItem.dark" v-dt-mode:invert as="p" kind="code" size="100" strength="bold" tone="primary">{{ surfaceItem.name }}</dt-text>
+            <dt-text v-else as="p" kind="code" size="100" strength="bold" tone="primary">{{ surfaceItem.name }}</dt-text>
+          </dt-box>
+          <dt-box padding="300" :surface="`${surfaceItem.name}-opaque`">
+            <dt-text v-if="surfaceItem.dark" v-dt-mode:invert as="p" kind="code" size="100" strength="bold" tone="primary">{{ surfaceItem.name }}-opaque</dt-text>
+            <dt-text v-else as="p" kind="code" size="100" strength="bold" tone="primary">{{ surfaceItem.name }}-opaque</dt-text>
+          </dt-box>
+        </dt-stack>
+      </dt-stack>
+      <dt-stack direction="row" align="start">
+        <dt-stack v-for="surfaceName in semanticSubtleSurfaces" :key="surfaceName">
+          <dt-box padding="300" :surface="surfaceName"><dt-text as="p" kind="code" size="100" strength="bold" tone="primary">{{ surfaceName }}</dt-text></dt-box>
+          <dt-box padding="300" :surface="`${surfaceName}-opaque`"><dt-text as="p" kind="code" size="100" strength="bold" tone="primary">{{ surfaceName }}-opaque</dt-text></dt-box>
+        </dt-stack>
+      </dt-stack>
+      <dt-stack direction="row" align="start">
+        <dt-box v-for="surfaceName in semanticStrongSurfaces" :key="surfaceName" padding="300" :surface="surfaceName">
+          <dt-text as="p" kind="code" size="100" strength="bold" tone="primary" v-dt-mode:invert>{{ surfaceName }}</dt-text>
+        </dt-box>
+      </dt-stack>
+      <dt-stack direction="row" align="start">
+        <dt-box padding="300" surface="backdrop"><dt-text as="p" kind="code" size="100" strength="bold" tone="primary">backdrop</dt-text></dt-box>
+      </dt-stack>
+    </dt-stack>
+    <dt-box surface="primary" padding="300" border-radius="200" v-dt-mode:invert>
+      <dt-stack gap="200">
+        <dt-text as="h3" kind="label" size="200" strength="bold" tone="primary">Surfaces — inverted</dt-text>
+        <dt-stack direction="row" align="start">
+          <dt-stack
+            v-for="surfaceItem in primarySurfaces"
+            :key="surfaceItem.name"
+          >
+            <dt-box padding="300" :surface="surfaceItem.name">
+              <dt-text as="p" kind="code" size="100" strength="bold" tone="primary">{{ surfaceItem.name }}-inv</dt-text>
+            </dt-box>
+            <dt-box padding="300" :surface="`${surfaceItem.name}-opaque`">
+              <dt-text as="p" kind="code" size="100" strength="bold" tone="primary">{{ surfaceItem.name }}-opa-inv</dt-text>
+            </dt-box>
+          </dt-stack>
+        </dt-stack>
+        <dt-stack direction="row" align="start">
+          <dt-stack v-for="surfaceName in semanticSubtleSurfaces" :key="surfaceName">
+            <dt-box padding="300" :surface="surfaceName"><dt-text as="p" kind="code" size="100" strength="bold" tone="primary">{{ surfaceName }}-inv</dt-text></dt-box>
+            <dt-box padding="300" :surface="`${surfaceName}-opaque`"><dt-text as="p" kind="code" size="100" strength="bold" tone="primary">{{ surfaceName }}-opa-inv</dt-text></dt-box>
+          </dt-stack>
+        </dt-stack>
+        <dt-stack direction="row" align="start">
+          <dt-box v-for="surfaceName in semanticStrongSurfaces" :key="surfaceName" padding="300" :surface="surfaceName">
+            <dt-text as="p" kind="code" size="100" strength="bold" tone="primary">{{ surfaceName }}-inv</dt-text>
+          </dt-box>
+        </dt-stack>
+      </dt-stack>
+    </dt-box>
+    <dt-stack gap="200">
+      <dt-text as="h3" kind="label" size="200" strength="bold" tone="primary">Borders</dt-text>
+      <dt-stack
+        v-for="borderRow in borderRows"
+        :key="borderRow.join()"
+        direction="row"
+        align="stretch"
+        gap="200"
+      >
+        <dt-box v-for="borderName in borderRow" :key="borderName" padding="200" border-width="200" border-radius="500" :border-color="borderName">
+          <dt-text as="p" kind="code" size="100" strength="bold" tone="primary">{{ borderName }}</dt-text>
+        </dt-box>
+      </dt-stack>
+    </dt-stack>
+    <dt-box surface="primary" padding="300" border-radius="200" v-dt-mode:invert>
+      <dt-stack gap="200">
+        <dt-text as="h3" kind="label" size="200" strength="bold" tone="primary">Borders — inverted</dt-text>
+        <dt-stack
+          v-for="borderRow in borderRows"
+          :key="borderRow.join()"
+          direction="row"
+          align="stretch"
+          gap="200"
+        >
+          <dt-box v-for="borderName in borderRow" :key="borderName" padding="200" border-width="200" border-radius="500" :border-color="borderName">
+            <dt-text as="p" kind="code" size="100" strength="bold" tone="primary">{{ borderName }}-inv</dt-text>
+          </dt-box>
+        </dt-stack>
+      </dt-stack>
+    </dt-box>
+    <dt-stack gap="200">
+      <dt-text as="h3" kind="label" size="200" strength="bold" tone="primary">Foreground (text tones)</dt-text>
+      <dt-stack direction="row" gap="100" align="baseline">
+        <dt-text v-for="toneName in foregroundTones" :key="toneName" :tone="toneName">{{ toneName }}</dt-text>
+      </dt-stack>
+    </dt-stack>
+    <dt-box surface="primary" padding="300" border-radius="200" v-dt-mode:invert>
+      <dt-stack gap="200">
+        <dt-text as="h3" kind="label" size="200" strength="bold" tone="primary">Foreground — inverted</dt-text>
+        <dt-stack direction="row" gap="100" align="baseline">
+          <dt-text v-for="toneName in foregroundTones" :key="toneName" :tone="toneName">{{ toneName }}</dt-text>
+        </dt-stack>
+      </dt-stack>
+    </dt-box>
+    <dt-stack gap="200">
+      <dt-text as="h3" kind="label" size="200" strength="bold" tone="primary">Links</dt-text>
+      <dt-stack direction="row" gap="100" align="baseline">
+        <dt-link v-for="linkTone in linkTones" :key="linkTone" href="#link" :tone="linkTone === 'base' ? undefined : linkTone">{{ capitalize(linkTone) }} link</dt-link>
+      </dt-stack>
+    </dt-stack>
+    <dt-box surface="primary" padding="300" border-radius="200" v-dt-mode:invert>
+      <dt-stack gap="200">
+        <dt-text as="h3" kind="label" size="200" strength="bold" tone="primary">Links — inverted</dt-text>
+        <dt-stack direction="row" gap="100" align="baseline">
+          <dt-link v-for="linkTone in linkTones" :key="linkTone" href="#link" :tone="linkTone === 'base' ? undefined : linkTone">{{ capitalize(linkTone) }} link</dt-link>
+        </dt-stack>
+      </dt-stack>
+    </dt-box>
+    <dt-stack gap="200">
+      <dt-stack
+        v-for="row in buttonVariants"
+        :key="row.kind || 'default'"
+        gap="100"
+        direction="row"
+      >
+        <dt-button v-for="imp in row.importances" :key="imp || 'filled'" :kind="row.kind" :importance="imp">Place Call</dt-button>
+      </dt-stack>
+    </dt-stack>
+    <dt-stack direction="row" gap="100">
+      <dt-presence presence="active" />
+      <dt-presence presence="busy" />
+      <dt-presence presence="away" />
+    </dt-stack>
+    <dt-stack direction="row" gap="100">
+      <template v-for="kind in badgeKinds" :key="kind || 'text'">
+        <dt-badge v-for="t in badgeTypes" :key="`${kind || 'text'}-${t || 'default'}`" :text="kind === 'count' ? '1' : 'Label'" :kind="kind" :type="t" />
+      </template>
+    </dt-stack>
+    <dt-stack direction="row" gap="200">
+      <dt-stack v-for="important in [false, true]" :key="important" gap="100">
+        <example-notice v-for="k in noticeKinds" :key="k" :important="important" :kind="k" :title="`${capitalize(k)} title (optional)`" />
+      </dt-stack>
+    </dt-stack>
+    <dt-stack direction="row" gap="200">
+      <dt-stack v-for="k in progressKinds" :key="k" gap="100">
+        <dt-progress-circle :kind="k" :progress="66" :aria-label="`kind ${k}`" />
+      </dt-stack>
+    </dt-stack>
+    <div class="d-d-grid d-g-200 d-g-cols3">
+      <template v-for="t in ['email', 'textarea']" :key="t">
+        <dt-input v-for="m in ['critical', 'positive', 'warning']" :key="`${t}-${m}`" label="Label" :type="t" model-value="Value" :messages="[messages[m]]" />
+      </template>
+    </div>
+<dialtone-usage>
+<template #do>
+
+- To flag and draw awareness to a specific element or feature of focus. For example, something is unique about that separates it from other like content.
+- As a notification system with minimal footprint.
+</template>
+
+<template #dont>
+
+- To indicate that interaction by the user is required.
+</template>
+
+</dialtone-usage>
+  </dt-stack>
+</dt-box>
+
+<script setup>
+import { useThemeManager } from '@composables/useThemeManager';
+import ExampleNotice from '@exampleComponents/ExampleNotice.vue';
+
+const messages = {
+  warning: { "message": "Warning validation message", "type": "warning" },
+  critical: { "message": "Critical validation message", "type": "critical" },
+  positive: { "message": "Positive validation message", "type": "positive" },
+};
+
+// Each section renders twice: once normally and once inside a v-dt-mode:invert
+// wrapper, which swaps all tokens to their *-inverted counterparts automatically.
+
+const primarySurfaces = [
+  { name: 'primary' },
+  { name: 'secondary' },
+  { name: 'moderate' },
+  { name: 'bold' },
+  { name: 'strong', dark: true },
+  { name: 'contrast', dark: true },
+];
+const semanticSubtleSurfaces = [
+  'info-subtle', 'info',
+  'brand-subtle', 'brand',
+  'positive-subtle', 'positive',
+  'warning-subtle', 'warning',
+  'critical-subtle', 'critical',
+];
+const semanticStrongSurfaces = [
+  'info-strong', 'brand-strong', 'positive-strong', 'warning-strong', 'critical-strong',
+];
+
+const borderRows = [
+  ['subtle', 'default', 'moderate', 'bold'],
+  ['critical-subtle', 'critical', 'critical-strong', 'info-subtle', 'info', 'info-strong', 'positive-subtle', 'positive', 'positive-strong', 'warning-subtle', 'warning', 'warning-strong', 'brand-subtle', 'brand', 'brand-strong'],
+  ['focus', 'accent'],
+];
+
+const foregroundTones = [
+  'primary', 'secondary', 'tertiary', 'muted', 'disabled', 'placeholder',
+  'positive', 'warning', 'critical', 'info',
+];
+const linkTones = ['base', 'critical', 'muted', 'positive', 'warning', 'info', 'mention'];
+const buttonVariants = [
+  { kind: undefined, importances: [undefined, 'outlined', 'clear'] },
+  { kind: 'critical', importances: [undefined, 'outlined', 'clear'] },
+  { kind: 'positive', importances: [undefined, 'outlined', 'clear'] },
+  { kind: 'muted', importances: ['clear', 'outlined'] },
+];
+const badgeKinds = [undefined, 'count'];
+const badgeTypes = [undefined, 'info', 'positive', 'warning', 'critical'];
+const noticeKinds = ['base', 'critical', 'info', 'positive', 'warning'];
+const progressKinds = ['default', 'brand', 'critical', 'positive', 'warning', 'info', 'ai'];
+
+const {
+  currentMode,
+  currentContrast,
+  currentModeIconName,
+  setMode,
+  setContrast,
+  currentTheme,
+  setTheme,
+  namedThemes,
+  numberedThemes,
+  formatThemeName,
+} = useThemeManager({ includeThemes: true });
+
+const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
+</script>

--- a/packages/dialtone-css/lib/build/less/components/link.less
+++ b/packages/dialtone-css/lib/build/less/components/link.less
@@ -17,7 +17,7 @@
 .d-link {
     --link-color-default: var(--dt-color-link-primary);
     --link-color-default-hover: var(--dt-color-link-primary-hover);
-    --link-text-decoration: none;
+    --link-text-decoration: underline;
     --link-padding: 0;
     --link-background-color: transparent;
 
@@ -45,7 +45,7 @@
     fill: currentColor;
 
     &:hover {
-        --link-text-decoration: underline;
+        --link-text-decoration: none;
 
         color: var(--link-color-default-hover);
         cursor: pointer;

--- a/packages/dialtone-css/lib/build/less/components/link.less
+++ b/packages/dialtone-css/lib/build/less/components/link.less
@@ -194,7 +194,7 @@
         --link-background-color: var(--dt-color-link-mention-inverted-background);
 
         line-height: var(--dt-font-line-height-200);
-        border-radius: var(--dt-size-radius-200);
+        border-radius: var(--dt-size-radius-300);
 
         &:hover {
             --link-background-color: var(--dt-color-link-mention-inverted-background-hover);

--- a/packages/dialtone-css/lib/build/less/components/link.less
+++ b/packages/dialtone-css/lib/build/less/components/link.less
@@ -17,7 +17,7 @@
 .d-link {
     --link-color-default: var(--dt-color-link-primary);
     --link-color-default-hover: var(--dt-color-link-primary-hover);
-    --link-text-decoration: underline;
+    --link-text-decoration: none;
     --link-padding: 0;
     --link-background-color: transparent;
 
@@ -45,14 +45,13 @@
     fill: currentColor;
 
     &:hover {
-        --link-text-decoration: none;
+        --link-text-decoration: underline;
 
         color: var(--link-color-default-hover);
         cursor: pointer;
     }
 
     &:active {
-        // --link-text-decoration: underline;
         color: var(--link-color-default);
     }
 
@@ -191,36 +190,32 @@
     &--inverted-mention {
         --link-color-default: var(--dt-color-link-primary-inverted);
         --link-color-default-hover: var(--dt-color-link-primary-inverted-hover);
-        --link-text-decoration: none;
         --link-padding: 0 var(--dt-spacing-25);
-        --link-background-color: oklch(from var(--dt-color-surface-brand-strong) l c h /0.3);
-
-        line-height: var(--dt-font-line-height-200);
-        border-radius: var(--dt-size-radius-200);
-    }
-
-    //  $$  MENTION
-    //  ----------------------------------------------------------------------------
-    // Styling specific to mentions such as @brad.paugh. The underline highlighting
-    // is reversed compared to a regular link, and it has a light background.
-    &--mention {
-        --link-text-decoration: none;
-        --link-padding: 0 var(--dt-spacing-25);
-        --link-background-color: oklch(from var(--dt-color-surface-brand-strong) l c h /0.1);
+        --link-background-color: var(--dt-color-link-mention-inverted-background);
 
         line-height: var(--dt-font-line-height-200);
         border-radius: var(--dt-size-radius-200);
 
         &:hover {
-            --link-text-decoration: underline;
-            --link-background-color: oklch(from var(--dt-color-surface-brand-strong) l c h /0.25);
-
-            text-underline-offset: var(--dt-spacing-25);
-            text-decoration-thickness: var(--dt-size-border-100);
+            --link-background-color: var(--dt-color-link-mention-inverted-background-hover);
         }
+    }
 
-        &:active {
-            --link-background-color: oklch(from var(--dt-color-surface-brand-strong) l c h /0.1);
+    //  $$  MENTION
+    //  ----------------------------------------------------------------------------
+    // Styling for @mention links (e.g. @brad.paugh). Displays as a pill-shaped
+    // background using brand surface tokens. Background changes on hover.
+    &--mention {
+        --link-color-default: var(--dt-color-link-mention);
+        --link-color-default-hover: var(--dt-color-link-mention-hover);
+        --link-padding: var(--dt-spacing-1) var(--dt-spacing-25);
+        --link-background-color: var(--dt-color-link-mention-background);
+
+        line-height: var(--dt-font-line-height-200);
+        border-radius: var(--dt-size-radius-300);
+
+        &:hover {
+            --link-background-color: var(--dt-color-link-mention-background-hover);
         }
     }
 }

--- a/packages/dialtone-css/lib/build/less/components/notice.less
+++ b/packages/dialtone-css/lib/build/less/components/notice.less
@@ -114,7 +114,7 @@
 .d-notice.d-notice--important,
 .d-banner.d-banner--important,
 .d-toast.d-toast--important {
-    --notice-color-background: var(--dt-color-surface-strong);
+    --notice-color-background: var(--dt-color-surface-primary-inverted);
     --notice-color-text: var(--dt-color-foreground-primary-inverted);
     --notice-color-icon: var(--notice-color-text);
     --notice-color-shadow: transparent;

--- a/packages/dialtone-tokens/tokens/base/dark.json
+++ b/packages/dialtone-tokens/tokens/base/dark.json
@@ -2,47 +2,47 @@
   "color": {
     "black": {
       "50": {
-        "value": "oklch(0 0 0)",
+        "value": "oklch(0.1595 0.0045 84.59)",
         "type": "color"
       },
       "100": {
-        "value": "oklch(0.2046 0 0)",
+        "value": "oklch(0.2134 0.006 91.63)",
         "type": "color"
       },
       "200": {
-        "value": "oklch(0.2393 0 0)",
+        "value": "oklch(0.2572 0.0063 78.21)",
         "type": "color"
       },
       "300": {
-        "value": "oklch(0.36 0 0)",
+        "value": "oklch(0.3352 0.0055 56.21)",
         "type": "color"
       },
       "400": {
-        "value": "oklch(0.4495 0 0)",
+        "value": "oklch(0.4468 0.0055 78.27)",
         "type": "color"
       },
       "500": {
-        "value": "oklch(0.5999 0 0)",
+        "value": "oklch(0.5134 0.0063 95.18)",
         "type": "color"
       },
       "600": {
-        "value": "oklch(0.7572 0 0)",
+        "value": "oklch(0.6001 0.0032 84.56)",
         "type": "color"
       },
       "700": {
-        "value": "oklch(0.8297 0 0)",
+        "value": "oklch(0.7321 0.0061 84.57)",
         "type": "color"
       },
       "800": {
-        "value": "oklch(0.8699 0 0)",
+        "value": "oklch(0.858 0.0059 84.57)",
         "type": "color"
       },
       "900": {
-        "value": "oklch(0.9249 0 0)",
+        "value": "oklch(0.9312 0.0029 84.56)",
         "type": "color"
       },
       "950": {
-        "value": "oklch(0.9821 0 0)",
+        "value": "oklch(0.9774 0.0025 48.72)",
         "type": "color"
       },
       "1000": {
@@ -52,201 +52,201 @@
     },
     "purple": {
       "50": {
-        "value": "oklch(0.1599 0.0811 291.62)",
+        "value": "oklch(0.1531 0.0859 291.49)",
         "type": "color"
       },
       "100": {
-        "value": "oklch(0.2281 0.1309 285.47)",
+        "value": "oklch(0.2244 0.131 285.15)",
         "type": "color"
       },
       "200": {
-        "value": "oklch(0.361 0.1955 283.93)",
+        "value": "oklch(0.2984 0.1549 283.05)",
         "type": "color"
       },
       "300": {
-        "value": "oklch(0.4638 0.2502 281.37)",
+        "value": "oklch(0.3629 0.1821 284.23)",
         "type": "color"
       },
       "400": {
-        "value": "oklch(0.5217 0.2647 284.59)",
+        "value": "oklch(0.4108 0.2066 284.07)",
         "type": "color"
       },
       "500": {
-        "value": "oklch(0.5851 0.2414 287.62)",
+        "value": "oklch(0.4831 0.2316 284.82)",
         "type": "color"
       },
       "600": {
-        "value": "oklch(0.6464 0.1985 289.97)",
+        "value": "oklch(0.5829 0.2426 287.41)",
         "type": "color"
       },
       "700": {
-        "value": "oklch(0.7113 0.1613 290.66)",
+        "value": "oklch(0.6717 0.189855 291.5342)",
         "type": "color"
       },
       "800": {
-        "value": "oklch(0.7755 0.1222 294.6)",
+        "value": "oklch(0.7697 0.130656 294.1037)",
         "type": "color"
       },
       "900": {
-        "value": "oklch(0.8371 0.0754 300.31)",
+        "value": "oklch(0.8546 0.085 300.63)",
         "type": "color"
       },
       "950": {
-        "value": "oklch(0.9347 0.0306 302.3)",
+        "value": "oklch(0.9029 0.056 301.24)",
         "type": "color"
       },
       "1000": {
-        "value": "oklch(0.978 0.0123 301.29)",
+        "value": "oklch(0.9514 0.0276 301.76)",
         "type": "color"
       }
     },
     "blue": {
       "50": {
-        "value": "oklch(0.1442 0.0315 244.16)",
+        "value": "oklch(0.163 0.0489 252.1)",
         "type": "color"
       },
       "100": {
-        "value": "oklch(0.2161 0.0514 247.62)",
+        "value": "oklch(0.2552 0.0945 258.02)",
         "type": "color"
       },
       "200": {
-        "value": "oklch(0.3449 0.0951 254.97)",
+        "value": "oklch(0.3269 0.1294 259.43)",
         "type": "color"
       },
       "300": {
-        "value": "oklch(0.4546 0.136 256.17)",
+        "value": "oklch(0.4126 0.1703 260.22)",
         "type": "color"
       },
       "400": {
-        "value": "oklch(0.5743 0.1498 251.06)",
+        "value": "oklch(0.4857 0.205 260.61)",
         "type": "color"
       },
       "500": {
-        "value": "oklch(0.6526 0.1385 246.51)",
+        "value": "oklch(0.5552 0.223 260.26)",
         "type": "color"
       },
       "600": {
-        "value": "oklch(0.706 0.1304 241.91)",
+        "value": "oklch(0.6089 0.2128 259.28)",
         "type": "color"
       },
       "700": {
-        "value": "oklch(0.7803 0.1096 234.16)",
+        "value": "oklch(0.6566 0.1838 258.62)",
         "type": "color"
       },
       "800": {
-        "value": "oklch(0.8614 0.0838 231.39)",
+        "value": "oklch(0.7558 0.1259 258.28)",
         "type": "color"
       },
       "900": {
-        "value": "oklch(0.9088 0.045 231.65)",
+        "value": "oklch(0.8437 0.0781 257.48)",
         "type": "color"
       },
       "950": {
-        "value": "oklch(0.9574 0.0137 247.97)",
+        "value": "oklch(0.9037 0.047 257.26)",
         "type": "color"
       },
       "1000": {
-        "value": "oklch(0.9802 0.0068 247.89)",
+        "value": "oklch(0.9486 0.0246 257.65)",
         "type": "color"
       }
     },
     "magenta": {
       "50": {
-        "value": "oklch(0.1639 0.062 340.52)",
+        "value": "oklch(0.1422 0.0604 345.16)",
         "type": "color"
       },
       "100": {
-        "value": "oklch(0.2373 0.0953 343.1)",
+        "value": "oklch(0.227 0.0946 350.32)",
         "type": "color"
       },
       "200": {
-        "value": "oklch(0.3726 0.1454 342.26)",
+        "value": "oklch(0.2808 0.1164 351.92)",
         "type": "color"
       },
       "300": {
-        "value": "oklch(0.4542 0.175 347.48)",
+        "value": "oklch(0.3868 0.1589 353.23)",
         "type": "color"
       },
       "400": {
-        "value": "oklch(0.5339 0.2193 349.23)",
+        "value": "oklch(0.4724 0.194579 353.8977)",
         "type": "color"
       },
       "500": {
-        "value": "oklch(0.5868 0.238 350.69)",
+        "value": "oklch(0.5768 0.237302 354.3202)",
         "type": "color"
       },
       "600": {
-        "value": "oklch(0.6629 0.2447 351.8)",
+        "value": "oklch(0.663 0.2652 351.9)",
         "type": "color"
       },
       "700": {
-        "value": "oklch(0.7048 0.2009 357.71)",
+        "value": "oklch(0.7038 0.232 347.8)",
         "type": "color"
       },
       "800": {
-        "value": "oklch(0.7677 0.1528 355.76)",
+        "value": "oklch(0.7802 0.164 344.57)",
         "type": "color"
       },
       "900": {
-        "value": "oklch(0.8428 0.0978 354.64)",
+        "value": "oklch(0.8232 0.1275 343.61)",
         "type": "color"
       },
       "950": {
-        "value": "oklch(0.9373 0.0412 342.14)",
+        "value": "oklch(0.8813 0.0822 342.24)",
         "type": "color"
       },
       "1000": {
-        "value": "oklch(0.9654 0.0225 341.31)",
+        "value": "oklch(0.9317 0.0463 340.48)",
         "type": "color"
       }
     },
     "gold": {
       "50": {
-        "value": "oklch(0.1994 0.0396 76.09)",
+        "value": "oklch(0.1849 0.0386 77.52)",
         "type": "color"
       },
       "100": {
-        "value": "oklch(0.2386 0.0474 74.23)",
+        "value": "oklch(0.2269 0.049661 68.4257)",
         "type": "color"
       },
       "200": {
-        "value": "oklch(0.3497 0.0735 68.31)",
+        "value": "oklch(0.3218 0.0723 64.75)",
         "type": "color"
       },
       "300": {
-        "value": "oklch(0.4762 0.101 68.29)",
+        "value": "oklch(0.418 0.096552 61.5939)",
         "type": "color"
       },
       "400": {
-        "value": "oklch(0.6203 0.1351 64.5)",
+        "value": "oklch(0.5888 0.138492 59.7021)",
         "type": "color"
       },
       "500": {
-        "value": "oklch(0.7111 0.1585 65.89)",
+        "value": "oklch(0.7336 0.174556 58.5601)",
         "type": "color"
       },
       "600": {
-        "value": "oklch(0.7806 0.1652 70.4)",
+        "value": "oklch(0.7807 0.1708 66.55)",
         "type": "color"
       },
       "700": {
-        "value": "oklch(0.8394 0.149 78.12)",
+        "value": "oklch(0.8105 0.1572 71.72)",
         "type": "color"
       },
       "800": {
-        "value": "oklch(0.903 0.1174 88.43)",
+        "value": "oklch(0.8585 0.122968 75.6919)",
         "type": "color"
       },
       "900": {
-        "value": "oklch(0.9328 0.0981 93.22)",
+        "value": "oklch(0.9018 0.0868 77.62)",
         "type": "color"
       },
       "950": {
-        "value": "oklch(0.9658 0.0531 94.43)",
+        "value": "oklch(0.9436 0.0483 77.26)",
         "type": "color"
       },
       "1000": {
-        "value": "oklch(0.9834 0.028 95.89)",
+        "value": "oklch(0.9818 0.0152 77.07)",
         "type": "color"
       }
     },
@@ -302,51 +302,51 @@
     },
     "red": {
       "50": {
-        "value": "oklch(0.173 0.0657 16.5)",
+        "value": "oklch(0.1721 0.0689 8)",
         "type": "color"
       },
       "100": {
-        "value": "oklch(0.2395 0.0904 17.78)",
+        "value": "oklch(0.2429 0.0952 12.48)",
         "type": "color"
       },
       "200": {
-        "value": "oklch(0.3207 0.125 12.36)",
+        "value": "oklch(0.3132 0.1252 14.67)",
         "type": "color"
       },
       "300": {
-        "value": "oklch(0.4046 0.1551 11.36)",
+        "value": "oklch(0.385 0.15406 16.4808)",
         "type": "color"
       },
       "400": {
-        "value": "oklch(0.4788 0.1855 16.67)",
+        "value": "oklch(0.4703 0.1879 17.53)",
         "type": "color"
       },
       "500": {
-        "value": "oklch(0.5638 0.2148 16.42)",
+        "value": "oklch(0.5724 0.229466 18.56)",
         "type": "color"
       },
       "600": {
-        "value": "oklch(0.6147 0.2301 18.88)",
+        "value": "oklch(0.6392 0.25 15.77)",
         "type": "color"
       },
       "700": {
-        "value": "oklch(0.6649 0.2 23.09)",
+        "value": "oklch(0.6886 0.204 14.67)",
         "type": "color"
       },
       "800": {
-        "value": "oklch(0.7202 0.1741 23.26)",
+        "value": "oklch(0.7713 0.1367 14.03)",
         "type": "color"
       },
       "900": {
-        "value": "oklch(0.8206 0.0707 24.14)",
+        "value": "oklch(0.8211 0.1019 12.69)",
         "type": "color"
       },
       "950": {
-        "value": "oklch(0.926 0.0299 15.15)",
+        "value": "oklch(0.8774 0.0653 17.3)",
         "type": "color"
       },
       "1000": {
-        "value": "oklch(0.9716 0.0141 12.01)",
+        "value": "oklch(0.936 0.0322 22.46)",
         "type": "color"
       }
     },

--- a/packages/dialtone-tokens/tokens/base/default.json
+++ b/packages/dialtone-tokens/tokens/base/default.json
@@ -23,247 +23,247 @@
         "type": "color"
       },
       "100": {
-        "value": "oklch(0.9821 0 0)",
+        "value": "oklch(0.9774 0.0025 48.72)",
         "type": "color"
       },
       "200": {
-        "value": "oklch(0.934 0 0)",
+        "value": "oklch(0.9312 0.0029 84.56)",
         "type": "color"
       },
       "300": {
-        "value": "oklch(0.8638 0 0)",
+        "value": "oklch(0.858 0.0059 84.57)",
         "type": "color"
       },
       "400": {
-        "value": "oklch(0.738 0 0)",
+        "value": "oklch(0.7321 0.0061 84.57)",
         "type": "color"
       },
       "500": {
-        "value": "oklch(0.5999 0 0)",
+        "value": "oklch(0.6001 0.0032 84.56)",
         "type": "color"
       },
       "600": {
-        "value": "oklch(0.4423 0 0)",
+        "value": "oklch(0.5134 0.0063 95.18)",
         "type": "color"
       },
       "700": {
-        "value": "oklch(0.3485 0 0)",
+        "value": "oklch(0.4468 0.0055 78.27)",
         "type": "color"
       },
       "800": {
-        "value": "oklch(0.2645 0 0)",
+        "value": "oklch(0.3352 0.0055 56.21)",
         "type": "color"
       },
       "900": {
-        "value": "oklch(0.2264 0 0)",
+        "value": "oklch(0.2572 0.0063 78.21)",
         "type": "color"
       },
       "950": {
-        "value": "oklch(0.2046 0 0)",
+        "value": "oklch(0.2134 0.006 91.63)",
         "type": "color"
       },
       "1000": {
-        "value": "oklch(0 0 0)",
+        "value": "oklch(0.1595 0.0045 84.59)",
         "type": "color"
       }
     },
     "purple": {
       "50": {
-        "value": "oklch(0.978 0.0123 301.29)",
+        "value": "oklch(0.9514 0.0276 301.76)",
         "type": "color"
       },
       "100": {
-        "value": "oklch(0.9347 0.0306 302.3)",
+        "value": "oklch(0.9029 0.056 301.24)",
         "type": "color"
       },
       "200": {
-        "value": "oklch(0.8371 0.0754 300.31)",
+        "value": "oklch(0.8546 0.085 300.63)",
         "type": "color"
       },
       "300": {
-        "value": "oklch(0.7755 0.1222 294.6)",
+        "value": "oklch(0.7697 0.130656 294.1037)",
         "type": "color"
       },
       "400": {
-        "value": "oklch(0.7113 0.1613 290.66)",
+        "value": "oklch(0.6717 0.189855 291.5342)",
         "type": "color"
       },
       "500": {
-        "value": "oklch(0.6464 0.1985 289.97)",
+        "value": "oklch(0.5829 0.2426 287.41)",
         "type": "color"
       },
       "600": {
-        "value": "oklch(0.5851 0.2414 287.62)",
+        "value": "oklch(0.4831 0.2316 284.82)",
         "type": "color"
       },
       "700": {
-        "value": "oklch(0.5217 0.2647 284.59)",
+        "value": "oklch(0.4108 0.2066 284.07)",
         "type": "color"
       },
       "800": {
-        "value": "oklch(0.4638 0.2502 281.37)",
+        "value": "oklch(0.3629 0.1821 284.23)",
         "type": "color"
       },
       "900": {
-        "value": "oklch(0.361 0.1955 283.93)",
+        "value": "oklch(0.2984 0.1549 283.05)",
         "type": "color"
       },
       "950": {
-        "value": "oklch(0.2281 0.1309 285.47)",
+        "value": "oklch(0.2244 0.131 285.15)",
         "type": "color"
       },
       "1000": {
-        "value": "oklch(0.1599 0.0811 291.62)",
+        "value": "oklch(0.1531 0.0859 291.49)",
         "type": "color"
       }
     },
     "blue": {
       "50": {
-        "value": "oklch(0.9802 0.0068 247.89)",
+        "value": "oklch(0.9486 0.0246 257.65)",
         "type": "color"
       },
       "100": {
-        "value": "oklch(0.9574 0.0137 247.97)",
+        "value": "oklch(0.9037 0.047 257.26)",
         "type": "color"
       },
       "200": {
-        "value": "oklch(0.9088 0.045 231.65)",
+        "value": "oklch(0.8437 0.0781 257.48)",
         "type": "color"
       },
       "300": {
-        "value": "oklch(0.8614 0.0838 231.39)",
+        "value": "oklch(0.7558 0.1259 258.28)",
         "type": "color"
       },
       "400": {
-        "value": "oklch(0.7803 0.1096 234.16)",
+        "value": "oklch(0.6566 0.1838 258.62)",
         "type": "color"
       },
       "500": {
-        "value": "oklch(0.706 0.1304 241.91)",
+        "value": "oklch(0.6089 0.2128 259.28)",
         "type": "color"
       },
       "600": {
-        "value": "oklch(0.6526 0.1385 246.51)",
+        "value": "oklch(0.5552 0.223 260.26)",
         "type": "color"
       },
       "700": {
-        "value": "oklch(0.5743 0.1498 251.06)",
+        "value": "oklch(0.4857 0.205 260.61)",
         "type": "color"
       },
       "800": {
-        "value": "oklch(0.4546 0.136 256.17)",
+        "value": "oklch(0.4126 0.1703 260.22)",
         "type": "color"
       },
       "900": {
-        "value": "oklch(0.3449 0.0951 254.97)",
+        "value": "oklch(0.3269 0.1294 259.43)",
         "type": "color"
       },
       "950": {
-        "value": "oklch(0.2161 0.0514 247.62)",
+        "value": "oklch(0.2552 0.0945 258.02)",
         "type": "color"
       },
       "1000": {
-        "value": "oklch(0.1442 0.0315 244.16)",
+        "value": "oklch(0.163 0.0489 252.1)",
         "type": "color"
       }
     },
     "magenta": {
       "50": {
-        "value": "oklch(0.9654 0.0225 341.31)",
+        "value": "oklch(0.9317 0.0463 340.48)",
         "type": "color"
       },
       "100": {
-        "value": "oklch(0.9373 0.0412 342.14)",
+        "value": "oklch(0.8813 0.0822 342.24)",
         "type": "color"
       },
       "200": {
-        "value": "oklch(0.8428 0.0978 354.64)",
+        "value": "oklch(0.8232 0.1275 343.61)",
         "type": "color"
       },
       "300": {
-        "value": "oklch(0.7677 0.1528 355.76)",
+        "value": "oklch(0.7802 0.164 344.57)",
         "type": "color"
       },
       "400": {
-        "value": "oklch(0.7048 0.2009 357.71)",
+        "value": "oklch(0.7038 0.232 347.8)",
         "type": "color"
       },
       "500": {
-        "value": "oklch(0.6629 0.2447 351.8)",
+        "value": "oklch(0.663 0.2652 351.9)",
         "type": "color"
       },
       "600": {
-        "value": "oklch(0.5868 0.238 350.69)",
+        "value": "oklch(0.5768 0.237302 354.3202)",
         "type": "color"
       },
       "700": {
-        "value": "oklch(0.5339 0.2193 349.23)",
+        "value": "oklch(0.4724 0.194579 353.8977)",
         "type": "color"
       },
       "800": {
-        "value": "oklch(0.4542 0.175 347.48)",
+        "value": "oklch(0.3868 0.1589 353.23)",
         "type": "color"
       },
       "900": {
-        "value": "oklch(0.3726 0.1454 342.26)",
+        "value": "oklch(0.2808 0.1164 351.92)",
         "type": "color"
       },
       "950": {
-        "value": "oklch(0.2373 0.0953 343.1)",
+        "value": "oklch(0.227 0.0946 350.32)",
         "type": "color"
       },
       "1000": {
-        "value": "oklch(0.1639 0.062 340.52)",
+        "value": "oklch(0.1422 0.0604 345.16)",
         "type": "color"
       }
     },
     "gold": {
       "50": {
-        "value": "oklch(0.9834 0.028 95.89)",
+        "value": "oklch(0.9818 0.0152 77.07)",
         "type": "color"
       },
       "100": {
-        "value": "oklch(0.9658 0.0531 94.43)",
+        "value": "oklch(0.9436 0.0483 77.26)",
         "type": "color"
       },
       "200": {
-        "value": "oklch(0.9328 0.0981 93.22)",
+        "value": "oklch(0.9018 0.0868 77.62)",
         "type": "color"
       },
       "300": {
-        "value": "oklch(0.903 0.1174 88.43)",
+        "value": "oklch(0.8585 0.122968 75.6919)",
         "type": "color"
       },
       "400": {
-        "value": "oklch(0.8394 0.149 78.12)",
+        "value": "oklch(0.8105 0.1572 71.72)",
         "type": "color"
       },
       "500": {
-        "value": "oklch(0.7806 0.1652 70.4)",
+        "value": "oklch(0.7807 0.1708 66.55)",
         "type": "color"
       },
       "600": {
-        "value": "oklch(0.7111 0.1585 65.89)",
+        "value": "oklch(0.7336 0.174556 58.5601)",
         "type": "color"
       },
       "700": {
-        "value": "oklch(0.6203 0.1351 64.5)",
+        "value": "oklch(0.5888 0.138492 59.7021)",
         "type": "color"
       },
       "800": {
-        "value": "oklch(0.4762 0.101 68.29)",
+        "value": "oklch(0.418 0.096552 61.5939)",
         "type": "color"
       },
       "900": {
-        "value": "oklch(0.3497 0.0735 68.31)",
+        "value": "oklch(0.3218 0.0723 64.75)",
         "type": "color"
       },
       "950": {
-        "value": "oklch(0.2386 0.0474 74.23)",
+        "value": "oklch(0.2269 0.049661 68.4257)",
         "type": "color"
       },
       "1000": {
-        "value": "oklch(0.1994 0.0396 76.09)",
+        "value": "oklch(0.1849 0.0386 77.52)",
         "type": "color"
       }
     },
@@ -319,51 +319,51 @@
     },
     "red": {
       "50": {
-        "value": "oklch(0.9716 0.0141 12.01)",
+        "value": "oklch(0.936 0.0322 22.46)",
         "type": "color"
       },
       "100": {
-        "value": "oklch(0.926 0.0299 15.15)",
+        "value": "oklch(0.8774 0.0653 17.3)",
         "type": "color"
       },
       "200": {
-        "value": "oklch(0.8206 0.0707 24.14)",
+        "value": "oklch(0.8211 0.1019 12.69)",
         "type": "color"
       },
       "300": {
-        "value": "oklch(0.7303 0.1397 25.27)",
+        "value": "oklch(0.7713 0.1367 14.03)",
         "type": "color"
       },
       "400": {
-        "value": "oklch(0.6649 0.2 23.09)",
+        "value": "oklch(0.6886 0.204 14.67)",
         "type": "color"
       },
       "500": {
-        "value": "oklch(0.6147 0.2301 18.88)",
+        "value": "oklch(0.6392 0.25 15.77)",
         "type": "color"
       },
       "600": {
-        "value": "oklch(0.5638 0.2148 16.42)",
+        "value": "oklch(0.5724 0.229466 18.56)",
         "type": "color"
       },
       "700": {
-        "value": "oklch(0.4788 0.1855 16.67)",
+        "value": "oklch(0.4703 0.1879 17.53)",
         "type": "color"
       },
       "800": {
-        "value": "oklch(0.4046 0.1551 11.36)",
+        "value": "oklch(0.385 0.15406 16.4808)",
         "type": "color"
       },
       "900": {
-        "value": "oklch(0.3207 0.125 12.36)",
+        "value": "oklch(0.3132 0.1252 14.67)",
         "type": "color"
       },
       "950": {
-        "value": "oklch(0.2395 0.0904 17.78)",
+        "value": "oklch(0.2429 0.0952 12.48)",
         "type": "color"
       },
       "1000": {
-        "value": "oklch(0.173 0.0657 16.5)",
+        "value": "oklch(0.1721 0.0689 8)",
         "type": "color"
       }
     },

--- a/packages/dialtone-tokens/tokens/theme/dp/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/dark.json
@@ -661,7 +661,7 @@
         "type": "color"
       },
       "success": {
-        "value": "{color.border.positive}",
+        "value": "{color.surface.positive}",
         "type": "color",
         "$deprecated": "Use positive instead."
       },
@@ -784,7 +784,7 @@
         "type": "color"
       },
       "success-inverted": {
-        "value": "{color.border.positive-inverted}",
+        "value": "{color.surface.positive-inverted}",
         "type": "color",
         "$deprecated": "Use positive-inverted instead."
       },

--- a/packages/dialtone-tokens/tokens/theme/dp/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/dark.json
@@ -43,7 +43,7 @@
         "type": "color"
       },
       "success": {
-        "value": "{color.green.500}",
+        "value": "{color.foreground.positive}",
         "type": "color",
         "$deprecated": "Use positive instead."
       },
@@ -56,7 +56,7 @@
         "type": "color"
       },
       "success-strong": {
-        "value": "{color.green.700}",
+        "value": "{color.foreground.positive-strong}",
         "type": "color",
         "$deprecated": "Use positive-strong instead."
       },
@@ -89,12 +89,12 @@
         "type": "color"
       },
       "success-inverted": {
-        "value": "{color.green.200}",
+        "value": "{color.foreground.positive-inverted}",
         "type": "color",
         "$deprecated": "Use positive-inverted instead."
       },
       "success-strong-inverted": {
-        "value": "{color.green.50}",
+        "value": "{color.foreground.positive-strong-inverted}",
         "type": "color",
         "$deprecated": "Use positive-strong-inverted instead."
       }
@@ -211,46 +211,9 @@
         }
       },
       "success-subtle": {
-        "value": "{color.green.200}",
+        "value": "{color.border.positive-subtle}",
         "type": "color",
-        "$extensions": {
-          "studio.tokens": {
-            "modify": {
-              "type": "darken",
-              "value": ".5",
-              "space": "oklch"
-            }
-          }
-        },
         "$deprecated": "Use positive-subtle instead. "
-      },
-      "success-subtle": {
-        "value": "{color.green.100}",
-        "type": "color",
-        "$extensions": {
-          "studio.tokens": {
-            "modify": {
-              "type": "darken",
-              "value": ".5",
-              "space": "oklch"
-            }
-          }
-        },
-       "$deprecated": "Use positive-subtle instead."
-      },
-      "success-subtle": {
-        "value": "{color.green.100}",
-        "type": "color",
-        "$extensions": {
-          "studio.tokens": {
-            "modify": {
-              "type": "darken",
-              "value": ".5",
-              "space": "oklch"
-            }
-          }
-        },
-        "$deprecated": "Use positive-subtle instead."
       },
       "info-subtle": {
         "value": "{color.blue.100}",
@@ -278,7 +241,7 @@
         "type": "color"
       },
       "success-strong": {
-        "value": "{color.green.500}",
+        "value": "{color.border.positive-strong}",
         "type": "color",
         "$deprecated": "Use positive-strong instead."
       },
@@ -408,17 +371,8 @@
         }
       },
       "success-opaque": {
-        "value": "{color.green.200}",
+        "value": "{color.surface.positive-opaque}",
         "type": "color",
-        "$extensions": {
-          "studio.tokens": {
-            "modify": {
-              "type": "alpha",
-              "value": ".28",
-              "space": "oklch"
-            }
-          }
-        },
         "$deprecated": "Use positive-opaque instead."
       },
       "info-opaque": {
@@ -702,8 +656,12 @@
         "value": "{color.blue.800}",
         "type": "color"
       },
-      "success": {
+      "positive": {
         "value": "{color.green.500}",
+        "type": "color"
+      },
+      "success": {
+        "value": "{color.border.positive}",
         "type": "color",
         "$deprecated": "Use positive instead."
       },
@@ -728,7 +686,7 @@
         "type": "color"
       },
       "success-subtle": {
-        "value": "{color.green.300}",
+        "value": "{color.border.positive-subtle}",
         "type": "color",
         "$deprecated": "Use positive-subtle instead."
       },
@@ -745,7 +703,7 @@
         "type": "color"
       },
       "success-strong": {
-        "value": "{color.green.800}",
+        "value": "{color.border.positive-strong}",
         "type": "color",
         "$deprecated": "Use positive-strong instead."
       },
@@ -826,7 +784,7 @@
         "type": "color"
       },
       "success-inverted": {
-        "value": "{color.green.300}",
+        "value": "{color.border.positive-inverted}",
         "type": "color",
         "$deprecated": "Use positive-inverted instead."
       },
@@ -842,13 +800,12 @@
         "value": "{color.gold.800}",
         "type": "color"
       },
-      "success-subtle-inverted": {
+      "positive-subtle-inverted": {
         "value": "{color.green.800}",
-        "$deprecated": "Use positive-subtle-inverted instead.",
         "type": "color"
       },
       "success-subtle-inverted": {
-        "value": "{color.green.600}",
+        "value": "{color.border.positive-subtle-inverted}",
         "type": "color",
         "$deprecated": "Use positive-subtle-inverted instead."
       },
@@ -864,17 +821,12 @@
         "value": "{color.gold.300}",
         "type": "color"
       },
-      "success-strong-inverted": {
-        "value": "{color.green.200}",
-        "type": "color",
-        "$deprecated": "Use positive-strong-inverted instead."
-      },
       "positive-strong-inverted": {
         "value": "{color.green.200}",
         "type": "color"
       },
       "success-strong-inverted": {
-        "value": "{color.green.200}",
+        "value": "{color.border.positive-strong-inverted}",
         "type": "color",
         "$deprecated": "Use positive-strong-inverted instead."
       },

--- a/packages/dialtone-tokens/tokens/theme/dp/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/dark.json
@@ -661,7 +661,7 @@
         "type": "color"
       },
       "success": {
-        "value": "{color.surface.positive}",
+        "value": "{color.border.positive}",
         "type": "color",
         "$deprecated": "Use positive instead."
       },
@@ -686,7 +686,7 @@
         "type": "color"
       },
       "success-subtle": {
-        "value": "{color.surface.positive-subtle}",
+        "value": "{color.border.positive-subtle}",
         "type": "color",
         "$deprecated": "Use positive-subtle instead."
       },
@@ -703,7 +703,7 @@
         "type": "color"
       },
       "success-strong": {
-        "value": "{color.surface.positive-strong}",
+        "value": "{color.border.positive-strong}",
         "type": "color",
         "$deprecated": "Use positive-strong instead."
       },
@@ -784,7 +784,7 @@
         "type": "color"
       },
       "success-inverted": {
-        "value": "{color.surface.positive-inverted}",
+        "value": "{color.border.positive-inverted}",
         "type": "color",
         "$deprecated": "Use positive-inverted instead."
       },
@@ -805,7 +805,7 @@
         "type": "color"
       },
       "success-subtle-inverted": {
-        "value": "{color.surface.positive-subtle-inverted}",
+        "value": "{color.border.positive-subtle-inverted}",
         "type": "color",
         "$deprecated": "Use positive-subtle-inverted instead."
       },
@@ -826,7 +826,7 @@
         "type": "color"
       },
       "success-strong-inverted": {
-        "value": "{color.surface.positive-strong-inverted}",
+        "value": "{color.border.positive-strong-inverted}",
         "type": "color",
         "$deprecated": "Use positive-strong-inverted instead."
       },

--- a/packages/dialtone-tokens/tokens/theme/dp/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/dark.json
@@ -127,6 +127,32 @@
       "disabled-inverted-hover": {
         "value": "{color.link.disabled-inverted}",
         "type": "color"
+      },
+      "mention-background": {
+        "value": "{color.surface.brand-opaque}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": ".15",
+              "space": "oklch"
+            }
+          }
+        }
+      },
+      "mention-background-hover": {
+        "value": "{color.surface.brand-opaque}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": ".25",
+              "space": "oklch"
+            }
+          }
+        }
       }
     },
     "surface": {

--- a/packages/dialtone-tokens/tokens/theme/dp/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/dark.json
@@ -211,7 +211,7 @@
         }
       },
       "success-subtle": {
-        "value": "{color.border.positive-subtle}",
+        "value": "{color.surface.positive-subtle}",
         "type": "color",
         "$deprecated": "Use positive-subtle instead. "
       },
@@ -241,7 +241,7 @@
         "type": "color"
       },
       "success-strong": {
-        "value": "{color.border.positive-strong}",
+        "value": "{color.surface.positive-strong}",
         "type": "color",
         "$deprecated": "Use positive-strong instead."
       },
@@ -686,7 +686,7 @@
         "type": "color"
       },
       "success-subtle": {
-        "value": "{color.border.positive-subtle}",
+        "value": "{color.surface.positive-subtle}",
         "type": "color",
         "$deprecated": "Use positive-subtle instead."
       },
@@ -703,7 +703,7 @@
         "type": "color"
       },
       "success-strong": {
-        "value": "{color.border.positive-strong}",
+        "value": "{color.surface.positive-strong}",
         "type": "color",
         "$deprecated": "Use positive-strong instead."
       },
@@ -805,7 +805,7 @@
         "type": "color"
       },
       "success-subtle-inverted": {
-        "value": "{color.border.positive-subtle-inverted}",
+        "value": "{color.surface.positive-subtle-inverted}",
         "type": "color",
         "$deprecated": "Use positive-subtle-inverted instead."
       },
@@ -826,7 +826,7 @@
         "type": "color"
       },
       "success-strong-inverted": {
-        "value": "{color.border.positive-strong-inverted}",
+        "value": "{color.surface.positive-strong-inverted}",
         "type": "color",
         "$deprecated": "Use positive-strong-inverted instead."
       },

--- a/packages/dialtone-tokens/tokens/theme/dp/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/dark.json
@@ -246,7 +246,7 @@
         "$deprecated": "Use positive-strong instead."
       },
       "info-strong": {
-        "value": "{color.blue.600}",
+        "value": "{color.blue.700}",
         "type": "color"
       },
       "brand-strong": {

--- a/packages/dialtone-tokens/tokens/theme/dp/default.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/default.json
@@ -60,13 +60,13 @@
         "description": "Indicates a strong positive state on surfaces that require a stronger contrast."
       },
       "success": {
-        "value": "{color.green.700}",
+        "value": "{color.foreground.positive}",
         "type": "color",
         "$deprecated": "Use positive instead.",
         "description": "Indicates a positive state."
       },
       "success-strong": {
-        "value": "{color.green.950}",
+        "value": "{color.foreground.positive-strong}",
         "type": "color",
         "$deprecated": "Use positive-strong instead.",
         "description": "Indicates a strong positive state on surfaces that require a stronger contrast."
@@ -146,13 +146,13 @@
         "description": "Positive strong text that sits on high-contrast surfaces or backgrounds."
       },
       "success-inverted": {
-        "value": "{color.green.200}",
+        "value": "{color.foreground.positive-inverted}",
         "type": "color",
         "$deprecated": "Use positive-inverted instead.",
         "description": "Success text that sits on high-contrast surfaces or backgrounds."
       },
       "success-strong-inverted": {
-        "value": "{color.green.50}",
+        "value": "{color.foreground.positive-strong-inverted}",
         "type": "color",
         "$deprecated": "Use positive-strong-inverted instead.",
         "description": "Success strong text that sits on high-contrast surfaces or backgrounds."
@@ -415,7 +415,7 @@
         "description": "Background surface color containing messaging or elements expressing a positive or successful state."
       },
       "success": {
-        "value": "{color.green.100}",
+        "value": "{color.surface.positive}",
         "type": "color",
         "$deprecated": "Use positive instead.",
         "description": "Background surface color containing messaging or elements expressing a positive or successful state."
@@ -446,7 +446,7 @@
         "description": "A softer version of the default positive surface."
       },
       "success-subtle": {
-        "value": "{color.green.50}",
+        "value": "{color.surface.positive-subtle}",
         "type": "color",
         "$deprecated": "Use positive-subtle instead.",
         "description": "A softer version of the default success surface."
@@ -477,7 +477,7 @@
         "description": "A contrasting positive state surface, most likely paired with inverted foreground colors."
       },
       "success-strong": {
-        "value": "{color.green.600}",
+        "value": "{color.surface.positive-strong}",
         "type": "color",
         "$deprecated": "Use positive-strong instead.",
         "description": "A contrasting positive state surface, most likely paired with inverted foreground colors."
@@ -619,17 +619,8 @@
         "description": "Positive surface as opaque background color."
       },
       "success-opaque": {
-        "value": "{color.green.400}",
+        "value": "{color.surface.positive-opaque}",
         "type": "color",
-        "$extensions": {
-          "studio.tokens": {
-            "modify": {
-              "type": "alpha",
-              "value": ".25",
-              "space": "oklch"
-            }
-          }
-        },
         "$deprecated": "Use positive-opaque instead. ",
         "description": "Success surface as opaque background color."
       },
@@ -704,17 +695,8 @@
         "description": "Positive subtle surface as opaque background color."
       },
       "success-subtle-opaque": {
-        "value": "{color.green.100}",
+        "value": "{color.surface.positive-subtle-opaque}",
         "type": "color",
-        "$extensions": {
-          "studio.tokens": {
-            "modify": {
-              "type": "alpha",
-              "value": ".50",
-              "space": "oklch"
-            }
-          }
-        },
         "$deprecated": "Use positive-subtle-opaque instead.",
         "description": "Success subtle surface as opaque background color."
       },
@@ -792,7 +774,7 @@
         "description": "Background surface color containing messaging or elements expressing a positive or successful state."
       },
       "success-inverted": {
-        "value": "{color.green.900}",
+        "value": "{color.surface.positive-inverted}",
         "type": "color",
         "$deprecated": "Use positive-inverted instead.",
         "description": "Background surface color containing messaging or elements expressing a positive or successful state."
@@ -823,7 +805,7 @@
         "description": "A softer version of the default positive surface."
       },
       "success-subtle-inverted": {
-        "value": "{color.green.1000}",
+        "value": "{color.surface.positive-subtle-inverted}",
         "type": "color",
         "$deprecated": "Use positive-subtle-inverted instead.",
         "description": "A softer version of the default success surface."
@@ -851,7 +833,6 @@
       "positive-strong-inverted": {
         "value": "{color.green.950}",
         "type": "color",
-        "$deprecated": "Use positive-strong-inverted instead.",
         "description": "A contrasting positive state surface, most likely paired with inverted foreground colors."
       },
       "info-strong-inverted": {
@@ -1181,7 +1162,7 @@
         "type": "color"
       },
       "success": {
-        "value": "{color.green.700}",
+        "value": "{color.border.positive}",
         "type": "color",
         "$deprecated": "Use positive instead."
       },
@@ -1203,15 +1184,10 @@
       },
       "positive-subtle": {
         "value": "{color.green.300}",
-        "type": "color",
+        "type": "color"
       },
       "success-subtle": {
-        "value": "{color.green.300}",
-        "type": "color",
-        "$deprecated": "Use positive-subtle instead."
-      },
-      "success-subtle": {
-        "value": "{color.green.300}",
+        "value": "{color.border.positive-subtle}",
         "type": "color",
         "$deprecated": "Use positive-subtle instead."
       },
@@ -1236,7 +1212,7 @@
         "type": "color"
       },
       "success-strong": {
-        "value": "{color.green.900}",
+        "value": "{color.border.positive-strong}",
         "type": "color",
         "$deprecated": "Use positive-strong instead."
       },
@@ -1313,7 +1289,7 @@
         "type": "color"
       },
       "success-inverted": {
-        "value": "{color.green.500}",
+        "value": "{color.border.positive-inverted}",
         "type": "color",
         "$deprecated": "Use positive-inverted instead."
       },
@@ -1339,7 +1315,7 @@
         "$deprecated": "Use positive-subtle-inverted instead."
       },
       "success-subtle-inverted": {
-        "value": "{color.green.900}",
+        "value": "{color.border.positive-subtle-inverted}",
         "type": "color",
         "$deprecated": "Use positive-subtle-inverted instead."
       },
@@ -1364,7 +1340,7 @@
         "type": "color"
       },
       "success-strong-inverted": {
-        "value": "{color.green.500}",
+        "value": "{color.border.positive-strong-inverted}",
         "type": "color",
         "$deprecated": "Use positive-strong-inverted instead."
       },
@@ -3907,15 +3883,15 @@
           },
           "primary": {
             "default": {
-              "value": "{color.purple.600}",
+              "value": "{color.purple.500}",
               "type": "color"
             },
             "hover": {
-              "value": "{color.purple.700}",
+              "value": "{color.purple.600}",
               "type": "color"
             },
             "active": {
-              "value": "{color.purple.800}",
+              "value": "{color.purple.700}",
               "type": "color"
             }
           }
@@ -4038,26 +4014,17 @@
           },
           "primary": {
             "default": {
-              "value": "{color.green.700}",
+              "value": "{color.green.600}",
               "type": "color",
               "description": "Postive, accepting, or success actions."
             },
             "hover": {
-              "value": "{color.green.800}",
+              "value": "{color.green.700}",
               "type": "color"
             },
             "active": {
-              "value": "{action.color.background.positive.primary.hover}",
-              "type": "color",
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "darken",
-                    "value": ".11",
-                    "space": "oklch"
-                  }
-                }
-              }
+              "value": "{color.green.800}",
+              "type": "color"
             }
           }
         }

--- a/packages/dialtone-tokens/tokens/theme/dp/default.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/default.json
@@ -218,11 +218,11 @@
         "type": "color"
       },
       "info": {
-        "value": "{color.foreground.info}",
+        "value": "{color.blue.600}",
         "type": "color"
       },
       "info-hover": {
-        "value": "{color.foreground.info-strong}",
+        "value": "{color.blue.700}",
         "type": "color"
       },
       "muted": {
@@ -306,6 +306,66 @@
       "disabled-inverted-hover": {
         "value": "{color.foreground.disabled-inverted}",
         "type": "color"
+      },
+      "mention": {
+        "value": "{color.link.primary}",
+        "type": "color"
+      },
+      "mention-hover": {
+        "value": "{color.link.primary-hover}",
+        "type": "color"
+      },
+      "mention-background": {
+        "value": "{color.surface.brand-opaque}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": ".1",
+              "space": "oklch"
+            }
+          }
+        }
+      },
+      "mention-background-hover": {
+        "value": "{color.surface.brand-opaque}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": ".15",
+              "space": "oklch"
+            }
+          }
+        }
+      },
+      "mention-inverted-background": {
+        "value": "{color.surface.brand-opaque}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": ".3",
+              "space": "oklch"
+            }
+          }
+        }
+      },
+      "mention-inverted-background-hover": {
+        "value": "{color.surface.brand-opaque}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": ".2",
+              "space": "oklch"
+            }
+          }
+        }
       }
     },
     "surface": {
@@ -931,17 +991,8 @@
         "description": "Positive surface as opaque background color."
       },
       "success-opaque-inverted": {
-        "value": "{color.green.900}",
+        "value": "{color.surface.positive-opaque-inverted}",
         "type": "color",
-        "$extensions": {
-          "studio.tokens": {
-            "modify": {
-              "type": "alpha",
-              "value": ".30",
-              "space": "oklch"
-            }
-          }
-        },
         "$deprecated": "Use positive-opaque-inverted instead.",
         "description": "Success surface as opaque background color."
       },
@@ -1016,17 +1067,8 @@
         "description": "Positive subtle surface as opaque background color."
       },
       "success-subtle-opaque-inverted": {
-        "value": "{color.green.1000}",
+        "value": "{color.surface.positive-subtle-opaque-inverted}",
         "type": "color",
-        "$extensions": {
-          "studio.tokens": {
-            "modify": {
-              "type": "alpha",
-              "value": ".66",
-              "space": "oklch"
-            }
-          }
-        },
         "$deprecated": "Use positive-subtle-opaque-inverted instead.",
         "description": "Success subtle surface as opaque background color."
       },

--- a/packages/dialtone-tokens/tokens/theme/dp/default.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/default.json
@@ -467,12 +467,12 @@
         "description": "A contrasting critical surface, most likely paired with inverted foreground colors."
       },
       "warning-strong": {
-        "value": "{color.gold.400}",
+        "value": "{color.gold.500}",
         "type": "color",
         "description": "A contrasting warning surface, most likely paired with inverted foreground colors."
       },
       "positive-strong": {
-        "value": "{color.green.800}",
+        "value": "{color.green.600}",
         "type": "color",
         "description": "A contrasting positive state surface, most likely paired with inverted foreground colors."
       },
@@ -483,7 +483,7 @@
         "description": "A contrasting positive state surface, most likely paired with inverted foreground colors."
       },
       "info-strong": {
-        "value": "{color.blue.800}",
+        "value": "{color.blue.600}",
         "type": "color",
         "description": "A contrasting informational surface, most likely paired with inverted foreground colors."
       },


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGh2dGo5eXpicm5sbHIybGV1OXhucnpwcW1kanF5NHU4MnBrMWUwbCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l41lKHuoS9ZniCeYE/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Feature
- [x] Refactor

## :book: Jira Ticket

[DLT-3360](https://dialpad.atlassian.net/browse/DLT-3360)

## :book: Description

**Blue palette retune** — adjusted OKLCH values across the blue ramp (`tokens/base/dark.json` + `tokens/base/default.json`) to improve visual consistency with the updated brand direction.

**success → positive semantic token migration** — added deprecated `success*` aliases in `dp/default.json` and `dp/dark.json` that proxy to their `positive*` counterparts, enabling a non-breaking migration path.

**Link mention variant semantic tokens** — moved inline OKLCH alpha expressions out of `link.less` into dedicated semantic tokens (`color.link.mention`, `color.link.mention-background`, `color.link.mention-background-hover`, and inverted variants). Updated `link.less` to consume the new tokens. Also corrected the dead `--link-color` → `--link-color-default` variable name that was silently falling back to primary link color.

**Surface token fixes** — corrected `notice.less` important variant background (`--dt-color-surface-strong` → `--dt-color-surface-primary-inverted`) and `dialtone-syntax.less` inline code background (`--dt-color-surface-info` → `--dt-color-surface-info-subtle`).

**Scratch-color dev page** — added `docs/scratch-color.md` as an unlinked visual test page for rendering all color/surface token variants in light and dark mode.

## :package: Cross-Package Impact

| Package | Changes | Downstream Impact |
|---|---|---|
| `dialtone-tokens` | Blue palette retune, `success*` deprecated aliases, new `link.mention*` semantic tokens | CSS consumers of mention variant tokens get the new semantic values |
| `dialtone-css` | `link.less` consumes new mention tokens, `notice.less` and `syntax.less` token corrections | Updated colors in mention links, notice important variant, and inline code |
| `dialtone-documentation` | Scratch-color visual test page, MCP server doc update | Dev tooling only — no public-facing doc changes |

Dependency flow: **tokens** → **CSS** → docs

## :page_facing_up: Documentation Artifacts

| Artifact | Status | Notes |
|---|---|---|
| Vue source | ✅ N/A | No Vue component changes |
| Tests | ✅ N/A | No new components |
| Storybook stories | ✅ N/A | No component changes |
| Component docs JSON | ✅ N/A | No component changes |
| VuePress docs | ✅ Updated | `scratch-color.md` added (unlinked dev page); MCP server guide updated |
| MCP server data | ✅ Auto | New tokens are discoverable by the MCP server without code changes |

## :bulb: Context

The blue palette retune is part of an ongoing brand color alignment (DLT-3360). The mention variant tokens replace inline OKLCH math that was hard to maintain and invisible to Tokens Studio — moving them into semantic tokens makes the intent explicit and gives design tooling visibility into the values.

The `success → positive` migration provides backward-compatible aliases so existing consumers don't break while the rename propagates.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

[DLT-3360]: https://dialpad.atlassian.net/browse/DLT-3360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
