### PR TITLE
fix(validation-messages): DLT-3430 fix VoiceOver silent on validation messages

### DIFF
--- a/packages/dialtone-vue/components/Checkbox/Checkbox.test.js
+++ b/packages/dialtone-vue/components/Checkbox/Checkbox.test.js
@@ -203,8 +203,8 @@ describe('DtCheckbox Tests', () => {
         expect(label.exists()).toBe(false);
       });
 
-      it('should remove the checkbox description/messages container if neither is provided', () => {
-        expect(descriptionMessagesContainer.exists()).toBe(false);
+      it('should keep the checkbox description/messages container in the DOM', () => {
+        expect(descriptionMessagesContainer.exists()).toBe(true);
       });
 
       it('should keep the input checkbox', () => {

--- a/packages/dialtone-vue/components/Checkbox/Checkbox.test.js
+++ b/packages/dialtone-vue/components/Checkbox/Checkbox.test.js
@@ -351,6 +351,36 @@ describe('DtCheckbox Tests', () => {
         });
       });
     });
+
+    describe('ARIA validation wiring', () => {
+      describe('When a critical validation message is provided', () => {
+        beforeEach(() => {
+          mockProps = { messages: [{ message: 'Error', type: VALIDATION_MESSAGE_TYPES.CRITICAL }] };
+
+          updateWrapper();
+        });
+
+        it('should set aria-invalid on the input', () => {
+          expect(input.attributes('aria-invalid')).toBe('true');
+        });
+
+        it('should set aria-describedby on the input pointing to the messages container', () => {
+          const messagesContainer = wrapper.find('[data-qa="dt-checkbox-validation-messages"]');
+
+          expect(input.attributes('aria-describedby')).toBe(messagesContainer.attributes('id'));
+        });
+      });
+
+      describe('When no validation messages are provided', () => {
+        it('should not set aria-invalid on the input', () => {
+          expect(input.attributes('aria-invalid')).toBeUndefined();
+        });
+
+        it('should not set aria-describedby on the input', () => {
+          expect(input.attributes('aria-describedby')).toBeUndefined();
+        });
+      });
+    });
   });
 
   describe('Interactivity Tests', () => {

--- a/packages/dialtone-vue/components/Checkbox/Checkbox.vue
+++ b/packages/dialtone-vue/components/Checkbox/Checkbox.vue
@@ -13,6 +13,8 @@
           :disabled="internalDisabled"
           :class="['d-checkbox', inputValidationClass, inputClass]"
           :aria-label="!showLabel && label ? label : undefined"
+          :aria-invalid="ariaInvalid"
+          :aria-describedby="ariaDescribedBy"
           v-bind="removeClassStyleAttrs($attrs)"
           :indeterminate.prop="internalIndeterminate"
           v-on="inputListeners"
@@ -34,12 +36,11 @@
       </dt-text>
     </label>
     <div
-      v-if="$slots.description || description || hasMessages"
+      v-if="$slots.description || description"
       class="d-checkbox__messages"
       data-qa="checkbox-description-messages"
     >
       <dt-text
-        v-if="$slots.description || description"
         kind="body"
         :size="200"
         tone="tertiary"
@@ -53,14 +54,15 @@
           {{ description }}
         </slot>
       </dt-text>
-      <dt-validation-messages
-        :validation-messages="formattedMessages"
-        :show-messages="showMessages"
-        :class="messagesClass"
-        v-bind="messagesChildProps"
-        data-qa="dt-checkbox-validation-messages"
-      />
     </div>
+    <dt-validation-messages
+      :id="messagesId"
+      :validation-messages="formattedMessages"
+      :show-messages="showMessages"
+      :class="messagesClass"
+      v-bind="messagesChildProps"
+      data-qa="dt-checkbox-validation-messages"
+    />
   </div>
 </template>
 
@@ -72,7 +74,8 @@ import {
   GroupableMixin,
   MessagesMixin,
 } from '@/common/mixins/input';
-import { removeClassStyleAttrs } from '@/common/utils';
+import { removeClassStyleAttrs, getUniqueString, getValidationState } from '@/common/utils';
+import { VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 import { CHECKBOX_INPUT_VALIDATION_CLASSES } from './CheckboxConstants';
 import { DtValidationMessages } from '../ValidationMessages';
 import { DtText, TEXT_SIZE_MODIFIERS, TEXT_STRENGTH_MODIFIERS } from '@/components/Text';
@@ -148,6 +151,12 @@ export default {
     'focusout',
   ],
 
+  data () {
+    return {
+      messagesId: getUniqueString(),
+    };
+  },
+
   computed: {
     resolvedLabelSize () {
       return this.labelSize ?? 300;
@@ -171,6 +180,14 @@ export default {
 
     hasMessages () {
       return this.formattedMessages.length && this.showMessages;
+    },
+
+    ariaInvalid () {
+      return getValidationState(this.formattedMessages) === VALIDATION_MESSAGE_TYPES.CRITICAL ? 'true' : undefined;
+    },
+
+    ariaDescribedBy () {
+      return this.showMessages && this.formattedMessages.length > 0 ? this.messagesId : undefined;
     },
 
     inputListeners () {

--- a/packages/dialtone-vue/components/Checkbox/Checkbox.vue
+++ b/packages/dialtone-vue/components/Checkbox/Checkbox.vue
@@ -36,11 +36,11 @@
       </dt-text>
     </label>
     <div
-      v-if="$slots.description || description"
       class="d-checkbox__messages"
       data-qa="checkbox-description-messages"
     >
       <dt-text
+        v-if="$slots.description || description"
         kind="body"
         :size="200"
         tone="tertiary"
@@ -54,15 +54,15 @@
           {{ description }}
         </slot>
       </dt-text>
+      <dt-validation-messages
+        :id="messagesId"
+        :validation-messages="formattedMessages"
+        :show-messages="showMessages"
+        :class="messagesClass"
+        v-bind="messagesChildProps"
+        data-qa="dt-checkbox-validation-messages"
+      />
     </div>
-    <dt-validation-messages
-      :id="messagesId"
-      :validation-messages="formattedMessages"
-      :show-messages="showMessages"
-      :class="messagesClass"
-      v-bind="messagesChildProps"
-      data-qa="dt-checkbox-validation-messages"
-    />
   </div>
 </template>
 

--- a/packages/dialtone-vue/components/Checkbox/Checkbox.vue
+++ b/packages/dialtone-vue/components/Checkbox/Checkbox.vue
@@ -55,11 +55,11 @@
         </slot>
       </dt-text>
       <dt-validation-messages
+        v-bind="messagesChildProps"
         :id="messagesId"
         :validation-messages="formattedMessages"
         :show-messages="showMessages"
         :class="messagesClass"
-        v-bind="messagesChildProps"
         data-qa="dt-checkbox-validation-messages"
       />
     </div>

--- a/packages/dialtone-vue/components/CheckboxGroup/CheckboxGroup.test.js
+++ b/packages/dialtone-vue/components/CheckboxGroup/CheckboxGroup.test.js
@@ -146,7 +146,7 @@ describe('Checkbox Group Tests', () => {
 
           updateWrapper();
 
-          expect(checkboxGroupMessages.exists()).toBe(false);
+          expect(checkboxGroupMessages.findAll('[data-qa="validation-message"]').length).toBe(0);
         });
       });
     });

--- a/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.test.js
+++ b/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.test.js
@@ -261,6 +261,39 @@ describe('DtComboboxMultiSelect Tests', () => {
         });
       });
     });
+
+    describe('ARIA validation wiring', () => {
+      describe('When a critical validation message is provided', () => {
+        beforeEach(async () => {
+          await wrapper.setProps({
+            maxSelected: 1,
+            maxSelectedMessage: [{ message: 'Too many selected', type: VALIDATION_MESSAGE_TYPES.CRITICAL }],
+            selectedItems: ['item1', 'item2'],
+          });
+          await flushPromises();
+          _setChildWrappers();
+        });
+
+        it('should set aria-invalid on the input', () => {
+          expect(input.attributes('aria-invalid')).toBe('true');
+        });
+
+        it('should set aria-describedby on the input pointing to the messages container', () => {
+          const messagesContainer = wrapper.find('[data-qa="validation-messages-container"]');
+          expect(input.attributes('aria-describedby')).toBe(messagesContainer.attributes('id'));
+        });
+      });
+
+      describe('When no validation messages are provided', () => {
+        it('should not set aria-invalid on the input', () => {
+          expect(input.attributes('aria-invalid')).toBeUndefined();
+        });
+
+        it('should not set aria-describedby on the input', () => {
+          expect(input.attributes('aria-describedby')).toBeUndefined();
+        });
+      });
+    });
   });
 
   describe('Interactivity Tests', () => {

--- a/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.vue
+++ b/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.vue
@@ -70,6 +70,7 @@
         />
 
         <dt-validation-messages
+          :id="messagesId"
           :validation-messages="maxSelectedMessage"
           :show-messages="showValidationMessages"
         />
@@ -131,7 +132,7 @@ import DtInput from '@/components/Input/Input.vue';
 import DtChip from '@/components/Chip/Chip.vue';
 import DtValidationMessages from '@/components/ValidationMessages/ValidationMessages.vue';
 import { validationMessageValidator } from '@/common/validators';
-import { extractVueListeners, extractNonListeners, hasSlotContent, returnFirstEl } from '@/common/utils';
+import { extractVueListeners, extractNonListeners, hasSlotContent, returnFirstEl, getUniqueString } from '@/common/utils';
 import {
   POPOVER_APPEND_TO_VALUES,
 } from '@/components/Popover/PopoverConstants';
@@ -503,6 +504,7 @@ export default {
       hasSlotContent,
       inputFocused: false,
       hideInputText: false,
+      messagesId: getUniqueString(),
     };
   },
 

--- a/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.vue
+++ b/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.vue
@@ -59,6 +59,8 @@
           :input-wrapper-class="inputWrapperClass"
           :disabled="disabled"
           :aria-label="label"
+          :aria-invalid="ariaInvalid"
+          :aria-describedby="ariaDescribedBy"
           :label="showLabel ? label : ''"
           :description="description"
           :placeholder="inputPlaceHolder"
@@ -132,7 +134,7 @@ import DtInput from '@/components/Input/Input.vue';
 import DtChip from '@/components/Chip/Chip.vue';
 import DtValidationMessages from '@/components/ValidationMessages/ValidationMessages.vue';
 import { validationMessageValidator } from '@/common/validators';
-import { extractVueListeners, extractNonListeners, hasSlotContent, returnFirstEl, getUniqueString } from '@/common/utils';
+import { extractVueListeners, extractNonListeners, hasSlotContent, returnFirstEl, getUniqueString, getValidationState } from '@/common/utils';
 import {
   POPOVER_APPEND_TO_VALUES,
 } from '@/components/Popover/PopoverConstants';
@@ -140,7 +142,7 @@ import {
   CHIP_SIZES,
   CHIP_TOP_POSITION,
 } from './ComboboxMultiSelectConstants';
-import { COMPONENT_SIZES } from '@/common/constants';
+import { COMPONENT_SIZES, VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 
 export default {
   name: 'DtComboboxMultiSelect',
@@ -553,6 +555,14 @@ export default {
           }
         },
       };
+    },
+
+    ariaInvalid () {
+      return getValidationState(this.maxSelectedMessage) === VALIDATION_MESSAGE_TYPES.CRITICAL ? 'true' : undefined;
+    },
+
+    ariaDescribedBy () {
+      return this.showValidationMessages && this.maxSelectedMessage.length > 0 ? this.messagesId : undefined;
     },
 
     chipWrapperClass () {

--- a/packages/dialtone-vue/components/Input/Input.test.js
+++ b/packages/dialtone-vue/components/Input/Input.test.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { INPUT_SIZES } from './InputConstants';
+import { VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 import { DtIcon } from '@/components/Icon';
 import { DtText } from '@/components/Text';
 import DtInput from './Input.vue';
@@ -51,7 +52,7 @@ describe('DtInput tests', () => {
     label = wrapper.find('[data-qa="dt-input-label"]');
     description = wrapper.find('[data-qa="dt-input-description"]');
     nativeInput = wrapper.find('input');
-    nativeTextarea = wrapper.find('textarea');
+    nativeTextarea = wrapper.find('[data-qa="dt-input-input"]');
     leftIconWrapper = wrapper.find('[data-qa="dt-input-left-icon-wrapper"]');
     rightIconWrapper = wrapper.find('[data-qa="dt-input-right-icon-wrapper"]');
   };
@@ -143,7 +144,7 @@ describe('DtInput tests', () => {
 
         updateWrapper();
 
-        nativeTextarea = wrapper.find('textarea');
+        nativeTextarea = wrapper.find('[data-qa="dt-input-input"]');
 
         expect(nativeTextarea.attributes('aria-label')).toBe(baseProps.label);
       });
@@ -824,6 +825,76 @@ describe('DtInput tests', () => {
         await wrapper.setProps({ modelValue: 'external update' });
 
         expect(nativeTextarea.element.value).toBe('composing...');
+      });
+    });
+  });
+
+  describe('Accessibility Tests', () => {
+    describe('ARIA validation wiring', () => {
+      describe('When type is input', () => {
+        describe('When a critical validation message is provided', () => {
+          beforeEach(() => {
+            mockProps = { messages: [{ message: 'Error', type: VALIDATION_MESSAGE_TYPES.CRITICAL }] };
+
+            updateWrapper();
+          });
+
+          it('should set aria-invalid on the input', () => {
+            expect(nativeInput.attributes('aria-invalid')).toBe('true');
+          });
+
+          it('should set aria-describedby on the input pointing to the messages container', () => {
+            const messagesContainer = wrapper.find('[data-qa="dt-input-messages"]');
+
+            expect(nativeInput.attributes('aria-describedby')).toBe(messagesContainer.attributes('id'));
+          });
+        });
+
+        describe('When no validation messages are provided', () => {
+          it('should not set aria-invalid on the input', () => {
+            expect(nativeInput.attributes('aria-invalid')).toBeUndefined();
+          });
+
+          it('should not set aria-describedby on the input', () => {
+            expect(nativeInput.attributes('aria-describedby')).toBeUndefined();
+          });
+        });
+      });
+
+      describe('When type is textarea', () => {
+        describe('When a critical validation message is provided', () => {
+          beforeEach(() => {
+            mockProps = { type: 'textarea', messages: [{ message: 'Error', type: VALIDATION_MESSAGE_TYPES.CRITICAL }] };
+
+            updateWrapper();
+          });
+
+          it('should set aria-invalid on the textarea', () => {
+            expect(wrapper.find('[data-qa="dt-input-input"]').attributes('aria-invalid')).toBe('true');
+          });
+
+          it('should set aria-describedby on the textarea pointing to the messages container', () => {
+            const messagesContainer = wrapper.find('[data-qa="dt-input-messages"]');
+
+            expect(wrapper.find('[data-qa="dt-input-input"]').attributes('aria-describedby')).toBe(messagesContainer.attributes('id'));
+          });
+        });
+
+        describe('When no validation messages are provided', () => {
+          beforeEach(() => {
+            mockProps = { type: 'textarea' };
+
+            updateWrapper();
+          });
+
+          it('should not set aria-invalid on the textarea', () => {
+            expect(wrapper.find('[data-qa="dt-input-input"]').attributes('aria-invalid')).toBeUndefined();
+          });
+
+          it('should not set aria-describedby on the textarea', () => {
+            expect(wrapper.find('[data-qa="dt-input-input"]').attributes('aria-describedby')).toBeUndefined();
+          });
+        });
       });
     });
   });

--- a/packages/dialtone-vue/components/Input/Input.vue
+++ b/packages/dialtone-vue/components/Input/Input.vue
@@ -86,6 +86,8 @@
           :class="inputClasses()"
           :maxlength="shouldLimitMaxLength ? validationProps.length.max : null"
           :aria-label="!showLabel && label ? label : undefined"
+          :aria-invalid="ariaInvalid"
+          :aria-describedby="ariaDescribedBy"
           data-qa="dt-input-input"
           v-bind="removeClassStyleAttrs($attrs)"
           v-on="inputListeners"
@@ -101,6 +103,8 @@
           :class="inputClasses()"
           :maxlength="shouldLimitMaxLength ? validationProps.length.max : null"
           :aria-label="!showLabel && label ? label : undefined"
+          :aria-invalid="ariaInvalid"
+          :aria-describedby="ariaDescribedBy"
           data-qa="dt-input-input"
           v-bind="removeClassStyleAttrs($attrs)"
           v-on="inputListeners"
@@ -128,10 +132,11 @@
       </div>
     </label>
     <dt-validation-messages
+      v-bind="messagesChildProps"
+      :id="messagesId"
       :validation-messages="validationMessages"
       :show-messages="showMessages"
       :class="messagesClass"
-      v-bind="messagesChildProps"
       data-qa="dt-input-messages"
     />
   </div>
@@ -431,6 +436,7 @@ export default {
       hasSlotContent,
       isComposing: false,
       justEndedComposition: false,
+      messagesId: getUniqueString(),
     };
   },
 
@@ -513,6 +519,14 @@ export default {
 
     inputState () {
       return getValidationState(this.validationMessages);
+    },
+
+    ariaInvalid () {
+      return this.inputState === VALIDATION_MESSAGE_TYPES.CRITICAL ? 'true' : undefined;
+    },
+
+    ariaDescribedBy () {
+      return this.showMessages && this.validationMessages.length > 0 ? this.messagesId : undefined;
     },
 
     defaultLengthCalculation () {

--- a/packages/dialtone-vue/components/InputGroup/InputGroup.test.js
+++ b/packages/dialtone-vue/components/InputGroup/InputGroup.test.js
@@ -154,6 +154,36 @@ describe('Input Group Tests', () => {
     });
   });
 
+  describe('Accessibility Tests', () => {
+    describe('When a critical validation message is provided', () => {
+      beforeEach(() => {
+        mockProps = { messages: ['Error'] };
+
+        updateWrapper();
+      });
+
+      it('should set aria-invalid on the fieldset', () => {
+        expect(inputGroup.attributes('aria-invalid')).toBe('true');
+      });
+
+      it('should set aria-describedby on the fieldset pointing to the messages container', () => {
+        const messagesContainer = wrapper.find('[data-qa="input-group-messages"]');
+
+        expect(inputGroup.attributes('aria-describedby')).toBe(messagesContainer.attributes('id'));
+      });
+    });
+
+    describe('When no validation messages are provided', () => {
+      it('should not set aria-invalid on the fieldset', () => {
+        expect(inputGroup.attributes('aria-invalid')).toBeUndefined();
+      });
+
+      it('should not set aria-describedby on the fieldset', () => {
+        expect(inputGroup.attributes('aria-describedby')).toBeUndefined();
+      });
+    });
+  });
+
   describe('Interactivity Tests', () => {
     const MOCK_SELECTED_VALUE = 'apple';
 

--- a/packages/dialtone-vue/components/InputGroup/InputGroup.test.js
+++ b/packages/dialtone-vue/components/InputGroup/InputGroup.test.js
@@ -31,7 +31,7 @@ describe('Input Group Tests', () => {
 
     inputGroup = wrapper.find('[data-qa="input-group"]');
     inputGroupLegend = wrapper.find('[data-qa="input-group-legend"]');
-    inputGroupMessages = wrapper.findComponent('[data-qa="input-group-messages"]');
+    inputGroupMessages = wrapper.findComponent(DtValidationMessages);
   };
 
   beforeEach(() => {

--- a/packages/dialtone-vue/components/InputGroup/InputGroup.vue
+++ b/packages/dialtone-vue/components/InputGroup/InputGroup.vue
@@ -2,6 +2,8 @@
   <fieldset
     class="d-input-group__fieldset"
     :data-qa="dataQaGroup"
+    :aria-invalid="ariaInvalid"
+    :aria-describedby="ariaDescribedBy"
   >
     <dt-text
       v-if="hasSlotContent($slots.legend) || legend"
@@ -20,6 +22,7 @@
     <!-- @slot slot for Input Group Components -->
     <slot />
     <dt-validation-messages
+      :id="messagesId"
       :validation-messages="formattedMessages"
       :show-messages="showMessages"
       :class="messagesClass"
@@ -33,7 +36,8 @@
 import { InputGroupMixin } from '@/common/mixins/input_group';
 import { DtValidationMessages } from '../ValidationMessages';
 import { DtText } from '@/components/Text';
-import { hasSlotContent } from '@/common/utils';
+import { hasSlotContent, getUniqueString, getValidationState } from '@/common/utils';
+import { VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 
 /**
  * Input Groups are convenience components for a grouping of related inputs.
@@ -78,7 +82,18 @@ export default {
     return {
       internalValue: this.value,
       hasSlotContent,
+      messagesId: getUniqueString(),
     };
+  },
+
+  computed: {
+    ariaInvalid () {
+      return getValidationState(this.formattedMessages) === VALIDATION_MESSAGE_TYPES.CRITICAL ? 'true' : undefined;
+    },
+
+    ariaDescribedBy () {
+      return this.showMessages && this.formattedMessages.length > 0 ? this.messagesId : undefined;
+    },
   },
 
   watch: {

--- a/packages/dialtone-vue/components/InputGroup/InputGroup.vue
+++ b/packages/dialtone-vue/components/InputGroup/InputGroup.vue
@@ -22,12 +22,12 @@
     <!-- @slot slot for Input Group Components -->
     <slot />
     <dt-validation-messages
+      v-bind="messagesChildProps"
       :id="messagesId"
       :validation-messages="formattedMessages"
       :show-messages="showMessages"
       :class="messagesClass"
       :data-qa="dataQaGroupMessages"
-      v-bind="messagesChildProps"
     />
   </fieldset>
 </template>

--- a/packages/dialtone-vue/components/Radio/Radio.test.js
+++ b/packages/dialtone-vue/components/Radio/Radio.test.js
@@ -556,6 +556,38 @@ describe('DtRadio Tests', () => {
     });
   });
 
+  describe('Accessibility Tests', () => {
+    describe('ARIA validation wiring', () => {
+      describe('When a critical validation message is provided', () => {
+        beforeEach(() => {
+          mockProps = { messages: [{ message: 'Error', type: VALIDATION_MESSAGE_TYPES.CRITICAL }] };
+
+          updateWrapper();
+        });
+
+        it('should set aria-invalid on the input', () => {
+          expect(input.attributes('aria-invalid')).toBe('true');
+        });
+
+        it('should set aria-describedby on the input pointing to the messages container', () => {
+          const messagesContainer = wrapper.find('[data-qa="dt-radio-validation-messages"]');
+
+          expect(input.attributes('aria-describedby')).toBe(messagesContainer.attributes('id'));
+        });
+      });
+
+      describe('When no validation messages are provided', () => {
+        it('should not set aria-invalid on the input', () => {
+          expect(input.attributes('aria-invalid')).toBeUndefined();
+        });
+
+        it('should not set aria-describedby on the input', () => {
+          expect(input.attributes('aria-describedby')).toBeUndefined();
+        });
+      });
+    });
+  });
+
   describe('Extendability Tests', () => {
     describe('When a class is provided', () => {
       it('should include the class', () => {

--- a/packages/dialtone-vue/components/Radio/Radio.vue
+++ b/packages/dialtone-vue/components/Radio/Radio.vue
@@ -13,6 +13,8 @@
           type="radio"
           :class="['d-radio', inputValidationClass, inputClass]"
           :aria-label="!showLabel && label ? label : undefined"
+          :aria-invalid="ariaInvalid"
+          :aria-describedby="ariaDescribedBy"
           v-bind="removeClassStyleAttrs($attrs)"
           v-on="inputListeners"
         >
@@ -33,12 +35,11 @@
       </dt-text>
     </label>
     <div
-      v-if="$slots.description || description || hasMessages"
+      v-if="$slots.description || description"
       class="d-radio__messages"
       data-qa="radio-description-messages"
     >
       <dt-text
-        v-if="$slots.description || description"
         kind="body"
         :size="200"
         tone="tertiary"
@@ -52,14 +53,15 @@
           {{ description }}
         </slot>
       </dt-text>
-      <dt-validation-messages
-        :validation-messages="formattedMessages"
-        :show-messages="showMessages"
-        :class="messagesClass"
-        v-bind="messagesChildProps"
-        data-qa="dt-radio-validation-messages"
-      />
     </div>
+    <dt-validation-messages
+      :id="messagesId"
+      :validation-messages="formattedMessages"
+      :show-messages="showMessages"
+      :class="messagesClass"
+      v-bind="messagesChildProps"
+      data-qa="dt-radio-validation-messages"
+    />
   </div>
 </template>
 
@@ -73,7 +75,8 @@ import {
 import { RADIO_INPUT_VALIDATION_CLASSES } from './RadioConstants';
 import { DtValidationMessages } from '../ValidationMessages';
 import { DtText, TEXT_SIZE_MODIFIERS, TEXT_STRENGTH_MODIFIERS } from '@/components/Text';
-import { hasSlotContent, removeClassStyleAttrs } from '@/common/utils';
+import { hasSlotContent, removeClassStyleAttrs, getUniqueString, getValidationState } from '@/common/utils';
+import { VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 
 /**
  * Radios are control elements that allow the user to make a single selection.
@@ -165,6 +168,7 @@ export default {
   data () {
     return {
       hasSlotContent,
+      messagesId: getUniqueString(),
     };
   },
 
@@ -205,6 +209,14 @@ export default {
 
     hasMessages () {
       return this.formattedMessages.length && this.showMessages;
+    },
+
+    ariaInvalid () {
+      return getValidationState(this.formattedMessages) === VALIDATION_MESSAGE_TYPES.CRITICAL ? 'true' : undefined;
+    },
+
+    ariaDescribedBy () {
+      return this.showMessages && this.formattedMessages.length > 0 ? this.messagesId : undefined;
     },
   },
 

--- a/packages/dialtone-vue/components/Radio/Radio.vue
+++ b/packages/dialtone-vue/components/Radio/Radio.vue
@@ -35,11 +35,11 @@
       </dt-text>
     </label>
     <div
-      v-if="$slots.description || description"
       class="d-radio__messages"
       data-qa="radio-description-messages"
     >
       <dt-text
+        v-if="$slots.description || description"
         kind="body"
         :size="200"
         tone="tertiary"
@@ -53,15 +53,15 @@
           {{ description }}
         </slot>
       </dt-text>
+      <dt-validation-messages
+        :id="messagesId"
+        :validation-messages="formattedMessages"
+        :show-messages="showMessages"
+        :class="messagesClass"
+        v-bind="messagesChildProps"
+        data-qa="dt-radio-validation-messages"
+      />
     </div>
-    <dt-validation-messages
-      :id="messagesId"
-      :validation-messages="formattedMessages"
-      :show-messages="showMessages"
-      :class="messagesClass"
-      v-bind="messagesChildProps"
-      data-qa="dt-radio-validation-messages"
-    />
   </div>
 </template>
 

--- a/packages/dialtone-vue/components/Radio/Radio.vue
+++ b/packages/dialtone-vue/components/Radio/Radio.vue
@@ -54,11 +54,11 @@
         </slot>
       </dt-text>
       <dt-validation-messages
+        v-bind="messagesChildProps"
         :id="messagesId"
         :validation-messages="formattedMessages"
         :show-messages="showMessages"
         :class="messagesClass"
-        v-bind="messagesChildProps"
         data-qa="dt-radio-validation-messages"
       />
     </div>

--- a/packages/dialtone-vue/components/SelectMenu/SelectMenu.test.js
+++ b/packages/dialtone-vue/components/SelectMenu/SelectMenu.test.js
@@ -275,6 +275,14 @@ describe('DtSelectMenu Tests', () => {
         it('should render validation message', () => {
           expect(messages?.findAll('[data-qa="validation-message"]').length).toBe(1);
         });
+
+        it('should set aria-invalid on the select element', () => {
+          expect(select.attributes('aria-invalid')).toBe('true');
+        });
+
+        it('should set aria-describedby on the select element pointing to the messages container', () => {
+          expect(select.attributes('aria-describedby')).toBe(messages.attributes('id'));
+        });
       });
 
       describe('When validation messages are hidden', () => {
@@ -290,6 +298,14 @@ describe('DtSelectMenu Tests', () => {
 
         it('should not render any validation messages', () => {
           expect(messages.findAll('[data-qa="validation-message"]').length).toBe(0);
+        });
+
+        it('should keep aria-invalid on the select element', () => {
+          expect(select.attributes('aria-invalid')).toBe('true');
+        });
+
+        it('should not set aria-describedby on the select element', () => {
+          expect(select.attributes('aria-describedby')).toBeUndefined();
         });
       });
     });

--- a/packages/dialtone-vue/components/SelectMenu/SelectMenu.test.js
+++ b/packages/dialtone-vue/components/SelectMenu/SelectMenu.test.js
@@ -91,7 +91,7 @@ describe('DtSelectMenu Tests', () => {
         });
       });
       it('should not render any validation messages', () => {
-        expect(messages.exists()).toBe(false);
+        expect(messages.findAll('[data-qa="validation-message"]').length).toBe(0);
       });
     });
 
@@ -289,7 +289,7 @@ describe('DtSelectMenu Tests', () => {
         });
 
         it('should not render any validation messages', () => {
-          expect(messages.exists()).toBe(false);
+          expect(messages.findAll('[data-qa="validation-message"]').length).toBe(0);
         });
       });
     });

--- a/packages/dialtone-vue/components/SelectMenu/SelectMenu.vue
+++ b/packages/dialtone-vue/components/SelectMenu/SelectMenu.vue
@@ -53,6 +53,8 @@
             SELECT_STATE_MODIFIERS[state],
           ]"
           :aria-label="!showLabel && label ? label : undefined"
+          :aria-invalid="ariaInvalid"
+          :aria-describedby="ariaDescribedBy"
           v-bind="removeClassStyleAttrs($attrs)"
           data-qa="dt-select"
           :disabled="disabled"
@@ -75,6 +77,7 @@
       </div>
     </label>
     <dt-validation-messages
+      :id="messagesId"
       :validation-messages="formattedMessages"
       :show-messages="showMessages"
       :class="messagesClass"
@@ -100,6 +103,7 @@ import {
 import { MessagesMixin } from '@/common/mixins/input';
 import { optionsValidator } from './SelectMenuValidators.js';
 import { DtValidationMessages } from '../ValidationMessages';
+import { VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 
 /**
  * A select menu is an input control that allows users to choose one option from a list.
@@ -279,6 +283,7 @@ export default {
       SELECT_SIZE_MODIFIERS,
       SELECT_STATE_MODIFIERS,
       hasSlotContent,
+      messagesId: getUniqueString(),
     };
   },
 
@@ -318,6 +323,14 @@ export default {
 
     state () {
       return getValidationState(this.formattedMessages);
+    },
+
+    ariaInvalid () {
+      return this.state === VALIDATION_MESSAGE_TYPES.CRITICAL ? 'true' : undefined;
+    },
+
+    ariaDescribedBy () {
+      return this.showMessages && this.formattedMessages.length > 0 ? this.messagesId : undefined;
     },
 
     selectKey () {

--- a/packages/dialtone-vue/components/SelectMenu/SelectMenu.vue
+++ b/packages/dialtone-vue/components/SelectMenu/SelectMenu.vue
@@ -77,11 +77,11 @@
       </div>
     </label>
     <dt-validation-messages
+      v-bind="messagesChildProps"
       :id="messagesId"
       :validation-messages="formattedMessages"
       :show-messages="showMessages"
       :class="messagesClass"
-      v-bind="messagesChildProps"
       data-qa="dt-select-messages"
     />
   </div>

--- a/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.stories.js
+++ b/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.stories.js
@@ -1,6 +1,15 @@
+import { ref } from 'vue';
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import { VALIDATION_MESSAGE_TYPES } from '@/common/constants';
 import DtValidationMessages from './ValidationMessages.vue';
+import DtInput from '@/components/Input/Input.vue';
+import DtSelectMenu from '@/components/SelectMenu/SelectMenu.vue';
+import DtRadioGroup from '@/components/RadioGroup/RadioGroup.vue';
+import DtRadio from '@/components/Radio/Radio.vue';
+import DtCheckboxGroup from '@/components/CheckboxGroup/CheckboxGroup.vue';
+import DtCheckbox from '@/components/Checkbox/Checkbox.vue';
+import DtStack from '@/components/Stack/Stack.vue';
+import DtButton from '@/components/Button/Button.vue';
 import {
   DtIconBell,
 } from '@dialpad/dialtone-icons/vue';
@@ -114,5 +123,205 @@ export const WithCustomIcon = {
   parameters: {
     options: { showPanel: false },
     controls: { disable: true },
+  },
+};
+
+const InteractiveFormTemplate = () => {
+  return {
+    components: { DtInput, DtSelectMenu, DtRadioGroup, DtRadio, DtCheckboxGroup, DtCheckbox, DtStack, DtButton },
+    setup () {
+      const nameValue = ref('');
+      const emailValue = ref('');
+      const usernameValue = ref('');
+      const countryValue = ref('');
+      const contactValue = ref('');
+      const interestsValue = ref([]);
+
+      const nameMessages = ref([]);
+      const emailMessages = ref([]);
+      const usernameMessages = ref([]);
+      const countryMessages = ref([]);
+      const contactMessages = ref([]);
+      const interestsMessages = ref([]);
+
+      const usernameChecking = ref(false);
+
+      function validateName () {
+        if (!nameValue.value) {
+          nameMessages.value = [{ message: 'Name is required', type: VALIDATION_MESSAGE_TYPES.CRITICAL }];
+        } else if (nameValue.value.length < 2) {
+          nameMessages.value = [{ message: 'Name must be at least 2 characters', type: VALIDATION_MESSAGE_TYPES.CRITICAL }];
+        } else {
+          nameMessages.value = [{ message: 'Looks good!', type: VALIDATION_MESSAGE_TYPES.POSITIVE }];
+        }
+      }
+
+      function validateEmail () {
+        if (!emailValue.value) {
+          emailMessages.value = [{ message: 'Email is required', type: VALIDATION_MESSAGE_TYPES.CRITICAL }];
+        } else if (!/.+@.+\..+/.test(emailValue.value)) {
+          emailMessages.value = [{ message: 'Please enter a valid email address', type: VALIDATION_MESSAGE_TYPES.CRITICAL }];
+        } else {
+          emailMessages.value = [{ message: 'Email looks good!', type: VALIDATION_MESSAGE_TYPES.POSITIVE }];
+        }
+      }
+
+      let usernameTimer = null;
+
+      function validateUsername () {
+        clearTimeout(usernameTimer);
+        usernameMessages.value = [{ message: 'Checking availability…', type: VALIDATION_MESSAGE_TYPES.INFO }];
+        usernameChecking.value = true;
+
+        usernameTimer = setTimeout(() => {
+          usernameChecking.value = false;
+          if (!usernameValue.value) {
+            usernameMessages.value = [{ message: 'Username is required', type: VALIDATION_MESSAGE_TYPES.CRITICAL }];
+          } else if (usernameValue.value.includes('taken')) {
+            usernameMessages.value = [{ message: 'Username already taken', type: VALIDATION_MESSAGE_TYPES.CRITICAL }];
+          } else {
+            usernameMessages.value = [{ message: 'Username is available', type: VALIDATION_MESSAGE_TYPES.POSITIVE }];
+          }
+        }, 1500);
+      }
+
+      function validateCountry () {
+        if (!countryValue.value) {
+          countryMessages.value = [{ message: 'Please select a country', type: VALIDATION_MESSAGE_TYPES.CRITICAL }];
+        } else {
+          countryMessages.value = [{ message: 'Country selected', type: VALIDATION_MESSAGE_TYPES.POSITIVE }];
+        }
+      }
+
+      function validateContact (value) {
+        if (!value) {
+          contactMessages.value = [{ message: 'Please select a contact method', type: VALIDATION_MESSAGE_TYPES.CRITICAL }];
+        } else {
+          contactMessages.value = [{ message: 'Contact method selected', type: VALIDATION_MESSAGE_TYPES.POSITIVE }];
+        }
+      }
+
+      function validateInterests (value) {
+        if (!value || value.length === 0) {
+          interestsMessages.value = [{ message: 'Please select at least one interest', type: VALIDATION_MESSAGE_TYPES.CRITICAL }];
+        } else {
+          interestsMessages.value = [{ message: `${value.length} interest(s) selected`, type: VALIDATION_MESSAGE_TYPES.POSITIVE }];
+        }
+      }
+
+      function clearAll () {
+        clearTimeout(usernameTimer);
+        nameValue.value = '';
+        emailValue.value = '';
+        usernameValue.value = '';
+        countryValue.value = '';
+        contactValue.value = '';
+        interestsValue.value = [];
+        nameMessages.value = [];
+        emailMessages.value = [];
+        usernameMessages.value = [];
+        countryMessages.value = [];
+        contactMessages.value = [];
+        interestsMessages.value = [];
+        usernameChecking.value = false;
+      }
+
+      return {
+        nameValue,
+        emailValue,
+        usernameValue,
+        countryValue,
+        contactValue,
+        interestsValue,
+        nameMessages,
+        emailMessages,
+        usernameMessages,
+        countryMessages,
+        contactMessages,
+        interestsMessages,
+        usernameChecking,
+        validateName,
+        validateEmail,
+        validateUsername,
+        validateCountry,
+        validateContact,
+        validateInterests,
+        clearAll,
+      };
+    },
+    template: `
+      <dt-stack direction="column" gap="500" style="max-width: 400px">
+        <dt-input
+          v-model="nameValue"
+          label="Name"
+          placeholder="Enter your name"
+          :messages="nameMessages"
+          @blur="validateName"
+        />
+        <dt-input
+          v-model="emailValue"
+          label="Email"
+          placeholder="Enter your email"
+          type="email"
+          :messages="emailMessages"
+          @blur="validateEmail"
+        />
+        <dt-input
+          v-model="usernameValue"
+          label="Username"
+          placeholder="Enter a username (try 'taken')"
+          :disabled="usernameChecking"
+          :messages="usernameMessages"
+          @blur="validateUsername"
+        />
+        <dt-select-menu
+          v-model="countryValue"
+          label="Country"
+          :messages="countryMessages"
+          :options="[
+            { value: 'ca', label: 'Canada' },
+            { value: 'us', label: 'United States' },
+            { value: 'uk', label: 'United Kingdom' },
+          ]"
+          @update:model-value="validateCountry"
+        />
+        <dt-radio-group
+          v-model="contactValue"
+          name="contact"
+          legend="Preferred contact"
+          :messages="contactMessages"
+          @update:model-value="validateContact"
+        >
+          <dt-radio value="email" label="Email" />
+          <dt-radio value="phone" label="Phone" />
+          <dt-radio value="sms" label="SMS" />
+        </dt-radio-group>
+        <dt-checkbox-group
+          v-model="interestsValue"
+          name="interests"
+          legend="Interests"
+          :messages="interestsMessages"
+          @update:model-value="validateInterests"
+        >
+          <dt-checkbox value="design" label="Design" />
+          <dt-checkbox value="engineering" label="Engineering" />
+          <dt-checkbox value="product" label="Product" />
+        </dt-checkbox-group>
+        <dt-button kind="muted" importance="outlined" @click="clearAll">Clear</dt-button>
+      </dt-stack>
+    `,
+  };
+};
+
+export const InteractiveForm = {
+  render: InteractiveFormTemplate,
+  parameters: {
+    options: { showPanel: false },
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: 'Interactive form to verify VoiceOver announces validation messages (DLT-3430). Enable VoiceOver (Cmd+F5), tab through the fields, and blur each one to trigger messages. The live-region container is always present in the DOM so VoiceOver detects mutations on a stable node.',
+      },
+    },
   },
 };

--- a/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.test.js
+++ b/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.test.js
@@ -73,6 +73,14 @@ describe('Validation Messages Tests', () => {
 
             expect(messages.length).toBe(0);
           });
+
+          it('should keep the live-region container mounted', () => {
+            mockProps = { validationMessages: MOCK_VALIDATION_MESSAGES, showMessages: false };
+
+            updateWrapper();
+
+            expect(wrapper.find('[data-qa="validation-messages-container"]').exists()).toBe(true);
+          });
         });
       });
 

--- a/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.test.js
+++ b/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.test.js
@@ -201,6 +201,12 @@ describe('Validation Messages Tests', () => {
   });
 
   describe('Accessibility Tests', () => {
+    describe('When there are no messages', () => {
+      it('renders the live-region container', () => {
+        expect(wrapper.find('[data-qa="validation-messages-container"]').exists()).toBe(true);
+      });
+    });
+
     describe('When there is a validation message', () => {
       beforeEach(() => {
         mockProps = { validationMessages: MOCK_BASE_VALIDATION_MESSAGES };
@@ -208,14 +214,27 @@ describe('Validation Messages Tests', () => {
         updateWrapper();
       });
 
-      describe('When validation messages are shown', () => {
-        it('has a status role', () => {
-          expect(messages.at(0).attributes('role')).toBe('status');
-        });
+      it('has aria-live set to assertive on the container', () => {
+        expect(wrapper.find('[data-qa="validation-messages-container"]').attributes('aria-live')).toBe('assertive');
+      });
 
-        it('has aria-live set to polite', () => {
-          expect(messages.at(0).attributes('aria-live')).toBe('polite');
-        });
+      it('does not re-mount the live-region container when messages change', async () => {
+        const containerBefore = wrapper.find('[data-qa="validation-messages-container"]').element;
+
+        await wrapper.setProps({ validationMessages: [] });
+        await wrapper.setProps({ validationMessages: MOCK_BASE_VALIDATION_MESSAGES });
+
+        expect(wrapper.find('[data-qa="validation-messages-container"]').element).toBe(containerBefore);
+      });
+    });
+
+    describe('When id prop is provided', () => {
+      it('binds the id to the container', () => {
+        mockProps = { id: 'test-messages-id', validationMessages: MOCK_BASE_VALIDATION_MESSAGES };
+
+        updateWrapper();
+
+        expect(wrapper.find('[data-qa="validation-messages-container"]').attributes('id')).toBe('test-messages-id');
       });
     });
   });

--- a/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.vue
+++ b/packages/dialtone-vue/components/ValidationMessages/ValidationMessages.vue
@@ -1,36 +1,38 @@
 <template>
+  <!-- Live region is always present so VoiceOver can detect mutations on a stable node (DLT-3430). -->
   <div
-    v-if="showMessages && !isFilteredValidationMessagesEmpty"
+    :id="id"
+    aria-live="assertive"
     class="base-input__messages d-validation-message__container"
     data-qa="validation-messages-container"
   >
-    <div
-      v-for="({ message, type }, index) in filteredValidationMessages"
-      :key="getMessageKey(type, index)"
-      role="status"
-      aria-live="polite"
-      data-qa="validation-message"
-      :class="[
-        'base-input__message',
-        'd-validation-message',
-        messageTypeClass(type),
-      ]"
-    >
-      <!-- @slot icon — replaces the default per-type DtIcon. Slot content must be a Dialtone icon (carries
-      the `d-icon` class) so the CSS pseudo-element fallback suppresses correctly. Receives { type } scope. -->
-      <slot
-        name="icon"
-        :type="type"
+    <template v-if="showMessages">
+      <div
+        v-for="({ message, type }, index) in filteredValidationMessages"
+        :key="getMessageKey(type, index)"
+        data-qa="validation-message"
+        :class="[
+          'base-input__message',
+          'd-validation-message',
+          messageTypeClass(type),
+        ]"
       >
-        <component
-          :is="iconForType(type)"
-          :class="['d-validation-message__icon', iconClass]"
-          data-qa="validation-message-icon"
-          size="300"
-        />
-      </slot>
-      <p v-html="message" />
-    </div>
+        <!-- @slot icon — replaces the default per-type DtIcon. Slot content must be a Dialtone icon (carries
+        the `d-icon` class) so the CSS pseudo-element fallback suppresses correctly. Receives { type } scope. -->
+        <slot
+          name="icon"
+          :type="type"
+        >
+          <component
+            :is="iconForType(type)"
+            :class="['d-validation-message__icon', iconClass]"
+            data-qa="validation-message-icon"
+            size="300"
+          />
+        </slot>
+        <p v-html="message" />
+      </div>
+    </template>
   </div>
 </template>
 
@@ -105,10 +107,6 @@ export default {
   },
 
   computed: {
-    isFilteredValidationMessagesEmpty () {
-      return this.filteredValidationMessages.length === 0;
-    },
-
     filteredValidationMessages () {
       return filterFormattedMessages(this.validationMessages);
     },


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExZGZrbDVnNDZnOWJoZGF4aGdwMXpraXo0dXRrZjU5eDZzaHR6bTQ5eCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/b59sth9fCri9y/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3430

## :book: Description

  1. **Always-present live region.** `DtValidationMessages` previously used `v-if` on the outer container, removing it from the DOM when there were no messages. Screen readers register live regions at
   insertion time, so inserting the container and its first message simultaneously caused VoiceOver to miss the mutation. The `v-if` was moved inward to guard only the message content, keeping the
  outer container always in the DOM.

  2. **Removed `role="status"`.** Adding this role appears to cause Safari/VoiceOver to drop announcements. Root cause is unconfirmed, but removing it resolved the issue.

  3. **`aria-invalid` on native controls.** `DtInput`, `DtSelectMenu`, `DtRadio`, `DtCheckbox`, and the `<fieldset>` in `DtInputGroup` (inherited by `DtRadioGroup`/`DtCheckboxGroup`) now set
  `aria-invalid="true"` when the validation state is critical. This improves semantics and ensures VoiceOver announces the field as invalid when the user focuses it, even before the messages are read.

  4. **`aria-describedby` linking controls to messages.** Each control now points to the validation messages container via a stable generated ID, giving screen readers a direct association between the
   field and its error text.

  5. **Interactive form story.** A new Storybook story (`InteractiveForm`) covers all input types — `DtInput`, `DtSelectMenu`, `DtRadioGroup`, and `DtCheckboxGroup` — with live validation triggered on
   blur/change, for manual VoiceOver testing.

## :bulb: Context

VoiceOver was silently ignoring validation messages on all form inputs. Two issues combined to cause this:

1. **Live region not in the DOM at the right time.** `DtValidationMessages` previously used `v-if` on the outer container, so the entire element — including the `aria-live` region — was inserted into the DOM at the same time as the first message. Screen readers register live regions when they first appear in the DOM; inserting the container and its content simultaneously means the reader has no prior awareness of the region and misses the mutation. The fix removes the `v-if` from the outer container so the `aria-live` region is always present. Only the inner message content is conditionally rendered, so VoiceOver observes mutations on a stable, pre-registered node.

2. **`role="status"` preventing announcement in Safari/VoiceOver.** Adding `role="status"` to the live-region container appears to cause VoiceOver on Safari to silently drop announcements. The root cause is not fully confirmed, but removing the role resolved the issue.

## :pencil: Checklist

- [ ] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [ ] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [ ] I have considered the performance impact of my change.
- [ ] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

- I have only tested with VoiceOver (on macOS); I believe NVDA and JAWS are more widely used so it would be great if we could test with other screenreaders. 
- This PR slightly improves accessibility when filling in a form; we might still need to address form submission


## :camera: Screenshots / GIFs

Enable audio in the video player. Notice on the "after" videos that 1) validation messages are announced on blur and on focus; and 2) fields are described as "invalid" when relevant

#### Before 

https://github.com/user-attachments/assets/63bd06df-64bc-4be3-b4be-98e227840abb

#### After (Chrome + VO)

https://github.com/user-attachments/assets/dfdcad05-d84b-4130-a407-5ede24e7bd4b

#### After (Safari + VO)

https://github.com/user-attachments/assets/f6d7d5b8-8c5f-4046-b859-25fb7c8b079f
