### PR TITLE
feat(dialtone-css): DLT-3495 add no-layers CSS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ npm install @dialpad/dialtone @dialpad/i18n
 
 ---
 
+### Import CSS
+
+```js
+import '@dialpad/dialtone/css';
+```
+
+#### No-Layers Build
+
+If your project cannot use CSS Cascade Layers, import the no-layers variant. You will likely need to use the no-layers build if you are upgrading from Dialtone <=9, unless you migrate your application CSS to support layers. See the [CSS Cascade Layers migration guide](https://dialtone.dialpad.com/guides/migration/css-cascade-layers/) for more details.
+
+```js
+import '@dialpad/dialtone/css/no-layers';
+```
+
+---
+
 ### Theming
 
 Dialtone has four theming dimensions: **mode** (light/dark), **brand** (the color palette), **material** (the neutral ramp), and **contrast** (default/high). Each switches at runtime via `@dialpad/dialtone/themes/config`. See the [Theme and Mode guide](https://dialtone.dialpad.com/guides/theme-and-mode/) for the full API.

--- a/apps/dialtone-documentation/docs/guides/migration/css-cascade-layers/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/css-cascade-layers/index.md
@@ -64,7 +64,7 @@ With cascade layers:
 4. `dialtone.utilities !important`
 5. **Unlayered `!important`** (lowest)
 
-> **Why utilities use `!important`**: Dialtone utilities are in the last layer with `!important`, giving them the highest effective priority for overriding component styles while staying organized.
+> **Why utilities use `!important`**: Within the layered system, Dialtone utility `!important` declarations outrank all other layered `!important` declarations and — because of how layers reverse `!important` priority — also outrank your unlayered `!important`. This guarantees utilities always win over components, but means consumer `!important` overrides targeting the same properties will not work. Put overrides in a named layer declared after `dialtone.utilities` instead.
 
 ## For Consumers
 
@@ -120,7 +120,7 @@ import '@dialpad/dialtone/css/no-layers/default-theme'; // optional theme
 This build is identical in output — all the same classes — but no `@layer` wrappers are present.
 
 > [!WARNING] `!important` behavior differs in the no-layers build
-> In the layered build, your unlayered `!important` declarations beat Dialtone's layered `!important`. In the no-layers build, Dialtone utility `!important` is fully unlayered and wins over your non-`!important` rules. You will need `!important` in your own overrides to beat utilities.
+> In the layered build, Dialtone's `!important` utility declarations beat your unlayered `!important` (because `!important` priority reverses across layers). In the no-layers build, both sides are unlayered, so your `!important` can beat Dialtone's through normal cascade. However, your non-`!important` rules will lose to Dialtone utility `!important` — you will need `!important` in your own overrides to beat utilities.
 
 ### Third-Party CSS
 

--- a/apps/dialtone-documentation/docs/guides/migration/css-cascade-layers/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/css-cascade-layers/index.md
@@ -7,7 +7,7 @@ description: Dialtone now uses CSS Cascade Layers to organize all styles into a 
 
 Dialtone now uses CSS Cascade Layers (`@layer`) to organize all styles into a predictable hierarchy. This improves specificity control, makes overrides more predictable, and eliminates the need for complex selector specificity hacks.
 
-**For Consumers**: No breaking changes. Styles work exactly as before, just more reliably.
+**For Consumers**: This is a breaking change. Any app CSS that isn't wrapped in a named `@layer` will now unconditionally win over all Dialtone styles, regardless of specificity. Apps upgrading from Dialtone ≤9 will likely need to either adopt layers or use the [no-layers build](#no-layers-build).
 
 **For Contributors**: All new styles must be wrapped in the appropriate `@layer` block. See the [CSS Cascade Layers Guide](/guides/css-layers/) for details.
 
@@ -68,25 +68,59 @@ With cascade layers:
 
 ## For Consumers
 
-### No Breaking Changes
+### What breaks
 
-Your existing code continues to work. Utility classes override components just as before, but now with guaranteed layer ordering.
+Because all Dialtone styles are now inside named `@layer` blocks, **any unlayered CSS in your app automatically wins over Dialtone** — regardless of specificity or source order. This is how the cascade layer spec works, and it has two practical consequences:
 
-### Writing Overrides
+**1. Your app styles may unexpectedly override Dialtone**
 
-If you need to override Dialtone styles, create your own layer after utilities:
+If your app has unlayered CSS targeting the same elements as Dialtone components, those rules now win even if they have lower specificity. You may see Dialtone component styles disappearing or being partially overridden where they previously showed correctly.
+
+**2. Your `!important` overrides now lose to Dialtone's layered `!important`**
+
+With layers, `!important` priority order reverses: Dialtone's `!important` utility classes are inside `@layer dialtone.utilities`, so your unlayered `!important` has *lower* priority than Dialtone's. Overrides that previously used `!important` to beat Dialtone may stop working.
+
+### Recommended migration
+
+Think about the *intent* of each piece of your app CSS before deciding where it belongs in the layer order:
+
+- **Before Dialtone** — foundational styles that Dialtone should be able to override: app-level resets, base element defaults, design tokens your own system defines.
+- **After Dialtone** — styles that must win over Dialtone: feature-specific layout rules, or customizations to a Dialtone component when the component's own props and tokens aren't sufficient. Prefer using component props, CSS custom properties, and Dialtone utility classes before reaching for overrides.
 
 ```css
-@layer dialtone.reset, dialtone.base, dialtone.components, dialtone.utilities, app;
+@layer app.base, dialtone.reset, dialtone.base, dialtone.components, dialtone.utilities, app.overrides;
 
-@layer app {
-  .my-custom-styles {
-    /* Your overrides here */
-  }
+@layer app.base {
+  /* Foundational styles Dialtone can override */
+}
+
+@layer app.overrides {
+  /* Component and page styles that override Dialtone */
 }
 ```
 
-See [Using CSS Layers with Dialtone](/guides/css-layers/) for detailed guidance.
+Specificity works as expected within each layer, so you don't need to increase selector specificity to win — layer order handles it.
+
+If you cannot migrate your app CSS to use layers, use the [no-layers build](#no-layers-build) instead.
+
+### No-Layers Build
+
+If your project cannot use CSS Cascade Layers — older browser requirements, an existing specificity system, or a bundler that doesn't support `@layer` — import the no-layers variant instead:
+
+```js
+// @dialpad/dialtone-css
+import '@dialpad/dialtone-css/no-layers';
+import '@dialpad/dialtone-css/no-layers/default-theme'; // optional theme
+
+// @dialpad/dialtone
+import '@dialpad/dialtone/css/no-layers';
+import '@dialpad/dialtone/css/no-layers/default-theme'; // optional theme
+```
+
+This build is identical in output — all the same classes — but no `@layer` wrappers are present.
+
+> [!WARNING] `!important` behavior differs in the no-layers build
+> In the layered build, your unlayered `!important` declarations beat Dialtone's layered `!important`. In the no-layers build, Dialtone utility `!important` is fully unlayered and wins over your non-`!important` rules. You will need `!important` in your own overrides to beat utilities.
 
 ### Third-Party CSS
 
@@ -189,7 +223,7 @@ CSS Cascade Layers are supported in all modern browsers:
 - Safari 15.4+
 - Edge 99+
 
-For older browsers, styles still apply (unlayered), maintaining visual consistency with potentially different cascade behavior.
+If you need to support older browsers, use the [no-layers build](#no-layers-build) instead of relying on undefined fallback behavior.
 
 ## Learn More
 
@@ -199,6 +233,32 @@ For older browsers, styles still apply (unlayered), maintaining visual consisten
 
 ## Migration Path
 
-No migration required for consumers. Existing Dialtone usage continues to work identically.
+### Option A — Adopt layers (recommended)
 
-If you have custom CSS that conflicts with Dialtone, consider wrapping it in a layer as described in [Using CSS Layers with Dialtone](/guides/css-layers/).
+Declare named app layers and place your CSS based on intent — foundational styles before Dialtone, overrides after. This is the forward-compatible path and gives you the full benefits of the cascade layer system.
+
+```css
+@layer app.base, dialtone.reset, dialtone.base, dialtone.components, dialtone.utilities, app.overrides;
+
+@layer app.base {
+  /* Foundational styles: resets, base element defaults, your own tokens */
+}
+
+@layer app.overrides {
+  /* Overrides: component customizations, feature-specific layout rules */
+}
+```
+
+See [Using CSS Layers with Dialtone](/guides/css-layers/) for detailed guidance on layer ordering, third-party CSS, and per-component overrides.
+
+### Option B — Use the no-layers build
+
+If adopting layers is not feasible, switch to the no-layers CSS import. All Dialtone classes are present; `@layer` wrappers are stripped at build time. Specificity and cascade behave as they did in Dialtone ≤9.
+
+```js
+import '@dialpad/dialtone/css/no-layers';       // @dialpad/dialtone
+import '@dialpad/dialtone-css/no-layers';        // @dialpad/dialtone-css
+```
+
+> [!WARNING] `!important` behavior in the no-layers build
+> Dialtone utility `!important` declarations are fully unlayered, so they beat your non-`!important` rules. Use `!important` in your own overrides where needed.

--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "access": "public"
   },
   "sideEffects": [
-    "./dist/css/*.css",
+    "./dist/css/**/*.css",
     "./dist/css/fonts.js"
   ],
   "nx": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "./CHANGELOG.json": "./CHANGELOG.json",
     "./css": "./dist/css/dialtone.min.css",
     "./css-default-theme": "./dist/css/dialtone-default-theme.min.css",
+    "./css/no-layers": "./dist/css/no-layers/dialtone.min.css",
+    "./css/no-layers/default-theme": "./dist/css/no-layers/dialtone-default-theme.min.css",
     "./tokens/*.css": "./dist/tokens/css/*.css",
     "./tokens/postcss/*": {
       "types": "./dist/tokens/types/postcss/*.d.ts",

--- a/packages/dialtone-css/README.md
+++ b/packages/dialtone-css/README.md
@@ -25,6 +25,14 @@ npm install @dialpad/dialtone-css@latest
 import '@dialpad/dialtone-css';
 ```
 
+#### No-Layers Build
+
+If your project cannot use CSS Cascade Layers, import the no-layers variant. You will likely need to use the no-layers build if you are upgrading from Dialtone <=9, unless you migrate your application CSS to support layers. See the [CSS Cascade Layers migration guide](https://dialtone.dialpad.com/guides/migration/css-cascade-layers/) for more details.
+
+```js
+import '@dialpad/dialtone-css/no-layers';
+```
+
 ### Add dialtone's theme class to the `<body>`
 
 - Light mode

--- a/packages/dialtone-css/gulpfile.cjs
+++ b/packages/dialtone-css/gulpfile.cjs
@@ -38,6 +38,7 @@ const postCSS = settings.styles ? require('gulp-postcss') : null;
 const postCSSNano = settings.styles ? require('cssnano')({ preset: ['default', { calc: false }] }) : null;
 const less = settings.styles ? require('gulp-less') : null;
 const postCSSDialtoneGenerator = settings.styles ? require('./postcss/dialtone-generators.cjs') : null;
+const postCSSLayerRemover = settings.styles ? require('./postcss/postcss-layer-remover.cjs') : null;
 const sourcemaps = settings.styles ? require('gulp-sourcemaps') : null;
 const autoprefixer = settings.styles ? require('autoprefixer') : null;
 
@@ -77,6 +78,7 @@ const paths = {
   styles: {
     inputLib: ['./lib/build/less/dialtone.less', './lib/build/less/dialtone-default-theme.less'],
     outputLib: './lib/dist/',
+    outputNoLayers: './lib/dist/no-layers/',
   },
   tokens: {
     input: 'node_modules/@dialpad/dialtone-tokens/dist/css/*.css',
@@ -207,6 +209,19 @@ const libStylesDev = function (done) {
     }))
     .pipe(sourcemaps.write())
     .pipe(dest(paths.styles.outputLib));
+};
+
+const libStylesNoLayers = function (done) {
+  if (!settings.styles) return done();
+
+  return src(paths.styles.inputLib)
+    .pipe(less({ paths: ['./node_modules'] }))
+    .pipe(replace('../fonts/', './fonts/'))
+    .pipe(postCSS([postCSSDialtoneGenerator, autoprefixer(), postCSSLayerRemover]))
+    .pipe(dest(paths.styles.outputNoLayers))
+    .pipe(postCSS([postCSSNano]))
+    .pipe(rename({ suffix: '.min' }))
+    .pipe(dest(paths.styles.outputNoLayers));
 };
 
 const moveStyleTagsToEOF = function (file, enc, cb) {
@@ -430,6 +445,7 @@ exports.default = series(
   exports.svg,
   tokens,
   libStyles,
+  libStylesNoLayers,
   libFontStyles,
   libFontsJS,
   libDocs,

--- a/packages/dialtone-css/gulpfile.cjs
+++ b/packages/dialtone-css/gulpfile.cjs
@@ -214,9 +214,10 @@ const libStylesDev = function (done) {
 const libStylesNoLayers = function (done) {
   if (!settings.styles) return done();
 
+  // No font URL rewrite needed — output is one level deeper than lib/dist/,
+  // so the compiled ../fonts/ paths already resolve correctly to lib/dist/fonts/.
   return src(paths.styles.inputLib)
     .pipe(less({ paths: ['./node_modules'] }))
-    .pipe(replace('../fonts/', './fonts/'))
     .pipe(postCSS([postCSSDialtoneGenerator, autoprefixer(), postCSSLayerRemover]))
     .pipe(dest(paths.styles.outputNoLayers))
     .pipe(postCSS([postCSSNano]))

--- a/packages/dialtone-css/package.json
+++ b/packages/dialtone-css/package.json
@@ -66,6 +66,14 @@
       "import": "./lib/dist/dialtone.min.css",
       "style": "./lib/dist/dialtone.min.css"
     },
+    "./no-layers": {
+      "import": "./lib/dist/no-layers/dialtone.min.css",
+      "style": "./lib/dist/no-layers/dialtone.min.css"
+    },
+    "./no-layers/default-theme": {
+      "import": "./lib/dist/no-layers/dialtone-default-theme.min.css",
+      "style": "./lib/dist/no-layers/dialtone-default-theme.min.css"
+    },
     "./*": "./*"
   },
   "browserslist": [

--- a/packages/dialtone-css/postcss/postcss-layer-remover.cjs
+++ b/packages/dialtone-css/postcss/postcss-layer-remover.cjs
@@ -1,0 +1,26 @@
+/**
+ * PostCSS plugin that strips CSS cascade layers from Dialtone output.
+ *
+ * Removes `@layer …;` ordering declarations and unwraps `@layer name { … }`
+ * blocks so that all rules become unlayered. Used to produce the
+ * `dialtone-no-layers.css` build artifact for consumers that manage their own
+ * cascade ordering or need to avoid @layer for browser-support reasons.
+ */
+
+module.exports = () => ({
+  postcssPlugin: 'postcss-layer-remover',
+
+  AtRule: {
+    layer (atRule) {
+      if (atRule.nodes) {
+        // @layer name { … } — hoist children to parent, drop the @layer wrapper
+        atRule.replaceWith(atRule.nodes);
+      } else {
+        // @layer a, b, c; — ordering declaration, remove entirely
+        atRule.remove();
+      }
+    },
+  },
+});
+
+module.exports.postcss = true;


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change
- [x] Feature

## :book: Jira Ticket
[DLT-3495](https://dialpad.atlassian.net/browse/DLT-3495)

## :book: Description
Adds a no-layers build artifact for consumers that cannot use CSS Cascade Layers (older browser requirements, existing specificity systems, or apps upgrading from Dialtone ≤9).

- New PostCSS plugin (`postcss/postcss-layer-remover.cjs`) strips `@layer` ordering declarations and unwraps `@layer` blocks
- New `libStylesNoLayers` gulp task outputs to `lib/dist/no-layers/`
- Named exports added to `@dialpad/dialtone-css` (`/no-layers`, `/no-layers/default-theme`) and `@dialpad/dialtone` (`/css/no-layers`, `/css/no-layers/default-theme`)
- Updated CSS Cascade Layers migration guide to be honest about breaking changes and document both migration paths (adopt layers vs. use no-layers build)
- Updated root and `dialtone-css` READMEs with import instructions

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description.
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.

[DLT-3495]: https://dialpad.atlassian.net/browse/DLT-3495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ