### PR TITLE
feat(combobox-with-popover, combobox-multi-select): DLT-3395 forward dialogClass to popover dialog

### DIFF
--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js
@@ -137,7 +137,7 @@ export const argTypesData = {
     },
   },
   dialogClass: {
-    description: 'Additional class for the popover dialog element. Supports descendant selectors for deep customization.',
+    description: 'Additional class for the popover dialog element.',
     control: {
       type: 'text',
     },

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.stories.js
@@ -136,6 +136,12 @@ export const argTypesData = {
       disable: true,
     },
   },
+  dialogClass: {
+    description: 'Additional class for the popover dialog element. Supports descendant selectors for deep customization.',
+    control: {
+      type: 'text',
+    },
+  },
 };
 
 // Story Collection

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import DtComboboxMultiSelect from './combobox_multi_select.vue';
+import DtPopover from '@/components/popover/popover.vue';
 import { VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 import { flushPromises } from '@/common/utils';
 import SrOnlyCloseButtonComponent from '@/common/sr_only_close_button.vue';
@@ -361,6 +362,20 @@ describe('DtComboboxMultiSelect Tests', () => {
         _setChildWrappers();
         expect(validationMsg.text()).toBe('More than 2 selected');
       });
+    });
+  });
+
+  describe('When dialogClass is provided', () => {
+    beforeEach(async () => {
+      props = { ...baseProps, dialogClass: 'custom-dialog-class' };
+      _setWrappers();
+      await input.trigger('focus');
+      await flushPromises();
+    });
+    it('should apply the class to the popover dialog element', () => {
+      const dialog = wrapper.findComponent(DtPopover).findComponent({ ref: 'content' });
+      expect(dialog.exists()).toBe(true);
+      expect(dialog.classes()).toContain('custom-dialog-class');
     });
   });
 });

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -368,6 +368,7 @@ describe('DtComboboxMultiSelect Tests', () => {
   describe('When dialogClass is provided', () => {
     beforeEach(async () => {
       props = { ...baseProps, dialogClass: 'custom-dialog-class' };
+      wrapper?.unmount();
       _setWrappers();
       await input.trigger('focus');
       await flushPromises();

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -365,18 +365,24 @@ describe('DtComboboxMultiSelect Tests', () => {
   });
 
   describe('When dialogClass is provided', () => {
+    // Popover teleports to body, so query body directly via data-qa
+    // (same pattern as tooltip/split_button/hovercard tests).
+    let dialog;
+
     beforeEach(async () => {
       props = { ...baseProps, dialogClass: 'custom-dialog-class' };
       wrapper?.unmount();
       _setWrappers();
       await input.trigger('focus');
       await flushPromises();
+      dialog = document.body.querySelector('[data-qa="dt-popover"]');
     });
-    it('should apply the class to the popover dialog element', () => {
-      // Popover teleports to body, so query body directly via data-qa
-      // (same pattern as tooltip/split_button/hovercard tests).
-      const dialog = document.body.querySelector('[data-qa="dt-popover"]');
+
+    it('should render the popover dialog element', () => {
       expect(dialog).not.toBeNull();
+    });
+
+    it('should apply the class to the popover dialog element', () => {
       expect(dialog.classList.contains('custom-dialog-class')).toBe(true);
     });
   });

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils';
 import DtComboboxMultiSelect from './combobox_multi_select.vue';
-import DtPopover from '@/components/popover/popover.vue';
 import { VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 import { flushPromises } from '@/common/utils';
 import SrOnlyCloseButtonComponent from '@/common/sr_only_close_button.vue';
@@ -374,9 +373,11 @@ describe('DtComboboxMultiSelect Tests', () => {
       await flushPromises();
     });
     it('should apply the class to the popover dialog element', () => {
-      const dialog = wrapper.findComponent(DtPopover).findComponent({ ref: 'content' });
-      expect(dialog.exists()).toBe(true);
-      expect(dialog.classes()).toContain('custom-dialog-class');
+      // Popover teleports to body, so query body directly via data-qa
+      // (same pattern as tooltip/split_button/hovercard tests).
+      const dialog = document.body.querySelector('[data-qa="dt-popover"]');
+      expect(dialog).not.toBeNull();
+      expect(dialog.classList.contains('custom-dialog-class')).toBe(true);
     });
   });
 });

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
@@ -10,6 +10,7 @@
     :has-suggestion-list="hasSuggestionList"
     content-width="anchor"
     :append-to="appendTo"
+    :dialog-class="dialogClass"
     :transition="transition"
     v-bind="extractNonListeners($attrs)"
     @select="onComboboxSelect"
@@ -372,6 +373,14 @@ export default {
     disabled: {
       type: Boolean,
       default: false,
+    },
+
+    /**
+     * Additional class for the popover dialog element.
+     */
+    dialogClass: {
+      type: [String, Object, Array],
+      default: '',
     },
   },
 

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select_default.story.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select_default.story.vue
@@ -23,6 +23,7 @@
     :max-selected-message="$attrs.maxSelectedMessage"
     :has-suggestion-list="$attrs.hasSuggestionList"
     :append-to="$attrs.appendTo"
+    :dialog-class="$attrs.dialogClass"
     :transition="$attrs.transition"
     :reserved-right-space="$attrs.reservedRightSpace"
     @input="onComboboxInput"

--- a/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.stories.js
+++ b/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.stories.js
@@ -151,7 +151,7 @@ export const argTypesData = {
   },
 
   dialogClass: {
-    description: 'Additional class for the popover dialog element. Supports descendant selectors for deep customization.',
+    description: 'Additional class for the popover dialog element.',
     control: {
       type: 'text',
     },

--- a/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.stories.js
+++ b/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.stories.js
@@ -150,6 +150,13 @@ export const argTypesData = {
     },
   },
 
+  dialogClass: {
+    description: 'Additional class for the popover dialog element. Supports descendant selectors for deep customization.',
+    control: {
+      type: 'text',
+    },
+  },
+
   // Action Event Handlers
   onEscape: {
     table: {

--- a/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.test.js
+++ b/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.test.js
@@ -553,6 +553,7 @@ describe('DtComboboxWithPopover Tests', () => {
   describe('When dialogClass is provided', () => {
     beforeEach(async () => {
       props = { ...baseProps, dialogClass: 'custom-dialog-class' };
+      wrapper?.unmount();
       _mountWrapper();
       await _openComboboxPopover();
     });

--- a/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.test.js
+++ b/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.test.js
@@ -558,9 +558,11 @@ describe('DtComboboxWithPopover Tests', () => {
       await _openComboboxPopover();
     });
     it('should apply the class to the popover dialog element', () => {
-      const dialog = wrapper.findComponent(DtPopover).findComponent({ ref: 'content' });
-      expect(dialog.exists()).toBe(true);
-      expect(dialog.classes()).toContain('custom-dialog-class');
+      // Popover teleports to body, so query body directly via data-qa
+      // (same pattern as tooltip/split_button/hovercard tests).
+      const dialog = document.body.querySelector('[data-qa="dt-popover"]');
+      expect(dialog).not.toBeNull();
+      expect(dialog.classList.contains('custom-dialog-class')).toBe(true);
     });
   });
 });

--- a/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.test.js
+++ b/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.test.js
@@ -551,17 +551,23 @@ describe('DtComboboxWithPopover Tests', () => {
   });
 
   describe('When dialogClass is provided', () => {
+    // Popover teleports to body, so query body directly via data-qa
+    // (same pattern as tooltip/split_button/hovercard tests).
+    let dialog;
+
     beforeEach(async () => {
       props = { ...baseProps, dialogClass: 'custom-dialog-class' };
       wrapper?.unmount();
       _mountWrapper();
       await _openComboboxPopover();
+      dialog = document.body.querySelector('[data-qa="dt-popover"]');
     });
-    it('should apply the class to the popover dialog element', () => {
-      // Popover teleports to body, so query body directly via data-qa
-      // (same pattern as tooltip/split_button/hovercard tests).
-      const dialog = document.body.querySelector('[data-qa="dt-popover"]');
+
+    it('should render the popover dialog element', () => {
       expect(dialog).not.toBeNull();
+    });
+
+    it('should apply the class to the popover dialog element', () => {
       expect(dialog.classList.contains('custom-dialog-class')).toBe(true);
     });
   });

--- a/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.test.js
+++ b/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.test.js
@@ -549,4 +549,17 @@ describe('DtComboboxWithPopover Tests', () => {
       );
     });
   });
+
+  describe('When dialogClass is provided', () => {
+    beforeEach(async () => {
+      props = { ...baseProps, dialogClass: 'custom-dialog-class' };
+      _mountWrapper();
+      await _openComboboxPopover();
+    });
+    it('should apply the class to the popover dialog element', () => {
+      const dialog = wrapper.findComponent(DtPopover).findComponent({ ref: 'content' });
+      expect(dialog.exists()).toBe(true);
+      expect(dialog.classes()).toContain('custom-dialog-class');
+    });
+  });
 });

--- a/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.vue
+++ b/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover.vue
@@ -54,6 +54,7 @@
         :modal="false"
         :auto-focus="false"
         :append-to="appendTo"
+        :dialog-class="dialogClass"
         :transition="transition"
         @opened="opened"
       >
@@ -191,6 +192,14 @@ export default {
      * Additional class for the wrapper list element.
      */
     listClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
+
+    /**
+     * Additional class for the popover dialog element.
+     */
+    dialogClass: {
       type: [String, Array, Object],
       default: '',
     },

--- a/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover_default.story.vue
+++ b/packages/dialtone-vue/components/combobox_with_popover/combobox_with_popover_default.story.vue
@@ -14,6 +14,7 @@
     :padding="$attrs.padding"
     :list-id="$attrs.listId"
     :list-class="$attrs.listClass"
+    :dialog-class="$attrs.dialogClass"
     :open-with-arrow-keys="$attrs.openWithArrowKeys"
     :empty-list="$attrs.emptyList"
     :empty-state-message="$attrs.emptyStateMessage"


### PR DESCRIPTION
# feat(combobox-with-popover, combobox-multi-select): DLT-3395 forward dialogClass to popover dialog

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExaHdkcDZtajN2cmU2cWtuazEzZDY2cnhydzd6cXFmd3FhaTZmNWhhNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Z9cRCMdAMzXi25dwhE/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-3395
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

<!--- Describe specifically what the changes are -->

Adds a `dialogClass` prop to `DtComboboxWithPopover` and `DtComboboxMultiSelect`. The prop forwards through to the underlying `<dt-popover>`'s existing `dialogClass`, which lands on the `d-popover__dialog` element.

**Forwarding chain:** `DtComboboxMultiSelect → DtComboboxWithPopover → DtPopover → d-popover__dialog`.

Matches the established forwarding pattern used by `DtHovercard`, `DtModal`, and `DtBanner`. Tested locally on the docs site and also via storybook (https://dialtone.dialpad.com/vue/deploy-previews/pr-1254/?path=/story/components-combobox-multi-select--default&args=dialogClass:test-class).

**Usage:**

```vue
<dt-combobox-with-popover dialog-class="my-flavor">...</dt-combobox-with-popover>

.my-flavor .d-popover__header { min-height: 0; }
```


## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

`DtPopover` already exposes a `dialogClass` prop (popover.vue:58), but neither combobox component forwarded it to consumers. This blocked any CSS customization scoped to a specific combobox usage — including overriding intrinsic styles like min-height on the popover header.

The `dialogClass` + descendant selector approach was chosen over per-element wrapper-class props (e.g. a separate headerWrapperClass) because it provides broader reach with a smaller API surface, and matches the convention already used elsewhere in Dialtone.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs
Context of where this may be useful: aligning tabs in the header of a combobox popover:
<img width="688" height="195" alt="587377937-593add6d-dff6-4867-a5cc-1d2814677f9b" src="https://github.com/user-attachments/assets/51ef8193-3aed-484f-aa4b-847847d4715d" />


<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
