### PR TITLE
feat(combinator): DLT-3480 add searchable filter to selection dropdowns

### DIFF
--- a/packages/combinator/src/components/controls/control_icon_slot.vue
+++ b/packages/combinator/src/components/controls/control_icon_slot.vue
@@ -1,81 +1,25 @@
 <template>
-  <dt-recipe-combobox-with-popover
-    ref="combobox"
-    label="Icon"
-    max-height="320px"
-    list-class="d-w-250 d-hmx-350"
-    :size="100"
-    append-to="body"
-    @select="e => onSelect(filteredIcons[e])"
-    @opened="onOpen"
-    @focusout="onFocusOut"
+  <dtc-control-selection
+    :value="iconName"
+    :valid-values="iconNames"
+    :default-value="null"
+    :disabled="disabled"
+    @update:value="onSelect"
   >
-    <template #input="{ inputProps, onInput }">
-      <dtc-control-string
-        v-bind="inputProps"
-        :value="searchText"
-        :disabled="disabled"
-        @update:value="e => onInputInternal(e, onInput)"
-      >
-        <template #default>
-          <slot />
-        </template>
-        <template #icon="{ iconSize }">
-          <dt-button
-            v-if="isModified"
-            kind="muted"
-            importance="clear"
-            :size="100"
-            class="d-p-25"
-            @click.stop="onReset"
-          >
-            <template #icon>
-              <dt-icon-close size="100" />
-            </template>
-          </dt-button>
-          <component
-            :is="DtIconChevronsUpDown"
-            v-else
-            :size="iconSize"
-            class="d-fc-muted"
-          />
-        </template>
-      </dtc-control-string>
-    </template>
-    <template #list="{ listProps }">
-      <ul
-        class="d-p-50"
-        v-bind="listProps"
-      >
-        <dt-list-item
-          v-for="(item, i) in filteredIcons"
-          :key="item"
-          navigation-type="arrow-keys"
-          role="option"
-          @click="onSelectInternal(i)"
-        >
-          {{ item }}
-        </dt-list-item>
-      </ul>
-    </template>
-  </dt-recipe-combobox-with-popover>
+    <slot />
+  </dtc-control-selection>
 </template>
 
 <script setup>
-import DtcControlString from './control_string.vue';
-import { DtButton, DtRecipeComboboxWithPopover, DtListItem } from '@dialpad/dialtone-vue';
-import { DtIconChevronsUpDown, DtIconClose } from '@dialpad/dialtone-icons/vue';
-
-import { VALUE_UPDATE_EVENT } from '@/src/lib/constants';
-import { computed, ref, watch } from 'vue';
+import DtcControlSelection from './control_selection.vue';
 import {
   iconNames,
   iconNameToTemplate,
   templateToIconName,
   hasIconSizeBinding,
 } from '@/src/lib/icons';
-
-const NONE_OPTION = '(none)';
+import { VALUE_UPDATE_EVENT } from '@/src/lib/constants';
+import { computed } from 'vue';
 
 const props = defineProps({
   value: {
@@ -98,66 +42,15 @@ const props = defineProps({
 
 const emit = defineEmits([VALUE_UPDATE_EVENT]);
 
-const searchText = ref(templateToIconName(props.value) ?? '');
+const iconName = computed(() => templateToIconName(props.value) ?? null);
 
-watch(() => props.value, (newVal) => {
-  searchText.value = templateToIconName(newVal) ?? '';
-});
-
-const isModified = computed(() => props.value !== props.defaultValue);
-
-const allIcons = computed(() => [NONE_OPTION, ...iconNames]);
-
-const filteredIcons = computed(() => {
-  const query = searchText.value.toLowerCase();
-  if (!query) return allIcons.value;
-  return allIcons.value.filter(name =>
-    name.toLowerCase().includes(query),
-  );
-});
-
-const combobox = ref();
-const open = ref(false);
-
-function onOpen (e) {
-  open.value = e;
-}
-
-function onFocusOut (e) {
-  if (e.relatedTarget?.closest('[data-tippy-root]')) return;
-  if (combobox.value?.$el?.contains(e.relatedTarget)) return;
-  if (open.value) {
-    combobox.value?.closeComboboxList();
-  }
-}
-
-function onSelectInternal (i) {
-  combobox.value.onSelect(i);
-  combobox.value.closeComboboxList();
-}
-
-function onSelect (iconName) {
-  if (iconName === NONE_OPTION) {
-    searchText.value = '';
+function onSelect (name) {
+  if (name === null) {
     emit(VALUE_UPDATE_EVENT, null);
     return;
   }
-  searchText.value = iconName;
   const isScoped = hasIconSizeBinding(props.bindings);
-  emit(VALUE_UPDATE_EVENT, iconNameToTemplate(iconName, isScoped));
-}
-
-function onReset () {
-  searchText.value = templateToIconName(props.defaultValue) ?? '';
-  emit(VALUE_UPDATE_EVENT, props.defaultValue);
-}
-
-function onInputInternal (value, onInput) {
-  searchText.value = value;
-  if (!value) {
-    emit(VALUE_UPDATE_EVENT, null);
-  }
-  onInput(value);
+  emit(VALUE_UPDATE_EVENT, iconNameToTemplate(name, isScoped));
 }
 </script>
 

--- a/packages/combinator/src/components/controls/control_icon_slot.vue
+++ b/packages/combinator/src/components/controls/control_icon_slot.vue
@@ -4,6 +4,7 @@
     :valid-values="iconNames"
     :default-value="null"
     :disabled="disabled"
+    :generate-preview-component="generatePreviewComponent"
     @update:value="onSelect"
   >
     <slot />
@@ -18,8 +19,9 @@ import {
   templateToIconName,
   hasIconSizeBinding,
 } from '@/src/lib/icons';
+import * as allIcons from '@dialpad/dialtone-icons/vue';
 import { VALUE_UPDATE_EVENT } from '@/src/lib/constants';
-import { computed } from 'vue';
+import { computed, markRaw } from 'vue';
 
 const props = defineProps({
   value: {
@@ -43,6 +45,13 @@ const props = defineProps({
 const emit = defineEmits([VALUE_UPDATE_EVENT]);
 
 const iconName = computed(() => templateToIconName(props.value) ?? null);
+
+function generatePreviewComponent (name) {
+  if (!name) return null;
+  const componentName = 'DtIcon' + name.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join('');
+  const component = allIcons[componentName];
+  return component ? markRaw(component) : null;
+}
 
 function onSelect (name) {
   if (name === null) {

--- a/packages/combinator/src/components/controls/control_selection.test.js
+++ b/packages/combinator/src/components/controls/control_selection.test.js
@@ -3,10 +3,16 @@ import DtcControlSelection from './control_selection.vue';
 import { expect } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 
-const selections = [
-  'selection1',
-  'selection2',
-  'selection3',
+const selections = ['selection1', 'selection2', 'selection3'];
+
+const manySelections = [
+  'alpha',
+  'beta',
+  'gamma',
+  'delta',
+  'epsilon',
+  'zeta',
+  'eta',
 ];
 
 const inputValue = selections[1];
@@ -14,11 +20,12 @@ const inputValue = selections[1];
 describe('control_selection.vue test', function () {
   let wrapper;
 
-  const _mountWrapper = () => {
+  const _mountWrapper = (props = {}) => {
     wrapper = shallowMount(DtcControlSelection, {
       props: {
         value: inputValue,
         validValues: selections,
+        ...props,
       },
     });
   };
@@ -35,9 +42,11 @@ describe('control_selection.vue test', function () {
 
   describe('When rendering options', function () {
     describe('Should create an option for each selection', function () {
-      selections.forEach(selection => {
+      selections.forEach((selection) => {
         it(`Should have a computed option for selection '${selection}'`, function () {
-          expect(wrapper.vm.options.some(o => o.value === selection)).toBe(true);
+          expect(wrapper.vm.options.some((o) => o.value === selection)).toBe(
+            true,
+          );
         });
       });
     });
@@ -46,6 +55,120 @@ describe('control_selection.vue test', function () {
       it('Should display the label for the selected value', function () {
         expect(wrapper.vm.selectedLabel).toBe(inputValue.toString());
       });
+    });
+  });
+
+  describe('Search visibility', function () {
+    it('Should not show search when options count is at or below threshold', function () {
+      _mountWrapper({ validValues: selections }); // 3 options
+      expect(wrapper.vm.showSearch).toBe(false);
+    });
+
+    it('Should not show search when options count equals threshold', function () {
+      // defaultValue suppresses the prepended null option, giving exactly 5 options
+      _mountWrapper({
+        validValues: ['a', 'b', 'c', 'd', 'e'],
+        defaultValue: 'a',
+      });
+      expect(wrapper.vm.showSearch).toBe(false);
+    });
+
+    it('Should show search when options count exceeds threshold', function () {
+      // defaultValue suppresses the prepended null option, giving exactly 7 options
+      _mountWrapper({
+        validValues: manySelections,
+        defaultValue: manySelections[0],
+      });
+      expect(wrapper.vm.showSearch).toBe(true);
+    });
+  });
+
+  describe('Search filtering', function () {
+    beforeEach(function () {
+      _mountWrapper({
+        validValues: manySelections,
+        defaultValue: manySelections[0],
+      });
+    });
+
+    it('Should return all options when query is empty', function () {
+      wrapper.vm.query = '';
+      expect(wrapper.vm.filteredOptions.length).toBe(wrapper.vm.options.length);
+    });
+
+    it('Should filter options by label', function () {
+      wrapper.vm.query = 'alp';
+      expect(wrapper.vm.filteredOptions).toHaveLength(1);
+      expect(wrapper.vm.filteredOptions[0].value).toBe('alpha');
+    });
+
+    it('Should be case-insensitive', function () {
+      wrapper.vm.query = 'ALPHA';
+      expect(wrapper.vm.filteredOptions).toHaveLength(1);
+      expect(wrapper.vm.filteredOptions[0].value).toBe('alpha');
+    });
+
+    it('Should return an empty list when no options match', function () {
+      wrapper.vm.query = 'zzz';
+      expect(wrapper.vm.filteredOptions).toHaveLength(0);
+    });
+  });
+
+  describe('Keyboard handling', function () {
+    let closeSpy;
+
+    beforeEach(function () {
+      _mountWrapper({
+        validValues: manySelections,
+        defaultValue: manySelections[0],
+      });
+      closeSpy = vi.fn();
+    });
+
+    it('Enter selects the first enabled option and closes', function () {
+      wrapper.vm.query = 'alp';
+      wrapper.vm.onSearchKeydown(
+        { key: 'Enter', stopPropagation: vi.fn(), preventDefault: vi.fn() },
+        closeSpy,
+      );
+      expect(closeSpy).toHaveBeenCalled();
+    });
+
+    it('Escape closes the dropdown', function () {
+      wrapper.vm.onSearchKeydown(
+        { key: 'Escape', stopPropagation: vi.fn(), preventDefault: vi.fn() },
+        closeSpy,
+      );
+      expect(closeSpy).toHaveBeenCalled();
+    });
+
+    it('Enter does nothing when no options match', function () {
+      wrapper.vm.query = 'zzz';
+      wrapper.vm.onSearchKeydown(
+        { key: 'Enter', stopPropagation: vi.fn(), preventDefault: vi.fn() },
+        closeSpy,
+      );
+      expect(closeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('selectFirst', function () {
+    beforeEach(function () {
+      _mountWrapper({
+        validValues: manySelections,
+        defaultValue: manySelections[0],
+        disabledValues: new Set(['alpha']),
+      });
+    });
+
+    it('Should skip disabled options and select the first enabled one', function () {
+      wrapper.vm.query = '';
+      const closeSpy = vi.fn();
+      wrapper.vm.selectFirst(closeSpy);
+      // 'alpha' is disabled — next enabled is 'beta'
+      const emitted = wrapper.emitted('update:value');
+      expect(emitted).toBeTruthy();
+      expect(emitted[0][0]).toBe('beta');
     });
   });
 });

--- a/packages/combinator/src/components/controls/control_selection.vue
+++ b/packages/combinator/src/components/controls/control_selection.vue
@@ -78,6 +78,21 @@
           <template #startIcon="{ iconSize }">
             <dt-icon-search :size="iconSize" />
           </template>
+          <template #endIcon="{ clear }">
+            <dt-button
+              :style="!query.length ? { visibility: 'hidden', pointerEvents: 'none' } : undefined"
+              kind="muted"
+              importance="clear"
+              :size="100"
+              circle
+              aria-label="Clear search"
+              @click="clear"
+            >
+              <template #startIcon="{ iconSize }">
+                <dt-icon-close :size="iconSize" />
+              </template>
+            </dt-button>
+          </template>
         </dt-input>
       </dt-box>
       <div ref="listWrapper" class="d-of-y-auto d-hmx-400">
@@ -137,7 +152,7 @@
 
 <script setup>
 import { DtBox, DtButton, DtInput, DtStack, DtText } from '@dialpad/dialtone-vue';
-import { DtIconChevronsUpDown, DtIconSearch } from '@dialpad/dialtone-icons/vue';
+import { DtIconClose, DtIconChevronsUpDown, DtIconSearch } from '@dialpad/dialtone-icons/vue';
 
 import { VALUE_UPDATE_EVENT } from '@/src/lib/constants';
 import { resolveTokenValue } from '@/src/lib/tokens';

--- a/packages/combinator/src/components/controls/control_selection.vue
+++ b/packages/combinator/src/components/controls/control_selection.vue
@@ -12,6 +12,7 @@
     placement="bottom-start"
     content-width="anchor"
     content-class="d-hmx-400"
+    @opened="onOpened"
   >
     <template #anchor="{ attrs }">
       <dt-button
@@ -53,49 +54,85 @@
       </dt-button>
     </template>
     <template #list="{ close }">
-      <dt-list-item
-        v-for="option in options"
-        :key="option.value"
-        role="menuitem"
-        navigation-type="arrow-keys"
-        :class="{ 'd-o50 d-pe-none': option.disabled, 'd-bgc-moderate-opaque': option.value === value }"
-        :aria-disabled="option.disabled || undefined"
-        @click="!option.disabled && (onInput(option.value), close())"
+      <dt-box
+        v-if="showSearch"
+        surface="overlay"
+        padding-block-end="50"
+        border-width-block-end="100"
+        border-color="subtle"
+        class="d-ps-sticky d-ibs-0 d-zi-base1"
       >
-        <dt-stack
-          direction="row"
-          gap="100"
-          align="baseline"
-          class="d-w100p"
+        <dt-input
+          ref="searchInput"
+          v-model="query"
+          type="search"
+          :size="100"
+          placeholder="Search"
+          @keydown="onSearchKeydown($event, close)"
         >
-          <span
-            v-if="option.resolved && isColor(option.resolved)"
-            class="d-ba d-bc-subtle d-bar-circle d-as-center"
-            :style="swatchStyle(option.resolved)"
-          />
-          <span>{{ option.label }}</span>
-          <dt-text
-            v-if="option.resolved && !isColor(option.resolved)"
-            kind="body"
-            :size="100"
-            tone="muted"
-            class="d-mis-auto"
+          <template #startIcon="{ iconSize }">
+            <dt-icon-search :size="iconSize" />
+          </template>
+        </dt-input>
+      </dt-box>
+      <div ref="listWrapper">
+        <dt-list-item
+          v-for="option in filteredOptions"
+          :key="option.value"
+          role="menuitem"
+          navigation-type="arrow-keys"
+          :class="{ 'd-o50 d-pe-none': option.disabled, 'd-bgc-moderate-opaque': option.value === value }"
+          :aria-disabled="option.disabled || undefined"
+          @click="!option.disabled && (onInput(option.value), close())"
+        >
+          <dt-stack
+            direction="row"
+            gap="100"
+            align="baseline"
+            class="d-w100p"
           >
-            {{ option.resolved }}
-          </dt-text>
-        </dt-stack>
-      </dt-list-item>
+            <span
+              v-if="option.resolved && isColor(option.resolved)"
+              class="d-ba d-bc-subtle d-bar-circle d-as-center"
+              :style="swatchStyle(option.resolved)"
+            />
+            <span>{{ option.label }}</span>
+            <dt-text
+              v-if="option.resolved && !isColor(option.resolved)"
+              kind="body"
+              :size="100"
+              tone="muted"
+              class="d-mis-auto"
+            >
+              {{ option.resolved }}
+            </dt-text>
+          </dt-stack>
+        </dt-list-item>
+      </div>
+      <dt-text
+        v-if="!filteredOptions.length"
+        kind="body"
+        :size="100"
+        tone="muted"
+        as="div"
+        class="d-px-200 d-py-150 d-ta-center"
+      >
+        No matches
+      </dt-text>
     </template>
   </dt-dropdown>
 </template>
 
 <script setup>
-import { DtButton, DtStack, DtText } from '@dialpad/dialtone-vue';
-import { DtIconChevronsUpDown } from '@dialpad/dialtone-icons/vue';
+import { DtBox, DtButton, DtInput, DtStack, DtText } from '@dialpad/dialtone-vue';
+import { DtIconChevronsUpDown, DtIconSearch } from '@dialpad/dialtone-icons/vue';
 
 import { VALUE_UPDATE_EVENT } from '@/src/lib/constants';
 import { resolveTokenValue } from '@/src/lib/tokens';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+
+// Show the in-popover search only for lists long enough to be worth filtering.
+const SEARCH_THRESHOLD = 5;
 
 const props = defineProps({
   value: {
@@ -168,6 +205,66 @@ const selectedOption = computed(() => {
 });
 
 const selectedLabel = computed(() => selectedOption.value?.label ?? '');
+
+const query = ref('');
+const searchInput = ref(null);
+const listWrapper = ref(null);
+
+const showSearch = computed(() => options.value.length > SEARCH_THRESHOLD);
+
+const filteredOptions = computed(() => {
+  const q = query.value.trim().toLowerCase();
+  if (!q) return options.value;
+  return options.value.filter(o => `${o.label} ${o.resolved ?? ''}`.toLowerCase().includes(q));
+});
+
+/**
+ * Resets and focuses the search field each time the dropdown opens. Runs on
+ * `opened` (after the popover has shown and applied its own initial focus to the
+ * dialog), and defers a frame so the search field reliably wins focus.
+ *
+ * @param {boolean} open - Whether the dropdown just opened.
+ */
+function onOpened (open) {
+  if (!open) return;
+  query.value = '';
+  requestAnimationFrame(() => {
+    searchInput.value?.$el?.querySelector('input')?.focus();
+  });
+}
+
+/**
+ * Selects the first enabled match — lets the user filter and press Enter.
+ *
+ * @param {Function} close - Closes the dropdown.
+ */
+function selectFirst (close) {
+  const first = filteredOptions.value.find(o => !o.disabled);
+  if (!first) return;
+  onInput(first.value);
+  close();
+}
+
+/**
+ * Handles keys in the search field. Stops propagation so the dropdown's own
+ * key handling (type-ahead / arrow navigation) doesn't intercept typing, while
+ * keeping Enter (select first match) and Escape (close) working.
+ *
+ * @param {KeyboardEvent} e - The keydown event.
+ * @param {Function} close - Closes the dropdown.
+ */
+function onSearchKeydown (e, close) {
+  e.stopPropagation();
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    selectFirst(close);
+  } else if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    listWrapper.value?.querySelector('[role="menuitem"]:not([aria-disabled="true"])')?.focus();
+  } else if (e.key === 'Escape') {
+    close();
+  }
+}
 </script>
 
 <script>

--- a/packages/combinator/src/components/controls/control_selection.vue
+++ b/packages/combinator/src/components/controls/control_selection.vue
@@ -11,6 +11,7 @@
     navigation-type="arrow-keys"
     placement="bottom-start"
     content-width="anchor"
+    max-height="400px"
     @opened="onOpened"
   >
     <template #anchor="{ attrs }">
@@ -62,6 +63,7 @@
     <template #list="{ close }">
       <dt-box
         v-if="showSearch"
+        class="dtc-search-box"
         surface="overlay"
         padding-block-end="50"
         border-width-block-end="100"
@@ -95,7 +97,7 @@
           </template>
         </dt-input>
       </dt-box>
-      <div ref="listWrapper" class="d-of-y-auto d-hmx-400">
+      <div>
         <dt-list-item
           v-for="option in filteredOptions"
           :key="option.value"
@@ -240,7 +242,6 @@ const selectedLabel = computed(() => selectedOption.value?.label ?? '');
 
 const query = ref('');
 const searchInput = ref(null);
-const listWrapper = ref(null);
 
 const showSearch = computed(() => options.value.length > SEARCH_THRESHOLD);
 
@@ -278,21 +279,22 @@ function selectFirst (close) {
 }
 
 /**
- * Handles keys in the search field. Stops propagation so the dropdown's own
- * key handling (type-ahead / arrow navigation) doesn't intercept typing, while
- * keeping Enter (select first match) and Escape (close) working.
+ * Handles keys in the search field. Arrow keys propagate to DtDropdown so its
+ * highlightIndex stays in sync (avoids the double-keystroke bug). All other
+ * keys are stopped to prevent DtDropdown's type-ahead from intercepting typing.
  *
  * @param {KeyboardEvent} e - The keydown event.
  * @param {Function} close - Closes the dropdown.
  */
 function onSearchKeydown (e, close) {
+  if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+    e.preventDefault(); // no page scroll
+    return; // let DtDropdown's navigation handle it
+  }
   e.stopPropagation();
   if (e.key === 'Enter') {
     e.preventDefault();
     selectFirst(close);
-  } else if (e.key === 'ArrowDown') {
-    e.preventDefault();
-    listWrapper.value?.querySelector('[role="menuitem"]:not([aria-disabled="true"])')?.focus();
   } else if (e.key === 'Escape') {
     close();
   }
@@ -307,3 +309,16 @@ export default {
   name: 'DtcControlSelection',
 };
 </script>
+
+<style scoped>
+/*
+ * Stick the search box to the top of the popover's scroll container so it
+ * stays visible as the user scrolls through the list. z-index: 1 keeps it
+ * above list items that slide under it.
+ */
+.dtc-search-box {
+  position: sticky;
+  inset-block-start: 0;
+  z-index: 1;
+}
+</style>

--- a/packages/combinator/src/components/controls/control_selection.vue
+++ b/packages/combinator/src/components/controls/control_selection.vue
@@ -125,7 +125,7 @@
             <dt-text
               v-if="option.resolved && !isColor(option.resolved)"
               kind="body"
-              :size="400"
+              size="100"
               tone="muted"
               class="d-mis-auto"
             >
@@ -133,12 +133,12 @@
             </dt-text>
           </dt-stack>
         </dt-list-item>
+        <dt-empty-state
+          v-if="!filteredOptions.length"
+          size="200"
+          body-text="No matches"
+        />
       </div>
-      <dt-empty-state
-        v-if="!filteredOptions.length"
-        size="200"
-        body-text="No matches"
-      />
     </template>
   </dt-dropdown>
 </template>
@@ -220,7 +220,7 @@ const options = computed(() => {
   }) ?? [];
 
   if (props.defaultValue === null || props.defaultValue === undefined) {
-    return [{ value: null, label: '\u2013' }, ...valueOptions];
+    return [{ value: null, label: '–' }, ...valueOptions];
   }
   return valueOptions;
 });

--- a/packages/combinator/src/components/controls/control_selection.vue
+++ b/packages/combinator/src/components/controls/control_selection.vue
@@ -79,6 +79,7 @@
         <dt-list-item
           v-for="option in filteredOptions"
           :key="option.value"
+          element-type="div"
           role="menuitem"
           navigation-type="arrow-keys"
           :class="{ 'd-o50 d-pe-none': option.disabled, 'd-bgc-moderate-opaque': option.value === value }"

--- a/packages/combinator/src/components/controls/control_selection.vue
+++ b/packages/combinator/src/components/controls/control_selection.vue
@@ -11,7 +11,6 @@
     navigation-type="arrow-keys"
     placement="bottom-start"
     content-width="anchor"
-    content-class="d-hmx-400"
     @opened="onOpened"
   >
     <template #anchor="{ attrs }">
@@ -26,12 +25,19 @@
         leading-class="d-pis-75"
       >
         <template
-          v-if="selectedOption?.resolved && isColor(selectedOption.resolved)"
+          v-if="(selectedOption?.resolved && isColor(selectedOption.resolved)) || selectedOption?.previewComponent"
           #leading
         >
           <span
+            v-if="selectedOption.resolved && isColor(selectedOption.resolved)"
             class="d-ba d-bc-subtle d-bar-circle"
             :style="swatchStyle(selectedOption.resolved)"
+          />
+          <component
+            v-else
+            :is="selectedOption.previewComponent"
+            size="200"
+            class="d-fc-muted"
           />
         </template>
         {{ selectedLabel }}
@@ -60,7 +66,6 @@
         padding-block-end="50"
         border-width-block-end="100"
         border-color="subtle"
-        class="d-ps-sticky d-ibs-0 d-zi-base1"
       >
         <dt-input
           ref="searchInput"
@@ -75,7 +80,7 @@
           </template>
         </dt-input>
       </dt-box>
-      <div ref="listWrapper">
+      <div ref="listWrapper" class="d-of-y-auto d-hmx-400">
         <dt-list-item
           v-for="option in filteredOptions"
           :key="option.value"
@@ -98,6 +103,12 @@
               :style="swatchStyle(option.resolved)"
             />
             <span>{{ option.label }}</span>
+            <component
+              v-if="option.previewComponent"
+              :is="option.previewComponent"
+              size="200"
+              class="d-mis-auto d-as-center d-fc-muted"
+            />
             <dt-text
               v-if="option.resolved && !isColor(option.resolved)"
               kind="body"
@@ -168,6 +179,10 @@ const props = defineProps({
     type: Set,
     default: undefined,
   },
+  generatePreviewComponent: {
+    type: Function,
+    default: null,
+  },
 });
 
 const emit = defineEmits([VALUE_UPDATE_EVENT]);
@@ -192,7 +207,8 @@ const options = computed(() => {
       : null;
     // Show color swatches even for disabled options; hide non-color values (misleading for disabled sizes)
     const resolved = optionDisabled && rawResolved && !isColor(rawResolved) ? null : rawResolved;
-    return { value: selection, label: props.generateLabel(selection), resolved, disabled: optionDisabled };
+    const previewComponent = props.generatePreviewComponent?.(selection) ?? null;
+    return { value: selection, label: props.generateLabel(selection), resolved, disabled: optionDisabled, previewComponent };
   }) ?? [];
 
   if (props.defaultValue === null || props.defaultValue === undefined) {

--- a/packages/combinator/src/components/controls/control_selection.vue
+++ b/packages/combinator/src/components/controls/control_selection.vue
@@ -11,7 +11,6 @@
     navigation-type="arrow-keys"
     placement="bottom-start"
     content-width="anchor"
-    max-height="400px"
     @opened="onOpened"
   >
     <template #anchor="{ attrs }">
@@ -35,8 +34,8 @@
             :style="swatchStyle(selectedOption.resolved)"
           />
           <component
-            v-else
             :is="selectedOption.previewComponent"
+            v-else
             size="200"
             class="d-fc-muted"
           />
@@ -63,7 +62,6 @@
     <template #list="{ close }">
       <dt-box
         v-if="showSearch"
-        class="dtc-search-box"
         surface="overlay"
         padding-block-end="50"
         border-width-block-end="100"
@@ -73,20 +71,18 @@
           ref="searchInput"
           v-model="query"
           type="search"
-          :size="100"
+          aria-label="Search"
           placeholder="Search"
           @keydown="onSearchKeydown($event, close)"
         >
           <template #startIcon="{ iconSize }">
             <dt-icon-search :size="iconSize" />
           </template>
-          <template #endIcon="{ clear }">
+          <template v-if="query.length" #endIcon="{ clear }">
             <dt-button
-              :style="!query.length ? { visibility: 'hidden', pointerEvents: 'none' } : undefined"
               kind="muted"
               importance="clear"
               :size="100"
-              circle
               aria-label="Clear search"
               @click="clear"
             >
@@ -97,7 +93,7 @@
           </template>
         </dt-input>
       </dt-box>
-      <div>
+      <div class="d-of-y-auto d-hmx-400 d-p-50" @keydown.up="onListArrowUp">
         <dt-list-item
           v-for="option in filteredOptions"
           :key="option.value"
@@ -119,17 +115,17 @@
               class="d-ba d-bc-subtle d-bar-circle d-as-center"
               :style="swatchStyle(option.resolved)"
             />
-            <span>{{ option.label }}</span>
             <component
-              v-if="option.previewComponent"
               :is="option.previewComponent"
-              size="200"
-              class="d-mis-auto d-as-center d-fc-muted"
+              v-if="option.previewComponent"
+              size="400"
+              class="d-as-center d-fc-tertiary"
             />
+            <span>{{ option.label }}</span>
             <dt-text
               v-if="option.resolved && !isColor(option.resolved)"
               kind="body"
-              :size="100"
+              :size="400"
               tone="muted"
               class="d-mis-auto"
             >
@@ -138,22 +134,17 @@
           </dt-stack>
         </dt-list-item>
       </div>
-      <dt-text
+      <dt-empty-state
         v-if="!filteredOptions.length"
-        kind="body"
-        :size="100"
-        tone="muted"
-        as="div"
-        class="d-px-200 d-py-150 d-ta-center"
-      >
-        No matches
-      </dt-text>
+        size="200"
+        body-text="No matches"
+      />
     </template>
   </dt-dropdown>
 </template>
 
 <script setup>
-import { DtBox, DtButton, DtInput, DtStack, DtText } from '@dialpad/dialtone-vue';
+import { DtBox, DtButton, DtEmptyState, DtInput, DtStack, DtText } from '@dialpad/dialtone-vue';
 import { DtIconClose, DtIconChevronsUpDown, DtIconSearch } from '@dialpad/dialtone-icons/vue';
 
 import { VALUE_UPDATE_EVENT } from '@/src/lib/constants';
@@ -291,6 +282,7 @@ function onSearchKeydown (e, close) {
     e.preventDefault(); // no page scroll
     return; // let DtDropdown's navigation handle it
   }
+  if (e.key === 'Tab') return; // let focus trap handle Tab/Shift+Tab
   e.stopPropagation();
   if (e.key === 'Enter') {
     e.preventDefault();
@@ -298,6 +290,21 @@ function onSearchKeydown (e, close) {
   } else if (e.key === 'Escape') {
     close();
   }
+}
+
+/**
+ * When ArrowUp is pressed on the first list item, returns focus to the search
+ * input so the user can refine the query without reaching for the mouse.
+ *
+ * @param {KeyboardEvent} e
+ */
+function onListArrowUp (e) {
+  if (!showSearch.value) return;
+  const items = e.currentTarget.querySelectorAll('[role="menuitem"]');
+  if (!items.length || !items[0].contains(e.target)) return;
+  e.preventDefault();
+  e.stopPropagation();
+  searchInput.value?.$el?.querySelector('input')?.focus();
 }
 </script>
 
@@ -309,16 +316,3 @@ export default {
   name: 'DtcControlSelection',
 };
 </script>
-
-<style scoped>
-/*
- * Stick the search box to the top of the popover's scroll container so it
- * stays visible as the user scrolls through the list. z-index: 1 keeps it
- * above list items that slide under it.
- */
-.dtc-search-box {
-  position: sticky;
-  inset-block-start: 0;
-  z-index: 1;
-}
-</style>


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWMzdGxyd3c1M3pvMjdvbXY5YzIydno0bXhkeTF6cGVzeTZncGxxcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/OQrx03s8VwOl7XmfiZ/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

[DLT-3480](https://dialpad.atlassian.net/browse/DLT-3480)

## :book: Description

Adds a live search field inside the Combinator option bar's selection dropdowns. The field appears only when a dropdown has more than 5 options. Typing filters the list in real time against both the option label and its resolved token value. Keyboard shortcuts: **Enter** selects the first enabled match, **↓** moves focus to the first list item (from where DtDropdown's arrow-key navigation takes over), **Escape** closes the dropdown. Focus is moved to the search field automatically when the dropdown opens.

## :bulb: Context

Token-backed props (e.g. `size`, `color`, `kind`) can surface dozens of valid values. Scrolling a long flat list to find a specific value slows down component exploration in the playground. A search field makes the option bar significantly faster to use for any prop with many options.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

https://github.com/user-attachments/assets/466656d3-3300-46c7-9298-fe8d655cdc51

[DLT-3480]: https://dialpad.atlassian.net/browse/DLT-3480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ