### PR TITLE
fix(dialtone-tokens): NO-JIRA fix shadow DOM setAttribute crash in theme setters

### DIFF
--- a/packages/dialtone-tokens/tests/config.test.js
+++ b/packages/dialtone-tokens/tests/config.test.js
@@ -184,7 +184,15 @@ describe('themes/config.js', () => {
       });
     });
 
-    it.skip('host-with-shadowRoot writes attribute on shadowRoot — pending bug fix', () => {});
+    it('host-with-shadowRoot: sets data-dt-* attributes on host, injects styles into shadowRoot', () => {
+      const { host, shadowRoot } = setupShadowHost();
+      initDialtoneTheme(dpStub, 'light', host);
+      expect(host.getAttribute('data-dt-mode')).toBe('light');
+      expect(host.getAttribute('data-dt-brand')).toBe(dpStub.brand.name);
+      expect(host.getAttribute('data-dt-contrast')).toBe('default');
+      expect(shadowRoot.querySelector('#dialtone-css-core')).not.toBeNull();
+      expect(shadowRoot.querySelector('#dialtone-css-brand-colors')).not.toBeNull();
+    });
   });
 
   describe('getBrandMaterial', () => {

--- a/packages/dialtone-tokens/themes/config.js
+++ b/packages/dialtone-tokens/themes/config.js
@@ -118,19 +118,17 @@ export function setTheme (theme, rootNode = document.documentElement, contrastTh
  */
 function _setThemeLegacy(theme, rootNode = document.documentElement, contrastTheme = null) {
   _setThemeAttributeOnRoot(theme.base.name, theme.brand.name, rootNode);
-  if (rootNode?.shadowRoot) {
-    rootNode = rootNode.shadowRoot;
-  }
+  const styleRoot = rootNode?.shadowRoot ?? rootNode;
   // Load css files
-  _setStyleTag('dialtone-css-theme', theme.base.css, rootNode);
-  _setStyleTag('dialtone-css-brand', theme.brand.css, rootNode);
+  _setStyleTag('dialtone-css-theme', theme.base.css, styleRoot);
+  _setStyleTag('dialtone-css-brand', theme.brand.css, styleRoot);
 
   // Apply contrast layer
   if (contrastTheme) {
-    _setStyleTag('dialtone-css-contrast', contrastTheme.css, rootNode);
+    _setStyleTag('dialtone-css-contrast', contrastTheme.css, styleRoot);
     rootNode?.setAttribute('data-dt-contrast', 'high');
   } else {
-    _removeStyleTag('dialtone-css-contrast', rootNode);
+    _removeStyleTag('dialtone-css-contrast', styleRoot);
     rootNode?.setAttribute('data-dt-contrast', 'default');
   }
 }
@@ -139,30 +137,28 @@ function _setThemeLegacy(theme, rootNode = document.documentElement, contrastThe
  * Layered theme setter (new optimized system)
  */
 function _setThemeLayered(theme, rootNode = document.documentElement) {
-  if (rootNode?.shadowRoot) {
-    rootNode = rootNode.shadowRoot;
-  }
+  const styleRoot = rootNode?.shadowRoot ?? rootNode;
 
   // Load core tokens only once per JavaScript instance
   if (theme.core && !coreTokensLoaded) {
-    _setStyleTag('dialtone-css-core', theme.core, rootNode);
+    _setStyleTag('dialtone-css-core', theme.core, styleRoot);
     coreTokensLoaded = true;
   }
 
   // Load base colors only once
-  if (theme.baseColors && !rootNode?.querySelector('#dialtone-css-base-colors')) {
-    _setStyleTag('dialtone-css-base-colors', theme.baseColors, rootNode);
+  if (theme.baseColors && !styleRoot?.querySelector('#dialtone-css-base-colors')) {
+    _setStyleTag('dialtone-css-base-colors', theme.baseColors, styleRoot);
   }
 
   // Load brand colors (dp base is always loaded, others are overrides)
   if (theme.brand) {
-    _setStyleTag('dialtone-css-brand-colors', theme.brand.css, rootNode);
+    _setStyleTag('dialtone-css-brand-colors', theme.brand.css, styleRoot);
     rootNode?.setAttribute('data-dt-brand', theme.brand.name);
   }
 
   // Apply contrast layer if provided
   if (theme.contrast) {
-    _setStyleTag('dialtone-css-contrast', theme.contrast.css, rootNode);
+    _setStyleTag('dialtone-css-contrast', theme.contrast.css, styleRoot);
     rootNode?.setAttribute('data-dt-contrast', theme.contrast.name);
   }
 }
@@ -249,10 +245,7 @@ export function setMode(mode, rootNode = document.documentElement) {
       '[Dialtone] You passed a ShadowRoot directly to setMode(). ' +
       'Please pass the host element instead. The function will access shadowRoot automatically.',
     );
-  }
-
-  if (rootNode?.shadowRoot) {
-    rootNode = rootNode.shadowRoot;
+    return;
   }
 
   rootNode?.setAttribute('data-dt-mode', mode);
@@ -315,13 +308,11 @@ export function setBrand(brandTheme, rootNode = document.documentElement) {
       '[Dialtone] You passed a ShadowRoot directly to setBrand(). ' +
       'Please pass the host element instead. The function will access shadowRoot automatically.',
     );
+    return;
   }
 
-  if (rootNode?.shadowRoot) {
-    rootNode = rootNode.shadowRoot;
-  }
-
-  _setStyleTag('dialtone-css-brand-colors', brandTheme.brand.css, rootNode);
+  const styleRoot = rootNode?.shadowRoot ?? rootNode;
+  _setStyleTag('dialtone-css-brand-colors', brandTheme.brand.css, styleRoot);
   rootNode?.setAttribute('data-dt-brand', brandTheme.brand.name);
 
   _applyBrandLockedMaterial(brandTheme, rootNode);
@@ -381,17 +372,15 @@ export function setContrast(contrastTheme, rootNode = document.documentElement) 
       '[Dialtone] You passed a ShadowRoot directly to setContrast(). ' +
       'Please pass the host element instead. The function will access shadowRoot automatically.',
     );
+    return;
   }
 
-  if (rootNode?.shadowRoot) {
-    rootNode = rootNode.shadowRoot;
-  }
-
+  const styleRoot = rootNode?.shadowRoot ?? rootNode;
   if (contrastTheme && contrastTheme.contrast) {
-    _setStyleTag('dialtone-css-contrast', contrastTheme.contrast.css, rootNode);
+    _setStyleTag('dialtone-css-contrast', contrastTheme.contrast.css, styleRoot);
     rootNode?.setAttribute('data-dt-contrast', contrastTheme.contrast.name);
   } else {
-    _removeStyleTag('dialtone-css-contrast', rootNode);
+    _removeStyleTag('dialtone-css-contrast', styleRoot);
     rootNode?.setAttribute('data-dt-contrast', 'default');
   }
 }
@@ -427,10 +416,7 @@ export function setMaterial (name, rootNode = document.documentElement) {
       '[Dialtone] You passed a ShadowRoot directly to setMaterial(). ' +
       'Please pass the host element instead. The function will access shadowRoot automatically.',
     );
-  }
-
-  if (rootNode?.shadowRoot) {
-    rootNode = rootNode.shadowRoot;
+    return;
   }
 
   const resolved = name || 'sandstone';
@@ -539,11 +525,10 @@ export function initDialtoneTheme(brandTheme, mode = 'light', rootNode = documen
       'Correct: initDialtoneTheme(brand, mode, hostElement)\n' +
       'Incorrect: initDialtoneTheme(brand, mode, hostElement.shadowRoot)',
     );
+    return;
   }
 
-  if (rootNode?.shadowRoot) {
-    rootNode = rootNode.shadowRoot;
-  }
+  const styleRoot = rootNode?.shadowRoot ?? rootNode;
 
   // CRITICAL: Detect embedded app trying to use document.documentElement
   // This check MUST run on first init, before idempotency check
@@ -581,11 +566,11 @@ export function initDialtoneTheme(brandTheme, mode = 'light', rootNode = documen
   }
 
   // Load core tokens (once per JavaScript instance)
-  _setStyleTag('dialtone-css-core', Core.core, rootNode);
+  _setStyleTag('dialtone-css-core', Core.core, styleRoot);
   coreTokensLoaded = true;
 
   // Load base colors (once)
-  _setStyleTag('dialtone-css-base-colors', Core.baseColors, rootNode);
+  _setStyleTag('dialtone-css-base-colors', Core.baseColors, styleRoot);
 
   // Set initial mode
   setMode(mode, rootNode);
@@ -649,8 +634,7 @@ export function hasBrandMaterialLock(brandTheme) {
  * }
  */
 export function resetTheme(rootNode = document.documentElement) {
-  // Access shadowRoot if present
-  const actualRoot = rootNode?.shadowRoot || rootNode;
+  const styleRoot = rootNode?.shadowRoot ?? rootNode;
 
   // Clear initialization state (only one instance per app)
   initializationState = null;
@@ -659,15 +643,15 @@ export function resetTheme(rootNode = document.documentElement) {
   // Remove all theme style tags. Material no longer injects a style tag
   // (attribute-driven), but resetTheme should still scrub any pre-existing
   // injection from older code paths.
-  _removeStyleTag('dialtone-css-core', actualRoot);
-  _removeStyleTag('dialtone-css-base-colors', actualRoot);
-  _removeStyleTag('dialtone-css-material', actualRoot);
-  _removeStyleTag('dialtone-css-brand-colors', actualRoot);
-  _removeStyleTag('dialtone-css-contrast', actualRoot);
+  _removeStyleTag('dialtone-css-core', styleRoot);
+  _removeStyleTag('dialtone-css-base-colors', styleRoot);
+  _removeStyleTag('dialtone-css-material', styleRoot);
+  _removeStyleTag('dialtone-css-brand-colors', styleRoot);
+  _removeStyleTag('dialtone-css-contrast', styleRoot);
 
-  // Remove theme attributes
-  actualRoot?.removeAttribute('data-dt-mode');
-  actualRoot?.removeAttribute('data-dt-brand');
-  actualRoot?.removeAttribute('data-dt-contrast');
-  actualRoot?.removeAttribute('data-dt-material');
+  // Remove theme attributes from the host element (not ShadowRoot — it has no removeAttribute)
+  rootNode?.removeAttribute('data-dt-mode');
+  rootNode?.removeAttribute('data-dt-brand');
+  rootNode?.removeAttribute('data-dt-contrast');
+  rootNode?.removeAttribute('data-dt-material');
 }


### PR DESCRIPTION
## Summary

Fix a `TypeError` crash in all theme setter functions (`setMode`, `setBrand`, `setContrast`, `setMaterial`, `initDialtoneTheme`) when called with a host element that has a shadow root.

## Problem

Every setter was reassigning `rootNode = rootNode.shadowRoot`, then calling `setAttribute` on the resulting `ShadowRoot`. `ShadowRoot` extends `DocumentFragment → Node`, not `Element`, so it has no `setAttribute` — causing a `TypeError`.

Additionally, even if it hadn't crashed, style tags injected into a `ShadowRoot` with `[data-dt-mode]` attributes set on the `ShadowRoot` itself would not match descendant selectors since `ShadowRoot` is not an element.

## Fix

Separate style injection from attribute-setting:

```js
// Before
if (rootNode?.shadowRoot) {
  rootNode = rootNode.shadowRoot;  // ShadowRoot — no setAttribute
}
rootNode?.setAttribute('data-dt-mode', mode);  // TypeError

// After
const styleRoot = rootNode?.shadowRoot ?? rootNode;
_setStyleTag('dialtone-css-core', ..., styleRoot);  // ShadowRoot: querySelector/appendChild ✓
rootNode?.setAttribute('data-dt-mode', mode);        // host Element: setAttribute ✓
```

- **Style tags** → injected into `ShadowRoot` (querySelector/appendChild work on it)
- **Attributes** → set on the host element (an actual `Element`)
- ShadowRoot-direct-pass warnings now also `return` early instead of crashing
