### PR TITLE
feat(design-tokens, modal, notice, popover, hovercard, emoji-picker): DLT-3436 add overlay surface color

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/emoji-picker.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji-picker.less
@@ -61,7 +61,7 @@
       gap: var(--dt-spacing-0);
 
       &::after {
-        background-color: transparent !important;
+        background-color: var(--dt-color-neutral-transparent) !important;
       }
 
       .d-tablist__item {
@@ -91,7 +91,7 @@
       margin: 0;
       padding: 0;
       background: none;
-      border: var(--dt-size-border-100) solid transparent;
+      border: var(--dt-size-border-100) solid var(--dt-color-neutral-transparent);
       border-radius: var(--dt-size-radius-circle);
       outline: none;
       cursor: pointer;
@@ -115,7 +115,7 @@
       margin: 0;
       padding: calc(var(--dt-spacing-75) + var(--dt-spacing-1));
       background: var(--dt-color-surface-moderate-opaque);
-      border: 1px solid transparent;
+      border: var(--dt-size-border-100) solid var(--dt-color-neutral-transparent);
       border-radius: var(--dt-size-radius-circle);
       outline: none;
       cursor: pointer;

--- a/packages/dialtone-css/lib/build/less/components/emoji-picker.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji-picker.less
@@ -17,7 +17,7 @@
   // with this width we have 9 emoji per row
   inline-size: var(--dt-layout-550);
   block-size: 100%;
-  background-color: var(--dt-color-surface-primary);
+  background-color: var(--dt-color-surface-overlay);
   border-radius: var(--dt-size-radius-300);
 
   &--header {
@@ -28,8 +28,8 @@
       position: absolute;
       inset-inline: 0;
       inset-block-end: 0;
-      block-size: var(--dt-size-border-200);
-      background-color: var(--dt-color-surface-moderate) !important;
+      block-size: var(--dt-size-border-100);
+      background-color: var(--dt-color-border-subtle) !important;
       content: '';
     }
   }
@@ -49,7 +49,6 @@
     justify-content: space-between;
     block-size: calc(var(--dt-layout-100) - var(--dt-spacing-75));
     padding: 0 var(--dt-spacing-200);
-    background: var(--dt-color-surface-secondary);
     border-block-start: var(--dt-size-border-100) solid var(--dt-color-border-subtle);
   }
 
@@ -62,7 +61,7 @@
       gap: var(--dt-spacing-0);
 
       &::after {
-        background-color: var(--dt-color-surface-moderate) !important;
+        background-color: transparent !important;
       }
 
       .d-tablist__item {
@@ -93,7 +92,7 @@
       padding: 0;
       background: none;
       border: var(--dt-size-border-100) solid transparent;
-      border-radius: var(--dt-size-radius-350);
+      border-radius: var(--dt-size-radius-circle);
       outline: none;
       cursor: pointer;
 
@@ -103,7 +102,7 @@
 
       &:active,
       &.selected {
-        border-color: var(--dt-color-border-bold);
+        border-color: var(--dt-color-border-moderate);
       }
     }
   }
@@ -116,13 +115,13 @@
       margin: 0;
       padding: calc(var(--dt-spacing-75) + var(--dt-spacing-1));
       background: var(--dt-color-surface-moderate-opaque);
-      border: none;
+      border: 1px solid transparent;
       border-radius: var(--dt-size-radius-circle);
       outline: none;
       cursor: pointer;
 
       &:hover {
-        background: var(--dt-color-surface-bold);
+        border-color: var(--dt-color-border-subtle);
       }
     }
   }
@@ -144,7 +143,7 @@
     inline-size: 100%;
     margin: 0;
     padding: var(--dt-spacing-200) var(--dt-spacing-200) 0 var(--dt-spacing-200);
-    background: var(--dt-color-surface-primary);
+    background: var(--dt-color-surface-overlay);
   }
 
   &__list {

--- a/packages/dialtone-css/lib/build/less/components/modal.less
+++ b/packages/dialtone-css/lib/build/less/components/modal.less
@@ -96,7 +96,7 @@
     //  ------------------------------------------------------------------------
     --modal-backdrop-color-background: var(--dt-color-surface-backdrop);
     --modal-dialog-padding: var(--dt-spacing-400);
-    --modal-dialog-color-background: var(--dt-color-surface-primary);
+    --modal-dialog-color-background: var(--dt-color-surface-overlay);
     --modal-dialog-color-border: var(--dt-color-border-subtle);
     --modal-dialog-color-text: var(--dt-color-foreground-primary);
     --modal-header-color-text: var(--dt-color-foreground-primary);

--- a/packages/dialtone-css/lib/build/less/components/notice.less
+++ b/packages/dialtone-css/lib/build/less/components/notice.less
@@ -16,7 +16,7 @@
 .d-toast {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
-    --notice-color-background: var(--dt-color-surface-secondary);
+    --notice-color-background: var(--dt-color-surface-secondary-opaque);
     --notice-color-text: var(--dt-color-foreground-primary);
     --notice-color-icon: var(--notice-color-text);
     --notice-color-shadow: var(--dt-color-border-subtle);
@@ -42,6 +42,10 @@
 .d-notice {
     display: flex;
     align-items: start;
+}
+
+.d-toast {
+    --notice-color-background: var(--dt-color-surface-overlay);
 }
 
 //  ============================================================================

--- a/packages/dialtone-css/lib/build/less/components/notice.less
+++ b/packages/dialtone-css/lib/build/less/components/notice.less
@@ -16,7 +16,7 @@
 .d-toast {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
-    --notice-color-background: var(--dt-color-surface-secondary-opaque);
+    --notice-color-background: var(--dt-color-surface-secondary);
     --notice-color-text: var(--dt-color-foreground-primary);
     --notice-color-icon: var(--notice-color-text);
     --notice-color-shadow: var(--dt-color-border-subtle);

--- a/packages/dialtone-css/lib/build/less/components/popover.less
+++ b/packages/dialtone-css/lib/build/less/components/popover.less
@@ -25,7 +25,7 @@
   &__dialog {
     //  $$  CSS CUSTOM PROPERTIES
     //  ----------------------------------------------------------------------------
-    --popover-color-background: var(--dt-color-surface-secondary);
+    --popover-color-background: var(--dt-color-surface-overlay);
     --popover-border-width: var(--dt-size-border-100);
     --popover-border-radius: var(--dt-size-radius-400);
     --popover-color-border: var(--dt-color-border-subtle);

--- a/packages/dialtone-tokens/tokens/theme/dp/dark.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/dark.json
@@ -172,6 +172,10 @@
       }
     },
     "surface": {
+      "overlay": {
+        "value": "{color.black.200}",
+        "type": "color"
+      },
       "primary": {
         "value": "{color.black.100}",
         "type": "color"

--- a/packages/dialtone-tokens/tokens/theme/dp/default.json
+++ b/packages/dialtone-tokens/tokens/theme/dp/default.json
@@ -374,6 +374,11 @@
       }
     },
     "surface": {
+      "overlay": {
+        "value": "{color.black.50}",
+        "type": "color",
+        "description": "For overlay surfaces like modals, popovers, and dialogs."
+      },
       "primary": {
         "value": "{color.black.50}",
         "type": "color",


### PR DESCRIPTION
<img width="300" height="145" alt="image" src="https://github.com/user-attachments/assets/179cbd16-eea6-46e0-9522-aacfa5f476db" />

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-3436](https://dialpad.atlassian.net/browse/DLT-3436)

## :book: Description

While we're not yet fully going with a proper Elevation strategy, I can at least instantiate an `surface.overlay` design token. This will allow us to control the perception that the overlay item's surface color is perceived to elevate, i.e. it's always the lightest surface regardless of mode.

- Created design token for light and dark modes. 
- CSS Utility is automatically created, i.e. `d-bgc-overlay`.
- Applied css variable to overlay components: 
  - Modal
  - Popover
  - Hovercard
  - Dropdown
  - Emoji Picker
  - But intentionally _not_ Tooltip.

Those components just generally use `surface.secondary`, which is only perceived in dark mode to be "more forward."

In the future, a true "Elevation" set of surfaces will likely be created, e.g. `elevated`, `raised`, `overlay` – likely with corresponding ones for border and shadow.

Pure Design Token and CSS Change. No Vue changes. No doc changes.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

[DLT-3436]: https://dialpad.atlassian.net/browse/DLT-3436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ