### PR TITLE
fix(scrollbar): DLT-3494 register --os-scroll-percent globally for shadow DOM support

### DIFF
--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
@@ -17,7 +17,15 @@ export const DtScrollbarDirective = {
             inherits: true,
             initialValue: '0',
           });
-        } catch { /* already registered — no-op */ }
+        } catch (error) {
+          // Chrome throws InvalidModificationError when the property is already
+          // registered — that's the expected case on non-web-component pages
+          // where overlayscrollbars.css is loaded globally. Anything else is a
+          // real failure and should not be silently swallowed.
+          if (!(error instanceof DOMException) || error.name !== 'InvalidModificationError') {
+            throw error;
+          }
+        }
 
         const os = OverlayScrollbars({
           target: el,

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.js
@@ -7,6 +7,18 @@ export const DtScrollbarDirective = {
     const instances = new WeakMap();
     app.directive('dt-scrollbar', {
       mounted (el, binding) {
+        // @property inside a shadow DOM stylesheet doesn't register globally.
+        // Without global registration Chrome's WAAPI can't interpolate
+        // --os-scroll-percent as a number and the scrollbar thumb never moves.
+        try {
+          CSS.registerProperty({
+            name: '--os-scroll-percent',
+            syntax: '<number>',
+            inherits: true,
+            initialValue: '0',
+          });
+        } catch { /* already registered — no-op */ }
+
         const os = OverlayScrollbars({
           target: el,
           elements: {

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
@@ -94,12 +94,24 @@ describe('DtScrollbarDirective Tests', () => {
     describe('when --os-scroll-percent is already registered', () => {
       beforeEach(() => {
         globalThis.CSS.registerProperty.mockImplementationOnce(() => {
-          throw new DOMException('already registered');
+          throw new DOMException('already registered', 'InvalidModificationError');
         });
       });
 
       it('should not throw', () => {
         expect(() => updateWrapper()).not.toThrow();
+      });
+    });
+
+    describe('when CSS.registerProperty fails for an unrelated reason', () => {
+      beforeEach(() => {
+        globalThis.CSS.registerProperty.mockImplementationOnce(() => {
+          throw new TypeError('invalid property descriptor');
+        });
+      });
+
+      it('should propagate the error', () => {
+        expect(() => updateWrapper()).toThrow(TypeError);
       });
     });
   });

--- a/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
+++ b/packages/dialtone-vue/directives/scrollbar_directive/scrollbar.test.js
@@ -36,6 +36,7 @@ describe('DtScrollbarDirective Tests', () => {
   beforeEach(() => {
     OverlayScrollbars.mockClear();
     mocks.destroy.mockClear();
+    globalThis.CSS = { registerProperty: vi.fn() };
   });
 
   beforeAll(() => {
@@ -78,6 +79,27 @@ describe('DtScrollbarDirective Tests', () => {
       it('should clean up directive', () => {
         wrapper.unmount();
         expect(mocks.destroy).toHaveBeenCalledTimes(1);
+      });
+
+      it('should register the --os-scroll-percent CSS property globally', () => {
+        expect(globalThis.CSS.registerProperty).toHaveBeenCalledWith({
+          name: '--os-scroll-percent',
+          syntax: '<number>',
+          inherits: true,
+          initialValue: '0',
+        });
+      });
+    });
+
+    describe('when --os-scroll-percent is already registered', () => {
+      beforeEach(() => {
+        globalThis.CSS.registerProperty.mockImplementationOnce(() => {
+          throw new DOMException('already registered');
+        });
+      });
+
+      it('should not throw', () => {
+        expect(() => updateWrapper()).not.toThrow();
       });
     });
   });


### PR DESCRIPTION
## Summary
- `v-dt-scrollbar` thumb didn't track scroll position inside web components (shadow DOM) because Chrome only registers `@property --os-scroll-percent` globally when it's loaded via `document.head`, not a shadow root
- Registers the property in `DtScrollbarDirective`'s `mounted()` hook so it's always globally typed, regardless of where `overlayscrollbars.css` is injected

## Test plan
- [x] Added unit tests verifying `CSS.registerProperty` is called with the correct args, and that a duplicate registration doesn't throw
- [x] `pnpm nx run dialtone-vue:test` passes for the scrollbar directive
