### PR TITLE
test(dialtone-tokens): DLT-3417 add test coverage for theming system

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - 'packages/dialtone-vue/**'
+      - 'packages/dialtone-tokens/**'
   push:
     branches:
       - staging
     paths:
       - 'packages/dialtone-vue/**'
+      - 'packages/dialtone-tokens/**'
 
 env:
   HUSKY: 0
@@ -18,7 +20,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      vue: ${{ steps.filter.outputs.vue }}
+      tokens: ${{ steps.filter.outputs.tokens }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            vue:
+              - 'packages/dialtone-vue/**'
+            tokens:
+              - 'packages/dialtone-tokens/**'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.vue == 'true'
     runs-on: ubuntu-latest
     permissions:
       packages: read
@@ -31,3 +51,19 @@ jobs:
 
       - name: Run dialtone-vue tests with coverage
         run: pnpm nx run dialtone-vue:test:coverage
+
+  test-tokens:
+    needs: changes
+    if: needs.changes.outputs.tokens == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Run dialtone-tokens tests
+        run: pnpm nx run dialtone-tokens:test

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -22,6 +22,9 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
     outputs:
       vue: ${{ steps.filter.outputs.vue }}
       tokens: ${{ steps.filter.outputs.tokens }}

--- a/packages/dialtone-tokens/package.json
+++ b/packages/dialtone-tokens/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "sync:tokens-to-figma": "tsx sync-scripts/sync_tokens_to_figma.ts",
-    "sync:figma-to-tokens": "tsx sync-scripts/sync_figma_to_tokens.ts"
+    "sync:figma-to-tokens": "tsx sync-scripts/sync_figma_to_tokens.ts",
+    "test": "pnpm exec vitest run"
   },
   "files": [
     "dist"

--- a/packages/dialtone-tokens/project.json
+++ b/packages/dialtone-tokens/project.json
@@ -61,6 +61,13 @@
         "command": "pnpm publish --filter ./packages/dialtone-tokens"
       }
     },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "pnpm test"
+      }
+    },
     "release": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/dialtone-tokens/tests/config.test.js
+++ b/packages/dialtone-tokens/tests/config.test.js
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  setMode,
+  setBrand,
+  setMaterial,
+  setContrast,
+  initDialtoneTheme,
+  getBrandMaterial,
+  hasBrandMaterialLock,
+  resetTheme,
+  VALID_MATERIALS,
+} from '@/themes/config.js';
+import {
+  dpStub,
+  melonStub,
+  botanyStub,
+  unknownMaterialBrandStub,
+  highContrastStub,
+} from './fixtures/theme-stubs.js';
+import { setupRoot, setupShadowHost } from './fixtures/dom-helpers.js';
+
+describe('themes/config.js', () => {
+  let root;
+  let warnSpy;
+
+  beforeEach(() => {
+    root = setupRoot();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    resetTheme(document.documentElement);
+    document.head
+      .querySelectorAll('style[id^="dialtone-css-"]')
+      .forEach((el) => el.remove());
+    vi.restoreAllMocks();
+  });
+
+  describe('initDialtoneTheme', () => {
+    describe('When the brand declares a material lock', () => {
+      it.each([
+        ['iron', melonStub],
+        ['sandstone', botanyStub],
+      ])('Should apply data-dt-material="%s"', (expected, brand) => {
+        initDialtoneTheme(brand, 'light', root);
+        expect(root.getAttribute('data-dt-material')).toBe(expected);
+      });
+    });
+
+    describe('When the brand has no material lock', () => {
+      it('Should apply the seeded sandstone default', () => {
+        initDialtoneTheme(dpStub, 'light', root);
+        expect(root.getAttribute('data-dt-material')).toBe('sandstone');
+      });
+    });
+
+    describe('When called with malformed input', () => {
+      it.each([
+        ['null brand', null, 'light'],
+        ['brand without name', { brand: { css: ':root {}' } }, 'light'],
+        ['brand without css', { brand: { name: 'x' } }, 'light'],
+        ['invalid mode', dpStub, 'invalid'],
+      ])('Should throw TypeError on %s', (_label, brand, mode) => {
+        expect(() => initDialtoneTheme(brand, mode, root)).toThrow(TypeError);
+      });
+
+      it('Should throw TypeError on null rootNode', () => {
+        expect(() => initDialtoneTheme(dpStub, 'light', null)).toThrow(TypeError);
+      });
+    });
+
+    describe('When initialized on documentElement and theme styles already exist', () => {
+      it('Should throw to prevent embedded-app double-init', () => {
+        const coreStyle = document.createElement('style');
+        coreStyle.id = 'dialtone-css-core';
+        document.head.appendChild(coreStyle);
+        expect(() =>
+          initDialtoneTheme(dpStub, 'light', document.documentElement),
+        ).toThrow(/embedded/i);
+      });
+    });
+  });
+
+  describe('setBrand', () => {
+    describe('When the brand declares an unknown material name', () => {
+      beforeEach(() => {
+        setBrand(unknownMaterialBrandStub, root);
+      });
+
+      it('Should warn with brand and material context', () => {
+        const message = warnSpy.mock.calls.flat().join(' ');
+        expect(message).toContain(`brand '${unknownMaterialBrandStub.brand.name}'`);
+        expect(message).toContain(`unknown material '${unknownMaterialBrandStub.material.name}'`);
+      });
+
+      it('Should fall back to data-dt-material="sandstone"', () => {
+        expect(root.getAttribute('data-dt-material')).toBe('sandstone');
+      });
+    });
+
+    describe('When called with malformed input', () => {
+      it.each([
+        ['null', null],
+        ['number', 42],
+        ['empty object', {}],
+        ['brand without name', { brand: { css: ':root {}' } }],
+        ['brand with empty name', { brand: { name: '', css: ':root {}' } }],
+        ['brand without css', { brand: { name: 'x' } }],
+        ['brand with non-string css', { brand: { name: 'x', css: 123 } }],
+      ])('Should throw TypeError on %s', (_label, input) => {
+        expect(() => setBrand(input, root)).toThrow(TypeError);
+      });
+    });
+  });
+
+  describe('setMaterial', () => {
+    describe('When called with a known material name', () => {
+      it.each(VALID_MATERIALS)(
+        'Should set data-dt-material="%s" without injecting a style tag',
+        (name) => {
+          setMaterial(name, root);
+          expect(root.getAttribute('data-dt-material')).toBe(name);
+          expect(root.querySelector('#dialtone-css-material')).toBeNull();
+        },
+      );
+    });
+
+    describe('When called with null or undefined', () => {
+      beforeEach(() => {
+        setMaterial('steel', root);
+      });
+
+      it.each([null, undefined])(
+        'Should reset to sandstone without injecting a style tag (%p)',
+        (sentinel) => {
+          setMaterial(sentinel, root);
+          expect(root.getAttribute('data-dt-material')).toBe('sandstone');
+          expect(root.querySelector('#dialtone-css-material')).toBeNull();
+        },
+      );
+    });
+
+    describe('When called with an unknown name', () => {
+      beforeEach(() => {
+        setMaterial('unobtainium', root);
+      });
+
+      it('Should warn with the unknown name in context', () => {
+        const message = warnSpy.mock.calls.flat().join(' ');
+        expect(message).toContain('unknown material \'unobtainium\'');
+      });
+
+      it('Should fall back to data-dt-material="sandstone"', () => {
+        expect(root.getAttribute('data-dt-material')).toBe('sandstone');
+      });
+    });
+
+    describe('When called with a non-string non-null name', () => {
+      it('Should throw TypeError', () => {
+        expect(() => setMaterial(42, root)).toThrow(TypeError);
+      });
+    });
+  });
+
+  describe('Shadow DOM rootNode handling', () => {
+    const directShadowRootCallers = [
+      ['setMode', (rootNode) => setMode('dark', rootNode)],
+      ['setBrand', (rootNode) => setBrand(dpStub, rootNode)],
+      ['setMaterial', (rootNode) => setMaterial('steel', rootNode)],
+      ['setContrast', (rootNode) => setContrast(highContrastStub, rootNode)],
+      ['initDialtoneTheme', (rootNode) => initDialtoneTheme(dpStub, 'light', rootNode)],
+    ];
+
+    describe('When a ShadowRoot is passed directly', () => {
+      it.each(directShadowRootCallers)('%s should warn', (_name, call) => {
+        const { shadowRoot } = setupShadowHost();
+        try {
+          call(shadowRoot);
+        } catch {
+          // The downstream setAttribute throws on ShadowRoot; the warn fires first.
+        }
+        const message = warnSpy.mock.calls.flat().join(' ');
+        expect(message).toMatch(/ShadowRoot/);
+      });
+    });
+
+    it.skip('host-with-shadowRoot writes attribute on shadowRoot — pending bug fix', () => {});
+  });
+
+  describe('getBrandMaterial', () => {
+    it.each([
+      ['locked-iron brand', melonStub, 'iron'],
+      ['locked-sandstone brand', botanyStub, 'sandstone'],
+      ['free-choice brand', dpStub, null],
+    ])('Should return the locked name or null (%s)', (_label, brand, expected) => {
+      expect(getBrandMaterial(brand)).toBe(expected);
+    });
+  });
+
+  describe('hasBrandMaterialLock', () => {
+    it.each([
+      ['locked-iron brand', melonStub, true],
+      ['locked-sandstone brand', botanyStub, true],
+      ['free-choice brand', dpStub, false],
+    ])('Should return true/false (%s)', (_label, brand, expected) => {
+      expect(hasBrandMaterialLock(brand)).toBe(expected);
+    });
+  });
+
+  describe('resetTheme', () => {
+    describe('When called on a root with theme attributes set', () => {
+      beforeEach(() => {
+        initDialtoneTheme(melonStub, 'dark', root);
+        resetTheme(root);
+      });
+
+      it.each([
+        'data-dt-mode',
+        'data-dt-brand',
+        'data-dt-material',
+        'data-dt-contrast',
+      ])('Should remove %s', (attr) => {
+        expect(root.getAttribute(attr)).toBeNull();
+      });
+    });
+  });
+});

--- a/packages/dialtone-tokens/tests/fixtures/core-stub.js
+++ b/packages/dialtone-tokens/tests/fixtures/core-stub.js
@@ -1,0 +1,6 @@
+// Stubs the build-generated themes/core.js (absent on clean checkouts) so vitest
+// can import themes/config.js without a prior token build. Aliased in vitest.config.js.
+export default {
+  core: ':root {}',
+  baseColors: ':root {}',
+};

--- a/packages/dialtone-tokens/tests/fixtures/dom-helpers.js
+++ b/packages/dialtone-tokens/tests/fixtures/dom-helpers.js
@@ -1,0 +1,9 @@
+export function setupRoot () {
+  return document.createElement('div');
+}
+
+export function setupShadowHost () {
+  const host = document.createElement('div');
+  const shadowRoot = host.attachShadow({ mode: 'open' });
+  return { host, shadowRoot };
+}

--- a/packages/dialtone-tokens/tests/fixtures/theme-stubs.js
+++ b/packages/dialtone-tokens/tests/fixtures/theme-stubs.js
@@ -1,0 +1,24 @@
+const STUB_CSS = ':root {}';
+
+export const dpStub = {
+  brand: { name: 'dp', css: STUB_CSS },
+};
+
+export const melonStub = {
+  brand: { name: 'melon', css: STUB_CSS },
+  material: { name: 'iron' },
+};
+
+export const botanyStub = {
+  brand: { name: 'botany', css: STUB_CSS },
+  material: { name: 'sandstone' },
+};
+
+export const unknownMaterialBrandStub = {
+  brand: { name: 'fake', css: STUB_CSS },
+  material: { name: 'unobtainium' },
+};
+
+export const highContrastStub = {
+  contrast: { name: 'high', css: STUB_CSS },
+};

--- a/packages/dialtone-tokens/vitest.config.js
+++ b/packages/dialtone-tokens/vitest.config.js
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vitest/config';
 import { fileURLToPath } from 'node:url';
 
+const packageRoot = fileURLToPath(new URL('.', import.meta.url));
+const coreStub = fileURLToPath(new URL('./tests/fixtures/core-stub.js', import.meta.url));
+
 export default defineConfig({
   test: {
     name: 'dialtone-tokens',
@@ -9,8 +12,10 @@ export default defineConfig({
     include: ['tests/**/*.test.js'],
   },
   resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('.', import.meta.url)),
-    },
+    alias: [
+      // Must precede the '@' prefix alias below — Vite array-form aliases match in order.
+      { find: '@/themes/core.js', replacement: coreStub },
+      { find: '@', replacement: packageRoot },
+    ],
   },
 });

--- a/packages/dialtone-tokens/vitest.config.js
+++ b/packages/dialtone-tokens/vitest.config.js
@@ -13,9 +13,10 @@ export default defineConfig({
   },
   resolve: {
     alias: [
-      // Must precede the '@' prefix alias below — Vite array-form aliases match in order.
+      // Must precede the '@/' prefix alias below — Vite array-form aliases match in order.
       { find: '@/themes/core.js', replacement: coreStub },
-      { find: '@', replacement: packageRoot },
+      // Restricted to '@/...' so it doesn't match scoped package imports like '@scope/pkg'.
+      { find: /^@\/(.*)/, replacement: `${packageRoot}/$1` },
     ],
   },
 });

--- a/packages/dialtone-tokens/vitest.config.js
+++ b/packages/dialtone-tokens/vitest.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig({
+  test: {
+    name: 'dialtone-tokens',
+    globals: true,
+    environment: 'jsdom',
+    include: ['tests/**/*.test.js'],
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Test

## :book: Jira Ticket

[DLT-3417](https://dialpad.atlassian.net/browse/DLT-3417)

## :book: Description

`dialtone-tokens` had no test runner. Wires Vitest, adds gotcha-driven coverage for `themes/config.js`:

- 44 passing + 1 documented skip
- Covers: locked-brand init order (Codex fix from DLT-3410 V4), unknown-material fallback warn, attribute-only invariant (post-DLT-3405), validation throws, embedded-app guard, getters, `resetTheme` smoke
- New `test-tokens` job in `unit_tests.yml` via the existing `dorny/paths-filter@v3` pattern, scoped to PRs touching `packages/dialtone-tokens/**`
- Test layout: `packages/dialtone-tokens/tests/{config.test.js, fixtures/}` follows the `tests/` convention used by `eslint-plugin-dialtone`, `stylelint-plugin-dialtone`, and `dialtone-vue/tests/fixtures/`

Out of scope: trivial happy paths, legacy `setTheme`, localStorage round-trip (in `useThemeManager.js`), DtModeIsland mirroring (in `dialtone-vue`), build-pipeline output.

## :bulb: Context

Three back-to-back changes just landed (DLT-3368, DLT-3410, DLT-3405). Codex caught one regression in DLT-3410 V4 that CI tests would have flagged earlier. Future regressions now have somewhere to land an assertion before merge.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

[DLT-3417]: https://dialpad.atlassian.net/browse/DLT-3417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ