### PR TITLE
fix(rich-text-editor): DP-188940 fix cursor jump after toggleCodeBlock

### DIFF
--- a/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.test.js
+++ b/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.test.js
@@ -2152,6 +2152,42 @@ describe('DtRichTextEditor tests', () => {
       });
     });
 
+    describe('Code block cursor fix tests', function () {
+      beforeEach(async function () {
+        await wrapper.setProps({ allowCodeblock: true, modelValue: '' });
+        await wrapper.vm.$nextTick();
+      });
+
+      describe('When toggling a multi-line code block with a trailing newline back to paragraphs', function () {
+        it('cursor stays in a content paragraph instead of jumping to the empty trailing paragraph', async function () {
+          const ed = wrapper.vm.editor;
+
+          // "line one\nline two\n" — the trailing \n produces an empty paragraph when
+          // split, which is the ghost-paragraph the cursor would jump to without the fix.
+          // Positions inside the codeBlock: 1 = before 'l' of "line one",
+          //   10 = before 'l' of "line two", 17 = after 'o' of "two", 18 = the trailing '\n'.
+          ed.commands.setContent({
+            type: 'doc',
+            content: [{
+              type: 'codeBlock',
+              content: [{ type: 'text', text: 'line one\nline two\n' }],
+            }],
+          });
+          ed.commands.setTextSelection(17); // after last char of "line two", before trailing '\n'
+          await wrapper.vm.$nextTick();
+
+          vi.useFakeTimers();
+          ed.commands.toggleCodeBlock();
+          vi.runAllTimers();
+          vi.useRealTimers();
+          await wrapper.vm.$nextTick();
+
+          const $anchor = ed.state.doc.resolve(ed.state.selection.anchor);
+          expect($anchor.parent.textContent).not.toBe('');
+        });
+      });
+    });
+
     describe('Variable with different output formats', function () {
       beforeEach(async function () {
         await wrapper.setProps({

--- a/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.vue
@@ -1326,6 +1326,24 @@ export default {
       this.editor.on('phone-click', (phoneData) => {
         this.$emit('phone-click', phoneData);
       });
+
+      // Fix cursor jump when toggleCodeBlock converts a multi-line code block back to
+      // paragraphs. ProseMirror's default right-biased step mapping moves the cursor to
+      // the start of the next paragraph; left-bias (assoc=-1) keeps it on the current line.
+      let prevAnchor = this.editor.state.selection.anchor;
+      let prevInCodeBlock = this.editor.isActive('codeBlock');
+      this.editor.on('selectionUpdate', ({ editor: selEd }) => {
+        prevAnchor = selEd.state.selection.anchor;
+        prevInCodeBlock = selEd.isActive('codeBlock');
+      });
+      this.editor.on('transaction', ({ editor: txEd, transaction }) => {
+        if (!transaction.docChanged || !prevInCodeBlock || txEd.isActive('codeBlock')) return;
+        const corrected = transaction.mapping.map(prevAnchor, -1);
+        if (corrected === txEd.state.selection.anchor) return;
+        setTimeout(() => {
+          if (!this.editor.isDestroyed) this.editor.commands.setTextSelection(corrected);
+        }, 0);
+      });
     },
 
     getOutput () {


### PR DESCRIPTION
## Obligatory GIF (super important!)

![fixing it](https://media.giphy.com/media/3oKIPsx2VAYAgEHC12/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-188940

## :book: Description

After `toggleCodeBlock` converts a multi-line code block back to paragraphs, the cursor jumped to the start of the next line instead of staying on the current line.

## :bulb: Context

ProseMirror's `replaceWith` uses right-biased step mapping (`assoc=1`) by default. When a multi-line code block is split into paragraphs, each `\n` becomes a paragraph boundary, and right-bias places the cursor at the start of the *next* paragraph.

Fix: track `prevAnchor` and `prevInCodeBlock` via the `selectionUpdate` event. On any doc-changing `transaction` that exits a code block, remap the anchor with left-bias (`assoc=-1`) and dispatch `setTextSelection` in `setTimeout(0)`, after ProseMirror's own step mapping has run.

The `setTimeout(0)` is necessary because setting selection inside a Tiptap chain command is overridden by the EditorView's DOM reconciliation after dispatch. The `isDestroyed` guard prevents the callback from running if the component unmounts in the interim.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
- [ ] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

Verified locally via Playwright against Storybook. No visual changes — behaviour fix only.