### PR TITLE
fix(editor): DP-194072 tiptap warning duplicate extension names found ['textStyle']

### DIFF
--- a/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.vue
+++ b/packages/dialtone-vue/components/rich_text_editor/rich_text_editor.vue
@@ -881,6 +881,9 @@ export default {
         this.allowBackgroundColor ||
         this.allowLineHeight) {
         extensions.push(TextStyleKit.configure({
+          // CustomTextStyle below provides the `textStyle` mark, so disable the
+          // kit's own copy to avoid a duplicate extension name.
+          textStyle: false,
           color: this.allowFontColor,
           backgroundColor: this.allowBackgroundColor,
           fontFamily: this.allowFontFamily,


### PR DESCRIPTION
# PR Title

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media.giphy.com/media/v1.Y2lkPWVjZjA1ZTQ3cDZyYXZwcHMzNTJibTR2ZmJqdGF4bWpiNGhwYnM1NHFvOTV4bmUyaiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/rlkpAmX3gaLWE/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-194072

## :book: Description

Loading the RichTextEditor displays the error `Tiptap Warning: Duplicate extension names found: ['textStyle']`

## :bulb: Context

Fixed by setting `textStyle: false` as the following `CustomTextStyle` already includes it.

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :camera: Screenshots / GIFs

Observed issue:

<img width="1920" height="915" alt="Screenshot 2026-06-30 at 1 09 32 PM" src="https://github.com/user-attachments/assets/069171d0-0ca4-448d-90c0-18d71b0eb615" />

Fix:
<img width="1914" height="888" alt="Screenshot 2026-06-30 at 1 10 42 PM" src="https://github.com/user-attachments/assets/75abb488-a2ab-44c0-9c0d-cfb3cdcd66ce" />
