### PR TITLE
fix(combinator): DLT-3232 pass app context to renderer target for directive resolution

### DIFF
--- a/packages/combinator/src/components/renderer/renderer_target.vue
+++ b/packages/combinator/src/components/renderer/renderer_target.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup>
-import { capitalize, computed, h, nextTick, onMounted, onUpdated, ref, render, useSlots } from 'vue';
+import { capitalize, computed, getCurrentInstance, h, nextTick, onMounted, onUpdated, ref, render, useSlots } from 'vue';
 import { DtNotice } from '@dialpad/dialtone-vue';
 
 const ERROR_MESSAGE = 'Invalid combination';
@@ -49,6 +49,11 @@ const emit = defineEmits([
 ]);
 
 const slots = useSlots();
+
+// Standalone render() creates an app-less context; attaching appContext here
+// lets the target component and all its children (including DtcNode slots)
+// resolve globally registered components, directives, and provides.
+const { appContext } = getCurrentInstance();
 
 /**
  * Map object containing events and their respective handlers.
@@ -114,11 +119,13 @@ function renderTarget () {
   const slotKey = Object.keys(slots).sort().join(',');
 
   try {
-    render(h(props.component, {
+    const vnode = h(props.component, {
       ...filteredBindings,
       ...events.value,
       key: slotKey,
-    }, slots), currentContainer);
+    }, slots);
+    vnode.appContext = appContext;
+    render(vnode, currentContainer);
   } catch (e) {
     console.warn('Rendering warning: \n', e);
     currentContainer = freshContainer();

--- a/packages/combinator/src/components/tools/node.test.js
+++ b/packages/combinator/src/components/tools/node.test.js
@@ -1,0 +1,62 @@
+import DtcNode from './node.vue';
+
+import { expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+describe('node.vue test', function () {
+  describe('When a globally registered directive is used in the slot template', function () {
+    let wrapper;
+    let mountedSpy;
+
+    beforeEach(function () {
+      mountedSpy = { called: false };
+
+      wrapper = mount(DtcNode, {
+        props: {
+          template: '<div v-x-test></div>',
+        },
+        global: {
+          directives: {
+            'x-test': {
+              mounted () { mountedSpy.called = true; },
+            },
+          },
+        },
+      });
+    });
+
+    afterEach(function () {
+      wrapper.unmount();
+    });
+
+    it('Should fire the directive mounted hook', function () {
+      expect(mountedSpy.called).toBe(true);
+    });
+  });
+
+  describe('When a component is passed via the library prop', function () {
+    let wrapper;
+
+    beforeEach(function () {
+      const StubComponent = {
+        name: 'StubComponent',
+        template: '<span class="stub-rendered">stub</span>',
+      };
+
+      wrapper = mount(DtcNode, {
+        props: {
+          template: '<stub-component />',
+          library: { StubComponent },
+        },
+      });
+    });
+
+    afterEach(function () {
+      wrapper.unmount();
+    });
+
+    it('Should render the library component', function () {
+      expect(wrapper.find('.stub-rendered').exists()).toBe(true);
+    });
+  });
+});

--- a/packages/combinator/src/variants/variants_box.js
+++ b/packages/combinator/src/variants/variants_box.js
@@ -90,16 +90,28 @@ export default {
     },
   },
 
-  'sized': {
+  'fixed height with scrollbar': {
     props: {
       padding: { initialValue: '200' },
       surface: { initialValue: 'moderate' },
       borderWidth: { initialValue: '100' },
       inlineSize: { initialValue: '500' },
       blockSize: { initialValue: '600' },
+      scrollbar: { initialValue: 'always' },
     },
     slots: {
-      default: { initialValue: 'Fixed size' },
+      default: { initialValue: `<dt-stack gap="200">
+  <dt-text as="p" kind="body" size="200">Paragraph 1: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</dt-text>
+  <dt-text as="p" kind="body" size="200">Paragraph 2: Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</dt-text>
+  <dt-text as="p" kind="body" size="200">Paragraph 3: Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</dt-text>
+  <dt-text as="p" kind="body" size="200">Paragraph 4: Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</dt-text>
+  <dt-text as="p" kind="body" size="200">Paragraph 5: Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.</dt-text>
+  <dt-text as="p" kind="body" size="200">Paragraph 6: Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit.</dt-text>
+  <dt-text as="p" kind="body" size="200">Paragraph 7: Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.</dt-text>
+  <dt-text as="p" kind="body" size="200">Paragraph 8: Ut labore et dolore magnam aliquam quaerat voluptatem.</dt-text>
+  <dt-text as="p" kind="body" size="200">Paragraph 9: Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur.</dt-text>
+  <dt-text as="p" kind="body" size="200">Paragraph 10: At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum.</dt-text>
+</dt-stack>` },
     },
   },
 


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3232

## :book: Description

Single-file change to `packages/combinator/src/components/renderer/renderer_target.vue`. Before calling Vue's standalone `render()`, we now attach the app's context to the vnode so the entire target render tree has access to globally registered directives, components, and provides.

## :bulb: Context

`renderer_target.vue` renders the playground component via Vue's standalone `render(vnode, container)` function. The side effect is that standalone `render()` creates an app-less context: globally registered directives, components, and provides are invisible to the entire target render tree. Any `v-dt-*` directive typed into the slot editor silently fails.

**Why `appContext.directives`:** Each `*Directive` export is a Vue plugin — an object with an `install(app)` method — not a directive definition you can use directly. The actual hooks (`mounted`, `updated`, `unmounted`) are only created when `app.use()` calls `install()`, so they don't exist until the app boots. After that, `appContext.directives` is the only place they live, keyed by the name the runtime compiler looks up (`dt-scrollbar` for `v-dt-scrollbar`).

Attaching `appContext` to the vnode fixes the root cause. Vue's `createComponentInstance` picks it up from the vnode when there's no parent, and all children in the tree inherit it from there. This means `resolveDirective` now works correctly throughout — not just for directives, but for anything relying on the app context.

As a side effect, the pre-existing `[Vue warn]: Failed to resolve directive: dt-scrollbar at <DtBox>` warning (from DtBox's own compiled template) also disappears.

## 📷 Before / After

**Before** No scrollbar added

https://github.com/user-attachments/assets/7823e704-5cdb-4d20-8a93-3ac521a2b705

**After** Scrollbar added via directive

https://github.com/user-attachments/assets/15bc97e9-fddf-4256-a438-6c10b818689e

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description.
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.
- [x] I have added / updated unit tests.

## :crystal_ball: Next Steps

**Testing infrastructure:** A unit test (`node.test.js`) is included but currently unrunnable. The entire combinator test suite (18 existing files + this new one) seems broken: `@vue/test-utils` is not declared in `devDependencies` and `mochapack`/`vue-cli-service test:unit` can't resolve it under pnpm. There is also no NX `test` target in `project.json`, so tests don't run in CI either. The fix is a standalone migration to Vitest.