### PR TITLE
fix(dialtone-css): DLT-3492 DLT-3493 fix codemod incorrectly mapping large spacing values to wrong tokens

### DIFF
--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -743,8 +743,8 @@ async function runConfigMigration (migration, opts) {
   // Loop until convergence: some config regexes only match one token per
   // property declaration per pass (e.g. border-width with two var(--dt-size-*)).
   for (const entry of matched) {
-    let changed = true;
-    while (changed) {
+    let changed;
+    do {
       changed = false;
       for (const expr of configData.expressions) {
         const before = entry.data;
@@ -758,7 +758,7 @@ async function runConfigMigration (migration, opts) {
           changed = true;
         }
       }
-    }
+    } while (changed && !configData.singlePass);
     if (entry.matches > 0) {
       await fs.writeFile(entry.file, entry.data, 'utf8');
       const shortname = path.relative(opts.cwd, entry.file);

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/space-to-spacing.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/space-to-spacing.mjs
@@ -28,8 +28,8 @@ export default {
       'eg. var(--dt-space-400) → var(--dt-spacing-100)\n' +
     '- Replaces var(--dt-space-{stop}-negative) with var(--dt-spacing-{newSuffix}-negative)\n\t' +
       'eg. var(--dt-space-400-negative) → var(--dt-spacing-100-negative)\n' +
-    '- Replaces var(--dt-space-{stop}-percent) with var(--dt-spacing-{newSuffix}-percent)\n\t' +
-      'eg. var(--dt-space-400-percent) → var(--dt-spacing-100-percent)\n' +
+    '- var(--dt-space-{stop}-percent) is left unchanged — percent tokens live under\n\t' +
+      '--dt-layout-*-percent (a different stop axis), so there is no safe automated mapping.\n' +
     '- Tokens with no equivalent (720, 730, 750+) are left unchanged for manual review.\n',
   patterns: ['**/*.{css,less,scss,sass,styl,html,vue,md,js,ts,jsx,tsx}'],
   globbyConfig: {
@@ -37,7 +37,10 @@ export default {
   },
   expressions: [
     {
-      from: /var\(--dt-space-([0-9]+)(-negative|-percent)?\)/g,
+      // -percent variants are intentionally excluded: --dt-spacing-*-percent tokens do not
+      // exist. Percent tokens live under --dt-layout-*-percent with a different stop axis
+      // (0/5/10…100 = percentages) and cannot be automatically mapped from space pixel stops.
+      from: /var\(--dt-space-([0-9]+)(-negative)?\)/g,
       to: (match, stop, suffix) => {
         const newSuffix = MAP[Number(stop)];
         if (newSuffix == null) return match;

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/stack-gap-to-spacing.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/stack-gap-to-spacing.mjs
@@ -35,6 +35,9 @@ function isAlreadyMigrated (content) {
 }
 
 export default {
+  // Gap values map directly to new spacing stops; the output of one pass (e.g. 200)
+  // is also a valid old input (200 → 25). A second pass would double-transform.
+  singlePass: true,
   description:
     'Migrates DtStack and DtDescriptionList gap prop values from old size stops to new spacing stops.\n' +
     '- Replaces gap="400" with gap="100" (8px)\n' +

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/utility-class-to-token-stops.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/utility-class-to-token-stops.mjs
@@ -36,7 +36,7 @@ const NEGATIVE_SPACING_MAP = {
   32: '400', 48: '600', 64: '800',
 };
 
-// Layout sizes for margin/padding (96px, 128px use layout tokens)
+// Layout sizes for sizing (96px, 128px use layout tokens)
 const SPACING_LAYOUT_MAP = {
   96: '150', 128: '200',
 };
@@ -77,8 +77,8 @@ export default {
     'Migrates pixel-based utility class names to token-stop-based names.\n' +
     '- Sizing: d-h16 → d-h-25, d-w64 → d-w-100, d-hmn96 → d-hmn-150\n' +
     '- Off-scale sizing: d-w1 → d-w-1px, d-h24 → d-h-24px (pixel-indexed exceptions)\n' +
-    '- Margin: d-m8 → d-m-100, d-mt16 → d-mt-200, d-mtn8 → d-mt-n100\n' +
-    '- Padding: d-p8 → d-p-100, d-pt16 → d-pt-200\n' +
+    '- Margin: d-m8 → d-m-100, d-mt16 → d-mt-200, d-mtn8 → d-mt-n100 (values ≥ 96px left unchanged)\n' +
+    '- Padding: d-p8 → d-p-100, d-pt16 → d-pt-200 (values ≥ 96px left unchanged — no layout-token padding class exists)\n' +
     '- Gap: d-g8 → d-g-100, d-rg16 → d-rg-200\n' +
     '- Position: d-t8 → d-t-100, d-tn8 → d-t-n100\n' +
     '- Border-radius all: d-bar6 → d-bar-350, d-bar24 → d-bar-550\n' +
@@ -134,18 +134,13 @@ export default {
     ]),
 
     // ── Margin: d-m{px} → d-m-{spacing-stop} ─────────────────────────────
-    ...['m', 'mt', 'mr', 'mb', 'ml', 'mx', 'my'].flatMap(prefix => [
-      // Spacing sizes (0-64px)
-      {
-        from: buildClassRegex(`d-${prefix}`, SPACING_MAP),
-        to: (match, pre, px, post) => `${pre}d-${prefix}-${SPACING_MAP[px]}${post}`,
-      },
-      // Layout sizes (96, 128px)
-      {
-        from: buildClassRegex(`d-${prefix}`, SPACING_LAYOUT_MAP),
-        to: (match, pre, px, post) => `${pre}d-${prefix}-${SPACING_LAYOUT_MAP[px]}${post}`,
-      },
-    ]),
+    // Only spacing-scale values (0-64px) are migrated. Values ≥ 96px (e.g. d-mt96)
+    // are left unchanged: token-stop margin classes use spacing tokens only, so
+    // d-mt-150 resolves to --dt-spacing-150 (12px), not --dt-layout-150 (96px).
+    ...['m', 'mt', 'mr', 'mb', 'ml', 'mx', 'my'].map(prefix => ({
+      from: buildClassRegex(`d-${prefix}`, SPACING_MAP),
+      to: (match, pre, px, post) => `${pre}d-${prefix}-${SPACING_MAP[px]}${post}`,
+    })),
 
     // ── Negative margin: d-m{dir}n{px} → d-m{dir}-n{spacing-stop} ────────
     ...['mt', 'mr', 'mb', 'ml', 'mx', 'my', 'm'].map(prefix => ({
@@ -154,16 +149,13 @@ export default {
     })),
 
     // ── Padding: d-p{px} → d-p-{spacing-stop} ────────────────────────────
-    ...['p', 'pt', 'pr', 'pb', 'pl', 'px', 'py'].flatMap(prefix => [
-      {
-        from: buildClassRegex(`d-${prefix}`, SPACING_MAP),
-        to: (match, pre, px, post) => `${pre}d-${prefix}-${SPACING_MAP[px]}${post}`,
-      },
-      {
-        from: buildClassRegex(`d-${prefix}`, SPACING_LAYOUT_MAP),
-        to: (match, pre, px, post) => `${pre}d-${prefix}-${SPACING_LAYOUT_MAP[px]}${post}`,
-      },
-    ]),
+    // Only spacing-scale values (0-64px) are migrated. Values ≥ 96px (e.g. d-pt96)
+    // are left unchanged: token-stop padding classes use spacing tokens only, so
+    // d-pt-150 resolves to --dt-spacing-150 (12px), not --dt-layout-150 (96px).
+    ...['p', 'pt', 'pr', 'pb', 'pl', 'px', 'py'].map(prefix => ({
+      from: buildClassRegex(`d-${prefix}`, SPACING_MAP),
+      to: (match, pre, px, post) => `${pre}d-${prefix}-${SPACING_MAP[px]}${post}`,
+    })),
 
     // ── Gap: d-g{px} → d-g-{spacing-stop} ────────────────────────────────
     ...['g', 'rg', 'cg'].map(prefix => ({
@@ -172,17 +164,13 @@ export default {
     })),
 
     // ── Position: d-t{px} → d-t-{spacing-stop} ───────────────────────────
-    ...['t', 'r', 'b', 'l', 'x', 'y', 'all'].flatMap(prefix => [
-      {
-        from: buildClassRegex(`d-${prefix}`, SPACING_MAP),
-        to: (match, pre, px, post) => `${pre}d-${prefix}-${SPACING_MAP[px]}${post}`,
-      },
-      // Layout position sizes (96px)
-      {
-        from: buildClassRegex(`d-${prefix}`, SPACING_LAYOUT_MAP),
-        to: (match, pre, px, post) => `${pre}d-${prefix}-${SPACING_LAYOUT_MAP[px]}${post}`,
-      },
-    ]),
+    // Only spacing-scale values (0-64px) are migrated. Values ≥ 96px (e.g. d-t96)
+    // are left unchanged: token-stop position classes use spacing tokens only, so
+    // d-t-150 resolves to --dt-spacing-150 (12px), not --dt-layout-150 (96px).
+    ...['t', 'r', 'b', 'l', 'x', 'y', 'all'].map(prefix => ({
+      from: buildClassRegex(`d-${prefix}`, SPACING_MAP),
+      to: (match, pre, px, post) => `${pre}d-${prefix}-${SPACING_MAP[px]}${post}`,
+    })),
 
     // ── Negative position: d-{dir}n{px} → d-{dir}-n{spacing-stop} ────────
     ...['t', 'r', 'b', 'l', 'x', 'y', 'all'].map(prefix => ({

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/space-to-spacing-test-examples.vue
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/space-to-spacing-test-examples.vue
@@ -149,22 +149,18 @@
 }
 
 /* ============================================ */
-/* PERCENT VARIANTS                             */
+/* SKIP CASES (should NOT be modified)          */
 /* ============================================ */
 
-/* space-400-percent → spacing-100-percent */
-.test-percent-400 {
+/* -percent variants — no --dt-spacing-*-percent tokens exist; percent tokens live under
+   --dt-layout-*-percent with a different stop axis, so these are left for manual review */
+.test-skip-percent-400 {
   padding: var(--dt-space-400-percent);
 }
 
-/* space-600-percent → spacing-400-percent */
-.test-percent-600 {
+.test-skip-percent-600 {
   gap: var(--dt-space-600-percent);
 }
-
-/* ============================================ */
-/* SKIP CASES (should NOT be modified)          */
-/* ============================================ */
 
 /* Stops with no --dt-spacing-* equivalent — leave unchanged */
 .test-skip-720 {

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/utility-class-to-token-stops.test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/tests/utility-class-to-token-stops.test.mjs
@@ -89,6 +89,28 @@ describe('utility-class-to-token-stops config', () => {
     });
   });
 
+
+  // ─── Large spacing values (≥ 96px) pass through unchanged ────────────
+  //
+  // Token-stop margin/padding/position classes (d-mt-{stop}, d-pt-{stop}, d-t-{stop})
+  // use spacing tokens only. d-mt-150 = --dt-spacing-150 (12px), not --dt-layout-150 (96px).
+  // These classes must be left for manual review rather than silently changed.
+
+  describe('large margin/padding/position values — pass through unchanged', () => {
+    const unchanged = [
+      'd-mt96', 'd-mb96', 'd-ml96', 'd-mr96', 'd-mx96', 'd-my96', 'd-m96',
+      'd-mt128', 'd-mb128', 'd-ml128', 'd-mr128', 'd-mx128', 'd-my128', 'd-m128',
+      'd-pt96', 'd-pb96', 'd-pl96', 'd-pr96', 'd-px96', 'd-py96', 'd-p96',
+      'd-pt128', 'd-pb128', 'd-pl128', 'd-pr128', 'd-px128', 'd-py128', 'd-p128',
+      'd-t96', 'd-r96', 'd-b96', 'd-l96',
+    ];
+    for (const cls of unchanged) {
+      it(`${cls} is left unchanged`, () => {
+        assert.equal(apply(`<div class="${cls}" />`), `<div class="${cls}" />`);
+      });
+    }
+  });
+
   // ─── Border-radius migration (DLT-3329) ───────────────────────────────
 
   describe('border-radius all-corners — legacy pixel-suffix to token stop', () => {

--- a/packages/eslint-plugin-dialtone/lib/rules/deprecated-pixel-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/lib/rules/deprecated-pixel-utility-classes.js
@@ -43,8 +43,6 @@ const NEGATIVE_SPACING_MAP = {
   32: '400', 48: '600', 64: '800',
 };
 
-const SPACING_LAYOUT_MAP = { 96: '150', 128: '200' };
-
 // Per-category regexes with capture groups. Negative variants precede positive so `d-mtn8`
 // matches the negative pattern (rule order is load-order in `rewriteClassString`).
 const SIZING_RE          = new RegExp(`${START}d-(h|w|hmn|hmx|wmn|wmx)(${SIZING_PIXELS})${END}`, 'g');
@@ -66,10 +64,10 @@ function rewriteClassString (input) {
     .replace(NEGATIVE_MARGIN_RE, (m, dir, px) => NEGATIVE_SPACING_MAP[px] ? `d-m${dir ?? ''}-n${NEGATIVE_SPACING_MAP[px]}` : m)
     .replace(NEGATIVE_POS_RE,    (m, dir, px) => NEGATIVE_SPACING_MAP[px] ? `d-${dir}-n${NEGATIVE_SPACING_MAP[px]}` : m)
     .replace(SIZING_RE,          (m, dir, px) => SIZING_MAP[px] ? `d-${dir}-${SIZING_MAP[px]}` : m)
-    .replace(MARGIN_RE,          (m, dir, px) => { const stop = SPACING_MAP[px] ?? SPACING_LAYOUT_MAP[px]; return stop ? `d-m${dir ?? ''}-${stop}` : m; })
-    .replace(PADDING_RE,         (m, dir, px) => { const stop = SPACING_MAP[px] ?? SPACING_LAYOUT_MAP[px]; return stop ? `d-p${dir ?? ''}-${stop}` : m; })
+    .replace(MARGIN_RE,          (m, dir, px) => { const stop = SPACING_MAP[px]; return stop ? `d-m${dir ?? ''}-${stop}` : m; })
+    .replace(PADDING_RE,         (m, dir, px) => { const stop = SPACING_MAP[px]; return stop ? `d-p${dir ?? ''}-${stop}` : m; })
     .replace(GAP_RE,             (m, dir, px) => SPACING_MAP[px] ? `d-${dir}-${SPACING_MAP[px]}` : m)
-    .replace(POSITION_RE,        (m, dir, px) => { const stop = SPACING_MAP[px] ?? SPACING_LAYOUT_MAP[px]; return stop ? `d-${dir}-${stop}` : m; });
+    .replace(POSITION_RE,        (m, dir, px) => { const stop = SPACING_MAP[px]; return stop ? `d-${dir}-${stop}` : m; });
 }
 
 module.exports = {

--- a/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-pixel-utility-classes.js
+++ b/packages/eslint-plugin-dialtone/tests/lib/rules/deprecated-pixel-utility-classes.js
@@ -9,7 +9,7 @@ const rule = require('../../../lib/rules/deprecated-pixel-utility-classes'),
 
 const ruleTester = new RuleTester({
   languageOptions: {
-    // eslint-disable-next-line n/no-extraneous-require
+     
     parser: require('vue-eslint-parser'),
     parserOptions: { ecmaVersion: 'latest' },
   },
@@ -154,6 +154,25 @@ ruleTester.run('deprecated-pixel-utility-classes', rule, {
     {
       code: '<template><div class=\'d-p8\' /></template>',
       output: '<template><div class=\'d-p-100\' /></template>',
+      errors: [{ messageId: 'deprecatedPixelClass' }],
+    },
+    // Large spacing values (96px, 128px) — deprecated but no token-stop equivalent in the
+    // spacing scale. Detected so consumers know to migrate manually; no autofix emitted
+    // because the old SPACING_LAYOUT_MAP fallback produced d-mt-150 (~12px) instead of
+    // a layout-backed class, silently regressing 96px/128px to 12px/16px.
+    {
+      code: '<template><div class="d-mt96" /></template>',
+      output: null,
+      errors: [{ messageId: 'deprecatedPixelClass' }],
+    },
+    {
+      code: '<template><div class="d-pt128" /></template>',
+      output: null,
+      errors: [{ messageId: 'deprecatedPixelClass' }],
+    },
+    {
+      code: '<template><div class="d-t96" /></template>',
+      output: null,
       errors: [{ messageId: 'deprecatedPixelClass' }],
     },
   ],


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change
- [x] Bug fix

## :book: Jira Ticket
[DLT-3492](https://dialpad.atlassian.net/browse/DLT-3492) | [DLT-3493](https://dialpad.atlassian.net/browse/DLT-3493)

## :book: Description

### `utility-class-to-token-stops` — silent spacing regression on large pixel values

The codemod was silently producing incorrect output for margin, padding, and position classes with pixel values ≥ 96px (e.g. `d-pt96`, `d-mt128`).

**Root cause:** The codemod mapped these via `SPACING_LAYOUT_MAP` to token-stop names like `d-pt-150`. However, token-stop padding/margin/position classes (`d-pt-{stop}`, `d-mt-{stop}`, `d-t-{stop}`) are generated exclusively from `SPACING_STOPS` using **spacing tokens** — not layout tokens. So `d-pt-150` resolves to `--dt-spacing-150` (~12px), not `--dt-layout-150` (96px). This is a significant and silent spacing regression.

**Fix:** Remove `SPACING_LAYOUT_MAP` from the margin, padding, and position expressions. Classes like `d-pt96` now pass through unchanged, consistent with how unrecognized sizing values like `d-h72` are handled — left for manual review. `SPACING_LAYOUT_MAP` is still correctly applied to sizing classes (`d-h`, `d-w`, etc.) where layout-token-backed classes do exist.

---

### `stack-gap-to-spacing` — double-transformation in convergence loop

The `stack-gap-to-spacing` codemod was double-transforming gap values. `gap="500"` would become `gap="25"` instead of the correct `gap="200"`.

**Root cause:** `runConfigMigration` in the master migration script uses a convergence loop (`while (changed)`) that re-runs all expressions until a full pass produces no changes. This was added for configs like `size-to-layout`, where a `border:` property with two `var(--dt-size-*)` tokens can only match the second token after the first pass reshapes the line prefix — so multi-pass is genuinely needed there.

For `stack-gap-to-spacing`, however, the GAP_MAP output values overlap with the input set: `500 → 200`, and `200` is itself a valid old input that maps to `25`. So the loop would transform `gap="500"` → `gap="200"` on pass one, then pick it up again and transform `gap="200"` → `gap="25"` on pass two. The same cascading problem exists at other stops: `600 → 400 → 100`, `650 → 600 → 400 → 100`, etc.

**Fix:** Add `singlePass: true` to `stack-gap-to-spacing.mjs` (with a comment explaining the invariant), and change the convergence loop in `runConfigMigration` from `while (changed)` to `do { … } while (changed && !configData.singlePass)`. Configs that need multi-pass convergence are unaffected.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

[DLT-3492]: https://dialpad.atlassian.net/browse/DLT-3492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DLT-3493]: https://dialpad.atlassian.net/browse/DLT-3493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ