### PR TITLE
fix(scripts): NO-JIRA improve theme-to-mode migration script

### DIFF
--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/theme-to-mode.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/theme-to-mode.mjs
@@ -129,7 +129,7 @@ export default {
     //    to find regions needing v-dt-mode review).
     //    The optional prefix makes this idempotent (same pattern as expressions 1–3).
     {
-      from: /(?:\/\* TODO: review for v-dt-mode[^\n]*\n)?(?:\[data-dt-mode="invert"\]|\[data-dt-mode=invert\])/g,
+      from: /(?:\/\* TODO: review for v-dt-mode[^\n]*\n)?\[data-dt-mode=(["']?)invert\1\]/g,
       to: (match) => {
         if (match.startsWith('/* TODO:')) return match;
         return `/* TODO: review for v-dt-mode adoption — see /guides/migration/theme-to-mode/ */\n${match}`;

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/theme-to-mode.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/theme-to-mode.mjs
@@ -44,35 +44,47 @@ export default {
     //    Must run BEFORE expression 3 so these are consumed before the fallthrough fires.
     //    setTheme() was re-entrant; initDialtoneTheme() is a one-shot bootstrap that
     //    throws if already initialized — the caller must decide which replacement applies.
+    //
+    //    The optional `(?:// TODO:[^\n]*\n)?` prefix makes this expression idempotent:
+    //    when the comment is already present the full block is captured and returned
+    //    unchanged, so the convergence loop in dialtone-migrate terminates.
     {
       from: new RegExp(
-        `(?<!\\.)setTheme\\(\\s*(${KNOWN_LIGHT.join('|')})\\s*\\)`,
+        `(?:// TODO:[^\\n]*\\n)?(?<!\\.)setTheme\\(\\s*(${KNOWN_LIGHT.join('|')})\\s*\\)`,
         'g',
       ),
-      to: (match, identifier) =>
-        `// TODO: startup → initDialtoneTheme(${identifier}, 'light')  or  per-toggle → setMode('light') — see /guides/migration/theme-to-mode/\n${match}`,
+      to: (match, identifier) => {
+        if (match.startsWith('// TODO:')) return match;
+        return `// TODO: startup → initDialtoneTheme(${identifier}, 'light')  or  per-toggle → setMode('light') — see /guides/migration/theme-to-mode/\n${match}`;
+      },
     },
 
     // 2. setTheme() calls with known dark identifiers → TODO comment with mode hint.
+    //    Same idempotency guard as expression 1.
     {
       from: new RegExp(
-        `(?<!\\.)setTheme\\(\\s*(${KNOWN_DARK.join('|')})\\s*\\)`,
+        `(?:// TODO:[^\\n]*\\n)?(?<!\\.)setTheme\\(\\s*(${KNOWN_DARK.join('|')})\\s*\\)`,
         'g',
       ),
-      to: (match, identifier) =>
-        `// TODO: startup → initDialtoneTheme(${identifier}, 'dark')  or  per-toggle → setMode('dark') — see /guides/migration/theme-to-mode/\n${match}`,
+      to: (match, identifier) => {
+        if (match.startsWith('// TODO:')) return match;
+        return `// TODO: startup → initDialtoneTheme(${identifier}, 'dark')  or  per-toggle → setMode('dark') — see /guides/migration/theme-to-mode/\n${match}`;
+      },
     },
 
     // 3. setTheme() calls with unknown / dynamic arguments → TODO comment.
     //    Negative-lookahead skips the eight known identifiers already handled above.
     //    Negative-lookbehind on '.' prevents matching unrelated .setTheme() methods.
+    //    Same idempotency guard as expressions 1–2.
     {
       from: new RegExp(
-        `(?<!\\.)setTheme\\(\\s*(?!(${KNOWN_PATTERN})\\s*\\))([^)]*)\\)`,
+        `(?:// TODO:[^\\n]*\\n)?(?<!\\.)setTheme\\(\\s*(?!(${KNOWN_PATTERN})\\s*\\))([^)]*)\\)`,
         'g',
       ),
-      to: (match) =>
-        `// TODO: review for layered API migration — see /guides/migration/theme-to-mode/\n${match}`,
+      to: (match) => {
+        if (match.startsWith('// TODO:')) return match;
+        return `// TODO: review for layered API migration — see /guides/migration/theme-to-mode/\n${match}`;
+      },
     },
 
     // 4. Attribute rename: data-dt-theme → data-dt-mode
@@ -86,25 +98,41 @@ export default {
       to: () => 'data-dt-mode',
     },
 
-    // 5. CSS selector invert — add TODO comment before the renamed selector.
+    // 5. Rewrite known legacy theme-name values to their mode equivalents.
+    //    Runs after expression 4 (which renamed data-dt-theme → data-dt-mode).
+    //    Handles HTML/Vue attributes, Vue bindings, and CSS selectors uniformly.
+    //    Known light: dp-light, tmo-light, expressive-light, expressive-sm-light
+    //    Known dark:  dp-dark,  tmo-dark,  expressive-dark,  expressive-sm-dark
+    //    The backreference \1 ensures the surrounding quote style is preserved.
+    //    Unknown theme values are left as-is; consumers can grep for data-dt-mode="
+    //    to find any remaining non-canonical values.
+    {
+      from: /\bdata-dt-mode=(["']?)((?:dp|tmo|expressive(?:-sm)?)-(?:light|dark))\1/g,
+      to: (_, q, value) => `data-dt-mode=${q}${value.endsWith('-light') ? 'light' : 'dark'}${q}`,
+    },
+
+    // 7. CSS selector invert — add TODO comment before the renamed selector.
     //    Expression 4 already renamed [data-dt-theme=...] → [data-dt-mode=...],
     //    so we match on the result.  HTML attribute invert is handled by
     //    expression 4 (just renamed, no comment — inserting HTML comments inside
     //    tags produces invalid markup; consumers grep for data-dt-mode="invert"
     //    to find regions needing v-dt-mode review).
+    //    The optional prefix makes this idempotent (same pattern as expressions 1–3).
     {
-      from: /\[data-dt-mode="invert"\]|\[data-dt-mode=invert\]/g,
-      to: (match) =>
-        `/* TODO: review for v-dt-mode adoption — see /guides/migration/theme-to-mode/ */\n${match}`,
+      from: /(?:\/\* TODO: review for v-dt-mode[^\n]*\n)?(?:\[data-dt-mode="invert"\]|\[data-dt-mode=invert\])/g,
+      to: (match) => {
+        if (match.startsWith('/* TODO:')) return match;
+        return `/* TODO: review for v-dt-mode adoption — see /guides/migration/theme-to-mode/ */\n${match}`;
+      },
     },
 
-    // 6. JS attribute methods: setAttribute/getAttribute/etc. on 'data-dt-theme'
+    // 8. JS attribute methods: setAttribute/getAttribute/etc. on 'data-dt-theme'
     {
       from: /(\.(?:set|get|toggle|remove|has)Attribute\(\s*['"])data-dt-theme(['"])/g,
       to: (_match, prefix, suffix) => `${prefix}data-dt-mode${suffix}`,
     },
 
-    // 7. CSS attribute selectors: [data-dt-theme...] → [data-dt-mode...]
+    // 9. CSS attribute selectors: [data-dt-theme...] → [data-dt-mode...]
     //    Runs after the invert-flagging expressions to avoid double-processing.
     {
       from: /\[data-dt-theme(\]|=[^\]]*\])/g,

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/theme-to-mode.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/theme-to-mode.mjs
@@ -50,7 +50,7 @@ export default {
     //    unchanged, so the convergence loop in dialtone-migrate terminates.
     {
       from: new RegExp(
-        `(?:// TODO:[^\\n]*\\n)?(?<!\\.)setTheme\\(\\s*(${KNOWN_LIGHT.join('|')})\\s*\\)`,
+        `(?:// TODO: startup →[^\\n]*\\n)?(?<!\\.)setTheme\\(\\s*(${KNOWN_LIGHT.join('|')})\\s*\\)`,
         'g',
       ),
       to: (match, identifier) => {
@@ -63,7 +63,7 @@ export default {
     //    Same idempotency guard as expression 1.
     {
       from: new RegExp(
-        `(?:// TODO:[^\\n]*\\n)?(?<!\\.)setTheme\\(\\s*(${KNOWN_DARK.join('|')})\\s*\\)`,
+        `(?:// TODO: startup →[^\\n]*\\n)?(?<!\\.)setTheme\\(\\s*(${KNOWN_DARK.join('|')})\\s*\\)`,
         'g',
       ),
       to: (match, identifier) => {
@@ -78,7 +78,7 @@ export default {
     //    Same idempotency guard as expressions 1–2.
     {
       from: new RegExp(
-        `(?:// TODO:[^\\n]*\\n)?(?<!\\.)setTheme\\(\\s*(?!(${KNOWN_PATTERN})\\s*\\))([^)]*)\\)`,
+        `(?:// TODO: review for layered API migration[^\\n]*\\n)?(?<!\\.)setTheme\\(\\s*(?!(${KNOWN_PATTERN})\\s*\\))([^)]*)\\)`,
         'g',
       ),
       to: (match) => {

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/theme-to-mode.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/theme-to-mode.mjs
@@ -54,7 +54,7 @@ export default {
         'g',
       ),
       to: (match, identifier) => {
-        if (match.startsWith('// TODO:')) return match;
+        if (match.startsWith('// TODO: startup →')) return match;
         return `// TODO: startup → initDialtoneTheme(${identifier}, 'light')  or  per-toggle → setMode('light') — see /guides/migration/theme-to-mode/\n${match}`;
       },
     },
@@ -67,7 +67,7 @@ export default {
         'g',
       ),
       to: (match, identifier) => {
-        if (match.startsWith('// TODO:')) return match;
+        if (match.startsWith('// TODO: startup →')) return match;
         return `// TODO: startup → initDialtoneTheme(${identifier}, 'dark')  or  per-toggle → setMode('dark') — see /guides/migration/theme-to-mode/\n${match}`;
       },
     },
@@ -82,7 +82,7 @@ export default {
         'g',
       ),
       to: (match) => {
-        if (match.startsWith('// TODO:')) return match;
+        if (match.startsWith('// TODO: review for layered API migration')) return match;
         return `// TODO: review for layered API migration — see /guides/migration/theme-to-mode/\n${match}`;
       },
     },
@@ -111,7 +111,7 @@ export default {
       to: (_, q, value) => `data-dt-mode=${q}${value.endsWith('-light') ? 'light' : 'dark'}${q}`,
     },
 
-    // 7. CSS selector invert — add TODO comment before the renamed selector.
+    // 6. CSS selector invert — add TODO comment before the renamed selector.
     //    Expression 4 already renamed [data-dt-theme=...] → [data-dt-mode=...],
     //    so we match on the result.  HTML attribute invert is handled by
     //    expression 4 (just renamed, no comment — inserting HTML comments inside
@@ -126,13 +126,13 @@ export default {
       },
     },
 
-    // 8. JS attribute methods: setAttribute/getAttribute/etc. on 'data-dt-theme'
+    // 7. JS attribute methods: setAttribute/getAttribute/etc. on 'data-dt-theme'
     {
       from: /(\.(?:set|get|toggle|remove|has)Attribute\(\s*['"])data-dt-theme(['"])/g,
       to: (_match, prefix, suffix) => `${prefix}data-dt-mode${suffix}`,
     },
 
-    // 9. CSS attribute selectors: [data-dt-theme...] → [data-dt-mode...]
+    // 8. CSS attribute selectors: [data-dt-theme...] → [data-dt-mode...]
     //    Runs after the invert-flagging expressions to avoid double-processing.
     {
       from: /\[data-dt-theme(\]|=[^\]]*\])/g,

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/theme-to-mode.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/theme-to-mode.mjs
@@ -100,15 +100,25 @@ export default {
 
     // 5. Rewrite known legacy theme-name values to their mode equivalents.
     //    Runs after expression 4 (which renamed data-dt-theme → data-dt-mode).
-    //    Handles HTML/Vue attributes, Vue bindings, and CSS selectors uniformly.
+    //    Handles two forms:
+    //      Plain:     data-dt-mode="dp-light"          → data-dt-mode="light"
+    //      Vue bound: :data-dt-mode="'dp-light'"       → :data-dt-mode="'light'"
+    //                 v-bind:data-dt-mode="'dp-light'" → v-bind:data-dt-mode="'light'"
     //    Known light: dp-light, tmo-light, expressive-light, expressive-sm-light
     //    Known dark:  dp-dark,  tmo-dark,  expressive-dark,  expressive-sm-dark
-    //    The backreference \1 ensures the surrounding quote style is preserved.
-    //    Unknown theme values are left as-is; consumers can grep for data-dt-mode="
-    //    to find any remaining non-canonical values.
+    //    Unknown theme values are left as-is.
     {
-      from: /\bdata-dt-mode=(["']?)((?:dp|tmo|expressive(?:-sm)?)-(?:light|dark))\1/g,
-      to: (_, q, value) => `data-dt-mode=${q}${value.endsWith('-light') ? 'light' : 'dark'}${q}`,
+      from: new RegExp(
+        '(?:(v-bind:|:)data-dt-mode=(["\'])(["\'])((?:dp|tmo|expressive(?:-sm)?)-(?:light|dark))\\3\\2' +
+          '|\\bdata-dt-mode=(["\']?)((?:dp|tmo|expressive(?:-sm)?)-(?:light|dark))\\5)',
+        'g',
+      ),
+      to: (_, prefix, outerQ, innerQ, boundVal, plainQ, plainVal) => {
+        if (prefix !== undefined) {
+          return `${prefix}data-dt-mode=${outerQ}${innerQ}${boundVal.endsWith('-light') ? 'light' : 'dark'}${innerQ}${outerQ}`;
+        }
+        return `data-dt-mode=${plainQ}${plainVal.endsWith('-light') ? 'light' : 'dark'}${plainQ}`;
+      },
     },
 
     // 6. CSS selector invert — add TODO comment before the renamed selector.

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/theme-to-mode.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/theme-to-mode.mjs
@@ -1,7 +1,11 @@
 // Migration: deprecated `setTheme()` and `data-dt-theme` attribute → layered API.
 //
-// - Startup call: setTheme(KnownTheme) → initDialtoneTheme(KnownTheme, 'mode')
-// - Dynamic calls: setTheme(expr) → flagged with TODO comment
+// - All setTheme() calls → flagged with a TODO comment (preserved, not rewritten).
+//   setTheme() was a re-entrant setter; initDialtoneTheme() is a one-shot bootstrap
+//   that throws if already initialized. The correct replacement depends on call site:
+//     • one-time startup  → initDialtoneTheme(brand, 'mode')
+//     • per-toggle/switch → setMode('mode')
+//   Static analysis cannot distinguish the two, so each call is flagged for manual review.
 // - HTML attributes: data-dt-theme= → data-dt-mode=
 // - JS attribute methods: setAttribute/getAttribute('data-dt-theme') → 'data-dt-mode'
 // - CSS selectors: [data-dt-theme...] → [data-dt-mode...]
@@ -18,9 +22,8 @@ const KNOWN_PATTERN = ALL_KNOWN.join('|');
 export default {
   description:
     'Migrates from the deprecated setTheme() / data-dt-theme API to the layered theming API.\n' +
-    '- setTheme(DpLight) → initDialtoneTheme(DpLight, \'light\')\n' +
-    '- setTheme(DpDark) → initDialtoneTheme(DpDark, \'dark\')\n' +
-    '- Same for TmoLight, TmoDark, ExpressiveLight, ExpressiveDark, ExpressiveSmLight, ExpressiveSmDark\n' +
+    '- setTheme(KnownTheme) → preserved + TODO comment with mode hint\n' +
+    '  (use initDialtoneTheme(brand, mode) once at startup OR setMode(mode) per toggle)\n' +
     '- setTheme(dynamicExpr) → preserved + TODO comment\n' +
     '- data-dt-theme= → data-dt-mode= (HTML attributes, JS attr methods, CSS selectors)\n' +
     '- data-dt-theme="invert" → preserved + TODO comment (review for v-dt-mode directive)\n',
@@ -37,28 +40,31 @@ export default {
   },
 
   expressions: [
-    // 1. setTheme() call rewrites for known light identifiers.
-    //    Must run BEFORE the unknown-call flag expression (3) so these are
-    //    fully consumed before the fallthrough regex fires.
+    // 1. setTheme() calls with known light identifiers → TODO comment with mode hint.
+    //    Must run BEFORE expression 3 so these are consumed before the fallthrough fires.
+    //    setTheme() was re-entrant; initDialtoneTheme() is a one-shot bootstrap that
+    //    throws if already initialized — the caller must decide which replacement applies.
     {
       from: new RegExp(
         `(?<!\\.)setTheme\\(\\s*(${KNOWN_LIGHT.join('|')})\\s*\\)`,
         'g',
       ),
-      to: (_match, identifier) => `initDialtoneTheme(${identifier}, 'light')`,
+      to: (match, identifier) =>
+        `// TODO: startup → initDialtoneTheme(${identifier}, 'light')  or  per-toggle → setMode('light') — see /guides/migration/theme-to-mode/\n${match}`,
     },
 
-    // 2. setTheme() call rewrites for known dark identifiers.
+    // 2. setTheme() calls with known dark identifiers → TODO comment with mode hint.
     {
       from: new RegExp(
         `(?<!\\.)setTheme\\(\\s*(${KNOWN_DARK.join('|')})\\s*\\)`,
         'g',
       ),
-      to: (_match, identifier) => `initDialtoneTheme(${identifier}, 'dark')`,
+      to: (match, identifier) =>
+        `// TODO: startup → initDialtoneTheme(${identifier}, 'dark')  or  per-toggle → setMode('dark') — see /guides/migration/theme-to-mode/\n${match}`,
     },
 
     // 3. setTheme() calls with unknown / dynamic arguments → TODO comment.
-    //    Negative-lookahead skips the eight known identifiers already rewritten above.
+    //    Negative-lookahead skips the eight known identifiers already handled above.
     //    Negative-lookbehind on '.' prevents matching unrelated .setTheme() methods.
     {
       from: new RegExp(
@@ -81,9 +87,9 @@ export default {
     },
 
     // 5. CSS selector invert — add TODO comment before the renamed selector.
-    //    Expression 5 already renamed [data-dt-theme=...] → [data-dt-mode=...],
+    //    Expression 4 already renamed [data-dt-theme=...] → [data-dt-mode=...],
     //    so we match on the result.  HTML attribute invert is handled by
-    //    expression 5 (just renamed, no comment — inserting HTML comments inside
+    //    expression 4 (just renamed, no comment — inserting HTML comments inside
     //    tags produces invalid markup; consumers grep for data-dt-mode="invert"
     //    to find regions needing v-dt-mode review).
     {

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/helpers.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/helpers.mjs
@@ -70,7 +70,8 @@ export const findMatchedFiles = async (fileList, config) => {
       })
       .filter((f) => {
         config.expressions.forEach((e) => {
-          if (e.from && e.from.test(f.data)) f.matches++;
+          if (e.from && new RegExp(e.from.source, e.from.flags.replace('g', '')).test(f.data)) f.matches++;
+          else if (typeof e.transform === 'function' && e.transform(f.data, f.file) !== f.data) f.matches++;
         });
         return f.matches > 0;
       });

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/helpers.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/helpers.mjs
@@ -70,7 +70,7 @@ export const findMatchedFiles = async (fileList, config) => {
       })
       .filter((f) => {
         config.expressions.forEach((e) => {
-          if (e.from.test(f.data)) f.matches++;
+          if (e.from && e.from.test(f.data)) f.matches++;
         });
         return f.matches > 0;
       });
@@ -155,10 +155,18 @@ export const modifyFileContents = async (content, expr) => {
     })
     .map((f) => {
       expr.forEach((e) => {
-        f.data = f.data.replace(e.from, (match) => {
-          f.matches++;
-          return match.replace(e.from, e.to);
-        });
+        if (typeof e.transform === 'function') {
+          const next = e.transform(f.data, f.file);
+          if (next !== f.data) {
+            f.matches++;
+            f.data = next;
+          }
+        } else {
+          f.data = f.data.replace(e.from, (match) => {
+            f.matches++;
+            return match.replace(e.from, e.to);
+          });
+        }
       });
       return f;
     });

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/helpers.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/helpers.mjs
@@ -1,13 +1,18 @@
 /**
- * Simulate modifyFileContents behavior from helpers.mjs (lines 158-160).
+ * Simulate modifyFileContents behavior from helpers.mjs.
  * For each expression, apply the regex replace with function replacer.
+ * Pass filepath to support transform expressions that check file extension.
  */
-export function applyConfig (config, input) {
+export function applyConfig (config, input, filepath = 'test.txt') {
   let result = input;
   for (const expr of config.expressions) {
-    result = result.replace(expr.from, (match) => {
-      return match.replace(expr.from, expr.to);
-    });
+    if (typeof expr.transform === 'function') {
+      result = expr.transform(result, filepath);
+    } else {
+      result = result.replace(expr.from, (match) => {
+        return match.replace(expr.from, expr.to);
+      });
+    }
   }
   return result;
 }

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/theme-to-mode.test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/theme-to-mode.test.mjs
@@ -206,6 +206,22 @@ describe('theme-to-mode config', () => {
       assert.equal(apply(light), light);
       assert.equal(apply(dark), dark);
     });
+
+    it('rewrites Vue bound :data-dt-theme="\'dp-light\'" → :data-dt-mode="\'light\'"', () => {
+      assert.equal(apply(`:data-dt-theme="'dp-light'"`), `:data-dt-mode="'light'"`);
+    });
+
+    it('rewrites Vue bound :data-dt-theme="\'dp-dark\'" → :data-dt-mode="\'dark\'"', () => {
+      assert.equal(apply(`:data-dt-theme="'dp-dark'"`), `:data-dt-mode="'dark'"`);
+    });
+
+    it('rewrites v-bind:data-dt-theme="\'tmo-light\'" → v-bind:data-dt-mode="\'light\'"', () => {
+      assert.equal(apply(`v-bind:data-dt-theme="'tmo-light'"`), `v-bind:data-dt-mode="'light'"`);
+    });
+
+    it('rewrites Vue bound with reversed quotes :data-dt-theme=\'"dp-dark"\' → :data-dt-mode=\'"dark"\'', () => {
+      assert.equal(apply(`:data-dt-theme='"dp-dark"'`), `:data-dt-mode='"dark"'`);
+    });
   });
 
   describe('data-dt-theme in CSS attribute selectors', () => {

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/theme-to-mode.test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/theme-to-mode.test.mjs
@@ -6,58 +6,69 @@ import { applyConfig } from './helpers.mjs';
 const apply = (input) => applyConfig(config, input);
 
 describe('theme-to-mode config', () => {
-  // ─── setTheme call rewrites ───────────────────────────────────────────────
+  // ─── setTheme call flagging ───────────────────────────────────────────────
 
-  describe('setTheme() → initDialtoneTheme() for known identifiers', () => {
-    it('rewrites setTheme(DpLight) → initDialtoneTheme(DpLight, \'light\')', () => {
+  describe('setTheme() → TODO comment for known identifiers', () => {
+    it('flags setTheme(DpLight) with a TODO that includes the light mode hint', () => {
       const input = `setTheme(DpLight);`;
-      const expected = `initDialtoneTheme(DpLight, 'light');`;
-      assert.equal(apply(input), expected);
+      const result = apply(input);
+      assert.ok(result.includes('setTheme(DpLight)'), 'original call preserved');
+      assert.ok(result.includes('TODO:'), 'TODO comment inserted');
+      assert.ok(result.includes('\'light\''), 'light mode hint present');
     });
 
-    it('rewrites setTheme(DpDark) → initDialtoneTheme(DpDark, \'dark\')', () => {
+    it('flags setTheme(DpDark) with a TODO that includes the dark mode hint', () => {
       const input = `setTheme(DpDark);`;
-      const expected = `initDialtoneTheme(DpDark, 'dark');`;
-      assert.equal(apply(input), expected);
+      const result = apply(input);
+      assert.ok(result.includes('setTheme(DpDark)'), 'original call preserved');
+      assert.ok(result.includes('TODO:'), 'TODO comment inserted');
+      assert.ok(result.includes('\'dark\''), 'dark mode hint present');
     });
 
-    it('rewrites setTheme(TmoLight) → initDialtoneTheme(TmoLight, \'light\')', () => {
-      const input = `setTheme(TmoLight);`;
-      const expected = `initDialtoneTheme(TmoLight, 'light');`;
-      assert.equal(apply(input), expected);
+    it('flags setTheme(TmoLight) with a light mode hint', () => {
+      const result = apply(`setTheme(TmoLight);`);
+      assert.ok(result.includes('setTheme(TmoLight)'), 'original call preserved');
+      assert.ok(result.includes('\'light\''), 'light mode hint present');
     });
 
-    it('rewrites setTheme(TmoDark) → initDialtoneTheme(TmoDark, \'dark\')', () => {
-      const input = `setTheme(TmoDark);`;
-      const expected = `initDialtoneTheme(TmoDark, 'dark');`;
-      assert.equal(apply(input), expected);
+    it('flags setTheme(TmoDark) with a dark mode hint', () => {
+      const result = apply(`setTheme(TmoDark);`);
+      assert.ok(result.includes('setTheme(TmoDark)'), 'original call preserved');
+      assert.ok(result.includes('\'dark\''), 'dark mode hint present');
     });
 
-    it('rewrites setTheme(ExpressiveLight) → initDialtoneTheme(ExpressiveLight, \'light\')', () => {
-      const input = `setTheme(ExpressiveLight);`;
-      const expected = `initDialtoneTheme(ExpressiveLight, 'light');`;
-      assert.equal(apply(input), expected);
+    it('flags setTheme(ExpressiveLight) with a light mode hint', () => {
+      const result = apply(`setTheme(ExpressiveLight);`);
+      assert.ok(result.includes('setTheme(ExpressiveLight)'), 'original call preserved');
+      assert.ok(result.includes('\'light\''), 'light mode hint present');
     });
 
-    it('rewrites setTheme(ExpressiveDark) → initDialtoneTheme(ExpressiveDark, \'dark\')', () => {
-      const input = `setTheme(ExpressiveDark);`;
-      const expected = `initDialtoneTheme(ExpressiveDark, 'dark');`;
-      assert.equal(apply(input), expected);
+    it('flags setTheme(ExpressiveDark) with a dark mode hint', () => {
+      const result = apply(`setTheme(ExpressiveDark);`);
+      assert.ok(result.includes('setTheme(ExpressiveDark)'), 'original call preserved');
+      assert.ok(result.includes('\'dark\''), 'dark mode hint present');
     });
 
     it('handles whitespace inside setTheme call', () => {
-      const input = `setTheme( DpLight );`;
-      const expected = `initDialtoneTheme(DpLight, 'light');`;
-      assert.equal(apply(input), expected);
+      const result = apply(`setTheme( DpLight );`);
+      assert.ok(result.includes('setTheme( DpLight )'), 'original call preserved');
+      assert.ok(result.includes('TODO:'), 'TODO comment inserted');
     });
 
-    it('rewrites setTheme(DpLight) as part of onMounted setup', () => {
+    it('flags setTheme(DpLight) inside an onMounted callback', () => {
       const input = `onMounted(() => { setTheme(DpLight); });`;
-      const expected = `onMounted(() => { initDialtoneTheme(DpLight, 'light'); });`;
-      assert.equal(apply(input), expected);
+      const result = apply(input);
+      assert.ok(result.includes('setTheme(DpLight)'), 'original call preserved');
+      assert.ok(result.includes('TODO:'), 'TODO comment inserted');
     });
 
-    it('does NOT rewrite setTheme() with a dynamic variable — emits TODO comment', () => {
+    it('TODO comment mentions both startup (initDialtoneTheme) and per-toggle (setMode) options', () => {
+      const result = apply(`setTheme(DpLight);`);
+      assert.ok(result.includes('initDialtoneTheme'), 'startup option mentioned');
+      assert.ok(result.includes('setMode'), 'toggle option mentioned');
+    });
+
+    it('does NOT rewrite setTheme() with a dynamic variable — emits generic TODO comment', () => {
       const input = `setTheme(myDynamicTheme);`;
       const result = apply(input);
       assert.ok(result.includes('setTheme(myDynamicTheme)'), 'original call preserved');
@@ -71,7 +82,7 @@ describe('theme-to-mode config', () => {
       assert.ok(result.includes('TODO: review for layered API migration'), 'TODO comment inserted');
     });
 
-    it('does NOT rewrite myObj.setTheme() — unrelated method', () => {
+    it('does NOT flag myObj.setTheme() — unrelated method', () => {
       const input = `myThemeManager.setTheme(DpLight);`;
       assert.equal(apply(input), input);
     });

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/theme-to-mode.test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/theme-to-mode.test.mjs
@@ -261,6 +261,13 @@ describe('theme-to-mode config', () => {
       assert.ok(result.includes('TODO: review for v-dt-mode adoption'), 'TODO inserted');
     });
 
+    it('adds TODO comment before [data-dt-theme=\'invert\'] single-quoted CSS selector', () => {
+      const input = `[data-dt-theme='invert'] .d-card { box-shadow: none; }`;
+      const result = apply(input);
+      assert.ok(result.includes('[data-dt-mode=\'invert\']'), 'selector renamed');
+      assert.ok(result.includes('TODO: review for v-dt-mode adoption'), 'TODO inserted');
+    });
+
     it('adds TODO comment before [data-dt-theme=invert] unquoted CSS selector', () => {
       const input = `[data-dt-theme=invert] { background: red; }`;
       const result = apply(input);

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/theme-to-mode.test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/theme-to-mode.test.mjs
@@ -86,6 +86,21 @@ describe('theme-to-mode config', () => {
       const input = `myThemeManager.setTheme(DpLight);`;
       assert.equal(apply(input), input);
     });
+
+    it('is idempotent — re-applying to already-flagged known light call produces no change', () => {
+      const once = apply(`setTheme(DpLight);`);
+      assert.equal(apply(once), once);
+    });
+
+    it('is idempotent — re-applying to already-flagged known dark call produces no change', () => {
+      const once = apply(`setTheme(DpDark);`);
+      assert.equal(apply(once), once);
+    });
+
+    it('is idempotent — re-applying to already-flagged dynamic call produces no change', () => {
+      const once = apply(`setTheme(myDynamic);`);
+      assert.equal(apply(once), once);
+    });
   });
 
   // ─── Attribute renames ────────────────────────────────────────────────────
@@ -93,7 +108,7 @@ describe('theme-to-mode config', () => {
   describe('data-dt-theme → data-dt-mode in HTML attributes', () => {
     it('rewrites data-dt-theme= in HTML attribute', () => {
       const input = `<html data-dt-theme="dp-light">`;
-      const expected = `<html data-dt-mode="dp-light">`;
+      const expected = `<html data-dt-mode="light">`;
       assert.equal(apply(input), expected);
     });
 
@@ -141,6 +156,58 @@ describe('theme-to-mode config', () => {
     });
   });
 
+  describe('data-dt-mode value rewrite — known theme names → light/dark', () => {
+    it('rewrites data-dt-theme="dp-light" → data-dt-mode="light"', () => {
+      assert.equal(apply(`<html data-dt-theme="dp-light">`), `<html data-dt-mode="light">`);
+    });
+
+    it('rewrites data-dt-theme="dp-dark" → data-dt-mode="dark"', () => {
+      assert.equal(apply(`<html data-dt-theme="dp-dark">`), `<html data-dt-mode="dark">`);
+    });
+
+    it('rewrites data-dt-theme="tmo-light" → data-dt-mode="light"', () => {
+      assert.equal(apply(`<html data-dt-theme="tmo-light">`), `<html data-dt-mode="light">`);
+    });
+
+    it('rewrites data-dt-theme="tmo-dark" → data-dt-mode="dark"', () => {
+      assert.equal(apply(`<section data-dt-theme="tmo-dark">`), `<section data-dt-mode="dark">`);
+    });
+
+    it('rewrites data-dt-theme="expressive-light" → data-dt-mode="light"', () => {
+      assert.equal(apply(`<html data-dt-theme="expressive-light">`), `<html data-dt-mode="light">`);
+    });
+
+    it('rewrites data-dt-theme="expressive-sm-dark" → data-dt-mode="dark"', () => {
+      assert.equal(apply(`<html data-dt-theme="expressive-sm-dark">`), `<html data-dt-mode="dark">`);
+    });
+
+    it('rewrites [data-dt-theme="dp-light"] CSS selector value', () => {
+      assert.equal(
+        apply(`[data-dt-theme="dp-light"] { background: white; }`),
+        `[data-dt-mode="light"] { background: white; }`,
+      );
+    });
+
+    it('rewrites unquoted [data-dt-theme=dp-dark] CSS selector value', () => {
+      assert.equal(
+        apply(`[data-dt-theme=dp-dark] .d-banner { border: 1px; }`),
+        `[data-dt-mode=dark] .d-banner { border: 1px; }`,
+      );
+    });
+
+    it('leaves unknown/custom theme values as-is', () => {
+      const input = `<html data-dt-theme="custom-brand">`;
+      assert.equal(apply(input), `<html data-dt-mode="custom-brand">`);
+    });
+
+    it('does not alter data-dt-mode="light" or data-dt-mode="dark" (already canonical)', () => {
+      const light = `<html data-dt-mode="light">`;
+      const dark = `<html data-dt-mode="dark">`;
+      assert.equal(apply(light), light);
+      assert.equal(apply(dark), dark);
+    });
+  });
+
   describe('data-dt-theme in CSS attribute selectors', () => {
     it('rewrites [data-dt-theme] bare selector', () => {
       const input = `[data-dt-theme] { color: red; }`;
@@ -150,7 +217,7 @@ describe('theme-to-mode config', () => {
 
     it('rewrites [data-dt-theme="value"] selector', () => {
       const input = `[data-dt-theme="dp-light"] { background: white; }`;
-      const expected = `[data-dt-mode="dp-light"] { background: white; }`;
+      const expected = `[data-dt-mode="light"] { background: white; }`;
       assert.equal(apply(input), expected);
     });
 
@@ -183,6 +250,11 @@ describe('theme-to-mode config', () => {
       const result = apply(input);
       assert.ok(result.includes('[data-dt-mode=invert]'), 'selector renamed');
       assert.ok(result.includes('TODO: review for v-dt-mode adoption'), 'TODO inserted');
+    });
+
+    it('is idempotent — re-applying to already-flagged CSS invert selector produces no change', () => {
+      const once = apply(`[data-dt-theme="invert"] .d-card { box-shadow: none; }`);
+      assert.equal(apply(once), once);
     });
   });
 });


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

NO-JIRA

## :book: Description

Improves the `theme-to-mode` migration script to avoid a semantic mismatch where `setTheme()` (a re-entrant setter) was rewritten 1:1 to `initDialtoneTheme()` (a one-shot bootstrap that throws if already initialized). Calls inside toggle handlers would silently no-op after the first switch, freezing the theme.

Now all `setTheme()` calls — known identifiers and dynamic alike — are preserved and flagged with a `// TODO` comment. For known identifiers the comment includes a mode-specific hint showing both options: `initDialtoneTheme(brand, 'mode')` for one-time startup, or `setMode('mode')` for per-toggle use. The import injection added earlier in this branch is also removed since it is no longer applicable.

Also adds `transform(content, filepath)` expression support to the migration helper so future configs can perform whole-file transformations, retained as a general capability even though it is not used by this config.

## :bulb: Context

Static analysis cannot distinguish a bootstrap call from a toggle handler, so auto-rewriting is unsafe. Flagging with a TODO is the correct conservative approach.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.