### PR TITLE
fix(segmented-control, button): DLT-3446 update disabled active button style

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/layouts/Layout.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/layouts/Layout.vue
@@ -16,17 +16,15 @@
           title="Dialtone homepage"
           to="/"
         >
-          <DtStack direction="row" gap="150">
+          <DtStack direction="row" gap="200">
             <DtIllustration name="dialpad-logo" />
-            <DtBox v-if="showBranchBadge" padding-block-start="100" :title="branchName">
-              <DtBadge>
-                <template #startIcon="{ iconSize }">
-                  <dt-icon-branch :size="iconSize" />
-                </template>
-                <DtText as="p" class="d-wmx-250" truncate>
+            <DtBox v-if="showBranchBadge" padding-block-start="200" :title="branchName">
+              <DtStack direction="row" gap="50">
+                <dt-icon-branch class="d-fc-muted" :size="100" />
+                <DtText as="p" kind="body" size="100" tone="muted" class="d-wmx-250" truncate>
                   {{ branchName }}
                 </DtText>
-              </DtBadge>
+              </DtStack>
             </DtBox>
           </DtStack>
         </router-link>

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -129,13 +129,21 @@
     transition: none;
     pointer-events: none;
 
-    &.d-btn--primary {
+    &:is(.d-btn--primary) {
       --opacity-adjust-text: 80%;
     }
 
-    &.d-btn--muted {
+    &:is(.d-btn--muted) {
       --opacity-adjust-text: 50%;
-      --opacity-adjust-border: 50%;
+      --opacity-adjust-border: 60%;
+    }
+
+    &:is(.d-btn--active.d-btn--outlined) {
+      --button-color-background: var(--dt-action-color-background-muted-active);
+    }
+
+    &:is(.d-btn--active.d-btn--muted) {
+      --button-color-background: var(--dt-action-color-background-muted-active);
     }
   }
 }

--- a/packages/dialtone-css/lib/build/less/components/button.less
+++ b/packages/dialtone-css/lib/build/less/components/button.less
@@ -113,39 +113,6 @@
     box-shadow: var(--dt-shadow-focus);
   }
 
-  &--disabled,
-  &:disabled {
-    --chroma-adjust-text: .08;
-    --chroma-adjust-background: .08;
-    --chroma-adjust-border: .08;
-    --opacity-adjust-text: 65%;
-    --opacity-adjust-background: 65%;
-    --opacity-adjust-border: 40%;
-
-    color:            color-mix(in oklch, oklch( from var(--button-color-text)       l calc(c - var(--chroma-adjust-text)) h ) var(--opacity-adjust-text), transparent );
-    background-color: color-mix(in oklch, oklch( from var(--button-color-background) l calc(c - var(--chroma-adjust-background)) h ) var(--opacity-adjust-background), transparent );
-    border-color:     color-mix(in oklch, oklch( from var(--button-color-border)     l calc(c - var(--chroma-adjust-border)) h ) var(--opacity-adjust-border), transparent );
-    cursor: not-allowed;
-    transition: none;
-    pointer-events: none;
-
-    &:is(.d-btn--primary) {
-      --opacity-adjust-text: 80%;
-    }
-
-    &:is(.d-btn--muted) {
-      --opacity-adjust-text: 50%;
-      --opacity-adjust-border: 60%;
-    }
-
-    &:is(.d-btn--active.d-btn--outlined) {
-      --button-color-background: var(--dt-action-color-background-muted-active);
-    }
-
-    &:is(.d-btn--active.d-btn--muted) {
-      --button-color-background: var(--dt-action-color-background-muted-active);
-    }
-  }
 }
 
 ._btn-circle() {
@@ -213,6 +180,36 @@
 .d-btn,
 .d-btn--md {
   ._btn();
+}
+
+.d-btn:where(.d-btn--disabled, :disabled),
+.d-btn--md:where(.d-btn--disabled, :disabled) {
+  --chroma-adjust-text: .08;
+  --chroma-adjust-background: .08;
+  --chroma-adjust-border: .08;
+  --opacity-adjust-text: 65%;
+  --opacity-adjust-background: 65%;
+  --opacity-adjust-border: 40%;
+
+  color:            color-mix(in oklch, oklch( from var(--button-color-text)       l calc(c - var(--chroma-adjust-text)) h ) var(--opacity-adjust-text), transparent );
+  background-color: color-mix(in oklch, oklch( from var(--button-color-background) l calc(c - var(--chroma-adjust-background)) h ) var(--opacity-adjust-background), transparent );
+  border-color:     color-mix(in oklch, oklch( from var(--button-color-border)     l calc(c - var(--chroma-adjust-border)) h ) var(--opacity-adjust-border), transparent );
+  cursor: not-allowed;
+  transition: none;
+  pointer-events: none;
+
+  &:where(.d-btn--primary) {
+    --opacity-adjust-text: 80%;
+  }
+
+  &:where(.d-btn--muted) {
+    --opacity-adjust-text: 50%;
+    --opacity-adjust-border: 60%;
+  }
+
+  &:where(.d-btn--active):where(.d-btn--outlined, .d-btn--muted) {
+    --button-color-background: var(--dt-action-color-background-muted-active);
+  }
 }
 
 .d-btn--unstyled {

--- a/packages/dialtone-css/lib/build/less/components/chip.less
+++ b/packages/dialtone-css/lib/build/less/components/chip.less
@@ -115,6 +115,38 @@
   }
 }
 
+// This is gnerally redundant since the button mixin already handles disabled states
+// but keeping it here for explicit chip close button styling.
+// PLUS it may be simplified outright with a Chip redesign/refactor incoming soon.
+.d-chip__close:where(.d-chip__close--disabled, :disabled) {
+  --chroma-adjust-text: .08;
+  --chroma-adjust-background: .08;
+  --chroma-adjust-border: .08;
+  --opacity-adjust-text: 65%;
+  --opacity-adjust-background: 65%;
+  --opacity-adjust-border: 40%;
+
+  color:            color-mix(in oklch, oklch( from var(--button-color-text)       l calc(c - var(--chroma-adjust-text)) h ) var(--opacity-adjust-text), transparent );
+  background-color: color-mix(in oklch, oklch( from var(--button-color-background) l calc(c - var(--chroma-adjust-background)) h ) var(--opacity-adjust-background), transparent );
+  border-color:     color-mix(in oklch, oklch( from var(--button-color-border)     l calc(c - var(--chroma-adjust-border)) h ) var(--opacity-adjust-border), transparent );
+  cursor: not-allowed;
+  transition: none;
+  pointer-events: none;
+
+  &:where(.d-btn--primary) {
+    --opacity-adjust-text: 80%;
+  }
+
+  &:where(.d-btn--muted) {
+    --opacity-adjust-text: 50%;
+    --opacity-adjust-border: 60%;
+  }
+
+  &:where(.d-btn--active):where(.d-btn--outlined, .d-btn--muted) {
+    --button-color-background: var(--dt-action-color-background-muted-active);
+  }
+}
+
 .d-chip__icon {
   --chip-icon-size: calc(var(--dt-layout-25) * 1.25);
 

--- a/packages/dialtone-css/lib/build/less/components/chip.less
+++ b/packages/dialtone-css/lib/build/less/components/chip.less
@@ -115,9 +115,9 @@
   }
 }
 
-// This is gnerally redundant since the button mixin already handles disabled states
-// but keeping it here for explicit chip close button styling.
-// PLUS it may be simplified outright with a Chip redesign/refactor incoming soon.
++// Explicit disabled styling for chip close button.
++// This duplicates the button disabled logic since the ._btn() mixin no longer includes disabled state handling.
++// PLUS it may be simplified with upcoming Chip redesign/refactor
 .d-chip__close:where(.d-chip__close--disabled, :disabled) {
   --chroma-adjust-text: .08;
   --chroma-adjust-background: .08;

--- a/packages/dialtone-css/lib/build/less/components/chip.less
+++ b/packages/dialtone-css/lib/build/less/components/chip.less
@@ -115,9 +115,9 @@
   }
 }
 
-+// Explicit disabled styling for chip close button.
-+// This duplicates the button disabled logic since the ._btn() mixin no longer includes disabled state handling.
-+// PLUS it may be simplified with upcoming Chip redesign/refactor
+// Explicit disabled styling for chip close button.
+// This duplicates the button disabled logic since the ._btn() mixin no longer includes disabled state handling.
+// PLUS it may be simplified with upcoming Chip redesign/refactor
 .d-chip__close:where(.d-chip__close--disabled, :disabled) {
   --chroma-adjust-text: .08;
   --chroma-adjust-background: .08;


### PR DESCRIPTION
<img width="177" height="142" alt="image" src="https://github.com/user-attachments/assets/46b3022a-2285-47f9-bbeb-bfc0748db566" />

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

DLT-3446

## :book: Description

A DtButton that is active while disabled completely removes background color. Segmented Control item is a DtButton. 

- Updated CSS to account for this. 
- Also piggy-backed in a basic simplification of the doc site's branch name in header. 

https://github.com/user-attachments/assets/c663e0c4-7a23-4c62-beea-27d33787b5fa

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.