### PR TITLE
fix(combinator): DLT-3171 update v-model bindings from rendered component events

### DIFF
--- a/packages/combinator/src/components/combinator.test.js
+++ b/packages/combinator/src/components/combinator.test.js
@@ -2,8 +2,14 @@ import DtcCombinator from './combinator.vue';
 
 import { assert } from 'chai';
 import { shallowMount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import { getSupportedComponents } from '@/src/lib/test/utils_test';
-import documentation from '@/node_modules/@dialpad/dialtone-vue/dist/component-documentation.json';
+import { DtInput, DtToggle } from '@dialpad/dialtone-vue';
+import allDocs from '@/node_modules/@dialpad/dialtone-vue/dist/component-documentation.json';
+
+const documentation = allDocs;
+const toggleDoc = allDocs.find(d => d.displayName === 'DtToggle');
+const inputDoc = allDocs.find(d => d.displayName === 'DtInput');
 
 describe('combinator.vue test', function () {
   const testComponents = getSupportedComponents();
@@ -30,6 +36,80 @@ describe('combinator.vue test', function () {
         it('Should render successfully', function () {
           assert.isTrue(wrapper.exists());
         });
+      });
+    });
+  });
+
+  describe('v-model writeback', function () {
+    describe('boolean modelValue (DtToggle)', function () {
+      beforeEach(function () {
+        wrapper = shallowMount(DtcCombinator, {
+          props: {
+            component: DtToggle,
+            documentation: toggleDoc,
+            variants: {},
+          },
+        });
+      });
+
+      afterEach(function () {
+        wrapper.unmount();
+      });
+
+      it('updates options.props when the renderer emits an update:modelValue event', async function () {
+        const renderer = wrapper.findComponent({ name: 'DtcRenderer' });
+        const initialValue = renderer.props('options').props.modelValue;
+
+        await renderer.vm.$emit('event', 'update:modelValue', !initialValue);
+        await nextTick();
+
+        assert.strictEqual(renderer.props('options').props.modelValue, !initialValue);
+      });
+
+      it('does not mutate options.props for non-update events (e.g. "change")', async function () {
+        const renderer = wrapper.findComponent({ name: 'DtcRenderer' });
+        const before = JSON.stringify(renderer.props('options').props);
+
+        await renderer.vm.$emit('event', 'change', 'something');
+        await nextTick();
+
+        assert.strictEqual(JSON.stringify(renderer.props('options').props), before);
+      });
+    });
+
+    describe('string modelValue (DtInput)', function () {
+      beforeEach(function () {
+        wrapper = shallowMount(DtcCombinator, {
+          props: {
+            component: DtInput,
+            documentation: inputDoc,
+            variants: {},
+          },
+        });
+      });
+
+      afterEach(function () {
+        wrapper.unmount();
+      });
+
+      it('updates options.props when the renderer emits an update:modelValue event', async function () {
+        const renderer = wrapper.findComponent({ name: 'DtcRenderer' });
+
+        await renderer.vm.$emit('event', 'update:modelValue', 'hello');
+        await nextTick();
+
+        assert.strictEqual(renderer.props('options').props.modelValue, 'hello');
+      });
+
+      it('reflects subsequent updates (simulates typing character by character)', async function () {
+        const renderer = wrapper.findComponent({ name: 'DtcRenderer' });
+
+        for (const value of ['h', 'he', 'hel', 'hell', 'hello']) {
+          await renderer.vm.$emit('event', 'update:modelValue', value);
+          await nextTick();
+        }
+
+        assert.strictEqual(renderer.props('options').props.modelValue, 'hello');
       });
     });
   });

--- a/packages/combinator/src/components/combinator.vue
+++ b/packages/combinator/src/components/combinator.vue
@@ -122,6 +122,7 @@
         :options="options"
         :library="library"
         :disabled-members="disabledMembers"
+        @event="onComponentEvent"
       />
       <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
       <div
@@ -353,6 +354,23 @@ const settings = computedModel(
 );
 
 watch(() => settings.value.root.theme, clearTokenCache);
+
+/**
+ * Handles events emitted by the rendered target component.
+ * For v-model events (`update:<prop>`), writes the new value back into the
+ * reactive options model so the preview and the generated code stay in sync.
+ *
+ * @param {string} name - The emitted event name (e.g. 'update:modelValue').
+ * @param {*} value - The emitted value.
+ */
+function onComponentEvent (name, value) {
+  if (!name?.startsWith('update:')) return;
+  const prop = name.slice('update:'.length);
+  options.value = (model) => {
+    if (model.props && prop in model.props) model.props[prop] = value;
+    else if (model.attributes && prop in model.attributes) model.attributes[prop] = value;
+  };
+}
 
 function updateVariant (e) {
   _presetChanging = true;


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExZWw5YnowZ2p6bDNndTlvZW1vYXoyOHRsbGVpbGtkcTA5MGMwbWp6diZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3ohzdFHDBEG32PmWJO/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

[DLT-3171](https://dialpad.atlassian.net/browse/DLT-3171)

## :book: Description

Adds an `@event` listener to `<dtc-renderer>` in `combinator.vue` and a handler (`onComponentEvent`) that writes `update:<prop>` events back into the reactive options model via the existing `computedModel` setter. For any `update:*` event (e.g. `update:modelValue`, `update:open`), the emitted value is written to the matching key in `options.props` or `options.attributes`, completing the v-model loop and keeping the live preview and generated code snippet in sync.

Also adds unit tests to `combinator.test.js` covering boolean (DtToggle) and string (DtInput) modelValue writebacks, and a guard asserting that non-`update:` events (e.g. `change`) do not mutate options.

## :bulb: Context

v-model–driven components rendered in the Combinator playground were controlled but had no writeback path — clicking them had no visible effect. The emitted `update:modelValue` event was captured by `renderer_target.vue`, bubbled through `renderer.vue`, and silently dropped at `combinator.vue` because no `@event` listener existed. `options.bindings` only exposed `.get()`, never a write path, so `modelValue` was frozen at its initial value.

The ticket attributed the bug to the event-name → handler-key conversion (`on${capitalize(name)}`), but investigation confirmed that conversion already produces the correct key for all event name forms (verified against Vue 3.5's `emit` resolution in `@vue/runtime-core`). The sole root cause was the missing listener and writeback.

## :camera: Before / After

**Before**

Changing Model Value in the Props panel updates the component, but the opposite doesn't happen (component interaction doesn't update Model Value).

https://github.com/user-attachments/assets/552c0fbe-4bc1-4d5c-aa58-6ae572176eb1

https://github.com/user-attachments/assets/faa45a39-8a87-4cbd-902b-43f44ae19c71

**After**

Both directions work (component interaction now updates Model Value).

https://github.com/user-attachments/assets/bd05f56d-46bc-450c-a12e-781916cb22b0

https://github.com/user-attachments/assets/473c9cab-e253-49d5-ac53-6929783e8623

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.


[DLT-3171]: https://dialpad.atlassian.net/browse/DLT-3171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ