### PR TITLE
fix(dialtone-cli): NO-JIRA wire into release and publish pipelines

### DIFF
--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -19,6 +19,7 @@ on:
           - stylelint-plugin-dialtone
           - postcss-responsive-variations
           - dialtone-mcp-server
+          - dialtone-cli
   push:
     branches:
       - production
@@ -78,6 +79,8 @@ jobs:
               - 'packages/postcss-responsive-variations/package.json'
             dialtone-mcp-server:
               - 'packages/dialtone-mcp-server/package.json'
+            dialtone-cli:
+              - 'packages/dialtone-cli/package.json'
 
       - name: Filter actions by input
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ on:
           - stylelint-plugin
           - postcss-responsive-variations
           - dialtone-mcp-server
+          - dialtone-cli
   schedule:
     - cron: "0 10 * * 2"
 
@@ -117,6 +118,10 @@ jobs:
       - name: Release Dialtone MCP Server ${{ env.RELEASE_TAG }}
         if: ${{ github.event_name == 'schedule' || github.event.inputs.package == 'all' || github.event.inputs.package == 'dialtone-mcp-server' }}
         run: pnpm nx run dialtone-mcp-server:release
+
+      - name: Release Dialtone CLI ${{ env.RELEASE_TAG }}
+        if: ${{ github.event_name == 'schedule' || github.event.inputs.package == 'all' || github.event.inputs.package == 'dialtone-cli' }}
+        run: pnpm nx run dialtone-cli:release
 
       - name: Release Dialtone ${{ env.RELEASE_TAG }}
         if: ${{ github.event_name == 'schedule' || github.event.inputs.package == 'all' || github.event.inputs.package == 'dialtone' }}

--- a/packages/dialtone-cli/package.json
+++ b/packages/dialtone-cli/package.json
@@ -43,6 +43,5 @@
     "url": "https://github.com/dialpad/dialtone.git",
     "directory": "packages/dialtone-cli"
   },
-  "license": "MIT",
-  "private": true
+  "license": "MIT"
 }


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

NO-JIRA — release-infra fix. Companion to Beacon's DDT-1949 (Beacon needs to install `@dialpad/dialtone-cli`). Happy to file a DLT ticket if the team prefers one on record.

## :book: Description

Other repos can't install `@dialpad/dialtone-cli` — `npm install @dialpad/dialtone-cli` returns a 404 because the package was never actually published. This PR turns on publishing for it, exactly the way every other `@dialpad/dialtone*` package already publishes.

## :bulb: Context

When the CLI was first added (#1142, DLT-3163) it shipped with `"private": true` and was never added to the two workflows that publish our packages — `release.yml` and `publish-web.yml`. A later commit (`make dialtone-cli private`, `cf555f2a0`) confirmed the private flag but didn't complete the publish path, so consuming repos — Beacon in particular — get a 404.

This finishes the wiring, modeled on `dialtone-mcp-server` (the closest sibling: same rollup `build/index.js`, same `dialtone-query-core` dependency):

- **`packages/dialtone-cli/package.json`** — remove `"private": true` so the package can be published.
- **`release.yml`** — add `dialtone-cli` so semantic-release versions and tags it.
- **`publish-web.yml`** — add `dialtone-cli` so the publish matrix uploads it to npm + GitHub Packages.

`npmPublish: false` is intentionally **kept** — every sibling uses it. semantic-release only versions/tags; `publish-web.yml` does the actual publish to both registries.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation. (No doc change needed — the CI-pipeline doc describes these workflows generically.)
- [x] I have considered the performance impact of my change. (CI-config only; no runtime impact.)

## :crystal_ball: Next Steps

Once merged to `staging`, the Tuesday semantic-release run (or a manual `release.yml` dispatch) cuts the first published `@dialpad/dialtone-cli` version, and `publish-web.yml` uploads it. Verify with `npm view @dialpad/dialtone-cli version` (currently 404). Beacon can then install it.

**For reviewers:** confirm the `dialtone-cli` entries in both workflows mirror the `dialtone-mcp-server` pattern, and that `packages/dialtone-cli/release-ci.config.cjs` still has `npmPublish: false`.

## :link: Sources

- Original CLI PR: #1142 (DLT-3163)
- Made private: `cf555f2a0`