### PR TITLE
fix(documentation): DLT-3451 migrate stale @change/@input handlers to @update:model-value

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleRichTextEditor.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleRichTextEditor.vue
@@ -23,7 +23,7 @@
     :allow-underline="$attrs.allowUnderline"
     :additional-extensions="$attrs.additionalExtensions"
     @blur="$attrs.onBlur"
-    @input="$attrs.onInput"
+    @update:model-value="$attrs.onInput"
     @focus="$attrs.onFocus"
     @enter="$attrs.onEnter"
   />

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Sidebar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Sidebar.vue
@@ -15,7 +15,7 @@
         aria-label="Search"
         placeholder="Search"
         type="search"
-        @input="focusedIndex = -1"
+        @update:model-value="focusedIndex = -1"
       >
         <template #startIcon="{ iconSize }">
           <dt-icon name="search" :size="iconSize" />

--- a/apps/dialtone-documentation/docs/foundations/icons/usage/index.md
+++ b/apps/dialtone-documentation/docs/foundations/icons/usage/index.md
@@ -29,8 +29,8 @@ For detailed instructions on using the icons, check the [DtIcon component](/comp
     <div class="d-fl-center">
       <dt-icon :name="selectedIcon" :size="selectedSize" />
     </div>
-    <dt-select-menu label="Name" :options="iconListOptions" @change="changeIcon" />
-    <dt-select-menu label="Size" :options="sizeValues" @change="changeIconSize" />
+    <dt-select-menu label="Name" :options="iconListOptions" @update:model-value="changeIcon" />
+    <dt-select-menu label="Size" :options="sizeValues" @update:model-value="changeIconSize" />
   </div>
 </code-well-header>
 </div>


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2toZ3ExamNkY2J6ZnRqbnYxc2Y4MHlnOWs3ZDY4bThkNmM1cDZubCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3rgXBGYrye5vSfhMdO/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

[DLT-3451](https://dialpad.atlassian.net/browse/DLT-3451)

## :book: Description

In Vue 3, `v-model` on a component binds to a prop named `modelValue` and listens for an `update:modelValue` event — components do not emit native-style `change` or `input` events. Dialtone form components follow this standard. Three places in the docs site had stale listeners using the old event names, making those handlers dead code that never fired:

- `docs/foundations/icons/usage/index.md` — two `<dt-select-menu @change>` handlers controlling the icon name/size preview selects. The icon preview was frozen regardless of what the user picked. **This is the only instance with _user-visible_ issues**
- `.vuepress/exampleComponents/ExampleRichTextEditor.vue` — `<dt-rich-text-editor @input>` forwarding a parent listener via `$attrs`.
- `.vuepress/theme/components/Sidebar.vue` — `<dt-input @input>` resetting keyboard focus index on each search keystroke.

All three replaced with `@update:model-value`. Handlers required no changes — they already expected a value argument, not a DOM event.

## :bulb: Context

These usages pre-date DLT-3160, which standardised all Dialtone form component events around the Vue 3 v-model contract. The docs site had a handful of survivors; this cleans up the remaining ones on the `next` branch.

The migration guide "Before" examples (`docs/guides/migration/component-props/index.md` lines 453–460) and the `<dt-tab-group @change>` in `CodeExampleTabs.vue` are intentionally left as-is — the former is teaching content, the latter is a legitimate component emit (`DtTabGroup` explicitly emits `change`).

**Scope vs. the attached plan**

The plan projected ~30 replacements across ~5 files. The actual count was 4 lines across 3 files — the bulk (`docs/scratch.md` with 27 occurrences, `docs/guides/theme-and-mode/index.md` with 2) had already been cleaned up in earlier PRs on `next`. `ExampleRichTextEditor.vue` was not in the plan but was found during the audit and included here.

**Why the migration script wasn't used**

`dialtone-migrate-props` was not used because it would have rewritten the intentional "Before" examples in the migration guide alongside the real fixes, requiring manual revert. With only 4 lines to change, manual edits were the safer and faster approach.

## 📷 Before / After

**Before**

https://github.com/user-attachments/assets/19871ce9-5411-41aa-b150-3d2aa61c3980

**After**

https://github.com/user-attachments/assets/fe71029c-8a96-4b22-bb41-5b673f203397

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.


[DLT-3451]: https://dialpad.atlassian.net/browse/DLT-3451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ