### PR TITLE
feat(master-script): no-jira migration script ignore gitignore folders

### DIFF
--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -302,11 +302,12 @@ const MIGRATIONS = [
   {
     id: 'vue3-to-vue-imports',
     name: 'Vue 3 Import Paths',
-    description: '@dialpad/dialtone-icons/vue3 and @dialpad/dialtone-vue/vue3 import paths renamed to /vue.',
+    description: '@dialpad/dialtone/vue3, @dialpad/dialtone-icons/vue3, and @dialpad/dialtone-vue/vue3 import paths renamed to /vue.',
     category: 'required',
     type: 'config',
     configName: 'vue3-to-vue-imports',
     detectPatterns: [
+      /@dialpad\/dialtone\/vue3/,
       /@dialpad\/dialtone-icons\/vue3/,
       /@dialpad\/dialtone-vue\/vue3/,
     ],

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -28,7 +28,7 @@
  *   npx dialtone-migrate --only color-stops,hsl-to-oklch
  */
 
-import { spawn } from 'node:child_process';
+import { spawn, execFileSync } from 'node:child_process';
 import fs from 'fs/promises';
 import path from 'path';
 import readline from 'readline';
@@ -370,7 +370,7 @@ Examples:
 // File walker (shared utility)
 // ---------------------------------------------------------------------------
 
-const DEFAULT_IGNORE = ['node_modules', 'dist', '.git', '.vuepress/public', '.vuepress/.temp', '.vuepress/.cache', 'storybook-static'];
+const DEFAULT_IGNORE = ['node_modules', 'dist', '.git', '.vuepress/public', '.vuepress/.temp', '.vuepress/.cache', 'storybook-static', 'compiled'];
 
 function isIgnoredPath (fullPath) {
   const segments = fullPath.split(path.sep);
@@ -384,6 +384,28 @@ function isIgnoredPath (fullPath) {
     }
     return segments.includes(ig);
   });
+}
+
+/**
+ * Filter out files that are ignored by .gitignore using git check-ignore.
+ * Falls back gracefully if git is not available.
+ */
+function filterGitIgnored (files, cwd) {
+  if (files.length === 0) return files;
+  try {
+    const input = files.join('\n');
+    const output = execFileSync('git', ['check-ignore', '--stdin'], {
+      input,
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+    const ignored = new Set(output.trim().split('\n').filter(Boolean));
+    return files.filter(f => !ignored.has(f));
+  } catch {
+    // git not available or not a git repo — return all files unfiltered
+    return files;
+  }
 }
 
 async function findFiles (dir, extensions) {
@@ -404,7 +426,7 @@ async function findFiles (dir, extensions) {
     }
   }
   await walk(dir);
-  return results;
+  return filterGitIgnored(results, dir);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -403,9 +403,12 @@ function filterGitIgnored (files, cwd) {
     });
     const ignored = new Set(output.trim().split('\n').filter(Boolean));
     return files.filter(f => !ignored.has(f));
-  } catch {
-    // git not available or not a git repo — return all files unfiltered
-    return files;
+  } catch (err) {
+    // status 1 → no paths ignored; status 128 → not a git repo; ENOENT → git missing
+    if (err.status === 1 || err.status === 128 || err.code === 'ENOENT') {
+      return files;
+    }
+    throw err;
   }
 }
 

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/vue3-to-vue-imports.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/vue3-to-vue-imports.mjs
@@ -5,10 +5,13 @@
 
 export default {
   description:
-    'Renames /vue3 import subpaths to /vue for @dialpad/dialtone-icons and\n' +
-    '@dialpad/dialtone-vue. After Vue 2 removal, /vue is the canonical path.',
+    'Renames /vue3 import subpaths to /vue for @dialpad/dialtone,\n' +
+    '@dialpad/dialtone-icons, and @dialpad/dialtone-vue.\n' +
+    'After Vue 2 removal, /vue is the canonical path.',
   patterns: ['**/*.{vue,js,ts,jsx,tsx,mjs,mts}'],
   expressions: [
+    // @dialpad/dialtone/vue3 → @dialpad/dialtone/vue
+    { from: /@dialpad\/dialtone\/vue3/g, to: '@dialpad/dialtone/vue' },
     // @dialpad/dialtone-icons/vue3 → @dialpad/dialtone-icons/vue
     { from: /@dialpad\/dialtone-icons\/vue3/g, to: '@dialpad/dialtone-icons/vue' },
     // @dialpad/dialtone-vue/vue3 → @dialpad/dialtone-vue (or /vue if used)


### PR DESCRIPTION
# Migration script improvements

- Added the ability to ignore gitignore folders (this will avoid the master script run in compiled folders).
- Added the pattern of `@dialpad/dialtone/vue3` to `@dialpad/dialtone/vue ` in `vue3-to-vue-imports` script.
