### PR TITLE
chore: NO-JIRA enforce 7-day minimum release age and migrate to pnpm 11

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -12,10 +12,6 @@ runs:
       with:
         node-version-file: ".nvmrc"
         cache: "pnpm"
-        registry-url: "https://npm.pkg.github.com"
-        scope: "dialpad"
-      env:
-        NODE_AUTH_TOKEN: ${{ github.token }}
 
     - name: Install dependencies
       shell: bash

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 publish-branch=production
 save-prefix=""
-@dialpad:registry=https://npm.pkg.github.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 publish-branch=production
 save-prefix=""
+@dialpad:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -260,11 +260,15 @@ We use PNPM to manage everything related to NPM, **adding, installing, removing 
 
 You will need to install PNPM locally to contribute to this project. <https://pnpm.io/installation>
 
+The repo pins an exact pnpm version via the `packageManager` field in `package.json`. The recommended way to automatically use the correct version per repo is [Corepack](https://nodejs.org/api/corepack.html), which ships with Node.js:
+
 ##### Installation
 
 ```bash
-npm install -g pnpm
+corepack enable
 ```
+
+Corepack reads the `packageManager` field and transparently uses the pinned pnpm version — no manual version switching needed across repos.
 
 ##### Do
 

--- a/apps/dialtone-documentation/docs/guides/getting-started/index.md
+++ b/apps/dialtone-documentation/docs/guides/getting-started/index.md
@@ -167,19 +167,20 @@ We're excited you want to install Dialtone locally as this most likely means you
 
 ### Install Node & npm
 
-To run Dialtone locally, you must have Node and NPM (Node Package Manager) installed. [Click here to download Node](https://nodejs.org/en/). The recommended Node version is fine. NPM is included with Node. If you already have Node installed, you may move onto the next step.
-
-Once Node finishes installing, ensure it is installed properly by typing the following command in your Terminal window:
+To run Dialtone locally, you must have Node installed. The required version is specified in `.nvmrc` at the repo root — use [nvm](https://github.com/nvm-sh/nvm) to install and switch to it automatically:
 
 ```bash
-node -v
+nvm install
+nvm use
 ```
 
-You should see the following response:
+Once Node is installed, enable [Corepack](https://nodejs.org/api/corepack.html) so that the correct pnpm version is used automatically:
 
 ```bash
-v16.x.x
+corepack enable
 ```
+
+Corepack reads the `packageManager` field in `package.json` and uses the pinned pnpm version without any manual version switching.
 
 ### Clone Project
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dialpad/dialtone",
   "version": "9.187.2",
-  "packageManager": "pnpm@9.9.0",
+  "packageManager": "pnpm@11.9.0",
   "description": "Dialpad's Dialtone design system monorepo",
   "scripts": {
     "prepare": "husky install",
@@ -9,37 +9,6 @@
     "clean": "pnpm clean:dist && pnpm clean:cache",
     "clean:dist": "rm -rf packages/dialtone-tokens/dist apps/dialtone-documentation/docs/.vuepress/.cache apps/dialtone-documentation/docs/.vuepress/.temp",
     "clean:cache": "pnpm nx reset --onlyCache"
-  },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "mem-fs": "^4.0.0",
-        "postcss": "^7.0.39 || ^8.3.3",
-        "react": "^18.3.1",
-        "typescript": "^5.2",
-        "vite": "^8.0.0",
-        "vue": "^3.2",
-        "vuepress": "^2.0.0-rc.24"
-      }
-    },
-    "overrides": {
-      "playwright-core": ">=1.60.0",
-      "@typescript-eslint/utils": "^8.44.1",
-      "braces": ">=3.0.3",
-      "cross-spawn": ">=7.0.5",
-      "nanoid": ">=3.3.8",
-      "sass": "^1.70.0",
-      "sugarss": "^5.0.0",
-      "semver-regex": "3.1.4",
-      "stylelint": "^16.25.0",
-      "tar-fs": ">=2.1.3",
-      "test-exclude": "^7.0.1",
-      "trim": ">=0.0.3",
-      "trim-newlines": ">=3.0.1"
-    },
-    "patchedDependencies": {
-      "@tiptap/vue-3@3.19.0": "patches/@tiptap__vue-3@3.19.0.patch"
-    }
   },
   "files": [
     "dist"
@@ -193,6 +162,9 @@
     "vue-template-compiler": "^2.7.16",
     "wait-on": "^7.2.0",
     "yo": "^5.0.0"
+  },
+  "engines": {
+    "pnpm": ">=11.9.0"
   },
   "peerDependencies": {
     "vue": "^3"

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@dialpad/conventional-changelog-angular": "^1.1.1",
     "@dialpad/dialtone-cli": "workspace:*",
     "@dialpad/semantic-release-changelog-json": "^1.0.0",
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.0.0",
     "@faker-js/faker": "8.4.1",
     "@percy/cli": "1.30.9",
     "@percy/storybook": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -98,11 +98,12 @@
     "vue-tsc": "3.2.6"
   },
   "devDependencies": {
-    "@dialpad/dialtone-cli": "workspace:*",
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-conventional": "^17.6.6",
     "@dialpad/conventional-changelog-angular": "^1.1.1",
+    "@dialpad/dialtone-cli": "workspace:*",
     "@dialpad/semantic-release-changelog-json": "^1.0.0",
+    "@eslint/js": "^10.0.1",
     "@faker-js/faker": "8.4.1",
     "@percy/cli": "1.30.9",
     "@percy/storybook": "6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,7 +278,7 @@ importers:
         version: 15.5.2(supports-color@8.1.1)
       markdownlint:
         specifier: ^0.38.0
-        version: 0.38.0(supports-color@8.1.1)
+        version: 0.38.0
       markdownlint-cli:
         specifier: ^0.45.0
         version: 0.45.0
@@ -1358,30 +1358,26 @@ packages:
       postcss-selector-parser: ^7.0.0
 
   '@dialpad/conventional-changelog-angular@1.1.1':
-    resolution: {integrity: sha512-qUT8qgaypYlGPXDO5HqYdq0Q670fqAxr5AaJUo3AOzBJ6IRTcG48kXo6Z9GRVgqrL21jd6MS+fx5nu1wKM0W0w==}
+    resolution: {integrity: sha512-TLsyNwTUmGK6TtvdoC4SE/13Ae501pdzhSIyOV9V3HOVf8YrVTOgLUJ/l97kZSxcTOeRbFeRjbWfH7W3ixn36g==, tarball: https://npm.pkg.github.com/download/@dialpad/conventional-changelog-angular/1.1.1/1c54240f941b2d02d73e4ca2d4e53420d128bbf6}
     engines: {node: '>=10'}
 
   '@dialpad/i18n-goblin-core@1.2.0':
-    resolution: {integrity: sha512-IsyKO2TKBIw0RZHiDmDqQ910DoUGgUhPexO7zsmz7IS8PNbR2BwMtaDAjrxaZcOnpW6lkR6tQpjtY/PXwPWlsA==}
+    resolution: {integrity: sha512-DQJ6kPkz2JfQMljPxxCCWoJneKHlUrxrxwwEZ3bkC1gc1ze+MDWo4d8pylkqypBYSDxw2l3Pa61Loy1cEdsqMg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-goblin-core/1.2.0/e78ef24567fc081840905a6594f241d5c8523688}
     peerDependencies:
-      '@vue/composition-api': '*'
       vue: ^3.0.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
 
   '@dialpad/i18n-goblin-services@1.3.0':
-    resolution: {integrity: sha512-h/2PCR9ZSlzGZ7gq94p/7EcV1JzRlH765afkIw7t1xyUGEuhdhBcBSNxj20xikcfcrAG9gh3neFpBLzhiXuW0A==}
+    resolution: {integrity: sha512-KTJGeRxw9DHfQP/vxjOZW4kzgBbZeTRYtl0/FdvFdVoBFZ8SDjf+FwOc57o/q/K8zvGVVjb8xxpyXBBJACRIeg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-goblin-services/1.3.0/069db4d56165365b9c0f4e0daca9a7b61ff7c534}
     hasBin: true
 
   '@dialpad/i18n@1.25.3':
-    resolution: {integrity: sha512-W1GGgOODxeDqNbdC96Hu30X3YB3jl8exZh9sYpxsPzfD74S2htu8K+8nAbeKfOVapLNuGt3WC6arRqn/FxcbCg==}
+    resolution: {integrity: sha512-7YmzXLzYGPfCFZhiA1NLmHJ8R4XgX/zSP6tL4mlUElcES5NexWwgUGUWa9HBBRRHU3GIXxA3Tj7FTUSZ4EgnNg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n/1.25.3/5af0753ad1eb8c97cea2836cd057283058dcceae}
     hasBin: true
     peerDependencies:
       vue: ^3.0.0
 
   '@dialpad/semantic-release-changelog-json@1.0.0':
-    resolution: {integrity: sha512-9bbDAiJR2MHI6M5KNsLQGebmg1d1exXP9O8lET6SIVWeaq6bIJrWM7WRqyohkBpq3Ad2ZPc0Rq6zCY0UC/wiVQ==}
+    resolution: {integrity: sha512-RIk5Wkco9pTucCO5Pi+4kx2CtmaDzY94V77bK/gluhb3IEDVktnzpS5SIWV+dTKtXUrHweoSXjCH+1cSifgefw==, tarball: https://npm.pkg.github.com/download/@dialpad/semantic-release-changelog-json/1.0.0/40fb236ee722da99879010c02f12b95cb2635ddc}
     engines: {node: '>=14.17'}
     peerDependencies:
       semantic-release: '>=18.0.0'
@@ -16568,6 +16564,8 @@ snapshots:
       '@fluent/bundle': 0.17.1
       fluent-vue: 3.7.2(@fluent/bundle@0.17.1)(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   '@dialpad/i18n-goblin-services@1.3.0':
     dependencies:
@@ -28121,16 +28119,16 @@ snapshots:
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
       markdown-it: 14.1.1
-      markdownlint: 0.38.0(supports-color@8.1.1)
+      markdownlint: 0.38.0
       minimatch: 10.0.3
       run-con: 1.3.2
       smol-toml: 1.3.4
     transitivePeerDependencies:
       - supports-color
 
-  markdownlint@0.38.0(supports-color@8.1.1):
+  markdownlint@0.38.0:
     dependencies:
-      micromark: 4.0.2(supports-color@8.1.1)
+      micromark: 4.0.2
       micromark-core-commonmark: 2.0.3
       micromark-extension-directive: 4.0.0
       micromark-extension-gfm-autolink-literal: 2.1.0
@@ -28191,7 +28189,7 @@ snapshots:
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@8.1.1)
+      micromark: 4.0.2
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -28541,7 +28539,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@8.1.1):
+  micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@8.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       '@dialpad/semantic-release-changelog-json':
         specifier: ^1.0.0
         version: 1.0.0(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       '@faker-js/faker':
         specifier: 8.4.1
         version: 8.4.1
@@ -1902,6 +1905,15 @@ packages:
   '@eslint/eslintrc@3.3.5':
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/js@9.39.4':
     resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
@@ -16883,6 +16895,10 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@eslint/js@10.0.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))':
+    optionalDependencies:
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
 
   '@eslint/js@9.39.4': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1358,26 +1358,30 @@ packages:
       postcss-selector-parser: ^7.0.0
 
   '@dialpad/conventional-changelog-angular@1.1.1':
-    resolution: {integrity: sha512-TLsyNwTUmGK6TtvdoC4SE/13Ae501pdzhSIyOV9V3HOVf8YrVTOgLUJ/l97kZSxcTOeRbFeRjbWfH7W3ixn36g==, tarball: https://npm.pkg.github.com/download/@dialpad/conventional-changelog-angular/1.1.1/1c54240f941b2d02d73e4ca2d4e53420d128bbf6}
+    resolution: {integrity: sha512-qUT8qgaypYlGPXDO5HqYdq0Q670fqAxr5AaJUo3AOzBJ6IRTcG48kXo6Z9GRVgqrL21jd6MS+fx5nu1wKM0W0w==}
     engines: {node: '>=10'}
 
   '@dialpad/i18n-goblin-core@1.2.0':
-    resolution: {integrity: sha512-DQJ6kPkz2JfQMljPxxCCWoJneKHlUrxrxwwEZ3bkC1gc1ze+MDWo4d8pylkqypBYSDxw2l3Pa61Loy1cEdsqMg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-goblin-core/1.2.0/e78ef24567fc081840905a6594f241d5c8523688}
+    resolution: {integrity: sha512-IsyKO2TKBIw0RZHiDmDqQ910DoUGgUhPexO7zsmz7IS8PNbR2BwMtaDAjrxaZcOnpW6lkR6tQpjtY/PXwPWlsA==}
     peerDependencies:
+      '@vue/composition-api': '*'
       vue: ^3.0.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
 
   '@dialpad/i18n-goblin-services@1.3.0':
-    resolution: {integrity: sha512-KTJGeRxw9DHfQP/vxjOZW4kzgBbZeTRYtl0/FdvFdVoBFZ8SDjf+FwOc57o/q/K8zvGVVjb8xxpyXBBJACRIeg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-goblin-services/1.3.0/069db4d56165365b9c0f4e0daca9a7b61ff7c534}
+    resolution: {integrity: sha512-h/2PCR9ZSlzGZ7gq94p/7EcV1JzRlH765afkIw7t1xyUGEuhdhBcBSNxj20xikcfcrAG9gh3neFpBLzhiXuW0A==}
     hasBin: true
 
   '@dialpad/i18n@1.25.3':
-    resolution: {integrity: sha512-7YmzXLzYGPfCFZhiA1NLmHJ8R4XgX/zSP6tL4mlUElcES5NexWwgUGUWa9HBBRRHU3GIXxA3Tj7FTUSZ4EgnNg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n/1.25.3/5af0753ad1eb8c97cea2836cd057283058dcceae}
+    resolution: {integrity: sha512-W1GGgOODxeDqNbdC96Hu30X3YB3jl8exZh9sYpxsPzfD74S2htu8K+8nAbeKfOVapLNuGt3WC6arRqn/FxcbCg==}
     hasBin: true
     peerDependencies:
       vue: ^3.0.0
 
   '@dialpad/semantic-release-changelog-json@1.0.0':
-    resolution: {integrity: sha512-RIk5Wkco9pTucCO5Pi+4kx2CtmaDzY94V77bK/gluhb3IEDVktnzpS5SIWV+dTKtXUrHweoSXjCH+1cSifgefw==, tarball: https://npm.pkg.github.com/download/@dialpad/semantic-release-changelog-json/1.0.0/40fb236ee722da99879010c02f12b95cb2635ddc}
+    resolution: {integrity: sha512-9bbDAiJR2MHI6M5KNsLQGebmg1d1exXP9O8lET6SIVWeaq6bIJrWM7WRqyohkBpq3Ad2ZPc0Rq6zCY0UC/wiVQ==}
     engines: {node: '>=14.17'}
     peerDependencies:
       semantic-release: '>=18.0.0'
@@ -16555,8 +16559,6 @@ snapshots:
       '@fluent/bundle': 0.17.1
       fluent-vue: 3.7.2(@fluent/bundle@0.17.1)(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
 
   '@dialpad/i18n-goblin-services@1.3.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,7 @@ overrides:
   trim-newlines: '>=3.0.1'
 
 patchedDependencies:
-  '@tiptap/vue-3@3.19.0':
-    hash: hlk524tqy4svh2bbayevihx324
-    path: patches/@tiptap__vue-3@3.19.0.patch
+  '@tiptap/vue-3@3.19.0': 65d98f737afae097542c692b176a81069e1b7b8d577d1d7e222a94436e128ea9
 
 importers:
 
@@ -172,25 +170,25 @@ importers:
         version: link:packages/dialtone-cli
       '@dialpad/semantic-release-changelog-json':
         specifier: ^1.0.0
-        version: 1.0.0(semantic-release@21.1.2(typescript@5.9.3))
+        version: 1.0.0(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))
       '@faker-js/faker':
         specifier: 8.4.1
         version: 8.4.1
       '@percy/cli':
         specifier: 1.30.9
-        version: 1.30.9(typescript@5.9.3)
+        version: 1.30.9(supports-color@8.1.1)(typescript@5.9.3)
       '@percy/storybook':
         specifier: 6.0.3
         version: 6.0.3(typescript@5.9.3)
       '@semantic-release/changelog':
         specifier: ^6.0.3
-        version: 6.0.3(semantic-release@21.1.2(typescript@5.9.3))
+        version: 6.0.3(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))
       '@semantic-release/exec':
         specifier: ^6.0.3
-        version: 6.0.3(semantic-release@21.1.2(typescript@5.9.3))
+        version: 6.0.3(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
       '@semantic-release/git':
         specifier: ^10.0.1
-        version: 10.0.1(semantic-release@21.1.2(typescript@5.9.3))
+        version: 10.0.1(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
       '@types/node':
         specifier: ^20.4.5
         version: 20.19.39
@@ -199,7 +197,7 @@ importers:
         version: 6.0.5(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.2(vitest@4.1.2(@types/node@20.19.39)(jsdom@24.1.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.1.2(vitest@4.1.2(@types/node@20.19.39)(jsdom@24.1.3(supports-color@8.1.1))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       '@vue/tsconfig':
         specifier: ^0.4.0
         version: 0.4.0
@@ -223,28 +221,28 @@ importers:
         version: 6.1.1
       eslint:
         specifier: ^9.33.0
-        version: 9.39.4(jiti@1.21.7)
+        version: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       eslint-plugin-eslint-plugin:
         specifier: 6.3.1
-        version: 6.3.1(eslint@9.39.4(jiti@1.21.7))
+        version: 6.3.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       eslint-plugin-jest:
         specifier: ^29.0.1
-        version: 29.15.1(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(jest@29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@20.19.39)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.15.1(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(jest@29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@20.19.39)(typescript@5.9.3)))(typescript@5.9.3)
       eslint-plugin-json:
         specifier: 4.0.1
         version: 4.0.1
       eslint-plugin-storybook:
         specifier: 10.3.0
-        version: 10.3.0(eslint@9.39.4(jiti@1.21.7))(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+        version: 10.3.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       eslint-plugin-vitest:
         specifier: ^0.5.4
-        version: 0.5.4(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)(vitest@4.1.2(@types/node@20.19.39)(jsdom@24.1.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.5.4(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)(vitest@4.1.2(@types/node@20.19.39)(jsdom@24.1.3(supports-color@8.1.1))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       eslint-plugin-vue:
         specifier: ^10.4.0
-        version: 10.8.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@1.21.7)))
+        version: 10.8.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)))
       eslint-plugin-vuejs-accessibility:
         specifier: ^2.4.1
-        version: 2.5.0(eslint@9.39.4(jiti@1.21.7))(globals@16.3.0)
+        version: 2.5.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(globals@16.3.0)
       glob:
         specifier: ^11.0.3
         version: 11.1.0
@@ -262,7 +260,7 @@ importers:
         version: 4.1.0
       http-server:
         specifier: ^14.1.1
-        version: 14.1.1
+        version: 14.1.1(supports-color@8.1.1)
       husky:
         specifier: ^8.0.3
         version: 8.0.3
@@ -271,13 +269,13 @@ importers:
         version: 29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@20.19.39)(typescript@5.9.3))
       jsdom:
         specifier: ^24.0.0
-        version: 24.1.3
+        version: 24.1.3(supports-color@8.1.1)
       lint-staged:
         specifier: ^15.2.0
-        version: 15.5.2
+        version: 15.5.2(supports-color@8.1.1)
       markdownlint:
         specifier: ^0.38.0
-        version: 0.38.0
+        version: 0.38.0(supports-color@8.1.1)
       markdownlint-cli:
         specifier: ^0.45.0
         version: 0.45.0
@@ -292,28 +290,28 @@ importers:
         version: 1.60.0
       semantic-release:
         specifier: ^21.0.6
-        version: 21.1.2(typescript@5.9.3)
+        version: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
       semantic-release-plus:
         specifier: ^20.0.0
-        version: 20.0.0(encoding@0.1.13)(semantic-release@21.1.2(typescript@5.9.3))
+        version: 20.0.0(encoding@0.1.13)(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
       stylelint:
         specifier: ^16.25.0
-        version: 16.26.1(typescript@5.9.3)
+        version: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
       stylelint-config-rational-order:
         specifier: ^0.1.2
         version: 0.1.2(typescript@5.9.3)
       stylelint-config-recommended-less:
         specifier: ^3.0.1
-        version: 3.0.1(postcss@8.5.8)(stylelint@16.26.1(typescript@5.9.3))
+        version: 3.0.1(postcss@8.5.8)(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
       stylelint-config-standard:
         specifier: ^39.0.1
-        version: 39.0.1(stylelint@16.26.1(typescript@5.9.3))
+        version: 39.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
       stylelint-less:
         specifier: ^3.0.1
-        version: 3.0.1(postcss@8.5.8)(stylelint@16.26.1(typescript@5.9.3))
+        version: 3.0.1(postcss@8.5.8)(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
       stylelint-no-px:
         specifier: ^1.0.1
-        version: 1.0.1(stylelint@16.26.1(typescript@5.9.3))
+        version: 1.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
       tinycolor2:
         specifier: ^1.6.0
         version: 1.6.0
@@ -331,13 +329,13 @@ importers:
         version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-bundle-visualizer:
         specifier: ^1.2.1
-        version: 1.2.1(rollup@4.60.1)
+        version: 1.2.1(rollup@4.60.1)(supports-color@8.1.1)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@20.19.39)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@20.19.39)(rollup@4.60.1)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.0
-        version: 4.1.2(@types/node@20.19.39)(jsdom@24.1.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@20.19.39)(jsdom@24.1.3(supports-color@8.1.1))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vue-docgen-api:
         specifier: ^4.75.0
         version: 4.79.2(vue@3.5.32(typescript@5.9.3))
@@ -349,7 +347,7 @@ importers:
         version: 7.2.0
       yo:
         specifier: ^5.0.0
-        version: 5.1.0(@types/node@20.19.39)(@yeoman/types@1.10.3(@types/node@20.19.39)(@yeoman/adapter@1.6.0(@types/node@20.19.39))(mem-fs@4.1.4))(mem-fs@4.1.4)
+        version: 5.1.0(@types/node@20.19.39)(@yeoman/types@1.10.3(@types/node@20.19.39)(@yeoman/adapter@1.6.0(@types/node@20.19.39))(mem-fs@4.1.4))(mem-fs@4.1.4)(supports-color@8.1.1)
 
   apps/dialtone-documentation:
     devDependencies:
@@ -424,7 +422,7 @@ importers:
         version: 1.6.0
       vite-svg-loader:
         specifier: ^5.1.0
-        version: 5.1.1(vue@3.5.32(typescript@5.9.3))
+        version: 5.1.1(supports-color@8.1.1)(vue@3.5.32(typescript@5.9.3))
       vue:
         specifier: ^3.5.21
         version: 3.5.32(typescript@5.9.3)
@@ -442,7 +440,7 @@ importers:
     dependencies:
       yeoman-generator:
         specifier: ^5.7.0
-        version: 5.10.0(encoding@0.1.13)(mem-fs@4.1.4)
+        version: 5.10.0(encoding@0.1.13)(mem-fs@4.1.4)(supports-color@8.1.1)
 
   packages/combinator:
     dependencies:
@@ -491,7 +489,7 @@ importers:
         version: 4.5.0
       eslint-plugin-jsdoc:
         specifier: ^51.4.1
-        version: 51.4.1(eslint@9.39.4(jiti@1.21.7))
+        version: 51.4.1(eslint@9.39.4(jiti@1.21.7))(supports-color@8.1.1)
       eslint-plugin-mocha:
         specifier: ^10.1.0
         version: 10.5.0(eslint@9.39.4(jiti@1.21.7))
@@ -667,7 +665,7 @@ importers:
         version: link:../dialtone-vue
       '@modelcontextprotocol/inspector':
         specifier: 0.16.7
-        version: 0.16.7(@swc/core@1.15.21)(@types/node@24.3.1)(@types/react@19.2.14)(typescript@5.9.3)
+        version: 0.16.7(@swc/core@1.15.21)(@types/node@24.3.1)(@types/react@19.2.14)(supports-color@8.1.1)(typescript@5.9.3)
       '@rollup/plugin-json':
         specifier: ^6.0.0
         version: 6.1.0(rollup@4.60.1)
@@ -866,7 +864,7 @@ importers:
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
       '@tiptap/vue-3':
         specifier: 3.19.0
-        version: 3.19.0(patch_hash=hlk524tqy4svh2bbayevihx324)(@floating-ui/dom@1.7.6)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(vue@3.5.32(typescript@5.9.3))
+        version: 3.19.0(patch_hash=65d98f737afae097542c692b176a81069e1b7b8d577d1d7e222a94436e128ea9)(@floating-ui/dom@1.7.6)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(vue@3.5.32(typescript@5.9.3))
       date-fns:
         specifier: 4.1.0
         version: 4.1.0
@@ -906,7 +904,7 @@ importers:
         version: 10.3.0(react@19.2.4)(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/test-runner':
         specifier: ^0.24.4
-        version: 0.24.4(@types/node@22.19.17)(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.17)(typescript@5.9.3))
+        version: 0.24.4(@types/node@22.19.17)(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.17)(typescript@5.9.3))
       '@storybook/vue3-vite':
         specifier: 10.3.0
         version: 10.3.0(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))(webpack@5.105.4(@swc/core@1.15.21)(esbuild@0.27.7))
@@ -1011,7 +1009,7 @@ importers:
     dependencies:
       stylelint:
         specifier: ^16.25.0
-        version: 16.26.1(typescript@5.9.3)
+        version: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
     devDependencies:
       eslint-plugin-n:
         specifier: ^17.0.0
@@ -1357,11 +1355,11 @@ packages:
       postcss-selector-parser: ^7.0.0
 
   '@dialpad/conventional-changelog-angular@1.1.1':
-    resolution: {integrity: sha512-TLsyNwTUmGK6TtvdoC4SE/13Ae501pdzhSIyOV9V3HOVf8YrVTOgLUJ/l97kZSxcTOeRbFeRjbWfH7W3ixn36g==, tarball: https://npm.pkg.github.com/download/@dialpad/conventional-changelog-angular/1.1.1/1c54240f941b2d02d73e4ca2d4e53420d128bbf6}
+    resolution: {integrity: sha512-qUT8qgaypYlGPXDO5HqYdq0Q670fqAxr5AaJUo3AOzBJ6IRTcG48kXo6Z9GRVgqrL21jd6MS+fx5nu1wKM0W0w==}
     engines: {node: '>=10'}
 
   '@dialpad/i18n-goblin-core@1.2.0':
-    resolution: {integrity: sha512-DQJ6kPkz2JfQMljPxxCCWoJneKHlUrxrxwwEZ3bkC1gc1ze+MDWo4d8pylkqypBYSDxw2l3Pa61Loy1cEdsqMg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-goblin-core/1.2.0/e78ef24567fc081840905a6594f241d5c8523688}
+    resolution: {integrity: sha512-IsyKO2TKBIw0RZHiDmDqQ910DoUGgUhPexO7zsmz7IS8PNbR2BwMtaDAjrxaZcOnpW6lkR6tQpjtY/PXwPWlsA==}
     peerDependencies:
       '@vue/composition-api': '*'
       vue: ^3.0.0
@@ -1370,17 +1368,17 @@ packages:
         optional: true
 
   '@dialpad/i18n-goblin-services@1.3.0':
-    resolution: {integrity: sha512-KTJGeRxw9DHfQP/vxjOZW4kzgBbZeTRYtl0/FdvFdVoBFZ8SDjf+FwOc57o/q/K8zvGVVjb8xxpyXBBJACRIeg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n-goblin-services/1.3.0/069db4d56165365b9c0f4e0daca9a7b61ff7c534}
+    resolution: {integrity: sha512-h/2PCR9ZSlzGZ7gq94p/7EcV1JzRlH765afkIw7t1xyUGEuhdhBcBSNxj20xikcfcrAG9gh3neFpBLzhiXuW0A==}
     hasBin: true
 
   '@dialpad/i18n@1.25.3':
-    resolution: {integrity: sha512-7YmzXLzYGPfCFZhiA1NLmHJ8R4XgX/zSP6tL4mlUElcES5NexWwgUGUWa9HBBRRHU3GIXxA3Tj7FTUSZ4EgnNg==, tarball: https://npm.pkg.github.com/download/@dialpad/i18n/1.25.3/5af0753ad1eb8c97cea2836cd057283058dcceae}
+    resolution: {integrity: sha512-W1GGgOODxeDqNbdC96Hu30X3YB3jl8exZh9sYpxsPzfD74S2htu8K+8nAbeKfOVapLNuGt3WC6arRqn/FxcbCg==}
     hasBin: true
     peerDependencies:
       vue: ^3.0.0
 
   '@dialpad/semantic-release-changelog-json@1.0.0':
-    resolution: {integrity: sha512-RIk5Wkco9pTucCO5Pi+4kx2CtmaDzY94V77bK/gluhb3IEDVktnzpS5SIWV+dTKtXUrHweoSXjCH+1cSifgefw==, tarball: https://npm.pkg.github.com/download/@dialpad/semantic-release-changelog-json/1.0.0/40fb236ee722da99879010c02f12b95cb2635ddc}
+    resolution: {integrity: sha512-9bbDAiJR2MHI6M5KNsLQGebmg1d1exXP9O8lET6SIVWeaq6bIJrWM7WRqyohkBpq3Ad2ZPc0Rq6zCY0UC/wiVQ==}
     engines: {node: '>=14.17'}
     peerDependencies:
       semantic-release: '>=18.0.0'
@@ -2701,24 +2699,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@19.8.0':
     resolution: {integrity: sha512-F3xEe7NGjsVKZTVlvUiUOTmCzxteRsQH2SSsYXyAfgJ42P3eZPc9HgeLx6RByjC/NBCwc7XEECMP1FjQgQXHVw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@19.8.0':
     resolution: {integrity: sha512-4uYuE+LvxOFXvi9z9ueJSVrME5D383SHNCjs6jYwc9KovCsmL5oPVXRieoE4/hYI4lrjly+CrAnPZU1P7ocBiw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@19.8.0':
     resolution: {integrity: sha512-9UDEGjOvNt+m+kMBCAB7CGisSwv05Xvaq8K3NJ+xM5GPG74EkQel24mSoIJfm/6zmDkdZCiRzNN9VRjOjzOz6Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@19.8.0':
     resolution: {integrity: sha512-JVzm0KjyLZY5ponBukZ/b35wttW0b3LB0nqaiiHY7WKwSzo+m0UGEYHD/Yk6rKA0RRZN2wQVeIzLeWfYcZYrhA==}
@@ -3478,24 +3480,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -3554,36 +3560,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
@@ -3697,66 +3709,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -4096,36 +4121,42 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.21':
     resolution: {integrity: sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.21':
     resolution: {integrity: sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.21':
     resolution: {integrity: sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.21':
     resolution: {integrity: sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.21':
     resolution: {integrity: sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.21':
     resolution: {integrity: sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ==}
@@ -4747,6 +4778,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -4787,41 +4819,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -5877,6 +5917,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
@@ -10439,24 +10480,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -15467,8 +15512,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.4:
-    resolution: {integrity: sha512-joip1uZTaQR0nD23N400gIdJ7xY+WiiiMA/BCKz842gvGBknqDQAzklUvDEhqFvvrhQY8S2ZANBMu4X70VMFGw==}
+  vue-component-type-helpers@3.3.5:
+    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -16525,14 +16570,14 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  '@dialpad/semantic-release-changelog-json@1.0.0(semantic-release@21.1.2(typescript@5.9.3))':
+  '@dialpad/semantic-release-changelog-json@1.0.0(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
       changelog-parser: 3.0.1
       fs-extra: 11.3.4
       lodash: 4.18.1
-      semantic-release: 21.1.2(typescript@5.9.3)
+      semantic-release: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -16797,6 +16842,11 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))':
+    dependencies:
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
     dependencies:
       eslint: 9.39.4(jiti@1.21.7)
@@ -16804,7 +16854,7 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@8.1.1)
@@ -16820,7 +16870,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5':
+  '@eslint/eslintrc@3.3.5(supports-color@8.1.1)':
     dependencies:
       ajv: 6.14.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -17806,7 +17856,7 @@ snapshots:
     dependencies:
       '@modelcontextprotocol/sdk': 1.18.0
       commander: 13.1.0
-      spawn-rx: 5.1.2
+      spawn-rx: 5.1.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17846,9 +17896,9 @@ snapshots:
     dependencies:
       '@modelcontextprotocol/sdk': 1.18.0
       cors: 2.8.6
-      express: 5.2.1
+      express: 5.2.1(supports-color@8.1.1)
       shell-quote: 1.8.3
-      spawn-rx: 5.1.2
+      spawn-rx: 5.1.2(supports-color@8.1.1)
       ws: 8.20.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -17856,7 +17906,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modelcontextprotocol/inspector@0.16.7(@swc/core@1.15.21)(@types/node@24.3.1)(@types/react@19.2.14)(typescript@5.9.3)':
+  '@modelcontextprotocol/inspector@0.16.7(@swc/core@1.15.21)(@types/node@24.3.1)(@types/react@19.2.14)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@modelcontextprotocol/inspector-cli': 0.16.8
       '@modelcontextprotocol/inspector-client': 0.16.8(@types/react@19.2.14)
@@ -17865,7 +17915,7 @@ snapshots:
       concurrently: 9.2.1
       open: 10.2.0
       shell-quote: 1.8.3
-      spawn-rx: 5.1.2
+      spawn-rx: 5.1.2(supports-color@8.1.1)
       ts-node: 10.9.2(@swc/core@1.15.21)(@types/node@24.3.1)(typescript@5.9.3)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -17887,8 +17937,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 7.5.1(express@5.2.1)
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 7.5.1(express@5.2.1(supports-color@8.1.1))
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 3.25.76
@@ -17935,14 +17985,14 @@ snapshots:
   '@npmcli/agent@2.2.2':
     dependencies:
       agent-base: 7.1.4
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       lru-cache: 10.4.3
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@npmcli/arborist@7.5.4':
+  '@npmcli/arborist@7.5.4(supports-color@8.1.1)':
     dependencies:
       '@isaacs/string-locale-compare': 1.1.0
       '@npmcli/fs': 3.1.1
@@ -17968,7 +18018,7 @@ snapshots:
       npm-package-arg: 11.0.3
       npm-pick-manifest: 9.1.0
       npm-registry-fetch: 17.1.0
-      pacote: 18.0.6
+      pacote: 18.0.6(supports-color@8.1.1)
       parse-conflict-json: 3.0.1
       proc-log: 4.2.0
       proggy: 2.0.0
@@ -18035,7 +18085,7 @@ snapshots:
     dependencies:
       cacache: 18.0.4
       json-parse-even-better-errors: 3.0.2
-      pacote: 18.0.6
+      pacote: 18.0.6(supports-color@8.1.1)
       proc-log: 4.2.0
       semver: 7.7.4
     transitivePeerDependencies:
@@ -18462,7 +18512,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/cli@1.30.9(typescript@5.9.3)':
+  '@percy/cli@1.30.9(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@percy/cli-app': 1.30.9(typescript@5.9.3)
       '@percy/cli-build': 1.30.9(typescript@5.9.3)
@@ -18471,7 +18521,7 @@ snapshots:
       '@percy/cli-exec': 1.30.9(typescript@5.9.3)
       '@percy/cli-snapshot': 1.30.9(typescript@5.9.3)
       '@percy/cli-upload': 1.30.9(typescript@5.9.3)
-      '@percy/client': 1.30.9
+      '@percy/client': 1.30.9(supports-color@8.1.1)
       '@percy/logger': 1.30.9
     transitivePeerDependencies:
       - bufferutil
@@ -18479,11 +18529,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/client@1.30.9':
+  '@percy/client@1.30.9(supports-color@8.1.1)':
     dependencies:
       '@percy/env': 1.30.9
       '@percy/logger': 1.30.9
-      pac-proxy-agent: 7.2.0
+      pac-proxy-agent: 7.2.0(supports-color@8.1.1)
       pako: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -18493,7 +18543,7 @@ snapshots:
       '@percy/config': 1.31.11(typescript@5.9.3)
       '@percy/env': 1.31.11
       '@percy/logger': 1.31.11
-      pac-proxy-agent: 7.2.0
+      pac-proxy-agent: 7.2.0(supports-color@8.1.1)
       pako: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -18519,7 +18569,7 @@ snapshots:
 
   '@percy/core@1.30.9(typescript@5.9.3)':
     dependencies:
-      '@percy/client': 1.30.9
+      '@percy/client': 1.30.9(supports-color@8.1.1)
       '@percy/config': 1.30.9(typescript@5.9.3)
       '@percy/dom': 1.30.9
       '@percy/logger': 1.30.9
@@ -18608,7 +18658,7 @@ snapshots:
 
   '@percy/sdk-utils@1.31.11':
     dependencies:
-      pac-proxy-agent: 7.2.0
+      pac-proxy-agent: 7.2.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19311,15 +19361,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@semantic-release/changelog@6.0.3(semantic-release@21.1.2(typescript@5.9.3))':
+  '@semantic-release/changelog@6.0.3(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
       fs-extra: 11.3.4
       lodash: 4.18.1
-      semantic-release: 21.1.2(typescript@5.9.3)
+      semantic-release: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
 
-  '@semantic-release/commit-analyzer@10.0.4(semantic-release@21.1.2(typescript@5.9.3))':
+  '@semantic-release/commit-analyzer@10.0.4(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
     dependencies:
       conventional-changelog-angular: 6.0.0
       conventional-commits-filter: 3.0.0
@@ -19328,11 +19378,11 @@ snapshots:
       import-from: 4.0.0
       lodash-es: 4.18.1
       micromatch: 4.0.8
-      semantic-release: 21.1.2(typescript@5.9.3)
+      semantic-release: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/commit-analyzer@9.0.2(semantic-release@21.1.2(typescript@5.9.3))':
+  '@semantic-release/commit-analyzer@9.0.2(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
     dependencies:
       conventional-changelog-angular: 5.0.13
       conventional-commits-filter: 2.0.7
@@ -19341,7 +19391,7 @@ snapshots:
       import-from: 4.0.0
       lodash: 4.18.1
       micromatch: 4.0.8
-      semantic-release: 21.1.2(typescript@5.9.3)
+      semantic-release: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -19349,7 +19399,7 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/exec@6.0.3(semantic-release@21.1.2(typescript@5.9.3))':
+  '@semantic-release/exec@6.0.3(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -19357,11 +19407,11 @@ snapshots:
       execa: 5.1.1
       lodash: 4.18.1
       parse-json: 5.2.0
-      semantic-release: 21.1.2(typescript@5.9.3)
+      semantic-release: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/git@10.0.1(semantic-release@21.1.2(typescript@5.9.3))':
+  '@semantic-release/git@10.0.1(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -19371,11 +19421,11 @@ snapshots:
       lodash: 4.18.1
       micromatch: 4.0.8
       p-reduce: 2.1.0
-      semantic-release: 21.1.2(typescript@5.9.3)
+      semantic-release: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@8.1.0(encoding@0.1.13)(semantic-release@21.1.2(typescript@5.9.3))':
+  '@semantic-release/github@8.1.0(encoding@0.1.13)(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
     dependencies:
       '@octokit/core': 4.2.4(encoding@0.1.13)
       '@octokit/plugin-paginate-rest': 6.1.2(@octokit/core@4.2.4(encoding@0.1.13))
@@ -19387,19 +19437,19 @@ snapshots:
       dir-glob: 3.0.1
       fs-extra: 11.3.4
       globby: 11.1.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       issue-parser: 6.0.0
       lodash: 4.18.1
       mime: 3.0.0
       p-filter: 2.1.0
-      semantic-release: 21.1.2(typescript@5.9.3)
+      semantic-release: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
       url-join: 4.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@semantic-release/github@9.2.6(semantic-release@21.1.2(typescript@5.9.3))':
+  '@semantic-release/github@9.2.6(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
     dependencies:
       '@octokit/core': 5.2.2
       '@octokit/plugin-paginate-rest': 9.2.2(@octokit/core@5.2.2)
@@ -19410,18 +19460,18 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       dir-glob: 3.0.1
       globby: 14.1.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       issue-parser: 6.0.0
       lodash-es: 4.18.1
       mime: 4.1.0
       p-filter: 4.1.0
-      semantic-release: 21.1.2(typescript@5.9.3)
+      semantic-release: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/npm@10.0.6(semantic-release@21.1.2(typescript@5.9.3))':
+  '@semantic-release/npm@10.0.6(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
@@ -19434,11 +19484,11 @@ snapshots:
       rc: 1.2.8
       read-pkg: 8.1.0
       registry-auth-token: 5.1.1
-      semantic-release: 21.1.2(typescript@5.9.3)
+      semantic-release: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
       semver: 7.7.4
       tempy: 3.2.0
 
-  '@semantic-release/npm@9.0.2(semantic-release@21.1.2(typescript@5.9.3))':
+  '@semantic-release/npm@9.0.2(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -19451,11 +19501,11 @@ snapshots:
       rc: 1.2.8
       read-pkg: 5.2.0
       registry-auth-token: 5.1.1
-      semantic-release: 21.1.2(typescript@5.9.3)
+      semantic-release: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
       semver: 7.7.4
       tempy: 1.0.1
 
-  '@semantic-release/release-notes-generator@10.0.3(semantic-release@21.1.2(typescript@5.9.3))':
+  '@semantic-release/release-notes-generator@10.0.3(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
     dependencies:
       conventional-changelog-angular: 5.0.13
       conventional-changelog-writer: 5.0.1
@@ -19467,11 +19517,11 @@ snapshots:
       into-stream: 6.0.0
       lodash: 4.18.1
       read-pkg-up: 7.0.1
-      semantic-release: 21.1.2(typescript@5.9.3)
+      semantic-release: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/release-notes-generator@11.0.7(semantic-release@21.1.2(typescript@5.9.3))':
+  '@semantic-release/release-notes-generator@11.0.7(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
     dependencies:
       conventional-changelog-angular: 6.0.0
       conventional-changelog-writer: 6.0.1
@@ -19483,7 +19533,7 @@ snapshots:
       into-stream: 7.0.0
       lodash-es: 4.18.1
       read-pkg-up: 10.1.0
-      semantic-release: 21.1.2(typescript@5.9.3)
+      semantic-release: 21.1.2(supports-color@8.1.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -19548,17 +19598,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/tuf@1.0.3':
+  '@sigstore/tuf@1.0.3(supports-color@8.1.1)':
     dependencies:
       '@sigstore/protobuf-specs': 0.2.1
-      tuf-js: 1.1.7
+      tuf-js: 1.1.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/tuf@2.3.4':
+  '@sigstore/tuf@2.3.4(supports-color@8.1.1)':
     dependencies:
       '@sigstore/protobuf-specs': 0.3.3
-      tuf-js: 2.2.1
+      tuf-js: 2.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19666,7 +19716,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/test-runner@0.24.4(@types/node@22.19.17)(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.17)(typescript@5.9.3))':
+  '@storybook/test-runner@0.24.4(@types/node@22.19.17)(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.17)(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -19680,7 +19730,7 @@ snapshots:
       jest-circus: 30.3.0
       jest-environment-node: 30.3.0
       jest-junit: 16.0.0
-      jest-process-manager: 0.4.0
+      jest-process-manager: 0.4.0(supports-color@8.1.1)
       jest-runner: 30.3.0
       jest-serializer-html: 7.1.0
       jest-watch-typeahead: 3.0.1(jest@30.3.0(@types/node@22.19.17)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.17)(typescript@5.9.3)))
@@ -19722,7 +19772,7 @@ snapshots:
       storybook: 10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       type-fest: 2.19.0
       vue: 3.5.32(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.4
+      vue-component-type-helpers: 3.3.5
 
   '@swc/core-darwin-arm64@1.15.21':
     optional: true
@@ -19984,7 +20034,7 @@ snapshots:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
       '@tiptap/pm': 3.19.0
 
-  '@tiptap/vue-3@3.19.0(patch_hash=hlk524tqy4svh2bbayevihx324)(@floating-ui/dom@1.7.6)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(vue@3.5.32(typescript@5.9.3))':
+  '@tiptap/vue-3@3.19.0(patch_hash=65d98f737afae097542c692b176a81069e1b7b8d577d1d7e222a94436e128ea9)(@floating-ui/dom@1.7.6)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
@@ -20073,11 +20123,11 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
 
   '@types/cacheable-request@6.0.3':
     dependencies:
@@ -20094,11 +20144,11 @@ snapshots:
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 5.1.1
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
 
   '@types/debug@4.1.13':
     dependencies:
@@ -20126,14 +20176,14 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -20173,7 +20223,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
 
   '@types/inquirer@9.0.9':
     dependencies:
@@ -20237,7 +20287,7 @@ snapshots:
 
   '@types/node-forge@1.3.14':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
 
   '@types/node@16.18.126': {}
 
@@ -20284,11 +20334,11 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -20297,18 +20347,18 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
       '@types/send': 0.17.6
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
 
   '@types/stack-utils@2.0.3': {}
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 24.3.1
 
   '@types/unist@2.0.11': {}
 
@@ -20331,7 +20381,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -20342,6 +20392,23 @@ snapshots:
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 20.19.39
+    optional: true
+
+  '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.58.0
+      '@typescript-eslint/type-utils': 8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.58.0
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
@@ -20359,6 +20426,19 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  '@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.58.0
+      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.58.0
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
@@ -20390,6 +20470,19 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  '@typescript-eslint/type-utils@8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@typescript-eslint/type-utils@8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.0
@@ -20415,6 +20508,17 @@ snapshots:
       semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+      '@typescript-eslint/scope-manager': 8.58.0
+      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -20510,7 +20614,7 @@ snapshots:
       vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@20.19.39)(jsdom@24.1.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@20.19.39)(jsdom@24.1.3(supports-color@8.1.1))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.2
@@ -20522,7 +20626,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@20.19.39)(jsdom@24.1.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.2(@types/node@20.19.39)(jsdom@24.1.3(supports-color@8.1.1))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@24.3.1)(jsdom@24.1.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.3.1)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
@@ -20730,7 +20834,7 @@ snapshots:
       mini-css-extract-plugin: 2.10.2(webpack@5.105.4(@swc/core@1.15.21)(esbuild@0.27.7))
       minimist: 1.2.8
       module-alias: 2.3.4
-      portfinder: 1.0.38
+      portfinder: 1.0.38(supports-color@8.1.1)
       postcss: 8.4.39
       postcss-loader: 6.2.1(postcss@8.4.39)(webpack@5.105.4(@swc/core@1.15.21)(esbuild@0.27.7))
       progress-webpack-plugin: 1.0.16(webpack@5.105.4(@swc/core@1.15.21)(esbuild@0.27.7))
@@ -22068,7 +22172,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.2:
+  body-parser@2.2.2(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -24124,24 +24228,24 @@ snapshots:
       eslint: 9.39.4(jiti@1.21.7)
       eslint-compat-utils: 0.5.1(eslint@9.39.4(jiti@1.21.7))
 
-  eslint-plugin-eslint-plugin@6.3.1(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-eslint-plugin@6.3.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
-      eslint: 9.39.4(jiti@1.21.7)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       estraverse: 5.3.0
 
-  eslint-plugin-jest@29.15.1(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(jest@29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@20.19.39)(typescript@5.9.3)))(typescript@5.9.3):
+  eslint-plugin-jest@29.15.1(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(jest@29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@20.19.39)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@1.21.7)
+      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
       jest: 29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@20.19.39)(typescript@5.9.3))
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsdoc@51.4.1(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-jsdoc@51.4.1(eslint@9.39.4(jiti@1.21.7))(supports-color@8.1.1):
     dependencies:
       '@es-joy/jsdoccomment': 0.52.0
       are-docs-informative: 0.0.2
@@ -24184,45 +24288,45 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-storybook@10.3.0(eslint@9.39.4(jiti@1.21.7))(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
+  eslint-plugin-storybook@10.3.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(storybook@10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@1.21.7)
+      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       storybook: 10.3.0(@testing-library/dom@10.4.1)(prettier@3.3.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)(vitest@4.1.2(@types/node@20.19.39)(jsdom@24.1.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
+  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)(vitest@4.1.2(@types/node@20.19.39)(jsdom@24.1.3(supports-color@8.1.1))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
-      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@1.21.7)
+      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      vitest: 4.1.2(@types/node@20.19.39)(jsdom@24.1.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@typescript-eslint/eslint-plugin': 8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
+      vitest: 4.1.2(@types/node@20.19.39)(jsdom@24.1.3(supports-color@8.1.1))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-vue@10.8.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@1.21.7))):
+  eslint-plugin-vue@10.8.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
-      eslint: 9.39.4(jiti@1.21.7)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.1
       semver: 7.7.4
-      vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@1.21.7))
+      vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.58.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
 
-  eslint-plugin-vuejs-accessibility@2.5.0(eslint@9.39.4(jiti@1.21.7))(globals@16.3.0):
+  eslint-plugin-vuejs-accessibility@2.5.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(globals@16.3.0):
     dependencies:
       aria-query: 5.3.2
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       globals: 16.3.0
-      vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@1.21.7))
+      vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -24260,10 +24364,51 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@8.1.1)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
+      '@eslint/eslintrc': 3.3.5(supports-color@8.1.1)
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 1.21.7
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2(supports-color@8.1.1)
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5(supports-color@8.1.1)
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
@@ -24474,9 +24619,9 @@ snapshots:
 
   expr-eval-fork@2.0.2: {}
 
-  express-rate-limit@7.5.1(express@5.2.1):
+  express-rate-limit@7.5.1(express@5.2.1(supports-color@8.1.1)):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@8.1.1)
 
   express@4.22.1:
     dependencies:
@@ -24514,10 +24659,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1:
+  express@5.2.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.2.2(supports-color@8.1.1)
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
@@ -24527,7 +24672,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -24538,8 +24683,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.0
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
@@ -24710,7 +24855,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -24845,9 +24990,9 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
 
-  fly-import@0.4.1:
+  fly-import@0.4.1(supports-color@8.1.1):
     dependencies:
-      '@npmcli/arborist': 7.5.4
+      '@npmcli/arborist': 7.5.4(supports-color@8.1.1)
       env-paths: 3.0.0
       registry-auth-token: 5.1.1
       registry-url: 6.0.1
@@ -25069,7 +25214,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-uri@6.0.5:
+  get-uri@6.0.5(supports-color@8.1.1):
     dependencies:
       basic-ftp: 5.2.0
       data-uri-to-buffer: 6.0.2
@@ -25780,7 +25925,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -25807,7 +25952,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-server@14.1.1:
+  http-server@14.1.1(supports-color@8.1.1):
     dependencies:
       basic-auth: 2.0.1
       chalk: 4.1.2
@@ -25818,7 +25963,7 @@ snapshots:
       mime: 1.6.0
       minimist: 1.2.8
       opener: 1.5.2
-      portfinder: 1.0.38
+      portfinder: 1.0.38(supports-color@8.1.1)
       secure-compare: 3.0.1
       union: 0.5.0
       url-join: 4.0.1
@@ -25838,7 +25983,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -25905,7 +26050,7 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-from-esm@1.3.4:
+  import-from-esm@1.3.4(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       import-meta-resolve: 4.2.0
@@ -26833,7 +26978,7 @@ snapshots:
     optionalDependencies:
       jest-resolve: 30.3.0
 
-  jest-process-manager@0.4.0:
+  jest-process-manager@0.4.0(supports-color@8.1.1):
     dependencies:
       '@types/wait-on': 5.3.4
       chalk: 4.1.2
@@ -26842,7 +26987,7 @@ snapshots:
       find-process: 1.4.11
       prompts: 2.4.2
       signal-exit: 3.0.7
-      spawnd: 5.0.0
+      spawnd: 5.0.0(supports-color@8.1.1)
       tree-kill: 1.2.2
       wait-on: 7.2.0
     transitivePeerDependencies:
@@ -27123,7 +27268,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -27262,15 +27407,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsdom@24.1.3:
+  jsdom@24.1.3(supports-color@8.1.1):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       form-data: 4.0.5
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -27556,7 +27701,7 @@ snapshots:
 
   linkifyjs@4.3.2: {}
 
-  lint-staged@15.5.2:
+  lint-staged@15.5.2(supports-color@8.1.1):
     dependencies:
       chalk: 5.6.2
       commander: 13.1.0
@@ -27960,16 +28105,16 @@ snapshots:
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
       markdown-it: 14.1.1
-      markdownlint: 0.38.0
+      markdownlint: 0.38.0(supports-color@8.1.1)
       minimatch: 10.0.3
       run-con: 1.3.2
       smol-toml: 1.3.4
     transitivePeerDependencies:
       - supports-color
 
-  markdownlint@0.38.0:
+  markdownlint@0.38.0(supports-color@8.1.1):
     dependencies:
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@8.1.1)
       micromark-core-commonmark: 2.0.3
       micromark-extension-directive: 4.0.0
       micromark-extension-gfm-autolink-literal: 2.1.0
@@ -28030,7 +28175,7 @@ snapshots:
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@8.1.1)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -28126,7 +28271,7 @@ snapshots:
 
   mem-fs@4.1.4:
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.3.1
       '@types/vinyl': 2.0.12
       vinyl: 3.0.1
       vinyl-file: 5.0.0
@@ -28380,7 +28525,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@8.1.1):
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@8.1.1)
@@ -29432,16 +29577,16 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  pac-proxy-agent@7.2.0:
+  pac-proxy-agent@7.2.0(supports-color@8.1.1):
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
-      get-uri: 6.0.5
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      get-uri: 6.0.5(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -29480,7 +29625,7 @@ snapshots:
       registry-url: 5.1.0
       semver: 7.7.4
 
-  pacote@15.2.0:
+  pacote@15.2.0(supports-color@8.1.1):
     dependencies:
       '@npmcli/git': 4.1.0
       '@npmcli/installed-package-contents': 2.1.0
@@ -29497,14 +29642,14 @@ snapshots:
       promise-retry: 2.0.1
       read-package-json: 6.0.4
       read-package-json-fast: 3.0.2
-      sigstore: 1.9.0
+      sigstore: 1.9.0(supports-color@8.1.1)
       ssri: 10.0.6
       tar: 6.2.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
 
-  pacote@18.0.6:
+  pacote@18.0.6(supports-color@8.1.1):
     dependencies:
       '@npmcli/git': 5.0.8
       '@npmcli/installed-package-contents': 2.1.0
@@ -29520,7 +29665,7 @@ snapshots:
       npm-registry-fetch: 17.1.0
       proc-log: 4.2.0
       promise-retry: 2.0.1
-      sigstore: 2.3.1
+      sigstore: 2.3.1(supports-color@8.1.1)
       ssri: 10.0.6
       tar: 6.2.1
     transitivePeerDependencies:
@@ -29841,7 +29986,7 @@ snapshots:
 
   pngjs@3.4.0: {}
 
-  portfinder@1.0.38:
+  portfinder@1.0.38(supports-color@8.1.1):
     dependencies:
       async: 3.2.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -31175,7 +31320,7 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
-  router@2.2.0:
+  router@2.2.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
@@ -31284,13 +31429,13 @@ snapshots:
       '@types/node-forge': 1.3.14
       node-forge: 1.4.0
 
-  semantic-release-plus@20.0.0(encoding@0.1.13)(semantic-release@21.1.2(typescript@5.9.3)):
+  semantic-release-plus@20.0.0(encoding@0.1.13)(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1):
     dependencies:
-      '@semantic-release/commit-analyzer': 9.0.2(semantic-release@21.1.2(typescript@5.9.3))
+      '@semantic-release/commit-analyzer': 9.0.2(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
       '@semantic-release/error': 3.0.0
-      '@semantic-release/github': 8.1.0(encoding@0.1.13)(semantic-release@21.1.2(typescript@5.9.3))
-      '@semantic-release/npm': 9.0.2(semantic-release@21.1.2(typescript@5.9.3))
-      '@semantic-release/release-notes-generator': 10.0.3(semantic-release@21.1.2(typescript@5.9.3))
+      '@semantic-release/github': 8.1.0(encoding@0.1.13)(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
+      '@semantic-release/npm': 9.0.2(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))
+      '@semantic-release/release-notes-generator': 10.0.3(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
       aggregate-error: 3.1.0
       cosmiconfig: 7.1.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -31319,13 +31464,13 @@ snapshots:
       - semantic-release
       - supports-color
 
-  semantic-release@21.1.2(typescript@5.9.3):
+  semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
-      '@semantic-release/commit-analyzer': 10.0.4(semantic-release@21.1.2(typescript@5.9.3))
+      '@semantic-release/commit-analyzer': 10.0.4(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 9.2.6(semantic-release@21.1.2(typescript@5.9.3))
-      '@semantic-release/npm': 10.0.6(semantic-release@21.1.2(typescript@5.9.3))
-      '@semantic-release/release-notes-generator': 11.0.7(semantic-release@21.1.2(typescript@5.9.3))
+      '@semantic-release/github': 9.2.6(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
+      '@semantic-release/npm': 10.0.6(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))
+      '@semantic-release/release-notes-generator': 11.0.7(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
       aggregate-error: 5.0.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
       debug: 4.4.3(supports-color@8.1.1)
@@ -31405,7 +31550,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1:
+  send@1.2.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -31475,7 +31620,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -31570,23 +31715,23 @@ snapshots:
       figures: 2.0.0
       pkg-conf: 2.1.0
 
-  sigstore@1.9.0:
+  sigstore@1.9.0(supports-color@8.1.1):
     dependencies:
       '@sigstore/bundle': 1.1.0
       '@sigstore/protobuf-specs': 0.2.1
       '@sigstore/sign': 1.0.0
-      '@sigstore/tuf': 1.0.3
+      '@sigstore/tuf': 1.0.3(supports-color@8.1.1)
       make-fetch-happen: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
-  sigstore@2.3.1:
+  sigstore@2.3.1(supports-color@8.1.1):
     dependencies:
       '@sigstore/bundle': 2.3.2
       '@sigstore/core': 1.1.0
       '@sigstore/protobuf-specs': 0.3.3
       '@sigstore/sign': 2.3.2
-      '@sigstore/tuf': 2.3.4
+      '@sigstore/tuf': 2.3.4(supports-color@8.1.1)
       '@sigstore/verify': 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -31674,7 +31819,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  socks-proxy-agent@8.0.5:
+  socks-proxy-agent@8.0.5(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -31737,7 +31882,7 @@ snapshots:
 
   spawn-error-forwarder@1.0.0: {}
 
-  spawn-rx@5.1.2:
+  spawn-rx@5.1.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       rxjs: 7.8.2
@@ -31758,12 +31903,12 @@ snapshots:
       signal-exit: 3.0.7
       which: 2.0.2
 
-  spawnd@5.0.0:
+  spawnd@5.0.0(supports-color@8.1.1):
     dependencies:
       exit: 0.1.2
       signal-exit: 3.0.7
       tree-kill: 1.2.2
-      wait-port: 0.2.14
+      wait-port: 0.2.14(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -32106,58 +32251,58 @@ snapshots:
 
   stylelint-config-rational-order@0.1.2(typescript@5.9.3):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-order: 2.2.1(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
+      stylelint-order: 2.2.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  stylelint-config-recommended-less@3.0.1(postcss@8.5.8)(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended-less@3.0.1(postcss@8.5.8)(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
     dependencies:
       postcss-less: 6.0.0(postcss@8.5.8)
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-config-recommended: 14.0.1(stylelint@16.26.1(typescript@5.9.3))
-      stylelint-less: 3.0.1(postcss@8.5.8)(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
+      stylelint-config-recommended: 14.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
+      stylelint-less: 3.0.1(postcss@8.5.8)(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
     optionalDependencies:
       postcss: 8.5.8
 
-  stylelint-config-recommended@14.0.1(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended@14.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
 
-  stylelint-config-recommended@17.0.0(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended@17.0.0(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
 
-  stylelint-config-standard@39.0.1(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-standard@39.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
+      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
 
-  stylelint-less@3.0.1(postcss@8.5.8)(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-less@3.0.1(postcss@8.5.8)(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
     dependencies:
       postcss: 8.5.8
       postcss-resolve-nested-selector: 0.1.6
       postcss-value-parser: 4.2.0
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
 
-  stylelint-no-px@1.0.1(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-no-px@1.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
     dependencies:
       postcss-value-parser: 4.2.0
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
 
-  stylelint-order@2.2.1(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-order@2.2.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
     dependencies:
       lodash: 4.18.1
       postcss: 7.0.39
       postcss-sorting: 4.1.0
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
 
   stylelint-test-rule-node@0.2.2(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
 
-  stylelint@16.26.1(typescript@5.9.3):
+  stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
@@ -32669,7 +32814,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  tuf-js@1.1.7:
+  tuf-js@1.1.7(supports-color@8.1.1):
     dependencies:
       '@tufjs/models': 1.0.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -32677,7 +32822,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  tuf-js@2.2.1:
+  tuf-js@2.2.1(supports-color@8.1.1):
     dependencies:
       '@tufjs/models': 2.0.1
       debug: 4.4.3(supports-color@8.1.1)
@@ -33190,10 +33335,10 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  vite-bundle-visualizer@1.2.1(rollup@4.60.1):
+  vite-bundle-visualizer@1.2.1(rollup@4.60.1)(supports-color@8.1.1):
     dependencies:
       cac: 6.7.14
-      import-from-esm: 1.3.4
+      import-from-esm: 1.3.4(supports-color@8.1.1)
       rollup-plugin-visualizer: 5.14.0(rollup@4.60.1)
       tmp: 0.2.5
     transitivePeerDependencies:
@@ -33201,7 +33346,7 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-dts@4.5.4(@types/node@20.19.39)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-dts@4.5.4(@types/node@20.19.39)(rollup@4.60.1)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@microsoft/api-extractor': 7.58.0(@types/node@20.19.39)
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
@@ -33220,7 +33365,7 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-svg-loader@5.1.1(vue@3.5.32(typescript@5.9.3)):
+  vite-svg-loader@5.1.1(supports-color@8.1.1)(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       svgo: 3.3.3
@@ -33306,7 +33451,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@types/node@20.19.39)(jsdom@24.1.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.2(@types/node@20.19.39)(jsdom@24.1.3(supports-color@8.1.1))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -33330,7 +33475,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39
-      jsdom: 24.1.3
+      jsdom: 24.1.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - msw
 
@@ -33358,7 +33503,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.3.1
-      jsdom: 24.1.3
+      jsdom: 24.1.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - msw
 
@@ -33444,7 +33589,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.4: {}
+  vue-component-type-helpers@3.3.5: {}
 
   vue-demi@0.14.10(vue@3.5.32(typescript@5.9.3)):
     dependencies:
@@ -33465,6 +33610,18 @@ snapshots:
       ts-map: 1.0.3
       vue: 3.5.32(typescript@5.9.3)
       vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.32(typescript@5.9.3))
+
+  vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
 
   vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
@@ -33665,7 +33822,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  wait-port@0.2.14:
+  wait-port@0.2.14(supports-color@8.1.1):
     dependencies:
       chalk: 2.4.2
       commander: 3.0.2
@@ -34204,7 +34361,7 @@ snapshots:
       twig: 1.17.1
       user-home: 2.0.0
 
-  yeoman-environment@4.4.3(@types/node@20.19.39)(@yeoman/types@1.10.3(@types/node@20.19.39)(@yeoman/adapter@1.6.0(@types/node@20.19.39))(mem-fs@4.1.4))(mem-fs@4.1.4):
+  yeoman-environment@4.4.3(@types/node@20.19.39)(@yeoman/types@1.10.3(@types/node@20.19.39)(@yeoman/adapter@1.6.0(@types/node@20.19.39))(mem-fs@4.1.4))(mem-fs@4.1.4)(supports-color@8.1.1):
     dependencies:
       '@yeoman/adapter': 1.6.0(@types/node@20.19.39)
       '@yeoman/conflicter': 2.4.0(@types/node@20.19.39)(@yeoman/types@1.10.3(@types/node@20.19.39)(@yeoman/adapter@1.6.0(@types/node@20.19.39))(mem-fs@4.1.4))(mem-fs@4.1.4)
@@ -34216,7 +34373,7 @@ snapshots:
       commander: 11.1.0
       debug: 4.4.3(supports-color@8.1.1)
       execa: 8.0.1
-      fly-import: 0.4.1
+      fly-import: 0.4.1(supports-color@8.1.1)
       globby: 14.1.0
       grouped-queue: 2.1.0
       locate-path: 7.2.0
@@ -34234,7 +34391,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  yeoman-generator@5.10.0(encoding@0.1.13)(mem-fs@4.1.4):
+  yeoman-generator@5.10.0(encoding@0.1.13)(mem-fs@4.1.4)(supports-color@8.1.1):
     dependencies:
       chalk: 4.1.2
       dargs: 7.0.0
@@ -34244,7 +34401,7 @@ snapshots:
       lodash: 4.18.1
       mem-fs-editor: 9.7.0(mem-fs@4.1.4)
       minimist: 1.2.8
-      pacote: 15.2.0
+      pacote: 15.2.0(supports-color@8.1.1)
       read-pkg-up: 7.0.1
       run-async: 2.4.1
       semver: 7.7.4
@@ -34259,7 +34416,7 @@ snapshots:
 
   yn@3.1.1: {}
 
-  yo@5.1.0(@types/node@20.19.39)(@yeoman/types@1.10.3(@types/node@20.19.39)(@yeoman/adapter@1.6.0(@types/node@20.19.39))(mem-fs@4.1.4))(mem-fs@4.1.4):
+  yo@5.1.0(@types/node@20.19.39)(@yeoman/types@1.10.3(@types/node@20.19.39)(@yeoman/adapter@1.6.0(@types/node@20.19.39))(mem-fs@4.1.4))(mem-fs@4.1.4)(supports-color@8.1.1):
     dependencies:
       async: 3.2.6
       chalk: 4.1.2
@@ -34288,7 +34445,7 @@ snapshots:
       update-notifier: 5.1.0
       yeoman-character: 1.1.0
       yeoman-doctor: 5.0.0
-      yeoman-environment: 4.4.3(@types/node@20.19.39)(@yeoman/types@1.10.3(@types/node@20.19.39)(@yeoman/adapter@1.6.0(@types/node@20.19.39))(mem-fs@4.1.4))(mem-fs@4.1.4)
+      yeoman-environment: 4.4.3(@types/node@20.19.39)(@yeoman/types@1.10.3(@types/node@20.19.39)(@yeoman/adapter@1.6.0(@types/node@20.19.39))(mem-fs@4.1.4))(mem-fs@4.1.4)(supports-color@8.1.1)
       yosay: 2.0.2
     transitivePeerDependencies:
       - '@types/node'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(semantic-release@21.1.2(supports-color@8.1.1)(typescript@5.9.3))
       '@eslint/js':
-        specifier: ^10.0.1
-        version: 10.0.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+        specifier: ^9.0.0
+        version: 9.39.4
       '@faker-js/faker':
         specifier: 8.4.1
         version: 8.4.1
@@ -278,7 +278,7 @@ importers:
         version: 15.5.2(supports-color@8.1.1)
       markdownlint:
         specifier: ^0.38.0
-        version: 0.38.0
+        version: 0.38.0(supports-color@8.1.1)
       markdownlint-cli:
         specifier: ^0.45.0
         version: 0.45.0
@@ -1901,15 +1901,6 @@ packages:
   '@eslint/eslintrc@3.3.5':
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/js@10.0.1':
-    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    peerDependencies:
-      eslint: ^10.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
 
   '@eslint/js@9.39.4':
     resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
@@ -16894,10 +16885,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@10.0.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))':
-    optionalDependencies:
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
-
   '@eslint/js@9.39.4': {}
 
   '@eslint/object-schema@2.1.7': {}
@@ -28119,16 +28106,16 @@ snapshots:
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
       markdown-it: 14.1.1
-      markdownlint: 0.38.0
+      markdownlint: 0.38.0(supports-color@8.1.1)
       minimatch: 10.0.3
       run-con: 1.3.2
       smol-toml: 1.3.4
     transitivePeerDependencies:
       - supports-color
 
-  markdownlint@0.38.0:
+  markdownlint@0.38.0(supports-color@8.1.1):
     dependencies:
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@8.1.1)
       micromark-core-commonmark: 2.0.3
       micromark-extension-directive: 4.0.0
       micromark-extension-gfm-autolink-literal: 2.1.0
@@ -28189,7 +28176,7 @@ snapshots:
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@8.1.1)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -28539,7 +28526,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@8.1.1):
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@8.1.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,56 @@ packages:
   - 'packages/language-server/*'
   # yeoman generator
   - 'generator-dialtone'
+
+engineStrict: true
+
+peerDependencyRules:
+  allowedVersions:
+    mem-fs: '^4.0.0'
+    postcss: '^7.0.39 || ^8.3.3'
+    react: '^18.3.1'
+    typescript: '^5.2'
+    vite: '^8.0.0'
+    vue: '^3.2'
+    vuepress: '^2.0.0-rc.24'
+
+overrides:
+  playwright-core: '>=1.60.0'
+  '@typescript-eslint/utils': '^8.44.1'
+  braces: '>=3.0.3'
+  cross-spawn: '>=7.0.5'
+  nanoid: '>=3.3.8'
+  sass: '^1.70.0'
+  sugarss: '^5.0.0'
+  semver-regex: '3.1.4'
+  stylelint: '^16.25.0'
+  tar-fs: '>=2.1.3'
+  test-exclude: '^7.0.1'
+  trim: '>=0.0.3'
+  trim-newlines: '>=3.0.1'
+
+patchedDependencies:
+  '@tiptap/vue-3@3.19.0': patches/@tiptap__vue-3@3.19.0.patch
+
+minimumReleaseAge: 10080
+minimumReleaseAgeStrict: true
+minimumReleaseAgeIgnoreMissingTime: false
+minimumReleaseAgeExclude:
+  - '@dialpad/*'
+allowBuilds:
+  '@bundled-es-modules/glob': true
+  '@percy/core': true
+  '@swc/core': true
+  core-js: true
+  core-js-pure: true
+  es5-ext: true
+  esbuild: true
+  fsevents: true
+  keytar: true
+  nodent-runtime: true
+  nx: true
+  spawn-sync: true
+  style-dictionary: true
+  unrs-resolver: true
+  vue-demi: true
+  yo: true


### PR DESCRIPTION
## Summary

Mirrors the same supply-chain hardening done in [web-clients#1907](https://github.com/dialpad/web-clients/pull/1907).

- Enforces a 7-day minimum release age on all installed dependencies — freshly published (potentially compromised) versions will be blocked until they have aged out of the quarantine window
- All `@dialpad/*` packages are excluded so first-party releases install immediately
- Upgrades pnpm from `9.9.0` to `11.9.0` (required for `minimumReleaseAge` support)

## Changes

**`pnpm-workspace.yaml`**
- Migrate `overrides`, `peerDependencyRules`, `patchedDependencies` from `package.json` (pnpm 11 no longer reads the `pnpm` field there)
- Add `minimumReleaseAge: 10080` (7 days in minutes), `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`
- Add `minimumReleaseAgeExclude: ['@dialpad/*']`
- Add `engineStrict: true`
- Add `allowBuilds` for all existing lifecycle script packages to retain parity with prior behaviour

**`package.json`**
- Bump `packageManager` to `pnpm@11.9.0`
- Add `engines.pnpm: '>=11.9.0'`
- Add `@eslint/js` as a direct devDependency (pnpm 11 strict mode requires explicit declaration for packages imported directly)
- Remove `pnpm` field (moved to `pnpm-workspace.yaml`)

**Docs**
- Update `README.md` and `getting-started/index.md` to recommend `corepack enable` over `npm install -g pnpm`
- Update stale Node `v16.x.x` requirement to use `.nvmrc` + `nvm install`

## Notes

- CI requires no changes — `pnpm/action-setup@v3` reads `packageManager` automatically, and Node 24 satisfies pnpm 11's `>=22.13` requirement
- `allowBuilds` entries retain existing behaviour and can be tightened in a follow-up

## JIRA

https://dialpad.atlassian.net/browse/DLT-194119