### PR TITLE
feat(dialtone-css): NO-JIRA add dialtone-migrate bin and color-stops run-once marker

### DIFF
--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -316,6 +316,30 @@ const MIGRATIONS = [
 ];
 
 // ---------------------------------------------------------------------------
+// Migration markers
+// ---------------------------------------------------------------------------
+
+const MARKER_DIR = '.dialtone-migrations';
+
+function markerPath (cwd, id) {
+  return path.join(cwd, MARKER_DIR, id);
+}
+
+async function checkMigrationMarker (cwd, id) {
+  try {
+    await fs.access(markerPath(cwd, id));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeMigrationMarker (cwd, id) {
+  await fs.mkdir(path.join(cwd, MARKER_DIR), { recursive: true });
+  await fs.writeFile(markerPath(cwd, id), '', 'utf8');
+}
+
+// ---------------------------------------------------------------------------
 // CLI parsing
 // ---------------------------------------------------------------------------
 
@@ -758,8 +782,21 @@ async function runStandaloneMigration (migration, opts) {
 }
 
 async function runMigration (migration, opts) {
+  if (migration.id === 'color-stops' && !opts.dryRun) {
+    if (await checkMigrationMarker(opts.cwd, migration.id)) {
+      console.log(`  ✓ Already applied on this branch (${MARKER_DIR}/${migration.id} exists). Skipping.\n`);
+      console.log(`    Remove that file to re-run.\n`);
+      return { skipped: true };
+    }
+  }
+
   if (migration.type === 'config') {
-    return runConfigMigration(migration, opts);
+    const result = await runConfigMigration(migration, opts);
+    if (migration.id === 'color-stops' && result.applied) {
+      await writeMigrationMarker(opts.cwd, migration.id);
+      console.log(`  Marker written to ${MARKER_DIR}/${migration.id} — commit this file with your changes.\n`);
+    }
+    return result;
   }
 
   if (migration.type === 'standalone') {

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -321,8 +321,20 @@ const MIGRATIONS = [
 
 const MARKER_DIR = '.dialtone-migrations';
 
+function getRepoRoot (cwd) {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return cwd;
+  }
+}
+
 function markerPath (cwd, id) {
-  return path.join(cwd, MARKER_DIR, id);
+  return path.join(getRepoRoot(cwd), MARKER_DIR, id);
 }
 
 async function checkMigrationMarker (cwd, id) {
@@ -335,8 +347,9 @@ async function checkMigrationMarker (cwd, id) {
 }
 
 async function writeMigrationMarker (cwd, id) {
-  await fs.mkdir(path.join(cwd, MARKER_DIR), { recursive: true });
-  await fs.writeFile(markerPath(cwd, id), '', 'utf8');
+  const p = markerPath(cwd, id);
+  await fs.mkdir(path.dirname(p), { recursive: true });
+  await fs.writeFile(p, '', 'utf8');
 }
 
 // ---------------------------------------------------------------------------
@@ -773,8 +786,11 @@ async function runStandaloneMigration (migration, opts) {
     });
 
     child.on('close', code => {
-      // Exit code 0 means success (or nothing to do)
-      resolve({ exitCode: code });
+      if (code !== 0) {
+        reject(new Error(`child process exited with code ${code}`));
+      } else {
+        resolve({ exitCode: code });
+      }
     });
 
     child.on('error', reject);
@@ -784,7 +800,7 @@ async function runStandaloneMigration (migration, opts) {
 async function runMigration (migration, opts) {
   if (migration.id === 'color-stops' && !opts.dryRun) {
     if (await checkMigrationMarker(opts.cwd, migration.id)) {
-      console.log(`  ✓ Already applied on this branch (${MARKER_DIR}/${migration.id} exists). Skipping.\n`);
+      console.log(`  ✓ Already applied on this branch (${path.join(getRepoRoot(opts.cwd), MARKER_DIR, migration.id)} exists). Skipping.\n`);
       console.log(`    Remove that file to re-run.\n`);
       return { skipped: true };
     }
@@ -794,7 +810,7 @@ async function runMigration (migration, opts) {
     const result = await runConfigMigration(migration, opts);
     if (migration.id === 'color-stops' && result.applied) {
       await writeMigrationMarker(opts.cwd, migration.id);
-      console.log(`  Marker written to ${MARKER_DIR}/${migration.id} — commit this file with your changes.\n`);
+      console.log(`  Marker written to ${path.join(getRepoRoot(opts.cwd), MARKER_DIR, migration.id)} — commit this file with your changes.\n`);
     }
     return result;
   }

--- a/packages/dialtone-css/package.json
+++ b/packages/dialtone-css/package.json
@@ -50,6 +50,7 @@
   ],
   "bin": {
     "dialtone-health-check": "./lib/dist/js/dialtone_health_check/index.cjs",
+    "dialtone-migrate": "./lib/dist/js/dialtone_migrate/index.mjs",
     "dialtone-migration-helper": "./lib/dist/js/dialtone_migration_helper/index.mjs",
     "dialtone-migrate-flex-to-stack": "./lib/dist/js/dialtone_migrate_flex_to_stack/index.mjs"
   },


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change
- [x] Feature

## :book: Jira Ticket
NO-JIRA

## :book: Description
Exposes `dialtone-migrate` as a named bin in `@dialpad/dialtone-css` so consumers can invoke the master migration script via `npx dialtone-migrate`. Adds a committed marker file guard (`.dialtone-migrations/color-stops`) to the color-stops migration to prevent it from running more than once per branch — re-running color-stops on already-migrated code would produce incorrect color values.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.