### PR TITLE
feat(modal): DLT-3432 add transparentBackdrop prop

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -1,12 +1,13 @@
 <template>
   <dt-modal
-    title="Example title"
+    header-text="Example title"
     :open="isOpen"
     :banner-title="bannerTitle"
     :banner-kind="bannerKind"
     :fixed-header-footer="fixedHeaderFooter"
     :size="size"
     :copy="copy"
+    :transparent-backdrop="transparentBackdrop"
     @update:open="isOpen = $event"
   >
     <template
@@ -65,6 +66,11 @@ export default {
     size: {
       type: String,
       default: 'default',
+    },
+
+    transparentBackdrop: {
+      type: Boolean,
+      default: false,
     },
 
     copy: {

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -2,7 +2,7 @@
   <dt-modal
     header-text="Example title"
     :open="isOpen"
-    :banner-title="bannerTitle"
+    :banner-header-text="bannerTitle"
     :banner-kind="bannerKind"
     :fixed-header-footer="fixedHeaderFooter"
     :size="size"

--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -71,7 +71,7 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
 <example-modal />
 <!-- @code -->
 <dt-modal
-  title="Example title"
+  header-text="Example title"
   :open="isOpen"
   @update:open="updateOpen"
   copy="Lorem ipsum ..."
@@ -109,7 +109,7 @@ This is the default behavior that adds the scroll automatically in the modal con
 <example-modal fixed-header-footer :copy="fixedHeaderFooterCopy" />
 <!-- @code -->
 <dt-modal
-  title="Example title"
+  header-text="Example title"
   :open="isOpen"
   @update:open="updateOpen"
   :showFooter="true"
@@ -149,7 +149,7 @@ A modal style for destructive or irreversible actions.
 <example-modal kind="critical" />
 <!-- @code -->
 <dt-modal
-  title="Example title"
+  header-text="Example title"
   :open="isOpen"
   kind="critical"
   copy="Sed at orci quis nunc finibus gravida eget vitae est..."
@@ -189,9 +189,48 @@ To make this modal take up as much of the screen as possible.
 <example-modal size="full" />
 <!-- @code -->
 <dt-modal
-  title="Example title"
+  header-text="Example title"
   :open="isOpen"
   size="full"
+  copy="Sed at orci quis nunc finibus gravida eget vitae est..."
+  @update:open="updateOpen"
+>
+  <template
+    #footer
+  >
+    <dt-button
+      id="cancel-button"
+      :kind="secondaryButtonKind"
+      importance="clear"
+    >
+      Cancel
+    </dt-button>
+    <dt-button
+      id="confirm-button"
+      importance="primary"
+    >
+      Confirm
+    </dt-button>
+  </template>
+</dt-modal>
+<dt-button
+  @click="isOpen = !isOpen"
+>
+  Click to open
+</dt-button>
+```
+
+### Transparent Backdrop
+
+By default, modals render a dimming overlay behind the dialog box. Set `transparent-backdrop` to render the surrounding backdrop fully transparent. The dialog box itself keeps its solid background. Use this when the underlying UI should remain visible behind the modal.
+
+```vue demo
+<example-modal transparent-backdrop />
+<!-- @code -->
+<dt-modal
+  header-text="Example title"
+  :open="isOpen"
+  transparent-backdrop
   copy="Sed at orci quis nunc finibus gravida eget vitae est..."
   @update:open="updateOpen"
 >
@@ -236,7 +275,7 @@ When there is a need of more context information regarding the content of the Mo
 </dt-stack>
 <!-- @code -->
 <dt-modal
-  title="Example title"
+  header-text="Example title"
   :open="isOpen"
   banner-title="This banner can have different kinds."
   :bannerKind="selectedBannerKind"
@@ -322,7 +361,7 @@ Modal content renders outside the DOM tree. Use the `contentMode` prop to apply 
   <dt-button @click="invertedModalOpen = true">Open Inverted Modal</dt-button>
   <dt-modal
     content-mode="invert"
-    title="Inverted Modal"
+    header-text="Inverted Modal"
     copy="This modal's content is in the inverted mode."
     :open="invertedModalOpen"
     @update:open="invertedModalOpen = $event"

--- a/packages/dialtone-css/lib/build/less/components/modal.less
+++ b/packages/dialtone-css/lib/build/less/components/modal.less
@@ -144,7 +144,7 @@
 }
 
 .d-modal--transparent {
-  --modal-backdrop-color-background: var(--d-bgc-transparent);
+  --modal-backdrop-color-background: var(--dt-color-neutral-transparent);
 
   // If we don't set this the native app header region will override all click events on the modal overlay
   -webkit-app-region: no-drag;
@@ -156,6 +156,12 @@
     inline-size: 100%;
     min-block-size: 100%;
   }
+}
+
+// Not to be confused with .d-modal--transparent above — that one is used
+// standalone (without .d-modal) by Popover/Tooltip.
+.d-modal--transparent-backdrop {
+  --modal-backdrop-color-background: var(--dt-color-neutral-transparent);
 }
 
 //  $$  MODAL DIALOG

--- a/packages/dialtone-vue/components/Modal/Modal.stories.js
+++ b/packages/dialtone-vue/components/Modal/Modal.stories.js
@@ -113,6 +113,11 @@ export const argTypesData = {
       type: 'boolean',
     },
   },
+  transparentBackdrop: {
+    control: {
+      type: 'boolean',
+    },
+  },
   open: {
     control: {
       type: 'boolean',
@@ -215,6 +220,17 @@ export const WithFullSize = {
 
   args: {
     size: 'full',
+    showFooter: true,
+  },
+
+  parameters: { ...Default.parameters },
+};
+
+export const WithTransparentBackdrop = {
+  render: DefaultTemplate,
+
+  args: {
+    transparentBackdrop: true,
     showFooter: true,
   },
 

--- a/packages/dialtone-vue/components/Modal/Modal.test.js
+++ b/packages/dialtone-vue/components/Modal/Modal.test.js
@@ -207,6 +207,16 @@ describe('DtModal Tests', () => {
       expect(overlay.classes(modalClass)).toBe(true);
     });
 
+    it('Should not apply transparent-backdrop modifier by default', () => {
+      expect(overlay.classes('d-modal--transparent-backdrop')).toBe(false);
+    });
+
+    it('Should apply transparent-backdrop modifier when transparentBackdrop is true', async () => {
+      await wrapper.setProps({ transparentBackdrop: true });
+
+      expect(overlay.classes('d-modal--transparent-backdrop')).toBe(true);
+    });
+
     it('Should pass content class through to content modal element', async () => {
       const contentClass = 'content-class';
 

--- a/packages/dialtone-vue/components/Modal/Modal.vue
+++ b/packages/dialtone-vue/components/Modal/Modal.vue
@@ -10,6 +10,7 @@
         'd-modal',
         MODAL_KIND_MODIFIERS[kind],
         MODAL_SIZE_MODIFIERS[size],
+        { 'd-modal--transparent-backdrop': transparentBackdrop },
         modalClass,
       ]"
       data-qa="dt-modal"
@@ -357,6 +358,17 @@ export default {
     appendTo: {
       type: String,
       default: undefined,
+    },
+
+    /**
+     * When true, the surrounding backdrop is rendered fully transparent
+     * instead of the default dimming overlay. The dialog box itself
+     * remains opaque. Useful when the underlying UI should remain visible.
+     * @values true, false
+     */
+    transparentBackdrop: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/packages/dialtone-vue/components/Modal/ModalDefault.story.vue
+++ b/packages/dialtone-vue/components/Modal/ModalDefault.story.vue
@@ -18,6 +18,7 @@
       :close-on-click="$attrs.closeOnClick"
       :append-to="$attrs.appendTo"
       :content-mode="$attrs.contentMode"
+      :transparent-backdrop="$attrs.transparentBackdrop"
       @update:open="close"
     >
       <template


### PR DESCRIPTION
<img width="168" height="173" alt="image" src="https://github.com/user-attachments/assets/ba434d45-dd9e-459f-8c2a-a1011f7abb7b" />

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-3432](https://dialpad.atlassian.net/browse/DLT-3432)

## :book: Description

New `transparentBackdrop` boolean prop on DtModal. Default `false`. When `true`, the modal's backdrop renders transparent. Dialog box keeps its solid background.

New BEM modifier `.d-modal--transparent-backdrop` that pairs with `.d-modal`.

## :bulb: Context

The `.d-modal--transparent` class has existed for a while but wasn't exposed through DtModal's API. Consumers had to set `modalClass="d-modal--transparent"` to get a transparent backdrop. Now there's a first-class prop.

### What this does NOT do

- Does not modify the legacy standalone `.d-modal--transparent` class (still used by Popover/Tooltip).
- Does not change default modal rendering.
- Does not couple to `closeOnClick` or any other prop.

## :package: Cross-Package Impact

| Package | Changes |
|---|---|
| dialtone-css | New `.d-modal--transparent-backdrop` modifier |
| dialtone-vue | New `transparentBackdrop` prop on DtModal |
| dialtone-documentation | New "Transparent Backdrop" section + example wiring |

Dependency flow: tokens → **CSS** → **Vue** → docs/MCP

## :page_facing_up: Documentation Artifacts

| Artifact | Status |
|---|---|
| Vue source | Updated |
| Tests | Updated (2 new) |
| Storybook stories | Updated (`WithTransparentBackdrop`) |
| Component docs JSON | Regenerated |
| VuePress docs | Updated |
| MCP server data | Regenerated |

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

https://github.com/user-attachments/assets/972d5db6-5737-4850-a17c-a8adda793f67

[DLT-3432]: https://dialpad.atlassian.net/browse/DLT-3432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ