### PR TITLE
fix(motion-text): DLT-3435 remove @property and animate mask-position directly

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/motion_text.less
+++ b/packages/dialtone-css/lib/build/less/components/motion_text.less
@@ -3,7 +3,6 @@
 //  RECIPES: MOTION TEXT
 //
 //  TABLE OF CONTENTS
-//  • CSS CUSTOM PROPERTIES
 //  • BASE STYLE
 //  • CHILD ELEMENTS
 //  • ANIMATION KEYFRAMES
@@ -15,15 +14,6 @@
 //  • MODIFIERS
 //  • ACCESSIBILITY
 //
-//  ============================================================================
-//  $   CSS CUSTOM PROPERTIES
-//  ----------------------------------------------------------------------------
-@property --d-motion-text-mask-pos {
-  inherits: true;
-  initial-value: 0%;
-  syntax: '<percentage>';
-}
-
 //  ============================================================================
 //  $   BASE STYLE
 //  ----------------------------------------------------------------------------
@@ -113,11 +103,11 @@
 
 @keyframes d-motion-text-gradient-in-word-reveal {
   from {
-    --d-motion-text-mask-pos: 100%;
+    mask-position: 100% 0%;
   }
 
   to {
-    --d-motion-text-mask-pos: 0%;
+    mask-position: 0% 0%;
   }
 }
 
@@ -178,11 +168,11 @@
   animation: d-motion-text-gradient-in-char-appear calc(var(--d-motion-text-char-duration) * 0.5) var(--ttf-out-quint) reverse;
 }
 
-.d-motion-text-word-gradient-in-enter-active {
+.d-motion-text-word-gradient-in-enter-active::before {
   animation: d-motion-text-gradient-in-word-reveal calc(var(--d-motion-text-word-duration) * 1.5) var(--ttf-out-quint);
 }
 
-.d-motion-text-word-gradient-in-leave-active {
+.d-motion-text-word-gradient-in-leave-active::before {
   animation: d-motion-text-gradient-in-word-reveal calc(var(--d-motion-text-word-duration) * 0.5) var(--ttf-out-quint) reverse;
 }
 
@@ -239,6 +229,10 @@
 .d-motion-text--shimmer {
   position: relative;
   display: inline-block;
+}
+
+.d-motion-text--gradient-sweep::before,
+.d-motion-text--shimmer {
   animation: d-motion-text-gradient-in-word-reveal calc(var(--d-motion-text-word-duration) * 1.5) var(--ttf-in-out) 1;
 }
 
@@ -255,13 +249,11 @@
   pointer-events: none;
   -webkit-text-fill-color: transparent;
   mask: var(--d-motion-text-gradient);
-  mask-position: var(--d-motion-text-mask-pos) 0%;
 }
 
 .d-motion-text--shimmer {
   content: attr(data-text-content);
   mask: var(--d-motion-text-shimmer-gradient);
-  mask-position: var(--d-motion-text-mask-pos) 0%;
 }
 
 //  ============================================================================
@@ -273,10 +265,12 @@
   opacity: 1;
 }
 
-.d-motion-text--paused {
+.d-motion-text--paused,
+.d-motion-text--paused::before {
   animation-play-state: paused !important;
 }
 
+.d-motion-text--looped::before,
 .d-motion-text--looped {
   animation-iteration-count: infinite !important;
 }

--- a/packages/dialtone-css/lib/build/less/components/motion_text.less
+++ b/packages/dialtone-css/lib/build/less/components/motion_text.less
@@ -22,25 +22,25 @@
   --d-motion-text-duration: 1000ms;
   --d-motion-text-char-duration: var(--d-motion-text-duration);
   --d-motion-text-word-duration: calc(var(--d-motion-text-duration) * 2);
-  --d-motion-text-highlight-color: linear-gradient(135deg, var(--dt-color-brand-magenta) 10%, var(--dt-color-brand-purple) 80%, var(--dt-color-brand-gold) 100%);
+  --d-motion-text-highlight-color: linear-gradient(135deg, var(--dt-color-brand-magenta) var(--dt-size-10-percent), var(--dt-color-brand-purple) var(--dt-size-80-percent), var(--dt-color-brand-gold) var(--dt-size-100-percent));
   --d-motion-text-gradient: linear-gradient(
     90deg,
-    transparent 0%,
-    transparent 20%,
-    black 40%,
-    black 60%,
-    transparent 80%,
-    transparent 100%
-  ) 0% 0% / 500% 100%;
+    transparent var(--dt-size-0-percent),
+    transparent var(--dt-size-20-percent),
+    black var(--dt-size-40-percent),
+    black var(--dt-size-60-percent),
+    transparent var(--dt-size-80-percent),
+    transparent var(--dt-size-100-percent)
+  ) var(--dt-size-0-percent) var(--dt-size-0-percent) / 500% var(--dt-size-100-percent);
   --d-motion-text-shimmer-gradient: linear-gradient(
     90deg,
-    black 0%,
-    black 20%,
-    #0005 40%,
-    #0005 60%,
-    black 80%,
-    black 100%
-  ) 0% 0% / 500% 100%;
+    black var(--dt-size-0-percent),
+    black var(--dt-size-20-percent),
+    #0005 var(--dt-size-40-percent),
+    #0005 var(--dt-size-60-percent),
+    black var(--dt-size-80-percent),
+    black var(--dt-size-100-percent)
+  ) var(--dt-size-0-percent) var(--dt-size-0-percent) / 500% var(--dt-size-100-percent);
 
   position: relative;
 }
@@ -50,11 +50,11 @@
 //  ----------------------------------------------------------------------------
 .d-motion-text__sr-only {
   position: absolute;
-  width: 1px;
-  height: 1px;
+  width: var(--dt-size-100);
+  height: var(--dt-size-100);
   overflow: hidden;
   white-space: nowrap;
-  clip-path: inset(50%);
+  clip-path: inset(var(--dt-size-50-percent));
 }
 
 .d-motion-text__content {
@@ -83,11 +83,11 @@
 // Gradient-in mode animations
 @keyframes d-motion-text-gradient-in-char-appear {
   from {
-    opacity: 0;
+    opacity: var(--dt-opacity-0);
   }
 
   to {
-    opacity: 1;
+    opacity: var(--dt-opacity-1300);
   }
 }
 
@@ -103,32 +103,32 @@
 
 @keyframes d-motion-text-gradient-in-word-reveal {
   from {
-    mask-position: 100% 0%;
+    mask-position: var(--dt-size-100-percent) var(--dt-size-0-percent);
   }
 
   to {
-    mask-position: 0% 0%;
+    mask-position: var(--dt-size-0-percent) var(--dt-size-0-percent);
   }
 }
 
 // Fade-in mode animations
 @keyframes d-motion-text-fade-in-char-appear {
   from {
-    opacity: 0;
+    opacity: var(--dt-opacity-0);
   }
 
   to {
-    opacity: 1;
+    opacity: var(--dt-opacity-1300);
   }
 }
 
 @keyframes d-motion-text-fade-in-word-appear {
   from {
-    opacity: 0;
+    opacity: var(--dt-opacity-0);
   }
 
   to {
-    opacity: 1;
+    opacity: var(--dt-opacity-1300);
   }
 }
 
@@ -136,24 +136,24 @@
 @keyframes d-motion-text-slide-in-char-appear {
   from {
     transform: translateY(0.3em);
-    opacity: 0;
+    opacity: var(--dt-opacity-0);
   }
 
   to {
-    transform: translateY(0);
-    opacity: 1;
+    transform: translateY(var(--dt-size-0));
+    opacity: var(--dt-opacity-1300);
   }
 }
 
 @keyframes d-motion-text-slide-in-word-appear {
   from {
     transform: translateY(0.5em);
-    opacity: 0;
+    opacity: var(--dt-opacity-0);
   }
 
   to {
-    transform: translateY(0);
-    opacity: 1;
+    transform: translateY(var(--dt-size-0));
+    opacity: var(--dt-opacity-1300);
   }
 }
 
@@ -262,7 +262,7 @@
 .d-motion-text--none .d-motion-text__word,
 .d-motion-text--none .d-motion-text__char {
   transform: none;
-  opacity: 1;
+  opacity: var(--dt-opacity-1300);
 }
 
 .d-motion-text--paused,


### PR DESCRIPTION
# fix(motion-text): DLT-3435 remove @property and animate mask-position directly

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExbnAwYmwyc2hjdXQ0dnpvczdicGlzNGhucWlvb3Z5MTNhNWI5dDl2dCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tMPSeKEplOfK0/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket
https://dialpad.atlassian.net/browse/DLT-3435
<!--- Enter the URL of the Jira ticket associated with this PR -->

## :book: Description

Removes `@property --d-motion-text-mask-pos` from `motion_text.less` and replaces it with direct `mask-position` animation in `@keyframes`. The `d-motion-text-gradient-in-word-reveal` keyframe now animates `mask-position: 100% 0%` → `0% 0%` directly. Word transition classes for gradient-in mode and the gradient-sweep animation now target `::before` directly rather than relying on custom property inheritance. The `--paused` and `--looped` modifier rules are extended to also target `::before` so pause and loop controls continue to work for static animation modes.

<!--- Describe specifically what the changes are -->

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

`@property` declarations are order-dependent — the browser requires them to appear before any `@keyframes` or rules that reference them. CSS post-processors used in consumer apps (e.g. clean-css) can reorder at-rules, moving `@property` after the rules that depend on it and silently breaking the animation. mask-position is a natively animatable property and requires no type registration, making this fix post-processor-proof with no burden on consumers.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [ ] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

Testing this out and sharing via the PR preview before having it officially reviewed. More details and screenshots coming soon to verify that the transition doesn't negatively impact any of the variants or expected behavior.

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
