### PR TITLE
feat(link): DLT-3529 add unstyled variant

### DIFF
--- a/apps/dialtone-documentation/docs/components/link.md
+++ b/apps/dialtone-documentation/docs/components/link.md
@@ -57,6 +57,9 @@ keywords: ["anchor", "hyperlink", "url", "d-link", "DtLink", "dt-link", "text li
 </DtStack>
 ```
 
+> [!WARNING]
+> `tone="unstyled"` removes default link color and underline. Use it only when the surrounding UI provides a non-color visual distinction, and keep a visible focus treatment.
+
 ### No underline
 
 This inverts the underline behavior. With `underline="false"`, the link will not have an underline by default, but will show one on hover.

--- a/apps/dialtone-documentation/docs/components/link.md
+++ b/apps/dialtone-documentation/docs/components/link.md
@@ -53,6 +53,7 @@ keywords: ["anchor", "hyperlink", "url", "d-link", "DtLink", "dt-link", "text li
   <dt-link href="#link" tone="warning">Warning link</dt-link>
   <dt-link href="#link" tone="info">Info link</dt-link>
   <dt-link href="#link" tone="mention">Mention link</dt-link>
+  <dt-link href="#link" tone="unstyled">Unstyled link</dt-link>
 </DtStack>
 ```
 

--- a/packages/combinator/src/variants/variants_link.js
+++ b/packages/combinator/src/variants/variants_link.js
@@ -17,6 +17,10 @@ export default {
       when: { tone: hasValue },
       ...disableAndClearProps(['kind']),
     },
+    {
+      when: { tone: 'unstyled' },
+      ...disableAndClearProps(['inverted', 'underline']),
+    },
   ],
 
   default: {
@@ -49,6 +53,16 @@ export default {
     },
     slots: {
       default: { initialValue: 'Mention link' },
+    },
+  },
+
+  unstyled: {
+    props: {
+      href: { initialValue: '#link' },
+      tone: { initialValue: 'unstyled' },
+    },
+    slots: {
+      default: { initialValue: 'Unstyled link' },
     },
   },
 

--- a/packages/dialtone-css/lib/build/less/components/link.less
+++ b/packages/dialtone-css/lib/build/less/components/link.less
@@ -219,4 +219,18 @@
         }
     }
 }
+
+.d-link--unstyled {
+    /* stylelint-disable */
+    all: unset; // Must be first!
+    /* stylelint-enable */
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: var(--dt-shadow-focus);
+    }
+}
 }

--- a/packages/dialtone-css/lib/build/less/components/link.less
+++ b/packages/dialtone-css/lib/build/less/components/link.less
@@ -221,9 +221,8 @@
 }
 
 .d-link--unstyled {
-    /* stylelint-disable */
+    /* stylelint-disable-next-line order/properties-order */
     all: unset; // Must be first!
-    /* stylelint-enable */
     color: inherit;
     font: inherit;
     cursor: pointer;

--- a/packages/dialtone-vue/components/Link/Link.stories.js
+++ b/packages/dialtone-vue/components/Link/Link.stories.js
@@ -12,7 +12,9 @@ export const argsData = {
   href: '#',
   to: null,
   replace: false,
-  kind: '',
+  tone: '',
+  kind: undefined,
+  underline: true,
   rel: undefined,
   onClick: action('click'),
   onFocusIn: action('focusin'),
@@ -32,11 +34,19 @@ export const argTypesData = {
   },
 
   // Props
+  tone: {
+    options: LINK_VARIANTS,
+    control: {
+      type: 'select',
+    },
+  },
   kind: {
     options: LINK_VARIANTS,
     control: {
       type: 'select',
     },
+    table: { category: 'Deprecated' },
+    description: 'Deprecated. Use tone instead.',
   },
   inverted: {
     table: { category: 'Deprecated' },
@@ -58,6 +68,10 @@ export const argTypesData = {
   },
   replace: {
     description: 'When true, navigation replaces the current history entry. Only applies when `to` is provided.',
+    control: 'boolean',
+  },
+  underline: {
+    description: 'Determines whether the link should display an underline.',
     control: 'boolean',
   },
 

--- a/packages/dialtone-vue/components/Link/Link.test.js
+++ b/packages/dialtone-vue/components/Link/Link.test.js
@@ -2,11 +2,13 @@ import { mount } from '@vue/test-utils';
 import DtLink from './Link.vue';
 import {
   LINK_KIND_MODIFIERS,
+  LINK_UNSTYLED_CLASS,
   LINK_VARIANTS,
+  UNSTYLED,
   getLinkKindModifier,
 } from './LinkConstants';
 
-const TONE_VALUES = LINK_VARIANTS.filter(v => v !== '');
+const TONE_VALUES = LINK_VARIANTS.filter(v => v !== '' && v !== UNSTYLED);
 
 const baseProps = {
   href: '#',
@@ -85,6 +87,36 @@ describe('DtLink tests', () => {
       updateWrapper();
 
       expect(nativeLink.classes(getLinkKindModifier(tone, true))).toBe(true);
+    });
+
+    describe('When unstyled', () => {
+      it('supports unstyled without adding it as a link kind modifier', () => {
+        expect(LINK_VARIANTS).toContain(UNSTYLED);
+        expect(Object.keys(LINK_KIND_MODIFIERS)).not.toContain(UNSTYLED);
+      });
+
+      it.each(['tone', 'kind'])('renders only the unstyled class when %s is unstyled', (prop) => {
+        mockProps = {
+          [prop]: UNSTYLED,
+          inverted: true,
+          underline: false,
+        };
+
+        updateWrapper();
+
+        expect(nativeLink.classes()).toEqual([LINK_UNSTYLED_CLASS]);
+      });
+
+      it('takes precedence over deprecated kind', () => {
+        mockProps = {
+          kind: 'muted',
+          tone: UNSTYLED,
+        };
+
+        updateWrapper();
+
+        expect(nativeLink.classes()).toEqual([LINK_UNSTYLED_CLASS]);
+      });
     });
 
     describe('When underline is false', () => {
@@ -225,6 +257,24 @@ describe('DtLink tests', () => {
         expect(routerLink.exists()).toBe(true);
         expect(wrapper.find('[data-qa="dt-link"]').classes()).toContain('d-link');
         expect(wrapper.find('[data-qa="dt-link"]').classes()).toContain(LINK_KIND_MODIFIERS.muted);
+      });
+
+      it('should apply only unstyled class to the router-link when tone is unstyled', () => {
+        mockProps = {
+          to: '/components/',
+          tone: UNSTYLED,
+          inverted: true,
+          underline: false,
+        };
+        mockGlobal = {
+          stubs: { RouterLink: RouterLinkStub },
+        };
+
+        updateWrapper();
+
+        const routerLink = wrapper.findComponent(RouterLinkStub);
+        expect(routerLink.exists()).toBe(true);
+        expect(wrapper.find('[data-qa="dt-link"]').classes()).toEqual([LINK_UNSTYLED_CLASS]);
       });
     });
   });

--- a/packages/dialtone-vue/components/Link/Link.test.js
+++ b/packages/dialtone-vue/components/Link/Link.test.js
@@ -90,8 +90,11 @@ describe('DtLink tests', () => {
     });
 
     describe('When unstyled', () => {
-      it('supports unstyled without adding it as a link kind modifier', () => {
+      it('is a supported tone variant', () => {
         expect(LINK_VARIANTS).toContain(UNSTYLED);
+      });
+
+      it('is not registered as a link kind modifier', () => {
         expect(Object.keys(LINK_KIND_MODIFIERS)).not.toContain(UNSTYLED);
       });
 
@@ -107,7 +110,7 @@ describe('DtLink tests', () => {
         expect(nativeLink.classes()).toEqual([LINK_UNSTYLED_CLASS]);
       });
 
-      it('takes precedence over deprecated kind', () => {
+      it('keeps deprecated kind precedence when both kind and tone are provided', () => {
         mockProps = {
           kind: 'muted',
           tone: UNSTYLED,
@@ -115,7 +118,7 @@ describe('DtLink tests', () => {
 
         updateWrapper();
 
-        expect(nativeLink.classes()).toEqual([LINK_UNSTYLED_CLASS]);
+        expect(nativeLink.classes()).toEqual(['d-link', LINK_KIND_MODIFIERS.muted]);
       });
     });
 
@@ -259,22 +262,32 @@ describe('DtLink tests', () => {
         expect(wrapper.find('[data-qa="dt-link"]').classes()).toContain(LINK_KIND_MODIFIERS.muted);
       });
 
-      it('should apply only unstyled class to the router-link when tone is unstyled', () => {
-        mockProps = {
-          to: '/components/',
-          tone: UNSTYLED,
-          inverted: true,
-          underline: false,
-        };
-        mockGlobal = {
-          stubs: { RouterLink: RouterLinkStub },
-        };
+      describe('When tone is unstyled', () => {
+        let routerLink;
 
-        updateWrapper();
+        beforeEach(() => {
+          mockProps = {
+            to: '/components/',
+            tone: UNSTYLED,
+            inverted: true,
+            underline: false,
+          };
+          mockGlobal = {
+            stubs: { RouterLink: RouterLinkStub },
+          };
 
-        const routerLink = wrapper.findComponent(RouterLinkStub);
-        expect(routerLink.exists()).toBe(true);
-        expect(wrapper.find('[data-qa="dt-link"]').classes()).toEqual([LINK_UNSTYLED_CLASS]);
+          updateWrapper();
+
+          routerLink = wrapper.findComponent(RouterLinkStub);
+        });
+
+        it('should render a router-link', () => {
+          expect(routerLink.exists()).toBe(true);
+        });
+
+        it('should apply only unstyled class to the router-link', () => {
+          expect(nativeLink.classes()).toEqual([LINK_UNSTYLED_CLASS]);
+        });
       });
     });
   });

--- a/packages/dialtone-vue/components/Link/Link.vue
+++ b/packages/dialtone-vue/components/Link/Link.vue
@@ -12,7 +12,13 @@
 
 <script>
 import { resolveComponent } from 'vue';
-import { LINK_VARIANTS, LINK_KIND_MODIFIERS, getLinkKindModifier } from './LinkConstants';
+import {
+  LINK_VARIANTS,
+  LINK_KIND_MODIFIERS,
+  LINK_UNSTYLED_CLASS,
+  UNSTYLED,
+  getLinkKindModifier,
+} from './LinkConstants';
 
 /**
  * A link is a navigational element that can be found on its own, within other text, or directly following content.
@@ -25,7 +31,7 @@ export default {
   props: {
     /**
      * Applies the link variant styles
-     * @values null, critical, warning, positive, info, muted, mention
+     * @values null, critical, warning, positive, info, muted, mention, unstyled
      */
     tone: {
       type: String,
@@ -103,6 +109,10 @@ export default {
       return this.kind ?? this.tone;
     },
 
+    isUnstyled () {
+      return this.tone === UNSTYLED || this.kind === UNSTYLED;
+    },
+
     computedTag () {
       if (this.to) {
         return resolveComponent('RouterLink');
@@ -125,6 +135,10 @@ export default {
 
   methods: {
     getLinkClasses () {
+      if (this.isUnstyled) {
+        return [LINK_UNSTYLED_CLASS];
+      }
+
       return [
         'd-link',
         getLinkKindModifier(this.resolvedTone, this.inverted),

--- a/packages/dialtone-vue/components/Link/Link.vue
+++ b/packages/dialtone-vue/components/Link/Link.vue
@@ -110,7 +110,7 @@ export default {
     },
 
     isUnstyled () {
-      return this.tone === UNSTYLED || this.kind === UNSTYLED;
+      return this.resolvedTone === UNSTYLED;
     },
 
     computedTag () {

--- a/packages/dialtone-vue/components/Link/LinkConstants.js
+++ b/packages/dialtone-vue/components/Link/LinkConstants.js
@@ -4,7 +4,9 @@ export const WARNING = 'warning';
 export const INFO = 'info';
 export const MUTED = 'muted';
 export const MENTION = 'mention';
-export const LINK_VARIANTS = ['', CRITICAL, WARNING, POSITIVE, INFO, MUTED, MENTION];
+export const UNSTYLED = 'unstyled';
+export const LINK_UNSTYLED_CLASS = 'd-link--unstyled';
+export const LINK_VARIANTS = ['', CRITICAL, WARNING, POSITIVE, INFO, MUTED, MENTION, UNSTYLED];
 
 export const LINK_KIND_MODIFIERS = {
   default: '',
@@ -36,5 +38,6 @@ export const getLinkKindModifier = (kind, inverted) => {
 export default {
   LINK_VARIANTS,
   LINK_KIND_MODIFIERS,
+  LINK_UNSTYLED_CLASS,
   getLinkKindModifier,
 };

--- a/packages/dialtone-vue/components/Link/LinkDefault.story.vue
+++ b/packages/dialtone-vue/components/Link/LinkDefault.story.vue
@@ -4,6 +4,7 @@
       :href="$attrs.href"
       :to="$attrs.to"
       :replace="$attrs.replace"
+      :tone="$attrs.tone"
       :kind="$attrs.kind"
       :inverted="$attrs.inverted"
       :underline="$attrs.underline"

--- a/packages/dialtone-vue/components/Link/LinkVariants.story.vue
+++ b/packages/dialtone-vue/components/Link/LinkVariants.story.vue
@@ -10,12 +10,12 @@
         align="baseline"
       >
         <dt-link
-          v-for="kind in LINK_VARIANTS"
-          :key="kind"
+          v-for="tone in LINK_VARIANTS"
+          :key="tone"
           href="#"
-          :kind="kind"
+          :tone="tone"
         >
-          {{ kind }} link
+          {{ tone || 'default' }} link
         </dt-link>
       </dt-stack>
       <dt-stack
@@ -28,7 +28,7 @@
           href="#"
           :underline="false"
         >
-          No underline {{ kind }} link
+          No underline link
         </dt-link>
       </dt-stack>
     </dt-stack>


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3529

## :book: Description

Adds `tone="unstyled"` to `DtLink`.

What changed:
- Adds `unstyled` to `DtLink` tone values
- Renders unstyled links with `d-link--unstyled`
- Resets default link visual styles while preserving pointer cursor and focus-visible styling
- Updates Link tests, stories, docs example, and Combinator variant controls

Does not:
- Add `unstyled` to `DtButton linkKind`
- Promote deprecated `DtLink kind`
- Migrate existing docs-site card/link utility overrides

## :bulb: Context

Consumers currently override `DtLink` styling with CSS utilities or custom classes when they need a link that visually inherits from surrounding text.

`tone="unstyled"` gives that use case an official component API.

https://github.com/user-attachments/assets/2333e6b7-bf80-4e28-afa0-a48f64beea16

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [x] I have validated components with a screen reader.
- [x] I have validated components keyboard navigation.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.
