### PR TITLE
feat(fonts): DLT-3475 export font module

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
       "import": "./dist/tokens/themes/*.js",
       "require": "./dist/tokens/themes/*.cjs"
     },
+    "./fonts": "./dist/css/fonts.js",
     "./*": "./dist/*"
   },
   "dependencies": {
@@ -216,7 +217,10 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/css/*.css",
+    "./dist/css/fonts.js"
+  ],
   "nx": {
     "includedScripts": []
   }

--- a/packages/dialtone-css/gulpfile.cjs
+++ b/packages/dialtone-css/gulpfile.cjs
@@ -363,6 +363,37 @@ const buildNewSVGIcons = function (done) {
 };
 
 //  ================================================================================
+//  @@  FONTS CSS + JS ENTRY POINT
+//      Extract @font-face declarations into a standalone CSS file and a JS entry
+//      point so consumers can import '@dialpad/dialtone/fonts' via a bundler.
+//      Webpack resolves the woff2 url() paths relative to dialtone-fonts.css in
+//      dist/css/, which is where the font files live — no symlinks needed.
+//  ================================================================================
+const libFontStyles = function (done) {
+  if (!settings.styles) return done();
+
+  const fs = require('fs');
+  const css = fs.readFileSync('./lib/dist/dialtone.css', 'utf8');
+
+  const fontFaceBlocks = [];
+  const regex = /@font-face\s*\{[^}]+\}/g;
+  let match;
+  while ((match = regex.exec(css)) !== null) {
+    fontFaceBlocks.push(match[0]);
+  }
+
+  fs.writeFileSync('./lib/dist/dialtone-fonts.css', fontFaceBlocks.join('\n') + '\n');
+  done();
+};
+
+const libFontsJS = function (done) {
+  const fs = require('fs');
+  // eslint-disable-next-line quotes
+  fs.writeFileSync('./lib/dist/fonts.js', "import './dialtone-fonts.css';\n");
+  done();
+};
+
+//  ================================================================================
 //  @@  BUILD DOCS
 //      Process files and generate documentation
 //  ================================================================================
@@ -399,6 +430,8 @@ exports.default = series(
   exports.svg,
   tokens,
   libStyles,
+  libFontStyles,
+  libFontsJS,
   libDocs,
   libScripts,
 );


### PR DESCRIPTION
## Obligatory GIF (super important!)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket
[DLT-3475](https://dialpad.atlassian.net/browse/DLT-3475)

## :book: Description
Adds a dedicated `@dialpad/dialtone/fonts` export that consumers can use to load only the font-face declarations without pulling in all of Dialtone's CSS. The build pipeline now extracts `@font-face` blocks from the compiled `dialtone.css` into a standalone `dialtone-fonts.css`, then generates a `fonts.js` entry point that imports it. The `sideEffects` field in `package.json` is updated from `false` to a list that includes CSS files and `fonts.js` so bundlers (Webpack, Rollup, etc.) don't tree-shake the side-effecting imports.

## :package: Cross-Package Impact

| Package | Changes | Downstream Impact |
|---|---|---|
| `dialtone-css` | New `libFontStyles` + `libFontsJS` gulp tasks produce `dist/css/dialtone-fonts.css` and `dist/css/fonts.js` | Consumers can now `import '@dialpad/dialtone/fonts'` in a bundler |
| root `package.json` | New `./fonts` export map entry; `sideEffects` expanded to list | Ensures font CSS is not dropped by tree-shaking |

## :bulb: Context

As @iropolo had requested in https://github.com/dialpad/firespotter/pull/76735#issuecomment-4680775520

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

[DLT-3475]: https://dialpad.atlassian.net/browse/DLT-3475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ