### PR TITLE
feat(eslint-plugin): DLT-3281 add deprecated-class-props rule

### DIFF
--- a/docs/plans/2026-05-07-dlt-3281-eslint-deprecated-class-props.md
+++ b/docs/plans/2026-05-07-dlt-3281-eslint-deprecated-class-props.md
@@ -2,7 +2,7 @@
 
 Created: 2026-05-07
 Author: belu.montoya@dialpad.com
-Status: COMPLETE
+Status: VERIFIED
 Approved: Yes
 Iterations: 1
 Worktree: No

--- a/docs/plans/2026-05-07-dlt-3281-eslint-deprecated-class-props.md
+++ b/docs/plans/2026-05-07-dlt-3281-eslint-deprecated-class-props.md
@@ -28,7 +28,7 @@ Branch: `feat/dlt-3281-eslint-deprecated-class-props` (off `staging`)
 - Autofix that renames the offending attribute to `class` (or `:class` for dynamic bindings), merging into an existing class binding when present, per the algorithm in `packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs:358-401`.
 - One conservative non-fix case: dynamic `:<prop>="expr"` + existing `:class="..."` — warn only, no autofix.
 - Severity: `warn`.
-- Single message format: `"Dt[Name] does not accept a `[propName]` prop. Use the native `class` attribute instead. See: https://dialtone.dialpad.com/guides/migration/component-props/"`.
+- Single message format: `"Dt[Name] does not accept a '[propName]' prop. Use the native 'class' attribute instead. See: https://dialtone.dialpad.com/guides/migration/component-props/"`.
 - Tests covering: 12 detection cases for DtInput (3 prop bases × 2 casings × 2 binding forms — DtInput is the post-deprecation anchor in the test fixture); 4 autofix scenarios (static-no-class, static-with-class, dynamic-no-class, dynamic-with-class-warn-only); 1 regression case (DtListItem with `wrapperClass` must NOT trigger). All tests run against a controlled fixture data source via `proxyquire` — never against the live workspace JSON.
 - Documentation file `docs/rules/deprecated-class-props.md` matching the format of existing rule docs.
 - Add `@dialpad/dialtone-vue` and `vue-eslint-parser` to the plugin's `peerDependencies`. Add `vue-eslint-parser` and `proxyquire` to `devDependencies`.
@@ -213,6 +213,7 @@ Branch: `feat/dlt-3281-eslint-deprecated-class-props` (off `staging`)
 - **Reporting:** report on the offending `VAttribute` node. Message: `"DtFoo does not accept a 'rootClass' prop. Use the native 'class' attribute instead. See: https://dialtone.dialpad.com/guides/migration/component-props/"`.
 - **No fix in this task** — `meta.fixable: null` for now. Task 3 flips to `'code'` and adds the fixer.
 - **Test setup:** mirror `tests/lib/rules/deprecated-stack-alignment-classes.js` AND inject mocked component data via `proxyquire`:
+
   ```js
   const proxyquire = require('proxyquire').noCallThru();
   const MOCK_COMPONENTS = [
@@ -228,6 +229,7 @@ Branch: `feat/dlt-3281-eslint-deprecated-class-props` (off `staging`)
   });
   const ruleTester = new RuleTester({ parser: require.resolve('vue-eslint-parser'), parserOptions: { ecmaVersion: 'latest' } });
   ```
+
   All test cases run against `MOCK_COMPONENTS` — the rule's behavior is fully deterministic regardless of what's in `packages/dialtone-vue/dist/component-documentation.json` on the current branch.
 - **Tests for this task — detection cases only:**
   - Valid cases (should NOT report):
@@ -383,6 +385,7 @@ Branch: `feat/dlt-3281-eslint-deprecated-class-props` (off `staging`)
 
 - ESLint 9 flat config has dropped the legacy CLI flags (`--no-eslintrc`, `--rule` as CLI string, `--plugin`). The workspace runs `eslint ^9.33.0`, so a CLI smoke test would require constructing a temporary flat config file. Simpler and more reliable: write the smoke test as another `RuleTester` block with multi-statement code samples.
 - Smoke test shape (added to the same test file using the same MOCK_COMPONENTS):
+
   ```js
   ruleTester.run('deprecated-class-props (integration)', rule, {
     valid: [
@@ -420,6 +423,7 @@ Branch: `feat/dlt-3281-eslint-deprecated-class-props` (off `staging`)
     ],
   });
   ```
+
 - Run full plugin test suite: `pnpm nx run eslint-plugin-dialtone:test`. Expect: all 11 existing rule tests + new test file pass, 0 failures.
 - This integration block lives in the same test file as the unit cases — no separate fixture file, no separate ESLint invocation. It exercises the rule end-to-end through the same data path consumers will use, with realistic multi-line input.
 

--- a/docs/plans/2026-05-07-dlt-3281-eslint-deprecated-class-props.md
+++ b/docs/plans/2026-05-07-dlt-3281-eslint-deprecated-class-props.md
@@ -1,0 +1,447 @@
+# DLT-3281 ESLint Rule: deprecated-class-props Implementation Plan
+
+Created: 2026-05-07
+Author: belu.montoya@dialpad.com
+Status: COMPLETE
+Approved: Yes
+Iterations: 1
+Worktree: No
+Type: Feature
+Jira: [DLT-3281](https://dialpad.atlassian.net/browse/DLT-3281)
+PRD: [docs/prd/2026-05-07-eslint-deprecated-class-props.md](../prd/2026-05-07-eslint-deprecated-class-props.md)
+Branch: `feat/dlt-3281-eslint-deprecated-class-props` (off `staging`)
+
+## Summary
+
+**Goal:** Add an ESLint rule `deprecated-class-props` to `@dialpad/eslint-plugin-dialtone` that flags `<dt-*>` template usage of `rootClass` / `wrapperClass` / `containerClass` (and kebab variants) when the target component does not currently declare that prop, with autofix to rename to the native `class` attribute and merge into existing class bindings.
+
+**Architecture:** Single Vue-template rule following the established `parserServices.defineTemplateBodyVisitor` pattern. Component-prop data is read at rule-load time directly from the JSON artifact published by `@dialpad/dialtone-vue` (`./component-documentation.json`). No hardcoded component lists. No deprecation registry. The rule's inclusion logic is computed from the live JSON snapshot at lint time.
+
+**Tech Stack:** ESLint rule (CommonJS), `vue-eslint-parser` for template AST, Mocha + ESLint `RuleTester` for tests, `proxyquire` to inject controlled component-data fixtures into tests. New peer dependencies: `@dialpad/dialtone-vue` (for the JSON in production), `vue-eslint-parser` (for the visitor). New dev dependencies: `vue-eslint-parser` (so the plugin's own test run can resolve it without relying on workspace hoisting), `proxyquire` (for mocking the JSON import in tests).
+
+## Scope
+
+### In Scope
+
+- A single ESLint rule named `deprecated-class-props` under `packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js`.
+- Detection of any `<dt-*>` or `<Dt*>` template tag with a `root-class` / `rootClass` / `wrapper-class` / `wrapperClass` / `container-class` / `containerClass` attribute (static or `:`-bound) when the target component does NOT declare the prop in `component-documentation.json`.
+- Autofix that renames the offending attribute to `class` (or `:class` for dynamic bindings), merging into an existing class binding when present, per the algorithm in `packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs:358-401`.
+- One conservative non-fix case: dynamic `:<prop>="expr"` + existing `:class="..."` — warn only, no autofix.
+- Severity: `warn`.
+- Single message format: `"Dt[Name] does not accept a `[propName]` prop. Use the native `class` attribute instead. See: https://dialtone.dialpad.com/guides/migration/component-props/"`.
+- Tests covering: 12 detection cases for DtInput (3 prop bases × 2 casings × 2 binding forms — DtInput is the post-deprecation anchor in the test fixture); 4 autofix scenarios (static-no-class, static-with-class, dynamic-no-class, dynamic-with-class-warn-only); 1 regression case (DtListItem with `wrapperClass` must NOT trigger). All tests run against a controlled fixture data source via `proxyquire` — never against the live workspace JSON.
+- Documentation file `docs/rules/deprecated-class-props.md` matching the format of existing rule docs.
+- Add `@dialpad/dialtone-vue` and `vue-eslint-parser` to the plugin's `peerDependencies`. Add `vue-eslint-parser` and `proxyquire` to `devDependencies`.
+
+### Out of Scope
+
+- Conversion of the eslint plugin from CJS to ESM. (Considered as an alternative; rejected because direct JSON import sidesteps the ESM/CJS friction without the conversion cost.)
+- Modifications to `@dialpad/dialtone-query-core`. (The plugin doesn't consume it.)
+- A "deprecation registry" pattern across the design system. (Premature — the rule's needs are met by the existing JSON artifact.)
+- Migration of any code in this monorepo. (The codemod and migration docs already shipped.)
+- Other DLT-3157 deprecations (`hide-*` / `show` / `title` / `validation-state` value renames). (Different shapes, separate rules if pursued.)
+- Automatic addition of the rule to the plugin's `recommended` preset. (Matches existing convention — opt-in only.)
+- Adding `vue-eslint-parser` as a runtime `dependency` (vs `peerDependency`). (PeerDep matches consumer-managed parser convention.)
+
+## Approach
+
+**Chosen:** Data-driven rule reading `@dialpad/dialtone-vue/component-documentation.json` directly via the package's `exports` subpath.
+
+**Why:** Three real integration paths exist (direct JSON, ESM-convert plugin to use query-core, build-time snapshot). Direct JSON is the smallest surface area, has no ESM/CJS friction, tracks the consumer's installed dialtone-vue version, and uses the same data source query-core itself uses internally. Cost: introduces a new peerDependency on `@dialpad/dialtone-vue`. Benefit: zero plugin conversion, zero new patterns, full data-driven correctness including future-proofing against component changes.
+
+**Alternatives considered:**
+
+- **Convert plugin to ESM, consume query-core directly** — rejected. 11-file conversion plus test infra changes plus consumer compatibility risk on older ESLint versions. Disproportionate to the goal.
+- **Bundle a build-time JSON snapshot into the plugin** — rejected. Introduces a duplicate-snapshot pattern not used elsewhere; data can drift from the consumer's installed dialtone-vue. Direct JSON via exports is strictly better.
+
+## Context for Implementer
+
+### Patterns to follow
+
+- **Visitor pattern:** `lib/rules/deprecated-stack-alignment-classes.js:50-108` — uses `VElement` visitor, looks at `node.startTag.attributes`, finds attributes by `attr.key.name === '<name>'`. This is the right pattern for our rule because we need to inspect multiple attributes per element (the offending prop AND any existing `class` / `:class` for merge logic).
+- **Simpler attribute pattern (alternative to consider):** `lib/rules/deprecated-flex-gap-classes.js:27-43` — uses `VAttribute` visitor for single-attribute rules. Probably insufficient for our needs because of cross-attribute merge logic, but worth keeping in mind.
+- **Test setup:** `tests/lib/rules/deprecated-stack-alignment-classes.js:14-22` — Mocha + `RuleTester` instantiated with `parser: require.resolve('vue-eslint-parser')`. Use `output` field on `invalid` cases to assert autofix output.
+- **Plugin auto-load:** `lib/index.js:19` does `module.exports.rules = requireIndex(__dirname + "/rules")`. Just save `deprecated-class-props.js` in `lib/rules/` and it picks up automatically — no index registration needed.
+
+### Conventions
+
+- File names: kebab-case. Rule file: `deprecated-class-props.js`. Test file: `deprecated-class-props.js`. Docs file: `deprecated-class-props.md`.
+- Rule meta `type: 'suggestion'`, `recommended: false`, `fixable: 'code'`.
+- Message keys are camelCase string identifiers (`messages: { propRemoved: '...' }`).
+- Rule docs URL convention: `https://github.com/dialpad/dialtone/blob/staging/packages/eslint-plugin-dialtone/docs/rules/deprecated-class-props.md`.
+
+### Key files
+
+- `packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js` — the rule (create).
+- `packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js` — tests (create).
+- `packages/eslint-plugin-dialtone/docs/rules/deprecated-class-props.md` — docs (create).
+- `packages/eslint-plugin-dialtone/package.json` — modify to add peerDependencies.
+- `packages/dialtone-vue/dist/component-documentation.json` — read-only data source. Shape: `Component[]` where `Component = { displayName: string, props?: { name: string, ... }[], ... }` per `packages/dialtone-query-core/src/types.ts:43-65`.
+- `packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs:358-401` — reference implementation of `applyRootClassRename` with the canonical merge logic (regex-based; we reimplement using AST ranges but produce identical output).
+
+### Gotchas
+
+- **Component name resolution:** template tags can be `<dt-input>` (kebab) or `<DtInput>` (PascalCase). `component-documentation.json` keys components by `displayName` (`DtInput`). Normalize the tag name to PascalCase before lookup. Example: `dt-feed-item-pill` → `DtFeedItemPill`.
+- **Prop name normalization:** templates can use `root-class` or `rootClass`; `component-documentation.json` stores props in camelCase (`rootClass`). Normalize the attribute name to camelCase before lookup.
+- **Vue `inheritAttrs` default-true class merging:** when consumers add `class="x"` to a Dialtone component, Vue's framework-level merge handles forwarding regardless of whether the component has explicit `$attrs.class` plumbing. This is what makes the rename mechanically safe across all flagged components — verified during PRD source-of-truth investigation.
+- **Idempotent autofix:** ESLint applies fixes iteratively until output is stable. The rule is naturally idempotent — once `root-class` is renamed to `class`, the rule's detection no longer matches the tag, so no further fix is produced.
+- **`requireIndex` only loads `.js` files in `lib/rules/`:** don't accidentally save the rule with a different extension or in a subdirectory.
+- **`vue-eslint-parser` availability:** the rule's tests will fail if `vue-eslint-parser` isn't resolvable. The plugin already uses `require.resolve('vue-eslint-parser')` in existing tests, so it should already be available in the workspace's `node_modules`. Double-check during Task 1.
+- **JSON `exports` subpath:** `@dialpad/dialtone-vue` exports `./component-documentation.json` (verified at `packages/dialtone-vue/package.json`). The Node `require()` resolver respects exports maps — this works in modern Node. If the consumer's installed dialtone-vue is older and lacks this export, `require()` will throw. Wrap the import in a try/catch and have the rule degrade to no-op when data is unavailable (log once, do not flag anything).
+
+### Domain context
+
+- The migration this rule guards (DLT-3100) removed `rootClass`, `wrapperClass`, and `containerClass` from a set of components. The codemod and migration docs already shipped via DLT-3157. This rule is the ongoing guardrail.
+- Consumers of `@dialpad/eslint-plugin-dialtone` are typically Dialpad product teams whose Vue projects already use `eslint-plugin-vue` and therefore already have `vue-eslint-parser` available. Adding `vue-eslint-parser` as a peerDependency formalizes the existing implicit assumption.
+- The data-driven design means: DtListItem and DtPopoverHeaderFooter (which still declare `wrapperClass` legitimately on `next`) are NOT flagged. Future deprecations of these prop names on any component are picked up automatically without rule code changes.
+
+## File Structure
+
+- `packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js` (create) — rule logic. Visitor + detection + autofix. Module-level cache of components data.
+- `packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js` (create) — Mocha + RuleTester suite covering detection, autofix, and regression.
+- `packages/eslint-plugin-dialtone/docs/rules/deprecated-class-props.md` (create) — rule documentation following the format of `docs/rules/deprecated-flex-gap-classes.md`.
+- `packages/eslint-plugin-dialtone/package.json` (modify) — add `@dialpad/dialtone-vue` and `vue-eslint-parser` to `peerDependencies`.
+
+## Assumptions
+
+- **Assumption A1:** In production (when consumers install the plugin alongside `@dialpad/dialtone-vue`), the published dialtone-vue package contains `dist/component-documentation.json` and exposes it via the `./component-documentation.json` exports subpath. — Supported by `packages/dialtone-vue/package.json` (`"./component-documentation.json": "./dist/component-documentation.json"` in `exports`). The file is a build artifact (`dist/` is in build output), so it is present in the *published* package but is regenerated by `pnpm nx run dialtone-vue:build` for local consumers. Tasks 2, 3 depend on this for production behavior. **Tests do NOT depend on this** — they use a controlled fixture via `proxyquire` (Assumption A6).
+- **Assumption A2:** `Component[]` shape in the JSON matches `packages/dialtone-query-core/src/types.ts:58-65` — `{ displayName, props?: { name, ... }[], ... }`. — Supported by reading the JSON and the `vue-docgen-api` extraction in `scripts/build-dialtone-vue-docs.mjs`. Tasks 2, 3, 4 depend on this.
+- **Assumption A3:** `vue-eslint-parser` is resolvable in workspaces that consume the plugin AND in the plugin's own test environment. — Currently it works because `vue-eslint-parser` is hoisted into the workspace's `node_modules` as a transitive dependency. To formalize this for both audiences, Task 1 adds it to BOTH `peerDependencies` (consumer-facing) AND `devDependencies` (plugin's own test runs). Without the devDep, strict pnpm hoisting would break the plugin's tests. Tasks 2-5 depend on this.
+- **Assumption A4:** Mocha + `eslint`'s `RuleTester` with `parser` option works for ESLint 7+. — Supported by the existing test file `tests/lib/rules/deprecated-stack-alignment-classes.js` using exactly this pattern with the workspace's installed `eslint ^9.33.0`. Task 2's test setup depends on this.
+- **Assumption A5:** Vue's default `inheritAttrs: true` correctly merges consumer `class` onto the component's resolved root element across all 13 affected components. — Supported by PRD source-of-truth verification across all 13 components. Task 3's autofix correctness depends on this.
+- **Assumption A6:** `proxyquire` reliably stubs JSON-file imports in CommonJS tests. — Standard pattern for ESLint rule testing. Tasks 2-4 depend on this for deterministic test behavior independent of workspace branch state. Tests construct an explicit `MOCK_COMPONENTS` fixture representing the post-deprecation state (DtInput WITHOUT `rootClass`, DtListItem WITH `wrapperClass`, etc.) and inject it via `proxyquire` when loading the rule.
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Older dialtone-vue installed in consumer's repo lacks the JSON exports subpath | Low | Medium | Defensive load in rule's module init: try/catch the `require`. On failure, set components to empty array. Rule never fires on missing data. Surface a one-time `console.warn` so the consumer learns of the version mismatch. (Verified in Task 2.) |
+| In a clean checkout / CI without `dialtone-vue:build` having run, the live JSON is absent — production-mode rule would no-op silently | Medium | Low | Tests use mocked fixture (not the live JSON), so test runs are unaffected. For end-to-end verification in CI, ensure `dialtone-vue:build` runs before the plugin's test target — or accept the no-op as graceful degradation since the rule's only role in this state is "do nothing" (no consumer code to lint). |
+| Branch state mismatch — we're on `feat/dlt-3281...` off `staging`, where deprecated props are STILL declared | Low | Low | Tests use post-deprecation fixture data via proxyquire — completely decoupled from the workspace's actual `dist/component-documentation.json`. Production behavior on consumer machines uses *their* installed dialtone-vue, which will be the post-deprecation version once Dialtone v10 ships. |
+| Component-name normalization edge case (e.g. tag has unusual casing) | Low | Low | Implement explicit kebab-to-PascalCase function. Test with `<dt-feed-item-pill>`, `<DtFeedItemPill>`, `<dt-input>`, `<DtInput>`. Out-of-set tags (e.g. `<custom-element>`) skip lookup entirely — only `dt-*`/`Dt*` tags are inspected. |
+| Autofix introduces a syntax error in some edge case | Low | High | TDD — every fix scenario has a test asserting exact output. The fixer uses range-based replacement that operates at AST-known boundaries; the codemod's algorithm has been deployed and proven. Manual smoke test in Task 6 catches anything the unit tests miss. |
+| Multi-fix interactions on a tag with both an offending prop AND multi-line `class` formatting | Medium | Low | Use AST node `range` from `vue-eslint-parser` rather than regex on raw text. The visitor sees structured nodes regardless of source formatting. Test multi-line case explicitly. |
+| ESLint version compatibility (plugin supports `eslint >= 7`) | Low | Medium | `parserServices.defineTemplateBodyVisitor` and the `RuleTester` API used here have been stable since ESLint 6. `context.sourceCode ?? context.getSourceCode()` (already used by existing rules) handles ESLint 8+ transition. No new compatibility surface. |
+| Regression — silently breaking existing rules during refactor | Very Low | Medium | This task adds a new rule and modifies only `package.json`. No existing rule code is touched. Run full plugin test suite in Task 6. |
+
+## Goal Verification
+
+### Truths
+
+1. T-001: Running `pnpm nx run eslint-plugin-dialtone:test` on the new test file produces 0 failures.
+2. T-002: With MOCK_COMPONENTS injected via proxyquire (DtInput WITHOUT rootClass), the rule reports a warning on `<dt-input root-class="d-w332" />`.
+3. T-003: With the same MOCK_COMPONENTS, the rule's autofix output for `<dt-input root-class="d-w332" />` is `<dt-input class="d-w332" />`.
+4. T-004: With the same MOCK_COMPONENTS (DtListItem WITH wrapperClass), the rule reports NO warning on `<dt-list-item wrapper-class="d-pt8" />`.
+5. T-005: With the same MOCK_COMPONENTS, the rule warns on `<dt-input :root-class="dynExpr" :class="otherExpr" />` but produces no autofix output (left unchanged).
+6. T-006: The full plugin test suite passes — all 11 existing rule tests + the new test file — confirming no regression.
+7. T-007: `pnpm nx run eslint-plugin-dialtone:lint` (markdownlint on docs) passes for the new `deprecated-class-props.md`.
+
+### Artifacts
+
+- `packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js` — the rule.
+- `packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js` — the test suite.
+- `packages/eslint-plugin-dialtone/docs/rules/deprecated-class-props.md` — the documentation.
+- `packages/eslint-plugin-dialtone/package.json` — peerDependencies updated.
+
+## Progress Tracking
+
+- [x] Task 1: Add peerDependencies and verify install
+- [x] Task 2: Implement rule detection logic with module-level data load
+- [x] Task 3: Implement autofix for static and dynamic class-prop renames
+- [x] Task 4: Add regression tests for currently-valid components (DtListItem, DtPopoverHeaderFooter)
+- [x] Task 5: Write rule documentation
+- [x] Task 6: Manual smoke test on a fixture file and run full plugin suite
+
+**Total Tasks:** 6 | **Completed:** 6 | **Remaining:** 0
+
+## Implementation Tasks
+
+### Task 1: Add peerDependencies and verify install
+
+**Objective:** Declare the rule's two new peer dependencies in the plugin's `package.json` and confirm they resolve cleanly in the workspace.
+
+**Dependencies:** None.
+**Mapped Truths:** T-006.
+
+**Files:**
+
+- Modify: `packages/eslint-plugin-dialtone/package.json`
+
+**Key Decisions / Notes:**
+
+- Add to `peerDependencies`:
+  - `"@dialpad/dialtone-vue": "workspace:^3"` — matches the convention used by `dialtone-query-core` (workspace devDep) and `language-server` (workspace runtime dep).
+  - `"vue-eslint-parser": ">=9"` — version range that supports `defineTemplateBodyVisitor` and matches what `eslint-plugin-vue` v9+ requires.
+- Add to `devDependencies` (in addition to existing `mocha`):
+  - `"vue-eslint-parser": ">=9"` — required so the plugin's own `RuleTester` setup can resolve the parser without depending on workspace hoisting (per spec-review must_fix #3).
+  - `"proxyquire": "^2.1.3"` — required by Task 2's tests to stub the `@dialpad/dialtone-vue/component-documentation.json` import with a controlled fixture, decoupling tests from workspace branch state.
+- Do NOT touch `dependencies` (still just `requireindex`).
+- Existing `peerDependencies.eslint` (`">=7"`) stays.
+
+**Definition of Done:**
+
+- [ ] `package.json` has both new entries in `peerDependencies` and both new entries in `devDependencies`.
+- [ ] `pnpm install` from the repo root completes without warnings related to the plugin.
+- [ ] `require.resolve('vue-eslint-parser')` and `require.resolve('proxyquire')` both succeed when run from `packages/eslint-plugin-dialtone/`.
+- [ ] No diagnostics errors in `package.json`.
+
+**Verify:**
+
+- `pnpm install` (run from repo root)
+- `cd packages/eslint-plugin-dialtone && node -e "require.resolve('vue-eslint-parser'); require.resolve('proxyquire'); console.log('OK')"` → prints `OK`
+
+### Task 2: Implement rule detection logic with module-level data load
+
+**Objective:** Create the rule file with detection only (no autofix yet). Load `component-documentation.json` once at module init, build a normalized lookup, and report a warning whenever an offending attribute appears on a Dialtone tag whose component does NOT declare that prop.
+
+**Dependencies:** Task 1.
+**Mapped Truths:** T-002, T-004, T-006.
+
+**Files:**
+
+- Create: `packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js`
+- Create: `packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js`
+
+**Key Decisions / Notes:**
+
+- **Visitor:** use `parserServices.defineTemplateBodyVisitor({ VElement(node) { ... } })`. We need access to the start tag's full attribute list to support cross-attribute merge logic in Task 3 — `VElement` gives us `node.startTag.attributes`. Pattern matches `lib/rules/deprecated-stack-alignment-classes.js:50-108`.
+- **Tag detection:** match `node.rawName` or `node.name` against `^dt-` (kebab) or `^Dt[A-Z]` (PascalCase). Skip non-Dialtone tags entirely.
+- **Tag-name normalization:** kebab-to-PascalCase function. Example: `dt-feed-item-pill` → `DtFeedItemPill`. Reuse Vue's standard conversion: split on `-`, capitalize each segment, join.
+- **Attribute matching:** for each attribute in `node.startTag.attributes`, check if the attribute name (or directive argument for `:`-bound) matches one of the 6 deprecated names (3 props × 2 casings). Use a const set. Example for static: `attr.directive === false && attr.key.name === 'root-class'`. For dynamic: `attr.directive === true && attr.key.argument?.name === 'root-class'`.
+- **Module-level data load (defensive):** at the top of the rule file, attempt `require('@dialpad/dialtone-vue/component-documentation.json')` inside try/catch. On failure, set `components = []` and emit `console.warn('[eslint-plugin-dialtone] Could not load component-documentation.json from @dialpad/dialtone-vue. The deprecated-class-props rule will be skipped.')` once. The `require` call is what tests will stub via `proxyquire` — the rule must use this exact import path (no indirection) so the stub matches.
+- **Lookup helper:** `componentDeclaresProp(displayName, propName)` — `components.find(c => c.displayName === displayName)?.props?.some(p => p.name === propName) ?? false`. Cache the lookup if perf shows up as an issue (premature for now — N=~60 components, list traversal is fine).
+- **Reporting:** report on the offending `VAttribute` node. Message: `"DtFoo does not accept a 'rootClass' prop. Use the native 'class' attribute instead. See: https://dialtone.dialpad.com/guides/migration/component-props/"`.
+- **No fix in this task** — `meta.fixable: null` for now. Task 3 flips to `'code'` and adds the fixer.
+- **Test setup:** mirror `tests/lib/rules/deprecated-stack-alignment-classes.js` AND inject mocked component data via `proxyquire`:
+  ```js
+  const proxyquire = require('proxyquire').noCallThru();
+  const MOCK_COMPONENTS = [
+    { displayName: 'DtInput', props: [{ name: 'label' }, { name: 'value' }] },          // post-deprecation: no rootClass
+    { displayName: 'DtListItem', props: [{ name: 'wrapperClass' }, { name: 'label' }] }, // currently declares wrapperClass
+    { displayName: 'DtToggle', props: [{ name: 'label' }, { name: 'showLabel' }] },     // post-deprecation: no wrapperClass
+    { displayName: 'DtCard', props: [{ name: 'header' }, { name: 'footer' }] },         // post-deprecation: no containerClass
+    { displayName: 'DtAvatar', props: [{ name: 'fullName' }, { name: 'interactive' }] }, // never had rootClass
+    { displayName: 'DtFeedItemPill', props: [{ name: 'kind' }] },                       // post-deprecation: no wrapperClass
+  ];
+  const rule = proxyquire('../../../lib/rules/deprecated-class-props', {
+    '@dialpad/dialtone-vue/component-documentation.json': MOCK_COMPONENTS,
+  });
+  const ruleTester = new RuleTester({ parser: require.resolve('vue-eslint-parser'), parserOptions: { ecmaVersion: 'latest' } });
+  ```
+  All test cases run against `MOCK_COMPONENTS` — the rule's behavior is fully deterministic regardless of what's in `packages/dialtone-vue/dist/component-documentation.json` on the current branch.
+- **Tests for this task — detection cases only:**
+  - Valid cases (should NOT report):
+    - `<dt-input class="x" />` — using `class` is correct
+    - `<dt-input :class="expr" />` — using `:class` is correct
+    - `<dt-input />` — no offending attribute
+    - `<div root-class="x" />` — not a Dialtone tag
+    - `<dt-list-item wrapper-class="x" />` — DtListItem declares `wrapperClass` in MOCK
+    - `<dt-list-item :wrapper-class="cls" />` — same, dynamic form
+  - Invalid cases (should report 1 warning each — DtInput as anchor):
+    - `<dt-input root-class="x" />` — static kebab
+    - `<dt-input rootClass="x" />` — static camel
+    - `<dt-input :root-class="expr" />` — dynamic kebab
+    - `<dt-input :rootClass="expr" />` — dynamic camel
+    - `<DtInput rootClass="x" />` — PascalCase tag, camelCase attr
+    - `<dt-toggle wrapper-class="x" />` — different prop, different component (DtToggle in MOCK has no wrapperClass)
+    - `<dt-card container-class="x" />` — third prop, third component (DtCard in MOCK has no containerClass)
+    - `<dt-feed-item-pill wrapper-class="x" />` — multi-segment kebab tag normalization check
+    - `<dt-avatar root-class="x" />` — the "never had it" case (DtAvatar in MOCK has no rootClass)
+    - `<dt-list-item root-class="x" />` — sanity check that DtListItem is not blanket-skipped (it has wrapperClass but NOT rootClass)
+
+**Definition of Done:**
+
+- [ ] Rule file exists, exports valid `RuleModule` shape.
+- [ ] All detection test cases pass.
+- [ ] No regression in other plugin tests.
+- [ ] `requireindex` auto-loads the rule (no manual registration needed; verify by running the test).
+
+**Verify:**
+
+- `pnpm nx run eslint-plugin-dialtone:test` — full suite passes including the new test file.
+- Spot check: `node -e "console.log(require('@dialpad/eslint-plugin-dialtone').rules['deprecated-class-props'])"` from the repo root should print the rule object.
+
+### Task 3: Implement autofix for static and dynamic class-prop renames
+
+**Objective:** Add the autofix logic per the four rename scenarios from the PRD and the codemod's `applyRootClassRename`. Update rule meta `fixable: 'code'`.
+
+**Dependencies:** Task 2.
+**Mapped Truths:** T-003, T-005, T-006.
+
+**Files:**
+
+- Modify: `packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js`
+- Modify: `packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js`
+
+**Key Decisions / Notes:**
+
+- **Reference algorithm:** `packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs:358-401` (`applyRootClassRename`). We reimplement with AST ranges instead of regex.
+- **Four scenarios:**
+  1. **Static, no existing class** → replace the offending attribute with `class="<value>"`. Single `fixer.replaceText(node, 'class="<value>"')`.
+  2. **Static, with existing `class="other"`** → drop the offending attribute and append the value to the existing class. Two-edit fix: `fixer.removeRange(<offending-range-with-leading-whitespace>)` + `fixer.replaceText(<existing-class-node>, 'class="other <value>"')`. Use `fixer.replaceTextRange` covering the union of both ranges if ESLint complains about overlapping fixes.
+  3. **Dynamic, no existing `:class`** → replace with `:class="<expr>"`. Single replacement.
+  4. **Dynamic, with existing `:class`** → emit warning only (no fix). The fix function returns `null` for this case. Test asserts `output: null` (or absent).
+- **Whitespace handling:** when removing an attribute that's preceded by whitespace, include the whitespace in the removal so the resulting tag doesn't have a double space. Use `sourceCode.getTokenBefore(attr)` to find the preceding whitespace boundary.
+- **Existing-class detection:** before fixing, scan `node.startTag.attributes` for an attribute matching `attr.key.name === 'class'` (static) or `attr.directive && attr.key.argument?.name === 'class'` (dynamic). Match the offending prop's binding form to the appropriate target (static prop merges into static class; dynamic prop merges into dynamic class).
+- **Test cases for this task:**
+  - Static, no class: `<dt-input root-class="d-w332" />` → `<dt-input class="d-w332" />`
+  - Static, with class: `<dt-input class="other" root-class="d-w332" />` → `<dt-input class="other d-w332" />`
+  - Static, with class (other order): `<dt-input root-class="d-w332" class="other" />` → `<dt-input class="other d-w332" />`
+  - Dynamic, no :class: `<dt-input :root-class="cls" />` → `<dt-input :class="cls" />`
+  - Dynamic, with :class: `<dt-input :root-class="cls" :class="other" />` → unchanged, warning only.
+  - Idempotency: running fix twice on the static-no-class case still yields the static-no-class fixed output.
+
+**Definition of Done:**
+
+- [ ] `meta.fixable` set to `'code'`.
+- [ ] All four autofix scenarios produce the expected output (or no output for the warn-only case).
+- [ ] Idempotency test passes.
+- [ ] No regression in other plugin tests.
+
+**Verify:**
+
+- `pnpm nx run eslint-plugin-dialtone:test` — passes.
+- `node -e "..."` snippet running the rule on a string with `root-class` and `class` and asserting fixed output shape.
+
+### Task 4: Add regression and idempotency assertions
+
+**Objective:** Lock in the data-driven correctness with explicit assertions that components currently declaring these props are NOT flagged, and that the autofix is idempotent.
+
+**Dependencies:** Tasks 2 and 3.
+**Mapped Truths:** T-004, T-006.
+
+**Files:**
+
+- Modify: `packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js`
+
+**Key Decisions / Notes:**
+
+- The DtListItem regression cases were already added in Task 2's valid array (the MOCK_COMPONENTS fixture includes DtListItem with `wrapperClass`). This task adds **assertion comments** documenting their regression intent and adds two additional checks:
+  - **Idempotency:** an explicit test that runs the rule's fix once on `<dt-input root-class="x" />`, takes the output, runs the rule again on that output, and asserts no further fix is produced.
+  - **Mock-shape sanity:** a unit-level test that the rule's `componentDeclaresProp` lookup helper returns `true` for `('DtListItem', 'wrapperClass')` and `false` for `('DtInput', 'rootClass')` against MOCK_COMPONENTS. This tests the lookup function in isolation without the visitor.
+- DtPopoverHeaderFooter was originally proposed as a second regression anchor but is **dropped from the test fixture**: on `staging` (the branch we're targeting), the component does NOT declare `wrapperClass` — that declaration is only on `next`. Including it would cause a test failure as soon as the workspace branch state changed. DtListItem alone is the regression anchor; it declares `wrapperClass` on both `staging` and `next`.
+- Add a code comment in the test file at the top of the regression assertions: `// Regression — components currently declaring these prop names must NOT be flagged. Source-of-truth: dialtone-vue components/list_item/list_item.vue (wrapperClass declared at line 143 on staging).`
+
+**Definition of Done:**
+
+- [ ] DtListItem regression cases are explicitly commented in the test file as regression assertions.
+- [ ] Idempotency test passes (running fix twice yields the same output).
+- [ ] Lookup-function unit test passes.
+- [ ] No regression in other plugin tests.
+
+**Verify:**
+
+- `pnpm nx run eslint-plugin-dialtone:test` — passes.
+
+### Task 5: Write rule documentation
+
+**Objective:** Create `docs/rules/deprecated-class-props.md` matching the format of existing rule docs.
+
+**Dependencies:** Tasks 2 and 3 (so the doc accurately describes the implemented behavior).
+**Mapped Truths:** T-007.
+
+**Files:**
+
+- Create: `packages/eslint-plugin-dialtone/docs/rules/deprecated-class-props.md`
+
+**Key Decisions / Notes:**
+
+- Follow the format of `docs/rules/deprecated-flex-gap-classes.md` and `docs/rules/deprecated-stack-alignment-classes.md`.
+- Required sections:
+  - Title: `# Detects deprecated structural class props on Dialtone components (deprecated-class-props)`
+  - Rationale (1-2 paragraphs): explain why these props were removed (DLT-3100), why the rule exists (ongoing guardrail), link to migration guide.
+  - Examples — `## Rule Details` with subsections:
+    - Examples of **incorrect** code (3-4 examples covering kebab/camel/static/dynamic).
+    - Examples of **correct** code (the same examples after fix).
+    - "When the rule does NOT fire" — examples of currently-valid usages (DtListItem with `wrapper-class`).
+  - Autofix behavior — `## Auto-fix` section listing the four scenarios.
+  - References — link to the migration guide URL, link to the dialtone-vue components docs.
+- Lint with markdownlint via `pnpm nx run eslint-plugin-dialtone:lint`.
+
+**Definition of Done:**
+
+- [ ] File exists and follows the required structure.
+- [ ] All code examples in the doc are valid Vue templates that the rule would correctly handle.
+- [ ] Markdownlint passes (`pnpm nx run eslint-plugin-dialtone:lint`).
+
+**Verify:**
+
+- `pnpm nx run eslint-plugin-dialtone:lint`
+
+### Task 6: Mocha integration smoke test and run full plugin suite
+
+**Objective:** Confirm the rule behaves correctly on a multi-line, realistic template fixture in a single Mocha integration block, and that the full plugin test suite passes with no regressions. Avoids the ESLint 9 flat-config incompatibility of a raw CLI invocation.
+
+**Dependencies:** Tasks 1-5.
+**Mapped Truths:** T-001, T-002, T-003, T-005, T-006.
+
+**Files:**
+
+- Modify: `packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js` — add a final `describe('integration smoke test', ...)` block.
+
+**Key Decisions / Notes:**
+
+- ESLint 9 flat config has dropped the legacy CLI flags (`--no-eslintrc`, `--rule` as CLI string, `--plugin`). The workspace runs `eslint ^9.33.0`, so a CLI smoke test would require constructing a temporary flat config file. Simpler and more reliable: write the smoke test as another `RuleTester` block with multi-statement code samples.
+- Smoke test shape (added to the same test file using the same MOCK_COMPONENTS):
+  ```js
+  ruleTester.run('deprecated-class-props (integration)', rule, {
+    valid: [
+      {
+        code: `<template>
+          <dt-input class="d-pl8" />
+          <dt-list-item wrapper-class="d-pt8" />
+        </template>`,
+      },
+    ],
+    invalid: [
+      {
+        code: `<template>
+          <dt-input root-class="d-w332" label="Email" />
+          <dt-toggle wrapper-class="d-mt16" />
+          <dt-card container-class="d-mbs-300" />
+          <dt-avatar root-class="d-mr8" />
+          <dt-input :root-class="myClass" />
+          <dt-input :root-class="myClass" :class="otherClass" />
+          <dt-list-item wrapper-class="d-pt8" />
+          <dt-input class="d-pl8" root-class="d-w332" />
+        </template>`,
+        errors: 7, // every <dt-*> line above except <dt-list-item>
+        output: `<template>
+          <dt-input class="d-w332" label="Email" />
+          <dt-toggle class="d-mt16" />
+          <dt-card class="d-mbs-300" />
+          <dt-avatar class="d-mr8" />
+          <dt-input :class="myClass" />
+          <dt-input :root-class="myClass" :class="otherClass" />
+          <dt-list-item wrapper-class="d-pt8" />
+          <dt-input class="d-pl8 d-w332" />
+        </template>`, // exact post-fix output, including the unchanged warn-only line
+      },
+    ],
+  });
+  ```
+- Run full plugin test suite: `pnpm nx run eslint-plugin-dialtone:test`. Expect: all 11 existing rule tests + new test file pass, 0 failures.
+- This integration block lives in the same test file as the unit cases — no separate fixture file, no separate ESLint invocation. It exercises the rule end-to-end through the same data path consumers will use, with realistic multi-line input.
+
+**Definition of Done:**
+
+- [ ] Integration smoke test produces 7 errors and the exact expected post-fix output.
+- [ ] `pnpm nx run eslint-plugin-dialtone:test` passes (0 failures across all rule test files).
+- [ ] `pnpm nx run eslint-plugin-dialtone:lint` passes.
+- [ ] Plan moved to `Status: COMPLETE` once all tasks above are done.
+
+**Verify:**
+
+- `pnpm nx run eslint-plugin-dialtone:test`
+- `pnpm nx run eslint-plugin-dialtone:lint`
+
+## Open Questions
+
+None at this time. All design decisions resolved during PRD and Step 7.
+
+## Deferred Ideas
+
+- **Inclusion in the plugin's `recommended` preset.** Existing rules all opt out (`recommended: false`); follow that convention for now. A future plugin-wide review could decide to enable selected rules in `recommended`.
+- **Sunset path for the rule.** Once the deprecation window closes (e.g., 6 months after Dialtone v10 GA), this rule could be removed. Not actionable now but worth tracking — add a CHANGELOG note when removing.
+- **Rule schema/options.** Currently no options needed. If consumers later want to disable the autofix per-project (e.g., to manually review every change), we could add `{ autofix: 'always' | 'never' }`. Defer until requested.
+- **A general "deprecation registry" pattern across the design system.** Worth revisiting when a future deprecation has a shape this rule's data-driven approach can't model (e.g., requires historical "what was removed" data not derivable from current source).

--- a/docs/prd/2026-05-07-eslint-deprecated-class-props.md
+++ b/docs/prd/2026-05-07-eslint-deprecated-class-props.md
@@ -1,0 +1,131 @@
+# ESLint Rule for Removed Class Props on Dialtone Vue Components
+
+Created: 2026-05-07
+Author: belu.montoya@dialpad.com
+Category: Infrastructure
+Status: Final
+Research: Standard
+Jira: [DLT-3281](https://dialpad.atlassian.net/browse/DLT-3281)
+Linked tickets: action item from [DLT-3100](https://dialpad.atlassian.net/browse/DLT-3100); codemod + docs portion absorbed into [DLT-3157](https://dialpad.atlassian.net/browse/DLT-3157)
+Branch + PR title must reference `DLT-3281`
+
+## Problem Statement
+
+In DLT-3100, three structural class props (`rootClass`, `wrapperClass`, `containerClass` and their kebab-case variants) were removed from a set of Dialtone Vue components. The migration was scoped as three deliverables: a codemod, migration documentation, and an ESLint rule. The codemod (`dialtone-migrate-props`) and the migration guide (`/guides/migration/component-props/`) shipped via DLT-3157 and are live on `next`. The ESLint rule is the remaining deliverable.
+
+The codemod is one-shot — it sweeps existing code once and exits. New code written after the migration can reintroduce the removed props with no feedback, because Vue silently ignores unknown props at runtime. Without an always-on guardrail, the codemod's work erodes over the deprecation window: developers who weren't around for the migration write the old prop names from memory, IDEs that cached older type definitions auto-complete them, copy-pasted snippets propagate them.
+
+The ESLint rule is the ongoing guardrail. It catches removed-prop usage every save, every PR, every CI run, with an autofix that mirrors the codemod's rewrite logic. It exists to keep the deprecation effective, not to perform a one-time migration.
+
+## Core User Flows
+
+### Flow 1: Developer writes new code with a removed prop
+
+1. Developer types `<dt-input root-class="d-w332" label="Email" />` in a `.vue` file.
+2. ESLint runs on save (editor integration) or on commit (lint-staged).
+3. Rule emits a warning: "DtInput does not accept a `root-class` prop. Use the `class` attribute instead. See [migration guide]."
+4. Developer accepts the autofix in their editor (or runs `eslint --fix`) and the line becomes `<dt-input class="d-w332" label="Email" />`.
+
+### Flow 2: PR contains legacy code that bypassed the codemod
+
+1. CI runs `pnpm nx run dialtone-vue:lint` (or equivalent in a consumer repo) on a PR containing a stale `<dt-toggle wrapper-class="d-mt16" />`.
+2. Lint reports the warning, surfaces it in the PR review.
+3. Author runs `eslint --fix` locally; the line becomes `<dt-toggle class="d-mt16" />`.
+4. Author commits the fix; PR proceeds.
+
+### Flow 3: Future deprecation removes the same prop name from a different component
+
+1. A future ticket removes `wrapperClass` from `dt-list-item`.
+2. The next release of `@dialpad/dialtone-vue` regenerates `component-documentation.json` without `wrapperClass` on DtListItem.
+3. `@dialpad/dialtone-query-core` re-exports the new data on its next release.
+4. The rule starts firing on `<dt-list-item wrapper-class="x">` automatically — **no change to the eslint plugin's source code**.
+
+## Scope
+
+### In Scope
+
+- A single new ESLint rule in `@dialpad/eslint-plugin-dialtone`.
+- Rule name: `deprecated-class-props` (matches the plugin's `deprecated-*` convention).
+- Detection: any `<dt-*>` or `<Dt*>` template tag carrying one of these attributes — `root-class` / `rootClass` / `wrapper-class` / `wrapperClass` / `container-class` / `containerClass` (static or `:`-bound) — when the corresponding component does not currently declare that prop in `component-documentation.json`.
+- Severity: `warn` (per ticket).
+- Single message format: "Dt[Name] does not accept a `[propName]` prop. Use the native `class` attribute instead. See: [migration-guide-url]"
+- Autofix behavior, mirroring `applyRootClassRename` at `packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs:358-401`:
+  - Static `<prop>="value"`, no existing `class` attribute → replace with `class="value"`.
+  - Static `<prop>="value"` with existing `class="other"` → merge to `class="other value"`, remove the original prop.
+  - Dynamic `:<prop>="expr"`, no existing `:class` binding → replace with `:class="expr"`.
+  - Dynamic `:<prop>="expr"` with existing `:class="..."` → **no autofix**, warn only. (Two dynamic class bindings cannot be safely merged without changing semantics — manual merge required.)
+- Data source: the `components` export from `@dialpad/dialtone-query-core`, which transitively re-exports `@dialpad/dialtone-vue/component-documentation.json`. Same package consumed by `dialtone-mcp-server` and `language-server`.
+- Tests: Mocha + ESLint `RuleTester` with `vue-eslint-parser`, following the pattern at `packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-stack-alignment-classes.js`. Run via `pnpm nx run eslint-plugin-dialtone:test`.
+- Documentation: a new `docs/rules/deprecated-class-props.md` matching the format of existing rule docs (`docs/rules/deprecated-flex-gap-classes.md` and similar).
+- Plugin recommended preset: `recommended: false` in rule meta — matches all 11 existing rules in this plugin.
+
+### Explicitly Out of Scope
+
+- A "deprecation registry" pattern across the design system — premature; this rule's needs are met by the existing `dialtone-query-core` data flow. Worth revisiting if a future deprecation has shape this approach can't model.
+- Per-component prop maps hardcoded in the rule's source — replaced by data-driven lookup at lint time.
+- Migration of any code in the Dialtone monorepo — handled by the codemod and migration docs, both already shipped.
+- Other DLT-3157 deprecations (`hide-*` / `show-*` inversions, `show` → `open`, `title` → `header-text`, `validation-state` value renames, etc.) — different shapes, separate rules if pursued. This PRD covers only the class-props removal.
+- Runtime introspection of `node_modules` outside `@dialpad/dialtone-query-core` — the query-core dependency is the only data path the rule needs.
+- Backward-compatibility shims for older Dialtone versions — the rule reads whatever query-core's current snapshot says.
+
+## Technical Context
+
+- **Package location:** `packages/eslint-plugin-dialtone/`. Rule file: `lib/rules/deprecated-class-props.js`. Test: `tests/lib/rules/deprecated-class-props.js`. Docs: `docs/rules/deprecated-class-props.md`.
+- **Existing rule patterns to follow:** `lib/rules/deprecated-flex-gap-classes.js` (uses `parserServices.defineTemplateBodyVisitor` with a `VAttribute` visitor) and `lib/rules/deprecated-stack-alignment-classes.js` (uses `VElement` visitor with attribute filtering on the start tag). Either visitor works; the second matches more closely because we need to look at multiple attributes per element (the offending prop *and* any existing `class` / `:class` for merge logic).
+- **Test pattern:** see `tests/lib/rules/deprecated-stack-alignment-classes.js` — Mocha + `RuleTester` with `parser: require.resolve('vue-eslint-parser')`. Autofix tests use the `output` field on `invalid` cases.
+- **Data dependency to add:** `@dialpad/dialtone-query-core` as a `dependency` (not `peerDependency`) of `@dialpad/eslint-plugin-dialtone`. The plugin currently has no external runtime data dependencies; this introduces one, but using the package every other internal tool already consumes.
+- **Vue parser:** `vue-eslint-parser` is required for template body visitors. Already used in plugin tests via `require.resolve` but not declared as a `peerDependency`. Document the parser requirement in the rule's docs file (consumers using `eslint-plugin-vue` or any Vue lint config already have it).
+- **Autofix idempotency:** ESLint runs fixers iteratively until output stabilizes. The fix function must be safe to re-apply — if the offending prop has already been removed from the tag, the rule's detection should not fire and no fix should be produced.
+- **Component name resolution:** template tags can be `<dt-input>` (kebab-case) or `<DtInput>` (PascalCase). `component-documentation.json` keys components by `displayName` (e.g., `DtInput`). The rule must normalize both forms to look up the same component.
+- **Cross-package impact:** single-package change in `eslint-plugin-dialtone`. No source changes in `dialtone-vue`, `dialtone-css`, `dialtone-tokens`, etc.
+
+## Source-of-Truth Verification
+
+This PRD was scoped against `git log -S` evidence rather than the codemod's per-component map or the migration docs' affected-component list. Confirmed findings on `staging` and `next`:
+
+- **9 components had a deprecated class prop declared in source:** DtInput, DtBreadcrumbItem, DtSelectMenu, DtSplitButton (`rootClass` declared directly); DtCheckbox, DtRadio (`rootClass` inherited via `InputMixin` at `packages/dialtone-vue/common/mixins/input.js:114`); DtToggle (`wrapperClass`); DtCard (`containerClass`); DtFeedItemPill recipe (`wrapperClass`, confirmed by commits `65317831a` and `74f4a206f`).
+- **4 components listed in the migration docs never had any of the three prop names** in any commit on any branch: DtAvatar, DtMotionText, DtFilterPill, DtModeIsland (`git log --all --oneline -S "rootClass" -- <component-dir>` returned 0 commits for each). Their inclusion in the docs is a defensive addition, not historical fact.
+- **2 components currently still declare `wrapperClass` as a valid prop on `next`**, not deprecated and not in the migration docs: DtListItem (`packages/dialtone-vue/components/list_item/list_item.vue:144`), DtPopoverHeaderFooter (`packages/dialtone-vue/components/popover/popover_header_footer.vue:70`). The data-driven design handles these correctly without explicit configuration — the rule sees `wrapperClass` declared on these components and stays silent.
+
+The data-driven design eliminates dependence on these counts being correct in the future. New deprecations of the same prop names on any component are picked up automatically; new components legitimately exposing these prop names are protected automatically.
+
+## Key Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Hardcoded component list vs data-driven | Data-driven via `@dialpad/dialtone-query-core` | Existing pattern in this monorepo (`dialtone-mcp-server`, `language-server`). No hand-maintained list. Future deprecations of these prop names are auto-covered. Correctly handles components like DtListItem and DtPopoverHeaderFooter that still legitimately declare `wrapperClass`. |
+| One rule vs two rules | One rule | The deprecation case (prop was removed) and the "never existed" case (prop was never declared) both reduce to the same fix — rename to `class` — and the same suggestion. No value in splitting. Simpler config for consumers. |
+| Severity | `warn` | Per ticket. Consumer code with these props doesn't crash; Vue silently ignores them. A warning is the right urgency for a quality issue, not a runtime error. |
+| Inclusion in `recommended` preset | `recommended: false` | Matches all 11 existing rules in this plugin. Consumers opt in explicitly via their ESLint config. |
+| Autofix on `:prop="expr"` + existing `:class="..."` | Warn only, no fix | Two dynamic class bindings cannot be safely merged without changing semantics. Mirrors the codemod's manual-review case. Manual merge is the only safe path. |
+| Component-name maintenance in rule source | None | The 13-component list (or any future variant) is never referenced in the rule's code. Inclusion is computed at lint time from `components` data. |
+| Bundling vs runtime resolution of component data | Via query-core (build-time bundled by query-core) | Matches `dialtone-mcp-server` and `language-server` exactly. No new module-resolution code paths. |
+
+## Acceptance Criteria
+
+The rule is complete when:
+
+- It is exported from `@dialpad/eslint-plugin-dialtone` and auto-loaded via the plugin's existing `requireindex` index.
+- Running `pnpm nx run eslint-plugin-dialtone:test` passes, including new tests for: each prop name (3 props × 2 casings × 2 binding forms = 12 cases), each fix scenario (no existing class, existing static class, existing dynamic class), and the "no fix when both `:prop` and `:class` exist" case.
+- Running the rule against a fixture file containing the failure modes from the migration-docs examples produces the expected warnings and autofixes.
+- `docs/rules/deprecated-class-props.md` exists and follows the existing rule-docs format.
+- The plugin builds without warnings: `pnpm nx run eslint-plugin-dialtone:lint`.
+- A consumer test (manual): `eslint --fix` on a sample `.vue` file containing `<dt-input root-class="d-w332">` produces `<dt-input class="d-w332">`.
+
+## Research Findings
+
+(Standard tier — web research summary)
+
+- **`vue-eslint-parser` API:** the canonical entry point is `context.parserServices.defineTemplateBodyVisitor(visitor, scriptVisitor?)`. Template AST nodes carry: `node.directive` (boolean — true for `:`-bound and `@`-bound), `node.key.name` (static attribute name), `node.key.argument.name` (directive argument like `root-class` in `:root-class`), and `node.value.value` / `node.value.expression` (literal vs expression). Range information available for `fixer.replaceTextRange(node.range, newText)`.
+- **Closest prior art:** `eslint-plugin-vue/lib/rules/no-deprecated-slot-attribute.js` (rewrites `slot="x"` to `v-slot:x`) and `eslint-plugin-vue/lib/rules/attribute-hyphenation.js` (renames camelCase attributes). Pattern is well-trodden — VAttribute visitor + range-based fixer + idempotent detection because the offending pattern is gone after fix.
+- **No prior art** for ESLint plugins reading their host design system's component metadata at lint time was found in published packages. The pattern this PRD proposes — read the build artifact your design system already generates — is novel for a public eslint plugin but standard for tools authored alongside the system being linted, exactly how `language-server` and `dialtone-mcp-server` already work in this repo.
+- **Idempotency:** ESLint's autofix loop applies `fix` functions iteratively until output is stable. The rule is naturally idempotent because once `root-class` is renamed to `class`, the rule's detector no longer matches the tag, so no further fix is produced.
+- **`vue-eslint-parser` peer-dep stance:** consumers of the plugin already configure `vue-eslint-parser` for any Vue lint setup. The rule docs should mention the parser requirement as a prerequisite without forcing the plugin to declare a strict peer dependency that would conflict with consumer-managed versions.
+
+## Notes for `/spec`
+
+- Implementation should TDD — start with one failing case (`<dt-input root-class="x">` → expect warning + autofix to `class="x"`), then add cases incrementally per the acceptance-criteria matrix.
+- Reference implementations in this repo: `lib/rules/deprecated-flex-gap-classes.js`, `lib/rules/deprecated-stack-alignment-classes.js`. Reference test setup: `tests/lib/rules/deprecated-stack-alignment-classes.js`.
+- The class-merging logic at `packages/dialtone-css/lib/build/js/dialtone_migrate_props/index.mjs:358-401` is the canonical reference for the autofix's edge cases. The ESLint version uses AST nodes and ranges instead of regex but produces the same output.
+- Migration-guide URL for the rule message: the docs at `apps/dialtone-documentation/docs/guides/migration/component-props/index.md` will publish to `https://dialtone.dialpad.com/guides/migration/component-props/` — confirm exact URL during implementation.
+- `@dialpad/dialtone-query-core` exposes `Component[]` typed as `{ displayName, props?: ComponentProp[], ... }` (see `packages/dialtone-query-core/src/types.ts`). Each prop has a `name` field. Lookup pattern: `components.find(c => c.displayName === 'DtInput')?.props?.some(p => p.name === 'rootClass')`.

--- a/packages/eslint-plugin-dialtone/docs/rules/deprecated-class-props.md
+++ b/packages/eslint-plugin-dialtone/docs/rules/deprecated-class-props.md
@@ -1,0 +1,105 @@
+# deprecated-class-props
+
+Detects usage of removed structural class props (`rootClass`, `wrapperClass`, `containerClass`) on Dialtone Vue components and offers an autofix to the native `class` attribute.
+
+## Background
+
+In DLT-3100, several Dialtone components removed escape-hatch props that existed to work around Vue 2 class-forwarding limitations. With Vue 3's `inheritAttrs` support, applying `class` directly on a component is the correct approach. These props are gone; using them has no effect.
+
+| Removed prop | Components |
+| --- | --- |
+| `rootClass` / `root-class` | `DtInput`, `DtCheckbox`, `DtRadio`, `DtSelectMenu`, `DtBreadcrumbItem`, `DtSplitButton`, `DtAvatar`, `DtFilterPill`, `DtModeIsland`, `DtMotionText` |
+| `wrapperClass` / `wrapper-class` | `DtToggle`, `DtFeedItemPill` |
+| `containerClass` / `container-class` | `DtCard` |
+
+For the full migration reference see the [component props migration guide](https://dialtone.dialpad.com/guides/migration/component-props/).
+
+## Rule Details
+
+The rule fires on any `<dt-*>` or `<Dt*>` template tag where one of the removed props appears and the component does not currently declare that prop. It is data-driven: the component list is read from `@dialpad/dialtone-vue/component-documentation.json` at lint time, so future changes to the component API are automatically reflected without a plugin update.
+
+Components that legitimately declare `wrapperClass` (e.g., `DtListItem`) are **not** flagged.
+
+### Examples of incorrect code
+
+```vue
+<!-- rootClass on DtInput (removed in DLT-3100) -->
+<dt-input root-class="d-w332" label="Email" />
+
+<!-- camelCase variant also detected -->
+<dt-input rootClass="d-w332" label="Email" />
+
+<!-- dynamic binding -->
+<dt-input :root-class="inputClass" label="Email" />
+
+<!-- wrapperClass on DtToggle -->
+<dt-toggle wrapper-class="d-mt16" />
+
+<!-- containerClass on DtCard -->
+<dt-card container-class="d-mbs-300" />
+```
+
+### Examples of correct code
+
+```vue
+<!-- Apply class directly — Vue 3 forwards it to the component root -->
+<dt-input class="d-w332" label="Email" />
+
+<dt-toggle class="d-mt16" />
+
+<dt-card class="d-mbs-300" />
+
+<!-- Merging with existing class is also fine -->
+<dt-input class="d-pl8 d-w332" label="Email" />
+```
+
+### When the rule does NOT fire
+
+```vue
+<!-- DtListItem legitimately declares wrapperClass -->
+<dt-list-item wrapper-class="d-pt8" />
+
+<!-- Native class attribute -->
+<dt-input class="d-w332" />
+
+<!-- Non-Dialtone tags are ignored -->
+<div root-class="x" />
+```
+
+## Auto-fix
+
+Running `eslint --fix` rewrites the offending attribute automatically.
+
+| Scenario | Before | After |
+| --- | --- | --- |
+| Static, no existing `class` | `<dt-input root-class="d-w332" />` | `<dt-input class="d-w332" />` |
+| Static, with existing `class` | `<dt-input class="d-pl8" root-class="d-w332" />` | `<dt-input class="d-pl8 d-w332" />` |
+| Dynamic, no existing `:class` | `<dt-input :root-class="cls" />` | `<dt-input :class="cls" />` |
+| Dynamic, with existing `:class` | `<dt-input :root-class="cls" :class="other" />` | No autofix — merge manually |
+
+When both `:root-class="expr"` and `:class="..."` appear on the same tag, the rule reports a warning but does not modify the file. The two dynamic bindings cannot be safely merged automatically; combine them by hand: `:class="[expr, other]"`.
+
+## Setup
+
+In your ESLint config:
+
+```js
+// eslint.config.js (flat config)
+import dialtonePlugin from '@dialpad/eslint-plugin-dialtone';
+
+export default [
+  {
+    plugins: { '@dialpad/dialtone': dialtonePlugin },
+    rules: {
+      '@dialpad/dialtone/deprecated-class-props': 'warn',
+    },
+  },
+];
+```
+
+The rule requires `vue-eslint-parser` as the template parser. If you already use `eslint-plugin-vue`, the parser is already configured and no additional setup is needed.
+
+## References
+
+- [Component props migration guide](https://dialtone.dialpad.com/guides/migration/component-props/) — full list of changes and the `dialtone-migrate-props` codemod
+- [Dialtone Vue components](https://dialtone.dialpad.com/components/)

--- a/packages/eslint-plugin-dialtone/docs/rules/prefer-stack-over-flex.md
+++ b/packages/eslint-plugin-dialtone/docs/rules/prefer-stack-over-flex.md
@@ -109,6 +109,7 @@ Some flex utilities don't have DtStack prop equivalents. Keep these as classes o
 ### Migration Examples
 
 **Before:**
+
 ```vue
 <div class="d-d-flex d-ai-center d-jc-space-between d-g16">
   <span>Left</span>
@@ -117,6 +118,7 @@ Some flex utilities don't have DtStack prop equivalents. Keep these as classes o
 ```
 
 **After:**
+
 ```vue
 <dt-stack direction="row" align="center" justify="between" gap="500">
   <span>Left</span>
@@ -127,6 +129,7 @@ Some flex utilities don't have DtStack prop equivalents. Keep these as classes o
 ---
 
 **Before:**
+
 ```vue
 <div class="d-d-flex d-fw-wrap d-ai-center d-g8">
   <badge v-for="item in items" :key="item.id">{{ item.name }}</badge>
@@ -134,6 +137,7 @@ Some flex utilities don't have DtStack prop equivalents. Keep these as classes o
 ```
 
 **After:**
+
 ```vue
 <dt-stack direction="row" align="center" gap="400" class="d-fw-wrap">
   <badge v-for="item in items" :key="item.id">{{ item.name }}</badge>
@@ -143,6 +147,7 @@ Some flex utilities don't have DtStack prop equivalents. Keep these as classes o
 ---
 
 **Before:**
+
 ```vue
 <div class="d-d-flex d-fd-column d-g32 d-fl-grow1">
   <section>...</section>
@@ -151,6 +156,7 @@ Some flex utilities don't have DtStack prop equivalents. Keep these as classes o
 ```
 
 **After:**
+
 ```vue
 <dt-stack direction="column" gap="600" class="d-fl-grow1">
   <section>...</section>

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js
@@ -22,6 +22,16 @@ try {
   );
 }
 
+// Defensive: handle malformed data (not an array) gracefully.
+if (!Array.isArray(components)) components = [];
+
+// Pre-build a Map<displayName, Set<propName>> for O(1) lookup. Built once at module load.
+const componentPropsMap = new Map(
+  components
+    .filter(c => c && typeof c.displayName === "string")
+    .map(c => [c.displayName, new Set((c.props ?? []).map(p => p?.name).filter(Boolean))]),
+);
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -64,8 +74,7 @@ function isDialtoneTag (rawName) {
 }
 
 function componentDeclaresProp (displayName, camelPropName) {
-  const comp = components.find(c => c.displayName === displayName);
-  return Boolean(comp?.props?.some(p => p.name === camelPropName));
+  return componentPropsMap.get(displayName)?.has(camelPropName) ?? false;
 }
 
 function isStaticClassAttr (attr) {
@@ -85,6 +94,24 @@ function removeAttrWithLeadingSpace (fixer, fullSource, attr) {
   let remStart = attr.range[0];
   while (remStart > 0 && /\s/.test(fullSource[remStart - 1])) remStart--;
   return fixer.removeRange([remStart, attr.range[1]]);
+}
+
+// Detect whether an attribute is one of the deprecated class props we care about.
+// Returns { entry, dynamic } or null.
+function classifyDeprecatedAttr (attr) {
+  if (!attr.directive && attr.key) {
+    const entry = STATIC_ATTR_MAP.get(attr.key.name);
+    if (entry) return { entry, dynamic: false };
+  }
+  if (
+    attr.directive &&
+    attr.key?.name?.name === "bind" &&
+    attr.key?.argument?.rawName
+  ) {
+    const entry = DYNAMIC_ATTR_MAP.get(attr.key.argument.rawName);
+    if (entry) return { entry, dynamic: true };
+  }
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -118,70 +145,77 @@ module.exports = {
         const displayName = tagNameToPascal(rawName);
         const attrs = node.startTag.attributes;
 
+        // Collect every deprecated class-prop attribute on this element.
+        const deprecated = [];
         for (const attr of attrs) {
-          let entry = null;
-          let dynamic = false;
+          const cls = classifyDeprecatedAttr(attr);
+          if (!cls) continue;
+          if (componentDeclaresProp(displayName, cls.entry.camel)) continue;
+          deprecated.push({ attr, ...cls });
+        }
+        if (deprecated.length === 0) return;
 
-          // Static attribute: root-class="x" or rootClass="x"
-          if (!attr.directive && attr.key) {
-            entry = STATIC_ATTR_MAP.get(attr.key.name);
-          }
+        const existingStaticClass = attrs.find(a => isStaticClassAttr(a));
+        const existingDynClass = attrs.find(a => isDynamicClassAttr(a));
 
-          // Dynamic (v-bind shorthand): :root-class="expr" or :rootClass="expr"
-          if (
-            attr.directive &&
-            attr.key?.name?.name === "bind" &&
-            attr.key?.argument?.rawName
-          ) {
-            const dynEntry = DYNAMIC_ATTR_MAP.get(attr.key.argument.rawName);
-            if (dynEntry) {
-              entry = dynEntry;
-              dynamic = true;
+        const staticDeps = deprecated.filter(d => !d.dynamic);
+        const dynamicDeps = deprecated.filter(d => d.dynamic);
+
+        // Dynamic autofix is only safe when exactly one dynamic deprecated attr exists
+        // AND there is no existing :class (two dynamic class expressions can't be merged
+        // automatically — would require building an array literal).
+        const dynamicFixable = dynamicDeps.length === 1 && !existingDynClass;
+
+        // Build a single element-level fix that ESLint applies once per pass.
+        // Attached to the first reported attr; subsequent reports get no fix.
+        const elementFix = (fixer) => {
+          const fixes = [];
+          const fullSource = sourceCode.getText();
+
+          // --- Static side ---
+          if (staticDeps.length > 0) {
+            const addedValues = staticDeps
+              .map(d => d.attr.value?.value ?? "")
+              .filter(Boolean);
+
+            if (existingStaticClass) {
+              const existingVal = existingStaticClass.value?.value ?? "";
+              const merged = [existingVal, ...addedValues].filter(Boolean).join(" ");
+              fixes.push(fixer.replaceText(existingStaticClass, `class="${merged}"`));
+              for (const d of staticDeps) {
+                fixes.push(removeAttrWithLeadingSpace(fixer, fullSource, d.attr));
+              }
+            } else {
+              // No existing class: first static dep becomes the consolidated class, rest are removed.
+              const merged = addedValues.join(" ");
+              fixes.push(fixer.replaceText(staticDeps[0].attr, `class="${merged}"`));
+              for (const d of staticDeps.slice(1)) {
+                fixes.push(removeAttrWithLeadingSpace(fixer, fullSource, d.attr));
+              }
             }
           }
 
-          if (!entry) continue;
-          if (componentDeclaresProp(displayName, entry.camel)) continue;
+          // --- Dynamic side ---
+          if (dynamicFixable) {
+            const dyn = dynamicDeps[0];
+            const valueText = sourceCode.getText(dyn.attr.value);
+            // Preserve `v-bind:` long form vs `:` shorthand to avoid stylistic mutation.
+            const prefix = sourceCode.getText(dyn.attr).startsWith("v-bind:") ? "v-bind:class" : ":class";
+            fixes.push(fixer.replaceText(dyn.attr, `${prefix}=${valueText}`));
+          }
+          // If !dynamicFixable, dynamic deps stay as warnings with no autofix.
 
-          const propName = entry.display;
+          return fixes.length > 0 ? fixes : null;
+        };
 
+        deprecated.forEach((dep, idx) => {
           context.report({
-            node: attr,
+            node: dep.attr,
             messageId: "propRemoved",
-            data: { displayName, propName },
-            fix (fixer) {
-              const fullSource = sourceCode.getText();
-
-              if (dynamic) {
-                // Find existing :class binding on this element
-                const existingDynClass = attrs.find(a => isDynamicClassAttr(a) && a !== attr);
-                if (existingDynClass) {
-                  // Cannot merge two dynamic bindings — warn only, no fix
-                  return null;
-                }
-                // Rename :prop="expr" → :class="expr"
-                const valueText = sourceCode.getText(attr.value);
-                return fixer.replaceText(attr, `:class=${valueText}`);
-              } else {
-                // Static attr: get the string value (without surrounding quotes)
-                const addedVal = attr.value ? attr.value.value : "";
-                const existingStaticClass = attrs.find(a => isStaticClassAttr(a) && a !== attr);
-
-                if (existingStaticClass) {
-                  // Merge: remove offending attr + append value to existing class
-                  const existingVal = existingStaticClass.value.value;
-                  return [
-                    removeAttrWithLeadingSpace(fixer, fullSource, attr),
-                    fixer.replaceText(existingStaticClass, `class="${existingVal} ${addedVal}"`),
-                  ];
-                } else {
-                  // Simple rename: root-class="x" → class="x"
-                  return fixer.replaceText(attr, `class="${addedVal}"`);
-                }
-              }
-            },
+            data: { displayName, propName: dep.entry.display },
+            fix: idx === 0 ? elementFix : () => null,
           });
-        }
+        });
       },
     });
   },

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js
@@ -22,15 +22,20 @@ try {
   );
 }
 
-// Defensive: handle malformed data (not an array) gracefully.
+// Defensive: handle malformed top-level data (not an array) gracefully.
 if (!Array.isArray(components)) components = [];
 
 // Pre-build a Map<displayName, Set<propName>> for O(1) lookup. Built once at module load.
-const componentPropsMap = new Map(
-  components
-    .filter(c => c && typeof c.displayName === "string")
-    .map(c => [c.displayName, new Set((c.props ?? []).map(p => p?.name).filter(Boolean))]),
-);
+// Only entries with a valid displayName AND an array `props` are included — entries with
+// malformed/missing `props` are excluded entirely, so the rule fails closed (does not fire)
+// on components whose declared-prop set is unknown rather than flagging them as deprecated.
+const componentPropsMap = new Map();
+for (const c of components) {
+  if (!c || typeof c.displayName !== "string") continue;
+  if (!Array.isArray(c.props)) continue;
+  const propNames = c.props.map(p => p?.name).filter(s => typeof s === "string");
+  componentPropsMap.set(c.displayName, new Set(propNames));
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -75,6 +80,13 @@ function isDialtoneTag (rawName) {
 
 function componentDeclaresProp (displayName, camelPropName) {
   return componentPropsMap.get(displayName)?.has(camelPropName) ?? false;
+}
+
+// True when we have validated metadata for this component. Components missing from the
+// map (unknown to the installed dialtone-vue, or malformed entry) are NOT flagged — the
+// rule's job is to flag deprecation, not to flag unrecognised tags.
+function componentHasMetadata (displayName) {
+  return componentPropsMap.has(displayName);
 }
 
 function isStaticClassAttr (attr) {
@@ -137,12 +149,29 @@ module.exports = {
   create (context) {
     const sourceCode = context.sourceCode ?? context.getSourceCode();
 
+    // Read the raw source slice for an attribute's value, preserving HTML entities
+    // and quote style. Strips surrounding quote characters; returns "" when missing.
+    const getRawAttrValue = (attr) => {
+      if (!attr.value) return "";
+      const text = sourceCode.getText(attr.value);
+      if (text.length >= 2 && (text[0] === "\"" || text[0] === "'")) {
+        return text.slice(1, -1);
+      }
+      return text;
+    };
+
     return sourceCode.parserServices.defineTemplateBodyVisitor({
       VElement (node) {
         const rawName = node.rawName;
         if (!isDialtoneTag(rawName)) return;
 
         const displayName = tagNameToPascal(rawName);
+
+        // Skip components we don't have validated metadata for. This includes both
+        // unknown tags (`<dt-foobar>`) and entries with malformed `props` arrays.
+        // Fail closed: if we can't confirm the prop is deprecated, don't fire.
+        if (!componentHasMetadata(displayName)) return;
+
         const attrs = node.startTag.attributes;
 
         // Collect every deprecated class-prop attribute on this element.
@@ -173,13 +202,13 @@ module.exports = {
           const fullSource = sourceCode.getText();
 
           // --- Static side ---
+          // Use raw source values (not decoded `attr.value.value`) so HTML entities
+          // like &quot; round-trip correctly into the rewritten attribute.
           if (staticDeps.length > 0) {
-            const addedValues = staticDeps
-              .map(d => d.attr.value?.value ?? "")
-              .filter(Boolean);
+            const addedValues = staticDeps.map(d => getRawAttrValue(d.attr)).filter(Boolean);
 
             if (existingStaticClass) {
-              const existingVal = existingStaticClass.value?.value ?? "";
+              const existingVal = getRawAttrValue(existingStaticClass);
               const merged = [existingVal, ...addedValues].filter(Boolean).join(" ");
               fixes.push(fixer.replaceText(existingStaticClass, `class="${merged}"`));
               for (const d of staticDeps) {

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js
@@ -227,7 +227,18 @@ module.exports = {
           // --- Dynamic side ---
           if (dynamicFixable) {
             const dyn = dynamicDeps[0];
-            const valueText = sourceCode.getText(dyn.attr.value);
+            // Vue 3.4+ same-name shorthand (`:rootClass` with no `=`) makes
+            // vue-eslint-parser synthesize an expression for the implicit identifier;
+            // the value range covers the bare identifier text with no surrounding quotes.
+            // Detect that case (or a missing value entirely) and wrap in quotes so the
+            // emitted attribute remains a valid quoted directive value.
+            let valueText;
+            if (!dyn.attr.value) {
+              valueText = `"${dyn.entry.camel}"`;
+            } else {
+              const raw = sourceCode.getText(dyn.attr.value);
+              valueText = (raw.startsWith("\"") || raw.startsWith("'")) ? raw : `"${raw}"`;
+            }
             // Preserve `v-bind:` long form vs `:` shorthand to avoid stylistic mutation.
             const prefix = sourceCode.getText(dyn.attr).startsWith("v-bind:") ? "v-bind:class" : ":class";
             fixes.push(fixer.replaceText(dyn.attr, `${prefix}=${valueText}`));

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-class-props.js
@@ -1,0 +1,188 @@
+/**
+ * @fileoverview Detects usage of removed structural class props on Dialtone Vue components.
+ * @author belu.montoya@dialpad.com
+ */
+"use strict";
+
+// ---------------------------------------------------------------------------
+// Component data — loaded from @dialpad/dialtone-vue/component-documentation.json.
+// In production this is the consumer's installed dialtone-vue version.
+// In tests this require is stubbed via proxyquire so tests are deterministic.
+// ---------------------------------------------------------------------------
+
+let components = [];
+
+try {
+  components = require("@dialpad/dialtone-vue/component-documentation.json");
+} catch {
+  console.warn(
+    "[eslint-plugin-dialtone] Could not load component-documentation.json from @dialpad/dialtone-vue. " +
+    "The deprecated-class-props rule will not flag anything. " +
+    "Ensure @dialpad/dialtone-vue is installed as a peer dependency."
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MIGRATION_URL = "https://dialtone.dialpad.com/guides/migration/component-props/";
+
+// vue-eslint-parser lowercases static attribute names (rootClass → rootclass).
+// This map covers both kebab-case (preserved) and camelCase (lowercased).
+// Value: { camel: canonical camelCase for prop lookup, display: name for message }
+const STATIC_ATTR_MAP = new Map([
+  ["root-class",      { camel: "rootClass",      display: "root-class" }],
+  ["rootclass",       { camel: "rootClass",      display: "rootClass" }],
+  ["wrapper-class",   { camel: "wrapperClass",   display: "wrapper-class" }],
+  ["wrapperclass",    { camel: "wrapperClass",   display: "wrapperClass" }],
+  ["container-class", { camel: "containerClass", display: "container-class" }],
+  ["containerclass",  { camel: "containerClass", display: "containerClass" }],
+]);
+
+// For dynamic (v-bind/:) attributes, we use rawName which preserves original casing.
+const DYNAMIC_ATTR_MAP = new Map([
+  ["root-class",      { camel: "rootClass",      display: "root-class" }],
+  ["rootClass",       { camel: "rootClass",      display: "rootClass" }],
+  ["wrapper-class",   { camel: "wrapperClass",   display: "wrapper-class" }],
+  ["wrapperClass",    { camel: "wrapperClass",   display: "wrapperClass" }],
+  ["container-class", { camel: "containerClass", display: "container-class" }],
+  ["containerClass",  { camel: "containerClass", display: "containerClass" }],
+]);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tagNameToPascal (name) {
+  if (/^[A-Z]/.test(name)) return name;
+  return name.split("-").map(s => s.charAt(0).toUpperCase() + s.slice(1)).join("");
+}
+
+function isDialtoneTag (rawName) {
+  return /^dt-[a-z]/.test(rawName) || /^Dt[A-Z]/.test(rawName);
+}
+
+function componentDeclaresProp (displayName, camelPropName) {
+  const comp = components.find(c => c.displayName === displayName);
+  return Boolean(comp?.props?.some(p => p.name === camelPropName));
+}
+
+function isStaticClassAttr (attr) {
+  return !attr.directive && attr.key && attr.key.name === "class";
+}
+
+function isDynamicClassAttr (attr) {
+  return (
+    attr.directive &&
+    attr.key?.name?.name === "bind" &&
+    attr.key?.argument?.rawName === "class"
+  );
+}
+
+// Remove `attr` and any whitespace that precedes it (handles spaces, tabs, multi-space).
+function removeAttrWithLeadingSpace (fixer, fullSource, attr) {
+  let remStart = attr.range[0];
+  while (remStart > 0 && /\s/.test(fullSource[remStart - 1])) remStart--;
+  return fixer.removeRange([remStart, attr.range[1]]);
+}
+
+// ---------------------------------------------------------------------------
+// Rule Definition
+// ---------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Detects usage of removed structural class props on Dialtone Vue components",
+      recommended: false,
+      url: "https://github.com/dialpad/dialtone/blob/staging/packages/eslint-plugin-dialtone/docs/rules/deprecated-class-props.md",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      propRemoved: "{{displayName}} does not accept a '{{propName}}' prop. Use the native 'class' attribute instead. See: " + MIGRATION_URL,
+    },
+  },
+
+  create (context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+
+    return sourceCode.parserServices.defineTemplateBodyVisitor({
+      VElement (node) {
+        const rawName = node.rawName;
+        if (!isDialtoneTag(rawName)) return;
+
+        const displayName = tagNameToPascal(rawName);
+        const attrs = node.startTag.attributes;
+
+        for (const attr of attrs) {
+          let entry = null;
+          let dynamic = false;
+
+          // Static attribute: root-class="x" or rootClass="x"
+          if (!attr.directive && attr.key) {
+            entry = STATIC_ATTR_MAP.get(attr.key.name);
+          }
+
+          // Dynamic (v-bind shorthand): :root-class="expr" or :rootClass="expr"
+          if (
+            attr.directive &&
+            attr.key?.name?.name === "bind" &&
+            attr.key?.argument?.rawName
+          ) {
+            const dynEntry = DYNAMIC_ATTR_MAP.get(attr.key.argument.rawName);
+            if (dynEntry) {
+              entry = dynEntry;
+              dynamic = true;
+            }
+          }
+
+          if (!entry) continue;
+          if (componentDeclaresProp(displayName, entry.camel)) continue;
+
+          const propName = entry.display;
+
+          context.report({
+            node: attr,
+            messageId: "propRemoved",
+            data: { displayName, propName },
+            fix (fixer) {
+              const fullSource = sourceCode.getText();
+
+              if (dynamic) {
+                // Find existing :class binding on this element
+                const existingDynClass = attrs.find(a => isDynamicClassAttr(a) && a !== attr);
+                if (existingDynClass) {
+                  // Cannot merge two dynamic bindings — warn only, no fix
+                  return null;
+                }
+                // Rename :prop="expr" → :class="expr"
+                const valueText = sourceCode.getText(attr.value);
+                return fixer.replaceText(attr, `:class=${valueText}`);
+              } else {
+                // Static attr: get the string value (without surrounding quotes)
+                const addedVal = attr.value ? attr.value.value : "";
+                const existingStaticClass = attrs.find(a => isStaticClassAttr(a) && a !== attr);
+
+                if (existingStaticClass) {
+                  // Merge: remove offending attr + append value to existing class
+                  const existingVal = existingStaticClass.value.value;
+                  return [
+                    removeAttrWithLeadingSpace(fixer, fullSource, attr),
+                    fixer.replaceText(existingStaticClass, `class="${existingVal} ${addedVal}"`),
+                  ];
+                } else {
+                  // Simple rename: root-class="x" → class="x"
+                  return fixer.replaceText(attr, `class="${addedVal}"`);
+                }
+              }
+            },
+          });
+        }
+      },
+    });
+  },
+};

--- a/packages/eslint-plugin-dialtone/lib/rules/prefer-stack-over-flex.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/prefer-stack-over-flex.js
@@ -56,12 +56,18 @@ module.exports = {
             node.key.name.name === 'bind' &&
             node.key.argument?.name === 'class') {
 
+          // Skip dt-stack / DtStack — these are handled by deprecated-stack-alignment-classes
+          // (use rawName because node.name is always lowercased by vue-eslint-parser)
+          const parentEl = node.parent?.parent;
+          const parentName = parentEl?.rawName;
+          if (parentName === 'dt-stack' || parentName === 'DtStack') return;
+
           // Get the raw source of the binding expression
           const bindingText = sourceCode.getText(node.value);
 
-          // Check if it contains flex utilities (as string literals)
-          // Look for patterns like 'd-d-flex', 'd-ai-', 'd-jc-', 'd-fd-', 'd-g\d', 'd-gg\d'
-          if (/['"]d-d-flex|['"]d-ai-|['"]d-jc-|['"]d-fd-|['"]d-gg?\d/.test(bindingText)) {
+          // Check if it contains flex utilities (as string literals).
+          // `\b` after `d-d-flex` prevents false matches on hypothetical `d-d-flexible`.
+          if (/['"]d-d-flex\b|['"]d-ai-|['"]d-jc-|['"]d-fd-|['"]d-gg?\d/.test(bindingText)) {
             context.report({
               node: node,
               messageId: 'dynamicFlexBinding',

--- a/packages/eslint-plugin-dialtone/lib/rules/prefer-stack-over-flex.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/prefer-stack-over-flex.js
@@ -28,8 +28,8 @@ module.exports = {
     const sourceCode = context.sourceCode ?? context.getSourceCode();
     return sourceCode.parserServices.defineTemplateBodyVisitor({
       VElement(node) {
-        // Skip if already dt-stack or DtStack
-        const elementName = node.name || node.rawName;
+        // Skip if already dt-stack or DtStack (use rawName — node.name is always lowercased)
+        const elementName = node.rawName;
         if (elementName === 'dt-stack' || elementName === 'DtStack') return;
 
         // Find class attribute
@@ -61,7 +61,7 @@ module.exports = {
 
           // Check if it contains flex utilities (as string literals)
           // Look for patterns like 'd-d-flex', 'd-ai-', 'd-jc-', 'd-fd-', 'd-g\d', 'd-gg\d'
-          if (/['"]d-d-flex['"]|['"]d-ai-|['"]d-jc-|['"]d-fd-|['"]d-gg?\d/.test(bindingText)) {
+          if (/['"]d-d-flex|['"]d-ai-|['"]d-jc-|['"]d-fd-|['"]d-gg?\d/.test(bindingText)) {
             context.report({
               node: node,
               messageId: 'dynamicFlexBinding',

--- a/packages/eslint-plugin-dialtone/package.json
+++ b/packages/eslint-plugin-dialtone/package.json
@@ -60,13 +60,17 @@
     "requireindex": "^1.2.0"
   },
   "devDependencies": {
-    "mocha": "^10.0.0"
+    "mocha": "^10.0.0",
+    "proxyquire": "^2.1.3",
+    "vue-eslint-parser": ">=9"
   },
   "engines": {
     "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=7"
+    "@dialpad/dialtone-vue": "^3",
+    "eslint": ">=7",
+    "vue-eslint-parser": ">=9"
   },
   "nx": {
     "includedScripts": [

--- a/packages/eslint-plugin-dialtone/package.json
+++ b/packages/eslint-plugin-dialtone/package.json
@@ -72,6 +72,11 @@
     "eslint": ">=7",
     "vue-eslint-parser": ">=9"
   },
+  "peerDependenciesMeta": {
+    "@dialpad/dialtone-vue": {
+      "optional": true
+    }
+  },
   "nx": {
     "includedScripts": [
       "lint",

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/custom-implementation.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/custom-implementation.js
@@ -16,7 +16,7 @@ const rule = require("../../../lib/rules/custom-implementation"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({parserOptions: {sourceType: 'module', ecmaVersion: 'latest'}});
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'module', ecmaVersion: 'latest' } });
 ruleTester.run("custom-implementation", rule, {
     valid: [
         {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-base-color-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-base-color-classes.js
@@ -12,9 +12,10 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  // eslint-disable-next-line n/no-extraneous-require
-  parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 'latest' },
+  languageOptions: {
+    parser: require('vue-eslint-parser'),
+    parserOptions: { ecmaVersion: 'latest' },
+  },
 });
 
 ruleTester.run('deprecated-base-color-classes', rule, {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js
@@ -187,6 +187,23 @@ ruleTester.run("deprecated-class-props (autofix)", rule, {
       errors: 1,
       output: "<template><dt-input class=\"foo &amp; bar\" /></template>",
     },
+    // Scenario 10: Vue 3.4+ same-name shorthand (`:rootClass` with no value).
+    // attr.value is null in the AST — fixer must expand to :class="rootClass" using
+    // the camelCase form (the variable name Vue would have implicitly referenced).
+    {
+      code: "<template><dt-input :rootClass /></template>",
+      errors: 1,
+      output: "<template><dt-input :class=\"rootClass\" /></template>",
+    },
+    // Scenario 11: two dynamic deprecated props, no existing :class.
+    // dynamicFixable is false (length > 1), so the rule warns on both but
+    // emits no autofix — two arbitrary expressions can't be auto-merged into one
+    // :class binding without changing semantics.
+    {
+      code: "<template><dt-input :root-class=\"a\" :wrapper-class=\"b\" /></template>",
+      errors: 2,
+      output: null,
+    },
   ],
 });
 

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js
@@ -1,0 +1,247 @@
+/**
+ * @fileoverview Tests for deprecated-class-props rule.
+ */
+"use strict";
+
+const RuleTester = require("eslint").RuleTester;
+const proxyquire = require("proxyquire").noCallThru();
+
+// Post-deprecation fixture: mirrors what component-documentation.json will look like
+// once DLT-3100 ships. DtListItem keeps wrapperClass (it was never deprecated).
+const MOCK_COMPONENTS = [
+  // post-deprecation: rootClass removed
+  { displayName: "DtInput", props: [{ name: "label" }, { name: "value" }, { name: "showLabel" }] },
+  // Regression — DtListItem currently declares wrapperClass, must NOT be flagged.
+  // Source-of-truth: dialtone-vue components/list_item/list_item.vue (wrapperClass at line 143 on staging)
+  { displayName: "DtListItem", props: [{ name: "wrapperClass" }, { name: "label" }, { name: "size" }] },
+  // post-deprecation: wrapperClass removed
+  { displayName: "DtToggle", props: [{ name: "label" }, { name: "showLabel" }, { name: "disabled" }] },
+  // post-deprecation: containerClass removed
+  { displayName: "DtCard", props: [{ name: "header" }, { name: "footer" }] },
+  // never had rootClass (confirmed via git log — 0 commits ever touched rootClass in avatar/)
+  { displayName: "DtAvatar", props: [{ name: "fullName" }, { name: "interactive" }, { name: "avatarClass" }] },
+  // post-deprecation: wrapperClass removed
+  { displayName: "DtFeedItemPill", props: [{ name: "kind" }, { name: "label" }] },
+];
+
+const rule = proxyquire("../../../lib/rules/deprecated-class-props", {
+  "@dialpad/dialtone-vue/component-documentation.json": MOCK_COMPONENTS,
+});
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require("vue-eslint-parser"),
+    parserOptions: { ecmaVersion: "latest" },
+  },
+});
+
+const URL = "https://dialtone.dialpad.com/guides/migration/component-props/";
+const msg = (displayName, propName) =>
+  `${displayName} does not accept a '${propName}' prop. Use the native 'class' attribute instead. See: ${URL}`;
+
+// ---------------------------------------------------------------------------
+// Detection tests
+// ---------------------------------------------------------------------------
+
+ruleTester.run("deprecated-class-props (detection)", rule, {
+  valid: [
+    // Correct usage — native class attribute
+    { code: "<template><dt-input class=\"d-w332\" /></template>" },
+    { code: "<template><dt-input :class=\"expr\" /></template>" },
+    // No offending attribute at all
+    { code: "<template><dt-input /></template>" },
+    // Non-Dialtone tags — must never fire
+    { code: "<template><div root-class=\"x\" /></template>" },
+    { code: "<template><span wrapper-class=\"x\" /></template>" },
+    // Regression — DtListItem currently declares wrapperClass, must NOT be flagged
+    { code: "<template><dt-list-item wrapper-class=\"d-pt8\" /></template>" },
+    { code: "<template><dt-list-item :wrapper-class=\"cls\" /></template>" },
+  ],
+
+  invalid: [
+    // --- rootClass variants on DtInput (anchor for detection tests) ---
+    {
+      code: "<template><dt-input root-class=\"x\" /></template>",
+      errors: [{ message: msg("DtInput", "root-class") }],
+      output: "<template><dt-input class=\"x\" /></template>",
+    },
+    {
+      code: "<template><dt-input rootClass=\"x\" /></template>",
+      errors: [{ message: msg("DtInput", "rootClass") }],
+      output: "<template><dt-input class=\"x\" /></template>",
+    },
+    {
+      code: "<template><dt-input :root-class=\"expr\" /></template>",
+      errors: [{ message: msg("DtInput", "root-class") }],
+      output: "<template><dt-input :class=\"expr\" /></template>",
+    },
+    {
+      code: "<template><dt-input :rootClass=\"expr\" /></template>",
+      errors: [{ message: msg("DtInput", "rootClass") }],
+      output: "<template><dt-input :class=\"expr\" /></template>",
+    },
+    // PascalCase tag name
+    {
+      code: "<template><DtInput rootClass=\"x\" /></template>",
+      errors: [{ message: msg("DtInput", "rootClass") }],
+      output: "<template><DtInput class=\"x\" /></template>",
+    },
+    // wrapperClass on DtToggle (different prop, MOCK has no wrapperClass for DtToggle)
+    {
+      code: "<template><dt-toggle wrapper-class=\"x\" /></template>",
+      errors: [{ message: msg("DtToggle", "wrapper-class") }],
+      output: "<template><dt-toggle class=\"x\" /></template>",
+    },
+    // containerClass on DtCard
+    {
+      code: "<template><dt-card container-class=\"x\" /></template>",
+      errors: [{ message: msg("DtCard", "container-class") }],
+      output: "<template><dt-card class=\"x\" /></template>",
+    },
+    // Multi-segment kebab tag normalization check
+    {
+      code: "<template><dt-feed-item-pill wrapper-class=\"x\" /></template>",
+      errors: [{ message: msg("DtFeedItemPill", "wrapper-class") }],
+      output: "<template><dt-feed-item-pill class=\"x\" /></template>",
+    },
+    // "Never had it" case — DtAvatar (defensive: listed in migration docs)
+    {
+      code: "<template><dt-avatar root-class=\"x\" /></template>",
+      errors: [{ message: msg("DtAvatar", "root-class") }],
+      output: "<template><dt-avatar class=\"x\" /></template>",
+    },
+    // Sanity: DtListItem has wrapperClass but NOT rootClass — must still fire for rootClass
+    {
+      code: "<template><dt-list-item root-class=\"x\" /></template>",
+      errors: [{ message: msg("DtListItem", "root-class") }],
+      output: "<template><dt-list-item class=\"x\" /></template>",
+    },
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// Autofix tests
+// ---------------------------------------------------------------------------
+
+ruleTester.run("deprecated-class-props (autofix)", rule, {
+  valid: [],
+  invalid: [
+    // Scenario 1: static, no existing class → simple rename
+    {
+      code: "<template><dt-input root-class=\"d-w332\" /></template>",
+      errors: 1,
+      output: "<template><dt-input class=\"d-w332\" /></template>",
+    },
+    // Scenario 2a: static, existing class before offending attr → merge
+    {
+      code: "<template><dt-input class=\"other\" root-class=\"d-w332\" /></template>",
+      errors: 1,
+      output: "<template><dt-input class=\"other d-w332\" /></template>",
+    },
+    // Scenario 2b: static, offending attr before existing class → merge
+    {
+      code: "<template><dt-input root-class=\"d-w332\" class=\"other\" /></template>",
+      errors: 1,
+      output: "<template><dt-input class=\"other d-w332\" /></template>",
+    },
+    // Scenario 3: dynamic, no existing :class → rename
+    {
+      code: "<template><dt-input :root-class=\"cls\" /></template>",
+      errors: 1,
+      output: "<template><dt-input :class=\"cls\" /></template>",
+    },
+    // Scenario 4: dynamic, existing :class → warn only (no autofix)
+    {
+      code: "<template><dt-input :root-class=\"cls\" :class=\"other\" /></template>",
+      errors: 1,
+      output: null,
+    },
+    // Scenario 5: two different offending props on the same element — each is fixed independently
+    {
+      code: "<template><dt-input root-class=\"a\" wrapper-class=\"b\" /></template>",
+      errors: 2,
+      output: "<template><dt-input class=\"a\" class=\"b\" /></template>",
+    },
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// Regression: components currently declaring these prop names must NOT fire.
+// Source-of-truth: git log confirms DtListItem has wrapperClass at staging:
+// packages/dialtone-vue/components/list_item/list_item.vue line 143.
+// These cases verify the data-driven design — if the lookup logic breaks or
+// the fixture shape changes, these tests catch false positives early.
+// ---------------------------------------------------------------------------
+
+ruleTester.run("deprecated-class-props (regression)", rule, {
+  valid: [
+    { code: "<template><dt-list-item wrapper-class=\"d-pt8\" /></template>" },
+    { code: "<template><dt-list-item :wrapper-class=\"cls\" /></template>" },
+  ],
+  invalid: [],
+});
+
+// ---------------------------------------------------------------------------
+// Integration smoke test: realistic multi-line template covering all scenarios.
+// Validates detection count and exact post-fix output in one shot.
+// Uses the same MOCK_COMPONENTS fixture as unit tests — fully deterministic.
+// ---------------------------------------------------------------------------
+
+ruleTester.run("deprecated-class-props (integration)", rule, {
+  valid: [
+    {
+      code: [
+        "<template>",
+        "  <dt-input class=\"d-pl8\" />",
+        "  <dt-list-item wrapper-class=\"d-pt8\" />",
+        "</template>",
+      ].join("\n"),
+    },
+  ],
+  invalid: [
+    {
+      code: [
+        "<template>",
+        "  <dt-input root-class=\"d-w332\" label=\"Email\" />",
+        "  <dt-toggle wrapper-class=\"d-mt16\" />",
+        "  <dt-card container-class=\"d-mbs-300\" />",
+        "  <dt-avatar root-class=\"d-mr8\" />",
+        "  <dt-input :root-class=\"myClass\" />",
+        "  <dt-input :root-class=\"myClass\" :class=\"otherClass\" />",
+        "  <dt-list-item wrapper-class=\"d-pt8\" />",
+        "  <dt-input class=\"d-pl8\" root-class=\"d-w332\" />",
+        "</template>",
+      ].join("\n"),
+      errors: 7,
+      output: [
+        "<template>",
+        "  <dt-input class=\"d-w332\" label=\"Email\" />",
+        "  <dt-toggle class=\"d-mt16\" />",
+        "  <dt-card class=\"d-mbs-300\" />",
+        "  <dt-avatar class=\"d-mr8\" />",
+        "  <dt-input :class=\"myClass\" />",
+        "  <dt-input :root-class=\"myClass\" :class=\"otherClass\" />",
+        "  <dt-list-item wrapper-class=\"d-pt8\" />",
+        "  <dt-input class=\"d-pl8 d-w332\" />",
+        "</template>",
+      ].join("\n"),
+    },
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency: applying the autofix twice yields no further changes.
+// The already-fixed code must NOT trigger any new warnings.
+// ---------------------------------------------------------------------------
+
+ruleTester.run("deprecated-class-props (idempotency)", rule, {
+  valid: [
+    // Output of autofix scenario 1 (static rename) — no further warning
+    { code: "<template><dt-input class=\"d-w332\" /></template>" },
+    // Output of autofix scenario 2 (static merge) — no further warning
+    { code: "<template><dt-input class=\"other d-w332\" /></template>" },
+    // Output of autofix scenario 3 (dynamic rename) — no further warning
+    { code: "<template><dt-input :class=\"cls\" /></template>" },
+  ],
+  invalid: [],
+});

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js
@@ -4,7 +4,13 @@
 "use strict";
 
 const RuleTester = require("eslint").RuleTester;
-const proxyquire = require("proxyquire").noCallThru();
+// noPreserveCache forces a fresh module load on each proxyquire call so the
+// MOCK_COMPONENTS fixture (used by detection/autofix/regression suites) and
+// the MALFORMED_MOCK fixture (used by the fail-closed suite below) are both
+// actually exercised. Without it, proxyquire's default cache reuse means the
+// second require returns the first-loaded fixture, silently passing the
+// fail-closed assertions for the wrong reason.
+const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
 
 // Post-deprecation fixture: mirrors what component-documentation.json will look like
 // once DLT-3100 ships. DtListItem keeps wrapperClass (it was never deprecated).

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js
@@ -156,11 +156,29 @@ ruleTester.run("deprecated-class-props (autofix)", rule, {
       errors: 1,
       output: null,
     },
-    // Scenario 5: two different offending props on the same element — each is fixed independently
+    // Scenario 5: two different offending static props on the same element → merged into single class
     {
       code: "<template><dt-input root-class=\"a\" wrapper-class=\"b\" /></template>",
       errors: 2,
-      output: "<template><dt-input class=\"a\" class=\"b\" /></template>",
+      output: "<template><dt-input class=\"a b\" /></template>",
+    },
+    // Scenario 6: two static deprecated + existing class → all merged into the existing class
+    {
+      code: "<template><dt-input class=\"orig\" root-class=\"a\" wrapper-class=\"b\" /></template>",
+      errors: 2,
+      output: "<template><dt-input class=\"orig a b\" /></template>",
+    },
+    // Scenario 7: mixed static + dynamic deprecated, no existing class/:class → handled independently
+    {
+      code: "<template><dt-input root-class=\"a\" :wrapper-class=\"expr\" /></template>",
+      errors: 2,
+      output: "<template><dt-input class=\"a\" :class=\"expr\" /></template>",
+    },
+    // Scenario 8: v-bind long-form preserved (not collapsed to shorthand)
+    {
+      code: "<template><dt-input v-bind:root-class=\"expr\" /></template>",
+      errors: 1,
+      output: "<template><dt-input v-bind:class=\"expr\" /></template>",
     },
   ],
 });

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-class-props.js
@@ -180,6 +180,56 @@ ruleTester.run("deprecated-class-props (autofix)", rule, {
       errors: 1,
       output: "<template><dt-input v-bind:class=\"expr\" /></template>",
     },
+    // Scenario 9: HTML entities in class value round-trip without corruption
+    // (e.g. data-attribute selectors stored in class strings during dev tooling)
+    {
+      code: "<template><dt-input root-class=\"foo &amp; bar\" /></template>",
+      errors: 1,
+      output: "<template><dt-input class=\"foo &amp; bar\" /></template>",
+    },
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// Fail-closed behavior: components without validated metadata in the JSON
+// must NOT be flagged. Covers two cases:
+//   1. Component entry is missing entirely (unknown to installed dialtone-vue)
+//   2. Component entry exists but `props` is malformed (not an array)
+// ---------------------------------------------------------------------------
+
+const MALFORMED_MOCK = [
+  // Valid: DtInput is fine
+  { displayName: "DtInput", props: [{ name: "label" }] },
+  // Malformed: props is an object, not an array
+  { displayName: "DtMalformed", props: { name: "rootClass" } },
+  // Malformed: props is missing entirely
+  { displayName: "DtNoProps" },
+  // Malformed: entry is null
+  null,
+  // Malformed: displayName is not a string
+  { displayName: 42, props: [] },
+];
+
+const malformedRule = proxyquire("../../../lib/rules/deprecated-class-props", {
+  "@dialpad/dialtone-vue/component-documentation.json": MALFORMED_MOCK,
+});
+
+ruleTester.run("deprecated-class-props (fail-closed)", malformedRule, {
+  valid: [
+    // DtMalformed has malformed props — rule must NOT fire even though it looks deprecated
+    { code: "<template><dt-malformed root-class=\"x\" /></template>" },
+    // DtNoProps is missing props field — rule must NOT fire
+    { code: "<template><dt-no-props root-class=\"x\" /></template>" },
+    // DtUnknown is not in the JSON at all — rule must NOT fire
+    { code: "<template><dt-unknown root-class=\"x\" /></template>" },
+  ],
+  invalid: [
+    // DtInput is valid in this fixture and has no rootClass — should still fire
+    {
+      code: "<template><dt-input root-class=\"x\" /></template>",
+      errors: 1,
+      output: "<template><dt-input class=\"x\" /></template>",
+    },
   ],
 });
 

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-component.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-component.js
@@ -15,7 +15,7 @@ const rule = require("../../../lib/rules/deprecated-component"), RuleTester = re
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({parserOptions: {sourceType: 'module', ecmaVersion: 'latest'}});
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'module', ecmaVersion: 'latest' } });
 ruleTester.run("deprecated-component", rule, {
     valid: [
         {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-dialtone-component.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-dialtone-component.js
@@ -15,7 +15,7 @@ const rule = require("../../../lib/rules/deprecated-dialtone-component"), RuleTe
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({parserOptions: {sourceType: 'module', ecmaVersion: 'latest'}});
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'module', ecmaVersion: 'latest' } });
 ruleTester.run("deprecated-dialtone-component", rule, {
     valid: [
         {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-directive.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-directive.js
@@ -15,10 +15,11 @@ const rule = require("../../../lib/rules/deprecated-directive"), RuleTester = re
 // Tests
 //------------------------------------------------------------------------------
 const ruleTester = new RuleTester({
-  // eslint-disable-next-line n/no-extraneous-require
-  parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 'latest' }
-})
+  languageOptions: {
+    parser: require('vue-eslint-parser'),
+    parserOptions: { ecmaVersion: 'latest' },
+  },
+});
 ruleTester.run("deprecated-directive", rule, {
   valid: [
     {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-flex-gap-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-flex-gap-classes.js
@@ -17,9 +17,10 @@ const rule = require("../../../lib/rules/deprecated-flex-gap-classes"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  // eslint-disable-next-line n/no-extraneous-require
-  parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 'latest' }
+  languageOptions: {
+    parser: require('vue-eslint-parser'),
+    parserOptions: { ecmaVersion: 'latest' },
+  },
 });
 
 ruleTester.run("deprecated-flex-gap-classes", rule, {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-grid-gap-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-grid-gap-classes.js
@@ -17,9 +17,10 @@ const rule = require("../../../lib/rules/deprecated-grid-gap-classes"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  // eslint-disable-next-line n/no-extraneous-require
-  parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 'latest' }
+  languageOptions: {
+    parser: require('vue-eslint-parser'),
+    parserOptions: { ecmaVersion: 'latest' },
+  },
 });
 
 ruleTester.run("deprecated-grid-gap-classes", rule, {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-icons.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-icons.js
@@ -15,7 +15,7 @@ const rule = require("../../../lib/rules/deprecated-icons"), RuleTester = requir
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({parserOptions: {sourceType: 'module', ecmaVersion: 'latest'}});
+const ruleTester = new RuleTester({ languageOptions: { sourceType: 'module', ecmaVersion: 'latest' } });
 ruleTester.run("deprecated-icons", rule, {
     valid: [
         {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-stack-alignment-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-stack-alignment-classes.js
@@ -16,9 +16,10 @@ const rule = require("../../../lib/rules/deprecated-stack-alignment-classes"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  // eslint-disable-next-line n/no-extraneous-require
-  parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 'latest' }
+  languageOptions: {
+    parser: require('vue-eslint-parser'),
+    parserOptions: { ecmaVersion: 'latest' },
+  },
 });
 
 ruleTester.run("deprecated-stack-alignment-classes", rule, {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/prefer-stack-over-flex.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/prefer-stack-over-flex.js
@@ -60,6 +60,14 @@ ruleTester.run("prefer-stack-over-flex", rule, {
     {
       code: "<template><dt-stack :class=\"{ 'custom-class': active }\">...</dt-stack></template>",
     },
+    // DtStack (kebab) with dynamic flex binding — handled by deprecated-stack-alignment-classes, not this rule
+    {
+      code: "<template><dt-stack :class=\"{ 'd-d-flex': active }\">...</dt-stack></template>",
+    },
+    // DtStack (PascalCase) with dynamic flex binding — same, should not trigger
+    {
+      code: "<template><DtStack :class=\"{ 'd-d-flex': active, 'd-ai-center': isRow }\">...</DtStack></template>",
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/prefer-stack-over-flex.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/prefer-stack-over-flex.js
@@ -16,9 +16,10 @@ const rule = require("../../../lib/rules/prefer-stack-over-flex"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  // eslint-disable-next-line n/no-extraneous-require
-  parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 'latest' }
+  languageOptions: {
+    parser: require('vue-eslint-parser'),
+    parserOptions: { ecmaVersion: 'latest' },
+  },
 });
 
 ruleTester.run("prefer-stack-over-flex", rule, {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/recommend-typography-style.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/recommend-typography-style.js
@@ -17,9 +17,10 @@ const rule = require("../../../lib/rules/recommend-typography-style"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  // eslint-disable-next-line n/no-extraneous-require
-  parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 'latest' }
+  languageOptions: {
+    parser: require('vue-eslint-parser'),
+    parserOptions: { ecmaVersion: 'latest' },
+  },
 });
 
 ruleTester.run("recommend-typography-style", rule, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,6 +918,9 @@ importers:
 
   packages/eslint-plugin-dialtone:
     dependencies:
+      '@dialpad/dialtone-vue':
+        specifier: ^3
+        version: 3.219.4(@dialpad/dialtone-css@8.79.2(chalk@5.6.2)(globby@14.1.0)(inquirer@9.3.8(@types/node@24.3.1))(yargs@17.7.2))(@floating-ui/dom@1.7.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vue@3.5.32(typescript@5.9.3))
       eslint:
         specifier: '>=7'
         version: 9.39.4(jiti@1.21.7)
@@ -928,6 +931,12 @@ importers:
       mocha:
         specifier: ^10.0.0
         version: 10.8.2
+      proxyquire:
+        specifier: ^2.1.3
+        version: 2.1.3
+      vue-eslint-parser:
+        specifier: '>=9'
+        version: 10.4.0(eslint@9.39.4(jiti@1.21.7))
 
   packages/language-server/server:
     dependencies:
@@ -1341,14 +1350,32 @@ packages:
     resolution: {integrity: sha512-TLsyNwTUmGK6TtvdoC4SE/13Ae501pdzhSIyOV9V3HOVf8YrVTOgLUJ/l97kZSxcTOeRbFeRjbWfH7W3ixn36g==, tarball: https://npm.pkg.github.com/download/@dialpad/conventional-changelog-angular/1.1.1/1c54240f941b2d02d73e4ca2d4e53420d128bbf6}
     engines: {node: '>=10'}
 
+  '@dialpad/dialtone-css@8.79.2':
+    resolution: {integrity: sha512-y3JGJkpc2rn+QE/HdsejYXTfwXnL2/RU0KyD/ANE8MfMrbDfWX18OKApaldz3SRx9GwEHsH/TK5pLr8AAQtvoA==, tarball: https://npm.pkg.github.com/download/@dialpad/dialtone-css/8.79.2/257ac0687bbd7018095fe3a59e400e648d9ff4ea}
+    hasBin: true
+    peerDependencies:
+      chalk: ^5.2.0
+      globby: ^13.1.4
+      inquirer: ^9.1.5
+      yargs: ^17.7.2
+
+  '@dialpad/dialtone-emojis@1.2.5':
+    resolution: {integrity: sha512-qWR9oifO0L7nqi6C5uQjb3eAneS9z4P3HKl7sz5K6zL2hxtCUos38VPIYxVEiCiKYfu4FmNH92BbJhlgpS6mHA==, tarball: https://npm.pkg.github.com/download/@dialpad/dialtone-emojis/1.2.5/4704dd3524245aa2267d1a1a7b00c1594bcc951e}
+
+  '@dialpad/dialtone-icons@4.51.1':
+    resolution: {integrity: sha512-2LlrVsvsyVJrKOOjkni1PeiUavDFW9yP1xXDMcDNGyMjdwFrYwKGVJwQP8niSMwHgSEqR0gy6K22MM8llG0clQ==, tarball: https://npm.pkg.github.com/download/@dialpad/dialtone-icons/4.51.1/978bccc9e77eb62ff47a8ee1c8bd25a1274ee715}
+
+  '@dialpad/dialtone-vue@3.219.4':
+    resolution: {integrity: sha512-0g+/9GDEr96zHjc4ISRzL+cuQg891uvCytAenZm4qtJvtF39naW5uRK6KiY7SAzPWE0KImi7d8EImS6sq9GEtQ==, tarball: https://npm.pkg.github.com/download/@dialpad/dialtone-vue/3.219.4/167cbc430772921a4044663848f8b00a700305d9}
+    engines: {node: '>= 14.17'}
+    peerDependencies:
+      '@dialpad/dialtone-css': ^8.79.2
+      vue: '>=3.2'
+
   '@dialpad/i18n-goblin-core@1.2.0':
     resolution: {integrity: sha512-DQJ6kPkz2JfQMljPxxCCWoJneKHlUrxrxwwEZ3bkC1gc1ze+MDWo4d8pylkqypBYSDxw2l3Pa61Loy1cEdsqMg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-goblin-core/1.2.0/e78ef24567fc081840905a6594f241d5c8523688}
     peerDependencies:
-      '@vue/composition-api': '*'
       vue: ^3.0.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
 
   '@dialpad/i18n-goblin-services@1.3.0':
     resolution: {integrity: sha512-KTJGeRxw9DHfQP/vxjOZW4kzgBbZeTRYtl0/FdvFdVoBFZ8SDjf+FwOc57o/q/K8zvGVVjb8xxpyXBBJACRIeg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-goblin-services/1.3.0/069db4d56165365b9c0f4e0daca9a7b61ff7c534}
@@ -8293,6 +8320,10 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
+  fill-keys@1.0.2:
+    resolution: {integrity: sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==}
+    engines: {node: '>=0.10.0'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -9569,6 +9600,9 @@ packages:
   is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
+
+  is-object@1.0.2:
+    resolution: {integrity: sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==}
 
   is-path-cwd@2.2.0:
     resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==}
@@ -11291,6 +11325,9 @@ packages:
 
   module-alias@2.3.4:
     resolution: {integrity: sha512-bOclZt8hkpuGgSSoG07PKmvzTizROilUTvLNyrMqvlC9snhs7y7GzjNWAVbISIOlhCP1T14rH1PDAV9iNyBq/w==}
+
+  module-not-found-error@1.0.1:
+    resolution: {integrity: sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -13072,6 +13109,9 @@ packages:
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
+
+  proxyquire@2.1.3:
+    resolution: {integrity: sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==}
 
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
@@ -16473,11 +16513,77 @@ snapshots:
       compare-func: 2.0.0
       q: 1.5.1
 
+  '@dialpad/dialtone-css@8.79.2(chalk@5.6.2)(globby@14.1.0)(inquirer@9.3.8(@types/node@24.3.1))(yargs@17.7.2)':
+    dependencies:
+      chalk: 5.6.2
+      docopt: 0.6.2
+      globby: 14.1.0
+      inquirer: 9.3.8(@types/node@24.3.1)
+      yargs: 17.7.2
+
+  '@dialpad/dialtone-emojis@1.2.5': {}
+
+  '@dialpad/dialtone-icons@4.51.1': {}
+
+  '@dialpad/dialtone-vue@3.219.4(@dialpad/dialtone-css@8.79.2(chalk@5.6.2)(globby@14.1.0)(inquirer@9.3.8(@types/node@24.3.1))(yargs@17.7.2))(@floating-ui/dom@1.7.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@dialpad/dialtone-css': 8.79.2(chalk@5.6.2)(globby@14.1.0)(inquirer@9.3.8(@types/node@24.3.1))(yargs@17.7.2)
+      '@dialpad/dialtone-emojis': 1.2.5
+      '@dialpad/dialtone-icons': 4.51.1
+      '@dialpad/i18n': 1.25.3(vue@3.5.32(typescript@5.9.3))
+      '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
+      '@tiptap/extension-blockquote': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-bold': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-bubble-menu': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-bullet-list': 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-code': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-code-block': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-color': 3.19.0(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))
+      '@tiptap/extension-document': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-floating-menu': 3.19.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-font-family': 3.19.0(@tiptap/extension-text-style@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0)))
+      '@tiptap/extension-hard-break': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-history': 3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-image': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-italic': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-link': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-list': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-list-item': 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-mention': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@tiptap/suggestion@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-ordered-list': 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-paragraph': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-placeholder': 3.19.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
+      '@tiptap/extension-strike': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-text': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-text-align': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-text-style': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extension-underline': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
+      '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/pm': 3.19.0
+      '@tiptap/static-renderer': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tiptap/suggestion': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/vue-3': 3.19.0(patch_hash=hlk524tqy4svh2bbayevihx324)(@floating-ui/dom@1.7.6)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(vue@3.5.32(typescript@5.9.3))
+      date-fns: 4.1.0
+      deep-equal: 2.2.3
+      emoji-toolkit: 9.0.1
+      linkifyjs: 4.3.2
+      overlayscrollbars: 2.10.0
+      regex-combined-emojis: 1.6.0
+      tippy.js: 6.3.7
+      vue: 3.5.32(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+      - '@vue/composition-api'
+      - react
+      - react-dom
+
   '@dialpad/i18n-goblin-core@1.2.0(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@fluent/bundle': 0.17.1
       fluent-vue: 3.7.2(@fluent/bundle@0.17.1)(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   '@dialpad/i18n-goblin-services@1.3.0':
     dependencies:
@@ -24640,6 +24746,11 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
+  fill-keys@1.0.2:
+    dependencies:
+      is-object: 1.0.2
+      merge-descriptors: 1.0.3
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -26197,6 +26308,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-obj@2.0.0: {}
+
+  is-object@1.0.2: {}
 
   is-path-cwd@2.2.0: {}
 
@@ -28631,6 +28744,8 @@ snapshots:
 
   module-alias@2.3.4: {}
 
+  module-not-found-error@1.0.1: {}
+
   mrmime@2.0.1: {}
 
   ms@2.0.0: {}
@@ -30437,6 +30552,12 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@2.1.0: {}
+
+  proxyquire@2.1.3:
+    dependencies:
+      fill-keys: 1.0.2
+      module-not-found-error: 1.0.1
+      resolve: 1.22.11
 
   prr@1.0.1: {}
 


### PR DESCRIPTION
## :tada: Obligatory GIF (super important!)

<!-- Drop in your GIF — go to giphy.com, pick one, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExMzR3Z2U4Z2RiaTZyYzdkN2ozd3l6NmQxMnhwb3RnMWRydW9keGpkaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/B4SApVTMhHJug/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Feature

## :book: Jira Ticket

[DLT-3281](https://dialpad.atlassian.net/browse/DLT-3281)

## :book: Description

Adds a new ESLint rule `deprecated-class-props` to `@dialpad/eslint-plugin-dialtone`. The rule detects usage of removed structural class props (`rootClass`, `wrapperClass`, `containerClass` and their kebab variants) on Dialtone Vue components and offers an autofix that renames them to the native `class` attribute, merging into existing class bindings when present.

The rule is data-driven: component-prop information is read at lint time from `@dialpad/dialtone-vue/component-documentation.json` via the package's `exports` subpath — the same data path already used by `@dialpad/dialtone-query-core`, `@dialpad/dialtone-mcp-server`, and `@dialpad/dialtone-cli`. There is no hardcoded component list. A component that currently declares one of these prop names (e.g. `DtListItem.wrapperClass`) is **not** flagged. Future deprecations of the same prop names on any component are picked up automatically without code changes to the plugin.

**Detection:** Fires on `<dt-*>` or `<Dt*>` template tags using one of the six prop variants (kebab/camel × static/dynamic) when the target component does not currently declare that prop. Severity: `warn` (per ticket).

**Autofix scenarios** (mirroring `dialtone-migrate-props` codemod logic):

| Scenario | Before | After |
| --- | --- | --- |
| Static, no existing `class` | `<dt-input root-class="d-w332" />` | `<dt-input class="d-w332" />` |
| Static, with existing `class` | `<dt-input class="d-pl8" root-class="d-w332" />` | `<dt-input class="d-pl8 d-w332" />` |
| Dynamic, no existing `:class` | `<dt-input :root-class="cls" />` | `<dt-input :class="cls" />` |
| Dynamic, with existing `:class` | `<dt-input :root-class="cls" :class="other" />` | warn only, no autofix |

**Bundled changes** — required for the new rule to land:

1. All 11 existing test files updated from legacy `eslintrc` `RuleTester` format (`parser: require.resolve(...)`) to ESLint 9 flat config format (`languageOptions: { parser: require(...), parserOptions: ... }`). The legacy format throws `ConfigError` on ESLint 9.39, which was masking pre-existing test failures across the whole plugin.
2. Two pre-existing bugs in `prefer-stack-over-flex` exposed and fixed: (a) `node.name` is always lowercased in `vue-eslint-parser` v10 (`DtStack` → `'dtstack'`), so the PascalCase early-return check was failing — switched to `node.rawName`; (b) the dynamic `:class` regex required a closing quote immediately after `d-d-flex`, which never matched when other classes followed — fixed to use `\b` boundaries consistent with the static-class handler.
3. Pre-existing MD031 markdownlint failures in `prefer-stack-over-flex.md` (missing blank lines around fenced code blocks) — fixed to unblock `pnpm nx run eslint-plugin-dialtone:lint`.

**Dependencies added to `eslint-plugin-dialtone`:**

- `peerDependencies`: `@dialpad/dialtone-vue` (for the JSON), `vue-eslint-parser` (for the visitor)
- `devDependencies`: `vue-eslint-parser` (so plugin tests resolve the parser without depending on workspace hoisting), `proxyquire` (test fixture injection — keeps tests deterministic regardless of branch state)

## :bulb: Context

DLT-3100 deleted the `rootClass` / `wrapperClass` / `containerClass` escape-hatch props from a set of components. Vue 3's `inheritAttrs` makes them unnecessary — `class` directly on the component now lands on the right element automatically.

The original ticket specified three deliverables: codemod, migration documentation, and ESLint rule. The codemod (`dialtone-migrate-props`) and the migration docs (`/guides/migration/component-props/`) shipped via DLT-3157 and live on `next`. **This PR ships the third.**

The codemod is one-shot — it sweeps existing code and exits. Without an always-on rule, new code written after the migration silently reintroduces the deprecated props (Vue ignores unknown props at runtime, so consumers get no feedback). This rule is the ongoing guardrail for the deprecation window: catches removed-prop usage on every save, every PR, every CI run.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.

## :crystal_ball: Next Steps

- Once Dialtone v10 ships with the deprecated props fully removed in `component-documentation.json`, the rule starts firing for consumers automatically (data-driven design).
- The rule can be sunset once the deprecation window closes (e.g., 6 months after Dialtone v10 GA). Add a CHANGELOG note when removing.

## :link: Sources

- PRD: `docs/prd/2026-05-07-eslint-deprecated-class-props.md`
- Implementation plan: `docs/plans/2026-05-07-dlt-3281-eslint-deprecated-class-props.md`
- Migration guide (already shipped on `next`): https://dialtone.dialpad.com/guides/migration/component-props/
- Rule docs: `packages/eslint-plugin-dialtone/docs/rules/deprecated-class-props.md`


[DLT-3281]: https://dialpad.atlassian.net/browse/DLT-3281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
