### PR TITLE
fix(modal): DLT-3476 do not close when drag starts inside dialog and ends on backdrop

### DIFF
--- a/packages/dialtone-vue/components/modal/modal.test.js
+++ b/packages/dialtone-vue/components/modal/modal.test.js
@@ -173,10 +173,20 @@ describe('DtModal Tests', () => {
     it('Should emit a sync-able update event when overlay is clicked', async () => {
       expect(wrapper.emitted(SYNC_EVENT_NAME)).toBeFalsy();
 
+      await overlay.trigger('mousedown');
       await overlay.trigger('click');
 
       expect(wrapper.emitted()[SYNC_EVENT_NAME].length).toBe(1);
       expect(wrapper.emitted()[SYNC_EVENT_NAME][0][0]).toBe(false);
+    });
+
+    it('Should NOT close when mousedown starts inside the dialog but click ends on the overlay', async () => {
+      expect(wrapper.emitted(SYNC_EVENT_NAME)).toBeFalsy();
+
+      await copy.trigger('mousedown');
+      await overlay.trigger('click');
+
+      expect(wrapper.emitted(SYNC_EVENT_NAME)).toBeFalsy();
     });
 
     it('Should emit a sync-able update event when close-icon is clicked', async () => {

--- a/packages/dialtone-vue/components/modal/modal.vue
+++ b/packages/dialtone-vue/components/modal/modal.vue
@@ -373,9 +373,17 @@ export default {
   computed: {
     modalListeners () {
       return {
+        mousedown: event => {
+          // Track whether the drag originated on the backdrop so that a drag
+          // starting inside the dialog and ending outside doesn't close the modal.
+          this._mousedownOnBackdrop = (event.target === event.currentTarget);
+        },
+
         click: event => {
-          // Handle backdrop clicks for closing modal
-          if (this.closeOnClick && event.target === event.currentTarget) {
+          // Handle backdrop clicks for closing modal.
+          // Require mousedown to have also started on the backdrop — prevents
+          // text-selection drags that end outside from dismissing the modal.
+          if (this.closeOnClick && event.target === event.currentTarget && this._mousedownOnBackdrop) {
             this.close();
           }
 
@@ -451,6 +459,7 @@ export default {
 
   created () {
     this._trapFocusGlobalBound = (e) => this._trapFocusGlobal(e);
+    this._mousedownOnBackdrop = false;
   },
 
   mounted () {


### PR DESCRIPTION
https://dialpad.atlassian.net/browse/DLT-3476

## Obligatory GIF (super important!)
![Obligatory GIF](path/to/gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3476

## :book: Description

The modal no longer closes when a user starts a click or text selection drag inside the dialog content and releases the mouse on the backdrop. A `mousedown` handler now tracks whether the press originated on the backdrop itself, and the `click` handler only closes the modal when both the `mousedown` and the `click` landed on the backdrop.

## :bulb: Context

Previously, the modal closed on any `click` event whose target was the backdrop overlay, regardless of where the mouse button was first pressed. This meant that dragging to select text inside the modal and releasing outside it would unexpectedly dismiss the dialog. The fix introduces a `_mousedownOnBackdrop` flag: it is set to `true` only when `mousedown` fires directly on the backdrop, and the `click` handler gates `close()` on that flag. The flag is initialised to `false` in `created()` so it is always in a known state.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

None.

## :camera: Screenshots / GIFs

None needed — this is a logic-only fix with no visual changes.

## :link: Sources