### PR TITLE
feat(scrollbar): DLT-3158 implement object props

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/UiKitsComparisonTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/UiKitsComparisonTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-dt-scrollbar:never class="d-hmx-700 d-bar-400 d-ba d-bc-subtle d-mbs-300">
+  <div v-dt-scrollbar:always class="d-hmx-700 d-bar-400 d-ba d-bc-subtle d-mbs-300">
     <div>
       <table class="d-table dialtone-doc-table">
         <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-ibs-0">

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenTable.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/tokens/TokenTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-dt-scrollbar:never>
+  <div v-dt-scrollbar:always>
     <div class="d-hmx-800 d-bar-400 d-ba d-bc-subtle">
       <table v-dt-mode:[mode] class="d-bgc-primary d-table dialtone-doc-table">
         <thead class="d-bgc-primary d-ps-sticky d-zi-base1 d-ibs-0">

--- a/apps/dialtone-documentation/docs/_data/site-nav.json
+++ b/apps/dialtone-documentation/docs/_data/site-nav.json
@@ -284,6 +284,10 @@
                     "link": "/guides/migration/chip-interactive/"
                   },
                   {
+                    "text": "Scrollbar :never → :always",
+                    "link": "/guides/migration/scrollbar-always/"
+                  },
+                  {
                     "text": "Vue 2 Removal",
                     "link": "/guides/migration/vue2-removal/"
                   }

--- a/apps/dialtone-documentation/docs/components/box.md
+++ b/apps/dialtone-documentation/docs/components/box.md
@@ -211,7 +211,7 @@ Integrates the `v-dt-scrollbar` directive. An inner viewport wrapper is inserted
   padding="200"
   border-width="100"
   border-radius="300"
-  scrollbar="never"
+  scrollbar="always"
   block-size="300"
 >
   <dt-stack gap="100">

--- a/apps/dialtone-documentation/docs/components/card.md
+++ b/apps/dialtone-documentation/docs/components/card.md
@@ -129,7 +129,7 @@ They should be easy to scan for relevant and actionable information. Elements, l
     </dt-button>
   </template>
   <template #content>
-    <div class="d-h-125 d-pie-200" v-dt-scrollbar:never>Content slot. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec fermentum molestie semper. Morbi finibus nulla turpis, nec molestie mi rutrum.</div>
+    <div class="d-h-125 d-pie-200" v-dt-scrollbar:always>Content slot. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec fermentum molestie semper. Morbi finibus nulla turpis, nec molestie mi rutrum.</div>
   </template>
   <template #footer>
     <dt-button

--- a/apps/dialtone-documentation/docs/components/scrollbar.md
+++ b/apps/dialtone-documentation/docs/components/scrollbar.md
@@ -141,8 +141,8 @@ In addition to using directive arguments for scrollbar visibility (`:always`, `:
 | `offset.blockEnd` | `number \| string` | `undefined` | Insets horizontal scrollbar from the block-end edge |
 | `offset.inlineStart` | `number \| string` | `undefined` | Insets horizontal scrollbar from the inline-start edge |
 | `offset.inlineEnd` | `number \| string` | `undefined` | Insets vertical scrollbar from the inline-end edge |
-| `verticalClasses` | `string` | `undefined` | CSS classes to apply to the vertical scrollbar |
-| `horizontalClasses` | `string` | `undefined` | CSS classes to apply to the horizontal scrollbar |
+| `blockClasses` | `string` | `undefined` | CSS classes to apply to the vertical scrollbar |
+| `inlineClasses` | `string` | `undefined` | CSS classes to apply to the horizontal scrollbar |
 
 ### Offset Option
 
@@ -203,10 +203,10 @@ The `offset` option allows you to adjust the positioning of scrollbars to accomm
 
 The directive supports applying custom CSS classes to scrollbar elements, allowing you to use utility classes or custom styles for scrollbar appearance.
 
-#### Vertical Scrollbar Classes
+#### Block Axis (Vertical) Scrollbar Classes
 
 ```vue demo
-<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar="{ verticalClasses: 'd-w12 d-bgc-purple-300', showScrollbar: 'always' }">
+<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar="{ blockClasses: 'd-w12 d-bgc-purple-300', showScrollbar: 'always' }">
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}
@@ -215,10 +215,10 @@ The directive supports applying custom CSS classes to scrollbar elements, allowi
 </div>
 ```
 
-#### Horizontal Scrollbar Classes
+#### Inline Axis (Horizontal) Scrollbar Classes
 
 ```vue code-only
-<div v-dt-scrollbar="{ horizontalClasses: 'd-h8 d-bgc-blue-300' }">
+<div v-dt-scrollbar="{ inlineClasses: 'd-h8 d-bgc-blue-300' }">
   <div>Scrollable content with styled horizontal scrollbar</div>
 </div>
 ```
@@ -227,8 +227,8 @@ The directive supports applying custom CSS classes to scrollbar elements, allowi
 
 ```vue code-only
 <div v-dt-scrollbar="{
-  verticalClasses: 'd-w12',
-  horizontalClasses: 'd-h8'
+  blockClasses: 'd-w12',
+  inlineClasses: 'd-h8'
 }">
   <div>Different classes for each scrollbar</div>
 </div>
@@ -237,7 +237,7 @@ The directive supports applying custom CSS classes to scrollbar elements, allowi
 #### Combined with Offset
 
 ```vue demo
-<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar="{ offset: { blockStart: 20, blockEnd: 20 }, verticalClasses: 'd-w12 d-bgc-magenta-300', showScrollbar: 'always' }">
+<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar="{ offset: { blockStart: 20, blockEnd: 20 }, blockClasses: 'd-w12 d-bgc-magenta-300', showScrollbar: 'always' }">
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}

--- a/apps/dialtone-documentation/docs/components/scrollbar.md
+++ b/apps/dialtone-documentation/docs/components/scrollbar.md
@@ -7,14 +7,12 @@ image: assets/images/components/scrollbar.png
 keywords: ["scrollable", "d-scrollbar", "DtScrollbar", "dt-scrollbar", "custom scrollbar", "scroll container", "v-dt", "directive"]
 ---
 
-<!-- <component-combinator component-name="DtScrollbar" /> -->
-
 ## Scrollbar Directive
 
 Allows to add overlay scrollbars that will look the same for every browser. The directive sets up the scrollbars from the library [OverlayScrollbars](https://kingsora.github.io/OverlayScrollbars/).
 
 ```vue demo
-<div class="d-hmx-250 d-w-400 d-bar-400 d-ba" v-dt-scrollbar>
+<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar>
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}
@@ -28,10 +26,10 @@ Allows to add overlay scrollbars that will look the same for every browser. The 
 Import the directive and styling from dialtone
 
 ```javascript
-import { DtScrollbarDirective } from "@dialpad/dialtone/vue";
+import { DtScrollbarDirective } from "@dialpad/dialtone/vue3";
 
 // Import styling
-import 'overlayscrollbars/overlayscrollbars.css';
+import "overlayscrollbars/overlayscrollbars.css";
 ```
 
 Install the directive into vue instance
@@ -46,23 +44,23 @@ There is no need to explicitly add an `overflow` property. If the section overfl
 
 ## Characteristics
 
-* Has an overlay style: it appears on top of the content rather than the scrollbar taking up space within the container.
-* It grows when hovering the scrollbar handle for better accessibility.
-* Appears when the mouse enters the scrollable area and disappears on mouse out after a certain time. This can be customized,
-see [variants](#variants).
-* The look and feel will be the same for every browser and OS.
-* Emulates a browser's native scrollbar keyboard and mouse events.
+- Has an overlay style: it appears on top of the content rather than the scrollbar taking up space within the container.
+- It grows when hovering the scrollbar handle for better accessibility.
+- Appears when the mouse enters the scrollable area and disappears on mouse out after a certain time. This can be customized,
+  see [variants](#variants).
+- The look and feel will be the same for every browser and OS.
+- Emulates a browser's native scrollbar keyboard and mouse events.
 
 ## Variants
 
-To customize the behavior of the scrollbar, you can use different arguments with the directive. The allowed arguments are 'leave' (default), 'never', 'scroll', and 'move'.
+To customize the behavior of the scrollbar, you can use different show modes with the directive. The allowed values are `'enter'` (default), `'always'`, `'scroll'`, and `'move'`.
 
 ### Enter (Default)
 
-Show the scrollbar when the mouse enters the scrollable area. This is the default option, so no argument is needed.
+Show the scrollbar when the mouse enters the scrollable area. This is the default option, so no configuration is needed.
 
 ```vue demo
-<div class="d-hmx-250 d-w-400 d-bar-400 d-ba" v-dt-scrollbar>
+<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar>
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}
@@ -76,7 +74,7 @@ Show the scrollbar when the mouse enters the scrollable area. This is the defaul
 Always show the scrollbar if the region is overflowing the available space.
 
 ```vue demo
-<div class="d-hmx-250 d-w-400 d-bar-400 d-ba" v-dt-scrollbar:never>
+<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar:always>
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}
@@ -85,12 +83,20 @@ Always show the scrollbar if the region is overflowing the available space.
 </div>
 ```
 
+The object syntax is also supported:
+
+```vue code-only
+<div v-dt-scrollbar="{ showScrollbar: 'always' }">
+  <div>content</div>
+</div>
+```
+
 ### Scroll
 
 Show the scrollbar on scroll.
 
 ```vue demo
-<div class="d-hmx-250 d-w-400 d-bar-400 d-ba" v-dt-scrollbar:scroll>
+<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar:scroll>
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}
@@ -104,7 +110,7 @@ Show the scrollbar on scroll.
 Show the scrollbar when the mouse moves inside the scrollable area.
 
 ```vue demo
-<div class="d-hmx-250 d-w-400 d-bar-400 d-ba" v-dt-scrollbar:move>
+<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar:move>
   <dt-stack>
     <div v-for="item in items" class="item">
       {{ item}}
@@ -113,16 +119,218 @@ Show the scrollbar when the mouse moves inside the scrollable area.
 </div>
 ```
 
+## Configuration Object
+
+In addition to using directive arguments for scrollbar visibility (`:always`, `:scroll`, `:move`), you can pass a configuration object to the directive that supports additional options like offsets, CSS classes, and explicit show behavior.
+
+### Basic Syntax
+
+```vue code-only
+<div v-dt-scrollbar="{ showScrollbar: 'always', offset: { blockStart: 64 } }">
+  <div>Scrollable content</div>
+</div>
+```
+
+### Configuration Properties
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `showScrollbar` | `'enter' \| 'always' \| 'scroll' \| 'move'` | `'enter'` | Scrollbar visibility mode |
+| `offset` | `Object` | `null` | Offset configuration for scrollbar positioning |
+| `offset.blockStart` | `number \| string` | `undefined` | Insets vertical scrollbar from the block-start edge |
+| `offset.blockEnd` | `number \| string` | `undefined` | Insets horizontal scrollbar from the block-end edge |
+| `offset.inlineStart` | `number \| string` | `undefined` | Insets horizontal scrollbar from the inline-start edge |
+| `offset.inlineEnd` | `number \| string` | `undefined` | Insets vertical scrollbar from the inline-end edge |
+| `verticalClasses` | `string` | `undefined` | CSS classes to apply to the vertical scrollbar |
+| `horizontalClasses` | `string` | `undefined` | CSS classes to apply to the horizontal scrollbar |
+
+### Offset Option
+
+The `offset` option allows you to adjust the positioning of scrollbars to accommodate fixed headers, footers, or other UI elements that overlap with the scrollable region. This eliminates the need for manual CSS overrides.
+
+```vue demo
+<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar="{ offset: { blockStart: 20, blockEnd: 20 }, showScrollbar: 'always' }">
+  <dt-stack>
+    <div v-for="item in items" class="item">
+      {{ item}}
+    </div>
+  </dt-stack>
+</div>
+```
+
+#### Offset Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `blockStart` | `number \| string` | Insets vertical scrollbar from the block-start edge |
+| `blockEnd` | `number \| string` | Insets horizontal scrollbar from the block-end edge |
+| `inlineStart` | `number \| string` | Insets horizontal scrollbar from the inline-start edge |
+| `inlineEnd` | `number \| string` | Insets vertical scrollbar from the inline-end edge |
+
+#### Numeric Values (Auto-converted to px)
+
+```vue code-only
+<div v-dt-scrollbar="{ offset: { blockStart: 64, blockEnd: 32 } }">
+  <div>Content with 64px block-start offset and 32px block-end offset</div>
+</div>
+```
+
+#### String Values (Supports any CSS unit)
+
+```vue code-only
+<div v-dt-scrollbar="{ offset: { blockStart: '4rem', blockEnd: '2em' } }">
+  <div>Content with rem/em offsets</div>
+</div>
+```
+
+#### CSS Variables
+
+```vue code-only
+<div v-dt-scrollbar="{ offset: { blockStart: 'var(--header-height)' } }">
+  <div>Content with CSS variable offset</div>
+</div>
+```
+
+#### Calc() Expressions
+
+```vue code-only
+<div v-dt-scrollbar="{ offset: { blockStart: 'calc(100% - 64px)' } }">
+  <div>Content with calculated offset</div>
+</div>
+```
+
+### CSS Classes
+
+The directive supports applying custom CSS classes to scrollbar elements, allowing you to use utility classes or custom styles for scrollbar appearance.
+
+#### Vertical Scrollbar Classes
+
+```vue demo
+<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar="{ verticalClasses: 'd-w12 d-bgc-purple-300', showScrollbar: 'always' }">
+  <dt-stack>
+    <div v-for="item in items" class="item">
+      {{ item}}
+    </div>
+  </dt-stack>
+</div>
+```
+
+#### Horizontal Scrollbar Classes
+
+```vue code-only
+<div v-dt-scrollbar="{ horizontalClasses: 'd-h8 d-bgc-blue-300' }">
+  <div>Scrollable content with styled horizontal scrollbar</div>
+</div>
+```
+
+#### Both Scrollbars
+
+```vue code-only
+<div v-dt-scrollbar="{
+  verticalClasses: 'd-w12',
+  horizontalClasses: 'd-h8'
+}">
+  <div>Different classes for each scrollbar</div>
+</div>
+```
+
+#### Combined with Offset
+
+```vue demo
+<div class="d-hmx164 d-w30p d-bar8 d-ba" v-dt-scrollbar="{ offset: { blockStart: 20, blockEnd: 20 }, verticalClasses: 'd-w12 d-bgc-magenta-300', showScrollbar: 'always' }">
+  <dt-stack>
+    <div v-for="item in items" class="item">
+      {{ item}}
+    </div>
+  </dt-stack>
+</div>
+```
+
+### ShowScrollbar Validation
+
+The `showScrollbar` property is validated to ensure only valid values are used. If an invalid value is provided, the directive will log an informational message and fall back to the default `'enter'` mode.
+
+**Valid values:** `'enter'`, `'always'`, `'scroll'`, `'move'`
+
+```vue code-only
+<!-- Valid -->
+<div v-dt-scrollbar="{ showScrollbar: 'always' }"></div>
+
+<!-- Invalid - falls back to 'enter' with console message -->
+<div v-dt-scrollbar="{ showScrollbar: 'invalid' }"></div>
+```
+
+### Common Use Cases
+
+#### Fixed Header
+
+When you have a fixed header that overlaps the scrollable region:
+
+```vue code-only
+<div class="page">
+  <header class="fixed-header">Fixed Header (64px tall)</header>
+  <div v-dt-scrollbar="{ offset: { blockStart: 64 } }" class="content">
+    <div>Scrollable content</div>
+  </div>
+</div>
+```
+
+#### Fixed Header and Footer
+
+When you have both fixed header and footer:
+
+```vue code-only
+<div class="page">
+  <header class="fixed-header">Header</header>
+  <div v-dt-scrollbar="{ offset: { blockStart: 64, blockEnd: 48 } }" class="content">
+    <div>Scrollable content</div>
+  </div>
+  <footer class="fixed-footer">Footer</footer>
+</div>
+```
+
+#### Dynamic Offsets (Reactive)
+
+Offsets can be reactive and will update automatically:
+
+```vue code-only
+<template>
+  <div v-dt-scrollbar="scrollbarConfig">
+    <div>Scrollable content</div>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      headerVisible: true
+    }
+  },
+  computed: {
+    scrollbarConfig() {
+      return {
+        offset: {
+          blockStart: this.headerVisible ? 64 : 0
+        },
+        showScrollbar: 'always'
+      }
+    }
+  }
+}
+</script>
+```
+
 ## Limitations
 
 Adding this directive to a DOM element or a Vue component will alter the DOM structure, by adding four elements inside the one that the directive was attached to. If the scrollable region is a Vue component, it's recommended to wrap it in a `<div v-dt-scrollbar></div>`, to avoid altering the structure that the component needs.
 
 The added elements are:
 
-* One with the class `os-size-observer`
-* The second one is the scrollable viewport
-* The horizontal scrollbar
-* The vertical scrollbar
+- One with the class `os-size-observer`
+- The second one is the scrollable viewport
+- The horizontal scrollbar
+- The vertical scrollbar
 
 This can make it challenging to use with components that rely on event listeners or may even render it unusable.
 
@@ -148,7 +356,7 @@ This can make it challenging to use with components that rely on event listeners
 
 <style lang="less" scoped>
 .item {
-  padding: var(--dt-spacing-50) var(--dt-spacing-100);
+  padding: var(--dt-size-300) var(--dt-size-400);
   border-block-end: var(--dt-size-border-100) solid var(--dt-color-border-default);
   &:last-child {
     border-block-end: none;

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-22.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2026-4-22.md
@@ -74,7 +74,7 @@ The prop names are self-documenting. The values are validated: pass `surface="fo
 The `scrollbar` prop integrates the [v-dt-scrollbar](components/scrollbar.md) directive as a first-class feature.
 
 ```vue demo
-<dt-box padding="100" border-width="100" border-radius="300" scrollbar="never" block-size="200" inline-size="200">
+<dt-box padding="100" border-width="100" border-radius="300" scrollbar="always" block-size="200" inline-size="200">
   <dt-stack gap="100" as="ul">
     <dt-text as="li" kind="body" :size="200" v-for="i in 20" :key="i">Item {{ i }}</dt-text>
   </dt-stack>

--- a/apps/dialtone-documentation/docs/guides/migration/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/index.md
@@ -35,6 +35,7 @@ Work through each applicable guide in order. Guides earlier in the list are prer
 | 12 | [Recipes to UI Kits](./recipes-to-ui-kits/) | **Yes** | Migration script | `DtRecipe*` components move to standalone `@dialpad/` UI Kit packages. |
 | 13 | [Component Props & Events](./component-props/) | **Yes** | `dialtone-migrate-props` | Value renames (including DtBox `surface`/`bc`, DtText `tone-strong`, DtButton `link-kind`), `show` becomes `open`, `hide-*` inversion, `title` becomes `header-text`, event/slot renames, `rootClass` removal. |
 | 14 | [DtChip interactive default](./chip-interactive/) | **Yes** | `dialtone-migrate-chip-interactive` | `interactive` prop default changed from `true` to `false`. Chips that need click/keyboard behavior must opt in with `:interactive="true"`. |
+| 15 | [Scrollbar :never → :always](./scrollbar-always/) | **Yes** | `dialtone-migrate-scrollbar-always` | `v-dt-scrollbar:never` renamed to `v-dt-scrollbar:always`; `DtBox` `scrollbar="never"` renamed to `scrollbar="always"`. |
 
 ### Framework
 
@@ -90,7 +91,10 @@ npx dialtone-migrate-props --cwd ./src
 # 12. DtChip interactive default (adds :interactive="true" to clickable chips)
 npx dialtone-migrate-chip-interactive --cwd ./src
 
-# 13. ESLint auto-fix pass
+# 13. Scrollbar :never → :always
+npx dialtone-migrate-scrollbar-always --cwd ./src
+
+# 14. ESLint auto-fix pass
 npx eslint --fix "src/**/*.vue"
 ```
 

--- a/apps/dialtone-documentation/docs/guides/migration/scrollbar-always/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/scrollbar-always/index.md
@@ -19,7 +19,7 @@ description: "The v-dt-scrollbar directive argument :never and the DtBox scrollb
 | `v-dt-scrollbar:never` | `v-dt-scrollbar:always` |
 | `scrollbar="never"` (DtBox) | `scrollbar="always"` (DtBox) |
 
-All other directive arguments (`leave`, `scroll`, `move`) and DtBox scrollbar values are unchanged.
+All other directive arguments (`enter`, `scroll`, `move`) and DtBox scrollbar values are unchanged.
 
 ## Migration
 

--- a/apps/dialtone-documentation/docs/guides/migration/scrollbar-always/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/scrollbar-always/index.md
@@ -1,0 +1,42 @@
+---
+title: "Scrollbar: :never renamed to :always"
+description: "The v-dt-scrollbar directive argument :never and the DtBox scrollbar=\"never\" prop value have been renamed to :always and scrollbar=\"always\" to reflect their actual meaning."
+---
+
+## TLDR
+
+> [!CRITICAL] Breaking Change
+> The `v-dt-scrollbar:never` directive argument and the `DtBox` `scrollbar="never"` prop value have been renamed to `:always` and `"always"`. Run the migration script to update your code automatically.
+
+## Why
+
+`v-dt-scrollbar:never` was confusing — "never" implied the scrollbar would never appear, when it actually meant "never auto-hide", i.e., the scrollbar is **always visible**. The rename to `:always` expresses the intent directly.
+
+## What Changed
+
+| Before | After |
+| --- | --- |
+| `v-dt-scrollbar:never` | `v-dt-scrollbar:always` |
+| `scrollbar="never"` (DtBox) | `scrollbar="always"` (DtBox) |
+
+All other directive arguments (`leave`, `scroll`, `move`) and DtBox scrollbar values are unchanged.
+
+## Migration
+
+Run the migration script from your project root:
+
+```bash
+npx dialtone-migrate-scrollbar-always --cwd ./src
+```
+
+The script replaces all occurrences of `v-dt-scrollbar:never` and `scrollbar="never"` in `.vue` and `.html` files. Add `--dry-run` to preview changes without writing files. Add `--yes` to apply without prompting.
+
+```html
+<!-- Before -->
+<div v-dt-scrollbar:never>...</div>
+<dt-box scrollbar="never">...</dt-box>
+
+<!-- After -->
+<div v-dt-scrollbar:always>...</div>
+<dt-box scrollbar="always">...</dt-box>
+```

--- a/apps/dialtone-documentation/docs/scratch.md
+++ b/apps/dialtone-documentation/docs/scratch.md
@@ -1869,7 +1869,7 @@ Real-world patterns showing how `v-dt-focusgroup` composes with Dialtone compone
   <dt-text kind="headline" size="md">Scrollbar integration</dt-text>
 
 ```vue demo
-<dt-box padding="200" surface="secondary" border-width="100" border-radius="200" scrollbar="never" max-block-size="300">
+<dt-box padding="200" surface="secondary" border-width="100" border-radius="200" scrollbar="always" max-block-size="300">
   <dt-stack gap="100">
     <div v-for="i in 20" :key="i">Scrollable item {{ i }}</div>
   </dt-stack>

--- a/apps/dialtone-documentation/docs/utilities/sizing/height.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/height.md
@@ -13,7 +13,7 @@ Use `d-h-{stop}` to set a fixed height for an element using layout token stops. 
 
 ```vue demo
 <!-- @class d-d-block d-bgc-secondary d-w100p d-hmn-400 -->
-<div v-dt-scrollbar:never class="d-bar-400 d-d-flex d-g-200 d-bgc-secondary d-hmx-800">
+<div v-dt-scrollbar:always class="d-bar-400 d-d-flex d-g-200 d-bgc-secondary d-hmx-800">
   <dt-stack direction="row" align="start" gap="200">
     <dt-stack gap="100" v-for="(i, index) in layout" :key="index" v-dt-tooltip="{ message: `${i.px}px`, delay: false }">
       <dt-text kind="code" size="100" class="d-us-all">d-h-{{i.stop}}</dt-text>
@@ -32,7 +32,7 @@ Use `d-h-{stop}` to set a fixed height for an element using layout token stops. 
 Use `d-h{n}p` to set a percentage height for an element. No hyphen before the number, `p` suffix indicates a literal percentage value. Note: `d-h33p` = 33.333% and `d-h66p` = 66.667%.
 
 ```vue demo
-<div v-dt-scrollbar:never class="d-bar-400 d-d-flex d-g-200 d-bgc-secondary d-h-500 d-ta-center">
+<div v-dt-scrollbar:always class="d-bar-400 d-d-flex d-g-200 d-bgc-secondary d-h-500 d-ta-center">
   <dt-stack direction="row" align="center" justify="center" class="d-h100p d-ps-relative" v-for="i in percentage" v-dt-tooltip="{ message: `${i}%`, delay: false }">
     <dt-text kind="code" size="100" class="d-zi-active d-w-100 d-us-all">d-h{{i}}p</dt-text>
     <div class="d-w-100 d-h-350 d-ps-absolute d-bgc-moderate">

--- a/apps/dialtone-documentation/docs/utilities/sizing/size.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/size.md
@@ -14,7 +14,7 @@ Use `d-size-{stop}` to set both width and height using layout token stops. The h
 > Bare integer stops (`25`, `50`, `100`, …) are scale-indexed on the 64px base — `value_in_px = stop × 64 / 100`, so `25` = 16px and `100` = 64px. Stops with a `px` suffix (`1px`, `2px`, `8px`, `20px`, `24px`) are off-scale exceptions that encode the literal pixel value.
 
 ```vue demo
-<div v-dt-scrollbar:never class="d-bar-400 d-d-flex d-bgc-secondary d-w100p d-hmx-500 d-ta-center">
+<div v-dt-scrollbar:always class="d-bar-400 d-d-flex d-bgc-secondary d-w100p d-hmx-500 d-ta-center">
   <dt-stack gap="100" align="start">
     <div v-for="(i, index) in layout" v-dt-tooltip="{ message: `${i.px}px`, delay: false }">
       <dt-text kind="code" size="100" class="d-w-100 d-us-all">d-size-{{i.stop}}</dt-text>

--- a/apps/dialtone-documentation/docs/utilities/sizing/width.md
+++ b/apps/dialtone-documentation/docs/utilities/sizing/width.md
@@ -12,7 +12,7 @@ Use `d-w-{stop}` to set a fixed width for an element using layout token stops. T
 > Bare integer stops (`25`, `50`, `100`, …) are scale-indexed on the 64px base — `value_in_px = stop × 64 / 100`, so `25` = 16px and `100` = 64px. Stops with a `px` suffix (`1px`, `2px`, `8px`, `20px`, `24px`) are off-scale exceptions that encode the literal pixel value.
 
 ```vue demo
-<div v-dt-scrollbar:never class="d-bar-400 d-d-flex d-bgc-secondary d-w100p d-hmx-500 d-ta-center">
+<div v-dt-scrollbar:always class="d-bar-400 d-d-flex d-bgc-secondary d-w100p d-hmx-500 d-ta-center">
   <dt-stack gap="100" align="start">
     <div v-for="(i, index) in layout" v-dt-tooltip="{ message: `${i.px}px`, delay: false }">
       <dt-text kind="code" size="100" class="d-w-100 d-us-all">d-w-{{i.stop}}</dt-text>
@@ -31,7 +31,7 @@ Use `d-w-{stop}` to set a fixed width for an element using layout token stops. T
 Use `d-w{n}p` to set a percentage width for an element. No hyphen before the number, `p` suffix indicates a literal percentage value. Note: `d-w33p` = 33.333% and `d-w66p` = 66.667%.
 
 ```vue demo
-<div v-dt-scrollbar:never class="d-bar-400 d-bgc-secondary d-w100p d-hmx-500">
+<div v-dt-scrollbar:always class="d-bar-400 d-bgc-secondary d-w100p d-hmx-500">
   <div>
     <dt-stack as="div" gap="200" align="center" justify="center" class="d-w100p">
       <div v-for="i in percentage" v-dt-tooltip="{ message: `${i}%`, delay: false }" class="d-bgc-moderate d-w100p">

--- a/packages/combinator/src/components/code_panel/code_panel.vue
+++ b/packages/combinator/src/components/code_panel/code_panel.vue
@@ -8,7 +8,7 @@
   >
     <template #content>
       <div
-        v-dt-scrollbar:never
+        v-dt-scrollbar:always
         :class="['dtc-theme__canvas d-p-200', { 'd-hmx-250': !fullScreen }]"
       >
         <dtc-code-editor

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_scrollbar_always/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_scrollbar_always/index.mjs
@@ -41,10 +41,10 @@ export function transformContent (content) {
   return content
     // v-dt-scrollbar:never → v-dt-scrollbar:always
     .replace(/v-dt-scrollbar:never\b/g, 'v-dt-scrollbar:always')
-    // scrollbar="never" → scrollbar="always"
-    .replace(/\bscrollbar="never"/g, 'scrollbar="always"')
-    // scrollbar='never' → scrollbar='always'
-    .replace(/\bscrollbar='never'/g, 'scrollbar=\'always\'')
+    // scrollbar="never" → scrollbar="always" (unbound prop only; negative lookbehind excludes :scrollbar="never")
+    .replace(/(?<!:)\bscrollbar="never"/g, 'scrollbar="always"')
+    // scrollbar='never' → scrollbar='always' (unbound prop only)
+    .replace(/(?<!:)\bscrollbar='never'/g, 'scrollbar=\'always\'')
     // :scrollbar="'never'" → :scrollbar="'always'"
     .replace(/:scrollbar="'never'"/g, ':scrollbar="\'always\'"')
     // :scrollbar="\"never\"" → :scrollbar="\"always\""

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_scrollbar_always/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_scrollbar_always/index.mjs
@@ -41,14 +41,18 @@ export function transformContent (content) {
   return content
     // v-dt-scrollbar:never → v-dt-scrollbar:always
     .replace(/v-dt-scrollbar:never\b/g, 'v-dt-scrollbar:always')
-    // scrollbar="never" → scrollbar="always" (unbound prop only; negative lookbehind excludes :scrollbar="never")
-    .replace(/(?<!:)\bscrollbar="never"/g, 'scrollbar="always"')
-    // scrollbar='never' → scrollbar='always' (unbound prop only)
-    .replace(/(?<!:)\bscrollbar='never'/g, 'scrollbar=\'always\'')
-    // :scrollbar="'never'" → :scrollbar="'always'"
-    .replace(/:scrollbar="'never'"/g, ':scrollbar="\'always\'"')
-    // :scrollbar="\"never\"" → :scrollbar="\"always\""
-    .replace(/:scrollbar='"never"'/g, ':scrollbar=\'"always"\'');
+    // DtBox scrollbar prop: match the entire opening <dt-box>/<DtBox> tag, rewrite only within it
+    .replace(/<(dt-box|DtBox)\b[\s\S]*?>/g, tag =>
+      tag
+        // scrollbar="never" → scrollbar="always" (unbound prop only; negative lookbehind excludes :scrollbar="never")
+        .replace(/(?<!:)\bscrollbar="never"/g, 'scrollbar="always"')
+        // scrollbar='never' → scrollbar='always' (unbound prop only)
+        .replace(/(?<!:)\bscrollbar='never'/g, 'scrollbar=\'always\'')
+        // :scrollbar="'never'" → :scrollbar="'always'"
+        .replace(/:scrollbar="'never'"/g, ':scrollbar="\'always\'"')
+        // :scrollbar="\"never\"" → :scrollbar="\"always\""
+        .replace(/:scrollbar='"never"'/g, ':scrollbar=\'"always"\''),
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_scrollbar_always/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_scrollbar_always/index.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+/**
+ * @fileoverview Migration script for v-dt-scrollbar :never → :always rename.
+ *
+ * DLT-3158  The `:never` directive argument was renamed to `:always` to reflect
+ *           its actual meaning (always show the scrollbar, never auto-hide it).
+ *           The `DtBox` `scrollbar="never"` prop value is similarly renamed to
+ *           `scrollbar="always"`.
+ *
+ * This script:
+ *   - Replaces `v-dt-scrollbar:never` with `v-dt-scrollbar:always` in .vue and .html files.
+ *   - Replaces `scrollbar="never"` with `scrollbar="always"` (DtBox prop) in .vue files.
+ *   - Replaces `:scrollbar="'never'"` and `scrollbar='never'` variants in .vue files.
+ *
+ * Usage:
+ *   npx dialtone-migrate-scrollbar-always [options]
+ *
+ * Options:
+ *   --cwd <path>   Working directory (default: cwd)
+ *   --dry-run      Show changes without applying them
+ *   --yes          Apply all changes without prompting
+ *   --help         Show help
+ */
+
+import fs from 'fs/promises';
+import { realpathSync } from 'node:fs';
+import path from 'path';
+import readline from 'readline';
+import { fileURLToPath } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// Transform
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply all renames to a single file's content.
+ * Returns the transformed string (may be identical to input if no matches).
+ */
+export function transformContent (content) {
+  return content
+    // v-dt-scrollbar:never → v-dt-scrollbar:always
+    .replace(/v-dt-scrollbar:never\b/g, 'v-dt-scrollbar:always')
+    // scrollbar="never" → scrollbar="always"
+    .replace(/\bscrollbar="never"/g, 'scrollbar="always"')
+    // scrollbar='never' → scrollbar='always'
+    .replace(/\bscrollbar='never'/g, 'scrollbar=\'always\'')
+    // :scrollbar="'never'" → :scrollbar="'always'"
+    .replace(/:scrollbar="'never'"/g, ':scrollbar="\'always\'"')
+    // :scrollbar="\"never\"" → :scrollbar="\"always\""
+    .replace(/:scrollbar='"never"'/g, ':scrollbar=\'"always"\'');
+}
+
+// ---------------------------------------------------------------------------
+// File walker
+// ---------------------------------------------------------------------------
+
+function isIgnoredPath (fullPath, ignore) {
+  const segments = fullPath.split(path.sep);
+  return ignore.some(ig => {
+    if (ig.includes('/')) {
+      const parts = ig.split('/');
+      for (let i = 0; i + parts.length <= segments.length; i++) {
+        if (parts.every((p, j) => segments[i + j] === p)) return true;
+      }
+      return false;
+    }
+    return segments.includes(ig);
+  });
+}
+
+async function findFiles (dir, extensions, ignore = []) {
+  const results = [];
+  async function walk (currentDir) {
+    let entries;
+    try {
+      entries = await fs.readdir(currentDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (isIgnoredPath(fullPath, ignore)) continue;
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.isFile() && extensions.some(ext => entry.name.endsWith(ext))) {
+        results.push(fullPath);
+      }
+    }
+  }
+  await walk(dir);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// CLI plumbing
+// ---------------------------------------------------------------------------
+
+function printHelp () {
+  console.log(`
+Usage: npx dialtone-migrate-scrollbar-always [options]
+
+Renames the v-dt-scrollbar ":never" directive argument to ":always" (DLT-3158).
+Also renames the DtBox scrollbar="never" prop value to scrollbar="always".
+
+Options:
+  --cwd <path>   Working directory (default: cwd)
+  --dry-run      Show changes without applying them
+  --yes          Apply all changes without prompting
+  --help         Show help
+
+Examples:
+  npx dialtone-migrate-scrollbar-always
+  npx dialtone-migrate-scrollbar-always --dry-run
+  npx dialtone-migrate-scrollbar-always --cwd ./src
+  npx dialtone-migrate-scrollbar-always --yes
+`);
+}
+
+function parseArgs (args) {
+  const cwdIndex = args.indexOf('--cwd');
+  return {
+    help: args.includes('--help'),
+    dryRun: args.includes('--dry-run'),
+    autoYes: args.includes('--yes'),
+    cwd: cwdIndex !== -1 && args[cwdIndex + 1]
+      ? path.resolve(args[cwdIndex + 1])
+      : process.cwd(),
+  };
+}
+
+async function prompt (question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise(resolve => {
+    rl.question(question, answer => {
+      rl.close();
+      resolve(answer.trim().toLowerCase());
+    });
+  });
+}
+
+async function scanFiles (cwd) {
+  const extensions = ['.vue', '.html'];
+  const ignore = ['node_modules', 'dist', '.git', '.vuepress/public', '.vuepress/.temp', '.vuepress/.cache', 'storybook-static'];
+  const files = await findFiles(cwd, extensions, ignore);
+
+  const changes = [];
+
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8');
+    const transformed = transformContent(content);
+    if (transformed !== content) {
+      changes.push({ file, content, transformed });
+    }
+  }
+
+  return changes;
+}
+
+async function applyChanges (changes, autoYes) {
+  if (!autoYes) {
+    const answer = await prompt('\nApply changes? (y/N) ');
+    if (answer !== 'y' && answer !== 'yes') {
+      console.log('Cancelled.');
+      return false;
+    }
+  }
+  for (const { file, transformed } of changes) {
+    await fs.writeFile(file, transformed, 'utf8');
+  }
+  return true;
+}
+
+function printChangeSummary (changes, cwd) {
+  console.log(`\nFound changes in ${changes.length} file(s):\n`);
+  for (const { file } of changes) {
+    console.log(`  ${path.relative(cwd, file)}`);
+  }
+}
+
+async function main () {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  console.log(`\nScanning ${opts.cwd} for v-dt-scrollbar:never and scrollbar="never" usages...`);
+
+  const changes = await scanFiles(opts.cwd);
+
+  if (changes.length === 0) {
+    console.log('No usages found. Nothing to migrate.');
+    process.exit(0);
+  }
+
+  printChangeSummary(changes, opts.cwd);
+
+  if (opts.dryRun) {
+    console.log('\n--dry-run: No files were modified.');
+    process.exit(0);
+  }
+
+  const applied = await applyChanges(changes, opts.autoYes);
+  if (applied) console.log(`\nMigrated ${changes.length} file(s).\n`);
+}
+
+const isDirectRun = (() => {
+  try {
+    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectRun) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/dialtone-css/lib/build/less/components/box.less
+++ b/packages/dialtone-css/lib/build/less/components/box.less
@@ -99,6 +99,7 @@
   });
 }
 
+
 //  ============================================================================
 //  $   VALUE LISTS
 //  ----------------------------------------------------------------------------
@@ -140,6 +141,7 @@
   // Padding cascade: specific → axis → shorthand → 0
   padding-block:  var(--box-pbs, var(--box-pbl, var(--box-p, 0))) var(--box-pbe, var(--box-pbl, var(--box-p, 0)));
   padding-inline: var(--box-pis, var(--box-pi,  var(--box-p, 0))) var(--box-pie, var(--box-pi,  var(--box-p, 0)));
+
 }
 
 //  ============================================================================

--- a/packages/dialtone-css/lib/build/less/components/scrollbar.less
+++ b/packages/dialtone-css/lib/build/less/components/scrollbar.less
@@ -31,6 +31,19 @@
       }
     }
   }
+
+  // Scrollbar track offsets via CSS custom properties set by v-dt-scrollbar directive.
+  // Vertical scrollbar: offset from block-start (top) and inline-end (right).
+  // Horizontal scrollbar: offset from block-end (bottom) and inline-start (left).
+  .os-scrollbar-vertical {
+    inset-block-start: var(--dt-scrollbar-offset-block-start, 0);
+    inset-inline-end: var(--dt-scrollbar-offset-inline-end, 0);
+  }
+
+  .os-scrollbar-horizontal {
+    inset-block-end: var(--dt-scrollbar-offset-block-end, 0);
+    inset-inline-start: var(--dt-scrollbar-offset-inline-start, 0);
+  }
 }
 
 // put this class on html element to disable the scrollbar on body (useful for modals)

--- a/packages/dialtone-css/lib/build/less/components/scrollbar.less
+++ b/packages/dialtone-css/lib/build/less/components/scrollbar.less
@@ -30,19 +30,28 @@
         opacity: var(--dt-opacity-1100);
       }
     }
-  }
 
-  // Scrollbar track offsets via CSS custom properties set by v-dt-scrollbar directive.
-  // Vertical scrollbar: offset from block-start (top) and inline-end (right).
-  // Horizontal scrollbar: offset from block-end (bottom) and inline-start (left).
-  .os-scrollbar-vertical {
-    inset-block-start: var(--dt-scrollbar-offset-block-start, 0);
-    inset-inline-end: var(--dt-scrollbar-offset-inline-end, 0);
-  }
+    // Track offsets via CSS custom properties set by v-dt-scrollbar directive.
+    // The base rules (0,3,0) beat OS's non-cornerless rules (0,1,0).
+    // The cornerless overrides (0,4,0) beat OS's cornerless rules (0,3,0) which reset
+    // top/bottom on vertical and left/right on horizontal — regardless of import order.
+    &.os-scrollbar-vertical {
+      inset-block-start: var(--dt-scrollbar-offset-block-start, 0);
+      inset-inline-end: var(--dt-scrollbar-offset-inline-end, 0);
+    }
 
-  .os-scrollbar-horizontal {
-    inset-block-end: var(--dt-scrollbar-offset-block-end, 0);
-    inset-inline-start: var(--dt-scrollbar-offset-inline-start, 0);
+    &.os-scrollbar-vertical.os-scrollbar-cornerless {
+      inset-block: var(--dt-scrollbar-offset-block-start, 0) var(--dt-scrollbar-offset-block-end, 0);
+    }
+
+    &.os-scrollbar-horizontal {
+      inset-block-end: var(--dt-scrollbar-offset-block-end, 0);
+      inset-inline-start: var(--dt-scrollbar-offset-inline-start, 0);
+    }
+
+    &.os-scrollbar-horizontal.os-scrollbar-cornerless {
+      inset-inline: var(--dt-scrollbar-offset-inline-start, 0) var(--dt-scrollbar-offset-inline-end, 0);
+    }
   }
 }
 

--- a/packages/dialtone-css/package.json
+++ b/packages/dialtone-css/package.json
@@ -53,7 +53,8 @@
     "dialtone-migration-helper": "./lib/dist/js/dialtone_migration_helper/index.mjs",
     "dialtone-migrate-flex-to-stack": "./lib/dist/js/dialtone_migrate_flex_to_stack/index.mjs",
     "dialtone-migrate-link-rendering": "./lib/dist/js/dialtone_migrate_link_rendering/index.mjs",
-    "dialtone-migrate-chip-interactive": "./lib/dist/js/dialtone_migrate_chip_interactive/index.mjs"
+    "dialtone-migrate-chip-interactive": "./lib/dist/js/dialtone_migrate_chip_interactive/index.mjs",
+    "dialtone-migrate-scrollbar-always": "./lib/dist/js/dialtone_migrate_scrollbar_always/index.mjs"
   },
   "type": "module",
   "scripts": {

--- a/packages/dialtone-vue/components/box/box.test.js
+++ b/packages/dialtone-vue/components/box/box.test.js
@@ -366,7 +366,7 @@ describe('DtBox', () => {
   // ── Scrollbar ──────────────────────────────────────────────
 
   it('renders scrollbar viewport wrapper when scrollbar prop is set', () => {
-    const wrapper = mountComponent({ scrollbar: 'never' });
+    const wrapper = mountComponent({ scrollbar: 'always' });
 
     expect(wrapper.find('[data-qa="dt-box-scrollbar-content"]').exists()).toBe(true);
   });

--- a/packages/dialtone-vue/components/box/box.vue
+++ b/packages/dialtone-vue/components/box/box.vue
@@ -55,7 +55,7 @@ const props = defineProps({
   /**
    * Custom scrollbar via OverlayScrollbars. When set, an inner viewport
    * wrapper (.d-box__scrollbar-content) is inserted automatically.
-   * @values leave, scroll, move, never
+   * @values leave, scroll, move, always
    */
   scrollbar: { type: [String, Boolean], default: undefined, validator: scrollbarValidator },
 

--- a/packages/dialtone-vue/components/box/box_constants.js
+++ b/packages/dialtone-vue/components/box/box_constants.js
@@ -10,6 +10,7 @@ export const DT_BOX_AS_VALUES = ['div', 'span', 'section', 'article', 'aside', '
  */
 export const DT_BOX_SPACING_VALUES = ['0', '1', '25', '50', '75', '100', '125', '150', '175', '200', '250', '300', '350', '400', '450', '500', '525', '550', '600', '650', '700', '750', '800'];
 
+
 /**
  * Surface color values (neutral + semantic + subtle/strong + opaque).
  * @type {string[]}
@@ -77,4 +78,4 @@ export const DT_BOX_OVERFLOW_VALUES = ['hidden', 'scroll', 'auto', 'clip', 'visi
  * Scrollbar autoHide mode values (maps to OverlayScrollbars autoHide option).
  * @type {string[]}
  */
-export const DT_BOX_SCROLLBAR_VALUES = ['leave', 'scroll', 'move', 'never'];
+export const DT_BOX_SCROLLBAR_VALUES = ['leave', 'scroll', 'move', 'always'];

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
@@ -1,5 +1,28 @@
 import { OverlayScrollbars, ClickScrollPlugin } from 'overlayscrollbars';
 
+function resolveShowScrollbar (value, arg) {
+  const mode = value?.showScrollbar ?? arg ?? 'leave';
+  // 'always' maps to OS autoHide 'never' (always visible); all other values pass through
+  return mode === 'always' ? 'never' : mode;
+}
+
+const OFFSET_SIDES = ['block-start', 'block-end', 'inline-start', 'inline-end'];
+
+function setProp (el, prop, val) {
+  val != null ? el.style.setProperty(prop, val) : el.style.removeProperty(prop);
+}
+
+function applyOffset (el, offset) {
+  if (!offset) {
+    for (const s of OFFSET_SIDES) el.style.removeProperty(`--dt-scrollbar-offset-${s}`);
+    return;
+  }
+  setProp(el, '--dt-scrollbar-offset-block-start', offset.blockStart ?? offset.block);
+  setProp(el, '--dt-scrollbar-offset-block-end', offset.blockEnd ?? offset.block);
+  setProp(el, '--dt-scrollbar-offset-inline-start', offset.inlineStart ?? offset.inline);
+  setProp(el, '--dt-scrollbar-offset-inline-end', offset.inlineEnd ?? offset.inline);
+}
+
 export const DtScrollbarDirective = {
   name: 'dt-scrollbar-directive',
   install (app) {
@@ -7,6 +30,8 @@ export const DtScrollbarDirective = {
     const instances = new WeakMap();
     app.directive('dt-scrollbar', {
       mounted (el, binding) {
+        const autoHide = resolveShowScrollbar(binding.value, binding.arg);
+        const noDelay = autoHide === 'never' || autoHide === 'leave';
         const os = OverlayScrollbars({
           target: el,
           elements: {
@@ -14,14 +39,28 @@ export const DtScrollbarDirective = {
           },
         }, {
           scrollbars: {
-            autoHide: `${binding.arg || 'leave'}`,
+            autoHide,
             clickScroll: true,
-            autoHideDelay: `${!binding.arg || binding.arg === 'leave' ? 0 : 1300}`,
+            autoHideDelay: `${noDelay ? 0 : 1300}`,
           },
         });
         el.setAttribute('data-overlayscrollbars-initialize', true);
         el.classList.add('d-scrollbar');
+        applyOffset(el, binding.value?.offset);
         instances.set(el, os);
+      },
+      updated (el, binding) {
+        const os = instances.get(el);
+        if (!os) return;
+        const autoHide = resolveShowScrollbar(binding.value, binding.arg);
+        const noDelay = autoHide === 'never' || autoHide === 'leave';
+        os.options({
+          scrollbars: {
+            autoHide,
+            autoHideDelay: noDelay ? 0 : 1300,
+          },
+        });
+        applyOffset(el, binding.value?.offset);
       },
       unmounted (el) {
         instances.get(el).destroy();

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
@@ -29,6 +29,14 @@ function applyOffset (el, offset) {
   setProp(el, '--dt-scrollbar-offset-inline-end', offset.inlineEnd ?? offset.inline);
 }
 
+function applyScrollbarClasses (os, value, prev) {
+  const { scrollbarVertical, scrollbarHorizontal } = os.elements();
+  if (prev?.blockClasses) scrollbarVertical.scrollbar.classList.remove(...prev.blockClasses.split(' ').filter(Boolean));
+  if (prev?.inlineClasses) scrollbarHorizontal.scrollbar.classList.remove(...prev.inlineClasses.split(' ').filter(Boolean));
+  if (value?.blockClasses) scrollbarVertical.scrollbar.classList.add(...value.blockClasses.split(' ').filter(Boolean));
+  if (value?.inlineClasses) scrollbarHorizontal.scrollbar.classList.add(...value.inlineClasses.split(' ').filter(Boolean));
+}
+
 export const DtScrollbarDirective = {
   name: 'dt-scrollbar-directive',
   install (app) {
@@ -53,6 +61,7 @@ export const DtScrollbarDirective = {
         el.setAttribute('data-overlayscrollbars-initialize', true);
         el.classList.add('d-scrollbar');
         applyOffset(el, binding.value?.offset);
+        applyScrollbarClasses(os, binding.value);
         instances.set(el, os);
       },
       updated (el, binding) {
@@ -67,6 +76,7 @@ export const DtScrollbarDirective = {
           },
         });
         applyOffset(el, binding.value?.offset);
+        applyScrollbarClasses(os, binding.value, binding.oldValue);
       },
       unmounted (el) {
         instances.get(el).destroy();

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
@@ -1,7 +1,13 @@
 import { OverlayScrollbars, ClickScrollPlugin } from 'overlayscrollbars';
 
+const VALID_SHOW_SCROLLBAR = new Set(['always', 'enter', 'scroll', 'move']);
+
 function resolveShowScrollbar (value, arg) {
   const mode = value?.showScrollbar ?? arg ?? 'enter';
+  if (!VALID_SHOW_SCROLLBAR.has(mode)) {
+    console.info(`[v-dt-scrollbar] Unknown showScrollbar value "${mode}". Valid values: ${[...VALID_SHOW_SCROLLBAR].join(', ')}. Falling back to "enter".`);
+    return 'leave'; // 'enter' resolved
+  }
   // 'always' → OS 'never' (always visible); 'enter' → OS 'leave' (show on enter, hide on leave)
   if (mode === 'always') return 'never';
   if (mode === 'enter') return 'leave';

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
@@ -47,7 +47,7 @@ export const DtScrollbarDirective = {
           scrollbars: {
             autoHide,
             clickScroll: true,
-            autoHideDelay: `${noDelay ? 0 : 1300}`,
+            autoHideDelay: noDelay ? 0 : 1300,
           },
         });
         el.setAttribute('data-overlayscrollbars-initialize', true);

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
@@ -1,15 +1,21 @@
 import { OverlayScrollbars, ClickScrollPlugin } from 'overlayscrollbars';
 
 function resolveShowScrollbar (value, arg) {
-  const mode = value?.showScrollbar ?? arg ?? 'leave';
-  // 'always' maps to OS autoHide 'never' (always visible); all other values pass through
-  return mode === 'always' ? 'never' : mode;
+  const mode = value?.showScrollbar ?? arg ?? 'enter';
+  // 'always' → OS 'never' (always visible); 'enter' → OS 'leave' (show on enter, hide on leave)
+  if (mode === 'always') return 'never';
+  if (mode === 'enter') return 'leave';
+  return mode;
 }
 
 const OFFSET_SIDES = ['block-start', 'block-end', 'inline-start', 'inline-end'];
 
+function toCssLength (val) {
+  return typeof val === 'number' ? `${val}px` : val;
+}
+
 function setProp (el, prop, val) {
-  val != null ? el.style.setProperty(prop, val) : el.style.removeProperty(prop);
+  val != null ? el.style.setProperty(prop, toCssLength(val)) : el.style.removeProperty(prop);
 }
 
 function applyOffset (el, offset) {
@@ -31,7 +37,7 @@ export const DtScrollbarDirective = {
     app.directive('dt-scrollbar', {
       mounted (el, binding) {
         const autoHide = resolveShowScrollbar(binding.value, binding.arg);
-        const noDelay = autoHide === 'never' || autoHide === 'leave';
+        const noDelay = autoHide === 'never' || autoHide === 'leave'; // OS values, already resolved
         const os = OverlayScrollbars({
           target: el,
           elements: {
@@ -53,7 +59,7 @@ export const DtScrollbarDirective = {
         const os = instances.get(el);
         if (!os) return;
         const autoHide = resolveShowScrollbar(binding.value, binding.arg);
-        const noDelay = autoHide === 'never' || autoHide === 'leave';
+        const noDelay = autoHide === 'never' || autoHide === 'leave'; // OS values, already resolved
         os.options({
           scrollbars: {
             autoHide,

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
@@ -85,7 +85,9 @@ export const DtScrollbarDirective = {
         applyScrollbarClasses(os, binding.value, binding.oldValue);
       },
       unmounted (el) {
-        instances.get(el).destroy();
+        const os = instances.get(el);
+        if (os) os.destroy();
+        instances.delete(el);
       },
     });
   },

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
@@ -274,4 +274,90 @@ describe('DtScrollbarDirective Tests', () => {
       });
     });
   });
+
+  describe('Interactivity Tests', () => {
+    const optsComponent = makeWrapper(
+      `<div v-dt-scrollbar="opts"><div id="viewport"></div></div>`,
+      { props: { opts: { type: Object, default: () => ({}) } } },
+    );
+
+    describe('when showScrollbar prop changes', () => {
+      beforeEach(async () => {
+        mountWith(optsComponent, { opts: { showScrollbar: 'enter' } });
+        await wrapper.setProps({ opts: { showScrollbar: 'always' } });
+      });
+
+      it('should call options on the existing instance with new autoHide', () => {
+        expect(mocks.options).toHaveBeenCalledWith(
+          { scrollbars: { autoHide: 'never', autoHideDelay: 0 } },
+        );
+      });
+
+      it('should not re-initialize OverlayScrollbars', () => {
+        expect(OverlayScrollbars).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not call destroy during update', () => {
+        expect(mocks.destroy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when showScrollbar changes from always to scroll', () => {
+      beforeEach(async () => {
+        mountWith(optsComponent, { opts: { showScrollbar: 'always' } });
+        await wrapper.setProps({ opts: { showScrollbar: 'scroll' } });
+      });
+
+      it('should call options with autoHide scroll and delay', () => {
+        expect(mocks.options).toHaveBeenCalledWith(
+          { scrollbars: { autoHide: 'scroll', autoHideDelay: 1300 } },
+        );
+      });
+    });
+
+    describe('when offset prop changes', () => {
+      beforeEach(async () => {
+        mountWith(optsComponent, { opts: { offset: { blockStart: '1rem' } } });
+        await wrapper.setProps({ opts: { offset: { blockStart: '3rem', inlineEnd: '2rem' } } });
+      });
+
+      it('should update block-start custom property', () => {
+        expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-block-start')).toBe('3rem');
+      });
+
+      it('should set newly added inline-end custom property', () => {
+        expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-inline-end')).toBe('2rem');
+      });
+    });
+
+    describe('when blockClasses prop changes', () => {
+      beforeEach(async () => {
+        mountWith(optsComponent, { opts: { blockClasses: 'd-w8' } });
+        await wrapper.setProps({ opts: { blockClasses: 'd-w12' } });
+      });
+
+      it('should remove old blockClasses from the vertical scrollbar', () => {
+        expect(mocks.blockScrollbar.classList.contains('d-w8')).toBe(false);
+      });
+
+      it('should add new blockClasses to the vertical scrollbar', () => {
+        expect(mocks.blockScrollbar.classList.contains('d-w12')).toBe(true);
+      });
+    });
+
+    describe('when inlineClasses prop changes', () => {
+      beforeEach(async () => {
+        mountWith(optsComponent, { opts: { inlineClasses: 'd-h8' } });
+        await wrapper.setProps({ opts: { inlineClasses: 'd-h12' } });
+      });
+
+      it('should remove old inlineClasses from the horizontal scrollbar', () => {
+        expect(mocks.inlineScrollbar.classList.contains('d-h8')).toBe(false);
+      });
+
+      it('should add new inlineClasses to the horizontal scrollbar', () => {
+        expect(mocks.inlineScrollbar.classList.contains('d-h12')).toBe(true);
+      });
+    });
+  });
 });

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
@@ -2,16 +2,18 @@ import { mount } from '@vue/test-utils';
 import { DtScrollbarDirective } from './scrollbar.js';
 import { OverlayScrollbars } from 'overlayscrollbars';
 
-const WrapperComponent = {
+const makeWrapper = (template, options = {}) => ({
   name: 'wrapper-component',
-  template: `
-    <div v-dt-scrollbar><div id="viewport"></div></div>
-  `,
-};
+  template,
+  ...options,
+});
+
+const WrapperDefault = makeWrapper(`<div v-dt-scrollbar><div id="viewport"></div></div>`);
 
 const mocks = vi.hoisted(() => {
   return {
     destroy: vi.fn(),
+    options: vi.fn(),
   };
 });
 
@@ -19,13 +21,11 @@ describe('DtScrollbarDirective Tests', () => {
   let wrapper;
   let viewportElement;
 
-  const updateWrapper = () => {
-    wrapper = mount(WrapperComponent, {
-      global: {
-        plugins: [DtScrollbarDirective],
-      },
+  const mountWith = (component, props = {}) => {
+    wrapper = mount(component, {
+      props,
+      global: { plugins: [DtScrollbarDirective] },
     });
-
     viewportElement = wrapper.find('#viewport').element;
   };
 
@@ -36,13 +36,16 @@ describe('DtScrollbarDirective Tests', () => {
   beforeEach(() => {
     OverlayScrollbars.mockClear();
     mocks.destroy.mockClear();
+    mocks.options.mockClear();
   });
 
   beforeAll(() => {
-    // Mock the overlayscrollbars plugin
     vi.mock('overlayscrollbars', () => {
-      const mockPlugin = vi.fn(); // Mock the plugin method
-      const OverlayScrollbarsMock = vi.fn().mockImplementation(() => ({ destroy: mocks.destroy }));
+      const mockPlugin = vi.fn();
+      const OverlayScrollbarsMock = vi.fn().mockImplementation(() => ({
+        destroy: mocks.destroy,
+        options: mocks.options,
+      }));
       OverlayScrollbarsMock.plugin = mockPlugin;
       return {
         OverlayScrollbars: OverlayScrollbarsMock,
@@ -52,32 +55,113 @@ describe('DtScrollbarDirective Tests', () => {
   });
 
   describe('Presentation Tests', () => {
-    describe('when scrollbars directive is present', () => {
+    describe('when directive has no argument (default leave)', () => {
       beforeEach(() => {
-        updateWrapper();
+        mountWith(WrapperDefault);
       });
 
       it('should render the component', () => {
         expect(wrapper.exists()).toBe(true);
       });
 
-      it('should setup directive', () => {
+      it('should initialize OverlayScrollbars with autoHide leave', () => {
         expect(OverlayScrollbars).toHaveBeenCalledWith(
-          {
-            target: wrapper.element,
-            elements: {
-              viewport: viewportElement,
-            },
-          },
-          { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: '0' } });
-        expect(OverlayScrollbars).toHaveBeenCalledTimes(1);
-        expect(wrapper.element.getAttribute('data-overlayscrollbars-initialize')).toBe('true');
-        expect(wrapper.element.classList.contains('d-scrollbar')).toBe(true);
+          { target: wrapper.element, elements: { viewport: viewportElement } },
+          { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: '0' } },
+        );
       });
 
-      it('should clean up directive', () => {
+      it('should add d-scrollbar class and data attribute', () => {
+        expect(wrapper.element.classList.contains('d-scrollbar')).toBe(true);
+        expect(wrapper.element.getAttribute('data-overlayscrollbars-initialize')).toBe('true');
+      });
+
+      it('should destroy on unmount', () => {
         wrapper.unmount();
         expect(mocks.destroy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when directive arg is :always', () => {
+      beforeEach(() => {
+        mountWith(makeWrapper(`<div v-dt-scrollbar:always><div id="viewport"></div></div>`));
+      });
+
+      it('should initialize with autoHide never', () => {
+        expect(OverlayScrollbars).toHaveBeenCalledWith(
+          expect.any(Object),
+          { scrollbars: { autoHide: 'never', clickScroll: true, autoHideDelay: '0' } },
+        );
+      });
+    });
+
+    describe('when directive arg is :scroll', () => {
+      beforeEach(() => {
+        mountWith(makeWrapper(`<div v-dt-scrollbar:scroll><div id="viewport"></div></div>`));
+      });
+
+      it('should initialize with autoHide scroll and delay', () => {
+        expect(OverlayScrollbars).toHaveBeenCalledWith(
+          expect.any(Object),
+          { scrollbars: { autoHide: 'scroll', clickScroll: true, autoHideDelay: '1300' } },
+        );
+      });
+    });
+
+    describe('when directive value is an object with showScrollbar', () => {
+      beforeEach(() => {
+        mountWith(
+          makeWrapper(`<div v-dt-scrollbar="opts"><div id="viewport"></div></div>`, { props: { opts: { type: Object, default: () => ({}) } } }),
+          { opts: { showScrollbar: 'always' } },
+        );
+      });
+
+      it('should initialize with autoHide from showScrollbar value', () => {
+        expect(OverlayScrollbars).toHaveBeenCalledWith(
+          expect.any(Object),
+          { scrollbars: { autoHide: 'never', clickScroll: true, autoHideDelay: '0' } },
+        );
+      });
+    });
+
+    describe('when directive value has offset', () => {
+      beforeEach(() => {
+        mountWith(
+          makeWrapper(`<div v-dt-scrollbar="opts"><div id="viewport"></div></div>`, { props: { opts: { type: Object, default: () => ({}) } } }),
+          { opts: { offset: { blockStart: '2rem', inlineEnd: '4rem' } } },
+        );
+      });
+
+      it('should set block-start offset custom property', () => {
+        expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-block-start')).toBe('2rem');
+      });
+
+      it('should set inline-end offset custom property', () => {
+        expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-inline-end')).toBe('4rem');
+      });
+
+      it('should not set unspecified offset properties', () => {
+        expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-block-end')).toBe('');
+        expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-inline-start')).toBe('');
+      });
+    });
+
+    describe('when directive value has block/inline shorthand offset', () => {
+      beforeEach(() => {
+        mountWith(
+          makeWrapper(`<div v-dt-scrollbar="opts"><div id="viewport"></div></div>`, { props: { opts: { type: Object, default: () => ({}) } } }),
+          { opts: { offset: { block: '1rem', inline: '2rem' } } },
+        );
+      });
+
+      it('should set block-start and block-end from block shorthand', () => {
+        expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-block-start')).toBe('1rem');
+        expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-block-end')).toBe('1rem');
+      });
+
+      it('should set inline-start and inline-end from inline shorthand', () => {
+        expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-inline-start')).toBe('2rem');
+        expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-inline-end')).toBe('2rem');
       });
     });
   });

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
@@ -221,13 +221,19 @@ describe('DtScrollbarDirective Tests', () => {
         );
       });
 
-      it('should set block-start and block-end from block shorthand', () => {
+      it('should set block-start from block shorthand', () => {
         expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-block-start')).toBe('1rem');
+      });
+
+      it('should set block-end from block shorthand', () => {
         expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-block-end')).toBe('1rem');
       });
 
-      it('should set inline-start and inline-end from inline shorthand', () => {
+      it('should set inline-start from inline shorthand', () => {
         expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-inline-start')).toBe('2rem');
+      });
+
+      it('should set inline-end from inline shorthand', () => {
         expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-inline-end')).toBe('2rem');
       });
     });

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
@@ -133,6 +133,31 @@ describe('DtScrollbarDirective Tests', () => {
       });
     });
 
+    describe('when directive value has an invalid showScrollbar', () => {
+      beforeEach(() => {
+        vi.spyOn(console, 'info').mockImplementation(() => {});
+        mountWith(
+          makeWrapper(`<div v-dt-scrollbar="opts"><div id="viewport"></div></div>`, { props: { opts: { type: Object, default: () => ({}) } } }),
+          { opts: { showScrollbar: 'invalid-value' } },
+        );
+      });
+
+      afterEach(() => {
+        console.info.mockRestore();
+      });
+
+      it('should log an informational message', () => {
+        expect(console.info).toHaveBeenCalledWith(expect.stringContaining('"invalid-value"'));
+      });
+
+      it('should fall back to enter mode (autoHide leave)', () => {
+        expect(OverlayScrollbars).toHaveBeenCalledWith(
+          expect.any(Object),
+          { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: 0 } },
+        );
+      });
+    });
+
     describe('when directive value is an object with showScrollbar', () => {
       beforeEach(() => {
         mountWith(

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
@@ -55,7 +55,7 @@ describe('DtScrollbarDirective Tests', () => {
   });
 
   describe('Presentation Tests', () => {
-    describe('when directive has no argument (default leave)', () => {
+    describe('when directive has no argument (default enter)', () => {
       beforeEach(() => {
         mountWith(WrapperDefault);
       });
@@ -64,7 +64,7 @@ describe('DtScrollbarDirective Tests', () => {
         expect(wrapper.exists()).toBe(true);
       });
 
-      it('should initialize OverlayScrollbars with autoHide leave', () => {
+      it('should initialize OverlayScrollbars with autoHide leave (enter mode)', () => {
         expect(OverlayScrollbars).toHaveBeenCalledWith(
           { target: wrapper.element, elements: { viewport: viewportElement } },
           { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: '0' } },
@@ -91,6 +91,19 @@ describe('DtScrollbarDirective Tests', () => {
         expect(OverlayScrollbars).toHaveBeenCalledWith(
           expect.any(Object),
           { scrollbars: { autoHide: 'never', clickScroll: true, autoHideDelay: '0' } },
+        );
+      });
+    });
+
+    describe('when directive arg is :enter', () => {
+      beforeEach(() => {
+        mountWith(makeWrapper(`<div v-dt-scrollbar:enter><div id="viewport"></div></div>`));
+      });
+
+      it('should initialize with autoHide leave', () => {
+        expect(OverlayScrollbars).toHaveBeenCalledWith(
+          expect.any(Object),
+          { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: '0' } },
         );
       });
     });
@@ -143,6 +156,23 @@ describe('DtScrollbarDirective Tests', () => {
       it('should not set unspecified offset properties', () => {
         expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-block-end')).toBe('');
         expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-inline-start')).toBe('');
+      });
+    });
+
+    describe('when directive value has numeric offset', () => {
+      beforeEach(() => {
+        mountWith(
+          makeWrapper(`<div v-dt-scrollbar="opts"><div id="viewport"></div></div>`, { props: { opts: { type: Object, default: () => ({}) } } }),
+          { opts: { offset: { blockStart: 64, inlineEnd: 16 } } },
+        );
+      });
+
+      it('should append px to numeric block-start offset', () => {
+        expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-block-start')).toBe('64px');
+      });
+
+      it('should append px to numeric inline-end offset', () => {
+        expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-inline-end')).toBe('16px');
       });
     });
 

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
@@ -11,9 +11,17 @@ const makeWrapper = (template, options = {}) => ({
 const WrapperDefault = makeWrapper(`<div v-dt-scrollbar><div id="viewport"></div></div>`);
 
 const mocks = vi.hoisted(() => {
+  const blockScrollbar = document.createElement('div');
+  const inlineScrollbar = document.createElement('div');
   return {
     destroy: vi.fn(),
     options: vi.fn(),
+    elements: vi.fn(() => ({
+      scrollbarVertical: { scrollbar: blockScrollbar },
+      scrollbarHorizontal: { scrollbar: inlineScrollbar },
+    })),
+    blockScrollbar,
+    inlineScrollbar,
   };
 });
 
@@ -37,6 +45,9 @@ describe('DtScrollbarDirective Tests', () => {
     OverlayScrollbars.mockClear();
     mocks.destroy.mockClear();
     mocks.options.mockClear();
+    mocks.elements.mockClear();
+    mocks.blockScrollbar.className = '';
+    mocks.inlineScrollbar.className = '';
   });
 
   beforeAll(() => {
@@ -45,6 +56,7 @@ describe('DtScrollbarDirective Tests', () => {
       const OverlayScrollbarsMock = vi.fn().mockImplementation(() => ({
         destroy: mocks.destroy,
         options: mocks.options,
+        elements: mocks.elements,
       }));
       OverlayScrollbarsMock.plugin = mockPlugin;
       return {
@@ -192,6 +204,42 @@ describe('DtScrollbarDirective Tests', () => {
       it('should set inline-start and inline-end from inline shorthand', () => {
         expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-inline-start')).toBe('2rem');
         expect(wrapper.element.style.getPropertyValue('--dt-scrollbar-offset-inline-end')).toBe('2rem');
+      });
+    });
+
+    describe('when directive value has blockClasses', () => {
+      beforeEach(() => {
+        mountWith(
+          makeWrapper(`<div v-dt-scrollbar="opts"><div id="viewport"></div></div>`, { props: { opts: { type: Object, default: () => ({}) } } }),
+          { opts: { blockClasses: 'd-w12 d-bgc-purple-300' } },
+        );
+      });
+
+      it('should add blockClasses to the vertical scrollbar element', () => {
+        expect(mocks.blockScrollbar.classList.contains('d-w12')).toBe(true);
+        expect(mocks.blockScrollbar.classList.contains('d-bgc-purple-300')).toBe(true);
+      });
+
+      it('should not add blockClasses to the horizontal scrollbar element', () => {
+        expect(mocks.inlineScrollbar.classList.contains('d-w12')).toBe(false);
+      });
+    });
+
+    describe('when directive value has inlineClasses', () => {
+      beforeEach(() => {
+        mountWith(
+          makeWrapper(`<div v-dt-scrollbar="opts"><div id="viewport"></div></div>`, { props: { opts: { type: Object, default: () => ({}) } } }),
+          { opts: { inlineClasses: 'd-h8 d-bgc-blue-300' } },
+        );
+      });
+
+      it('should add inlineClasses to the horizontal scrollbar element', () => {
+        expect(mocks.inlineScrollbar.classList.contains('d-h8')).toBe(true);
+        expect(mocks.inlineScrollbar.classList.contains('d-bgc-blue-300')).toBe(true);
+      });
+
+      it('should not add inlineClasses to the vertical scrollbar element', () => {
+        expect(mocks.blockScrollbar.classList.contains('d-h8')).toBe(false);
       });
     });
   });

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
@@ -67,7 +67,7 @@ describe('DtScrollbarDirective Tests', () => {
       it('should initialize OverlayScrollbars with autoHide leave (enter mode)', () => {
         expect(OverlayScrollbars).toHaveBeenCalledWith(
           { target: wrapper.element, elements: { viewport: viewportElement } },
-          { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: '0' } },
+          { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: 0 } },
         );
       });
 
@@ -90,7 +90,7 @@ describe('DtScrollbarDirective Tests', () => {
       it('should initialize with autoHide never', () => {
         expect(OverlayScrollbars).toHaveBeenCalledWith(
           expect.any(Object),
-          { scrollbars: { autoHide: 'never', clickScroll: true, autoHideDelay: '0' } },
+          { scrollbars: { autoHide: 'never', clickScroll: true, autoHideDelay: 0 } },
         );
       });
     });
@@ -103,7 +103,7 @@ describe('DtScrollbarDirective Tests', () => {
       it('should initialize with autoHide leave', () => {
         expect(OverlayScrollbars).toHaveBeenCalledWith(
           expect.any(Object),
-          { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: '0' } },
+          { scrollbars: { autoHide: 'leave', clickScroll: true, autoHideDelay: 0 } },
         );
       });
     });
@@ -116,7 +116,7 @@ describe('DtScrollbarDirective Tests', () => {
       it('should initialize with autoHide scroll and delay', () => {
         expect(OverlayScrollbars).toHaveBeenCalledWith(
           expect.any(Object),
-          { scrollbars: { autoHide: 'scroll', clickScroll: true, autoHideDelay: '1300' } },
+          { scrollbars: { autoHide: 'scroll', clickScroll: true, autoHideDelay: 1300 } },
         );
       });
     });
@@ -132,7 +132,7 @@ describe('DtScrollbarDirective Tests', () => {
       it('should initialize with autoHide from showScrollbar value', () => {
         expect(OverlayScrollbars).toHaveBeenCalledWith(
           expect.any(Object),
-          { scrollbars: { autoHide: 'never', clickScroll: true, autoHideDelay: '0' } },
+          { scrollbars: { autoHide: 'never', clickScroll: true, autoHideDelay: 0 } },
         );
       });
     });

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar_directive_default.story.vue
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar_directive_default.story.vue
@@ -60,6 +60,46 @@
         </div>
       </div>
     </div>
+    <div>
+      <p class="d-label--md-compact d-mbe-100">
+        Offset — block-start &amp; block-end (2rem each)
+      </p>
+      <div
+        v-dt-scrollbar="{ showScrollbar: 'always', offset: { block: '2rem' } }"
+        class="d-h-250 d-w-400 d-bar-400 d-bc-default d-ba"
+      >
+        <div class="d-p-200">
+          <p
+            v-for="i in 20"
+            :key="i"
+            class="d-body--md"
+          >
+            Scrollable content line {{ i }}
+          </p>
+        </div>
+      </div>
+    </div>
+    <div>
+      <p class="d-label--md-compact d-mbe-100">
+        Offset — individual sides (blockStart 3rem, blockEnd 1rem, inlineEnd 1rem)
+      </p>
+      <div
+        v-dt-scrollbar="{
+          showScrollbar: 'always', offset: { blockStart: '3rem', blockEnd: '1rem', inlineEnd: '1rem' },
+        }"
+        class="d-h-250 d-w-400 d-bar-400 d-bc-default d-ba"
+      >
+        <div class="d-p-200">
+          <p
+            v-for="i in 20"
+            :key="i"
+            class="d-body--md"
+          >
+            Scrollable content line {{ i }}
+          </p>
+        </div>
+      </div>
+    </div>
   </dt-stack>
 </template>
 

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar_directive_default.story.vue
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar_directive_default.story.vue
@@ -24,10 +24,10 @@
     </div>
     <div>
       <p class="d-label--md-compact d-mbe-100">
-        Never auto-hide
+        Always visible
       </p>
       <div
-        v-dt-scrollbar:never
+        v-dt-scrollbar:always
         class="d-h-250 d-w-400 d-bar-400 d-bc-default d-ba"
       >
         <div class="d-p-200">


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media.giphy.com/media/3o7TKSjRrfIPjeiVyM/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-3158](https://dialpad.atlassian.net/browse/DLT-3158)

## :book: Description

Transitions `v-dt-scrollbar` to an object-based API and renames the confusing `:never` argument to `:always`.

Key changes:
- **Object API**: `v-dt-scrollbar="{ showScrollbar: 'always', offset: { blockStart: '2rem', inlineEnd: '4rem' } }"` — directive now accepts an optional config object with `showScrollbar` and `offset` fields. The existing arg shorthand (`:always`, `:scroll`, `:move`) is preserved.
- **Offset support**: New `offset` object on the directive sets CSS custom properties (`--dt-scrollbar-offset-block-start/end`, `--dt-scrollbar-offset-inline-start/end`) on the host element. Supports `block`/`inline` shorthands that expand to both sides. CSS in `scrollbar.less` uses these to reposition the scrollbar tracks via logical property overrides.
- **`:never` → `:always` rename**: The `:never` arg was unintuitive ("never auto-hide" = always visible). Renamed to `:always`. A migration script (`dialtone-migrate-scrollbar-always`) and migration guide are included.
- **`DtBox` alignment**: `scrollbar="never"` prop value updated to `scrollbar="always"`.
- **`updated` hook**: Directive now reacts to binding changes after mount.
- **Simplified internals**: `AUTO_HIDE_MAP`, `OFFSET_SIDES`, and `resolveOffset` collapsed into a ternary + `applyOffset` helper.

## :bulb: Context

The `:never` shorthand was confusing — it mapped to OverlayScrollbars' `autoHide: 'never'` (meaning always show), which reads backwards. The offset feature was requested to support use cases where fixed headers/footers overlap the scrollable region without requiring manual CSS overrides.

## :package: Cross-Package Impact

| Package | Changes | Downstream Impact |
| --- | --- | --- |
| `dialtone-css` | New offset CSS custom property rules in `scrollbar.less`; new migration script | Vue directive depends on these custom properties |
| `dialtone-vue` | Updated directive (`scrollbar.js`), updated `DtBox` scrollbar constant | Documentation site demos updated |
| `dialtone-documentation` | Updated `scrollbar.md` (object API docs, new Offset variant), migration guide, `site-nav.json` | — |

## :page_facing_up: Documentation Artifacts

| Artifact | Status |
| --- | --- |
| Vue source (`scrollbar.js`, `box.vue`) | ✅ Updated |
| Tests (`scrollbar.test.js`, `box.test.js`) | ✅ Updated |
| Storybook story (`scrollbar_directive_default.story.vue`) | ✅ Updated |
| VuePress docs (`scrollbar.md`, `box.md`) | ✅ Updated |
| Migration guide (`guides/migration/scrollbar-always/`) | ✅ Added |
| Migration script (`dialtone-migrate-scrollbar-always`) | ✅ Added |

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.


[DLT-3158]: https://dialpad.atlassian.net/browse/DLT-3158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ