### PR TITLE
feat(chip): DLT-3195 change interactive prop default from true to false

### DIFF
--- a/apps/dialtone-documentation/docs/_data/site-nav.json
+++ b/apps/dialtone-documentation/docs/_data/site-nav.json
@@ -280,6 +280,10 @@
                     "link": "/guides/migration/component-props/"
                   },
                   {
+                    "text": "DtChip interactive default",
+                    "link": "/guides/migration/chip-interactive/"
+                  },
+                  {
                     "text": "Vue 2 Removal",
                     "link": "/guides/migration/vue2-removal/"
                   }

--- a/apps/dialtone-documentation/docs/guides/migration/chip-interactive/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/chip-interactive/index.md
@@ -1,0 +1,60 @@
+---
+title: "DtChip: interactive defaults to false"
+description: "DtChip's interactive prop default changed from true to false. Chips now render as non-interactive <span> elements by default. Chips that are meant to be clickable must opt in with :interactive=\"true\"."
+---
+
+## TLDR
+
+> [!CRITICAL] Breaking Change
+> `DtChip`'s `interactive` prop default changed from `true` to `false`. Chips that are meant to be clickable must now explicitly pass `:interactive="true"`.
+
+Previously, every `<dt-chip>` without an explicit `interactive` prop rendered as a `<button>` with hover, focus, and pointer styles — even when the chip had no click handler and was purely decorative. This caused chips to appear clickable when they did nothing, which is misleading to users and a screen reader accessibility problem.
+
+## What Changed
+
+| | Before | After |
+| --- | --- | --- |
+| Default HTML element | `<button>` | `<span>` |
+| Default `interactive` | `true` | `false` |
+| Hover/focus/active styles | Present by default | Only when `:interactive="true"` |
+
+The close button on chips is **unaffected** — it always renders as a `<button>` regardless of `interactive`.
+
+## Migration
+
+Run the migration script from your project root:
+
+```bash
+npx dialtone-migrate-chip-interactive --cwd ./src
+```
+
+The script:
+- **Auto-adds** `:interactive="true"` to chips that have a `@click` handler or a `v-on` object binding.
+- **Warns** about chips with no `interactive` prop and no detected click handler — these need manual review.
+
+Add `--dry-run` to preview changes without writing files. Add `--yes` to apply without prompting.
+
+For chips flagged in warnings, decide:
+
+- **Display-only chip** (no click handler, not keyboard-navigable) — no change needed. The chip now correctly renders as a `<span>`.
+- **Clickable chip** (has `@click`, keyboard nav, or must be focusable) — add `:interactive="true"`.
+
+```html
+<!-- Before: rendered as <button> by default -->
+<dt-chip>Label</dt-chip>
+
+<!-- After: renders as <span> by default — correct for display-only chips -->
+<dt-chip>Label</dt-chip>
+
+<!-- Clickable chip — must opt in -->
+<dt-chip :interactive="true" @click="onChipClick">Label</dt-chip>
+```
+
+## Close Button
+
+The close button (`showClose`) is not affected by this change. A chip with `showClose` and `interactive` both at their defaults renders the chip body as a `<span>` and the close button as a `<button>`.
+
+```html
+<!-- Close button always renders as <button> regardless of interactive -->
+<dt-chip @close="onRemove">Label</dt-chip>
+```

--- a/apps/dialtone-documentation/docs/guides/migration/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/index.md
@@ -87,7 +87,10 @@ npx dialtone-migration-helper --cwd ./src
 # 11. Component props, events, and slots
 npx dialtone-migrate-props --cwd ./src
 
-# 12. ESLint auto-fix pass
+# 12. DtChip interactive default (adds :interactive="true" to clickable chips)
+npx dialtone-migrate-chip-interactive --cwd ./src
+
+# 13. ESLint auto-fix pass
 npx eslint --fix "src/**/*.vue"
 ```
 

--- a/apps/dialtone-documentation/docs/guides/migration/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/index.md
@@ -34,12 +34,13 @@ Work through each applicable guide in order. Guides earlier in the list are prer
 | 11 | [Logical Naming](./logical-naming/) | Deprecation | `dialtone-migration-helper` | Slots, props, events: `left`/`right` becomes `start`/`end`. |
 | 12 | [Recipes to UI Kits](./recipes-to-ui-kits/) | **Yes** | Migration script | `DtRecipe*` components move to standalone `@dialpad/` UI Kit packages. |
 | 13 | [Component Props & Events](./component-props/) | **Yes** | `dialtone-migrate-props` | Value renames (including DtBox `surface`/`bc`, DtText `tone-strong`, DtButton `link-kind`), `show` becomes `open`, `hide-*` inversion, `title` becomes `header-text`, event/slot renames, `rootClass` removal. |
+| 14 | [DtChip interactive default](./chip-interactive/) | **Yes** | `dialtone-migrate-chip-interactive` | `interactive` prop default changed from `true` to `false`. Chips that need click/keyboard behavior must opt in with `:interactive="true"`. |
 
 ### Framework
 
 | # | Guide | Breaking? | Tool | Summary |
 | --- | --- | --- | --- | --- |
-| 14 | [Vue 2 Removal](./vue2-removal/) | **Yes** | — | Vue 2 support dropped. Last Vue 2 version: `9.154.0`. |
+| 15 | [Vue 2 Removal](./vue2-removal/) | **Yes** | — | Vue 2 support dropped. Last Vue 2 version: `9.154.0`. |
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   ],
   "bin": {
     "dialtone-migrate-flex-to-stack": "./dist/js/dialtone_migrate_flex_to_stack/index.mjs",
-    "dialtone-migrate-link-rendering": "./dist/js/dialtone_migrate_link_rendering/index.mjs"
+    "dialtone-migrate-link-rendering": "./dist/js/dialtone_migrate_link_rendering/index.mjs",
+    "dialtone-migrate-chip-interactive": "./dist/js/dialtone_migrate_chip_interactive/index.mjs"
   },
   "exports": {
     "./CHANGELOG.json": "./CHANGELOG.json",

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_chip_interactive/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_chip_interactive/index.mjs
@@ -65,6 +65,17 @@ const HAS_VON_OBJECT_RE = /(?:^|\s)v-on\s*=\s*(?:"[^"]*"|'[^']*')/;
 // ---------------------------------------------------------------------------
 
 /**
+ * Strip quoted attribute values from an attrs string before regex testing.
+ * Replaces "…" and '…' with empty equivalents so keywords that happen to
+ * appear inside a quoted value (e.g. :title=" @click is cool") don't
+ * false-positive against HAS_CLICK_RE / HAS_INTERACTIVE_RE / HAS_VON_OBJECT_RE.
+ * Real attribute tokens like @click="handler" survive as @click="" and still match.
+ */
+function stripQuotedValues (attrs) {
+  return attrs.replace(/"[^"]*"|'[^']*'/g, match => (match[0] === '"' ? '""' : '\'\''));
+}
+
+/**
  * Find the position to insert `:interactive="true"` — immediately after the
  * tag name so it appears first in the attribute list (consistent with existing
  * Dialtone convention where `:interactive` is an early structural prop).
@@ -94,7 +105,7 @@ export function transformContent (content, opts = {}) {
 
   // Mask inert content (HTML comments, <script>, <style>) so we don't
   // accidentally match tag-like text inside them.
-  const { masked, segments } = maskInertContent(content);
+  const { masked, segments, token } = maskInertContent(content);
 
   let out = masked;
   const replacements = [];
@@ -108,11 +119,15 @@ export function transformContent (content, opts = {}) {
     const matchStart = m.index;
     const matchEnd = matchStart + fullMatch.length;
 
-    // Already has the interactive prop — nothing to do.
-    if (HAS_INTERACTIVE_RE.test(attrs)) continue;
+    // Strip quoted values before regex testing so keywords inside quoted
+    // attribute values don't produce false positives.
+    const attrsForTest = stripQuotedValues(attrs);
 
-    const hasClick = HAS_CLICK_RE.test(attrs);
-    const hasVOnObject = HAS_VON_OBJECT_RE.test(attrs);
+    // Already has the interactive prop — nothing to do.
+    if (HAS_INTERACTIVE_RE.test(attrsForTest)) continue;
+
+    const hasClick = HAS_CLICK_RE.test(attrsForTest);
+    const hasVOnObject = HAS_VON_OBJECT_RE.test(attrsForTest);
 
     if (hasClick || hasVOnObject) {
       // Auto-add :interactive="true"
@@ -140,7 +155,7 @@ export function transformContent (content, opts = {}) {
     out = out.slice(0, r.start) + r.text + out.slice(r.end);
   }
 
-  return { transformed: unmaskInertContent(out, segments), warnings };
+  return { transformed: unmaskInertContent(out, segments, token), warnings };
 }
 
 // ---------------------------------------------------------------------------
@@ -148,18 +163,19 @@ export function transformContent (content, opts = {}) {
 // ---------------------------------------------------------------------------
 
 function maskInertContent (content) {
+  const token = Math.random().toString(36).slice(2, 10);
   const innerRe = /<!--[\s\S]*?-->|<script\b[^>]*>[\s\S]*?<\/script>|<style\b[^>]*>[\s\S]*?<\/style>/g;
   const segments = [];
   const masked = content.replace(innerRe, (match) => {
-    const placeholder = ` DT_MIGRATE_INERT_${segments.length} `;
+    const placeholder = ` DT_MIGRATE_INERT_${token}_${segments.length} `;
     segments.push(match);
     return placeholder;
   });
-  return { masked, segments };
+  return { masked, segments, token };
 }
 
-function unmaskInertContent (masked, segments) {
-  return masked.replace(/ DT_MIGRATE_INERT_(\d+) /g, (_, idx) => segments[Number(idx)]);
+function unmaskInertContent (masked, segments, token) {
+  return masked.replace(new RegExp(` DT_MIGRATE_INERT_${token}_(\\d+) `, 'g'), (_, idx) => segments[Number(idx)]);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_chip_interactive/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_chip_interactive/index.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+
+/**
+ * @fileoverview Migration script for DtChip `interactive` prop default change.
+ *
+ * DLT-3195  DtChip `interactive` prop default changed from `true` → `false`.
+ *           Chips that need click/keyboard behavior must now explicitly set
+ *           `:interactive="true"`.
+ *
+ * This script:
+ *   - Adds `:interactive="true"` to <dt-chip> tags that have a click event
+ *     listener (@click, v-on:click) or an object v-on binding (v-on="…"),
+ *     since those clearly need interactive behavior.
+ *   - Skips chips that already set the `interactive` prop (any form).
+ *   - Warns about remaining chips with no `interactive` prop and no detected
+ *     click handler — these may be display-only (no change needed) or may
+ *     need `:interactive="true"` added manually.
+ *
+ * Usage:
+ *   npx dialtone-migrate-chip-interactive [options]
+ *
+ * Options:
+ *   --cwd <path>   Working directory (default: cwd)
+ *   --dry-run      Show changes without applying them
+ *   --yes          Apply all changes without prompting
+ *   --help         Show help
+ */
+
+import fs from 'fs/promises';
+import { realpathSync } from 'node:fs';
+import path from 'path';
+import readline from 'readline';
+import { fileURLToPath } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// Matches `<dt-chip` or `<DtChip` opening tags (including self-closing).
+// Capture group 1: everything between the tag name and the closing `>` or `/>`.
+const CHIP_TAG_RE = /(<(?:dt-chip|DtChip)\b)([\s\S]*?)(\s*\/?>)/g;
+
+// Detects that the `interactive` prop is already present in any form:
+//   interactive, :interactive, v-bind:interactive
+const HAS_INTERACTIVE_RE = /(?:^|\s)(?::|v-bind:)?interactive(?:\s*=|\s|\/|>)/;
+
+// Detects a click event listener:
+//   @click, v-on:click, @click.stop, @click.prevent, etc.
+const HAS_CLICK_RE = /(?:^|\s)(?:@click|v-on:click)(?:\s*=|\s*\.|\/|>|\s)/;
+
+// Detects an object-form v-on binding (v-on="…") which may contain click.
+// We treat this conservatively as "may be interactive" and add the prop.
+const HAS_VON_OBJECT_RE = /(?:^|\s)v-on\s*=\s*(?:"[^"]*"|'[^']*')/;
+
+// ---------------------------------------------------------------------------
+// Transform
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the position to insert `:interactive="true"` — immediately after the
+ * tag name so it appears first in the attribute list (consistent with existing
+ * Dialtone convention where `:interactive` is an early structural prop).
+ *
+ * Returns the index within `attrs` where the insertion should happen.
+ * We insert after any leading whitespace on the attribute string.
+ */
+function insertInteractiveProp (attrs) {
+  const leadingSpace = attrs.match(/^\s*/)[0];
+  const rest = attrs.slice(leadingSpace.length);
+  // Preserve the original leading whitespace, then prepend the prop
+  return `${leadingSpace}:interactive="true" ${rest}`;
+}
+
+/**
+ * Transform a single file's content.
+ * Returns { transformed, warnings } where warnings are strings.
+ */
+export function transformContent (content, opts = {}) {
+  const filePath = opts.filePath || '<input>';
+  const warnings = [];
+
+  // Fast path: skip files with no dt-chip / DtChip reference at all.
+  if (!/(?:dt-chip|DtChip)/i.test(content)) {
+    return { transformed: content, warnings };
+  }
+
+  // Mask inert content (HTML comments, <script>, <style>) so we don't
+  // accidentally match tag-like text inside them.
+  const { masked, segments } = maskInertContent(content);
+
+  let out = masked;
+  const replacements = [];
+
+  // Reset lastIndex before iterating
+  CHIP_TAG_RE.lastIndex = 0;
+
+  let m;
+  while ((m = CHIP_TAG_RE.exec(out)) !== null) {
+    const [fullMatch, openTag, attrs, closer] = m;
+    const matchStart = m.index;
+    const matchEnd = matchStart + fullMatch.length;
+
+    // Already has the interactive prop — nothing to do.
+    if (HAS_INTERACTIVE_RE.test(attrs)) continue;
+
+    const hasClick = HAS_CLICK_RE.test(attrs);
+    const hasVOnObject = HAS_VON_OBJECT_RE.test(attrs);
+
+    if (hasClick || hasVOnObject) {
+      // Auto-add :interactive="true"
+      const newAttrs = insertInteractiveProp(attrs);
+      replacements.push({
+        start: matchStart,
+        end: matchEnd,
+        text: `${openTag}${newAttrs}${closer}`,
+      });
+    } else {
+      // No click handler and no interactive prop.
+      // Warn: this chip will now render as a <span>. May be intentional
+      // (display-only) or may need :interactive="true" manually.
+      warnings.push(
+        `${filePath}: <dt-chip> has no interactive prop and no @click handler — ` +
+        `will now render as a non-interactive <span>. ` +
+        `Add :interactive="true" if this chip should be clickable.`,
+      );
+    }
+  }
+
+  // Apply replacements in reverse order to preserve indices
+  replacements.sort((a, b) => b.start - a.start);
+  for (const r of replacements) {
+    out = out.slice(0, r.start) + r.text + out.slice(r.end);
+  }
+
+  return { transformed: unmaskInertContent(out, segments), warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Inert-content masking (same pattern as dialtone_migrate_link_rendering)
+// ---------------------------------------------------------------------------
+
+function maskInertContent (content) {
+  const innerRe = /<!--[\s\S]*?-->|<script\b[^>]*>[\s\S]*?<\/script>|<style\b[^>]*>[\s\S]*?<\/style>/g;
+  const segments = [];
+  const masked = content.replace(innerRe, (match) => {
+    const placeholder = ` DT_MIGRATE_INERT_${segments.length} `;
+    segments.push(match);
+    return placeholder;
+  });
+  return { masked, segments };
+}
+
+function unmaskInertContent (masked, segments) {
+  return masked.replace(/ DT_MIGRATE_INERT_(\d+) /g, (_, idx) => segments[Number(idx)]);
+}
+
+// ---------------------------------------------------------------------------
+// File walker
+// ---------------------------------------------------------------------------
+
+function isIgnoredPath (fullPath, ignore) {
+  const segments = fullPath.split(path.sep);
+  return ignore.some(ig => {
+    if (ig.includes('/')) {
+      const parts = ig.split('/');
+      for (let i = 0; i + parts.length <= segments.length; i++) {
+        if (parts.every((p, j) => segments[i + j] === p)) return true;
+      }
+      return false;
+    }
+    return segments.includes(ig);
+  });
+}
+
+async function findFiles (dir, extensions, ignore = []) {
+  const results = [];
+  async function walk (currentDir) {
+    let entries;
+    try {
+      entries = await fs.readdir(currentDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (isIgnoredPath(fullPath, ignore)) continue;
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.isFile() && extensions.some(ext => entry.name.endsWith(ext))) {
+        results.push(fullPath);
+      }
+    }
+  }
+  await walk(dir);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// CLI plumbing
+// ---------------------------------------------------------------------------
+
+function printHelp () {
+  console.log(`
+Usage: npx dialtone-migrate-chip-interactive [options]
+
+Migrates DtChip usage after the \`interactive\` prop default changed from
+\`true\` to \`false\` (DLT-3195).
+
+Chips with a @click handler or v-on object binding automatically receive
+:interactive="true". All other chips without an existing interactive prop
+are listed as warnings for manual review.
+
+Options:
+  --cwd <path>   Working directory (default: cwd)
+  --dry-run      Show changes without applying them
+  --yes          Apply all changes without prompting
+  --help         Show help
+
+Examples:
+  npx dialtone-migrate-chip-interactive
+  npx dialtone-migrate-chip-interactive --dry-run
+  npx dialtone-migrate-chip-interactive --cwd ./src
+  npx dialtone-migrate-chip-interactive --yes
+`);
+}
+
+function parseArgs (args) {
+  const cwdIndex = args.indexOf('--cwd');
+  return {
+    help: args.includes('--help'),
+    dryRun: args.includes('--dry-run'),
+    autoYes: args.includes('--yes'),
+    cwd: cwdIndex !== -1 && args[cwdIndex + 1]
+      ? path.resolve(args[cwdIndex + 1])
+      : process.cwd(),
+  };
+}
+
+async function prompt (question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise(resolve => {
+    rl.question(question, answer => {
+      rl.close();
+      resolve(answer.trim().toLowerCase());
+    });
+  });
+}
+
+async function scanFiles (cwd) {
+  const extensions = ['.vue'];
+  const ignore = ['node_modules', 'dist', '.git', '.vuepress/public', '.vuepress/.temp', '.vuepress/.cache'];
+  const files = await findFiles(cwd, extensions, ignore);
+
+  const changes = [];
+  const allWarnings = [];
+
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8');
+    const { transformed, warnings } = transformContent(content, {
+      filePath: path.relative(cwd, file),
+    });
+    if (transformed !== content) {
+      changes.push({ file, content, transformed });
+    }
+    if (warnings.length) allWarnings.push(...warnings);
+  }
+
+  return { changes, allWarnings };
+}
+
+async function applyChanges (changes, autoYes) {
+  if (!autoYes) {
+    const answer = await prompt('\nApply changes? (y/N) ');
+    if (answer !== 'y' && answer !== 'yes') {
+      console.log('Cancelled.');
+      return false;
+    }
+  }
+  for (const { file, transformed } of changes) {
+    await fs.writeFile(file, transformed, 'utf8');
+  }
+  return true;
+}
+
+function printWarnings (warnings) {
+  if (!warnings.length) return;
+  console.log('\nWarnings — manual review required:\n');
+  for (const w of warnings) console.log(`  ${w}`);
+  console.log();
+}
+
+function printChangeSummary (changes, cwd) {
+  console.log(`\nFound changes in ${changes.length} file(s):\n`);
+  for (const { file } of changes) {
+    console.log(`  ${path.relative(cwd, file)}`);
+  }
+}
+
+async function main () {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  console.log(`\nScanning ${opts.cwd} for DtChip usages...`);
+
+  const { changes, allWarnings } = await scanFiles(opts.cwd);
+
+  printWarnings(allWarnings);
+
+  if (changes.length === 0) {
+    console.log(allWarnings.length
+      ? 'No automated code changes needed. See manual review items above.'
+      : 'No DtChip usages found. Nothing to migrate.');
+    process.exit(0);
+  }
+
+  printChangeSummary(changes, opts.cwd);
+
+  if (opts.dryRun) {
+    console.log('\n--dry-run: No files were modified.');
+    process.exit(0);
+  }
+
+  const applied = await applyChanges(changes, opts.autoYes);
+  if (applied) console.log(`\nMigrated ${changes.length} file(s).\n`);
+}
+
+const isDirectRun = (() => {
+  try {
+    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectRun) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_chip_interactive/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_chip_interactive/index.mjs
@@ -36,9 +36,17 @@ import { fileURLToPath } from 'node:url';
 // Constants
 // ---------------------------------------------------------------------------
 
+// Quote-aware attribute body. Matches sequences of non-quote/non-gt chars
+// optionally followed by a fully-quoted attribute value, so `>` inside a
+// quoted value like `:class="a > b"` does not prematurely terminate the tag.
+const QUOTE_AWARE_ATTRS = '(?:[^>"\']|"[^"]*"|\'[^\']*\')*';
+
 // Matches `<dt-chip` or `<DtChip` opening tags (including self-closing).
-// Capture group 1: everything between the tag name and the closing `>` or `/>`.
-const CHIP_TAG_RE = /(<(?:dt-chip|DtChip)\b)([\s\S]*?)(\s*\/?>)/g;
+// Group 1: tag name; group 2: attributes (quote-aware); group 3: closer (`>` or `/>`).
+const CHIP_TAG_RE = new RegExp(
+  `(<(?:dt-chip|DtChip)\\b)(${QUOTE_AWARE_ATTRS})(\\s*\\/?>)`,
+  'g',
+);
 
 // Detects that the `interactive` prop is already present in any form:
 //   interactive, :interactive, v-bind:interactive

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_chip_interactive/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_chip_interactive/test.mjs
@@ -21,6 +21,26 @@ function warnings (input) {
 // Auto-add :interactive="true" for chips with click handlers
 // ---------------------------------------------------------------------------
 
+describe('quoted value false-positive prevention', () => {
+  it('does not false-positive on @click inside a quoted attribute value', () => {
+    const input = '<dt-chip :title=" @click is cool">Label</dt-chip>';
+    assert.equal(run(input), input);
+    assert.equal(warnings(input).length, 1);
+  });
+
+  it('does not false-positive on interactive inside a quoted attribute value', () => {
+    // HAS_INTERACTIVE_RE must not fire on this — chip still needs fixing
+    const input = '<dt-chip :aria-label="set interactive prop" @click="go">Label</dt-chip>';
+    const expected = '<dt-chip :interactive="true" :aria-label="set interactive prop" @click="go">Label</dt-chip>';
+    assert.equal(run(input), expected);
+  });
+
+  it('real :interactive prop still prevents insertion', () => {
+    const input = '<dt-chip :interactive="false" @click="go">Label</dt-chip>';
+    assert.equal(run(input), input);
+  });
+});
+
 describe('quote-aware attribute parsing — > inside quoted value', () => {
   it('handles > inside a quoted attribute value before @click', () => {
     const input = '<dt-chip :class="a > b" @click="onClick">Label</dt-chip>';

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_chip_interactive/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_chip_interactive/test.mjs
@@ -1,0 +1,205 @@
+/**
+ * DLT-3195 — dialtone-migrate-chip-interactive tests.
+ *
+ * One assertion per test; data-driven via for..of where multiple cases share a concept.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { transformContent } from './index.mjs';
+
+function run (input) {
+  const { transformed } = transformContent(input, { filePath: 'test.vue' });
+  return transformed;
+}
+
+function warnings (input) {
+  return transformContent(input, { filePath: 'test.vue' }).warnings;
+}
+
+// ---------------------------------------------------------------------------
+// Auto-add :interactive="true" for chips with click handlers
+// ---------------------------------------------------------------------------
+
+describe('chips with @click — auto-add :interactive="true"', () => {
+  const cases = [
+    [
+      'single-line chip with @click',
+      '<dt-chip @click="handleClick">Label</dt-chip>',
+      '<dt-chip :interactive="true" @click="handleClick">Label</dt-chip>',
+    ],
+    [
+      'chip with @click.stop modifier',
+      '<dt-chip @click.stop="handleClick">Label</dt-chip>',
+      '<dt-chip :interactive="true" @click.stop="handleClick">Label</dt-chip>',
+    ],
+    [
+      'chip with @click.prevent modifier',
+      '<dt-chip @click.prevent="handleClick">Label</dt-chip>',
+      '<dt-chip :interactive="true" @click.prevent="handleClick">Label</dt-chip>',
+    ],
+    [
+      'chip with v-on:click',
+      '<dt-chip v-on:click="handleClick">Label</dt-chip>',
+      '<dt-chip :interactive="true" v-on:click="handleClick">Label</dt-chip>',
+    ],
+    [
+      'chip with other props and @click',
+      '<dt-chip :size="200" :disabled="isDisabled" @click="handleClick">Label</dt-chip>',
+      '<dt-chip :interactive="true" :size="200" :disabled="isDisabled" @click="handleClick">Label</dt-chip>',
+    ],
+    [
+      'self-closing chip with @click',
+      '<dt-chip @click="handleClick" />',
+      '<dt-chip :interactive="true" @click="handleClick" />',
+    ],
+    [
+      'PascalCase DtChip with @click',
+      '<DtChip @click="handleClick">Label</DtChip>',
+      '<DtChip :interactive="true" @click="handleClick">Label</DtChip>',
+    ],
+  ];
+
+  for (const [label, input, expected] of cases) {
+    it(label, () => {
+      assert.equal(run(input), expected);
+    });
+  }
+});
+
+describe('chips with v-on object binding — auto-add :interactive="true"', () => {
+  const cases = [
+    [
+      'chip with v-on object binding (double quotes)',
+      '<dt-chip v-on="chipListeners">Label</dt-chip>',
+      '<dt-chip :interactive="true" v-on="chipListeners">Label</dt-chip>',
+    ],
+    [
+      'chip with v-on object binding (single quotes)',
+      '<dt-chip v-on=\'chipListeners\'>Label</dt-chip>',
+      '<dt-chip :interactive="true" v-on=\'chipListeners\'>Label</dt-chip>',
+    ],
+  ];
+
+  for (const [label, input, expected] of cases) {
+    it(label, () => {
+      assert.equal(run(input), expected);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Skip chips that already have the interactive prop
+// ---------------------------------------------------------------------------
+
+describe('chips that already have interactive prop — no change', () => {
+  const cases = [
+    [
+      'already has :interactive="true"',
+      '<dt-chip :interactive="true" @click="handleClick">Label</dt-chip>',
+    ],
+    [
+      'already has :interactive="false"',
+      '<dt-chip :interactive="false">Label</dt-chip>',
+    ],
+    [
+      'already has plain interactive',
+      '<dt-chip interactive>Label</dt-chip>',
+    ],
+    [
+      'already has v-bind:interactive',
+      '<dt-chip v-bind:interactive="isInteractive">Label</dt-chip>',
+    ],
+  ];
+
+  for (const [label, input] of cases) {
+    it(label, () => {
+      assert.equal(run(input), input);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Chips with no click handler — warn, no change
+// ---------------------------------------------------------------------------
+
+describe('chips with no click handler — no change, emit warning', () => {
+  it('display-only chip produces no output change', () => {
+    const input = '<dt-chip>Label</dt-chip>';
+    assert.equal(run(input), input);
+  });
+
+  it('display-only chip emits a warning', () => {
+    const input = '<dt-chip>Label</dt-chip>';
+    assert.equal(warnings(input).length, 1);
+  });
+
+  it('warning message mentions the file path', () => {
+    const { warnings: w } = transformContent('<dt-chip>Label</dt-chip>', { filePath: 'src/MyComponent.vue' });
+    assert.ok(w[0].includes('src/MyComponent.vue'));
+  });
+
+  it('chip with @close only (no @click) emits warning, no auto-change', () => {
+    const input = '<dt-chip @close="onRemove">Label</dt-chip>';
+    assert.equal(run(input), input);
+    assert.equal(warnings(input).length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple chips in one file
+// ---------------------------------------------------------------------------
+
+describe('multiple chips in one file', () => {
+  it('adds :interactive to the clickable chip only', () => {
+    const input = [
+      '<dt-chip @click="onClick">Clickable</dt-chip>',
+      '<dt-chip>Display</dt-chip>',
+    ].join('\n');
+    const expected = [
+      '<dt-chip :interactive="true" @click="onClick">Clickable</dt-chip>',
+      '<dt-chip>Display</dt-chip>',
+    ].join('\n');
+    assert.equal(run(input), expected);
+  });
+
+  it('warns once per display-only chip', () => {
+    const input = [
+      '<dt-chip>Label A</dt-chip>',
+      '<dt-chip>Label B</dt-chip>',
+    ].join('\n');
+    assert.equal(warnings(input).length, 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inert content masking — should not match chips in comments or script
+// ---------------------------------------------------------------------------
+
+describe('inert content masking', () => {
+  it('does not transform chip inside HTML comment', () => {
+    const input = '<!-- <dt-chip @click="x">hidden</dt-chip> -->';
+    assert.equal(run(input), input);
+  });
+
+  it('does not transform chip inside <script>', () => {
+    const input = '<script>\nconst example = `<dt-chip @click="x">Label</dt-chip>`;\n</script>';
+    assert.equal(run(input), input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fast path — no-op on files with no dt-chip reference
+// ---------------------------------------------------------------------------
+
+describe('fast path', () => {
+  it('returns unchanged content when no dt-chip present', () => {
+    const input = '<dt-button @click="x">Click</dt-button>';
+    assert.equal(run(input), input);
+  });
+
+  it('emits no warnings when no dt-chip present', () => {
+    const input = '<dt-button @click="x">Click</dt-button>';
+    assert.equal(warnings(input).length, 0);
+  });
+});

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_chip_interactive/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_chip_interactive/test.mjs
@@ -21,6 +21,25 @@ function warnings (input) {
 // Auto-add :interactive="true" for chips with click handlers
 // ---------------------------------------------------------------------------
 
+describe('quote-aware attribute parsing — > inside quoted value', () => {
+  it('handles > inside a quoted attribute value before @click', () => {
+    const input = '<dt-chip :class="a > b" @click="onClick">Label</dt-chip>';
+    const expected = '<dt-chip :interactive="true" :class="a > b" @click="onClick">Label</dt-chip>';
+    assert.equal(run(input), expected);
+  });
+
+  it('does not warn when @click is present but attrs contain quoted >', () => {
+    const input = '<dt-chip :class="a > b" @click="onClick">Label</dt-chip>';
+    assert.equal(warnings(input).length, 0);
+  });
+
+  it('handles > inside a single-quoted attribute value', () => {
+    const input = '<dt-chip :title="x > y" @click="onClick">Label</dt-chip>';
+    const expected = '<dt-chip :interactive="true" :title="x > y" @click="onClick">Label</dt-chip>';
+    assert.equal(run(input), expected);
+  });
+});
+
 describe('chips with @click — auto-add :interactive="true"', () => {
   const cases = [
     [

--- a/packages/dialtone-css/package.json
+++ b/packages/dialtone-css/package.json
@@ -52,7 +52,8 @@
     "dialtone-health-check": "./lib/dist/js/dialtone_health_check/index.cjs",
     "dialtone-migration-helper": "./lib/dist/js/dialtone_migration_helper/index.mjs",
     "dialtone-migrate-flex-to-stack": "./lib/dist/js/dialtone_migrate_flex_to_stack/index.mjs",
-    "dialtone-migrate-link-rendering": "./lib/dist/js/dialtone_migrate_link_rendering/index.mjs"
+    "dialtone-migrate-link-rendering": "./lib/dist/js/dialtone_migrate_link_rendering/index.mjs",
+    "dialtone-migrate-chip-interactive": "./lib/dist/js/dialtone_migrate_chip_interactive/index.mjs"
   },
   "type": "module",
   "scripts": {

--- a/packages/dialtone-vue/components/chip/chip.test.js
+++ b/packages/dialtone-vue/components/chip/chip.test.js
@@ -76,8 +76,8 @@ describe('DtChip Tests', () => {
         expect(avatar.exists()).toBe(false);
       });
 
-      it('default interactive', () => {
-        expect(chip.element.tagName).toBe('BUTTON');
+      it('default interactive is false, renders as span', () => {
+        expect(chip.element.tagName).toBe('SPAN');
       });
 
       it('chip should have aria-labelledby', () => {

--- a/packages/dialtone-vue/components/chip/chip.vue
+++ b/packages/dialtone-vue/components/chip/chip.vue
@@ -119,7 +119,7 @@ export default {
      */
     interactive: {
       type: Boolean,
-      default: true,
+      default: false,
     },
 
     /**

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
@@ -30,6 +30,7 @@
             v-for="(item, index) in selectedItems"
             ref="chips"
             :key="`${index}-${item}`"
+            :interactive="true"
             :label-class="['d-chip__label']"
             :class="[
               'd-recipe-combobox-multi-select__chip',


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change
- [x] Feature

## :book: Jira Ticket
[DLT-3195](https://dialpad.atlassian.net/browse/DLT-3195)

## :book: Description
Changes `DtChip`'s `interactive` prop default from `true` to `false`. Previously, chips without an explicit `interactive` prop rendered as `<button>` elements with hover/focus/pointer states even when they had no click handler — misleading UX and a screen reader accessibility issue.

After this change, chips render as `<span>` by default. The close button is unaffected. `ComboboxMultiSelect` (the one internal consumer that relies on clickable chips) is updated to explicitly set `:interactive="true"`.

A migration script (`dialtone-migrate-chip-interactive`) is included to auto-add `:interactive="true"` to chips with `@click` / `v-on:click` / `v-on` object bindings in consumer codebases. Chips with no click handler are flagged as warnings for manual review.

## :package: Cross-Package Impact

| Package | Changes | Downstream Impact |
|---|---|---|
| `dialtone-vue` | `DtChip.interactive` default `true` to `false`; `ComboboxMultiSelect` updated | Any consumer using `<dt-chip>` without `interactive` will now render a non-interactive `<span>` |
| `dialtone-css` | New `dialtone-migrate-chip-interactive` bin added | Consumers can run `npx dialtone-migrate-chip-interactive` to auto-fix clickable chips |

## :page_facing_up: Documentation Artifacts

| Artifact | Status |
|---|---|
| Vue source | Updated (`chip.vue`, `combobox_multi_select.vue`) |
| Tests | Updated (`chip.test.js`, `test.mjs` for migration script) |
| Storybook stories | Not affected (no new variants) |
| Component docs JSON | Not affected (prop default not surfaced in JSON) |
| VuePress docs | Migration guide added (`guides/migration/chip-interactive/`) |
| MCP server data | Not affected |

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

[DLT-3195]: https://dialpad.atlassian.net/browse/DLT-3195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ