### PR TITLE
refactor(validation-messages): DLT-3422 update to use icon slot over embedded icon

### DIFF
--- a/packages/combinator/src/components/code_editor/code_editor.vue
+++ b/packages/combinator/src/components/code_editor/code_editor.vue
@@ -41,7 +41,7 @@
     </div>
     <dt-stack
       direction="row"
-      gap="200"
+      gap="50"
       class="d-ps-sticky d-ibs-0 d-iie-0"
     >
       <dt-button

--- a/packages/dialtone-css/lib/build/less/components/forms.less
+++ b/packages/dialtone-css/lib/build/less/components/forms.less
@@ -118,6 +118,8 @@ fieldset {
 //  ----------------------------------------------------------------------------
 .d-validation-message {
   --validation-color-text: var(--dt-color-foreground-tertiary);
+  --validation-size-icon: var(--dt-layout-25);
+  --validation-icon: initial;
 
   display: flex;
   gap: var(--dt-spacing-50);
@@ -129,20 +131,28 @@ fieldset {
   font-family: inherit;
   line-height: var(--dt-font-line-height-300);
 
-  // Icon Slot
-  &::before {
+  // Raw-HTML icon fallback — suppressed when a real .d-icon child is present
+  &:not(:has(.d-icon))::before {
     display: block;
     margin-block-start: var(--dt-spacing-25);
-    inline-size: var(--dt-layout-25); // 16
-    min-inline-size: var(--dt-layout-25); // 16
-    block-size: var(--dt-layout-25); // 16
+    inline-size: var(--validation-size-icon);
+    min-inline-size: var(--validation-size-icon);
+    block-size: var(--validation-size-icon);
     background-color: var(--validation-color-text);
+    mask: var(--validation-icon);
     content: '';
   }
 
   &__container {
     display: flex;
     flex-direction: column;
+  }
+
+  &__icon {
+    margin-block-start: calc(var(--dt-spacing-25) / 2);
+    color: var(--validation-color-text);
+    inline-size: var(--validation-size-icon);
+    block-size: var(--validation-size-icon);
   }
 }
 
@@ -151,27 +161,18 @@ fieldset {
 
 .d-validation-message--warning {
   --validation-color-text: var(--dt-color-foreground-warning);
-
-  &::before {
-    mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDEyIDEyIj4gPHBhdGggZmlsbD0iIzY4M2UwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNS4yNCAxLjE5N2ExLjUgMS41IDAgMCAxIDIuMDYuNTU2bDMuOTk4IDYuOTk3YTEuNTA0IDEuNTA0IDAgMCAxIDAgMS41IDEuNSAxLjUgMCAwIDEtMS4yOTcuNzVIMi4wMDJhMS41IDEuNSAwIDAgMS0xLjMxLTIuMjQ5VjguNzVMNC42OSAxLjc1M2ExLjUgMS41IDAgMCAxIC41NS0uNTU2Wm0uNzU1Ljc5NmEuNS41IDAgMCAwLS40MzUuMjU0di4wMDFMMS41NTcgOS4yNWEuNS41IDAgMCAwIC40MzguNzVIMTBhLjUuNSAwIDAgMCAuNDMyLS43NWwtLjAwMS0uMDAyLTQtNy0uMDAxLS4wMDFhLjUuNSAwIDAgMC0uNDM1LS4yNTRaIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiLz4gPHBhdGggZmlsbD0iIzY4M2UwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNiA0YS41LjUgMCAwIDEgLjUuNXYyYS41LjUgMCAwIDEtMSAwdi0yQS41LjUgMCAwIDEgNiA0Wm0tLjUgNC41QS41LjUgMCAwIDEgNiA4aC4wMDVhLjUuNSAwIDAgMSAwIDFINmEuNS41IDAgMCAxLS41LS41WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+IDwvc3ZnPg==') repeat;
-  }
+  --validation-icon: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDEyIDEyIj4gPHBhdGggZmlsbD0iIzY4M2UwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNS4yNCAxLjE5N2ExLjUgMS41IDAgMCAxIDIuMDYuNTU2bDMuOTk4IDYuOTk3YTEuNTA0IDEuNTA0IDAgMCAxIDAgMS41IDEuNSAxLjUgMCAwIDEtMS4yOTcuNzVIMi4wMDJhMS41IDEuNSAwIDAgMS0xLjMxLTIuMjQ5VjguNzVMNC42OSAxLjc1M2ExLjUgMS41IDAgMCAxIC41NS0uNTU2Wm0uNzU1Ljc5NmEuNS41IDAgMCAwLS40MzUuMjU0di4wMDFMMS41NTcgOS4yNWEuNS41IDAgMCAwIC40MzguNzVIMTBhLjUuNSAwIDAgMCAuNDMyLS43NWwtLjAwMS0uMDAyLTQtNy0uMDAxLS4wMDFhLjUuNSAwIDAgMC0uNDM1LS4yNTRaIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiLz4gPHBhdGggZmlsbD0iIzY4M2UwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNiA0YS41LjUgMCAwIDEgLjUuNXYyYS41LjUgMCAwIDEtMSAwdi0yQS41LjUgMCAwIDEgNiA0Wm0tLjUgNC41QS41LjUgMCAwIDEgNiA4aC4wMDVhLjUuNSAwIDAgMSAwIDFINmEuNS41IDAgMCAxLS41LS41WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+IDwvc3ZnPg==') repeat;
 }
 
 .d-validation-message--critical,
 .d-validation-message--error {
   --validation-color-text: var(--dt-color-foreground-critical);
-
-  &::before {
-    mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDEyIDEyIj4gPGcgY2xpcC1wYXRoPSJ1cmwoI2EpIj4gPHBhdGggZmlsbD0iI2VjMGUwZSIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNiAxLjVhNC41IDQuNSAwIDEgMCAwIDkgNC41IDQuNSAwIDAgMCAwLTlaTS41IDZhNS41IDUuNSAwIDEgMSAxMSAwIDUuNSA1LjUgMCAwIDEtMTEgMFpNNiAzLjVhLjUuNSAwIDAgMSAuNS41djJhLjUuNSAwIDAgMS0xIDBWNGEuNS41IDAgMCAxIC41LS41Wk01LjUgOGEuNS41IDAgMCAxIC41LS41aC4wMDVhLjUuNSAwIDAgMSAwIDFINmEuNS41IDAgMCAxLS41LS41WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+IDwvZz4gPGRlZnM+IDxjbGlwUGF0aCBpZD0iYSI+IDxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0wIDBoMTJ2MTJIMHoiLz4gPC9jbGlwUGF0aD4gPC9kZWZzPiA8L3N2Zz4=') no-repeat;
-  }
+  --validation-icon: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDEyIDEyIj4gPGcgY2xpcC1wYXRoPSJ1cmwoI2EpIj4gPHBhdGggZmlsbD0iI2VjMGUwZSIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNiAxLjVhNC41IDQuNSAwIDEgMCAwIDkgNC41IDQuNSAwIDAgMCAwLTlaTS41IDZhNS41IDUuNSAwIDEgMSAxMSAwIDUuNSA1LjUgMCAwIDEtMTEgMFpNNiAzLjVhLjUuNSAwIDAgMSAuNS41djJhLjUuNSAwIDAgMS0xIDBWNGEuNS41IDAgMCAxIC41LS41Wk01LjUgOGEuNS41IDAgMCAxIC41LS41aC4wMDVhLjUuNSAwIDAgMSAwIDFINmEuNS41IDAgMCAxLS41LS41WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+IDwvZz4gPGRlZnM+IDxjbGlwUGF0aCBpZD0iYSI+IDxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0wIDBoMTJ2MTJIMHoiLz4gPC9jbGlwUGF0aD4gPC9kZWZzPiA8L3N2Zz4=') no-repeat;
 }
 
 .d-validation-message--positive,
 .d-validation-message--success {
   --validation-color-text: var(--dt-color-foreground-positive);
-
-  &::before {
-    mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDEyIDEyIj4gPGcgY2xpcC1wYXRoPSJ1cmwoI2EpIj4gPHBhdGggZmlsbD0iIzAwNjcxZCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNLjUgNmE1LjUgNS41IDAgMSAxIDExIDAgNS41IDUuNSAwIDAgMS0xMSAwWk02IDEuNWE0LjUgNC41IDAgMSAwIDAgOSA0LjUgNC41IDAgMCAwIDAtOVptMS44NTQgMy4xNDZhLjUuNSAwIDAgMSAwIC43MDhsLTIgMmEuNS41IDAgMCAxLS43MDggMGwtMS0xYS41LjUgMCAxIDEgLjcwOC0uNzA4bC42NDYuNjQ3IDEuNjQ2LTEuNjQ3YS41LjUgMCAwIDEgLjcwOCAwWiIgY2xpcC1ydWxlPSJldmVub2RkIi8+IDwvZz4gPGRlZnM+IDxjbGlwUGF0aCBpZD0iYSI+IDxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0wIDBoMTJ2MTJIMHoiLz4gPC9jbGlwUGF0aD4gPC9kZWZzPiA8L3N2Zz4=') no-repeat;
-  }
+  --validation-icon: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0ibm9uZSIgdmlld0JveD0iMCAwIDEyIDEyIj4gPGcgY2xpcC1wYXRoPSJ1cmwoI2EpIj4gPHBhdGggZmlsbD0iIzAwNjcxZCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNLjUgNmE1LjUgNS41IDAgMSAxIDExIDAgNS41IDUuNSAwIDAgMS0xMSAwWk02IDEuNWE0LjUgNC41IDAgMSAwIDAgOSA0LjUgNC41IDAgMCAwIDAtOVptMS44NTQgMy4xNDZhLjUuNSAwIDAgMSAwIC43MDhsLTIgMmEuNS41IDAgMCAxLS43MDggMGwtMS0xYS41LjUgMCAxIDEgLjcwOC0uNzA4bC42NDYuNjQ3IDEuNjQ2LTEuNjQ3YS41LjUgMCAwIDEgLjcwOCAwWiIgY2xpcC1ydWxlPSJldmVub2RkIi8+IDwvZz4gPGRlZnM+IDxjbGlwUGF0aCBpZD0iYSI+IDxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0wIDBoMTJ2MTJIMHoiLz4gPC9jbGlwUGF0aD4gPC9kZWZzPiA8L3N2Zz4=') no-repeat;
 }
 }

--- a/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.stories.js
+++ b/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.stories.js
@@ -27,6 +27,9 @@ export const argTypesData = {
       },
     },
   },
+  iconClass: {
+    description: 'Additional class name for the icon wrapper element.',
+  },
 };
 
 // Story Collection

--- a/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.stories.js
+++ b/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.stories.js
@@ -1,6 +1,9 @@
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import { VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 import DtValidationMessages from './ValidationMessages.vue';
+import {
+  DtIconBell,
+} from '@dialpad/dialtone-icons/vue';
 
 // Constants
 const VALIDATION_MESSAGES = [
@@ -81,5 +84,28 @@ export const Variants = {
         ],
       },
     },
+  },
+};
+
+const WithCustomIconTemplate = () => {
+  return {
+    components: { DtValidationMessages, DtIconBell },
+    template: `
+      <dt-validation-messages
+        :validationMessages="[{ message: 'Custom icon override', type: 'warning' }]"
+      >
+        <template #icon>
+          <dt-icon-bell size="300" />
+        </template>
+      </dt-validation-messages>
+    `,
+  };
+};
+
+export const WithCustomIcon = {
+  render: WithCustomIconTemplate,
+  parameters: {
+    options: { showPanel: false },
+    controls: { disable: true },
   },
 };

--- a/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.test.js
+++ b/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.test.js
@@ -219,6 +219,113 @@ describe('Validation Messages Tests', () => {
     });
   });
 
+  describe('Icon Tests', () => {
+    beforeEach(() => {
+      mockProps = { validationMessages: MOCK_BASE_VALIDATION_MESSAGES };
+
+      updateWrapper();
+    });
+
+    it('renders the icon wrapper', () => {
+      expect(wrapper.find('[data-qa="validation-message-icon"]').exists()).toBe(true);
+    });
+
+    describe('When type is warning', () => {
+      beforeEach(() => {
+        mockProps = {
+          validationMessages: setFormattedValidationMessages(
+            VALIDATION_MESSAGE_TYPES.WARNING,
+            'Warning message',
+          ),
+        };
+
+        updateWrapper();
+      });
+
+      it('renders the warning icon', () => {
+        expect(wrapper.find('[data-qa="validation-message-icon"]').classes()).toContain('d-icon--alert-triangle');
+      });
+    });
+
+    describe('When type is critical', () => {
+      beforeEach(() => {
+        mockProps = {
+          validationMessages: setFormattedValidationMessages(
+            VALIDATION_MESSAGE_TYPES.CRITICAL,
+            'Critical message',
+          ),
+        };
+
+        updateWrapper();
+      });
+
+      it('renders the critical icon', () => {
+        expect(wrapper.find('[data-qa="validation-message-icon"]').classes()).toContain('d-icon--alert-circle');
+      });
+    });
+
+    describe('When type is positive', () => {
+      beforeEach(() => {
+        mockProps = {
+          validationMessages: setFormattedValidationMessages(
+            VALIDATION_MESSAGE_TYPES.POSITIVE,
+            'Positive message',
+          ),
+        };
+
+        updateWrapper();
+      });
+
+      it('renders the positive icon', () => {
+        expect(wrapper.find('[data-qa="validation-message-icon"]').classes()).toContain('d-icon--check-circle');
+      });
+    });
+
+    describe('When the icon slot is overridden', () => {
+      beforeEach(() => {
+        mockProps = {
+          validationMessages: setFormattedValidationMessages(
+            VALIDATION_MESSAGE_TYPES.CRITICAL,
+            'Critical message',
+          ),
+        };
+
+        wrapper = mount(DtValidationMessages, {
+          props: { ...baseProps, ...mockProps },
+          slots: { icon: '<svg class="d-icon d-icon--custom-test" data-qa="dt-icon" />' },
+        });
+
+        messages = wrapper.findAll('[data-qa="validation-message"]');
+      });
+
+      it('renders the custom icon', () => {
+        expect(wrapper.find('[data-qa="dt-icon"]').classes()).toContain('d-icon--custom-test');
+      });
+
+      it('does not render the default icon', () => {
+        expect(wrapper.find('[data-qa="dt-icon"]').classes()).not.toContain('d-icon--alert-circle');
+      });
+    });
+
+    describe('When iconClass prop is provided', () => {
+      beforeEach(() => {
+        mockProps = {
+          validationMessages: setFormattedValidationMessages(
+            VALIDATION_MESSAGE_TYPES.CRITICAL,
+            'Critical message',
+          ),
+          iconClass: 'custom-class',
+        };
+
+        updateWrapper();
+      });
+
+      it('applies iconClass to the icon wrapper', () => {
+        expect(wrapper.find('[data-qa="validation-message-icon"]').classes()).toContain('custom-class');
+      });
+    });
+  });
+
   describe('Validation Tests', () => {
     describe('When there are validation messages', () => {
       const MOCK_PROP = DtValidationMessages.props.validationMessages;

--- a/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.test.js
+++ b/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.test.js
@@ -34,6 +34,7 @@ describe('Validation Messages Tests', () => {
   });
 
   afterEach(() => {
+    wrapper?.unmount();
     mockProps = {};
   });
 
@@ -303,7 +304,7 @@ describe('Validation Messages Tests', () => {
       });
 
       it('does not render the default icon', () => {
-        expect(wrapper.find('[data-qa="dt-icon"]').classes()).not.toContain('d-icon--alert-circle');
+        expect(wrapper.find('[data-qa="validation-message-icon"]').exists()).toBe(false);
       });
     });
 

--- a/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.vue
+++ b/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.vue
@@ -16,7 +16,8 @@
         messageTypeClass(type),
       ]"
     >
-      <!-- @slot icon — replaces the default per-type DtIcon. Receives { type } scope. -->
+      <!-- @slot icon — replaces the default per-type DtIcon. Slot content must be a Dialtone icon (carries
+      the `d-icon` class) so the CSS pseudo-element fallback suppresses correctly. Receives { type } scope. -->
       <slot
         name="icon"
         :type="type"

--- a/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.vue
+++ b/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.vue
@@ -16,6 +16,18 @@
         messageTypeClass(type),
       ]"
     >
+      <!-- @slot icon — replaces the default per-type DtIcon. Receives { type } scope. -->
+      <slot
+        name="icon"
+        :type="type"
+      >
+        <component
+          :is="iconForType(type)"
+          :class="['d-validation-message__icon', iconClass]"
+          data-qa="validation-message-icon"
+          size="300"
+        />
+      </slot>
       <p v-html="message" />
     </div>
   </div>
@@ -28,6 +40,17 @@ import {
   filterFormattedMessages,
   getValidationState,
 } from '@/common/utils';
+import {
+  DtIconAlertTriangle,
+  DtIconAlertCircle,
+  DtIconCheckCircle,
+} from '@dialpad/dialtone-icons/vue';
+
+const kindToIcon = Object.freeze({
+  warning: DtIconAlertTriangle,
+  critical: DtIconAlertCircle,
+  positive: DtIconCheckCircle,
+});
 
 /**
  * Validation messages are used to convey information to the user about the current state of the input element.
@@ -36,6 +59,8 @@ import {
  */
 export default {
   name: 'DtValidationMessages',
+
+  components: { DtIconAlertTriangle, DtIconAlertCircle, DtIconCheckCircle },
 
   props: {
     /**
@@ -66,6 +91,14 @@ export default {
       type: Boolean,
       default: true,
     },
+
+    /**
+     * Additional class name for the icon wrapper element.
+     */
+    iconClass: {
+      type: [String, Array, Object],
+      default: '',
+    },
   },
 
   computed: {
@@ -85,6 +118,10 @@ export default {
   methods: {
     getMessageKey (type, index) {
       return `validation-message-${type}-${index}-${this.id}`;
+    },
+
+    iconForType (type) {
+      return kindToIcon[type] ?? null;
     },
 
     messageTypeClass (type) {

--- a/packages/dialtone-vue/components/ValidationMessages/ValidationMessagesDefault.story.vue
+++ b/packages/dialtone-vue/components/ValidationMessages/ValidationMessagesDefault.story.vue
@@ -4,6 +4,7 @@
       :id="$attrs.id"
       :validation-messages="$attrs.validationMessages"
       :show-messages="$attrs.showMessages"
+      :icon-class="$attrs.iconClass"
     />
   </div>
 </template>


### PR DESCRIPTION
<img width="498" height="373" alt="valid" src="https://github.com/user-attachments/assets/4f0706d8-4c12-40a4-b621-d100b099746a" />

## :hammer_and_wrench: Type Of Change

- [x] Refactor

## :book: Jira Ticket

[DLT-3422](https://dialpad.atlassian.net/browse/DLT-3422)

## :book: Description

`DtValidationMessages` previously rendered status icons via CSS `::before` pseudo-elements with base64-encoded SVG masks. Replaced with real `DtIcon` components rendered by the Vue component.

- Per-type icons: `DtIconAlertTriangle` (warning), `DtIconAlertCircle` (critical/error), `DtIconCheckCircle` (positive/success)
- New `#icon` slot — overridable, scoped `{ type }` binding
- New `iconClass` prop on the icon element
- CSS `::before` suppressed via `:not(:has(.d-icon))` when a real icon child is present 
- **BACKWARDS COMPATIBILITY:** raw-HTML usage (`<div class="d-validation-message d-validation-message--critical">`) still gets the icon via CSS, no markup changes needed
- `forms.less`: base64 mask values consolidated under `--validation-icon` CSS custom property per modifier

Does not change the public Vue API (`validationMessages`, `showMessages`, `id`). Does not touch components that consume `DtValidationMessages` internally (`DtInput`, `DtRadio`, etc.).

## :bulb: Context

Brings `DtValidationMessages` in line with how `DtNotice` / `DtBanner` / `DtToast` handle icons in `next`. Base64 SVG masks in CSS were opaque, couldn't reuse the shared icon set, and couldn't be themed.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

[DLT-3422]: https://dialpad.atlassian.net/browse/DLT-3422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ