### PR TITLE
fix(modal): DLT-3442 fix focus snapping back to first button on click

### DIFF
--- a/packages/dialtone-vue/components/modal/modal.test.js
+++ b/packages/dialtone-vue/components/modal/modal.test.js
@@ -162,7 +162,7 @@ describe('DtModal Tests', () => {
       it('Should return focus to the modal when Tab is subsequently pressed', async () => {
         const cancelBtn = wrapper.find('[data-qa="dt-modal-cancel"]');
         await copy.trigger('click');
-        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }));
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', code: 'Tab', bubbles: true, cancelable: true }));
         await wrapper.vm.$nextTick();
         await wrapper.vm.$nextTick();
 

--- a/packages/dialtone-vue/components/modal/modal.test.js
+++ b/packages/dialtone-vue/components/modal/modal.test.js
@@ -144,6 +144,32 @@ describe('DtModal Tests', () => {
   });
 
   describe('Interactivity Tests', () => {
+    describe('When clicking non-focusable modal content', () => {
+      beforeEach(() => {
+        wrapper.unmount();
+        mockSlots = { footer: '<button data-qa="dt-modal-cancel">Cancel</button>' };
+        updateWrapper();
+      });
+
+      it('Should NOT refocus the first focusable element', async () => {
+        const cancelBtn = wrapper.find('[data-qa="dt-modal-cancel"]');
+        await copy.trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(document.activeElement).not.toBe(cancelBtn.element);
+      });
+
+      it('Should return focus to the modal when Tab is subsequently pressed', async () => {
+        const cancelBtn = wrapper.find('[data-qa="dt-modal-cancel"]');
+        await copy.trigger('click');
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }));
+        await wrapper.vm.$nextTick();
+        await wrapper.vm.$nextTick();
+
+        expect(document.activeElement).toBe(cancelBtn.element);
+      });
+    });
+
     it('Should emit a sync-able update event when overlay is clicked', async () => {
       expect(wrapper.emitted(SYNC_EVENT_NAME)).toBeFalsy();
 

--- a/packages/dialtone-vue/components/modal/modal.vue
+++ b/packages/dialtone-vue/components/modal/modal.vue
@@ -487,7 +487,7 @@ export default {
     },
 
     _trapFocusGlobal (e) {
-      if (!this.show || e.key !== 'Tab') return;
+      if (!this.show || e.code !== EVENT_KEYNAMES.tab) return;
       const modalEl = this.$refs.modalRoot?.$el || this.$el;
       if (modalEl && !modalEl.contains(document.activeElement)) {
         e.preventDefault();

--- a/packages/dialtone-vue/components/modal/modal.vue
+++ b/packages/dialtone-vue/components/modal/modal.vue
@@ -377,9 +377,6 @@ export default {
           // Handle backdrop clicks for closing modal
           if (this.closeOnClick && event.target === event.currentTarget) {
             this.close();
-          } else if (this.show && event.target !== event.currentTarget) {
-            // Ensure focus stays within modal when clicking inside it
-            this.handleModalClick(event);
           }
 
           this.$emit('click', event);
@@ -439,15 +436,31 @@ export default {
           this.previousActiveElement = document.activeElement;
           const modalEl = this.$refs.modalRoot?.$el || this.$el;
           disableRootScrolling(returnFirstEl(modalEl).getRootNode().host);
+          document.addEventListener('keydown', this._trapFocusGlobalBound);
         } else {
           const modalEl = this.$refs.modalRoot?.$el || this.$el;
           enableRootScrolling(returnFirstEl(modalEl).getRootNode().host);
           // Modal is being hidden, so return focus to the previously active element before clearing the reference.
           this.previousActiveElement?.focus();
           this.previousActiveElement = null;
+          document.removeEventListener('keydown', this._trapFocusGlobalBound);
         }
       },
     },
+  },
+
+  created () {
+    this._trapFocusGlobalBound = (e) => this._trapFocusGlobal(e);
+  },
+
+  mounted () {
+    if (this.show) {
+      document.addEventListener('keydown', this._trapFocusGlobalBound);
+    }
+  },
+
+  beforeUnmount () {
+    document.removeEventListener('keydown', this._trapFocusGlobalBound);
   },
 
   methods: {
@@ -473,18 +486,12 @@ export default {
       }
     },
 
-    handleModalClick (event) {
-      // Ensure focus stays within modal when clicking inside it
-      const clickedElement = event.target;
+    _trapFocusGlobal (e) {
+      if (!this.show || e.key !== 'Tab') return;
       const modalEl = this.$refs.modalRoot?.$el || this.$el;
-      const focusableElements = this._getFocusableElements(modalEl);
-
-      // If the clicked element is not focusable, ensure focus stays in modal
-      if (focusableElements.length && !focusableElements.includes(clickedElement)) {
-        // Check if current active element is still within the modal
-        if (!focusableElements.includes(document.activeElement)) {
-          this.focusFirstElement(modalEl);
-        }
+      if (modalEl && !modalEl.contains(document.activeElement)) {
+        e.preventDefault();
+        this.focusFirstElement(modalEl);
       }
     },
   },


### PR DESCRIPTION
# fix(modal): DLT-3442 fix focus snapping back to first button on body click

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3MwMGRranhxdWh6b2J2ZTgyNHVrY3liMmVsbXlzbDV3cHhhNjF5NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/THJ2ageyNjvALKm6gH/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->
https://dialpad.atlassian.net/browse/DLT-3442 (originally DP-188688)

## :book: Description

<!--- Describe specifically what the changes are -->

Removes `handleModalClick` and replaces it with a document-level `keydown` listener (`_trapFocusGlobal`) that is active only while the modal is open.

- Clicking non-focusable content inside the modal (body text, headings) no longer forces focus back to the first focusable element.
- Pressing Tab after such a click still returns focus to the modal, satisfying the WAI-ARIA modal dialog focus-containment requirement.
- The listener is added on `show: true` (and in `mounted` for initially-show modals) and removed on `show: false` and `beforeUnmount`.

Two regression tests added: one asserting click-on-inert-content does not snap focus, one asserting subsequent Tab does return focus.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

### The bug

In the "With Fixed Header Footer" story (and any modal with footer buttons): tab to the Cancel button, then click anywhere on the body text — Cancel re-focuses immediately. The same bug exists in the Default story but produces no visible focus ring there. `document.activeElement` is set to the Close X (confirm in DevTools), but `:focus-visible` does not fire. The reason: Chrome only activates keyboard mode (required for `:focus-visible` on programmatic focus) when Tab actually moves focus between elements. In the Default story the Close X is the only focusable element, so `focusTrappedTabPress` cycles focus back to the same element — Chrome does not register this as genuine keyboard navigation and does not activate keyboard mode. The ring therefore never appears even though the snap-back is happening.

### Root cause

`handleModalClick` was added in PR #825 ("NO-JIRA prevent losing focus when clicking inside the modal") to keep focus trapped in the modal. Its condition was too coarse:

```js
if (!focusableElements.includes(document.activeElement)) {
  this.focusFirstElement(modalEl);
}
```

When a user clicks inert text, the browser blurs the previously-focused button and moves `document.activeElement` to `<body>`. Body is not in `focusableElements`, so the condition fires and focus is forced back — even though the user intentionally clicked away.

### Why the original intent was still valid

Removing `handleModalClick` without a replacement left a real gap: if focus landed on `<body>` (outside the modal's keydown listener scope), pressing Tab would let focus escape the modal entirely via native browser tab order. The new `_trapFocusGlobal` closes that gap by intercepting Tab at the document level only when focus has actually escaped (`!modalEl.contains(activeElement)`).

### Known gaps (pre-existing, not introduced by this PR)

- **Shift+Tab direction**: if focus escapes and the user presses Shift+Tab, focus returns to the *first* modal element rather than the last. The same was true of the original `handleModalClick`. Fully directional recovery would require passing the `shiftKey` state to `focusFirstElement` / adding a `focusLastElement` path — deferred.
- **Teleport/portal children**: if a consuming app renders a dropdown inside a modal via `<Teleport to="body">`, `_trapFocusGlobal` will see focus leave `modalEl` and snap it back. The original `handleModalClick` wouldn't have recovered this case at all (it only fired on clicks inside the modal). An `allowOutsideSelector` escape hatch could be added as a prop if this surfaces — deferred.

Shift+Tab directional recovery is pre-existing. Portal-rendered children remain unsupported; this PR changes that failure mode from no recovery to document-level Tab recovery that returns focus to the modal.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.


## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

- Directional Tab recovery (Shift+Tab → last element) if reported as an issue.
- `allowOutsideSelector` prop if portal-rendered children inside modals become a use case.
- This fix targets the pre-`<dialog>` modal. DLT-3262 (native dialog migration) will supersede this focus management on that branch.

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

### Before

https://github.com/user-attachments/assets/6b911d24-495c-4cfa-a660-15f98be519d3

### After

https://github.com/user-attachments/assets/2d184740-d60c-47dd-bb3a-d175a320da25
