### PR TITLE
fix(eslint-plugin-dialtone): guard against null value on valueless class attributes

### DIFF
--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-base-color-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-base-color-classes.js
@@ -33,7 +33,7 @@ module.exports = {
     return sourceCode.parserServices.defineTemplateBodyVisitor({
       // Visitor functions for Vue templates
       VAttribute (node) {
-        if (node.key.name === 'class' && node.value) {
+        if (node.key.name === 'class' && node.value && typeof node.value.value === 'string') {
           const classes = node.value.value;
           if (classes.match(/d-bgc-\w+-\d{2,4}/)) {
             context.report({ node, messageId: 'recommendBackgroundSemanticColor' });

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-base-color-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-base-color-classes.js
@@ -33,7 +33,7 @@ module.exports = {
     return sourceCode.parserServices.defineTemplateBodyVisitor({
       // Visitor functions for Vue templates
       VAttribute (node) {
-        if (node.key.name === 'class') {
+        if (node.key.name === 'class' && node.value) {
           const classes = node.value.value;
           if (classes.match(/d-bgc-\w+-\d{2,4}/)) {
             context.report({ node, messageId: 'recommendBackgroundSemanticColor' });

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-flex-gap-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-flex-gap-classes.js
@@ -29,7 +29,7 @@ module.exports = {
     return sourceCode.parserServices.defineTemplateBodyVisitor({
       // Visitor functions for Vue templates
       VAttribute(node) {
-        if (node.key.name === 'class' && node.value) {
+        if (node.key.name === 'class' && node.value && typeof node.value.value === 'string') {
           const classes = node.value.value;
           if (classes.match(/d-flg\d{1,2}/)) {
             context.report({

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-flex-gap-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-flex-gap-classes.js
@@ -29,7 +29,7 @@ module.exports = {
     return sourceCode.parserServices.defineTemplateBodyVisitor({
       // Visitor functions for Vue templates
       VAttribute(node) {
-        if (node.key.name === 'class') {
+        if (node.key.name === 'class' && node.value) {
           const classes = node.value.value;
           if (classes.match(/d-flg\d{1,2}/)) {
             context.report({

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-grid-gap-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-grid-gap-classes.js
@@ -29,7 +29,7 @@ module.exports = {
     return sourceCode.parserServices.defineTemplateBodyVisitor({
       // Visitor functions for Vue templates
       VAttribute(node) {
-        if (node.key.name === 'class') {
+        if (node.key.name === 'class' && node.value) {
           const classes = node.value.value.split(' ');
           const gapClasses = ['d-gg', 'd-grg', 'd-gcg'];
           const gapClassesFound = classes.filter((className) =>

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-grid-gap-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-grid-gap-classes.js
@@ -29,7 +29,7 @@ module.exports = {
     return sourceCode.parserServices.defineTemplateBodyVisitor({
       // Visitor functions for Vue templates
       VAttribute(node) {
-        if (node.key.name === 'class' && node.value) {
+        if (node.key.name === 'class' && node.value && typeof node.value.value === 'string') {
           const classes = node.value.value.split(' ');
           const gapClasses = ['d-gg', 'd-grg', 'd-gcg'];
           const gapClassesFound = classes.filter((className) =>

--- a/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/recommend-typography-style.js
@@ -40,7 +40,7 @@ module.exports = {
     return sourceCode.parserServices.defineTemplateBodyVisitor({
       // Visitor functions for Vue templates
       VAttribute (node) {
-        if (node.key.name === 'class') {
+        if (node.key.name === 'class' && node.value) {
           const classes = node.value.value.split(' ');
 
           // For each class, determine which category it belongs to and track all matches

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-base-color-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-base-color-classes.js
@@ -21,6 +21,7 @@ const ruleTester = new RuleTester({
 ruleTester.run('deprecated-base-color-classes', rule, {
   valid: [
     { code: '<template><div class /></template>' },
+    { code: '<template><div class="" /></template>' },
     { code: '<template><div class="d-bgc-primary" /></template>' },
     { code: '<template><div class="d-fc-secondary" /></template>' },
     { code: '<template><div class="d-bc-positive" /></template>' },

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-base-color-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-base-color-classes.js
@@ -20,6 +20,7 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('deprecated-base-color-classes', rule, {
   valid: [
+    { code: '<template><div class /></template>' },
     { code: '<template><div class="d-bgc-primary" /></template>' },
     { code: '<template><div class="d-fc-secondary" /></template>' },
     { code: '<template><div class="d-bc-positive" /></template>' },

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-flex-gap-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-flex-gap-classes.js
@@ -26,6 +26,9 @@ const ruleTester = new RuleTester({
 ruleTester.run("deprecated-flex-gap-classes", rule, {
   valid: [
     {
+      code: "<template><div class /></template>",
+    },
+    {
       code: "<template><div class=\"d-fl-col2 d-g8\" /></template>",
     },
     {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-flex-gap-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-flex-gap-classes.js
@@ -29,6 +29,9 @@ ruleTester.run("deprecated-flex-gap-classes", rule, {
       code: "<template><div class /></template>",
     },
     {
+      code: "<template><div class=\"\" /></template>",
+    },
+    {
       code: "<template><div class=\"d-fl-col2 d-g8\" /></template>",
     },
     {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-grid-gap-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-grid-gap-classes.js
@@ -29,6 +29,9 @@ ruleTester.run("deprecated-grid-gap-classes", rule, {
       code: "<template><div class /></template>",
     },
     {
+      code: "<template><div class=\"\" /></template>",
+    },
+    {
       code: "<template><div class=\"d-g8\" /></template>",
     },
     {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-grid-gap-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-grid-gap-classes.js
@@ -26,6 +26,9 @@ const ruleTester = new RuleTester({
 ruleTester.run("deprecated-grid-gap-classes", rule, {
   valid: [
     {
+      code: "<template><div class /></template>",
+    },
+    {
       code: "<template><div class=\"d-g8\" /></template>",
     },
     {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/recommend-typography-style.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/recommend-typography-style.js
@@ -25,6 +25,10 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("recommend-typography-style", rule, {
   valid: [
+    // Boolean/valueless class attribute should not crash
+    {
+      code: "<template><div class /></template>",
+    },
     // Composed typography utilities are valid
     {
       code: "<template><div class=\"d-label--md-plain\" /></template>",


### PR DESCRIPTION
## Description

Four ESLint rules in `eslint-plugin-dialtone` crash with `TypeError: Cannot read properties of null (reading 'value')` when linting Vue templates that contain a valueless `class` attribute (e.g. `<div class>`). The rules all check `node.key.name === 'class'` but then unconditionally dereference `node.value.value` without checking whether `node.value` is null first.

## Summary of changes requested

- Added `&& node.value` null guard to the `VAttribute` condition in four rules:
  - `deprecated-base-color-classes`
  - `deprecated-flex-gap-classes`
  - `deprecated-grid-gap-classes`
  - `recommend-typography-style`
- Added a `<template><div class /></template>` valid test case to each of the four corresponding test files to cover this scenario

## Technical Details

Each affected rule has the same pattern:

```js
// Before — crashes on <div class> (node.value is null)
if (node.key.name === 'class') {
  const classes = node.value.value...

// After — safely skips valueless attributes
if (node.key.name === 'class' && node.value) {
  const classes = node.value.value...
```

Test results: 4 new passing tests added, no regressions (pre-existing 60 failures are unrelated).