### PR TITLE
fix(components): no-jira update tree-shaking export

### DIFF
--- a/packages/dialtone-vue/vite.config.js
+++ b/packages/dialtone-vue/vite.config.js
@@ -24,6 +24,7 @@ function _getEntries (pathPrefix, globRegex) {
       .replace(`${pathPrefix}/`, '')
       .replace(/\.(vue|js)/, '')
       .replaceAll('_', '-')
+      .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
       .toLowerCase();
 
     entries[`${pathPrefix}/${entryName}`] = path;


### PR DESCRIPTION
# Update tree-shaking export

## :hammer_and_wrench: Type Of Change
These types will increment the version number on release:

- [x] Fix


## :book: Description

This previous adjust https://github.com/dialpad/dialtone/pull/1255/changes/d1c369b379e94dfe57116643b4d9b6093496cc10
Was to tackle the first letter uppercase issue, but .toLowerCase() alone loses the hyphens.

Im updating the way we do it to achieve the expected result:

e.g.:
ComboboxMultiSelect/ComboboxMultiSelect -> combobox-multi-select
Avatar/Avatar -> avatar/avatar
InputGroup/InputGroup -> input-group/input-group
.....
