### PR TITLE
fix(localization): DLT-3522 use unsupported locale in fallback tests

### DIFF
--- a/packages/dialtone-vue/localization/index.test.js
+++ b/packages/dialtone-vue/localization/index.test.js
@@ -16,14 +16,14 @@ describe('DialtoneLocalization Tests', () => {
     });
 
     it('falls back to English when the stored locale is not supported by Dialtone', () => {
-      window.localStorage.setItem(localeManagerStorageKey, 'ko-KR');
-      vi.stubGlobal('navigator', { language: 'ko-KR' });
+      window.localStorage.setItem(localeManagerStorageKey, 'tr-TR');
+      vi.stubGlobal('navigator', { language: 'tr-TR' });
 
       expect(DialtoneLocalization.getPreferredLocale()).toBe('en-US');
     });
 
     it('falls back to the navigator language when no stored locale is supported', () => {
-      window.localStorage.setItem(localeManagerStorageKey, 'ko-KR');
+      window.localStorage.setItem(localeManagerStorageKey, 'tr-TR');
       vi.stubGlobal('navigator', { language: 'de-DE' });
 
       expect(DialtoneLocalization.getPreferredLocale()).toBe('de-DE');


### PR DESCRIPTION
ko-KR became a supported locale, which broke the tests that relied on it being unsupported to exercise the fallback path.