### PR TITLE
fix(resizable): DLT-3444 center handle position

### DIFF
--- a/packages/dialtone-vue/components/Resizable/Composables/UseResizableDrag.ts
+++ b/packages/dialtone-vue/components/Resizable/Composables/UseResizableDrag.ts
@@ -14,6 +14,7 @@
 
 import { reactive, onUnmounted, type ComputedRef, type Ref } from 'vue';
 import type { ResizableDirection, ResizablePanelState } from '../ResizableConstants';
+import { RESIZABLE_HANDLE_CENTER_OFFSET_PX } from '../ResizableConstants';
 import type { ResizeHandler } from './UseResizableCalculations';
 
 // ============================================================================
@@ -304,7 +305,7 @@ export function useResizableDrag(options: UseResizableDragOptions) {
     const containerSizeValue = containerSize.value;
     const constrainedCursor = result.constrainedCursorPosition;
     const beforeRight = containerSizeValue - constrainedCursor;
-    const handlePos = constrainedCursor - 2;
+    const handlePos = constrainedCursor - RESIZABLE_HANDLE_CENTER_OFFSET_PX;
 
     const afterRight = containerSizeValue - constrainedCursor - result.afterPanelSize;
 

--- a/packages/dialtone-vue/components/Resizable/Composables/UseResizableKeyboard.ts
+++ b/packages/dialtone-vue/components/Resizable/Composables/UseResizableKeyboard.ts
@@ -3,7 +3,7 @@ import type {
   ResizablePanelState,
   ResizableDirection,
 } from '../ResizableConstants';
-import { MIN_PANEL_SIZE_PX, buildHandleId } from '../ResizableConstants';
+import { MIN_PANEL_SIZE_PX, RESIZABLE_HANDLE_CENTER_OFFSET_PX, buildHandleId } from '../ResizableConstants';
 import { useResizeHandling } from './UseResizableCalculations';
 
 export interface ResizableKeyboardMessages {
@@ -160,7 +160,7 @@ export function useResizableKeyboard(options: ResizableKeyboardOptions) {
     afterEl.style.inlineSize = '';
 
     if (handleEl) {
-      handleEl.style.insetInlineStart = `${Math.max(0, cursorPos - 2)}px`;
+      handleEl.style.insetInlineStart = `${Math.max(0, cursorPos - RESIZABLE_HANDLE_CENTER_OFFSET_PX)}px`;
     }
   }
 

--- a/packages/dialtone-vue/components/Resizable/Resizable.test.js
+++ b/packages/dialtone-vue/components/Resizable/Resizable.test.js
@@ -285,7 +285,7 @@ describe('DtResizable Tests', () => {
         attachTo: document.body,
       });
 
-      const handle = wrapper.find('.d-resizable-handle');
+      const handle = wrapper.find('[data-qa="dt-resizable-handle"]');
       expect(handle.element.style.insetInlineStart).toBe('498px');
     });
   });

--- a/packages/dialtone-vue/components/Resizable/Resizable.test.js
+++ b/packages/dialtone-vue/components/Resizable/Resizable.test.js
@@ -232,4 +232,61 @@ describe('DtResizable Tests', () => {
       expect(emits).toContain('resize-end');
     });
   });
+
+  describe('Handle positioning', () => {
+    it('should center the resting handle over the panel boundary', () => {
+      wrapper = mount(DtResizableHandle, {
+        global: {
+          provide: {
+            [RESIZABLE_CONTEXT_KEY]: {
+              layout: computed(() => ({
+                panels: new Map(),
+                handles: [{
+                  id: 'left:right',
+                  beforePanelId: 'left',
+                  afterPanelId: 'right',
+                  left: 500,
+                  disabled: false,
+                }],
+              })),
+              panels: computed(() => []),
+              panelMap: computed(() => new Map([[
+                'left',
+                {
+                  id: 'left',
+                  pixelSize: 500,
+                  userMinSizePixels: 0,
+                  userMaxSizePixels: 1000,
+                },
+              ]])),
+              direction: computed(() => 'row'),
+              containerSize: computed(() => 1000),
+              isResizing: computed(() => false),
+              activeHandleId: computed(() => undefined),
+              isInitializing: computed(() => false),
+              messages: {},
+              startResize: vi.fn(),
+              resetPanels: vi.fn(),
+              registerHandle: vi.fn(),
+              unregisterHandle: vi.fn(),
+              registerPanel: vi.fn(),
+              unregisterPanel: vi.fn(),
+              saveToStorage: vi.fn(),
+              announce: vi.fn(),
+              offsetHandleStyles: computed(() => ({})),
+              offsetContentStyles: computed(() => ({})),
+              collapsePanel: vi.fn(),
+              emitPanelResize: vi.fn(),
+              commitPanelSize: vi.fn(),
+              updateSavedPanel: vi.fn(),
+            },
+          },
+        },
+        attachTo: document.body,
+      });
+
+      const handle = wrapper.find('.d-resizable-handle');
+      expect(handle.element.style.insetInlineStart).toBe('498px');
+    });
+  });
 });

--- a/packages/dialtone-vue/components/Resizable/Resizable.test.js
+++ b/packages/dialtone-vue/components/Resizable/Resizable.test.js
@@ -11,7 +11,7 @@ import { defineComponent, inject, computed, h } from 'vue';
 import DtResizable from './Resizable.vue';
 import DtResizablePanel from './ResizablePanel.vue';
 import DtResizableHandle from './ResizableHandle.vue';
-import { RESIZABLE_CONTEXT_KEY } from './ResizableConstants';
+import { RESIZABLE_CONTEXT_KEY, RESIZABLE_HANDLE_CENTER_OFFSET_PX } from './ResizableConstants';
 
 // Mock ResizeObserver for test environment
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
@@ -19,6 +19,21 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   unobserve: vi.fn(),
   disconnect: vi.fn(),
 }));
+
+const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+
+function mockClientWidth (width) {
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get () { return width; },
+  });
+}
+
+function restoreClientWidth () {
+  if (originalClientWidth) {
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+  }
+}
 
 // ─── Test child component that reads injected values ────────────────────────
 const InjectionReader = defineComponent({
@@ -46,6 +61,9 @@ const InjectionReader = defineComponent({
 
 let wrapper;
 
+const CONTAINER_WIDTH = 1000;
+const PANEL_BOUNDARY = CONTAINER_WIDTH / 2;
+
 const _setWrapper = (props = {}, slots = {}) => {
   wrapper = mount(DtResizable, {
     props: { ...props },
@@ -57,6 +75,7 @@ const _setWrapper = (props = {}, slots = {}) => {
 describe('DtResizable Tests', () => {
   afterEach(() => {
     wrapper?.unmount();
+    restoreClientWidth();
   });
 
   describe('Presentation', () => {
@@ -234,59 +253,30 @@ describe('DtResizable Tests', () => {
   });
 
   describe('Handle positioning', () => {
-    it('should center the resting handle over the panel boundary', () => {
-      wrapper = mount(DtResizableHandle, {
-        global: {
-          provide: {
-            [RESIZABLE_CONTEXT_KEY]: {
-              layout: computed(() => ({
-                panels: new Map(),
-                handles: [{
-                  id: 'left:right',
-                  beforePanelId: 'left',
-                  afterPanelId: 'right',
-                  left: 500,
-                  disabled: false,
-                }],
-              })),
-              panels: computed(() => []),
-              panelMap: computed(() => new Map([[
-                'left',
-                {
-                  id: 'left',
-                  pixelSize: 500,
-                  userMinSizePixels: 0,
-                  userMaxSizePixels: 1000,
-                },
-              ]])),
-              direction: computed(() => 'row'),
-              containerSize: computed(() => 1000),
-              isResizing: computed(() => false),
-              activeHandleId: computed(() => undefined),
-              isInitializing: computed(() => false),
-              messages: {},
-              startResize: vi.fn(),
-              resetPanels: vi.fn(),
-              registerHandle: vi.fn(),
-              unregisterHandle: vi.fn(),
-              registerPanel: vi.fn(),
-              unregisterPanel: vi.fn(),
-              saveToStorage: vi.fn(),
-              announce: vi.fn(),
-              offsetHandleStyles: computed(() => ({})),
-              offsetContentStyles: computed(() => ({})),
-              collapsePanel: vi.fn(),
-              emitPanelResize: vi.fn(),
-              commitPanelSize: vi.fn(),
-              updateSavedPanel: vi.fn(),
-            },
-          },
-        },
-        attachTo: document.body,
-      });
+    const CenteredHandleLayout = defineComponent({
+      name: 'CenteredHandleLayout',
+      components: { DtResizable, DtResizablePanel, DtResizableHandle },
+      template: `
+        <div style="width: 1000px; height: 400px;">
+          <dt-resizable>
+            <dt-resizable-panel id="left" initial-size="50p" />
+            <dt-resizable-handle />
+            <dt-resizable-panel id="right" initial-size="50p" />
+          </dt-resizable>
+        </div>
+      `,
+    });
+
+    it('should center the resting handle over the panel boundary', async () => {
+      mockClientWidth(CONTAINER_WIDTH);
+
+      wrapper = mount(CenteredHandleLayout, { attachTo: document.body });
+      await wrapper.vm.$nextTick();
 
       const handle = wrapper.find('[data-qa="dt-resizable-handle"]');
-      expect(handle.element.style.insetInlineStart).toBe('498px');
+      expect(handle.element.style.insetInlineStart).toBe(
+        `${PANEL_BOUNDARY - RESIZABLE_HANDLE_CENTER_OFFSET_PX}px`,
+      );
     });
   });
 });

--- a/packages/dialtone-vue/components/Resizable/ResizableConstants.ts
+++ b/packages/dialtone-vue/components/Resizable/ResizableConstants.ts
@@ -175,6 +175,9 @@ export const DEFAULT_PANEL_SIZE = '50p';
 /** Minimum panel size in pixels below which a resize is rejected. */
 export const MIN_PANEL_SIZE_PX = 10;
 
+/** Centers the 4px handle over the panel boundary. */
+export const RESIZABLE_HANDLE_CENTER_OFFSET_PX = 2;
+
 // ─── Storage Adapter ───────────────────────────────────────────────────────
 
 /**

--- a/packages/dialtone-vue/components/Resizable/ResizableHandle.vue
+++ b/packages/dialtone-vue/components/Resizable/ResizableHandle.vue
@@ -2,6 +2,7 @@
   <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
   <div
     ref="handleElement"
+    data-qa="dt-resizable-handle"
     :class="[
       'd-resizable-handle',
       `d-resizable-handle--${direction}`,

--- a/packages/dialtone-vue/components/Resizable/ResizableHandle.vue
+++ b/packages/dialtone-vue/components/Resizable/ResizableHandle.vue
@@ -35,7 +35,7 @@
 
 <script setup>
 import { computed, inject, onMounted, onUnmounted, ref, getCurrentInstance } from 'vue';
-import { RESIZABLE_CONTEXT_KEY, buildHandleId } from './ResizableConstants';
+import { RESIZABLE_CONTEXT_KEY, RESIZABLE_HANDLE_CENTER_OFFSET_PX, buildHandleId } from './ResizableConstants';
 import { pixelsToPercentage } from './ResizableUtils';
 import { useResizableKeyboard } from './Composables/UseResizableKeyboard';
 
@@ -131,7 +131,7 @@ const handleStyles = computed(() => {
   }
 
   return {
-    insetInlineStart: `${Math.max(0, pos.left)}px`,
+    insetInlineStart: `${Math.max(0, pos.left - RESIZABLE_HANDLE_CENTER_OFFSET_PX)}px`,
     visibility: '',
     ...offsetHandleStyles.value,
   };


### PR DESCRIPTION
## Summary

- Add a shared 2px Resizable handle center offset constant.
- Apply the same offset to resting, drag, and keyboard resize handle positioning.
- Add regression coverage for a layout boundary at `left: 500` rendering the handle at `insetInlineStart: 498px`.

## Root Cause

During drag and keyboard resize, the handle was centered over the panel boundary with `panelBoundary - 2`, but the resting layout path used `panelBoundary` directly. Releasing a drag cleared the inline drag style and returned to the layout-driven value, causing a visible 2px jump.

## Validation

- `PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" pnpm exec vitest run components/Resizable/Resizable.test.js components/Resizable/ResizableDrag.test.js components/Resizable/ResizableKeyboard.test.js --test-timeout=10000`
- `git diff --check`
- User tested locally and confirmed the fix works.