### PR TITLE
fix(localization): UC-27003 fall back to a supported locale instead of crashing

### DIFF
--- a/packages/dialtone-vue/localization/index.js
+++ b/packages/dialtone-vue/localization/index.js
@@ -101,7 +101,13 @@ export class DialtoneLocalization {
       return fallbackLocale;
     }
 
-    const localStorageLanguage = window.localStorage.getItem(localeManagerStorageKey);
+    // Only trust the stored locale if it's one Dialtone actually ships a bundle for.
+    // Callers (e.g. UC/UV) may allow locales Dialtone doesn't support, which would
+    // otherwise crash the LocaleManager during render.
+    const storedLanguage = window.localStorage.getItem(localeManagerStorageKey);
+    const localStorageLanguage = Object.values(allowedLocales).includes(storedLanguage)
+      ? storedLanguage
+      : null;
 
     // Get the first two letters of the navigator language and check if it's in the allowed locales
     const navigatorLanguage = Object.values(allowedLocales)

--- a/packages/dialtone-vue/localization/index.test.js
+++ b/packages/dialtone-vue/localization/index.test.js
@@ -17,6 +17,7 @@ describe('DialtoneLocalization Tests', () => {
 
     it('falls back to English when the stored locale is not supported by Dialtone', () => {
       window.localStorage.setItem(localeManagerStorageKey, 'ko-KR');
+      vi.stubGlobal('navigator', { language: 'ko-KR' });
 
       expect(DialtoneLocalization.getPreferredLocale()).toBe('en-US');
     });

--- a/packages/dialtone-vue/localization/index.test.js
+++ b/packages/dialtone-vue/localization/index.test.js
@@ -1,0 +1,31 @@
+import { DialtoneLocalization } from './index';
+
+describe('DialtoneLocalization Tests', () => {
+  const localeManagerStorageKey = 'user-locale';
+
+  afterEach(() => {
+    window.localStorage.removeItem(localeManagerStorageKey);
+    vi.unstubAllGlobals();
+  });
+
+  describe('getPreferredLocale', () => {
+    it('returns the stored locale when it is supported', () => {
+      window.localStorage.setItem(localeManagerStorageKey, 'fr-FR');
+
+      expect(DialtoneLocalization.getPreferredLocale()).toBe('fr-FR');
+    });
+
+    it('falls back to English when the stored locale is not supported by Dialtone', () => {
+      window.localStorage.setItem(localeManagerStorageKey, 'ko-KR');
+
+      expect(DialtoneLocalization.getPreferredLocale()).toBe('en-US');
+    });
+
+    it('falls back to the navigator language when no stored locale is supported', () => {
+      window.localStorage.setItem(localeManagerStorageKey, 'ko-KR');
+      vi.stubGlobal('navigator', { language: 'de-DE' });
+
+      expect(DialtoneLocalization.getPreferredLocale()).toBe('de-DE');
+    });
+  });
+});

--- a/packages/dialtone-vue/vite.config.js
+++ b/packages/dialtone-vue/vite.config.js
@@ -105,7 +105,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './tests/setupTests.js',
     exclude: ['common/custom-emoji.test.js'],
-    include: ['./{common,components,directives,recipes}/**/*.test.js'],
+    include: ['./{common,components,directives,recipes,localization}/**/*.test.js'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'json'],
@@ -115,6 +115,7 @@ export default defineConfig({
         'common/**/*.{js,vue}',
         'directives/**/*.{js,vue}',
         'recipes/**/*.{js,vue}',
+        'localization/**/*.{js,vue}',
       ],
       exclude: [
         '**/*.test.js',


### PR DESCRIPTION
## Obligatory GIF (super important!)
<!--- add a gif here -->

## :hammer_and_wrench: Type Of Change
- [x] Bug fix

## :book: Jira Ticket
[UC-27003](https://dialpad.atlassian.net/browse/UC-27003)

## :book: Description
Accounts whose language preference is set to a locale Dialtone doesn't ship a bundle for (e.g. `ko-KR`) crashed the app to a blank page on load, since `DialtoneLocalization.getPreferredLocale()` returned the raw stored/browser locale without checking it against Dialtone's supported locale list before handing it to `LocaleManager`. Once the app crashed, users were locked out of the language selector entirely and couldn't self-recover.

`getPreferredLocale()` now validates the stored locale (and the navigator-derived locale) against `allowedLocales` before using it, falling back to `en-US` if neither is supported. Added unit tests covering the supported, unsupported, and navigator-fallback cases, and added `localization/` to the Vitest include/coverage globs since it previously had no test coverage.

## :bulb: Context
Root cause and repro were already diagnosed on the ticket by Sanskar Khandelwal: Dialtone only supports 10 locales, but UC/UV allows selecting locales (Korean, Swedish, `dp-DP`) outside that set, and previously any unsupported locale would crash rendering. This PR addresses the crash side of the fix (fall back instead of crashing). Adding first-class support for the missing locales (translated bundles) is tracked as a separate follow-up, along with a corresponding fix in `uc_client`/firespotter.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps
- Add supported locale bundles for `ko-KR`, `sv-SE`, and `dp-DP` in Dialtone.
- Update `uc_client` (firespotter) once this fallback fix is released.


[UC-27003]: https://dialpad.atlassian.net/browse/UC-27003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ