### PR TITLE
feat(whats-new): DLT-3450 show author photos from GitHub avatars

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/BlogPost.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/BlogPost.vue
@@ -23,6 +23,8 @@
           :size="300"
           :seed="author"
           :full-name="author"
+          :image-src="avatarSrc"
+          :image-alt="`${author} avatar`"
         />
         <dt-stack>
           <dt-text :size="200" kind="label" tone="secondary" density="200">
@@ -56,8 +58,9 @@
 import { format } from 'date-fns';
 import { computed } from 'vue';
 import CopyButton from './CopyButton.vue';
+import { authorAvatarUrl } from './authorHandles.js';
 
-defineProps({
+const props = defineProps({
   posted: {
     type: Date,
     required: true,
@@ -79,6 +82,8 @@ defineProps({
     default: '',
   },
 });
+
+const avatarSrc = computed(() => authorAvatarUrl(props.author));
 
 const blogLink = computed(() => {
   return window.location.href;

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/authorHandles.js
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/authorHandles.js
@@ -1,0 +1,21 @@
+export const authorHandles = {
+  'Brad Paugh': 'braddialpad',
+  'Francis Rupert': 'francisrupert',
+  'Tico Ortega': 'juliodialpad',
+  'Nina Repetto': 'ninarepetto',
+  'Yorbi Barriento': 'yorbi-dp',
+  'Julio Ortega': 'juliodialpad',
+  'Federico Sarassola': 'fede-dp',
+  'Josh Everhart': 'jeverhart-dialpad',
+  'Joshua Hynes': 'hynes-dialpad',
+  'Belu Montoya': 'belumontoya',
+  'Ignacio Ropolo': 'iropolo',
+  'Paulo Reis': 'paulojreis-dialpad',
+};
+
+// Returns the GitHub avatar URL for an author, or '' if unmapped.
+// '' means DtAvatar renders seeded initials (the unmapped fallback).
+export function authorAvatarUrl (author) {
+  const handle = authorHandles[author];
+  return handle ? `https://github.com/${handle}.png` : '';
+}


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWd1ajJwMTF6cnhscXhyYjFyN3NoODEwN2d3YXByZDNzejRiaWo3OCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/eU2sRBEme4GIM/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3450

## :book: Description

- New `authorHandles.js` file mapping author display names (used in post frontmatter) to GitHub handles.
- `BlogPost.vue` now passes `:image-src` to `DtAvatar`, pulling the photo from `https://github.com/<handle>.png` at render time.
- Both fallbacks are covered: unmapped authors (no handle in the map) and failed image loads both silently fall back to the existing colored-initials behavior via `DtAvatar`'s built-in error handling.

## :bulb: Context

The What's New blog was rendering every author as colored initials. This switches to real GitHub profile photos, with no changes to post frontmatter, no build-time fetches, no API keys, and no in-repo photo hosting.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description.
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

- I couldn't find a GitHub handle for Tico Ortega, and then it occurred to me "Wait, is Tico Ortega = Julio Ortega?". I assumed so, so both point to `juliodialpad`. Correct me if I'm wrong
- If it's indeed the same person, should we change the posts to have a consistent author? Which name would we prefer?
- To add a future author: add one line in `authorHandles.js`, `'Display Name': 'github-handle'`.

## :camera: Screenshots / GIFs

**Before**

What's new?

<img width="1064" height="1066" alt="image" src="https://github.com/user-attachments/assets/96776bc6-1408-453c-ba13-65221ada4d0f" />

Individual post

<img width="952" height="595" alt="image" src="https://github.com/user-attachments/assets/ba6b3893-0dbc-4611-9843-99a1374fe97e" />


**After**

What's new?

<img width="1087" height="1067" alt="image" src="https://github.com/user-attachments/assets/d15a33f9-7099-4828-b98e-3c926bb86042" />

Individual post

<img width="931" height="587" alt="image" src="https://github.com/user-attachments/assets/a982583e-994c-4622-8c36-5442992e867f" />

