### PR TITLE
feat(modal): NO-JIRA apply headerClass to header text element

### DIFF
--- a/packages/dialtone-vue/components/Modal/Modal.test.js
+++ b/packages/dialtone-vue/components/Modal/Modal.test.js
@@ -232,6 +232,16 @@ describe('DtModal Tests', () => {
       expect(banner.classes(bannerClass)).toBe(true);
     });
 
+    it('Should apply header class to the header text element', async () => {
+      const headerClass = 'header-class';
+
+      expect(title.classes(headerClass)).toBe(false);
+
+      await wrapper.setProps({ headerClass });
+
+      expect(title.classes(headerClass)).toBe(true);
+    });
+
     it('Should apply banner kind', async () => {
       await wrapper.setProps({
         open: true,

--- a/packages/dialtone-vue/components/Modal/Modal.vue
+++ b/packages/dialtone-vue/components/Modal/Modal.vue
@@ -66,7 +66,7 @@
             density="100"
             text-box-trim="start"
             as="h2"
-            class="d-modal__header"
+            :class="['d-modal__header', headerClass]"
             data-qa="dt-modal-title"
           >
             {{ headerText }}

--- a/packages/dialtone-vue/components/Modal/ModalDefault.story.vue
+++ b/packages/dialtone-vue/components/Modal/ModalDefault.story.vue
@@ -12,6 +12,8 @@
       :banner-kind="$attrs.bannerKind"
       :dialog-class="$attrs.dialogClass"
       :content-class="$attrs.contentClass"
+      :header-class="$attrs.headerClass"
+      :footer-class="$attrs.footerClass"
       :show-close="$attrs.showClose"
       :labelled-by-id="$attrs.labelledById"
       :fixed-header-footer="$attrs.fixedHeaderFooter"


### PR DESCRIPTION
# feat(modal): NO-JIRA apply headerClass to header text element

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExY29odnk5Y2NjOTZvc3VwazVpbmN0dXF0b29rdGQya25paW5kNjN5NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/e9naycep2pz7OHQ4n0/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->
NO-JIRA

## :book: Description

<!--- Describe specifically what the changes are -->

Apply the `headerClass` prop on `DtModal` to the element with class `d-modal__header`, even when it is the default output with no slot override. Not 100% sure if this would be considered a fix or a feature.

### What

`headerClass` was declared as a prop on `DtModal` and applied correctly when using the `#header` slot, but was not bound on the `DtText` element used when `headerText` is supplied directly. The class was silently dropped in the common case.

### Why

The `v-if` (slot) and `v-else` (text) branches both render the same `d-modal__header` element — seems like both should accept the same consumer class.

### Changes

- `Modal.vue` — bind `headerClass` on the `DtText` `v-else` branch to match the existing binding on the `#header` slot `div`
- `Modal.test.js` — add test asserting the class is applied when the prop is set


## :bulb: Context

Noticed while using DtModal in Beacon that the `headerClass` wasn't applying as I expected.

However, I could see a case for omitting it if we want to reserve it only for when slots are provided as overrides. I also started this in order to fix the `headerText` in the docs examples, but it looks like that is already covered in https://github.com/dialpad/dialtone/pull/1277, so I think this could just be considered an optional follow up to that PR.

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->
Check other components for similar quirks.

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

### Before
Showing with `headerClass` prop in use, but no custom header slot.

<img width="1029" height="84" alt="Screenshot 2026-05-18 at 7 52 02 AM" src="https://github.com/user-attachments/assets/c0ec5c42-28ff-41da-9e5c-e0956d66f165" />


### After

<img width="1079" height="123" alt="Screenshot 2026-05-18 at 7 50 52 AM" src="https://github.com/user-attachments/assets/bdc3c6d3-647d-4ce8-95df-36cbd96d9e48" />


## :link: Sources

<!--- Add any links to external reference material -->
