### PR TITLE
fix(segmented-control, button): NO-JIRA correct layering of slot items

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/layouts/Layout.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/layouts/Layout.vue
@@ -18,12 +18,14 @@
         >
           <DtStack direction="row" gap="150">
             <DtIllustration name="dialpad-logo" />
-            <DtBox v-if="showBranchBadge" padding-block-start="100">
+            <DtBox v-if="showBranchBadge" padding-block-start="100" :title="branchName">
               <DtBadge>
                 <template #startIcon="{ iconSize }">
                   <dt-icon-branch :size="iconSize" />
                 </template>
-                {{ branchName }}
+                <DtText as="p" class="d-wmx-250" truncate>
+                  {{ branchName }}
+                </DtText>
               </DtBadge>
             </DtBox>
           </DtStack>

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -274,6 +274,7 @@
 //  ----------------------------------------------------------------------------
 .d-btn__leading,
 .d-btn__trailing {
+  z-index: var(--zi-base1);
   display: inline-flex;
   align-items: center;
   align-self: stretch;
@@ -318,6 +319,7 @@
 }
 
 .d-btn__icon {
+  z-index: var(--zi-base1);
   display: flex;
 
   :where(.d-btn--disabled) & ,


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Description

Layering correction of slot elements within Button, and therefore Segmented Control. 

Also a minor tweak to the dev-only branch name in header.

See videos below for before/after.

## :camera: Screenshots / GIFs

In the "before", you'll notice a little flash of the icon as the traveling indicator moves over it. In the "after" video it's fixed.

**👎 Before**

https://github.com/user-attachments/assets/8a407388-ea74-4809-87c1-612e39dba932

**👍 After**

https://github.com/user-attachments/assets/164c1164-f48c-4835-84c2-547193c09100

