### PR TITLE
feat(combobox-multi-select): DLT-3366 forward input-level escape, enter, keydown events

### DIFF
--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js
@@ -100,6 +100,16 @@ export const argTypesData = {
       disable: true,
     },
   },
+  onEnter: {
+    table: {
+      disable: true,
+    },
+  },
+  onKeydown: {
+    table: {
+      disable: true,
+    },
+  },
   onHighlight: {
     table: {
       disable: true,

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js
@@ -27,6 +27,7 @@ export const argsData = {
   onComboboxHighlight: action('comboboxHighlight'),
   onFocus: action('focus'),
   onKeydown: action('keydown'),
+  onInputKeydown: action('input-keydown'),
   onEscape: action('escape'),
   onEnter: action('enter'),
 };
@@ -106,6 +107,11 @@ export const argTypesData = {
     },
   },
   onKeydown: {
+    table: {
+      disable: true,
+    },
+  },
+  onInputKeydown: {
     table: {
       disable: true,
     },

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js
@@ -26,6 +26,9 @@ export const argsData = {
   onMaxSelected: action('maxSelected'),
   onComboboxHighlight: action('comboboxHighlight'),
   onFocus: action('focus'),
+  onKeydown: action('keydown'),
+  onEscape: action('escape'),
+  onEnter: action('enter'),
 };
 
 export const argTypesData = {

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js
@@ -27,7 +27,7 @@ export const argsData = {
   onComboboxHighlight: action('comboboxHighlight'),
   onFocus: action('focus'),
   onKeydown: action('keydown'),
-  onInputKeydown: action('input-keydown'),
+  onChipKeydown: action('chip-keydown'),
   onEscape: action('escape'),
   onEnter: action('enter'),
 };
@@ -111,7 +111,7 @@ export const argTypesData = {
       disable: true,
     },
   },
-  onInputKeydown: {
+  onChipKeydown: {
     table: {
       disable: true,
     },

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -208,7 +208,7 @@ describe('DtComboboxMultiSelect Tests', () => {
 
         describe('When LEFT key is pressed', () => {
           beforeEach(async () => {
-            input.trigger('keydown', { code: 'arrowleft' });
+            input.trigger('keydown', { key: 'arrowleft' });
           });
 
           it('should focus the last chip', () => {
@@ -220,14 +220,14 @@ describe('DtComboboxMultiSelect Tests', () => {
           it('should not call moveFromInputToChip when input has text', async () => {
             const spy = vi.spyOn(wrapper.vm, 'moveFromInputToChip');
             await input.setValue('a');
-            await input.trigger('keydown', { code: 'arrowleft' });
+            await input.trigger('keydown', { key: 'arrowleft' });
             expect(spy).not.toHaveBeenCalled();
           });
         });
 
         describe('When BACKSPACE key is pressed', () => {
           beforeEach(async () => {
-            input.trigger('keydown', { code: 'backspace' });
+            input.trigger('keydown', { key: 'backspace' });
           });
 
           it('should focus the last chip', () => {
@@ -239,7 +239,7 @@ describe('DtComboboxMultiSelect Tests', () => {
           it('should not call moveFromInputToChip when input has text', async () => {
             const spy = vi.spyOn(wrapper.vm, 'moveFromInputToChip');
             await input.setValue('a');
-            await input.trigger('keydown', { code: 'backspace' });
+            await input.trigger('keydown', { key: 'backspace' });
             expect(spy).not.toHaveBeenCalled();
           });
         });

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -340,23 +340,35 @@ describe('DtComboboxMultiSelect Tests', () => {
       });
     });
 
+    it.each([
+      { key: 'Escape', code: 'Escape' },
+      { key: 'Enter', code: 'Enter' },
+      { key: 'Enter', code: 'NumpadEnter' },
+    ])('Should emit "input-keydown" for key=$key code=$code', async ({ key, code }) => {
+      await input.trigger('keydown', { key, code });
+      expect(wrapper.emitted('input-keydown').length).toBe(1);
+    });
+
     describe('When chips are present', () => {
       beforeEach(async () => {
         await wrapper.setProps({ selectedItems: ['1'] });
         _setChildWrappers();
       });
 
-      describe('When Escape is pressed while a chip is focused', () => {
+      describe.each([
+        { key: 'Escape', semanticEvent: 'escape' },
+        { key: 'Enter', semanticEvent: 'enter' },
+      ])('When $key is pressed while a chip is focused', ({ key, semanticEvent }) => {
         beforeEach(async () => {
-          await chips.at(0).trigger('keydown', { key: 'Escape', code: 'Escape' });
+          await chips.at(0).trigger('keydown', { key, code: key });
         });
 
         it('Should still emit "keydown" from the chip', () => {
           expect(wrapper.emitted('keydown').length).toBe(1);
         });
 
-        it('Should not emit "escape"', () => {
-          expect(wrapper.emitted('escape')).toBeUndefined();
+        it(`Should not emit "${semanticEvent}"`, () => {
+          expect(wrapper.emitted(semanticEvent)).toBeUndefined();
         });
       });
 
@@ -366,13 +378,28 @@ describe('DtComboboxMultiSelect Tests', () => {
       });
     });
 
-    it('Should not emit "input-keydown" when the component is disabled', async () => {
+    describe('When the component is disabled', () => {
       // Suppressed by the explicit `if (this.disabled) return;` guard in
       // inputListeners.onKeydown — not by native DOM disabled semantics
       // (JSDOM's trigger() fires regardless of the HTML disabled attribute).
-      await wrapper.setProps({ disabled: true });
-      await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
-      expect(wrapper.emitted('input-keydown')).toBeUndefined();
+      beforeEach(async () => {
+        await wrapper.setProps({ disabled: true });
+      });
+
+      it('Should not emit "input-keydown"', async () => {
+        await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
+        expect(wrapper.emitted('input-keydown')).toBeUndefined();
+      });
+
+      it('Should not emit "escape"', async () => {
+        await input.trigger('keydown', { key: 'Escape', code: 'Escape' });
+        expect(wrapper.emitted('escape')).toBeUndefined();
+      });
+
+      it('Should not emit "enter"', async () => {
+        await input.trigger('keydown', { key: 'Enter', code: 'Enter' });
+        expect(wrapper.emitted('enter')).toBeUndefined();
+      });
     });
   });
 

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -305,6 +305,57 @@ describe('DtComboboxMultiSelect Tests', () => {
     });
   });
 
+  describe('Input Key Event Tests', () => {
+    it('Should emit "escape" when Escape is pressed while input is focused', async () => {
+      await input.trigger('keydown', { key: 'Escape' });
+      expect(wrapper.emitted('escape').length).toBe(1);
+    });
+
+    it('Should emit "enter" when Enter is pressed while input is focused', async () => {
+      await input.trigger('keydown', { key: 'Enter', code: 'Enter' });
+      expect(wrapper.emitted('enter').length).toBe(1);
+    });
+
+    it('Should emit "enter" when NumpadEnter is pressed while input is focused', async () => {
+      // event.key normalizes NumpadEnter to 'Enter'; using event.code would miss this.
+      await input.trigger('keydown', { key: 'Enter', code: 'NumpadEnter' });
+      expect(wrapper.emitted('enter').length).toBe(1);
+    });
+
+    it('Should emit "keydown" with KeyboardEvent when a key is pressed in the input', async () => {
+      await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
+      expect(wrapper.emitted('keydown').length).toBe(1);
+      expect(wrapper.emitted('keydown')[0][0]).toBeInstanceOf(KeyboardEvent);
+    });
+
+    describe('When chips are present', () => {
+      beforeEach(async () => {
+        await wrapper.setProps({ selectedItems: ['1'] });
+        _setChildWrappers();
+      });
+
+      it('Should not emit "escape" when Escape is pressed while a chip is focused', async () => {
+        await chips.at(0).trigger('keydown', { key: 'Escape', code: 'Escape' });
+        expect(wrapper.emitted('keydown').length).toBeGreaterThanOrEqual(1);
+        expect(wrapper.emitted('escape')).toBeUndefined();
+      });
+
+      it('Should still emit "keydown" when a key is pressed on a chip (backward compatibility)', async () => {
+        await chips.at(0).trigger('keydown', { key: 'ArrowLeft', code: 'ArrowLeft' });
+        expect(wrapper.emitted('keydown').length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('Should not emit input-level keydown when the component is disabled', async () => {
+      // Suppressed by the explicit `if (this.disabled) return;` guard in
+      // inputListeners.onKeydown — not by native DOM disabled semantics
+      // (JSDOM's trigger() fires regardless of the HTML disabled attribute).
+      await wrapper.setProps({ disabled: true });
+      await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
+      expect(wrapper.emitted('keydown')).toBeUndefined();
+    });
+  });
+
   describe('Duplicate Items Tests', () => {
     beforeEach(async () => {
       await wrapper.setProps({ selectedItems: ['item1', 'item1', 'item1'] });

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -322,10 +322,18 @@ describe('DtComboboxMultiSelect Tests', () => {
       expect(wrapper.emitted('enter').length).toBe(1);
     });
 
-    it('Should emit "keydown" with KeyboardEvent when a key is pressed in the input', async () => {
-      await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
-      expect(wrapper.emitted('keydown').length).toBe(1);
-      expect(wrapper.emitted('keydown')[0][0]).toBeInstanceOf(KeyboardEvent);
+    describe('When a key is pressed in the input', () => {
+      beforeEach(async () => {
+        await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
+      });
+
+      it('Should emit "keydown" once', () => {
+        expect(wrapper.emitted('keydown').length).toBe(1);
+      });
+
+      it('Should emit "keydown" with a KeyboardEvent payload', () => {
+        expect(wrapper.emitted('keydown')[0][0]).toBeInstanceOf(KeyboardEvent);
+      });
     });
 
     describe('When chips are present', () => {
@@ -334,10 +342,18 @@ describe('DtComboboxMultiSelect Tests', () => {
         _setChildWrappers();
       });
 
-      it('Should not emit "escape" when Escape is pressed while a chip is focused', async () => {
-        await chips.at(0).trigger('keydown', { key: 'Escape', code: 'Escape' });
-        expect(wrapper.emitted('keydown').length).toBeGreaterThanOrEqual(1);
-        expect(wrapper.emitted('escape')).toBeUndefined();
+      describe('When Escape is pressed while a chip is focused', () => {
+        beforeEach(async () => {
+          await chips.at(0).trigger('keydown', { key: 'Escape', code: 'Escape' });
+        });
+
+        it('Should still emit "keydown" from the chip', () => {
+          expect(wrapper.emitted('keydown').length).toBeGreaterThanOrEqual(1);
+        });
+
+        it('Should not emit "escape"', () => {
+          expect(wrapper.emitted('escape')).toBeUndefined();
+        });
       });
 
       it('Should still emit "keydown" when a key is pressed on a chip (backward compatibility)', async () => {

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -327,12 +327,16 @@ describe('DtComboboxMultiSelect Tests', () => {
         await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
       });
 
-      it('Should emit "keydown" once', () => {
-        expect(wrapper.emitted('keydown').length).toBe(1);
+      it('Should emit "input-keydown" once', () => {
+        expect(wrapper.emitted('input-keydown').length).toBe(1);
       });
 
-      it('Should emit "keydown" with a KeyboardEvent payload', () => {
-        expect(wrapper.emitted('keydown')[0][0]).toBeInstanceOf(KeyboardEvent);
+      it('Should emit "input-keydown" with a KeyboardEvent payload', () => {
+        expect(wrapper.emitted('input-keydown')[0][0]).toBeInstanceOf(KeyboardEvent);
+      });
+
+      it('Should not emit "keydown" (chip-only contract)', () => {
+        expect(wrapper.emitted('keydown')).toBeUndefined();
       });
     });
 
@@ -362,13 +366,13 @@ describe('DtComboboxMultiSelect Tests', () => {
       });
     });
 
-    it('Should not emit input-level keydown when the component is disabled', async () => {
+    it('Should not emit "input-keydown" when the component is disabled', async () => {
       // Suppressed by the explicit `if (this.disabled) return;` guard in
       // inputListeners.onKeydown — not by native DOM disabled semantics
       // (JSDOM's trigger() fires regardless of the HTML disabled attribute).
       await wrapper.setProps({ disabled: true });
       await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
-      expect(wrapper.emitted('keydown')).toBeUndefined();
+      expect(wrapper.emitted('input-keydown')).toBeUndefined();
     });
   });
 

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -352,7 +352,7 @@ describe('DtComboboxMultiSelect Tests', () => {
         });
 
         it('Should still emit "keydown" from the chip', () => {
-          expect(wrapper.emitted('keydown').length).toBeGreaterThanOrEqual(1);
+          expect(wrapper.emitted('keydown').length).toBe(1);
         });
 
         it('Should not emit "escape"', () => {
@@ -362,7 +362,7 @@ describe('DtComboboxMultiSelect Tests', () => {
 
       it('Should still emit "keydown" when a key is pressed on a chip (backward compatibility)', async () => {
         await chips.at(0).trigger('keydown', { key: 'ArrowLeft', code: 'ArrowLeft' });
-        expect(wrapper.emitted('keydown').length).toBeGreaterThanOrEqual(1);
+        expect(wrapper.emitted('keydown').length).toBe(1);
       });
     });
 

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -208,7 +208,7 @@ describe('DtComboboxMultiSelect Tests', () => {
 
         describe('When LEFT key is pressed', () => {
           beforeEach(async () => {
-            input.trigger('keydown', { key: 'arrowleft' });
+            input.trigger('keydown', { key: 'ArrowLeft' });
           });
 
           it('should focus the last chip', () => {
@@ -220,14 +220,14 @@ describe('DtComboboxMultiSelect Tests', () => {
           it('should not call moveFromInputToChip when input has text', async () => {
             const spy = vi.spyOn(wrapper.vm, 'moveFromInputToChip');
             await input.setValue('a');
-            await input.trigger('keydown', { key: 'arrowleft' });
+            await input.trigger('keydown', { key: 'ArrowLeft' });
             expect(spy).not.toHaveBeenCalled();
           });
         });
 
         describe('When BACKSPACE key is pressed', () => {
           beforeEach(async () => {
-            input.trigger('keydown', { key: 'backspace' });
+            input.trigger('keydown', { key: 'Backspace' });
           });
 
           it('should focus the last chip', () => {
@@ -239,7 +239,7 @@ describe('DtComboboxMultiSelect Tests', () => {
           it('should not call moveFromInputToChip when input has text', async () => {
             const spy = vi.spyOn(wrapper.vm, 'moveFromInputToChip');
             await input.setValue('a');
-            await input.trigger('keydown', { key: 'backspace' });
+            await input.trigger('keydown', { key: 'Backspace' });
             expect(spy).not.toHaveBeenCalled();
           });
         });
@@ -417,6 +417,13 @@ describe('DtComboboxMultiSelect Tests', () => {
       it('Should not emit "enter"', async () => {
         await input.trigger('keydown', { key: 'Enter', code: 'Enter' });
         expect(wrapper.emitted('enter')).toBeUndefined();
+      });
+
+      it('Should not emit "chip-keydown" when a key is pressed on a chip', async () => {
+        await wrapper.setProps({ selectedItems: ['1'] });
+        _setChildWrappers();
+        await chips.at(0).trigger('keydown', { key: 'ArrowLeft', code: 'ArrowLeft' });
+        expect(wrapper.emitted('chip-keydown')).toBeUndefined();
       });
     });
   });

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -319,9 +319,19 @@ describe('DtComboboxMultiSelect Tests', () => {
       expect(wrapper.emitted('escape').length).toBe(1);
     });
 
+    it('Should emit "escape" with a KeyboardEvent payload', async () => {
+      await input.trigger('keydown', { key: 'Escape' });
+      expect(wrapper.emitted('escape')[0][0]).toBeInstanceOf(KeyboardEvent);
+    });
+
     it('Should emit "enter" when Enter is pressed while input is focused', async () => {
       await input.trigger('keydown', { key: 'Enter', code: 'Enter' });
       expect(wrapper.emitted('enter').length).toBe(1);
+    });
+
+    it('Should emit "enter" with a KeyboardEvent payload', async () => {
+      await input.trigger('keydown', { key: 'Enter', code: 'Enter' });
+      expect(wrapper.emitted('enter')[0][0]).toBeInstanceOf(KeyboardEvent);
     });
 
     it('Should emit "enter" when NumpadEnter is pressed while input is focused', async () => {

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -306,6 +306,14 @@ describe('DtComboboxMultiSelect Tests', () => {
   });
 
   describe('Input Key Event Tests', () => {
+    beforeEach(async () => {
+      // Establish the "while input is focused" precondition the spec describes
+      // before each keydown trigger. Nested describes that target chips manage
+      // their own keydown source — triggering focus on the input is a no-op
+      // for those code paths.
+      await input.trigger('focus');
+    });
+
     it('Should emit "escape" when Escape is pressed while input is focused', async () => {
       await input.trigger('keydown', { key: 'Escape' });
       expect(wrapper.emitted('escape').length).toBe(1);

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -335,16 +335,12 @@ describe('DtComboboxMultiSelect Tests', () => {
         await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
       });
 
-      it('Should emit "input-keydown" once', () => {
-        expect(wrapper.emitted('input-keydown').length).toBe(1);
+      it('Should emit "keydown" once', () => {
+        expect(wrapper.emitted('keydown').length).toBe(1);
       });
 
-      it('Should emit "input-keydown" with a KeyboardEvent payload', () => {
-        expect(wrapper.emitted('input-keydown')[0][0]).toBeInstanceOf(KeyboardEvent);
-      });
-
-      it('Should not emit "keydown" (chip-only contract)', () => {
-        expect(wrapper.emitted('keydown')).toBeUndefined();
+      it('Should emit "keydown" with a KeyboardEvent payload', () => {
+        expect(wrapper.emitted('keydown')[0][0]).toBeInstanceOf(KeyboardEvent);
       });
     });
 
@@ -352,9 +348,9 @@ describe('DtComboboxMultiSelect Tests', () => {
       { key: 'Escape', code: 'Escape' },
       { key: 'Enter', code: 'Enter' },
       { key: 'Enter', code: 'NumpadEnter' },
-    ])('Should emit "input-keydown" for key=$key code=$code', async ({ key, code }) => {
+    ])('Should emit "keydown" for key=$key code=$code', async ({ key, code }) => {
       await input.trigger('keydown', { key, code });
-      expect(wrapper.emitted('input-keydown').length).toBe(1);
+      expect(wrapper.emitted('keydown').length).toBe(1);
     });
 
     describe('When chips are present', () => {
@@ -371,8 +367,12 @@ describe('DtComboboxMultiSelect Tests', () => {
           await chips.at(0).trigger('keydown', { key, code: key });
         });
 
-        it('Should still emit "keydown" from the chip', () => {
-          expect(wrapper.emitted('keydown').length).toBe(1);
+        it('Should emit "chip-keydown" from the chip', () => {
+          expect(wrapper.emitted('chip-keydown').length).toBe(1);
+        });
+
+        it('Should not emit unprefixed "keydown" from the chip', () => {
+          expect(wrapper.emitted('keydown')).toBeUndefined();
         });
 
         it(`Should not emit "${semanticEvent}"`, () => {
@@ -380,9 +380,9 @@ describe('DtComboboxMultiSelect Tests', () => {
         });
       });
 
-      it('Should still emit "keydown" when a key is pressed on a chip (backward compatibility)', async () => {
+      it('Should emit "chip-keydown" when a key is pressed on a chip', async () => {
         await chips.at(0).trigger('keydown', { key: 'ArrowLeft', code: 'ArrowLeft' });
-        expect(wrapper.emitted('keydown').length).toBe(1);
+        expect(wrapper.emitted('chip-keydown').length).toBe(1);
       });
     });
 
@@ -394,9 +394,9 @@ describe('DtComboboxMultiSelect Tests', () => {
         await wrapper.setProps({ disabled: true });
       });
 
-      it('Should not emit "input-keydown"', async () => {
+      it('Should not emit "keydown"', async () => {
         await input.trigger('keydown', { key: 'Tab', code: 'Tab' });
-        expect(wrapper.emitted('input-keydown')).toBeUndefined();
+        expect(wrapper.emitted('keydown')).toBeUndefined();
       });
 
       it('Should not emit "escape"', async () => {

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
@@ -417,8 +417,8 @@ export default {
     'keyup',
 
     /**
-     * Native keydown event fired when a key is pressed while a chip is focused.
-     * For input-level keystrokes, listen to `input-keydown`.
+     * Native keydown event fired when a key is pressed in the text input.
+     * For the common Escape and Enter cases, listen to `escape` / `enter` instead.
      *
      * @event keydown
      * @type {KeyboardEvent}
@@ -426,14 +426,12 @@ export default {
     'keydown',
 
     /**
-     * Native keydown event fired when a key is pressed while the text input is focused.
-     * Use this to handle arbitrary keys (e.g., Tab) in the search input. For the
-     * common Escape and Enter cases, listen to `escape` / `enter` instead.
+     * Native keydown event fired when a key is pressed while a chip is focused.
      *
-     * @event input-keydown
+     * @event chip-keydown
      * @type {KeyboardEvent}
      */
-    'input-keydown',
+    'chip-keydown',
 
     /**
      * Native escape event fired when Escape is pressed in the text input.
@@ -483,7 +481,7 @@ export default {
       return {
         keydown: event => {
           this.onChipKeyDown(event);
-          this.$emit('keydown', event);
+          this.$emit('chip-keydown', event);
         },
       };
     },
@@ -501,7 +499,7 @@ export default {
         onKeydown: event => {
           if (this.disabled) return;
           this.onInputKeyDown(event);
-          this.$emit('input-keydown', event);
+          this.$emit('keydown', event);
           // Use event.key (not event.code) so NumpadEnter normalizes to 'Enter'
           // and consumers don't have to special-case the numpad.
           const key = event.key?.toLowerCase();

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
@@ -434,18 +434,20 @@ export default {
     'chip-keydown',
 
     /**
-     * Native escape event fired when Escape is pressed in the text input.
+     * Fired when Escape is pressed in the text input.
      * Not fired when a chip is focused.
      *
      * @event escape
+     * @type {KeyboardEvent}
      */
     'escape',
 
     /**
-     * Native enter event fired when Enter is pressed in the text input.
+     * Fired when Enter is pressed in the text input.
      * Not fired when a chip is focused.
      *
      * @event enter
+     * @type {KeyboardEvent}
      */
     'enter',
 
@@ -504,9 +506,9 @@ export default {
           // and consumers don't have to special-case the numpad.
           const key = event.key?.toLowerCase();
           if (key === 'escape') {
-            this.$emit('escape');
+            this.$emit('escape', event);
           } else if (key === 'enter') {
-            this.$emit('enter');
+            this.$emit('enter', event);
           }
         },
 

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
@@ -417,12 +417,29 @@ export default {
     'keyup',
 
     /**
-     * Native keydown event
+     * Native keydown event. Fired for any key pressed while a chip is focused
+     * or while the text input is focused. Inspect `event.target` to disambiguate.
      *
      * @event keydown
      * @type {KeyboardEvent}
-      */
+     */
     'keydown',
+
+    /**
+     * Native escape event fired when Escape is pressed in the text input.
+     * Not fired when a chip is focused.
+     *
+     * @event escape
+     */
+    'escape',
+
+    /**
+     * Native enter event fired when Enter is pressed in the text input.
+     * Not fired when a chip is focused.
+     *
+     * @event enter
+     */
+    'enter',
 
     /**
      * Event fired when combobox item is highlighted
@@ -472,7 +489,17 @@ export default {
         },
 
         onKeydown: event => {
+          if (this.disabled) return;
           this.onInputKeyDown(event);
+          this.$emit('keydown', event);
+          // Use event.key (not event.code) so NumpadEnter normalizes to 'Enter'
+          // and consumers don't have to special-case the numpad.
+          const key = event.key?.toLowerCase();
+          if (key === 'escape') {
+            this.$emit('escape');
+          } else if (key === 'enter') {
+            this.$emit('enter');
+          }
         },
 
         onKeyup: event => {

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
@@ -409,14 +409,6 @@ export default {
     'max-selected',
 
     /**
-     * Native keyup event
-     *
-     * @event keyup
-     * @type {KeyboardEvent}
-      */
-    'keyup',
-
-    /**
      * Native keydown event fired when a key is pressed in the text input.
      * For the common Escape and Enter cases, listen to `escape` / `enter` instead.
      *
@@ -510,10 +502,6 @@ export default {
           } else if (key === 'enter') {
             this.$emit('enter', event);
           }
-        },
-
-        onKeyup: event => {
-          this.$emit('keyup', event);
         },
 
         onClick: () => {

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
@@ -417,13 +417,23 @@ export default {
     'keyup',
 
     /**
-     * Native keydown event. Fired for any key pressed while a chip is focused
-     * or while the text input is focused. Inspect `event.target` to disambiguate.
+     * Native keydown event fired when a key is pressed while a chip is focused.
+     * For input-level keystrokes, listen to `input-keydown`.
      *
      * @event keydown
      * @type {KeyboardEvent}
      */
     'keydown',
+
+    /**
+     * Native keydown event fired when a key is pressed while the text input is focused.
+     * Use this to handle arbitrary keys (e.g., Tab) in the search input. For the
+     * common Escape and Enter cases, listen to `escape` / `enter` instead.
+     *
+     * @event input-keydown
+     * @type {KeyboardEvent}
+     */
+    'input-keydown',
 
     /**
      * Native escape event fired when Escape is pressed in the text input.
@@ -491,7 +501,7 @@ export default {
         onKeydown: event => {
           if (this.disabled) return;
           this.onInputKeyDown(event);
-          this.$emit('keydown', event);
+          this.$emit('input-keydown', event);
           // Use event.key (not event.code) so NumpadEnter normalizes to 'Enter'
           // and consumers don't have to special-case the numpad.
           const key = event.key?.toLowerCase();

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
@@ -474,6 +474,7 @@ export default {
     chipListeners () {
       return {
         keydown: event => {
+          if (this.disabled) return;
           this.onChipKeyDown(event);
           this.$emit('chip-keydown', event);
         },

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
@@ -681,7 +681,7 @@ export default {
     },
 
     onInputKeyDown (event) {
-      const key = event.code?.toLowerCase();
+      const key = event.key?.toLowerCase();
       // If the cursor is at the start of the text,
       // press 'backspace' or 'left' focuses the last chip
       if (this.selectedItems.length > 0 && event.target.selectionStart === 0) {


### PR DESCRIPTION
# feat(combobox-multi-select): DLT-3366 forward input-level escape, enter, keydown events

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZG1kdDM0NXUyeDBlbWRjM2VmZzJnOGp1dGoxdGhlNTE5MnFsM3FkNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/qN8mwUPAt7gByge3W1/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-3366
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description
Note: This task may best be done by an Dialtone engineer, but I took a swing at it with Claude to see how it would go. I've been working from Bianca's notes that she added in the Jira ticket.

<!--- Describe specifically what the changes are -->

### Summary

`DtComboboxMultiSelect` now exposes input-level keyboard events to consumers, and clarifies the existing chip-level keydown event with a dedicated name:

| Event | Payload | When it fires |
|---|---|---|
| `escape` | `KeyboardEvent` | Escape pressed while text input is focused |
| `enter` | `KeyboardEvent` | Enter or NumpadEnter pressed while text input is focused |
| `keydown` | `KeyboardEvent` | Any key pressed while text input is focused |
| `chip-keydown` | `KeyboardEvent` | Any key pressed while a chip is focused |

Existing `@keydown` consumers: the event previously fired only when a chip was focused. It has been renamed to `@chip-keydown`. `@keydown` now fires from the text input. No consumers of this component in the codebase were using `@keydown` or `@keyup`, so there is no migration needed.

### Changes

#### `packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue`

1. **Added four new/renamed emits with JSDoc:** `escape`, `enter`, `keydown` (repurposed from chip to input), and `chip-keydown` (renamed from the original chip-scoped `keydown`).
2. **Updated `chip-keydown` JSDoc** to clarify it fires from chip focus only and points consumers to `keydown`, `escape`, and `enter` for input-level keystrokes.
3. **Modified `inputListeners.onKeydown`** to:
   - Bail early if `disabled` is true.
   - Continue calling `onInputKeyDown` to preserve existing chip-navigation behavior (backspace, arrow-left).
   - Emit `keydown` with the full `KeyboardEvent`.
   - Emit `escape` when Escape is pressed; emit `enter` when Enter or NumpadEnter is pressed (uses `event.key`, not `event.code`, so NumpadEnter normalizes to `'Enter'`).
4. **Added disabled guard** to `chipListeners.keydown` — chip keyboard events are now suppressed when the component is disabled, matching the input handler behavior.
5. **Changed `event.code` → `event.key`** in `onInputKeyDown` for consistent key matching.

#### `packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js`

131 lines of new tests covering: `escape`, `enter`, `keydown` (input-level), `chip-keydown`, NumpadEnter normalization, and disabled suppression for all events. Existing navigation tests updated from `event.code` to `event.key`.

#### `packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js`

Added `onKeydown`, `onChipKeydown`, `onEscape`, `onEnter` to `argsData` and matching `disable: true` entries in `argTypesData`.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

`DtComboboxMultiSelect` previously emitted `keydown` only when a chip had focus. Keystrokes in the text input (Escape, Enter, arbitrary keys) were not forwarded to consumers, making it impossible for callers to react to them — for example, to confirm a phone number entry on Enter or move focus to a specific item on a custom key.

### Why `chip-keydown` and a repurposed `keydown` (not a dual-source `keydown`)

The original draft of this change forwarded input keystrokes via the existing `keydown` emit, making it dual-source (chip + input). A reviewer flagged that this silently broadens a public event's contract — any existing `@keydown` consumer would start receiving input keystrokes they did not get before. Because `@dialpad/dialtone-vue` ships via `semantic-release`, that change would land as a `feat:` MINOR but still surprise consumers.

The final approach instead gives each source its own named event: `chip-keydown` for chip focus, `keydown` for input focus. The rename is technically breaking, but a search across all org repos confirmed zero consumers were binding `@keydown` or `@keyup` on this component, so no migration is needed.

### Why `event.key` (not `event.code`)

`event.key` normalizes `'NumpadEnter'` to `'Enter'`. Using `event.code` would miss the numpad case and require special-casing.


## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

Product use case for context:
<img width="688" height="195" alt="Screenshot 2026-05-04 at 5 43 42 PM" src="https://github.com/user-attachments/assets/593add6d-dff6-4867-a5cc-1d2814677f9b" />


## :link: Sources

<!--- Add any links to external reference material -->
