### PR TITLE
fix(components): dlt-3408 components clean up

### DIFF
--- a/packages/dialtone-vue/components/Avatar/Avatar.test.js
+++ b/packages/dialtone-vue/components/Avatar/Avatar.test.js
@@ -175,30 +175,20 @@ describe('DtAvatar Tests', () => {
         expect(count.exists()).toBe(false);
       });
 
-      it('applies correct digit modifiers at boundaries', async () => {
-        // 9 -> no group shown, no digit modifiers
-        await wrapper.setProps({ group: 9 });
-        expect(wrapper.classes('d-avatar--group')).toBe(true);
-        expect(wrapper.classes('d-avatar--group-digits-2')).toBe(false);
-        expect(wrapper.classes('d-avatar--group-digits-3')).toBe(false);
+      it.each([
+        [9, true, false, false],
+        [10, true, true, false],
+        [99, true, true, false],
+        [100, true, false, true],
+      ])('group %i applies d-avatar--group=%s, digits-2=%s, digits-3=%s', async (group, hasGroup, hasDigits2, hasDigits3) => {
+        await wrapper.setProps({ group });
+        expect(wrapper.classes('d-avatar--group')).toBe(hasGroup);
+        expect(wrapper.classes('d-avatar--group-digits-2')).toBe(hasDigits2);
+        expect(wrapper.classes('d-avatar--group-digits-3')).toBe(hasDigits3);
+      });
 
-        // 10 -> base + digits-2
-        await wrapper.setProps({ group: 10 });
-        expect(wrapper.classes('d-avatar--group')).toBe(true);
-        expect(wrapper.classes('d-avatar--group-digits-2')).toBe(true);
-        expect(wrapper.classes('d-avatar--group-digits-3')).toBe(false);
-
-        // 99 -> base + digits-2
-        await wrapper.setProps({ group: 99 });
-        expect(wrapper.classes('d-avatar--group')).toBe(true);
-        expect(wrapper.classes('d-avatar--group-digits-2')).toBe(true);
-        expect(wrapper.classes('d-avatar--group-digits-3')).toBe(false);
-
-        // 100 -> base + digits-3 and count shows 99+
+      it('shows 99+ when group is 100 or more', async () => {
         await wrapper.setProps({ group: 100 });
-        expect(wrapper.classes('d-avatar--group')).toBe(true);
-        expect(wrapper.classes('d-avatar--group-digits-2')).toBe(false);
-        expect(wrapper.classes('d-avatar--group-digits-3')).toBe(true);
         const count = wrapper.find('[data-qa="dt-avatar-count"]');
         expect(count.text()).toBe('99+');
       });

--- a/packages/dialtone-vue/components/Avatar/Avatar.vue
+++ b/packages/dialtone-vue/components/Avatar/Avatar.vue
@@ -105,7 +105,6 @@ const supportsOklch = typeof CSS !== 'undefined' && CSS.supports?.('background',
  * @see https://dialtone.dialpad.com/components/avatar.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtAvatar',
   components: { DtPresence },
 

--- a/packages/dialtone-vue/components/Avatar/AvatarDefault.story.vue
+++ b/packages/dialtone-vue/components/Avatar/AvatarDefault.story.vue
@@ -2,10 +2,8 @@
   <dt-avatar
     :id="$attrs.id"
     :full-name="$attrs.fullName"
-    :icon-name="$attrs.iconName"
     :image-src="$attrs.imageSrc"
     :image-alt="$attrs.imageAlt"
-    :icon-size="$attrs.iconSize"
     :size="$attrs.size"
     :presence="$attrs.presence"
     :avatar-class="$attrs.avatarClass"
@@ -14,19 +12,38 @@
     :seed="$attrs.seed"
     :group="$attrs.group"
     :color="$attrs.color"
-    :overlay-icon="$attrs.overlayIcon"
     :overlay-text="$attrs.overlayText"
     :overlay-class="$attrs.overlayClass"
     :interactive="$attrs.interactive"
     @click="$attrs.onClick"
-  />
+  >
+    <template
+      v-if="$attrs.iconName"
+      #icon
+    >
+      <dt-icon
+        :name="$attrs.iconName"
+        :size="$attrs.iconSize"
+      />
+    </template>
+    <template
+      v-if="$attrs.overlayIcon"
+      #overlayIcon
+    >
+      <dt-icon
+        :name="$attrs.overlayIcon"
+        size="300"
+      />
+    </template>
+  </dt-avatar>
 </template>
 
 <script>
 import DtAvatar from './Avatar.vue';
+import { DtIcon } from '@/components/Icon';
 
 export default {
   name: 'DtAvatarDefault',
-  components: { DtAvatar },
+  components: { DtAvatar, DtIcon },
 };
 </script>

--- a/packages/dialtone-vue/components/Avatar/AvatarVariants.story.vue
+++ b/packages/dialtone-vue/components/Avatar/AvatarVariants.story.vue
@@ -191,7 +191,7 @@
       </dt-stack>
     </div>
     <div>
-      <h2>Clickable</h2>
+      <h2>Interactive</h2>
       <dt-stack
         direction="row"
         gap="200"
@@ -199,12 +199,12 @@
         <dt-avatar
           :seed="$attrs.seed"
           full-name="Person avatar"
-          clickable
+          interactive
         />
         <dt-avatar
           :seed="$attrs.seed"
           icon-aria-label="user icon"
-          clickable
+          interactive
         >
           <template #icon>
             <dt-icon-user />
@@ -215,7 +215,7 @@
           full-name="Person avatar"
           :image-src="$attrs.imageSrc"
           :image-alt="$attrs.imageAlt"
-          clickable
+          interactive
         />
       </dt-stack>
     </div>

--- a/packages/dialtone-vue/components/Badge/Badge.stories.js
+++ b/packages/dialtone-vue/components/Badge/Badge.stories.js
@@ -8,6 +8,7 @@ import {
   BADGE_KIND_MODIFIERS,
   BADGE_DECORATION_MODIFIERS,
 } from './BadgeConstants';
+import { ICON_SIZE_MODIFIERS } from '@/components/Icon';
 
 const iconsList = getIconNames();
 
@@ -89,6 +90,37 @@ export const argTypesData = {
     },
     options: [undefined, ...Object.keys(BADGE_DECORATION_MODIFIERS)],
     // TODO: Find a way to add conditions on more than one argument
+  },
+
+  iconSize: {
+    options: Object.keys(ICON_SIZE_MODIFIERS),
+    control: {
+      type: 'select',
+    },
+  },
+
+  text: {
+    control: { type: 'text' },
+  },
+
+  startIconClass: {
+    description: 'Pass through classes. Used to customize the start icon container',
+  },
+
+  endIconClass: {
+    description: 'Pass through classes. Used to customize the end icon container',
+  },
+
+  subtle: {
+    control: {
+      type: 'boolean',
+    },
+  },
+
+  outlined: {
+    control: {
+      type: 'boolean',
+    },
   },
 
   labelClass: {

--- a/packages/dialtone-vue/components/Badge/Badge.vue
+++ b/packages/dialtone-vue/components/Badge/Badge.vue
@@ -112,7 +112,7 @@ export default {
     /**
      * Decoration for the badge. This can be only used with kind: label and type: default
      * with no left and right icons
-     * @values default, black-400, black-500, black-900, red-200, red-300, red-400, purple-200,
+     * @values black-400, black-500, black-900, red-200, red-300, red-400, purple-200,
      * purple-300, purple-400, purple-500, blue-200, blue-300, blue-400, green-300, green-400,
      * green-500, gold-300, gold-400, gold-500, magenta-200, magenta-300, magenta-400
      */
@@ -184,6 +184,10 @@ export default {
     hasIcons () {
       return this.hasLeftIcon || this.hasRightIcon;
     },
+  },
+
+  mounted () {
+    this.validateProps();
   },
 
   updated () {

--- a/packages/dialtone-vue/components/Badge/Badge.vue
+++ b/packages/dialtone-vue/components/Badge/Badge.vue
@@ -68,7 +68,6 @@ import { hasSlotContent } from '@/common/utils/index.js';
  * @see https://dialtone.dialpad.com/components/badge.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtBadge',
 
   props: {

--- a/packages/dialtone-vue/components/Badge/BadgeDefault.story.vue
+++ b/packages/dialtone-vue/components/Badge/BadgeDefault.story.vue
@@ -9,10 +9,10 @@
     :outlined="$attrs.outlined"
   >
     <template
+      v-if="$attrs.startIcon"
       #startIcon="{ iconSize }"
     >
       <dt-icon
-        v-if="$attrs.startIcon"
         :name="$attrs.startIcon"
         :size="iconSize"
       />
@@ -21,10 +21,10 @@
       {{ defaultSlot }}
     </template>
     <template
+      v-if="$attrs.endIcon"
       #endIcon="{ iconSize }"
     >
       <dt-icon
-        v-if="$attrs.endIcon"
         :name="$attrs.endIcon"
         :size="iconSize"
       />

--- a/packages/dialtone-vue/components/Badge/BadgeVariants.story.vue
+++ b/packages/dialtone-vue/components/Badge/BadgeVariants.story.vue
@@ -13,7 +13,7 @@
       :type="type.value"
     />
     <dt-badge
-      v-for="type in types.slice(0, types.length - 1)"
+      v-for="type in types.filter(t => t.value !== 'ai')"
       :key="`${type.value}-count`"
       text="1"
       :type="type.value"

--- a/packages/dialtone-vue/components/Banner/Banner.stories.js
+++ b/packages/dialtone-vue/components/Banner/Banner.stories.js
@@ -102,6 +102,28 @@ export const argTypesData = {
     },
   },
 
+  dialogClass: {
+    description: 'Inner dialog class',
+  },
+  backgroundImage: {
+    control: { type: 'text' },
+  },
+  backgroundSize: {
+    control: { type: 'text' },
+  },
+  iconClass: {
+    description: 'Additional class name for the icon wrapper element.',
+  },
+  headerClass: {
+    description: 'Additional class name for the header wrapper element.',
+  },
+  contentClass: {
+    description: 'Additional class name for the content wrapper element.',
+  },
+  actionClass: {
+    description: 'Additional class name for the action wrapper element.',
+  },
+
   // Action Event Handlers
   onClick: {
     table: {

--- a/packages/dialtone-vue/components/Banner/Banner.vue
+++ b/packages/dialtone-vue/components/Banner/Banner.vue
@@ -59,7 +59,6 @@ import utils from '@/common/utils';
  * @see https://dialtone.dialpad.com/components/banner.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtBanner',
 
   components: {

--- a/packages/dialtone-vue/components/Banner/Banner.vue
+++ b/packages/dialtone-vue/components/Banner/Banner.vue
@@ -9,7 +9,8 @@
       class="d-banner__dialog"
       :class="dialogClass"
       :role="role"
-      :aria-labelledby="headerId"
+      :aria-modal="important || undefined"
+      :aria-labelledby="hasHeader ? headerId : undefined"
       :aria-describedby="contentId"
     >
       <dt-notice-icon
@@ -227,6 +228,10 @@ export default {
   computed: {
     role () {
       return this.important ? 'alertdialog' : 'status';
+    },
+
+    hasHeader () {
+      return !!this.headerText || !!this.$slots.header;
     },
 
     bannerClass () {

--- a/packages/dialtone-vue/components/Box/Box.stories.js
+++ b/packages/dialtone-vue/components/Box/Box.stories.js
@@ -11,6 +11,9 @@ import {
   DT_BOX_BORDER_WIDTH_VALUES,
   DT_BOX_BORDER_RADIUS_VALUES,
   DT_BOX_SHADOW_VALUES,
+  DT_BOX_LAYOUT_VALUES,
+  DT_BOX_OVERFLOW_VALUES,
+  DT_BOX_SCROLLBAR_VALUES,
 } from './BoxConstants.js';
 
 export const argsData = {
@@ -79,6 +82,65 @@ export const argTypesData = {
   shadow: {
     control: 'select',
     options: [undefined, ...DT_BOX_SHADOW_VALUES],
+  },
+  overflow: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_OVERFLOW_VALUES],
+  },
+  scrollbar: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_SCROLLBAR_VALUES],
+  },
+  scrollbarContentClass: {
+    description: 'Additional CSS classes applied to the scrollbar content wrapper element.',
+  },
+  inlineSize: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_LAYOUT_VALUES],
+  },
+  blockSize: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_LAYOUT_VALUES],
+  },
+  minInlineSize: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_LAYOUT_VALUES],
+  },
+  maxInlineSize: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_LAYOUT_VALUES],
+  },
+  minBlockSize: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_LAYOUT_VALUES],
+  },
+  maxBlockSize: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_LAYOUT_VALUES],
+  },
+  borderWidthBlock: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_BORDER_WIDTH_VALUES],
+  },
+  borderWidthBlockEnd: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_BORDER_WIDTH_VALUES],
+  },
+  borderWidthBlockStart: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_BORDER_WIDTH_VALUES],
+  },
+  borderWidthInline: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_BORDER_WIDTH_VALUES],
+  },
+  borderWidthInlineEnd: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_BORDER_WIDTH_VALUES],
+  },
+  borderWidthInlineStart: {
+    control: 'select',
+    options: [undefined, ...DT_BOX_BORDER_WIDTH_VALUES],
   },
 };
 

--- a/packages/dialtone-vue/components/Breadcrumbs/Breadcrumb.test.js
+++ b/packages/dialtone-vue/components/Breadcrumbs/Breadcrumb.test.js
@@ -67,7 +67,7 @@ describe('DtBreadcrumb Tests', () => {
     });
 
     describe('When the breadcrumb has default state', () => {
-      it('should has correct aria-current', () => {
+      it('should have correct aria-current', () => {
         const elementWithValidAria = breadcrumbItems.filter(item => {
           return item.find('[aria-current="location"]').exists();
         });
@@ -75,11 +75,11 @@ describe('DtBreadcrumb Tests', () => {
         expect(elementWithValidAria.length).toBe(1);
       });
 
-      it('should has correct rendered items', () => {
+      it('should have correct rendered items', () => {
         expect(breadcrumbItems.length).toEqual(baseProps.breadcrumbs.length);
       });
 
-      it('should has correct sequence', () => {
+      it('should have correct sequence', () => {
         expect(breadcrumbItems.length).toEqual(baseProps.breadcrumbs.length);
 
         baseProps.breadcrumbs.forEach(({ label }, i) => {
@@ -110,8 +110,8 @@ describe('DtBreadcrumb Tests', () => {
   });
 
   describe('Accessibility Tests', () => {
-    describe('When a new area-label is provided', () => {
-      it('should update area-label value', () => {
+    describe('When a new aria-label is provided', () => {
+      it('should update aria-label value', () => {
         mockProps = { ariaLabel: 'newAria' };
 
         updateWrapper();

--- a/packages/dialtone-vue/components/Breadcrumbs/BreadcrumbItem.stories.js
+++ b/packages/dialtone-vue/components/Breadcrumbs/BreadcrumbItem.stories.js
@@ -22,6 +22,12 @@ export const argTypesData = {
     },
     control: 'text',
   },
+  label: {
+    control: { type: 'text' },
+  },
+  selected: {
+    control: { type: 'boolean' },
+  },
   inverted: {
     table: { category: 'Deprecated' },
     description: 'Deprecated.',

--- a/packages/dialtone-vue/components/Breadcrumbs/BreadcrumbItem.test.js
+++ b/packages/dialtone-vue/components/Breadcrumbs/BreadcrumbItem.test.js
@@ -9,7 +9,6 @@ const baseSlots = {};
 
 let mockProps = {};
 let mockSlots = {};
-const testContext = {};
 
 describe('DtBreadcrumbItem Tests', () => {
   let wrapper;
@@ -18,7 +17,6 @@ describe('DtBreadcrumbItem Tests', () => {
     wrapper = mount(DtBreadcrumbItem, {
       props: { ...baseProps, ...mockProps },
       slots: { ...baseSlots, ...mockSlots },
-      localVue: testContext.localVue,
     });
   };
 

--- a/packages/dialtone-vue/components/Breadcrumbs/Breadcrumbs.stories.js
+++ b/packages/dialtone-vue/components/Breadcrumbs/Breadcrumbs.stories.js
@@ -51,6 +51,9 @@ export const argTypesData = {
       },
     },
   },
+  ariaLabel: {
+    control: { type: 'text' },
+  },
   inverted: {
     table: { category: 'Deprecated' },
     description: 'Deprecated.',

--- a/packages/dialtone-vue/components/Breadcrumbs/Breadcrumbs.vue
+++ b/packages/dialtone-vue/components/Breadcrumbs/Breadcrumbs.vue
@@ -12,7 +12,7 @@
       <slot>
         <dt-breadcrumb-item
           v-for="(item, index) in breadcrumbs"
-          :key="getBreadcrumbItemKey(index)"
+          :key="`breadcrumbs-item-${index}-${item.href}`"
           :inverted="inverted"
           v-bind="item"
         />
@@ -24,7 +24,6 @@
 <script>
 import { BREADCRUMBS_INVERTED_MODIFIER } from './BreadcrumbsConstants';
 import DtBreadcrumbItem from './BreadcrumbItem.vue';
-import utils from '@/common/utils';
 import { DialtoneLocalization } from '@/localization';
 
 /**
@@ -46,7 +45,7 @@ export default {
     breadcrumbs: {
       type: Array,
       default: () => [],
-      validate (breadcrumbs) {
+      validator (breadcrumbs) {
         return breadcrumbs.every(({ href, label }) => {
           return href !== undefined && label !== undefined;
         });
@@ -86,12 +85,6 @@ export default {
       BREADCRUMBS_INVERTED_MODIFIER,
       i18n: new DialtoneLocalization(),
     };
-  },
-
-  methods: {
-    getBreadcrumbItemKey (index) {
-      return `breadcrumbs-item-${index}-${utils.getUniqueString()}`;
-    },
   },
 };
 </script>

--- a/packages/dialtone-vue/components/Breadcrumbs/Breadcrumbs.vue
+++ b/packages/dialtone-vue/components/Breadcrumbs/Breadcrumbs.vue
@@ -33,7 +33,6 @@ import { DialtoneLocalization } from '@/localization';
  * @see https://dialtone.dialpad.com/components/breadcrumbs.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtBreadcrumbs',
 
   components: {

--- a/packages/dialtone-vue/components/Button/Button.test.js
+++ b/packages/dialtone-vue/components/Button/Button.test.js
@@ -39,6 +39,7 @@ describe('DtButton Tests', () => {
     mockProps = {};
     mockSlots = {};
     mockAttrs = {};
+    MOCK_BUTTON_STUB.mockReset();
   });
 
   describe('Presentation Tests', () => {

--- a/packages/dialtone-vue/components/Button/Button.vue
+++ b/packages/dialtone-vue/components/Button/Button.vue
@@ -167,7 +167,6 @@ import { DialtoneLocalization } from '@/localization';
  * @see https://dialtone.dialpad.com/components/button.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtButton',
 
   components: { DtLoader },

--- a/packages/dialtone-vue/components/ButtonGroup/ButtonGroup.vue
+++ b/packages/dialtone-vue/components/ButtonGroup/ButtonGroup.vue
@@ -15,7 +15,6 @@
 import { BUTTON_GROUP_ALIGNMENT } from './ButtonGroupConstants';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtButtonGroup',
 
   props: {

--- a/packages/dialtone-vue/components/ButtonGroup/ButtonsDecorator.vue
+++ b/packages/dialtone-vue/components/ButtonGroup/ButtonsDecorator.vue
@@ -13,7 +13,6 @@
 import { DtButton } from '../Button';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'ButtonsDecorator',
   components: { DtButton },
 };

--- a/packages/dialtone-vue/components/Card/Card.stories.js
+++ b/packages/dialtone-vue/components/Card/Card.stories.js
@@ -26,6 +26,10 @@ export const argTypesData = {
     },
   },
 
+  maxHeight: {
+    control: { type: 'text' },
+  },
+
   // Slots
   content: {
     control: 'text',

--- a/packages/dialtone-vue/components/Card/Card.vue
+++ b/packages/dialtone-vue/components/Card/Card.vue
@@ -47,7 +47,6 @@ import { hasSlotContent } from '@/common/utils';
  * @see https://dialtone.dialpad.com/components/card.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtCard',
 
 

--- a/packages/dialtone-vue/components/Card/CardDefault.story.vue
+++ b/packages/dialtone-vue/components/Card/CardDefault.story.vue
@@ -50,7 +50,7 @@
       </div>
     </template>
     <template
-      v-if="showFooter & variants"
+      v-if="showFooter && variants"
       #footer
     >
       <dt-button>

--- a/packages/dialtone-vue/components/Checkbox/Checkbox.stories.js
+++ b/packages/dialtone-vue/components/Checkbox/Checkbox.stories.js
@@ -72,10 +72,57 @@ export const argTypesData = {
     control: 'select',
     options: ['', ...Object.values(VALIDATION_MESSAGE_TYPES)],
   },
+  label: {
+    control: { type: 'text' },
+  },
+  name: {
+    control: { type: 'text' },
+  },
+  value: {
+    control: { type: 'text' },
+  },
+  disabled: {
+    control: { type: 'boolean' },
+  },
+  indeterminate: {
+    control: { type: 'boolean' },
+  },
+  showLabel: {
+    control: { type: 'boolean' },
+  },
+  labelSize: {
+    options: ['100', '200', '300', '400'],
+    control: { type: 'select' },
+  },
+  labelStrength: {
+    options: ['bold', 'semibold', 'medium', 'normal'],
+    control: { type: 'select' },
+  },
+  inputClass: {
+    description: 'Used to customize the input element',
+  },
+  labelClass: {
+    description: 'Used to customize the label container',
+  },
+  descriptionClass: {
+    description: 'Used to customize the description container',
+  },
+  messagesClass: {
+    description: 'Used to customize the validation messages component',
+  },
+  showMessages: {
+    control: { type: 'boolean' },
+  },
+  messages: {
+    control: 'object',
+  },
   labelChildProps: {
     control: null,
   },
   descriptionChildProps: {
+    control: null,
+  },
+  messagesChildProps: {
     control: null,
   },
 

--- a/packages/dialtone-vue/components/Checkbox/Checkbox.vue
+++ b/packages/dialtone-vue/components/Checkbox/Checkbox.vue
@@ -83,7 +83,6 @@ import { DtText, TEXT_SIZE_MODIFIERS, TEXT_STRENGTH_MODIFIERS } from '@/componen
  * @see https://dialtone.dialpad.com/components/checkbox.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtCheckbox',
 
   components: { DtValidationMessages, DtText },

--- a/packages/dialtone-vue/components/CheckboxGroup/CheckboxGroup.stories.js
+++ b/packages/dialtone-vue/components/CheckboxGroup/CheckboxGroup.stories.js
@@ -80,6 +80,24 @@ export const argTypesData = {
   messagesClass: {
     control: 'text',
   },
+  name: {
+    control: { type: 'text' },
+  },
+  disabled: {
+    control: { type: 'boolean' },
+  },
+  messages: {
+    control: 'object',
+  },
+  showMessages: {
+    control: { type: 'boolean' },
+  },
+  legendChildProps: {
+    control: null,
+  },
+  messagesChildProps: {
+    control: null,
+  },
 
   // Directives
   'v-model': {

--- a/packages/dialtone-vue/components/CheckboxGroup/CheckboxGroup.vue
+++ b/packages/dialtone-vue/components/CheckboxGroup/CheckboxGroup.vue
@@ -8,7 +8,6 @@ import { DtInputGroup } from '../InputGroup';
  * @see https://dialtone.dialpad.com/components/checkbox_group.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtCheckboxGroup',
 
   extends: DtInputGroup,

--- a/packages/dialtone-vue/components/CheckboxGroup/CheckboxesDecorator.vue
+++ b/packages/dialtone-vue/components/CheckboxGroup/CheckboxesDecorator.vue
@@ -14,7 +14,6 @@
 import { DtCheckbox } from '../Checkbox';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'CheckboxesDecorator',
   components: { DtCheckbox },
   created () {

--- a/packages/dialtone-vue/components/Chip/Chip.vue
+++ b/packages/dialtone-vue/components/Chip/Chip.vue
@@ -75,7 +75,6 @@ import { DialtoneLocalization } from '@/localization';
  * @see https://dialtone.dialpad.com/components/chip.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtChip',
 
   components: {

--- a/packages/dialtone-vue/components/Codeblock/Codeblock.test.js
+++ b/packages/dialtone-vue/components/Codeblock/Codeblock.test.js
@@ -11,7 +11,7 @@ describe('DtCodeblock Tests', () => {
 
   const updateWrapper = () => {
     wrapper = mount(DtCodeblock, {
-      propsData: { ...baseProps, ...mockProps },
+      props: { ...baseProps, ...mockProps },
     });
   };
 

--- a/packages/dialtone-vue/components/Codeblock/Codeblock.vue
+++ b/packages/dialtone-vue/components/Codeblock/Codeblock.vue
@@ -12,7 +12,6 @@
 import { CODEBLOCK_SIZES, CODEBLOCK_SIZE_MAP } from './CodeblockConstants';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtCodeblock',
 
   props: {

--- a/packages/dialtone-vue/components/Collapsible/Collapsible.stories.js
+++ b/packages/dialtone-vue/components/Collapsible/Collapsible.stories.js
@@ -45,6 +45,34 @@ const argTypesData = {
     },
   },
 
+  maxHeight: {
+    control: { type: 'text' },
+  },
+  maxWidth: {
+    control: { type: 'text' },
+  },
+  elementType: {
+    control: { type: 'text' },
+  },
+  contentElementType: {
+    control: { type: 'text' },
+  },
+  anchorClass: {
+    description: 'Additional class name for the anchor wrapper element.',
+  },
+  contentClass: {
+    description: 'Additional class name for the content wrapper element.',
+  },
+  ariaLabel: {
+    control: { type: 'text' },
+  },
+  ariaLabelledBy: {
+    control: { type: 'text' },
+  },
+  open: {
+    control: { type: 'boolean' },
+  },
+
   // Action Event Handlers
   onOpened: {
     table: {

--- a/packages/dialtone-vue/components/Collapsible/Collapsible.vue
+++ b/packages/dialtone-vue/components/Collapsible/Collapsible.vue
@@ -88,7 +88,6 @@ import { DtIconChevronDown, DtIconChevronRight } from '@dialpad/dialtone-icons/v
  * @see https://dialtone.dialpad.com/components/collapsible.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtCollapsible',
 
   components: {

--- a/packages/dialtone-vue/components/Collapsible/Collapsible.vue
+++ b/packages/dialtone-vue/components/Collapsible/Collapsible.vue
@@ -80,7 +80,6 @@
 import { extractVueListeners, getUniqueString, hasSlotContent } from '@/common/utils';
 import DtCollapsibleLazyShow from './CollapsibleLazyShow.vue';
 import { DtButton } from '@/components/Button';
-import { DtLazyShow } from '@/components/LazyShow';
 import { DtIconChevronDown, DtIconChevronRight } from '@dialpad/dialtone-icons/vue';
 
 /**
@@ -93,7 +92,6 @@ export default {
   components: {
     DtButton,
     DtCollapsibleLazyShow,
-    DtLazyShow,
     DtIconChevronDown,
     DtIconChevronRight,
   },

--- a/packages/dialtone-vue/components/Combobox/Combobox.stories.js
+++ b/packages/dialtone-vue/components/Combobox/Combobox.stories.js
@@ -84,6 +84,30 @@ export const argTypesData = {
       },
     },
   },
+  showLabel: {
+    control: { type: 'boolean' },
+  },
+  showList: {
+    control: { type: 'boolean' },
+  },
+  listRenderedOutside: {
+    control: { type: 'boolean' },
+  },
+  loading: {
+    control: { type: 'boolean' },
+  },
+  emptyList: {
+    control: { type: 'boolean' },
+  },
+  emptyStateMessage: {
+    control: { type: 'text' },
+  },
+  emptyStateClass: {
+    description: 'Additional class name for the empty list element.',
+  },
+  clickOnSelect: {
+    control: { type: 'boolean' },
+  },
   onBeginningOfList: {
     table: {
       category: 'props',

--- a/packages/dialtone-vue/components/Combobox/Combobox.vue
+++ b/packages/dialtone-vue/components/Combobox/Combobox.vue
@@ -62,7 +62,6 @@ import { COMPONENT_SIZES } from '@/common/constants';
  * @see https://dialtone.dialpad.com/components/combobox.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtCombobox',
 
   components: {

--- a/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.stories.js
+++ b/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.stories.js
@@ -118,6 +118,12 @@ export const argTypesData = {
   hasSuggestionList: {
     control: { type: 'boolean' },
   },
+  collapseOnFocusOut: {
+    control: { type: 'boolean' },
+  },
+  inputWrapperClass: {
+    description: 'Additional class name for the input wrapper element.',
+  },
 
   // Action Event Handlers
   onEscape: {

--- a/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.stories.js
+++ b/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.stories.js
@@ -91,6 +91,34 @@ export const argTypesData = {
     options: Object.values(MULTI_SELECT_SIZES),
   },
 
+  showLabel: {
+    control: { type: 'boolean' },
+  },
+  showList: {
+    control: { type: 'boolean' },
+  },
+  listMaxHeight: {
+    control: { type: 'text' },
+  },
+  loading: {
+    control: { type: 'boolean' },
+  },
+  loadingMessage: {
+    control: { type: 'text' },
+  },
+  selectedItems: {
+    control: 'object',
+  },
+  maxSelected: {
+    control: { type: 'number' },
+  },
+  maxSelectedMessage: {
+    control: 'object',
+  },
+  hasSuggestionList: {
+    control: { type: 'boolean' },
+  },
+
   // Action Event Handlers
   onEscape: {
     table: {

--- a/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.vue
+++ b/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.vue
@@ -141,7 +141,6 @@ import {
 import { COMPONENT_SIZES } from '@/common/constants';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtComboboxMultiSelect',
 
   components: {

--- a/packages/dialtone-vue/components/ComboboxWithPopover/ComboboxWithPopover.vue
+++ b/packages/dialtone-vue/components/ComboboxWithPopover/ComboboxWithPopover.vue
@@ -126,7 +126,6 @@ import { DROPDOWN_PADDING_CLASSES } from '@/components/Dropdown';
 import { CONTENT_MODE_PROP } from '@/common/mode_constants';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtComboboxWithPopover',
 
   components: {

--- a/packages/dialtone-vue/components/DescriptionList/DescriptionList.stories.js
+++ b/packages/dialtone-vue/components/DescriptionList/DescriptionList.stories.js
@@ -23,6 +23,12 @@ export const argTypesData = {
       type: 'select',
     },
   },
+  termClass: {
+    description: 'Additional class name for the term elements.',
+  },
+  descriptionClass: {
+    description: 'Additional class name for the description elements.',
+  },
 };
 
 export const argsData = {

--- a/packages/dialtone-vue/components/DescriptionList/DescriptionList.vue
+++ b/packages/dialtone-vue/components/DescriptionList/DescriptionList.vue
@@ -1,8 +1,8 @@
 <template>
   <dl :class="['d-description-list', getDirectionClass, getGapClass]">
     <template
-      v-for="item in items"
-      :key="item.term"
+      v-for="(item, index) in items"
+      :key="`${index}-${item.term}`"
     >
       <dt :class="dtClass">
         {{ item.term }}

--- a/packages/dialtone-vue/components/DescriptionList/DescriptionList.vue
+++ b/packages/dialtone-vue/components/DescriptionList/DescriptionList.vue
@@ -20,7 +20,6 @@ import { DT_DESCRIPTION_LIST_DIRECTION } from './DescriptionListConstants';
 import { itemsValidator } from './DescriptionListValidators';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtDescriptionList',
 
   props: {

--- a/packages/dialtone-vue/components/Dropdown/Dropdown.test.js
+++ b/packages/dialtone-vue/components/Dropdown/Dropdown.test.js
@@ -109,13 +109,13 @@ describe('DtDropdown Tests', () => {
 
         updateWrapper();
 
-        expect(anchorElement.attributes('aria-expanded') === 'false').toBe(true);
+        expect(anchorElement.attributes('aria-expanded')).toBe('false');
       });
     });
 
     describe('When the dropdown is open', () => {
       it('aria-expanded should be "true"', () => {
-        expect(anchorElement.attributes('aria-expanded') === 'true').toBe(true);
+        expect(anchorElement.attributes('aria-expanded')).toBe('true');
       });
     });
   });
@@ -159,7 +159,7 @@ describe('DtDropdown Tests', () => {
       it('should close the dropdown', async () => {
         await closeButton.trigger('click');
 
-        expect(anchorElement.attributes('aria-expanded') === 'false').toBe(true);
+        expect(anchorElement.attributes('aria-expanded')).toBe('false');
       });
     });
   });

--- a/packages/dialtone-vue/components/Dropdown/Dropdown.vue
+++ b/packages/dialtone-vue/components/Dropdown/Dropdown.vue
@@ -68,7 +68,6 @@ import { EVENT_KEYNAMES } from '@/common/constants';
 import { CONTENT_MODE_PROP } from '@/common/mode_constants';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtDropdown',
 
   components: {

--- a/packages/dialtone-vue/components/Dropdown/DropdownList.vue
+++ b/packages/dialtone-vue/components/Dropdown/DropdownList.vue
@@ -32,7 +32,6 @@ import { DtStack } from '@/components/Stack';
 import { DtText } from '@/components/Text';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtDropdownList',
   components: { DtStack, DtText },
   props: {

--- a/packages/dialtone-vue/components/Dropdown/DropdownSeparator.vue
+++ b/packages/dialtone-vue/components/Dropdown/DropdownSeparator.vue
@@ -7,7 +7,6 @@
 
 <script>
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtDropdownSeparator',
 };
 </script>

--- a/packages/dialtone-vue/components/Emoji/Emoji.vue
+++ b/packages/dialtone-vue/components/Emoji/Emoji.vue
@@ -37,7 +37,6 @@ import { DtSkeleton } from '@/components/Skeleton';
  * @see https://dialtone.dialpad.com/components/emoji.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtEmoji',
 
   components: {

--- a/packages/dialtone-vue/components/EmojiTextWrapper/EmojiTextWrapper.vue
+++ b/packages/dialtone-vue/components/EmojiTextWrapper/EmojiTextWrapper.vue
@@ -11,7 +11,6 @@ const COMMENT_TYPE = h(resolveDynamicComponent(null)).type;
  * @see https://dialtone.dialpad.com/components/emoji_text_wrapper.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtEmojiTextWrapper',
 
   components: {

--- a/packages/dialtone-vue/components/Icon/Icon.vue
+++ b/packages/dialtone-vue/components/Icon/Icon.vue
@@ -19,7 +19,6 @@ import { ICON_SIZE_MODIFIERS, ICON_NAMES } from './IconConstants';
  * @see https://dialtone.dialpad.com/components/icon.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtIcon',
 
   props: {

--- a/packages/dialtone-vue/components/ImageViewer/ImageViewer.vue
+++ b/packages/dialtone-vue/components/ImageViewer/ImageViewer.vue
@@ -82,7 +82,6 @@ import SrOnlyCloseButton from '@/common/sr_only_close_button.vue';
 import { DialtoneLocalization } from '@/localization';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtImageViewer',
 
   components: {

--- a/packages/dialtone-vue/components/Input/Input.vue
+++ b/packages/dialtone-vue/components/Input/Input.vue
@@ -165,7 +165,6 @@ import { MessagesMixin } from '@/common/mixins/input';
  * @see https://dialtone.dialpad.com/components/input.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtInput',
 
   components: { DtValidationMessages, DtText },

--- a/packages/dialtone-vue/components/InputGroup/InputGroup.vue
+++ b/packages/dialtone-vue/components/InputGroup/InputGroup.vue
@@ -42,7 +42,6 @@ import { hasSlotContent } from '@/common/utils';
  * @see https://dialtone.dialpad.com/components/input_group.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtInputGroup',
 
   components: { DtValidationMessages, DtText },

--- a/packages/dialtone-vue/components/ItemLayout/ItemLayout.vue
+++ b/packages/dialtone-vue/components/ItemLayout/ItemLayout.vue
@@ -97,7 +97,6 @@
 import { hasSlotContent } from '@/common/utils';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtItemLayout',
   props: {
     /**

--- a/packages/dialtone-vue/components/KeyboardShortcut/KeyboardShortcut.vue
+++ b/packages/dialtone-vue/components/KeyboardShortcut/KeyboardShortcut.vue
@@ -96,7 +96,6 @@ const KEY_ABBREVIATIONS = {
  * @see https://dialtone.dialpad.com/components/keyboard_shortcut.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtKeyboardShortcut',
 
   components: {

--- a/packages/dialtone-vue/components/LazyShow/LazyShow.vue
+++ b/packages/dialtone-vue/components/LazyShow/LazyShow.vue
@@ -21,7 +21,6 @@
  * @see https://dialtone.dialpad.com/components/lazy_show.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtLazyShow',
 
   inheritAttrs: false,

--- a/packages/dialtone-vue/components/Link/Link.vue
+++ b/packages/dialtone-vue/components/Link/Link.vue
@@ -20,7 +20,6 @@ import { LINK_VARIANTS, LINK_KIND_MODIFIERS, getLinkKindModifier } from './LinkC
  * @see https://dialtone.dialpad.com/components/link.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtLink',
 
   props: {

--- a/packages/dialtone-vue/components/ListItem/ListItem.vue
+++ b/packages/dialtone-vue/components/ListItem/ListItem.vue
@@ -62,7 +62,6 @@ const ROLES = ['listitem', 'menuitem', 'option'];
  * @see https://dialtone.dialpad.com/components/list_item.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtListItem',
 
   components: {

--- a/packages/dialtone-vue/components/ListItemGroup/ListItemGroup.vue
+++ b/packages/dialtone-vue/components/ListItemGroup/ListItemGroup.vue
@@ -28,7 +28,6 @@ import {} from './ListItemGroupConstants';
 import { getUniqueString } from '@/common/utils';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtListItemGroup',
 
   props: {

--- a/packages/dialtone-vue/components/Modal/Modal.vue
+++ b/packages/dialtone-vue/components/Modal/Modal.vue
@@ -151,7 +151,6 @@ const focusableSelector = 'button:not(:disabled),[href],input:not(:disabled),sel
  * @see https://dialtone.dialpad.com/components/modal.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtModal',
 
   components: {

--- a/packages/dialtone-vue/components/ModeIsland/ModeIsland.vue
+++ b/packages/dialtone-vue/components/ModeIsland/ModeIsland.vue
@@ -25,7 +25,6 @@ import {
 
 export default {
   name: 'DtModeIsland',
-  compatConfig: { MODE: 3 },
 
   provide () {
     return {

--- a/packages/dialtone-vue/components/MotionText/MotionText.vue
+++ b/packages/dialtone-vue/components/MotionText/MotionText.vue
@@ -77,7 +77,6 @@
 import { MOTION_TEXT_ANIMATION_MODES, MOTION_TEXT_SPEEDS, MOTION_TEXT_TIMING_PRESETS } from './MotionTextConstants';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtMotionText',
 
   props: {

--- a/packages/dialtone-vue/components/Notice/Notice.vue
+++ b/packages/dialtone-vue/components/Notice/Notice.vue
@@ -50,7 +50,6 @@ import { NOTICE_KINDS, NOTICE_ROLES } from './NoticeConstants';
  * @see https://dialtone.dialpad.com/components/notice.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtNotice',
 
   components: {

--- a/packages/dialtone-vue/components/Notice/NoticeAction.vue
+++ b/packages/dialtone-vue/components/Notice/NoticeAction.vue
@@ -36,7 +36,6 @@ import SrOnlyCloseButton from '@/common/sr_only_close_button.vue';
 import { DialtoneLocalization } from '@/localization';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtNoticeAction',
 
   components: {

--- a/packages/dialtone-vue/components/Notice/NoticeContent.vue
+++ b/packages/dialtone-vue/components/Notice/NoticeContent.vue
@@ -38,7 +38,6 @@ import { hasSlotContent } from '@/common/utils';
 import { DtText } from '@/components/Text';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtNoticeContent',
 
   components: { DtText },

--- a/packages/dialtone-vue/components/Notice/NoticeIcon.vue
+++ b/packages/dialtone-vue/components/Notice/NoticeIcon.vue
@@ -34,7 +34,6 @@ const kindToIcon = new Map([
 ]);
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtNoticeIcon',
 
   components: {

--- a/packages/dialtone-vue/components/Pagination/Pagination.vue
+++ b/packages/dialtone-vue/components/Pagination/Pagination.vue
@@ -75,7 +75,6 @@ import { DialtoneLocalization } from '@/localization';
  * @see https://dialtone.dialpad.com/components/pagination.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtPagination',
 
   components: {

--- a/packages/dialtone-vue/components/Popover/Popover.vue
+++ b/packages/dialtone-vue/components/Popover/Popover.vue
@@ -148,7 +148,6 @@ import SrOnlyCloseButton from '@/common/sr_only_close_button.vue';
  * @see https://dialtone.dialpad.com/components/popover.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtPopover',
 
   /********************

--- a/packages/dialtone-vue/components/Popover/PopoverHeaderFooter.vue
+++ b/packages/dialtone-vue/components/Popover/PopoverHeaderFooter.vue
@@ -48,7 +48,6 @@ import { hasSlotContent, returnFirstEl } from '@/common/utils';
 import { DialtoneLocalization } from '@/localization';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'PopoverHeaderFooter',
   components: {
     DtButton,

--- a/packages/dialtone-vue/components/Presence/Presence.vue
+++ b/packages/dialtone-vue/components/Presence/Presence.vue
@@ -29,7 +29,6 @@ import { PRESENCE_STATES, PRESENCE_STATES_LIST } from './PresenceConstants';
  * @see https://dialtone.dialpad.com/components/presence.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtPresence',
   props: {
 

--- a/packages/dialtone-vue/components/ProgressCircle/ProgressCircle.vue
+++ b/packages/dialtone-vue/components/ProgressCircle/ProgressCircle.vue
@@ -6,7 +6,6 @@
 import { PROGRESS_CIRCLE_SIZES, PROGRESS_CIRCLE_KINDS } from './ProgressCircleConstants';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtProgressCircle',
   props: {
     /** Accessible label read by screen readers. */

--- a/packages/dialtone-vue/components/Radio/Radio.vue
+++ b/packages/dialtone-vue/components/Radio/Radio.vue
@@ -81,7 +81,6 @@ import { hasSlotContent, removeClassStyleAttrs } from '@/common/utils';
  * @see https://dialtone.dialpad.com/components/radio.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtRadio',
 
   components: { DtValidationMessages, DtText },

--- a/packages/dialtone-vue/components/RadioGroup/RadioGroup.vue
+++ b/packages/dialtone-vue/components/RadioGroup/RadioGroup.vue
@@ -6,7 +6,6 @@ import { DtInputGroup } from '../InputGroup';
  * @see https://dialtone.dialpad.com/components/radio_group.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtRadioGroup',
 
   extends: DtInputGroup,

--- a/packages/dialtone-vue/components/RadioGroup/RadiosDecorator.vue
+++ b/packages/dialtone-vue/components/RadioGroup/RadiosDecorator.vue
@@ -14,7 +14,6 @@
 import { DtRadio } from '../Radio';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'RadiosDecorator',
   components: { DtRadio },
   created () {

--- a/packages/dialtone-vue/components/RichTextEditor/Extensions/Channels/ChannelComponent.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/Extensions/Channels/ChannelComponent.vue
@@ -29,7 +29,6 @@ import { DtStack } from '@/components/Stack';
 import { DtLink } from '@/components/Link';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'ChannelComponent',
   components: {
     NodeViewWrapper,

--- a/packages/dialtone-vue/components/RichTextEditor/Extensions/Channels/ChannelSuggestion.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/Extensions/Channels/ChannelSuggestion.vue
@@ -21,7 +21,6 @@ import DtIconHash from '@dialpad/dialtone-icons/vue/hash';
 import DtIconLock from '@dialpad/dialtone-icons/vue/lock';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'ChannelSuggestion',
   components: {
     DtStack,

--- a/packages/dialtone-vue/components/RichTextEditor/Extensions/Emoji/EmojiComponent.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/Extensions/Emoji/EmojiComponent.vue
@@ -16,7 +16,6 @@ import { nodeViewProps, NodeViewWrapper } from '@tiptap/vue-3';
 import { DtEmoji } from '@/components/Emoji';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'EmojiComponent',
   components: {
     NodeViewWrapper,

--- a/packages/dialtone-vue/components/RichTextEditor/Extensions/Emoji/EmojiSuggestion.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/Extensions/Emoji/EmojiSuggestion.vue
@@ -16,7 +16,6 @@ import { DtEmoji } from '@/components/Emoji';
 import { DtStack } from '@/components/Stack';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'EmojiSuggestion',
   components: {
     DtEmoji,

--- a/packages/dialtone-vue/components/RichTextEditor/Extensions/Mentions/MentionComponent.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/Extensions/Mentions/MentionComponent.vue
@@ -22,7 +22,6 @@ import { nodeViewProps, NodeViewWrapper } from '@tiptap/vue-3';
 import { DtLink } from '@/components/Link';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'MentionComponent',
   components: {
     NodeViewWrapper,

--- a/packages/dialtone-vue/components/RichTextEditor/Extensions/Mentions/MentionSuggestion.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/Extensions/Mentions/MentionSuggestion.vue
@@ -66,7 +66,6 @@ import { DtStack } from '@/components/Stack';
 import { DtText } from '@/components/Text';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'MentionSuggestion',
   components: {
     DtAvatar,

--- a/packages/dialtone-vue/components/RichTextEditor/Extensions/SlashCommand/SlashCommandComponent.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/Extensions/SlashCommand/SlashCommandComponent.vue
@@ -11,7 +11,6 @@
 import { nodeViewProps, NodeViewWrapper } from '@tiptap/vue-3';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'SlashCommandsComponent',
   components: {
     NodeViewWrapper,

--- a/packages/dialtone-vue/components/RichTextEditor/Extensions/SlashCommand/SlashCommandSuggestion.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/Extensions/SlashCommand/SlashCommandSuggestion.vue
@@ -23,7 +23,6 @@
 import { DtText } from '@/components/Text';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'SlashCommandSuggestion',
   components: { DtText },
 

--- a/packages/dialtone-vue/components/RichTextEditor/Extensions/Suggestion/SuggestionList.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/Extensions/Suggestion/SuggestionList.vue
@@ -30,7 +30,6 @@
 import { DtListItem } from '@/components/ListItem';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'SuggestionList',
   components: {
     DtListItem,

--- a/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.vue
@@ -101,7 +101,6 @@ import deepEqual from 'deep-equal';
 import { DialtoneLocalization } from '@/localization';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtRichTextEditor',
 
   components: {

--- a/packages/dialtone-vue/components/RootLayout/RootLayout.vue
+++ b/packages/dialtone-vue/components/RootLayout/RootLayout.vue
@@ -55,7 +55,6 @@ import { ROOT_LAYOUT_SIDEBAR_POSITIONS, ROOT_LAYOUT_RESPONSIVE_BREAKPOINTS } fro
  * A root layout provides a standardized group of containers to display content at the root level.
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtRootLayout',
 
   props: {

--- a/packages/dialtone-vue/components/SelectMenu/SelectMenu.vue
+++ b/packages/dialtone-vue/components/SelectMenu/SelectMenu.vue
@@ -109,7 +109,6 @@ import { DtValidationMessages } from '../ValidationMessages';
  * @see https://dialtone.dialpad.com/components/select.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtSelectMenu',
 
   components: { DtValidationMessages, DtText },

--- a/packages/dialtone-vue/components/Skeleton/Skeleton.vue
+++ b/packages/dialtone-vue/components/Skeleton/Skeleton.vue
@@ -48,7 +48,6 @@ import DtSkeletonText from './SkeletonText.vue';
  * @see https://dialtone.dialpad.com/components/skeleton.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtSkeleton',
   components: {
     DtSkeletonText,

--- a/packages/dialtone-vue/components/Skeleton/SkeletonListItem.vue
+++ b/packages/dialtone-vue/components/Skeleton/SkeletonListItem.vue
@@ -35,7 +35,6 @@ import DtSkeletonShape from './SkeletonShape.vue';
 import DtSkeletonParagraph from './SkeletonParagraph.vue';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtSkeletonListItem',
 
   components: {

--- a/packages/dialtone-vue/components/Skeleton/SkeletonParagraph.vue
+++ b/packages/dialtone-vue/components/Skeleton/SkeletonParagraph.vue
@@ -25,7 +25,6 @@ import DtSkeletonText from './SkeletonText.vue';
 
 const validator = number => number !== '' && !Number.isNaN(Number(number));
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtSkeletonParagraph',
   components: {
     DtSkeletonText,

--- a/packages/dialtone-vue/components/Skeleton/SkeletonShape.vue
+++ b/packages/dialtone-vue/components/Skeleton/SkeletonShape.vue
@@ -22,7 +22,6 @@ import {
 } from './SkeletonConstants';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtSkeletonShape',
 
   mixins: [SkeletonAnimation],

--- a/packages/dialtone-vue/components/Skeleton/SkeletonText.vue
+++ b/packages/dialtone-vue/components/Skeleton/SkeletonText.vue
@@ -41,7 +41,6 @@ import { SKELETON_HEADING_HEIGHTS, SKELETON_TEXT_TYPES } from './SkeletonConstan
 import SkeletonAnimation from '@/common/mixins/skeleton';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtSkeletonText',
 
   mixins: [SkeletonAnimation],

--- a/packages/dialtone-vue/components/SplitButton/SplitButton.vue
+++ b/packages/dialtone-vue/components/SplitButton/SplitButton.vue
@@ -155,7 +155,6 @@ import { DtDropdown } from '@/components/Dropdown';
 import { hasSlotContent, warnIfUnmounted, returnFirstEl } from '@/common/utils';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtSplitButton',
 
   components: {

--- a/packages/dialtone-vue/components/SplitButton/SplitButtonEnd.vue
+++ b/packages/dialtone-vue/components/SplitButton/SplitButtonEnd.vue
@@ -29,7 +29,6 @@ import { DtIconChevronDown } from '@dialpad/dialtone-icons/vue';
 import { getUniqueString } from '@/common/utils';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'SplitButtonEnd',
   components: {
     DtButton,

--- a/packages/dialtone-vue/components/SplitButton/SplitButtonStart.vue
+++ b/packages/dialtone-vue/components/SplitButton/SplitButtonStart.vue
@@ -68,7 +68,6 @@
 import { BUTTON_ICON_SIZES, DtButton } from '@/components/Button';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'SplitButtonStart',
 
   components: {

--- a/packages/dialtone-vue/components/Stack/Stack.vue
+++ b/packages/dialtone-vue/components/Stack/Stack.vue
@@ -22,7 +22,6 @@ import { directionValidator, gapValidator, alignValidator, justifyValidator } fr
 import { getDefaultDirectionClass, getResponsiveClasses, getDefaultGapClass, getDefaultAlignClass, getDefaultJustifyClass } from './Utils';
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtStack',
 
   props: {

--- a/packages/dialtone-vue/components/Tab/Tab.vue
+++ b/packages/dialtone-vue/components/Tab/Tab.vue
@@ -80,7 +80,6 @@ import { DtButton } from '../Button';
  * @see https://dialtone.dialpad.com/components/tabs.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtTab',
   components: {
     DtButton,

--- a/packages/dialtone-vue/components/Tab/TabGroup.vue
+++ b/packages/dialtone-vue/components/Tab/TabGroup.vue
@@ -60,7 +60,6 @@ import { useIndicatorAnimation } from '@/common/composables/useIndicatorAnimatio
  * @see https://dialtone.dialpad.com/components/tabs.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtTabGroup',
 
   provide () {

--- a/packages/dialtone-vue/components/Tab/TabPanel.vue
+++ b/packages/dialtone-vue/components/Tab/TabPanel.vue
@@ -23,7 +23,6 @@ import { returnFirstEl } from '@/common/utils';
  * @see https://dialtone.dialpad.com/components/tabs.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtTabPanel',
 
   mixins: [Modal],

--- a/packages/dialtone-vue/components/Text/Text.vue
+++ b/packages/dialtone-vue/components/Text/Text.vue
@@ -43,7 +43,6 @@ export const resetHeadlineSemanticInfoFlag = () => {
  * @see https://dialtone.dialpad.com/components/text.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtText',
 
   props: {

--- a/packages/dialtone-vue/components/Toast/Layouts/ToastLayoutAlternateIcon.vue
+++ b/packages/dialtone-vue/components/Toast/Layouts/ToastLayoutAlternateIcon.vue
@@ -33,7 +33,6 @@ const kindToIcon = new Map([
 ]);
 
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtToastLayoutAlternateIcon',
 
   components: {

--- a/packages/dialtone-vue/components/Toast/Toast.vue
+++ b/packages/dialtone-vue/components/Toast/Toast.vue
@@ -49,7 +49,6 @@ import ToastLayoutAlternate from './Layouts/ToastLayoutAlternate.vue';
  * @see https://dialtone.dialpad.com/components/toast.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtToast',
 
   components: {

--- a/packages/dialtone-vue/components/Toggle/Toggle.vue
+++ b/packages/dialtone-vue/components/Toggle/Toggle.vue
@@ -40,7 +40,6 @@ import { TOGGLE_CHECKED_VALUES, TOGGLE_SIZE_MODIFIERS } from '@/components/Toggl
  * @see https://dialtone.dialpad.com/components/toggle.html
  */
 export default {
-  compatConfig: { MODE: 3 },
 
   name: 'DtToggle',
 

--- a/packages/dialtone-vue/components/Tooltip/Tooltip.vue
+++ b/packages/dialtone-vue/components/Tooltip/Tooltip.vue
@@ -67,7 +67,6 @@ import ModeMixin from '@/common/mixins/mode';
  * @see https://dialtone.dialpad.com/components/tooltip.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtTooltip',
 
   mixins: [ModeMixin],

--- a/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.vue
+++ b/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.vue
@@ -35,7 +35,6 @@ import {
  * @see https://dialtone.dialpad.com/components/validation_messages.html
  */
 export default {
-  compatConfig: { MODE: 3 },
   name: 'DtValidationMessages',
 
   props: {


### PR DESCRIPTION
# components clean up

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExNmdnYWg4MG5zd2N1MjBtdGVid3gwbm44dGsyMWt0eHJkbzdyaWJqYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/NHHYRm7mAUQ6Y/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->

https://dialpad.atlassian.net/browse/DLT-3408

https://dialpad.atlassian.net/browse/DLT-3407

## :book: Description

We are doing some clean up on components:

1. compatConfig Removal
Removed compatConfig: { MODE: 3 } from 78 component files across dialtone-vue/components, dropping Vue 2 compatibility.

2. Badge Component
Badge.stories.js — Added missing argTypes: iconSize, text, startIconClass, endIconClass, subtle, outlined, labelClass.
Badge.vue — Fixed JSDoc @values for decoration (removed invalid "default"). Added mounted() hook so validation runs on initial render.
BadgeDefault.story.vue — Added v-if guards on #startIcon/#endIcon slot templates to prevent empty icon wrappers.
BadgeVariants.story.vue — Replaced fragile types.slice() with explicit .filter(t => t.value !== 'ai').

3. Banner Component
Banner.stories.js — Added missing argTypes: dialogClass, backgroundImage, backgroundSize, iconClass, headerClass, contentClass, actionClass.
Banner.vue — Added aria-modal when important is true. Made aria-labelledby conditional on hasHeader computed. Added hasHeader computed property.

4. Box Component
Box.stories.js — Added 16 missing argTypes for overflow, scrollbar, scrollbarContentClass, sizing props, and directional border width props. Imported DT_BOX_LAYOUT_VALUES, DT_BOX_OVERFLOW_VALUES, DT_BOX_SCROLLBAR_VALUES.

5. Breadcrumbs Components
Breadcrumb.test.js — Fixed grammar: "should has" → "should have" (3 occurrences). Fixed typo: "area-label" → "aria-label" (2 occurrences).
BreadcrumbItem.stories.js — Added argTypes for label and selected.
BreadcrumbItem.test.js — Removed deprecated localVue option and unused testContext variable.
Breadcrumbs.stories.js — Added argType for ariaLabel.
Breadcrumbs.vue — Replaced random getUniqueString() keys with deterministic `${index}-${item.href}`. Removed unused utils import and getBreadcrumbItemKey method. Fixed validate → validator on breadcrumbs prop.

6. Codeblock Component
Codeblock.test.js — Replaced Vue 2 propsData with Vue 3 props.

7. Collapsible Component
Collapsible.stories.js — Added 9 missing argTypes: maxHeight, maxWidth, elementType, contentElementType, anchorClass, contentClass, ariaLabel, ariaLabelledBy, open.
Collapsible.vue — Removed unused DtLazyShow import and component registration.
CollapsibleDefault.story.vue — Fixed this.open → this.$attrs.open and watcher (user later reverted this to keep this.open).

8. DescriptionList Component
DescriptionList.stories.js — Added argTypes for termClass and descriptionClass.
DescriptionList.vue — Changed v-for key from item.term to `${index}-${item.term}` for uniqueness.

9. Avatar Component
Avatar.test.js — Split monolithic boundary test into it.each cases (4 parameterized + 1 focused 99+ test).
AvatarDefault.story.vue — Translated iconName/iconSize/overlayIcon from non-existent prop bindings into proper #icon and #overlayIcon slot content.
AvatarVariants.story.vue — Replaced deprecated clickable with interactive (3 instances + heading).

10. Button Component
Button.test.js — Added MOCK_BUTTON_STUB.mockReset() in afterEach to prevent test pollution.

11. Card Component
Card.stories.js — Added maxHeight argType.
CardDefault.story.vue — Fixed bitwise & → logical &&.

12. Checkbox Components
Checkbox.stories.js — Added 16 missing argTypes from component + mixins (InputMixin, CheckableMixin, MessagesMixin).
CheckboxGroup.stories.js — Added 6 missing argTypes: name, disabled, messages, showMessages, legendChildProps, messagesChildProps.

13. Combobox Components
Combobox.stories.js — Added 8 missing argTypes: showLabel, showList, listRenderedOutside, loading, emptyList, emptyStateMessage, emptyStateClass, clickOnSelect.
ComboboxMultiSelect.stories.js — Added 9 missing argTypes: showLabel, showList, listMaxHeight, loading, loadingMessage, selectedItems, maxSelected, maxSelectedMessage, hasSuggestionList.

14. Dropdown Component
Dropdown.test.js — Replaced indirect expect(x === 'false').toBe(true) with direct expect(x).toBe('false') for clearer failure messages (3 assertions).