### PR TITLE
docs(tabs, skeleton, rich-text-editor): DLT-3347 update doc page code examples on next branch

### DIFF
--- a/apps/dialtone-documentation/docs/components/rich-text-editor.md
+++ b/apps/dialtone-documentation/docs/components/rich-text-editor.md
@@ -104,7 +104,7 @@ To see it in action type char '@' into rich editor With channel mentions.
 ```vue demo
 <example-rich-text-editor
   modelValue="<p>The editor can also suggest mentions: <mention-component name='Test Person' avatarsrc='' id='test.person'></mention-component>, <mention-component name='Test Person 2' avatarsrc='' id='test.person2'></mention-component>! The suggestions dropdown will wait 1000ms to simulate an API call.</p>"
-  :mentionSuggestion="{ items }"
+  :mention-suggestion="{ items }"
 />
 <!-- @code -->
 <dt-rich-text-editor

--- a/apps/dialtone-documentation/docs/components/skeleton.md
+++ b/apps/dialtone-documentation/docs/components/skeleton.md
@@ -64,7 +64,7 @@ keywords: ["loading placeholder", "shimmer", "ghost", "d-skeleton", "DtSkeleton"
 ```vue demo
 <!-- @wrapper -->
 <div class="d-w-400">
-  <dt-skeleton :animate="false" arial-label="Loading" />
+  <dt-skeleton :animate="false" aria-label="Loading" />
 </div>
 ```
 
@@ -73,7 +73,7 @@ keywords: ["loading placeholder", "shimmer", "ghost", "d-skeleton", "DtSkeleton"
 ```vue demo
 <!-- @wrapper -->
 <div class="d-w-400">
-  <dt-skeleton arial-label="Loading" />
+  <dt-skeleton aria-label="Loading" />
 </div>
 ```
 
@@ -89,7 +89,7 @@ To customize a non-animating Skeleton background color modify the `--placeholder
     :text-option="{
       style: '--placeholder-from-color: var(--dt-color-blue-400)',
     }"
-    arial-label="Loading"
+    aria-label="Loading"
   />
 </div>
 ```
@@ -103,7 +103,7 @@ Customize an animating Skeleton by modifying the `--placeholder-from-color` and 
     :text-option="{
       style: '--placeholder-from-color: var(--dt-color-blue-400); --placeholder-to-color: var(--dt-color-blue-200);',
     }"
-    arial-label="Loading"
+    aria-label="Loading"
   />
 </div>
 ```

--- a/apps/dialtone-documentation/docs/components/tabs.md
+++ b/apps/dialtone-documentation/docs/components/tabs.md
@@ -19,11 +19,11 @@ keywords: ["tab panel", "tab navigation", "d-tabs", "DtTabs", "dt-tabs", "segmen
   <example-tabs />
 </div>
 <!-- @code -->
-<dt-tab-group>
+<dt-tab-group label="Label Example Group">
   <template #tabs>
-    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
-    <dt-tab id="3" panel-id="4">Second</dt-tab>
-    <dt-tab id="5" panel-id="6">Third</dt-tab>
+    <dt-tab id="1" panel-id="2" selected>First tab</dt-tab>
+    <dt-tab id="3" panel-id="4">Second tab</dt-tab>
+    <dt-tab id="5" panel-id="6">Third tab</dt-tab>
   </template>
 </dt-tab-group>
 ```
@@ -37,7 +37,7 @@ Remove the bottom border of any tablist.
   <example-tabs borderless />
 </div>
 <!-- @code -->
-<dt-tab-group borderless>
+<dt-tab-group label="Label Example Group" borderless>
   ...
 </dt-tab-group>
 ```
@@ -51,11 +51,11 @@ All tabs render as muted buttons. The selected tab is distinguished with active 
   <example-tabs kind="muted" />
 </div>
 <!-- @code -->
-<dt-tab-group kind="muted">
+<dt-tab-group label="Label Example Group" kind="muted">
   <template #tabs>
-    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
-    <dt-tab id="3" panel-id="4">Second</dt-tab>
-    <dt-tab id="5" panel-id="6">Third</dt-tab>
+    <dt-tab id="1" panel-id="2" selected>First tab</dt-tab>
+    <dt-tab id="3" panel-id="4">Second tab</dt-tab>
+    <dt-tab id="5" panel-id="6">Third tab</dt-tab>
   </template>
 </dt-tab-group>
 ```
@@ -69,11 +69,11 @@ The selected tab renders with an outlined border instead of a filled style.
   <example-tabs outlined />
 </div>
 <!-- @code -->
-<dt-tab-group outlined>
+<dt-tab-group label="Label Example Group" outlined>
   <template #tabs>
-    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
-    <dt-tab id="3" panel-id="4">Second</dt-tab>
-    <dt-tab id="5" panel-id="6">Third</dt-tab>
+    <dt-tab id="1" panel-id="2" selected>First tab</dt-tab>
+    <dt-tab id="3" panel-id="4">Second tab</dt-tab>
+    <dt-tab id="5" panel-id="6">Third tab</dt-tab>
   </template>
 </dt-tab-group>
 ```
@@ -87,11 +87,11 @@ Combines muted kind with outlined selected state.
   <example-tabs kind="muted" outlined />
 </div>
 <!-- @code -->
-<dt-tab-group kind="muted" outlined>
+<dt-tab-group label="Label Example Group" kind="muted" outlined>
   <template #tabs>
-    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
-    <dt-tab id="3" panel-id="4">Second</dt-tab>
-    <dt-tab id="5" panel-id="6">Third</dt-tab>
+    <dt-tab id="1" panel-id="2" selected>First tab</dt-tab>
+    <dt-tab id="3" panel-id="4">Second tab</dt-tab>
+    <dt-tab id="5" panel-id="6">Third tab</dt-tab>
   </template>
 </dt-tab-group>
 ```
@@ -101,12 +101,12 @@ Combines muted kind with outlined selected state.
 Add `disabled` to a specific tab.
 
 ```vue demo
-<dt-tab-group>
+<dt-tab-group label="Label Example Group">
   <template #tabs>
-    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
-    <dt-tab id="3" panel-id="4">Second</dt-tab>
-    <dt-tab id="5" panel-id="6">Third</dt-tab>
-    <dt-tab id="7" panel-id="8" disabled>Fourth</dt-tab>
+    <dt-tab id="1" panel-id="2" selected>First tab</dt-tab>
+    <dt-tab id="3" panel-id="4">Second tab</dt-tab>
+    <dt-tab id="5" panel-id="6">Third tab</dt-tab>
+    <dt-tab id="7" panel-id="8" disabled>Fourth tab</dt-tab>
   </template>
 </dt-tab-group>
 ```
@@ -116,11 +116,11 @@ Add `disabled` to the tab group to disable all.
 ```vue demo
 <example-tabs disabled />
 <!-- @code -->
-<dt-tab-group disabled>
+<dt-tab-group label="Label Example Group" disabled>
   <template #tabs>
-    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
-    <dt-tab id="3" panel-id="4">Second</dt-tab>
-    <dt-tab id="5" panel-id="6">Third</dt-tab>
+    <dt-tab id="1" panel-id="2" selected>First tab</dt-tab>
+    <dt-tab id="3" panel-id="4">Second tab</dt-tab>
+    <dt-tab id="5" panel-id="6">Third tab</dt-tab>
   </template>
 </dt-tab-group>
 ```
@@ -139,10 +139,10 @@ In place of the `inverted` prop, use the [v-dt-mode directive](mode-island.html#
   </div>
 </div>
 <!-- @code -->
-<dt-tab-group v-dt-mode:invert>
+<dt-tab-group label="Label Example Group" v-dt-mode:invert>
   <template #tabs>
-    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
-    <dt-tab id="3" panel-id="4">Second</dt-tab>
+    <dt-tab id="1" panel-id="2" selected>First tab</dt-tab>
+    <dt-tab id="3" panel-id="4">Second tab</dt-tab>
   </template>
 </dt-tab-group>
 ```
@@ -158,7 +158,7 @@ Tabs expand proportionally to fill the container. Longer labels receive more spa
 ```vue demo
 <!-- @wrapper -->
 <div class="d-w100p">
-  <dt-tab-group spread="grow">
+  <dt-tab-group label="Label Example Group" spread="grow">
     <template #tabs>
       <dt-tab id="sg1" panel-id="sg2" selected>Tab 1</dt-tab>
       <dt-tab id="sg3" panel-id="sg4">Tab the second</dt-tab>
@@ -175,7 +175,7 @@ All tabs share the same width, regardless of label length.
 ```vue demo
 <!-- @wrapper -->
 <div class="d-w-800">
-  <dt-tab-group spread="equal">
+  <dt-tab-group label="Label Example Group" spread="equal">
     <template #tabs>
       <dt-tab id="se1" panel-id="se2" selected>Tab 1</dt-tab>
       <dt-tab id="se3" panel-id="se4">Tab the second</dt-tab>
@@ -189,7 +189,7 @@ All tabs share the same width, regardless of label length.
 
 ```vue demo
 <dt-stack gap="200" class="d-w100p">
-  <dt-tab-group :size="100">
+  <dt-tab-group label="Label Example Group" :size="100">
     <template #tabs>
       <dt-tab id="1" panel-id="2" selected>
         First
@@ -202,7 +202,7 @@ All tabs share the same width, regardless of label length.
       </dt-tab>
     </template>
   </dt-tab-group>
-  <dt-tab-group :size="200">
+  <dt-tab-group label="Label Example Group" :size="200">
     <template #tabs>
       <dt-tab id="1" panel-id="2" selected>
         First
@@ -215,7 +215,7 @@ All tabs share the same width, regardless of label length.
       </dt-tab>
     </template>
   </dt-tab-group>
-  <dt-tab-group>
+  <dt-tab-group label="Label Example Group">
     <template #tabs>
       <dt-tab id="1" panel-id="2" selected>
         First
@@ -228,7 +228,7 @@ All tabs share the same width, regardless of label length.
       </dt-tab>
     </template>
   </dt-tab-group>
-  <dt-tab-group :size="400">
+  <dt-tab-group label="Label Example Group" :size="400">
     <template #tabs>
       <dt-tab id="1" panel-id="2" selected>
         First
@@ -241,7 +241,7 @@ All tabs share the same width, regardless of label length.
       </dt-tab>
     </template>
   </dt-tab-group>
-  <dt-tab-group :size="500">
+  <dt-tab-group label="Label Example Group" :size="500">
     <template #tabs>
       <dt-tab id="1" panel-id="2" selected>
         First
@@ -256,7 +256,7 @@ All tabs share the same width, regardless of label length.
   </dt-tab-group>
 </dt-stack>
 <!-- @code -->
-<dt-tab-group :size="100|200|300|400|500">
+<dt-tab-group label="Label Example Group" :size="100|200|300|400|500">
   ...
 </dt-tab-group>
 ```
@@ -273,7 +273,7 @@ Use the `#startIcon` or `#endIcon` slot on `dt-tab` to add an icon. The slot pro
 ```vue demo
 <!-- @wrapper -->
 <div class="d-w100p">
-  <dt-tab-group>
+  <dt-tab-group label="Label Example Group">
     <template #tabs>
       <dt-tab id="1" panel-id="2" selected>
         First
@@ -308,7 +308,7 @@ Use the `#leading` and `#trailing` slots on `dt-tab` to render content like badg
 ```vue demo
 <!-- @wrapper -->
 <div class="d-w100p">
-  <dt-tab-group>
+  <dt-tab-group label="Label Example Group">
     <template #tabs>
       <dt-tab id="lt1" panel-id="lt2" selected trailing-class="d-pie-100">
         Inbox
@@ -337,11 +337,11 @@ Set `orientation="vertical"` to stack tabs vertically alongside the panel.
 ```vue demo
 <example-tabs orientation="vertical" />
 <!-- @code -->
-<dt-tab-group orientation="vertical">
+<dt-tab-group label="Label Example Group" orientation="vertical">
   <template #tabs>
-    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
-    <dt-tab id="3" panel-id="4">Second</dt-tab>
-    <dt-tab id="5" panel-id="6">Third</dt-tab>
+    <dt-tab id="1" panel-id="2" selected>First tab</dt-tab>
+    <dt-tab id="3" panel-id="4">Second tab</dt-tab>
+    <dt-tab id="5" panel-id="6">Third tab</dt-tab>
   </template>
 </dt-tab-group>
 ```
@@ -355,11 +355,11 @@ By default, tabs use manual activation — the user must press `Enter` or `Space
 ```vue demo
 <example-tabs activation-mode="auto" />
 <!-- @code -->
-<dt-tab-group activation-mode="auto">
+<dt-tab-group label="Label Example Group" activation-mode="auto">
   <template #tabs>
-    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
-    <dt-tab id="3" panel-id="4">Second</dt-tab>
-    <dt-tab id="5" panel-id="6">Third</dt-tab>
+    <dt-tab id="1" panel-id="2" selected>First tab</dt-tab>
+    <dt-tab id="3" panel-id="4">Second tab</dt-tab>
+    <dt-tab id="5" panel-id="6">Third tab</dt-tab>
   </template>
 </dt-tab-group>
 ```
@@ -371,11 +371,11 @@ If you need to do some validation before changing tabs, you can use the `before-
 ```vue demo
 <example-tabs validate />
 <!-- @code -->
-<dt-tab-group @before-change="confirmBeforeLeave">
+<dt-tab-group label="Label Example Group" @before-change="confirmBeforeLeave">
   <template #tabs>
-    <dt-tab id="1" panel-id="2" selected>First</dt-tab>
-    <dt-tab id="3" panel-id="4">Second</dt-tab>
-    <dt-tab id="5" panel-id="6">Third</dt-tab>
+    <dt-tab id="1" panel-id="2" selected>First tab</dt-tab>
+    <dt-tab id="3" panel-id="4">Second tab</dt-tab>
+    <dt-tab id="5" panel-id="6">Third tab</dt-tab>
   </template>
 </dt-tab-group>
 <script setup>


### PR DESCRIPTION
# docs(tabs, skeleton, rich-text-editor): DLT-3347 update doc page code examples on next branch

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTN4bjJ1d3B1Njh4cXl5em5lamozeTlyZGJkMDFqamJxZzltNjlsciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/OTszKBXzfG5e8/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-3347
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

<!--- Describe specifically what the changes are -->

## Summary

Documentation page fixes for typos, formatting, and code example mismatches.

### `skeleton.md`
- Fix `arial-label` → `aria-label` (4 occurrences). The misspelled attribute was silently ignored by browsers, so the loading state had no accessible label.

### `tabs.md`
- Add `label="Label Example Group"` to every `<dt-tab-group>` in displayed code blocks (18 occurrences). Without it, copy-pasting any snippet produces an unlabeled tablist (a11y violation — `aria-label` on `[role="tablist"]` won't be set).
- Align tab labels in code snippets paired with `<example-tabs />` so they match what the live demo renders: `First` → `First tab`, `Second` → `Second tab`, `Third` → `Third tab`, `Fourth` → `Fourth tab`. Previously a reader saw "First tab" rendered next to a code snippet labeled just "First".

### `rich-text-editor.md`
- Change `:mentionSuggestion` → `:mention-suggestion` in the mentions demo wrapper (line 107) to match the kebab-case used in the displayed code block below it. Both work in Vue, but the inconsistency was confusing.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

These fixes originated in [PR #1221](https://github.com/dialpad/dialtone/pull/1221). Some of that is fixed in `next` already; this PR catches the remainder.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->
Example of a mismatch:

<img width="1343" height="880" alt="Screenshot 2026-05-01 at 4 56 55 PM" src="https://github.com/user-attachments/assets/42b7bd84-49e1-4466-9a64-1dfd959cc756" />


## :link: Sources

<!--- Add any links to external reference material -->
