### PR TITLE
feat(banner): DLT-3454 trap focus with v-dt-focustrap directive

### DIFF
--- a/apps/dialtone-documentation/docs/components/banner.md
+++ b/apps/dialtone-documentation/docs/components/banner.md
@@ -46,11 +46,11 @@ Banners are a type of notice and so you can use the following [Notice](notice.md
 ```
 
 <dt-banner
+  v-if="shownBanner === 'example-kind'"
   :pinned="pinned"
   :important="important"
   :kind="selectedKind"
   header-text="Optional banner title"
-  v-show="shownBanner === 'example-kind'"
   @close="closeBanner"
 >
   Message body
@@ -110,6 +110,12 @@ Pins the banner to the top of the window.
 <component-class-table component-name="banner"></component-class-table>
 
 ## Accessibility
+
+### Focus management
+
+When `important` is set, the banner is presented as a modal `alertdialog`: keyboard focus moves to the first focusable element when it appears, stays trapped within the banner while it is shown, and returns to the previously focused element when the banner is dismissed. Reserve `important` for messages that must block the rest of the page until they are addressed.
+
+Non-important banners use the `status` role and do **not** trap focus — keyboard users can Tab straight through them.
 
 <component-accessible-table component-name="banner"></component-accessible-table>
 

--- a/packages/dialtone-vue/components/Banner/Banner.test.js
+++ b/packages/dialtone-vue/components/Banner/Banner.test.js
@@ -39,6 +39,10 @@ describe('DtBanner Tests', () => {
   });
 
   afterEach(() => {
+    // Tear down the mounted instance so it doesn't stay attached to document.body
+    // after the final test. Null it so updateWrapper's unmount-first is a no-op next run.
+    wrapper?.unmount();
+    wrapper = null;
     mockProps = {};
     mockSlots = {};
   });

--- a/packages/dialtone-vue/components/Banner/Banner.test.js
+++ b/packages/dialtone-vue/components/Banner/Banner.test.js
@@ -1,0 +1,184 @@
+import { mount } from '@vue/test-utils';
+import { flushPromises } from '@/common/utils';
+import { DtFocustrapDirective } from '@/directives/focustrap_directive';
+import DtBanner from './Banner.vue';
+
+const MOCK_ACTION_SLOT = '<a href="#" data-qa="banner-action">Action</a>';
+
+const baseProps = {};
+const baseSlots = {};
+
+let mockProps = {};
+let mockSlots = {};
+
+describe('DtBanner Tests', () => {
+  let wrapper;
+  let banner;
+  let dialog;
+
+  const updateWrapper = () => {
+    // Unmount any previous instance first: focus tests attach to document.body,
+    // so leftover nodes would leak across tests.
+    wrapper?.unmount();
+    wrapper = mount(DtBanner, {
+      props: { ...baseProps, ...mockProps },
+      slots: { ...baseSlots, ...mockSlots },
+      global: { plugins: [DtFocustrapDirective] },
+      attachTo: document.body,
+    });
+
+    banner = wrapper.find('[data-qa="dt-banner"]');
+    dialog = wrapper.find('[data-qa="dt-banner-dialog"]');
+  };
+
+  const actionEl = () => wrapper.find('[data-qa="banner-action"]').element;
+  const closeEl = () => wrapper.find('[data-qa="dt-notice-action-close-button"]').element;
+
+  beforeEach(() => {
+    updateWrapper();
+  });
+
+  afterEach(() => {
+    mockProps = {};
+    mockSlots = {};
+  });
+
+  describe('Presentation Tests', () => {
+    it('should render the banner and its dialog', () => {
+      expect(banner.exists()).toBe(true);
+      expect(dialog.exists()).toBe(true);
+    });
+
+    it('should render default slot content', () => {
+      mockSlots = { default: '<p data-qa="banner-body">Body</p>' };
+
+      updateWrapper();
+
+      expect(wrapper.find('[data-qa="banner-body"]').text()).toBe('Body');
+    });
+  });
+
+  describe('Accessibility Tests', () => {
+    describe('When not important (default)', () => {
+      beforeEach(() => {
+        mockSlots = { action: MOCK_ACTION_SLOT };
+
+        updateWrapper();
+      });
+
+      it('should use the status role and omit aria-modal', () => {
+        expect(dialog.attributes('role')).toBe('status');
+        expect(dialog.attributes('aria-modal')).toBeUndefined();
+      });
+
+      it('should not move initial focus on mount', async () => {
+        await flushPromises();
+
+        expect(banner.element.contains(document.activeElement)).toBe(false);
+      });
+
+      it('should not wrap focus on Tab (trap inactive)', async () => {
+        await flushPromises();
+        closeEl().focus();
+
+        await banner.trigger('keydown', { key: 'Tab' });
+
+        // Trap is inactive, so focus is NOT wrapped back to the first element.
+        expect(document.activeElement).toBe(closeEl());
+        expect(document.activeElement).not.toBe(actionEl());
+      });
+    });
+
+    describe('When important', () => {
+      beforeEach(async () => {
+        mockProps = { important: true };
+        mockSlots = { action: MOCK_ACTION_SLOT };
+
+        updateWrapper();
+        await flushPromises();
+      });
+
+      it('should use the alertdialog role and set aria-modal', () => {
+        expect(dialog.attributes('role')).toBe('alertdialog');
+        expect(dialog.attributes('aria-modal')).toBe('true');
+      });
+
+      it('should move initial focus to the first focusable element', () => {
+        expect(document.activeElement).toBe(actionEl());
+      });
+
+      it('should wrap focus to the first element on Tab from the last', async () => {
+        closeEl().focus();
+
+        await banner.trigger('keydown', { key: 'Tab' });
+
+        expect(document.activeElement).toBe(actionEl());
+      });
+
+      it('should wrap focus to the last element on Shift+Tab from the first', async () => {
+        actionEl().focus();
+
+        await banner.trigger('keydown', { key: 'Tab', shiftKey: true });
+
+        expect(document.activeElement).toBe(closeEl());
+      });
+    });
+
+    describe('When important is toggled on at runtime', () => {
+      it('should activate the trap and move focus into the banner', async () => {
+        mockSlots = { action: MOCK_ACTION_SLOT };
+
+        updateWrapper();
+        await flushPromises();
+        expect(banner.element.contains(document.activeElement)).toBe(false);
+
+        await wrapper.setProps({ important: true });
+        await flushPromises();
+
+        expect(document.activeElement).toBe(actionEl());
+      });
+    });
+
+    describe('Focus restoration', () => {
+      let outsideButton;
+
+      beforeEach(() => {
+        outsideButton = document.createElement('button');
+        document.body.appendChild(outsideButton);
+        outsideButton.focus();
+      });
+
+      afterEach(() => {
+        outsideButton.remove();
+      });
+
+      it('should restore focus via the directive when an important banner unmounts', async () => {
+        // showClose: false disables NoticeAction's own focus restoration, so this
+        // proves the v-dt-focustrap directive (restoreFocus: true) is the restorer.
+        mockProps = { important: true, showClose: false };
+        mockSlots = { action: MOCK_ACTION_SLOT };
+
+        updateWrapper();
+        await flushPromises();
+        // Focus has moved into the banner.
+        expect(document.activeElement).toBe(actionEl());
+
+        wrapper.unmount();
+        // Null out so teardown / the next mount does not double-unmount.
+        wrapper = null;
+
+        expect(document.activeElement).toBe(outsideButton);
+      });
+    });
+  });
+
+  describe('Interactivity Tests', () => {
+    describe('When the close button is clicked', () => {
+      it('should emit a close event', async () => {
+        await wrapper.find('[data-qa="dt-notice-action-close-button"]').trigger('click');
+
+        expect(wrapper.emitted('close')).toBeTruthy();
+      });
+    });
+  });
+});

--- a/packages/dialtone-vue/components/Banner/Banner.vue
+++ b/packages/dialtone-vue/components/Banner/Banner.vue
@@ -1,13 +1,14 @@
-<!-- eslint-disable vuejs-accessibility/no-static-element-interactions -->
 <template>
   <aside
+    v-dt-focustrap="{ active: important, initialFocus: 'auto', restoreFocus: true }"
     :class="bannerClass"
     :style="bannerBackgroundImage"
-    @keydown.tab="trapFocus"
+    data-qa="dt-banner"
   >
     <div
       class="d-banner__dialog"
       :class="dialogClass"
+      data-qa="dt-banner-dialog"
       :role="role"
       :aria-modal="important || undefined"
       :aria-labelledby="hasHeader ? headerId : undefined"
@@ -51,7 +52,6 @@
 
 <script>
 import { DtNoticeIcon, DtNoticeContent, DtNoticeAction, NOTICE_KINDS } from '@/components/Notice';
-import Modal from '@/common/mixins/modal';
 import utils from '@/common/utils';
 
 /**
@@ -67,8 +67,6 @@ export default {
     DtNoticeContent,
     DtNoticeAction,
   },
-
-  mixins: [Modal],
 
   props: {
     /**
@@ -99,8 +97,9 @@ export default {
 
     /**
      * Used in scenarios where the message needs to visually dominate the screen.
-     * This will also change the aria role from status to alertdialog.
-     * and will modally trap the keyboard focus in the dialog as soon as it displays.
+     * This will also change the aria role from status to alertdialog,
+     * and will modally trap keyboard focus within the banner while it is shown (via the
+     * v-dt-focustrap directive), restoring focus to the previously focused element on close.
      * @values true, false
      */
     important: {
@@ -258,20 +257,6 @@ export default {
 
       return `background-image: url(${this.backgroundImage});
               background-size: ${this.backgroundSize};`;
-    },
-  },
-
-  mounted () {
-    if (this.important) {
-      this.focusFirstElement();
-    }
-  },
-
-  methods: {
-    trapFocus (e) {
-      if (this.important) {
-        this.focusTrappedTabPress(e);
-      }
     },
   },
 };


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExaW0zdXN6YnNvNmIzcDF1YTVjc3VlMnRnb2x2OGN0OW43Y2Zxa2ZqMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/zOlog7jgIIFfq/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

[DLT-3454](https://dialpad.atlassian.net/browse/DLT-3454)

## :book: Description

Migrates `DtBanner`'s focus trapping from the legacy `common/mixins/modal.js` mixin to the new `v-dt-focustrap` directive — the first internal adopter of the directive (part of [DLT-3452](https://dialpad.atlassian.net/browse/DLT-3452)). Trapping behaviour is preserved: an `important` banner (`role="alertdialog"`) traps Tab/Shift+Tab and receives initial focus; non-important `status` banners don't trap.

- **`Banner.vue`** — replace `mixins: [Modal]` + `@keydown.tab="trapFocus"` + the `trapFocus` method + the `mounted()` focus call with `v-dt-focustrap="{ active: important, initialFocus: 'auto', restoreFocus: true }"` on the root `<aside>`. Add `data-qa` hooks (`dt-banner`, `dt-banner-dialog`) and refresh the `important` prop JSDoc. Removes the now-unused `eslint-disable vuejs-accessibility/no-static-element-interactions`.
- **`Banner.test.js`** — **new** test suite (Banner previously had no tests): role/`aria-modal` toggling, gated initial focus, Tab/Shift+Tab wrap, no-trap when not important, runtime `important` toggle, and directive focus-restoration.
- **`banner.md`** — add an Accessibility “Focus management” note, and switch the interactive Kind demo from `v-show` to `v-if` (see the gotcha in Context).

## :bulb: Context

Focus trapping was scattered across components via the Modal mixin; DLT-3452 consolidates it on one directive (`v-dt-focustrap`, shipped in #1195). Banner is the pilot.

**Global registration dependency:** `v-dt-focustrap` is a globally-installed plugin — components use it in the template with no local `directives:` registration. The migrated banner is inert for focus-trapping unless the host app calls `app.use(DtFocustrapDirective)`; confirmed consumer apps already do, and Storybook registers it in `preview.jsx`.

**Behaviour deltas (additive, intended):**
- Focus restoration is now consistent — the directive restores focus on close for **both** `showClose: true` and `showClose: false` (previously `NoticeAction` only restored when `showClose: true`).
- Reactive activation — toggling `important` `false→true` at runtime now moves focus into the banner; the old `mounted`-only code didn't.

**`v-show` pitfall (why the demo now uses `v-if`):** the directive activates when `important` becomes truthy, **not** when the banner becomes visible. If an always-mounted banner (`v-show`) has `important` set *before* it's revealed, no activation fires on reveal, so focus stays on the trigger (the trap still works once you Tab). Rendering with `v-if` — or setting `important` at show-time — mounts/activates the banner while visible, so focus moves in on appearance and restores on close. The Kind demo was switched to `v-if` to demonstrate this faithfully; consumers building alert banners should prefer `v-if`.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

These screen-recordings will illustrate the pitfall mentioned above: what happens when a banner is controlled via `v-show`. Pay attention to:
1) The focus ring;
2) The `document.activeElement` watcher in dev tools

This is the current state, and also what we'd get post-migration if we control a banner with `v-show` (the directive doesn't fix it). Notice how focus stays on the button that triggers the modal.

https://github.com/user-attachments/assets/55ac3128-76ca-47ef-ab0f-567593044e5e

And this is what happens when using `v-if` instead of `v-show` — this guarantees that the component is actually mounted when toggled on. Notice how the focus moves from the trigger button to the button in the banner, and then is restored back to the trigger button when the banner is closed.

https://github.com/user-attachments/assets/e62629ec-99b0-42c8-b1cb-2ee82e18fe52

## :crystal_ball: Next Steps

I guess we should document the `v-if` / `v-show` oddity. I could do it in the banner docs, but this is likely to affect all components that use the focus trap directive AND have their visibility controlled via `v-show`. Probably we should update both the banner AND the directive docs. What do you think? cc @francisrupert @braddialpad 



[DLT-3454]: https://dialpad.atlassian.net/browse/DLT-3454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DLT-3452]: https://dialpad.atlassian.net/browse/DLT-3452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ