### PR TITLE
fix(combobox): DLT-3520 prevent list element error during popover transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ dist
 out
 coverage
 
+# Generated raw markdown and LLM discovery files #
+apps/dialtone-documentation/docs/.vuepress/public/md/
+apps/dialtone-documentation/docs/.vuepress/public/llms.txt
+apps/dialtone-documentation/docs/.vuepress/public/llms-full.txt
+
 # Dialtone icons #
 packages/dialtone-icons/index.js
 packages/dialtone-icons/src/icons

--- a/packages/dialtone-vue/components/combobox/combobox.test.js
+++ b/packages/dialtone-vue/components/combobox/combobox.test.js
@@ -515,5 +515,39 @@ describe('DtCombobox Tests', () => {
         expect(wrapper.vm.highlightIndex).toBe(-1);
       });
     });
+
+    // When the list is rendered outside (e.g. in a popover), the list element is
+    // unreachable until the popover's enter transition completes (DLT-3520).
+    describe('When the list is rendered outside and its element is not reachable', () => {
+      let consoleErrorSpy;
+
+      beforeEach(() => {
+        mockProps = { listRenderedOutside: true };
+        mockSlots = { list: '<div data-qa="popover-stub"></div>' };
+
+        updateWrapper();
+
+        consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      });
+
+      describe('When mouseleave is detected on the list wrapper', () => {
+        it('should not log an error', async () => {
+          await listWrapper.trigger('mouseleave');
+
+          expect(consoleErrorSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('When loading changes', () => {
+        it('should not log an error', async () => {
+          await wrapper.setProps({ loading: true });
+          await wrapper.setProps({ loading: false });
+          await wrapper.vm.$nextTick();
+          await wrapper.vm.$nextTick();
+
+          expect(consoleErrorSpy).not.toHaveBeenCalled();
+        });
+      });
+    });
   });
 });

--- a/packages/dialtone-vue/components/combobox/combobox.vue
+++ b/packages/dialtone-vue/components/combobox/combobox.vue
@@ -349,7 +349,7 @@ export default {
     },
 
     clearHighlightIndex () {
-      if (this.showList) {
+      if (this.showList && this.getListElement()) {
         this.setHighlightIndex(-1);
       }
     },
@@ -394,8 +394,12 @@ export default {
     setInitialHighlightIndex () {
       if (!this.showList) return;
       this.$nextTick(() => {
-      // When the list's is shown, reset the highlight index.
-      // If the list is loading, set to -1
+        // Re-check inside the tick: the list may have closed, or when rendered
+        // outside its element is unreachable until the popover's enter
+        // transition completes (DLT-3520).
+        if (!this.showList || !this.getListElement()) return;
+        // When the list's is shown, reset the highlight index.
+        // If the list is loading, set to -1
         this.setHighlightIndex(this.loading ? -1 : 0);
       });
     },


### PR DESCRIPTION
https://dialpad.atlassian.net/browse/DLT-3520

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Description

Fixes a console error that appeared repeatedly when using a combobox with its list rendered in a popover: `listElementKey is required or the referenced element doesn't exist. Received listElement: null`.

When the list lives inside a popover, `DtCombobox` only receives the reference to the list element after the popover's enter transition finishes (and loses it again on close). Anything that tried to update the highlighted item while the popover was still fading — a `loading` toggle from fetching suggestions, or the mouse leaving the list — reached the keyboard navigation mixin without a list element and logged the error.

Two guards fix this:

- `clearHighlightIndex()` now checks the list element exists before resetting the highlight.
- `setInitialHighlightIndex()` re-checks `showList` and the list element inside its `$nextTick` callback instead of only before it.

Behavior is unchanged otherwise: the highlight still initializes as soon as the popover finishes opening, and the mixin's error remains in place as a signal for genuinely misconfigured consumers.

Also adds the generated `llms.txt` / `llms-full.txt` / `md/` docs artifacts to `.gitignore` — the ignore entries existed on `next` but not on `staging`, so these files showed up as untracked noise on every staging-based branch. Same lines and placement as `next`, so future merges won't conflict.

## :bulb: Context

Reported in DLT-3520: the error fired constantly before the popover finished its fade. Root cause is the transition window described above — the reference to the outside-rendered list is only wired up on the popover's `after-enter` hook, so during the fade the combobox falls back to querying its own (empty) list wrapper and gets `null`.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

None.