### PR TITLE
refactor(combinator): DLT-3418 migrate controls prop changes

### DIFF
--- a/packages/combinator/src/components/controls/control_boolean.vue
+++ b/packages/combinator/src/components/controls/control_boolean.vue
@@ -7,7 +7,7 @@
       :size="200"
       class="d-jc-space-between"
       data-qa="dtc-control-boolean-input"
-      @change="e => emit(VALUE_UPDATE_EVENT, e)"
+      @update:model-value="e => emit(VALUE_UPDATE_EVENT, e)"
     >
       <dt-text
         kind="label"

--- a/packages/combinator/src/components/controls/control_icon_slot.vue
+++ b/packages/combinator/src/components/controls/control_icon_slot.vue
@@ -15,7 +15,7 @@
         v-bind="inputProps"
         :value="searchText"
         :disabled="disabled"
-        @input="e => onInputInternal(e, onInput)"
+        @update:value="e => onInputInternal(e, onInput)"
       >
         <template #default>
           <slot />

--- a/packages/combinator/src/components/controls/control_number.vue
+++ b/packages/combinator/src/components/controls/control_number.vue
@@ -4,7 +4,7 @@
     :disabled="disabled"
     type="number"
     :size="100"
-    @input="e => emit(VALUE_UPDATE_EVENT, e === '' ? undefined : parseInt(e))"
+    @update:model-value="e => emit(VALUE_UPDATE_EVENT, e === '' ? undefined : parseInt(e))"
   >
     <template #label>
       <dt-text

--- a/packages/combinator/src/components/controls/control_slot.vue
+++ b/packages/combinator/src/components/controls/control_slot.vue
@@ -6,7 +6,7 @@
     input-class="d-pie-400"
     spellcheck="false"
     :size="100"
-    @input="updateValue"
+    @update:model-value="updateValue"
   >
     <template #label>
       <dt-text

--- a/packages/combinator/src/components/controls/control_string.vue
+++ b/packages/combinator/src/components/controls/control_string.vue
@@ -4,7 +4,7 @@
     :disabled="disabled"
     :messages="messages"
     :size="100"
-    @input="e => emit(VALUE_UPDATE_EVENT, e)"
+    @update:model-value="e => emit(VALUE_UPDATE_EVENT, e)"
   >
     <template #label>
       <dt-text

--- a/packages/combinator/src/components/controls/control_suggestion.vue
+++ b/packages/combinator/src/components/controls/control_suggestion.vue
@@ -15,7 +15,7 @@
           :value="value"
           :warning="warning"
           :disabled="disabled"
-          @input="e => onInputInternal(e, onInput)"
+          @update:value="e => onInputInternal(e, onInput)"
         >
           <template #default>
             <slot />

--- a/packages/combinator/src/components/header/header.vue
+++ b/packages/combinator/src/components/header/header.vue
@@ -20,10 +20,10 @@
             label="Select target component variant"
             label-class="d-vi-visible-sr"
             name="select-menu"
-            :value="selectedVariant"
+            :model-value="selectedVariant"
             :options="variantOptions"
             :size="500"
-            @input="e => emit('update:variant', e)"
+            @update:model-value="e => emit('update:variant', e)"
           />
         </div>
       </dt-stack>

--- a/packages/combinator/src/components/settings_menu/settings_menu.vue
+++ b/packages/combinator/src/components/settings_menu/settings_menu.vue
@@ -23,8 +23,8 @@
           <dt-radio-group
             name="theme-radio-group"
             legend="Theme"
-            :value="settings.root.theme"
-            @input="e => updateSettings('root', 'theme', e)"
+            :model-value="settings.root.theme"
+            @update:model-value="e => updateSettings('root', 'theme', e)"
           >
             <dt-radio value="light">
               Light
@@ -38,8 +38,8 @@
           <dt-radio-group
             name="scheme-radio-group"
             legend="Scheme"
-            :value="settings.code.scheme"
-            @input="e => updateSettings('code', 'scheme', e)"
+            :model-value="settings.code.scheme"
+            @update:model-value="e => updateSettings('code', 'scheme', e)"
           >
             <dt-radio value="mono">
               Mono
@@ -53,8 +53,8 @@
           <dt-radio-group
             name="sidebar-radio-group"
             legend="Sidebar Position"
-            :value="settings.root.sidebar"
-            @input="e => updateSettings('root', 'sidebar', e)"
+            :model-value="settings.root.sidebar"
+            @update:model-value="e => updateSettings('root', 'sidebar', e)"
           >
             <dt-radio value="left">
               Left
@@ -69,14 +69,14 @@
             :key="indentKey"
             type="number"
             label="Indent Spaces"
-            :value="settings.code.indent"
-            @input="updateIndent"
+            :model-value="settings.code.indent"
+            @update:model-value="updateIndent"
           />
         </section>
         <section class="d-p-100">
           <dt-checkbox
-            :checked="settings.code.verbose"
-            @input="e => updateSettings('code', 'verbose', e)"
+            :model-value="settings.code.verbose"
+            @update:model-value="e => updateSettings('code', 'verbose', e)"
           >
             Verbose
           </dt-checkbox>

--- a/packages/combinator/src/variants/variants_banner.js
+++ b/packages/combinator/src/variants/variants_banner.js
@@ -4,7 +4,7 @@ export default {
   default: {
     slots: {
       default: {
-        initialValue: 'Message body with <a href="#" class="d-link d-link--muted">a link</a>.',
+        initialValue: 'Message body with <dt-link href="#" tone="muted">a link</dt-link>.',
       },
     },
     props: {

--- a/packages/combinator/src/variants/variants_button.js
+++ b/packages/combinator/src/variants/variants_button.js
@@ -168,7 +168,7 @@ export default {
       kind: { initialValue: 'muted' },
       importance: { initialValue: 'outlined' },
       size: { initialValue: '200' },
-      iconPosition: { initialValue: 'right' },
+      iconPosition: { initialValue: 'end' },
     },
     slots: {
       icon: { initialValue: '<dt-icon name="external-link" :size="iconSize" />' },

--- a/packages/combinator/src/variants/variants_toast.js
+++ b/packages/combinator/src/variants/variants_toast.js
@@ -8,14 +8,14 @@ export default {
   default: {
     slots: {
       default: {
-        initialValue: 'Message body with <a href="#" class="d-link">a link</a>.',
+        initialValue: 'Message body with <dt-link href="#">a link</dt-link>.',
       },
     },
     props: {
       headerText: {
         initialValue: 'Base title (optional)',
       },
-      show: {
+      open: {
         initialValue: true,
       },
     },
@@ -26,10 +26,10 @@ export default {
       headerText: { initialValue: 'Info title' },
       kind: { initialValue: 'info' },
       showClose: { initialValue: false },
-      show: { initialValue: true },
+      open: { initialValue: true },
     },
     slots: {
-      default: { initialValue: 'Message body with <a href="#" class="d-link">a link</a>.' },
+      default: { initialValue: 'Message body with <dt-link href="#">a link</dt-link>.' },
       action: { initialValue: '<dt-button :size="200" importance="outlined" kind="muted">Action</dt-button>' },
     },
   },
@@ -39,7 +39,7 @@ export default {
       headerText: { initialValue: 'Warning title' },
       kind: { initialValue: 'warning' },
       important: { initialValue: true },
-      show: { initialValue: true },
+      open: { initialValue: true },
     },
   },
 };

--- a/packages/combinator/src/variants/variants_tooltip.js
+++ b/packages/combinator/src/variants/variants_tooltip.js
@@ -1,9 +1,9 @@
- 
+
 
 export default {
   default: {
     props: {
-      show: {
+      open: {
         initialValue: false,
       },
       message: {
@@ -18,7 +18,7 @@ export default {
   },
   inverted: {
     props: {
-      show: {
+      open: {
         initialValue: false,
       },
       message: {


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :book: Jira Ticket

[DLT-3418](https://dialpad.atlassian.net/browse/DLT-3418)

## :book: Description

Update Combinator package to match current dialtone-vue v-model APIs from DLT-3160, plus catch up to overlay `show -> open` and logical-naming renames in variant fixtures. After this PR, option-bar controls, settings menu, and variant picker work again on `next`.

Files touched (combinator only):

- 6 control wrappers in `packages/combinator/src/components/controls/`: `@input` / `@change` swapped for `@update:model-value` (or `@update:value` for cross-control wiring)
- `components/header/header.vue`: DtSelectMenu `:value` / `@input` swapped for `:model-value` / `@update:model-value`
- `components/settings_menu/settings_menu.vue`: same pattern across 3 DtRadioGroup, 1 DtInput, 1 DtCheckbox
- `variants/variants_tooltip.js`, `variants/variants_toast.js`: `show:` → `open:`
- `variants/variants_button.js`: `iconPosition: 'right'` → `'end'` (logical naming)
- `variants/variants_banner.js`, `variants/variants_toast.js`: slot strings `<a class="d-link">` → `<dt-link>`

Out of scope:

- DtRecipe → UI Kit migration (recipe combobox still used in icon-slot / suggestion controls)
- Wider audit of `<a class="d-link">` slot strings outside banner / toast
- Existing emit-assertion gaps in `controls/*.test.js`

## :bulb: Context

DLT-3160 removed legacy `change` and `input` events from Dt form components in favor of `update:modelValue`. Combinator wasn't migrated alongside, so option-bar boolean / string / number / slot / icon-slot / suggestion controls, settings menu (theme / scheme / sidebar / indent / verbose), and header variant picker stopped responding on `next`. Variant fixtures also predated the overlay `show -> open` rename and the logical-naming sweep.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :link: Sources

- DLT-3160: standardize v-model event handling (commit `f1624d46e`)
- [Component Props & Events](https://dialtone.dialpad.com/guides/migration/component-props/)
- [Logical Naming](https://dialtone.dialpad.com/guides/migration/logical-naming/)
- [Link and Button Navigation](https://dialtone.dialpad.com/guides/migration/link-and-button-navigation/)

[DLT-3418]: https://dialpad.atlassian.net/browse/DLT-3418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ