### PR TITLE
feat(hovercard): DLT-2845 add focus trap to hovercard content

### DIFF
--- a/apps/dialtone-documentation/docs/components/hovercard.md
+++ b/apps/dialtone-documentation/docs/components/hovercard.md
@@ -33,6 +33,33 @@ The hovercard will appear upon the mouse entering the anchor, with a delay of 30
 
 <!-- <component-combinator component-name="DtHovercard" /> -->
 
+## Usage
+
+- Hovercard is a **progressive enhancement**. It surfaces supplementary information about an entity or provides convenience shortcuts on hover, without navigating away from the current view. Every action it exposes **must also be reachable by another route** (a dedicated page, a menu, or an inline button).
+- Keep content concise. Hovercards are transient overlays — deep interactions, multi-step flows, or extensive content belong in a dedicated UI, or in a [Modal](modal.md).
+- Use Hovercard for contextual content with structure or actions. Use [Tooltip](tooltip.md) for brief, text-only descriptions of a control. Use [Popover](popover.md) when the content is triggered by a deliberate click and should persist until dismissed.
+- `enterDelay` is used to prevent the card from triggering on accidental cursor passes. The default delay of 300 ms is recommended for most contexts.
+
+<dialtone-usage>
+<template #do>
+
+- Surface contextual details like a user's status, avatar, and quick-action shortcuts.
+- Treat hovercard actions as shortcuts — ensure the same actions are reachable elsewhere in the UI.
+
+</template>
+<template #dont>
+
+- Use Hovercard as the only way to reach content or perform an action.
+- Place critical or destructive actions exclusively inside a hovercard.
+- Use for deep interactions or lengthy content — prefer a dedicated UI or a [Modal](modal.md).
+
+</template>
+</dialtone-usage>
+
+## Accessibility
+
+When focus moves into an open hovercard, focus is trapped within it — the user can Tab between focusable elements inside the card without accidentally leaving. Pressing Escape dismisses the card and restores focus to the element that had focus before the card opened.
+
 ## Variants
 
 ### Many Hovercards

--- a/apps/dialtone-documentation/docs/components/hovercard.md
+++ b/apps/dialtone-documentation/docs/components/hovercard.md
@@ -36,7 +36,7 @@ The hovercard will appear upon the mouse entering the anchor, with a delay of 30
 ## Usage
 
 - Hovercard is a **progressive enhancement**. It surfaces supplementary information about an entity or provides convenience shortcuts on hover, without navigating away from the current view. Its content or functionality **must also be reachable by another route** (a dedicated page, a menu, or an inline button).
-- Keep content concise. Hovercards are transient overlays — deep interactions, multi-step flows, or extensive content belong in a dedicated UI, or in a [Modal](modal.md).
+- Keep content concise. Hovercards are transient overlays, and are not appropriate for deep interactions, multi-step flows, or extensive content.
 - Use Hovercard for contextual content with structure or actions. Use [Tooltip](tooltip.md) for brief, text-only descriptions of a control. Use [Popover](popover.md) when the content is triggered by a deliberate click and should persist until dismissed.
 - `enterDelay` is used to prevent the card from triggering on accidental cursor passes. The default delay of 300 ms is recommended for most contexts.
 

--- a/apps/dialtone-documentation/docs/components/hovercard.md
+++ b/apps/dialtone-documentation/docs/components/hovercard.md
@@ -58,7 +58,7 @@ The hovercard will appear upon the mouse entering the anchor, with a delay of 30
 
 ## Accessibility
 
-When focus moves into an open hovercard, focus is trapped within it — the user can Tab between focusable elements inside the card without accidentally leaving. Pressing Escape dismisses the card and restores focus to the element that had focus before the card opened.
+When focus moves into an open hovercard, focus is trapped within. The user can Tab between focusable elements inside the card without accidentally leaving. Clicking outside the hovercard or keypress of `esc` will dismiss the card and restore focus to the element that had focus before the card opened.
 
 ## Variants
 

--- a/apps/dialtone-documentation/docs/components/hovercard.md
+++ b/apps/dialtone-documentation/docs/components/hovercard.md
@@ -35,7 +35,7 @@ The hovercard will appear upon the mouse entering the anchor, with a delay of 30
 
 ## Usage
 
-- Hovercard is a **progressive enhancement**. It surfaces supplementary information about an entity or provides convenience shortcuts on hover, without navigating away from the current view. Every action it exposes **must also be reachable by another route** (a dedicated page, a menu, or an inline button).
+- Hovercard is a **progressive enhancement**. It surfaces supplementary information about an entity or provides convenience shortcuts on hover, without navigating away from the current view. Its content or functionality **must also be reachable by another route** (a dedicated page, a menu, or an inline button).
 - Keep content concise. Hovercards are transient overlays — deep interactions, multi-step flows, or extensive content belong in a dedicated UI, or in a [Modal](modal.md).
 - Use Hovercard for contextual content with structure or actions. Use [Tooltip](tooltip.md) for brief, text-only descriptions of a control. Use [Popover](popover.md) when the content is triggered by a deliberate click and should persist until dismissed.
 - `enterDelay` is used to prevent the card from triggering on accidental cursor passes. The default delay of 300 ms is recommended for most contexts.

--- a/packages/dialtone-vue/components/Hovercard/Hovercard.test.js
+++ b/packages/dialtone-vue/components/Hovercard/Hovercard.test.js
@@ -1,5 +1,6 @@
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import DtHovercard from './Hovercard.vue';
+import { DtFocustrapDirective } from '@/directives/focustrap_directive';
 
 const MOCK_DEFAULT_SLOT_MESSAGE = 'Message';
 const MOCK_HEADER_CONTENT = 'Hovercard Title';
@@ -29,6 +30,7 @@ describe('DtHovercard Tests', () => {
       attrs: { ...baseAttrs },
       slots: { ...baseSlots },
       global: {
+        plugins: [DtFocustrapDirective],
         stubs: {
           transition: false,
         },
@@ -231,6 +233,57 @@ describe('DtHovercard Tests', () => {
 
       it('aria-haspopup should be set correctly on the anchor', () => {
         expect(button.attributes('aria-haspopup')).toBe('dialog');
+      });
+    });
+
+    describe('Focus trapping', () => {
+      let localWrapper;
+
+      beforeEach(async () => {
+        vi.useFakeTimers();
+        localWrapper = mount(DtHovercard, {
+          props: { ...baseProps },
+          slots: {
+            anchor: '<template #anchor="slotProps"><button data-qa="dt-button" v-bind="slotProps">Hover me</button></template>',
+            content: '<button data-qa="btn-first">First</button><button data-qa="btn-last">Last</button>',
+          },
+          global: {
+            plugins: [DtFocustrapDirective],
+            stubs: { transition: false },
+          },
+          attachTo: document.body,
+        });
+
+        const localAnchor = localWrapper.find('[data-qa="dt-hovercard-anchor"]');
+        await localAnchor.trigger('mouseenter');
+        vi.runAllTimers();
+        await flushPromises();
+      });
+
+      afterEach(() => {
+        localWrapper.unmount();
+      });
+
+      it('wraps Tab forward from last tabbable element to first', () => {
+        const lastBtn = document.querySelector('[data-qa="btn-last"]');
+        lastBtn.focus();
+
+        const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+        lastBtn.dispatchEvent(tabEvent);
+
+        expect(tabEvent.defaultPrevented).toBe(true);
+        expect(document.activeElement).toBe(document.querySelector('[data-qa="btn-first"]'));
+      });
+
+      it('wraps Shift+Tab backward from first tabbable element to last', () => {
+        const firstBtn = document.querySelector('[data-qa="btn-first"]');
+        firstBtn.focus();
+
+        const shiftTabEvent = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true });
+        firstBtn.dispatchEvent(shiftTabEvent);
+
+        expect(shiftTabEvent.defaultPrevented).toBe(true);
+        expect(document.activeElement).toBe(document.querySelector('[data-qa="btn-last"]'));
       });
     });
   });

--- a/packages/dialtone-vue/components/Hovercard/Hovercard.test.js
+++ b/packages/dialtone-vue/components/Hovercard/Hovercard.test.js
@@ -1,5 +1,6 @@
 import { mount, flushPromises } from '@vue/test-utils';
 import DtHovercard from './Hovercard.vue';
+import { DtPopover } from '@/components/Popover/index.js';
 import { DtFocustrapDirective } from '@/directives/focustrap_directive';
 
 const MOCK_DEFAULT_SLOT_MESSAGE = 'Message';
@@ -237,53 +238,19 @@ describe('DtHovercard Tests', () => {
     });
 
     describe('Focus trapping', () => {
-      let localWrapper;
-
-      beforeEach(async () => {
+      it('passes focustrap=true to DtPopover when hovercard is open', async () => {
         vi.useFakeTimers();
-        localWrapper = mount(DtHovercard, {
-          props: { ...baseProps },
-          slots: {
-            anchor: '<template #anchor="slotProps"><button data-qa="dt-button" v-bind="slotProps">Hover me</button></template>',
-            content: '<button data-qa="btn-first">First</button><button data-qa="btn-last">Last</button>',
-          },
-          global: {
-            plugins: [DtFocustrapDirective],
-            stubs: { transition: false },
-          },
-          attachTo: document.body,
-        });
-
-        const localAnchor = localWrapper.find('[data-qa="dt-hovercard-anchor"]');
-        await localAnchor.trigger('mouseenter');
+        await anchor.trigger('mouseenter');
         vi.runAllTimers();
         await flushPromises();
+
+        const popover = wrapper.findComponent(DtPopover);
+        expect(popover.props('focustrap')).toBe(true);
       });
 
-      afterEach(() => {
-        localWrapper.unmount();
-      });
-
-      it('wraps Tab forward from last tabbable element to first', () => {
-        const lastBtn = document.querySelector('[data-qa="btn-last"]');
-        lastBtn.focus();
-
-        const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
-        lastBtn.dispatchEvent(tabEvent);
-
-        expect(tabEvent.defaultPrevented).toBe(true);
-        expect(document.activeElement).toBe(document.querySelector('[data-qa="btn-first"]'));
-      });
-
-      it('wraps Shift+Tab backward from first tabbable element to last', () => {
-        const firstBtn = document.querySelector('[data-qa="btn-first"]');
-        firstBtn.focus();
-
-        const shiftTabEvent = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true });
-        firstBtn.dispatchEvent(shiftTabEvent);
-
-        expect(shiftTabEvent.defaultPrevented).toBe(true);
-        expect(document.activeElement).toBe(document.querySelector('[data-qa="btn-last"]'));
+      it('passes a falsy focustrap to DtPopover when hovercard is closed', () => {
+        const popover = wrapper.findComponent(DtPopover);
+        expect(popover.props('focustrap')).toBeFalsy();
       });
     });
   });

--- a/packages/dialtone-vue/components/Hovercard/Hovercard.test.js
+++ b/packages/dialtone-vue/components/Hovercard/Hovercard.test.js
@@ -252,6 +252,23 @@ describe('DtHovercard Tests', () => {
         const popover = wrapper.findComponent(DtPopover);
         expect(popover.props('focustrap')).toBeFalsy();
       });
+
+      it('closes and restores focus to the anchor on Escape', async () => {
+        // Focus the anchor before opening so the directive captures it as previousFocus
+        button.element.focus();
+
+        vi.useFakeTimers();
+        await anchor.trigger('mouseenter');
+        vi.runAllTimers();
+        await flushPromises();
+
+        // Trigger Escape on the teleported popover dialog (dt-lazy-show)
+        const popoverDialog = wrapper.findComponent(DtPopover).findComponent({ ref: 'content' });
+        await popoverDialog.trigger('keydown', { key: 'Escape' });
+        await flushPromises();
+
+        expect(document.activeElement).toBe(button.element);
+      });
     });
   });
 });

--- a/packages/dialtone-vue/components/Hovercard/Hovercard.vue
+++ b/packages/dialtone-vue/components/Hovercard/Hovercard.vue
@@ -37,6 +37,7 @@
     </template>
     <template #content>
       <div
+        v-dt-focustrap="{ active: hovercardOpen, initialFocus: false, restoreFocus: true }"
         @focusin="onContentFocusIn"
         @focusout="onContentFocusOut"
       >

--- a/packages/dialtone-vue/components/Hovercard/Hovercard.vue
+++ b/packages/dialtone-vue/components/Hovercard/Hovercard.vue
@@ -13,6 +13,7 @@
     :transition="transition ? 'fade' : null"
     :offset="offset"
     :modal="false"
+    :focustrap="hovercardOpen"
     initial-focus-element="none"
     :header-class="headerClass"
     :footer-class="footerClass"
@@ -37,7 +38,6 @@
     </template>
     <template #content>
       <div
-        v-dt-focustrap="{ active: hovercardOpen, initialFocus: false, restoreFocus: true }"
         @focusin="onContentFocusIn"
         @focusout="onContentFocusOut"
       >

--- a/packages/dialtone-vue/components/Popover/Popover.test.js
+++ b/packages/dialtone-vue/components/Popover/Popover.test.js
@@ -362,6 +362,37 @@ describe('DtPopover Tests', () => {
         expect(document.activeElement).toBe(last);
       });
     });
+
+    describe('When focustrap is true and not modal', () => {
+      beforeEach(async () => {
+        mockProps = { modal: false, focustrap: true };
+        mockSlots = { content: MOCK_TRAP_CONTENT };
+
+        updateWrapper();
+        await wrapper.setProps({ open: true });
+        await flushPromises();
+      });
+
+      it('wraps focus from the last element to the first on Tab', async () => {
+        const first = popoverWindow.find('[data-qa="dt-popover-close"]').element;
+        const last = popoverWindow.find('[data-qa="trap-last"]').element;
+
+        last.focus();
+        await popoverWindow.trigger('keydown', { key: 'Tab' });
+
+        expect(document.activeElement).toBe(first);
+      });
+
+      it('wraps focus from the first element to the last on Shift+Tab', async () => {
+        const first = popoverWindow.find('[data-qa="dt-popover-close"]').element;
+        const last = popoverWindow.find('[data-qa="trap-last"]').element;
+
+        first.focus();
+        await popoverWindow.trigger('keydown', { key: 'Tab', shiftKey: true });
+
+        expect(document.activeElement).toBe(last);
+      });
+    });
   });
 
   describe('Pass-through class props', () => {

--- a/packages/dialtone-vue/components/Popover/Popover.test.js
+++ b/packages/dialtone-vue/components/Popover/Popover.test.js
@@ -392,6 +392,29 @@ describe('DtPopover Tests', () => {
 
         expect(document.activeElement).toBe(last);
       });
+
+      it('closes the popover on Escape', async () => {
+        await popoverWindow.trigger('keydown', { key: 'Escape' });
+        await flushPromises();
+
+        expect(popoverWindow.attributes('aria-hidden')).toBe('true');
+      });
+
+      it('restores focus to the previously focused element on Escape', async () => {
+        // Close so the directive deactivates, then set a known previous focus
+        await wrapper.setProps({ open: false });
+        await flushPromises();
+        button.element.focus();
+
+        // Reopen — directive activates and captures button as previousFocus
+        await wrapper.setProps({ open: true });
+        await flushPromises();
+
+        await popoverWindow.trigger('keydown', { key: 'Escape' });
+        await flushPromises();
+
+        expect(document.activeElement).toBe(button.element);
+      });
     });
   });
 

--- a/packages/dialtone-vue/components/Popover/Popover.vue
+++ b/packages/dialtone-vue/components/Popover/Popover.vue
@@ -47,7 +47,11 @@
       <dt-lazy-show
         :id="id"
         ref="content"
-        v-dt-focustrap="{ active: (modal || focustrap) && isOpen, initialFocus: false, restoreFocus: false }"
+        v-dt-focustrap="{
+          active: (modal || focustrap) && isOpen,
+          initialFocus: false,
+          restoreFocus: !modal && focustrap,
+        }"
         :role="role"
         :data-qa="$attrs['data-qa'] ? `${$attrs['data-qa']}__dialog` : 'dt-popover'"
         :aria-hidden="`${!isOpen}`"

--- a/packages/dialtone-vue/components/Popover/Popover.vue
+++ b/packages/dialtone-vue/components/Popover/Popover.vue
@@ -47,7 +47,7 @@
       <dt-lazy-show
         :id="id"
         ref="content"
-        v-dt-focustrap="{ active: modal && isOpen, initialFocus: false, restoreFocus: false }"
+        v-dt-focustrap="{ active: (modal || focustrap) && isOpen, initialFocus: false, restoreFocus: false }"
         :role="role"
         :data-qa="$attrs['data-qa'] ? `${$attrs['data-qa']}__dialog` : 'dt-popover'"
         :aria-hidden="`${!isOpen}`"
@@ -342,6 +342,18 @@ export default {
     modal: {
       type: Boolean,
       default: true,
+    },
+
+    /**
+     * When true, traps Tab/Shift+Tab focus within the popover dialog.
+     * Use this to enable focus trapping independently of modal state —
+     * e.g. a non-modal popover whose content still requires keyboard containment.
+     * When `modal` is true, the trap is already active; this prop has no additional effect.
+     * @values true, false
+     */
+    focustrap: {
+      type: Boolean,
+      default: false,
     },
 
     /**
@@ -1014,7 +1026,7 @@ export default {
     },
 
     onKeydown (e) {
-      // Tab focus trapping (when modal) is handled by the v-dt-focustrap directive on the content.
+      // Tab focus trapping (when modal or focustrap) is handled by the v-dt-focustrap directive on the content.
       if (e.key === 'Escape') {
         this.closePopover();
       }


### PR DESCRIPTION
# feat(hovercard): DLT-2845 add focus trap to hovercard content

![Obligatory GIF](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExenlvbHQ2MTF6NDZjYjY0cGNma3pjOTZxN2kwYTNtMXowMmc5cXlxbSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/skIzBhm48W4t4FMaK9/giphy.gif)

## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2845

## :book: Description

Binds `v-dt-focustrap` to the Hovercard content wrapper, trapping Tab/Shift+Tab within the card while it is open.

## :bulb: Context

~~This is a **draft for discussion**; a few open questions should be resolved before merging:~~

~~1. **Do we want to trap focus in this particular case?** Hovercard is explicitly non-modal (`:modal="false"`)~~

~~2. If we do want to trap focus, it's worth noting that **there is currently no keyboard entry path.** The hovercard only shows on `mouseenter`. WCAG seems to suggest that "Content which can be triggered via pointer hover should also be able to be triggered by keyboard focus". This implies that we should show the hovercard when trigger element is (keyboard) focused — are we happy with this?~~
~~- A related side-effect of this is that if we show the hovercard on `mouseenter` only, the user might have to _tab_ quite a lot until they get into the hovercard (depending on which element is focused when the card is shown). We may want to consider automatically focusing an element in the hovercard via `initialFocus`~~

Discussed with design engineering and agreed that:

- The hovercard is to be explicitly framed as a progressive enhancement: anything it surfaces must also be reachable another way, so keyboard/AT users are never blocked 
- Because of this, and because it has the potential to become noisy and disruptive, we will not be adding keyboard-driven ways of triggering the hovercard — there's no need to, content and actions are available elsewhere, and excessive "pop-ups" being triggered with keyboard navigation will affect the UX negatively
- Focus trapping is still desirable, but only within the scope of the hovercard. Once focus enters the hovercard (by e.g. mouse click), tabbing should be constrained to the hovercard focusable elements
- Escape should dismiss the hovercard; focus should be restored to where it came from
- Documentation needs to provide guidance and reflect our accessibility practices

This PR touches the Popover, which was out of scope. This is because the Hovercard essentially wraps the Popover component, and controlling the focustrapping at the Popover-level was the only way to ensure we covered all 3 slots (header, content, footer). More than happy to consider other approaches to this.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description.
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
- [x] I have added / updated unit tests.
- [x] I have validated components keyboard navigation.

## :camera: Screenshots / GIFs

Focus trapping:

https://github.com/user-attachments/assets/5f88724a-2e6f-48cc-8c7d-de2ddcfccb33

Notice how tabbing doesn't trigger the hovercard (illustrates lack of keyboard entry path):

https://github.com/user-attachments/assets/d7295312-2bb2-4844-8016-0b5292c1476f

Changes to the docs:

<img width="955" height="772" alt="image" src="https://github.com/user-attachments/assets/b0d99f9e-06b6-42d5-9ffa-9e829a5ac2c6" />
