### PR TITLE
fix(dt-popover): DLT-3519 added boundary prop

### DIFF
--- a/packages/dialtone-vue/components/popover/popover.test.js
+++ b/packages/dialtone-vue/components/popover/popover.test.js
@@ -263,6 +263,38 @@ describe('DtPopover Tests', () => {
     });
   });
 
+  describe('Popper Options Tests', () => {
+    it('defaults the boundary to "clippingParents"', () => {
+      const flipModifier = wrapper.vm.popperOptions().modifiers.find(modifier => modifier.name === 'flip');
+
+      expect(flipModifier.options.boundary).toBe('clippingParents');
+    });
+
+    describe('When boundary prop is set', () => {
+      beforeEach(() => {
+        mockProps = { boundary: document.body };
+        updateWrapper();
+      });
+
+      it('passes the boundary to the flip modifier options', () => {
+        const flipModifier = wrapper.vm.popperOptions().modifiers.find(modifier => modifier.name === 'flip');
+
+        expect(flipModifier.options.boundary).toBe(document.body);
+      });
+    });
+
+    describe('When boundary prop changes while the popover is open', () => {
+      it('updates the tippy instance with the new popperOptions', async () => {
+        await wrapper.setProps({ open: true });
+        const setPropsSpy = vi.spyOn(wrapper.vm.tip, 'setProps');
+
+        await wrapper.setProps({ boundary: document.body });
+
+        expect(setPropsSpy).toHaveBeenCalledWith({ popperOptions: wrapper.vm.popperOptions() });
+      });
+    });
+  });
+
   describe('Accessibility Tests', () => {
     describe('When popover is open', () => {
       beforeEach(async () => {

--- a/packages/dialtone-vue/components/popover/popover.vue
+++ b/packages/dialtone-vue/components/popover/popover.vue
@@ -361,6 +361,21 @@ export default {
     },
 
     /**
+     * The element used to determine overflow boundaries for the popover.
+     * <a
+     *   class="d-link"
+     *   href="https://popper.js.org/docs/v2/utils/detect-overflow/#boundary"
+     *   target="_blank"
+     * >
+     *   Popper.js docs
+     * </a>
+     */
+    boundary: {
+      type: [String, Element],
+      default: 'clippingParents',
+    },
+
+    /**
      * The direction the popover displays relative to the anchor.
      * <a
      *   class="d-link"
@@ -653,6 +668,10 @@ export default {
       });
     },
 
+    boundary () {
+      this.tip?.setProps({ popperOptions: this.popperOptions() });
+    },
+
     externalAnchorElement () {
       this.updateAnchorEl();
     },
@@ -768,6 +787,7 @@ export default {
         fallbackPlacements: this.fallbackPlacements,
         tether: this.tether,
         hasHideModifierEnabled: true,
+        boundary: this.boundary,
       });
     },
 

--- a/packages/dialtone-vue/components/popover/popover.vue
+++ b/packages/dialtone-vue/components/popover/popover.vue
@@ -126,6 +126,7 @@
 /* eslint-disable max-lines */
 import {
   POPOVER_APPEND_TO_VALUES,
+  POPOVER_BOUNDARY_VALUES,
   POPOVER_CONTENT_WIDTHS,
   POPOVER_HEADER_FOOTER_PADDING_CLASSES,
   POPOVER_INITIAL_FOCUS_STRINGS,
@@ -369,10 +370,15 @@ export default {
      * >
      *   Popper.js docs
      * </a>
+     * @values clippingParents, viewport, document, HTMLElement
      */
     boundary: {
-      type: [String, Element],
+      type: [String, HTML_ELEMENT_TYPE],
       default: 'clippingParents',
+      validator: boundary => {
+        return POPOVER_BOUNDARY_VALUES.includes(boundary) ||
+          (boundary instanceof HTMLElement);
+      },
     },
 
     /**

--- a/packages/dialtone-vue/components/popover/popover_constants.js
+++ b/packages/dialtone-vue/components/popover/popover_constants.js
@@ -13,6 +13,7 @@ export const POPOVER_HEADER_FOOTER_PADDING_CLASSES = {
   large: 'd-pl16',
 };
 export const POPOVER_ROLES = ['dialog', 'menu', 'listbox', 'tree', 'grid'];
+export const POPOVER_BOUNDARY_VALUES = ['clippingParents', 'viewport', 'document'];
 export const POPOVER_CONTENT_WIDTHS = ['', 'anchor'];
 export const POPOVER_INITIAL_FOCUS_STRINGS = ['none', 'dialog', 'first'];
 export const POPOVER_APPEND_TO_VALUES = ['parent', 'body', 'root'];
@@ -27,6 +28,7 @@ export default {
   POPOVER_PADDING_CLASSES,
   POPOVER_HEADER_FOOTER_PADDING_CLASSES,
   POPOVER_ROLES,
+  POPOVER_BOUNDARY_VALUES,
   POPOVER_CONTENT_WIDTHS,
   POPOVER_INITIAL_FOCUS_STRINGS,
   POPOVER_APPEND_TO_VALUES,

--- a/packages/dialtone-vue/components/popover/tippy_utils.js
+++ b/packages/dialtone-vue/components/popover/tippy_utils.js
@@ -51,6 +51,7 @@ export const getPopperOptions = ({
         options: {
           altAxis: !tether,
           tether,
+          boundary,
         },
       },
     ],


### PR DESCRIPTION
# PR Title

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExYWticjNjaHlwMXV6YzVrNTJwMmtxNDFuMmE4bm04bTFtbWExbGF5ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MNM33GTh6XedMtLO1E/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3519

## :book: Description

- Adding a boundary prop so that nested popovers can pass in a boundary override for popper options

## :bulb: Context

- Nested popovers were not calculating available space properly on the page, so they would sometimes reach outside of the viewport. This change keeps the default option the same but allows devs to override when necessary

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

For all CSS changes:

- [ ] I have used design tokens whenever possible.
- [ ] I have considered how this change will behave on different screen sizes.
- [ ] I have visually validated my change in light and dark mode.
- [ ] I have used gap or flexbox properties for layout instead of margin whenever possible.

If new component:

<!--- There are lots of things to remember when adding a new component to the system! This is so you don't forget any of them. -->

- I am exporting any new components or constants:
  - [ ] from the index.js in the component directory.
  - [ ] from the index.js in the root (like `packages/dialtone-vue`).
- [ ] I have added the styles for the new component to the `packages/dialtone-css` package.
- [ ] I have created a page for the new component on the documentation site in `apps/dialtone-documentation`.
- [ ] I have added the new component to `common/components_list.js`
- [ ] I have created a component story in storybook
- [ ] I have created story / stories for any relevant component variants in storybook
- [ ] I have created a docs page for the component in storybook.
- [ ] I have checked that changing all props/slots via the UI in storybook works as expected.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

## :link: Sources

<!--- Add any links to external reference material -->
