### PR TITLE
feat(dialtone-tokens): NO-JIRA publish swift prerelease tokens on next

### DIFF
--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - production
+      - next
     paths:
       - 'packages/dialtone-tokens/dist_ios/**'
 
@@ -37,7 +38,7 @@ jobs:
       - name: Build swift
         run: pnpm nx run dialtone-tokens:build:ios
 
-      - name: Publish production - Swift
+      - name: Publish - Swift
         uses: cpina/github-action-push-to-another-repository@v1.5.1
         env:
           API_TOKEN_GITHUB: ${{ secrets.DIALTONE_CI_TOKEN }}
@@ -46,4 +47,5 @@ jobs:
           source-directory: 'packages/dialtone-tokens/dist_ios'
           destination-repository-name: 'dialtone-tokens-swift'
           destination-github-username: 'dialpad'
-          commit-message: "dialtone-tokens-swift release"
+          target-branch: ${{ github.ref_name == 'production' && 'main' || format('prerelease-{0}', github.ref_name) }}
+          commit-message: ${{ github.ref_name == 'production' && 'dialtone-tokens-swift release' || format('dialtone-tokens-swift prerelease ({0})', github.ref_name) }}

--- a/packages/dialtone-tokens/dist_ios/Package.swift
+++ b/packages/dialtone-tokens/dist_ios/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// Prerelease sync: forces publish-ios.yml to pick up accumulated next-branch token changes.
 
 import PackageDescription
 


### PR DESCRIPTION
## Summary
- Extends `.github/workflows/publish-ios.yml` to also trigger on push to `next`, publishing to a `prerelease-next` branch in `dialtone-tokens-swift` (instead of `main`, which stays reserved for `production` releases).
- Adds a marker comment to `dist_ios/Package.swift` to force this run to pick up the token changes already accumulated on `next` but never published to the Swift package before this workflow change existed.

## Breaking change
This commit is intentionally marked as a breaking change (`BREAKING CHANGE: Dialtone version 10`) to force a major version bump on `@dialpad/dialtone-tokens`, since one hasn't happened yet on `next` despite the volume of accumulated token changes.

## Test plan
- [ ] Confirm `publish-ios.yml` runs on merge to `next` and successfully pushes to the `prerelease-next` branch of `dialtone-tokens-swift`
- [ ] Confirm semantic-release bumps `dialtone-tokens` to a new major prerelease version on `next`
- [ ] Confirm `production` pushes still target `main` in `dialtone-tokens-swift` (no regression)
