### PR TITLE
docs(recipes): dlt-3308 recipes removed from dialtone - migration guide

### DIFF
--- a/apps/dialtone-documentation/docs/_data/site-nav.json
+++ b/apps/dialtone-documentation/docs/_data/site-nav.json
@@ -272,7 +272,7 @@
                     "link": "/guides/migration/logical-naming/"
                   },
                   {
-                    "text": "Recipes to UI Kits",
+                    "text": "Removal of Dialtone Recipes",
                     "link": "/guides/migration/recipes-to-ui-kits/"
                   },
                   {

--- a/apps/dialtone-documentation/docs/guides/migration/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/index.md
@@ -32,7 +32,7 @@ Work through each applicable guide in order. Guides earlier in the list are prer
 | 9 | [Component Sizes to Numeric](./component-sizes/) | Deprecation | ESLint + `dialtone-migrate-tshirt-to-numeric` | `size="sm"` becomes `:size="200"` across all components. |
 | 10 | [Avatar Updates](./avatar-updates/) | **Yes** | Manual (grep) | `DtAvatar` size prop moves to numeric, `iconSize` removed, group avatar behavior changed. |
 | 11 | [Logical Naming](./logical-naming/) | Deprecation | `dialtone-migration-helper` | Slots, props, events: `left`/`right` becomes `start`/`end`. |
-| 12 | [Recipes to UI Kits](./recipes-to-ui-kits/) | **Yes** | Migration script | `DtRecipe*` components move to standalone `@dialpad/` UI Kit packages. |
+| 12 | [Removal of Dialtone Recipes](./recipes-to-ui-kits/) | **Yes** | Migration script | All `DtRecipe*` components have been removed. Use standalone `@dialpad/` UI Kit packages instead. |
 | 13 | [Component Props & Events](./component-props/) | **Yes** | `dialtone-migrate-props` | Value renames (including DtBox `surface`/`bc`, DtText `tone-strong`, DtButton `link-kind`), `show` becomes `open`, `hide-*` inversion, `title` becomes `header-text`, event/slot renames, `rootClass` removal. |
 | 14 | [DtChip interactive default](./chip-interactive/) | **Yes** | `dialtone-migrate-chip-interactive` | `interactive` prop default changed from `true` to `false`. Chips that need click/keyboard behavior must opt in with `:interactive="true"`. |
 | 15 | [Scrollbar :never → :always](./scrollbar-always/) | **Yes** | `dialtone-migrate-scrollbar-always` | `v-dt-scrollbar:never` renamed to `v-dt-scrollbar:always`; `DtBox` `scrollbar="never"` renamed to `scrollbar="always"`. |

--- a/apps/dialtone-documentation/docs/guides/migration/recipes-to-ui-kits/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/recipes-to-ui-kits/index.md
@@ -1,14 +1,14 @@
 ---
-title: Migrating Recipes to UI Kits
-description: Dialtone recipes have been deprecated and moved to the UI-Kits repository. Includes migration mappings and automated script.
+title: Removal of Dialtone Recipes
+description: All Dialtone recipe components have been removed. Use the standalone UI-Kit packages instead.
 ---
 
 ## TLDR
 
-- All `DtRecipe*` components are deprecated and moved to standalone UI-Kit packages.
-- A few recipes have been upgraded to core Dialtone components.
-- An automated migration script handles import rewrites, component renames, and CSS class changes.
-- `DtRecipe*` components will remain until the next major Dialtone release but **will no longer receive updates**.
+- All `DtRecipe*` components have been **removed** from `@dialpad/dialtone`.
+- They have been replaced by standalone UI-Kit packages or promoted to core Dialtone components.
+- If you haven't migrated yet, refer to the migration mapping and automated script below — originally published as part of the [Migrating Recipes to UI Kits](#migration-mapping) deprecation guide.
+- Any `DtRecipe*` imports remaining in your codebase will break after upgrading to this major version.
 
 ## New Packages
 
@@ -68,8 +68,8 @@ Import the CSS for each kit you install:
 
 ## Timeline
 
-- `DtRecipe*` components will remain available until the next major Dialtone release (Q2 2026), but **will no longer receive updates**
-- Migrate before then to stay current with improvements and bug fixes
+- `DtRecipe*` components were deprecated in a previous release and have now been **fully removed** in this major version.
+- If you have not yet migrated, you **must** do so before upgrading.
 
 ## Automated Migration Script
 


### PR DESCRIPTION
# Recipes removed from dialtone - migration guide

## :hammer_and_wrench: Type Of Change


These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation


## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3308

## :book: Description

We already had the `Migrating Recipes to UI Kits` blog post.
I reused it to not create a new blog post about the same topic.
So in this PR Im doing the following changes:

- Title changed from "Migrating Recipes to UI Kits" → "Removal of Dialtone Recipes".
- Description updated to state recipes have been removed.
- Rewritten to reflect full removal (not deprecation), with a note that remaining DtRecipe* imports will break, and an anchor link to the Migration Mapping section for the original migration details.
- Timeline updated from "will remain until next major" to "have been fully removed in this major version"
