### PR TITLE
feat(dialtone-icons): NO-JIRA add /vue export to dialtone-icon

### DIFF
--- a/packages/dialtone-icons/package.json
+++ b/packages/dialtone-icons/package.json
@@ -12,7 +12,26 @@
       "import": "./vue3/dist/dialtone-icons.js",
       "require": "./vue3/dist/dialtone-icons.cjs"
     },
+    "./vue": {
+      "types": "./vue3/dist/types/index.d.ts",
+      "import": "./vue3/dist/dialtone-icons.js",
+      "require": "./vue3/dist/dialtone-icons.cjs"
+    },
     "./vue3/*": {
+      "types": [
+        "./vue3/dist/types/src/icons/*.vue.d.ts",
+        "./vue3/dist/types/src/illustrations/*.vue.d.ts"
+      ],
+      "import": [
+        "./vue3/dist/components/icons/*.js",
+        "./vue3/dist/components/illustrations/*.js"
+      ],
+      "require": [
+        "./vue3/dist/components/icons/*.cjs",
+        "./vue3/dist/components/illustrations/*.cjs"
+      ]
+    },
+    "./vue/*": {
       "types": [
         "./vue3/dist/types/src/icons/*.vue.d.ts",
         "./vue3/dist/types/src/illustrations/*.vue.d.ts"


### PR DESCRIPTION
# add /vue export to dialtone-icon

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Feature


## :book: Description

If we follow the migration guide to refactor every `vue3` -> `vue`.
the icons coming from `import { DtIconChevronUp } from '@dialpad/dialtone-icons/vue';` stop working.
Because dialtone-icons does not export to `/vue`. 
Then we need to add `"@dialpad/dialtone-icons": "4.52.1-next.1",` dependency which we don't want.

With this fix we will be able to import dialtone-icons similar to what we do for components.
`/vue3` (backward compatibility and `/vue` (new standard)
