### PR TITLE
fix(rich-text-editor): DP-190440 strip trailing <br> before </p> on paste

### DIFF
--- a/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.vue
@@ -1007,7 +1007,12 @@ export default {
           transformPastedHTML (html) {
             return html
               .replace(/<hr[^>]*\/?>/gi, '<p><br></p>')
-              .replace(/(<\/\w+>)((<br \/>)+)/g, '$2$1');
+              .replace(/(<\/\w+>)((<br \/>)+)/g, '$2$1')
+              // Strip trailing <br> just before the final </p> so pasted content
+              // doesn't produce an extra blank line at the end of the message.
+              // Anchored to end-of-string to avoid removing intentional hard breaks
+              // inside non-final paragraphs.
+              .replace(/(<br[^>]*>\s*)+<\/p>(\s*)$/i, '</p>$2');
           },
         },
       });


### PR DESCRIPTION
## Obligatory GIF (super important!)

![fixing it](https://media.giphy.com/media/3oKIPsx2VAYAgEHC12/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-190440

## :book: Description

Pasting text copied from a conversation (Tiptap read-only renderer) produced extra blank lines in the compose input. Added a regex to `transformPastedHTML` to strip the trailing `<br>` before the final `</p>` is parsed by ProseMirror.

## :bulb: Context

ProseMirror serializes paragraphs as `<p>text<br></p>` for internal cursor positioning. When that HTML is pasted back into the editor, the `<br>` is parsed as a hard-break node, producing an unwanted blank line after each paragraph.

Two regexes already exist in `transformPastedHTML` (for `<hr>` and misplaced `<br />` tags). This adds a third, anchored to end-of-string (`$`) so only the terminal `<br></p>` is stripped. Intermediate `<br>` nodes inside non-final paragraphs are left untouched.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
- [ ] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

Verified locally via Playwright against Storybook. No visual changes — behaviour fix only.