### PR TITLE
feat: DLT-3534 align size prop types across components and modal fullscreen

### DIFF
--- a/.claude/rules/vue-components.md
+++ b/.claude/rules/vue-components.md
@@ -38,7 +38,7 @@ paths:
 - T-shirt aliases (`xs`, `sm`, `md`, `lg`, `xl`) remain in constants for backward compat but are deprecated.
 - `@values` JSDoc: list numeric only (e.g., `@values 100, 200, 300, 400, 500`). Do not list t-shirt aliases.
 - Text headline extends the scale: `500` (xl), `600` (2xl), `700` (3xl).
-- Icons: separate numeric scale `100`–`800` (unchanged, do not modify).
+- Icons: separate numeric scale `100`–`800`, distinct from the `100`-`500` component scale (do not remap icon values onto the component scale). Icon-family `size` props (`Icon`, `Loader`, `Emoji`, `EmojiTextWrapper`, `ProgressCircle`, `ToastLayoutAlternateIcon`) still use `[String, Number]`.
 - Shared scale definition: `packages/dialtone-vue/common/constants/sizes.js`.
 - Export from `*_constants.js`: `COMPONENT_SIZE_MODIFIERS` object with both numeric and t-shirt keys.
 

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -5,7 +5,7 @@
     :banner-header-text="bannerTitle"
     :banner-kind="bannerKind"
     :fixed-header-footer="fixedHeaderFooter"
-    :size="size"
+    :fullscreen="fullscreen"
     :copy="copy"
     :transparent-backdrop="transparentBackdrop"
     @update:open="isOpen = $event"
@@ -63,9 +63,9 @@ export default {
       default: false,
     },
 
-    size: {
-      type: String,
-      default: 'default',
+    fullscreen: {
+      type: Boolean,
+      default: false,
     },
 
     transparentBackdrop: {

--- a/apps/dialtone-documentation/docs/.vuepress/views/IconCatalog.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/views/IconCatalog.vue
@@ -101,7 +101,7 @@
   <dt-modal
     v-if="selectedIcon"
     :open="isModalOpen"
-    size="full"
+    fullscreen
     content-class="d-wmx100p d-pie-400"
     @update:open="isModalOpen = false"
   >

--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -185,12 +185,12 @@ A modal style for destructive or irreversible actions.
 To make this modal take up as much of the screen as possible.
 
 ```vue demo
-<example-modal size="full" />
+<example-modal fullscreen />
 <!-- @code -->
 <dt-modal
   header-text="Example title"
   :open="isOpen"
-  size="full"
+  fullscreen
   copy="Sed at orci quis nunc finibus gravida eget vitae est..."
   @update:open="updateOpen"
 >

--- a/apps/dialtone-documentation/docs/guides/migration/component-sizes/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/component-sizes/index.md
@@ -8,7 +8,8 @@ description: Component size props move from t-shirt labels (xs, sm, md) to a num
 - Component `size` props now favor numeric values, e.g. `100` (xs), `200` (sm), `300` (md), `400` (lg), `500` (xl).
 - T-shirt aliases still work — this is **not a breaking change**, and are marked to be sunset.
 - Use the [ESLint rule](#eslint-rule) or [migration script](#migration-script) to update your code.
-- **Unchanged**: Icon sizes.
+- Icon-family `size` props (`DtIcon`, `DtLoader`, `DtEmoji`, `DtEmojiTextWrapper`, `DtProgressCircle`, `DtBadge`'s `iconSize`) now also accept a `Number`, matching every other component.
+- `DtModal`'s `size` prop (`default` / `full`) is replaced by a `fullscreen` boolean. See [migration script](#migration-script).
 
 ## Why Numeric?
 
@@ -73,9 +74,27 @@ description: Component size props move from t-shirt labels (xs, sm, md) to a num
 
 ## What's NOT Affected
 
-- **Icon sizes** (`dt-icon`, `dt-loader`, `dt-emoji`, `dt-progress-circle`) — already numeric, unchanged.
+- **Icon sizes** — the `100`-`800` icon scale itself is unchanged; icon-family components just now also accept `Number` values on the same scale (see below).
 - **DtAvatar** — already migrated to numeric in a prior release.
 - **CSS utility classes** — no changes. Numeric prop values map to the same CSS classes as before.
+
+## Icon-Family `size` Props Now Accept `Number`
+
+`DtIcon`, `DtLoader`, `DtEmoji`, `DtEmojiTextWrapper`, `DtProgressCircle`, and `DtBadge`'s `iconSize` prop previously only accepted `size="500"` (a string). They now also accept `:size="500"` (a number), matching every other Dialtone component. Existing string usage is unaffected.
+
+## DtModal: `size` → `fullscreen`
+
+`DtModal`'s `size` prop (`default` / `full`) is replaced by a `fullscreen` boolean:
+
+```vue
+<!-- Before -->
+<dt-modal size="full">...</dt-modal>
+
+<!-- After -->
+<dt-modal fullscreen>...</dt-modal>
+```
+
+The [migration script](#migration-script) below handles this transform alongside the t-shirt-to-numeric conversion.
 
 ## ESLint Rule
 
@@ -134,6 +153,7 @@ npx dialtone-migrate-tshirt-to-numeric --yes --cwd ./src
 - `.vue`, `.md`, `.html`, `.js`, `.ts`, `.jsx`, `.tsx` files
 - Multiline component tags
 - Any prop ending in `size`, `Size`, `speed`, or `Speed` (future-proof)
+- `DtModal`'s `size="full"` → `fullscreen` and `size="default"` → removed
 
 **Skipped:**
 

--- a/apps/dialtone-documentation/docs/guides/migration/component-sizes/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/component-sizes/index.md
@@ -9,7 +9,7 @@ description: Component size props move from t-shirt labels (xs, sm, md) to a num
 - T-shirt aliases still work — this is **not a breaking change**, and are marked to be sunset.
 - Use the [ESLint rule](#eslint-rule) or [migration script](#migration-script) to update your code.
 - Icon-family `size` props (`DtIcon`, `DtLoader`, `DtEmoji`, `DtEmojiTextWrapper`, `DtProgressCircle`, `DtBadge`'s `iconSize`) now also accept a `Number`, matching every other component.
-- `DtModal`'s `size` prop (`default` / `full`) is replaced by a `fullscreen` boolean. See [migration script](#migration-script).
+- **Breaking change**: `DtModal`'s `size` prop (`default` / `full`) is removed and replaced by a `fullscreen` boolean. See [migration script](#migration-script).
 
 ## Why Numeric?
 
@@ -83,6 +83,9 @@ description: Component size props move from t-shirt labels (xs, sm, md) to a num
 `DtIcon`, `DtLoader`, `DtEmoji`, `DtEmojiTextWrapper`, `DtProgressCircle`, and `DtBadge`'s `iconSize` prop previously only accepted `size="500"` (a string). They now also accept `:size="500"` (a number), matching every other Dialtone component. Existing string usage is unaffected.
 
 ## DtModal: `size` → `fullscreen`
+
+> [!CRITICAL] Breaking change
+> `DtModal`'s `size` prop is removed, unlike the t-shirt-to-numeric change above. Update any `size="full"` or `size="default"` usage before upgrading.
 
 `DtModal`'s `size` prop (`default` / `full`) is replaced by a `fullscreen` boolean:
 

--- a/packages/combinator/src/variants/variants_modal.js
+++ b/packages/combinator/src/variants/variants_modal.js
@@ -29,4 +29,17 @@ export default {
       },
     },
   },
+  fullscreen: {
+    props: {
+      headerText: {
+        initialValue: 'Example title',
+      },
+      copy: {
+        initialValue: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      },
+      fullscreen: {
+        initialValue: true,
+      },
+    },
+  },
 };

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -190,6 +190,18 @@ const MIGRATIONS = [
     ],
     fileExtensions: ['.vue', '.html'],
   },
+  {
+    id: 'modal-fullscreen',
+    name: 'DtModal size → fullscreen',
+    description: 'DtModal size prop (default/full) removed. Use the fullscreen boolean instead.',
+    category: 'required',
+    type: 'standalone',
+    scriptDir: 'dialtone_migrate_tshirt_to_numeric',
+    detectPatterns: [
+      /<(?:dt-modal|DtModal)(?![\w-])[^>]*\bsize="(?:full|default)"/,
+    ],
+    fileExtensions: ['.vue', '.html', '.md'],
+  },
 
   // ── Opt-in (deprecation, best practices) ──────────────────────────
   {

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_tshirt_to_numeric/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_tshirt_to_numeric/index.mjs
@@ -4,6 +4,8 @@
  * @fileoverview Migration script to convert t-shirt size props to numeric scale on Dialtone components.
  *
  * Transforms: size="sm" → :size="200", label-size="xs" → :label-size="100", speed="md" → :speed="300"
+ * Also transforms DtModal's `size` prop to the `fullscreen` boolean (DLT-3534):
+ *   size="full" → fullscreen, size="default" → (removed)
  *
  * Usage:
  *   npx dialtone-migrate-tshirt-to-numeric [options]
@@ -56,6 +58,9 @@ const EXCLUDED_PROPS = ['button-width-size', 'buttonWidthSize', 'background-size
 // Use [\s\S] instead of [^>] to match across newlines in multiline tags
 const DT_TAG_PATTERN = /<(dt-[\w-]+|Dt\w+)\b[\s\S]*?>/g;
 
+// DtModal's `size` prop (default | full) became the `fullscreen` boolean (DLT-3534).
+const MODAL_TAG_PATTERN = /<(dt-modal|DtModal)\b[\s\S]*?>/g;
+
 // ---------------------------------------------------------------------------
 // File finder
 // ---------------------------------------------------------------------------
@@ -90,6 +95,21 @@ async function findFiles (dir, extensions, ignore = []) {
 // Transform logic
 // ---------------------------------------------------------------------------
 
+function transformModalSize (tag) {
+  let count = 0;
+  let newTag = tag;
+
+  if (/\ssize="full"/.test(newTag)) {
+    newTag = newTag.replace(/\ssize="full"/, ' fullscreen');
+    count++;
+  } else if (/\ssize="default"/.test(newTag)) {
+    newTag = newTag.replace(/\ssize="default"/, '');
+    count++;
+  }
+
+  return { tag: newTag, count };
+}
+
 function transformContent (content) {
   let transformed = content;
   let count = 0;
@@ -110,6 +130,13 @@ function transformContent (content) {
     });
   });
 
+  // DtModal: size="full"/"default" → fullscreen boolean (DLT-3534)
+  transformed = transformed.replace(MODAL_TAG_PATTERN, (tag) => {
+    const result = transformModalSize(tag);
+    count += result.count;
+    return result.tag;
+  });
+
   return { transformed, count };
 }
 
@@ -128,6 +155,10 @@ Converts t-shirt size props to numeric scale on Dialtone components.
   size="sm"       → :size="200"
   label-size="xs" → :label-size="100"
   speed="md"      → :speed="300"
+
+  DtModal only:
+  size="full"     → fullscreen
+  size="default"  → (removed)
 
 Options:
   --cwd <path>     Working directory (default: current directory)

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_tshirt_to_numeric/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_tshirt_to_numeric/index.mjs
@@ -59,8 +59,7 @@ const EXCLUDED_PROPS = ['button-width-size', 'buttonWidthSize', 'background-size
 const DT_TAG_PATTERN = /<(dt-[\w-]+|Dt\w+)\b[\s\S]*?>/g;
 
 // DtModal's `size` prop (default | full) became the `fullscreen` boolean (DLT-3534).
-const MODAL_TAG_PATTERN = /<(dt-modal|DtModal)\b[\s\S]*?>/g;
-
+const MODAL_TAG_PATTERN = /<(dt-modal|DtModal)(?=[\s/>])[\s\S]*?>/g;
 // ---------------------------------------------------------------------------
 // File finder
 // ---------------------------------------------------------------------------

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_tshirt_to_numeric/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_tshirt_to_numeric/index.mjs
@@ -59,7 +59,10 @@ const EXCLUDED_PROPS = ['button-width-size', 'buttonWidthSize', 'background-size
 const DT_TAG_PATTERN = /<(dt-[\w-]+|Dt\w+)\b[\s\S]*?>/g;
 
 // DtModal's `size` prop (default | full) became the `fullscreen` boolean (DLT-3534).
-const MODAL_TAG_PATTERN = /<(dt-modal|DtModal)(?=[\s/>])[\s\S]*?>/g;
+// (?![\w-]) instead of \b: a plain word boundary would still match tags like
+// <dt-modal-header>, since '-' is a non-word char and creates a boundary after "modal".
+const MODAL_TAG_PATTERN = /<(dt-modal|DtModal)(?![\w-])[\s\S]*?>/g;
+
 // ---------------------------------------------------------------------------
 // File finder
 // ---------------------------------------------------------------------------

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_tshirt_to_numeric/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_tshirt_to_numeric/test.mjs
@@ -314,6 +314,53 @@ describe('Excluded props (not component scale sizes)', () => {
   });
 });
 
+describe('DtModal size → fullscreen transform', () => {
+  it('transforms size="full" to fullscreen', () => {
+    const input = '<dt-modal size="full" header-text="Title" />';
+    const expected = '<dt-modal fullscreen header-text="Title" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, expected);
+    assert.equal(count, 1);
+  });
+
+  it('removes size="default"', () => {
+    const input = '<dt-modal size="default" header-text="Title" />';
+    const expected = '<dt-modal header-text="Title" />';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, expected);
+    assert.equal(count, 1);
+  });
+
+  it('transforms PascalCase DtModal size="full"', () => {
+    const input = '<DtModal size="full">Content</DtModal>';
+    const expected = '<DtModal fullscreen>Content</DtModal>';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, expected);
+    assert.equal(count, 1);
+  });
+
+  it('ignores size="full" on non-modal components', () => {
+    const input = '<dt-button size="full">Click</dt-button>';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+
+  it('handles multiline dt-modal tags', () => {
+    const input = `<dt-modal
+      size="full"
+      header-text="Title"
+    >`;
+    const expected = `<dt-modal
+      fullscreen
+      header-text="Title"
+    >`;
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, expected);
+    assert.equal(count, 1);
+  });
+});
+
 describe('Edge cases', () => {
   it('does not transform size inside text content', () => {
     const input = '<dt-text>The size="sm" option is deprecated</dt-text>';

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate_tshirt_to_numeric/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate_tshirt_to_numeric/test.mjs
@@ -346,6 +346,13 @@ describe('DtModal size → fullscreen transform', () => {
     assert.equal(count, 0);
   });
 
+  it('ignores size="full" on tags that merely start with dt-modal', () => {
+    const input = '<dt-modal-header size="full">Content</dt-modal-header>';
+    const { transformed, count } = transformContent(input);
+    assert.equal(transformed, input);
+    assert.equal(count, 0);
+  });
+
   it('handles multiline dt-modal tags', () => {
     const input = `<dt-modal
       size="full"

--- a/packages/dialtone-docs/src/content/reference/reference-component-api-patterns.md
+++ b/packages/dialtone-docs/src/content/reference/reference-component-api-patterns.md
@@ -20,7 +20,7 @@ keywords:
     logical-props,
   ]
 ai_summary: Cross-component API contract for Dialtone Vue components — standard props, events, slots, and patterns shared by all components.
-last_updated: 2026-07-03
+last_updated: 2026-07-09
 related_packages: [dialtone-vue]
 ---
 
@@ -55,7 +55,7 @@ Most sizable components accept a `size` prop with values: `xs`, `sm`, `md`, `lg`
 
 Exceptions exist:
 
-- DtModal uses `default` and `full`.
+- DtModal has no `size` prop. Use the `fullscreen` boolean instead (`fullscreen: true` for a fullscreen modal, `false` for the default size).
 - DtText uses numeric font-size token stops for raw font-size control when paired with `variant`: `50`, `75`, `100`, `125`, `150`, `200`, `250`, `300`, `350`, `400`, `450`, `500`, `550`, `600`, `650`, `700`, `750`, `800`.
 
 DtText `size` must be paired with `variant`, or with legacy `kind` while older code migrates. DtText also keeps legacy `kind + size` composition behavior for backward compatibility when `variant` is not set.

--- a/packages/dialtone-icons/src/IconTemplate.vue
+++ b/packages/dialtone-icons/src/IconTemplate.vue
@@ -16,7 +16,7 @@ export default {
      */
     size: {
       type: [String, Number],
-      default: '500',
+      default: 500,
       validator: (s) => Object.keys(ICON_SIZE_MODIFIERS).includes(String(s)),
     },
 

--- a/packages/dialtone-icons/src/IconTemplate.vue
+++ b/packages/dialtone-icons/src/IconTemplate.vue
@@ -15,9 +15,9 @@ export default {
      * @values 100, 200, 300, 400, 500, 600, 700, 800
      */
     size: {
-      type: String,
+      type: [String, Number],
       default: '500',
-      validator: (s) => Object.keys(ICON_SIZE_MODIFIERS).includes(s),
+      validator: (s) => Object.keys(ICON_SIZE_MODIFIERS).includes(String(s)),
     },
 
     /**

--- a/packages/dialtone-vue/common/validators.test.js
+++ b/packages/dialtone-vue/common/validators.test.js
@@ -1,5 +1,5 @@
 import { VALIDATION_MESSAGE_TYPES } from './constants';
-import { validationMessageValidator } from './validators';
+import { validationMessageValidator, ordinalSizeValidator } from './validators';
 
 describe('Validator Tests', () => {
   describe('validationMessageValidator', () => {
@@ -100,6 +100,59 @@ describe('Validator Tests', () => {
       it(
         'should return false',
         () => { expect(validationMessageValidator(rawMessages)).toBe(false); },
+      );
+    });
+  });
+
+  describe('ordinalSizeValidator', () => {
+    // Test Environment
+    let validate;
+
+    beforeEach(() => {
+      validate = ordinalSizeValidator({ 100: 'a', 200: 'b', xs: 'a', sm: 'b' });
+    });
+
+    describe('when given a string that matches a key', () => {
+      it(
+        'should return true',
+        () => { expect(validate('100')).toBe(true); },
+      );
+    });
+
+    describe('when given a number that matches a key', () => {
+      it(
+        'should return true',
+        () => { expect(validate(100)).toBe(true); },
+      );
+    });
+
+    describe('when given a deprecated t-shirt alias', () => {
+      it(
+        'should return true',
+        () => { expect(validate('xs')).toBe(true); },
+      );
+    });
+
+    describe('when given a value with no matching key', () => {
+      it(
+        'should return false',
+        () => { expect(validate(999)).toBe(false); },
+      );
+    });
+
+    describe('when given an array of valid sizes', () => {
+      beforeEach(() => {
+        validate = ordinalSizeValidator(['100', '200', 'xs']);
+      });
+
+      it(
+        'should return true for a matching number',
+        () => { expect(validate(100)).toBe(true); },
+      );
+
+      it(
+        'should return false for a non-matching value',
+        () => { expect(validate(300)).toBe(false); },
       );
     });
   });

--- a/packages/dialtone-vue/common/validators/index.js
+++ b/packages/dialtone-vue/common/validators/index.js
@@ -20,6 +20,19 @@ export function validationMessageValidator (rawMessages) {
   });
 }
 
+/**
+ * Builds a `size`-prop validator for components on an ordinal size scale
+ * (numeric keys, optionally with deprecated t-shirt aliases), accepting
+ * either a modifiers map (`{ 100: '...' }`) or a plain array of valid values.
+ * Coerces the incoming value to a string so both `size="300"` and
+ * `:size="300"` validate against the same set.
+ */
+export function ordinalSizeValidator (validSizes) {
+  const keys = Array.isArray(validSizes) ? validSizes.map(String) : Object.keys(validSizes);
+  return (size) => keys.includes(String(size));
+}
+
 export default {
   validationMessageValidator,
+  ordinalSizeValidator,
 };

--- a/packages/dialtone-vue/components/Avatar/Avatar.vue
+++ b/packages/dialtone-vue/components/Avatar/Avatar.vue
@@ -82,6 +82,7 @@
 
 <script>
 import { getUniqueString, hasSlotContent } from '@/common/utils';
+import { ordinalSizeValidator } from '@/common/validators';
 import { DtPresence } from '../Presence';
 import {
   AVATAR_KIND_MODIFIERS,
@@ -173,7 +174,7 @@ export default {
     size: {
       type: [String, Number],
       default: 300,
-      validator: (size) => Object.keys(AVATAR_SIZE_MODIFIERS).includes(String(size)),
+      validator: ordinalSizeValidator(AVATAR_SIZE_MODIFIERS),
     },
 
     /**

--- a/packages/dialtone-vue/components/Badge/Badge.vue
+++ b/packages/dialtone-vue/components/Badge/Badge.vue
@@ -61,6 +61,7 @@
 import { BADGE_TYPE_MODIFIERS, BADGE_KIND_MODIFIERS, BADGE_DECORATION_MODIFIERS } from './BadgeConstants';
 import { ICON_SIZE_MODIFIERS } from '@/components/Icon';
 import { hasSlotContent } from '@/common/utils/index.js';
+import { ordinalSizeValidator } from '@/common/validators';
 
 /**
  * A badge is a compact UI element that provides brief, descriptive information about an element.
@@ -76,9 +77,9 @@ export default {
      * @values 100, 200, 300, 400, 500, 600, 700, 800
      */
     iconSize: {
-      type: String,
+      type: [String, Number],
       default: '200',
-      validator: (s) => Object.keys(ICON_SIZE_MODIFIERS).includes(s),
+      validator: ordinalSizeValidator(ICON_SIZE_MODIFIERS),
     },
 
     /**

--- a/packages/dialtone-vue/components/Badge/Badge.vue
+++ b/packages/dialtone-vue/components/Badge/Badge.vue
@@ -78,7 +78,7 @@ export default {
      */
     iconSize: {
       type: [String, Number],
-      default: '200',
+      default: 200,
       validator: ordinalSizeValidator(ICON_SIZE_MODIFIERS),
     },
 

--- a/packages/dialtone-vue/components/Button/Button.vue
+++ b/packages/dialtone-vue/components/Button/Button.vue
@@ -145,6 +145,7 @@
 <script>
 import { warn, resolveComponent } from 'vue';
 import { hasSlotContent } from '@/common/utils';
+import { ordinalSizeValidator } from '@/common/validators';
 import DtLoader from '@/components/Loader/Loader.vue';
 
 import {
@@ -290,7 +291,7 @@ export default {
     size: {
       type: [String, Number],
       default: 300,
-      validator: (s) => Object.keys(BUTTON_SIZE_MODIFIERS).includes(String(s)),
+      validator: ordinalSizeValidator(BUTTON_SIZE_MODIFIERS),
     },
 
     /**

--- a/packages/dialtone-vue/components/Chip/Chip.vue
+++ b/packages/dialtone-vue/components/Chip/Chip.vue
@@ -66,6 +66,7 @@ import {
   CHIP_ICON_SIZES,
 } from './ChipConstants';
 import { getUniqueString, hasSlotContent } from '@/common/utils';
+import { ordinalSizeValidator } from '@/common/validators';
 import { DialtoneLocalization } from '@/localization';
 
 /**
@@ -108,7 +109,7 @@ export default {
     size: {
       type: [String, Number],
       default: 300,
-      validator: (s) => Object.keys(CHIP_SIZE_MODIFIERS).includes(String(s)),
+      validator: ordinalSizeValidator(CHIP_SIZE_MODIFIERS),
     },
 
     /**

--- a/packages/dialtone-vue/components/Codeblock/Codeblock.vue
+++ b/packages/dialtone-vue/components/Codeblock/Codeblock.vue
@@ -10,6 +10,7 @@
 
 <script>
 import { CODEBLOCK_SIZES, CODEBLOCK_SIZE_MAP } from './CodeblockConstants';
+import { ordinalSizeValidator } from '@/common/validators';
 
 export default {
   name: 'DtCodeblock',
@@ -38,7 +39,7 @@ export default {
     size: {
       type: [String, Number],
       default: 200,
-      validator: (val) => CODEBLOCK_SIZES.includes(String(val)),
+      validator: ordinalSizeValidator(CODEBLOCK_SIZES),
     },
   },
 

--- a/packages/dialtone-vue/components/Combobox/Combobox.vue
+++ b/packages/dialtone-vue/components/Combobox/Combobox.vue
@@ -55,6 +55,7 @@ import { DtKeyboardListNavigationMixin } from '@/common/mixins';
 import { getUniqueString, hasSlotContent } from '@/common/utils';
 import { COMBOBOX_LABEL_SIZES } from '@/components/Combobox';
 import { COMPONENT_SIZES } from '@/common/constants';
+import { ordinalSizeValidator } from '@/common/validators';
 
 /**
  * A combobox is a semantic component that displays an input element combined with a listbox,
@@ -108,7 +109,7 @@ export default {
       default: null,
       validator: (t) => t === null
         || Object.values(COMBOBOX_LABEL_SIZES).includes(t)
-        || Object.keys(COMPONENT_SIZES).includes(String(t)),
+        || ordinalSizeValidator(COMPONENT_SIZES)(t),
     },
 
     /**

--- a/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.vue
+++ b/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.vue
@@ -133,7 +133,7 @@ import DtComboboxWithPopover from '@/components/ComboboxWithPopover/ComboboxWith
 import DtInput from '@/components/Input/Input.vue';
 import DtChip from '@/components/Chip/Chip.vue';
 import DtValidationMessages from '@/components/ValidationMessages/ValidationMessages.vue';
-import { validationMessageValidator } from '@/common/validators';
+import { validationMessageValidator, ordinalSizeValidator } from '@/common/validators';
 import { extractVueListeners, extractNonListeners, hasSlotContent, returnFirstEl, getUniqueString, getValidationState } from '@/common/utils';
 import { HTML_ELEMENT_TYPE } from '@/common/constants';
 import {
@@ -294,7 +294,7 @@ export default {
     size: {
       type: [String, Number],
       default: 300,
-      validator: (t) => Object.keys(CHIP_SIZES).includes(String(t)),
+      validator: ordinalSizeValidator(CHIP_SIZES),
     },
 
     /**

--- a/packages/dialtone-vue/components/ComboboxWithPopover/ComboboxWithPopover.vue
+++ b/packages/dialtone-vue/components/ComboboxWithPopover/ComboboxWithPopover.vue
@@ -123,6 +123,7 @@ import { DtCombobox, COMBOBOX_LABEL_SIZES } from '@/components/Combobox';
 import { DtPopover, POPOVER_APPEND_TO_VALUES, POPOVER_CONTENT_WIDTHS } from '@/components/Popover';
 import { getUniqueString, hasSlotContent } from '@/common/utils';
 import { COMPONENT_SIZES, HTML_ELEMENT_TYPE } from '@/common/constants';
+import { ordinalSizeValidator } from '@/common/validators';
 import { DROPDOWN_PADDING_CLASSES } from '@/components/Dropdown';
 import { CONTENT_MODE_PROP } from '@/common/mode_constants';
 
@@ -169,7 +170,7 @@ export default {
       default: null,
       validator: (t) => t === null
         || Object.values(COMBOBOX_LABEL_SIZES).includes(t)
-        || Object.keys(COMPONENT_SIZES).includes(String(t)),
+        || ordinalSizeValidator(COMPONENT_SIZES)(t),
     },
 
     /**

--- a/packages/dialtone-vue/components/Emoji/Emoji.vue
+++ b/packages/dialtone-vue/components/Emoji/Emoji.vue
@@ -22,6 +22,7 @@
 
 <script>
 import { ICON_SIZE_MODIFIERS } from '@/components/Icon';
+import { ordinalSizeValidator } from '@/common/validators';
 import {
   codeToEmojiData,
   stringToUnicode,
@@ -60,9 +61,9 @@ export default {
      * @values 100, 200, 300, 400, 500, 600, 700, 800
      */
     size: {
-      type: String,
+      type: [String, Number],
       default: '500',
-      validator: (t) => Object.keys(ICON_SIZE_MODIFIERS).includes(t),
+      validator: ordinalSizeValidator(ICON_SIZE_MODIFIERS),
     },
 
     /**
@@ -116,7 +117,7 @@ export default {
         return this.emojiData.image;
       }
 
-      if (['100', '200'].includes(this.size)) {
+      if (['100', '200'].includes(String(this.size))) {
         return emojiImageUrlSmall + this.emojiData.key + emojiFileExtensionSmall;
       } else {
         return emojiImageUrlLarge + this.emojiData.key + emojiFileExtensionLarge;

--- a/packages/dialtone-vue/components/Emoji/Emoji.vue
+++ b/packages/dialtone-vue/components/Emoji/Emoji.vue
@@ -62,7 +62,7 @@ export default {
      */
     size: {
       type: [String, Number],
-      default: '500',
+      default: 500,
       validator: ordinalSizeValidator(ICON_SIZE_MODIFIERS),
     },
 

--- a/packages/dialtone-vue/components/EmojiTextWrapper/EmojiTextWrapper.vue
+++ b/packages/dialtone-vue/components/EmojiTextWrapper/EmojiTextWrapper.vue
@@ -33,7 +33,7 @@ export default {
      */
     size: {
       type: [String, Number],
-      default: '500',
+      default: 500,
       validator: ordinalSizeValidator(ICON_SIZE_MODIFIERS),
     },
   },

--- a/packages/dialtone-vue/components/EmojiTextWrapper/EmojiTextWrapper.vue
+++ b/packages/dialtone-vue/components/EmojiTextWrapper/EmojiTextWrapper.vue
@@ -3,6 +3,7 @@ import { DtEmoji } from '../Emoji';
 import { findEmojis, findShortCodes } from '@/common/emoji';
 import { h, resolveDynamicComponent } from 'vue';
 import { ICON_SIZE_MODIFIERS } from '@/components/Icon/IconConstants';
+import { ordinalSizeValidator } from '@/common/validators';
 
 const COMMENT_TYPE = h(resolveDynamicComponent(null)).type;
 
@@ -31,9 +32,9 @@ export default {
      * @values 100, 200, 300, 400, 500, 600, 700, 800
      */
     size: {
-      type: String,
+      type: [String, Number],
       default: '500',
-      validator: (t) => Object.keys(ICON_SIZE_MODIFIERS).includes(t),
+      validator: ordinalSizeValidator(ICON_SIZE_MODIFIERS),
     },
   },
 

--- a/packages/dialtone-vue/components/EmptyState/EmptyState.vue
+++ b/packages/dialtone-vue/components/EmptyState/EmptyState.vue
@@ -64,6 +64,7 @@ import { useSlots, computed, onMounted } from 'vue';
 import { DtStack } from '@/components/Stack';
 import { DtText } from '@/components/Text';
 import { hasSlotContent } from '@/common/utils';
+import { ordinalSizeValidator } from '@/common/validators';
 import {
   EMPTY_STATE_BODY_DENSITIES,
   EMPTY_STATE_BODY_SIZES,
@@ -87,7 +88,7 @@ const props = defineProps({
   size: {
     type: [String, Number],
     default: 400,
-    validator: (s) => Object.keys(EMPTY_STATE_SIZE_MODIFIERS).includes(String(s)),
+    validator: ordinalSizeValidator(EMPTY_STATE_SIZE_MODIFIERS),
   },
 
   /**

--- a/packages/dialtone-vue/components/FilterPill/FilterPill.vue
+++ b/packages/dialtone-vue/components/FilterPill/FilterPill.vue
@@ -208,6 +208,7 @@
 import { DtPopover, POPOVER_APPEND_TO_VALUES, POPOVER_PADDING_CLASSES } from '@/components/Popover';
 import { HTML_ELEMENT_TYPE } from '@/common/constants';
 import { CONTENT_MODE_PROP } from '@/common/mode_constants';
+import { ordinalSizeValidator } from '@/common/validators';
 import { BUTTON_SIZE_MODIFIERS, BUTTON_ICON_SIZES, DtButton } from '@/components/Button';
 import { DtIconChevronDown, DtIconClose } from '@dialpad/dialtone-icons/vue';
 import { DialtoneLocalization } from '@/localization';
@@ -456,7 +457,7 @@ export default {
     size: {
       type: [String, Number],
       default: 200,
-      validator: (s) => Object.keys(BUTTON_SIZE_MODIFIERS).includes(String(s)),
+      validator: ordinalSizeValidator(BUTTON_SIZE_MODIFIERS),
     },
   },
 

--- a/packages/dialtone-vue/components/Icon/Icon.vue
+++ b/packages/dialtone-vue/components/Icon/Icon.vue
@@ -29,7 +29,7 @@ export default {
      */
     size: {
       type: [String, Number],
-      default: '500',
+      default: 500,
       validator: ordinalSizeValidator(ICON_SIZE_MODIFIERS),
     },
 

--- a/packages/dialtone-vue/components/Icon/Icon.vue
+++ b/packages/dialtone-vue/components/Icon/Icon.vue
@@ -11,6 +11,7 @@
 <script>
 import { icons } from '@dialpad/dialtone-icons/vue';
 import { ICON_SIZE_MODIFIERS, ICON_NAMES } from './IconConstants';
+import { ordinalSizeValidator } from '@/common/validators';
 // import { DialtoneLocalization } from '@/localization';
 // import { toFluentKeyString } from '@/common/utils';
 
@@ -27,9 +28,9 @@ export default {
      * @values 100, 200, 300, 400, 500, 600, 700, 800
      */
     size: {
-      type: String,
+      type: [String, Number],
       default: '500',
-      validator: (s) => Object.keys(ICON_SIZE_MODIFIERS).includes(s),
+      validator: ordinalSizeValidator(ICON_SIZE_MODIFIERS),
     },
 
     /**

--- a/packages/dialtone-vue/components/Input/Input.vue
+++ b/packages/dialtone-vue/components/Input/Input.vue
@@ -158,9 +158,12 @@ import {
   hasSlotContent,
   removeClassStyleAttrs,
 } from '@/common/utils';
+import { ordinalSizeValidator } from '@/common/validators';
 import { DtValidationMessages } from '@/components/ValidationMessages';
 import { DtText, TEXT_SIZE_MODIFIERS, TEXT_STRENGTH_MODIFIERS } from '@/components/Text';
 import { MessagesMixin } from '@/common/mixins/input';
+
+const isValidInputSize = ordinalSizeValidator(INPUT_ICON_SIZES);
 
 /**
  * An input field is an input control that allows users to enter alphanumeric information.
@@ -257,7 +260,7 @@ export default {
     size: {
       type: [String, Number],
       default: 300,
-      validator: (t) => Object.keys(INPUT_ICON_SIZES).includes(String(t)),
+      validator: isValidInputSize,
     },
 
     /**
@@ -455,7 +458,7 @@ export default {
     },
 
     isValidSize () {
-      return Object.keys(INPUT_ICON_SIZES).includes(String(this.size));
+      return isValidInputSize(this.size);
     },
 
     isValidDescriptionSize () {

--- a/packages/dialtone-vue/components/Loader/Loader.vue
+++ b/packages/dialtone-vue/components/Loader/Loader.vue
@@ -73,7 +73,7 @@ export default {
      */
     size: {
       type: [String, Number],
-      default: '500',
+      default: 500,
       validator: ordinalSizeValidator(ICON_SIZE_MODIFIERS),
     },
   },

--- a/packages/dialtone-vue/components/Loader/Loader.vue
+++ b/packages/dialtone-vue/components/Loader/Loader.vue
@@ -52,6 +52,7 @@
 
 <script>
 import { ICON_SIZE_MODIFIERS } from '@/components/Icon';
+import { ordinalSizeValidator } from '@/common/validators';
 
 export default {
   name: 'DtLoader',
@@ -71,9 +72,9 @@ export default {
      * @values 100, 200, 300, 400, 500, 600, 700, 800
      */
     size: {
-      type: String,
+      type: [String, Number],
       default: '500',
-      validator: (s) => Object.keys(ICON_SIZE_MODIFIERS).includes(s),
+      validator: ordinalSizeValidator(ICON_SIZE_MODIFIERS),
     },
   },
 };

--- a/packages/dialtone-vue/components/Modal/Modal.stories.js
+++ b/packages/dialtone-vue/components/Modal/Modal.stories.js
@@ -1,7 +1,7 @@
 import DtModal from './Modal.vue';
 
 import DtModalDefaultTemplate from './ModalDefault.story.vue';
-import { MODAL_KIND_MODIFIERS, MODAL_SIZE_MODIFIERS } from './ModalConstants';
+import { MODAL_KIND_MODIFIERS } from './ModalConstants';
 import { createTemplateFromVueFile } from '@/common/storybook_utils';
 import { action } from 'storybook/actions';
 import { NOTICE_KINDS } from '@/components/Notice';
@@ -9,7 +9,7 @@ import { CONTENT_MODE_ARG_TYPE } from '@/common/mode_constants';
 
 // Default Props for all variations
 export const argsData = {
-  size: 'default',
+  fullscreen: false,
   kind: 'default',
   bannerKind: 'warning',
   copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget lacus quis velit \
@@ -68,10 +68,9 @@ export const argTypesData = {
     },
   },
   contentMode: CONTENT_MODE_ARG_TYPE,
-  size: {
-    options: Object.keys(MODAL_SIZE_MODIFIERS),
+  fullscreen: {
     control: {
-      type: 'select',
+      type: 'boolean',
     },
   },
   kind: {
@@ -215,11 +214,11 @@ export const WithCriticalStyle = {
   parameters: { ...Default.parameters },
 };
 
-export const WithFullSize = {
+export const WithFullscreen = {
   render: DefaultTemplate,
 
   args: {
-    size: 'full',
+    fullscreen: true,
     showFooter: true,
   },
 

--- a/packages/dialtone-vue/components/Modal/Modal.test.js
+++ b/packages/dialtone-vue/components/Modal/Modal.test.js
@@ -118,6 +118,24 @@ describe('DtModal Tests', () => {
       expect(overlay.element.showModal).toHaveBeenCalled();
     });
 
+    describe('When fullscreen prop is true', () => {
+      beforeEach(async () => {
+        mockProps = { ...mockProps, fullscreen: true };
+
+        updateWrapper();
+      });
+
+      it('Should apply the fullscreen modifier class', () => {
+        expect(overlay.classes('d-modal--full')).toBe(true);
+      });
+    });
+
+    describe('When fullscreen prop is false', () => {
+      it('Should NOT apply the fullscreen modifier class', () => {
+        expect(overlay.classes('d-modal--full')).toBe(false);
+      });
+    });
+
     describe('When showClose prop is false', () => {
       beforeEach(async () => {
         mockProps = { ...mockProps, showClose: false };

--- a/packages/dialtone-vue/components/Modal/Modal.vue
+++ b/packages/dialtone-vue/components/Modal/Modal.vue
@@ -10,7 +10,7 @@
       :class="[
         'd-modal',
         MODAL_KIND_MODIFIERS[kind],
-        MODAL_SIZE_MODIFIERS[size],
+        { 'd-modal--full': fullscreen },
         { 'd-modal--transparent-backdrop': transparentBackdrop },
         modalClass,
       ]"
@@ -137,7 +137,6 @@ import ModeMixin from '@/common/mixins/mode';
 import {
   MODAL_BANNER_KINDS,
   MODAL_KIND_MODIFIERS,
-  MODAL_SIZE_MODIFIERS,
 } from './ModalConstants';
 import { getUniqueString, hasSlotContent, returnFirstEl, disableRootScrolling, enableRootScrolling } from '@/common/utils';
 import { HTML_ELEMENT_TYPE } from '@/common/constants';
@@ -229,13 +228,12 @@ export default {
     },
 
     /**
-     * The size of the modal. size - default or full,
-     * @values default, full
+     * Whether the modal fills the viewport instead of rendering at its default size.
+     * @values true, false
      */
-    size: {
-      type: String,
-      default: 'default',
-      validator: (s) => Object.keys(MODAL_SIZE_MODIFIERS).includes(s),
+    fullscreen: {
+      type: Boolean,
+      default: false,
     },
 
     /**
@@ -404,7 +402,6 @@ export default {
   data () {
     return {
       MODAL_KIND_MODIFIERS,
-      MODAL_SIZE_MODIFIERS,
       MODAL_BANNER_KINDS,
       hasSlotContent,
       i18n: new DialtoneLocalization(),

--- a/packages/dialtone-vue/components/Modal/ModalConstants.js
+++ b/packages/dialtone-vue/components/Modal/ModalConstants.js
@@ -4,12 +4,6 @@ export const MODAL_KIND_MODIFIERS = {
   critical: 'd-modal--critical',
 };
 
-// Modal size modifiers
-export const MODAL_SIZE_MODIFIERS = {
-  default: '',
-  full: 'd-modal--full',
-};
-
 export const MODAL_BANNER_KINDS = {
   critical: 'd-modal__banner--critical',
   info: 'd-modal__banner--info',

--- a/packages/dialtone-vue/components/Modal/ModalDefault.story.vue
+++ b/packages/dialtone-vue/components/Modal/ModalDefault.story.vue
@@ -5,7 +5,7 @@
       :banner-header-text="$attrs.bannerHeaderText"
       :open="isOpen"
       :kind="$attrs.kind"
-      :size="$attrs.size"
+      :fullscreen="$attrs.fullscreen"
       :copy="$attrs.copy"
       :modal-class="$attrs.modalClass"
       :banner-class="$attrs.bannerClass"

--- a/packages/dialtone-vue/components/Modal/index.js
+++ b/packages/dialtone-vue/components/Modal/index.js
@@ -1,2 +1,2 @@
 export { default as DtModal } from './Modal.vue';
-export { MODAL_KIND_MODIFIERS, MODAL_BANNER_KINDS, MODAL_SIZE_MODIFIERS } from './ModalConstants';
+export { MODAL_KIND_MODIFIERS, MODAL_BANNER_KINDS } from './ModalConstants';

--- a/packages/dialtone-vue/components/ProgressCircle/ProgressCircle.vue
+++ b/packages/dialtone-vue/components/ProgressCircle/ProgressCircle.vue
@@ -4,6 +4,7 @@
  * @see https://dialtone.dialpad.com/components/progress-circle.html
  */
 import { PROGRESS_CIRCLE_SIZES, PROGRESS_CIRCLE_KINDS } from './ProgressCircleConstants';
+import { ordinalSizeValidator } from '@/common/validators';
 
 export default {
   name: 'DtProgressCircle',
@@ -22,9 +23,9 @@ export default {
      * @values 100, 200, 300, 400, 500, 600, 700, 800
      */
     size: {
-      type: String,
+      type: [String, Number],
       default: '500',
-      validator: (s) => Object.keys(PROGRESS_CIRCLE_SIZES).includes(s),
+      validator: ordinalSizeValidator(PROGRESS_CIRCLE_SIZES),
     },
 
     /**

--- a/packages/dialtone-vue/components/ProgressCircle/ProgressCircle.vue
+++ b/packages/dialtone-vue/components/ProgressCircle/ProgressCircle.vue
@@ -24,7 +24,7 @@ export default {
      */
     size: {
       type: [String, Number],
-      default: '500',
+      default: 500,
       validator: ordinalSizeValidator(PROGRESS_CIRCLE_SIZES),
     },
 

--- a/packages/dialtone-vue/components/Prose/Prose.vue
+++ b/packages/dialtone-vue/components/Prose/Prose.vue
@@ -14,6 +14,7 @@
 defineOptions({ name: 'DtProse' });
 
 import { computed, ref, onMounted, onUpdated } from 'vue';
+import { ordinalSizeValidator } from '@/common/validators';
 import {
   PROSE_DISALLOWED_ELEMENTS,
   PROSE_ALLOWED_ATTRIBUTES,
@@ -32,7 +33,7 @@ const props = defineProps({
   size: {
     type: [String, Number],
     default: 300,
-    validator: (s) => Object.keys(PROSE_SIZE_MODIFIERS).includes(String(s)),
+    validator: ordinalSizeValidator(PROSE_SIZE_MODIFIERS),
   },
 
   /**

--- a/packages/dialtone-vue/components/SegmentedControl/SegmentedControl.vue
+++ b/packages/dialtone-vue/components/SegmentedControl/SegmentedControl.vue
@@ -21,6 +21,7 @@ import { ref, computed, reactive, watchEffect, watch, provide, onMounted, nextTi
 import { getUniqueString } from '@/common/utils';
 import { DtStack } from '@/components/Stack';
 import { useIndicatorAnimation } from '@/common/composables/useIndicatorAnimation';
+import { ordinalSizeValidator } from '@/common/validators';
 import {
   SEGMENTED_CONTROL_SIZES,
   SEGMENTED_CONTROL_SIZE_DEFAULT,
@@ -84,7 +85,7 @@ const props = defineProps({
   size: {
     type: [String, Number],
     default: SEGMENTED_CONTROL_SIZE_DEFAULT,
-    validator: (v) => SEGMENTED_CONTROL_SIZES.includes(String(v)),
+    validator: ordinalSizeValidator(SEGMENTED_CONTROL_SIZES),
   },
 
   /**

--- a/packages/dialtone-vue/components/SelectMenu/SelectMenu.vue
+++ b/packages/dialtone-vue/components/SelectMenu/SelectMenu.vue
@@ -89,6 +89,7 @@
 
 <script>
 import { warn } from 'vue';
+import { ordinalSizeValidator } from '@/common/validators';
 import { DtText, TEXT_SIZE_MODIFIERS, TEXT_STRENGTH_MODIFIERS } from '@/components/Text';
 import {
   SELECT_SIZE_MODIFIERS,
@@ -169,7 +170,7 @@ export default {
     size: {
       type: [String, Number],
       default: 300,
-      validator: (s) => Object.keys(SELECT_SIZE_MODIFIERS).includes(String(s)),
+      validator: ordinalSizeValidator(SELECT_SIZE_MODIFIERS),
     },
 
     /**

--- a/packages/dialtone-vue/components/SplitButton/SplitButton.vue
+++ b/packages/dialtone-vue/components/SplitButton/SplitButton.vue
@@ -153,6 +153,7 @@ import SplitButtonStart from './SplitButtonStart.vue';
 import SplitButtonEnd from './SplitButtonEnd.vue';
 import { DtDropdown } from '@/components/Dropdown';
 import { hasSlotContent, warnIfUnmounted, returnFirstEl } from '@/common/utils';
+import { ordinalSizeValidator } from '@/common/validators';
 
 export default {
   name: 'DtSplitButton',
@@ -473,7 +474,7 @@ export default {
     size: {
       type: [String, Number],
       default: 300,
-      validator: (s) => Object.keys(BUTTON_SIZE_MODIFIERS).includes(String(s)),
+      validator: ordinalSizeValidator(BUTTON_SIZE_MODIFIERS),
     },
 
     /**

--- a/packages/dialtone-vue/components/Tab/TabGroup.vue
+++ b/packages/dialtone-vue/components/Tab/TabGroup.vue
@@ -54,6 +54,7 @@ import {
 } from './TabsConstants';
 import { ref } from 'vue';
 import { useIndicatorAnimation } from '@/common/composables/useIndicatorAnimation';
+import { ordinalSizeValidator } from '@/common/validators';
 
 /**
  * Tabs allow users to navigation between grouped content in different views while within the same page context.
@@ -145,9 +146,7 @@ export default {
     size: {
       type: [String, Number],
       default: 300,
-      validator (size) {
-        return TAB_LIST_SIZES.includes(String(size));
-      },
+      validator: ordinalSizeValidator(TAB_LIST_SIZES),
     },
 
     /**

--- a/packages/dialtone-vue/components/Toast/Layouts/ToastLayoutAlternateIcon.vue
+++ b/packages/dialtone-vue/components/Toast/Layouts/ToastLayoutAlternateIcon.vue
@@ -22,6 +22,7 @@ import {
 } from '@dialpad/dialtone-icons/vue';
 import { TOAST_ALTERNATE_KINDS } from '../ToastConstants.js';
 import { ICON_SIZE_MODIFIERS } from '@/components/Icon/IconConstants.js';
+import { ordinalSizeValidator } from '@/common/validators';
 
 const kindToIcon = new Map([
   ['info', DtIconInfo],
@@ -56,9 +57,9 @@ export default {
     },
 
     size: {
-      type: String,
+      type: [String, Number],
       default: '400',
-      validator: (s) => Object.keys(ICON_SIZE_MODIFIERS).includes(s),
+      validator: ordinalSizeValidator(ICON_SIZE_MODIFIERS),
     },
 
     /**

--- a/packages/dialtone-vue/components/Toast/Layouts/ToastLayoutAlternateIcon.vue
+++ b/packages/dialtone-vue/components/Toast/Layouts/ToastLayoutAlternateIcon.vue
@@ -58,7 +58,7 @@ export default {
 
     size: {
       type: [String, Number],
-      default: '400',
+      default: 400,
       validator: ordinalSizeValidator(ICON_SIZE_MODIFIERS),
     },
 

--- a/packages/dialtone-vue/components/Toggle/Toggle.vue
+++ b/packages/dialtone-vue/components/Toggle/Toggle.vue
@@ -34,6 +34,7 @@
 <script>
 import { getUniqueString, hasSlotContent, removeClassStyleAttrs } from '@/common/utils';
 import { TOGGLE_CHECKED_VALUES, TOGGLE_SIZE_MODIFIERS } from '@/components/Toggle/ToggleConstants';
+import { ordinalSizeValidator } from '@/common/validators';
 
 /**
  * A toggle (or "switch") is a button control element that allows the user to make a binary (on/off) selection.
@@ -91,7 +92,7 @@ export default {
     size: {
       type: [String, Number],
       default: 300,
-      validator: (s) => Object.keys(TOGGLE_SIZE_MODIFIERS).includes(String(s)),
+      validator: ordinalSizeValidator(TOGGLE_SIZE_MODIFIERS),
     },
 
     /**


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExb2JsNzRoYmo2cTJ3N2p3YzBnYW00dXVsMjJpeTN6MDFqYW9haHEwYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3jlSr3Q75Q51DVP3ow/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Feature
- [x] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [x] Documentation
- [x] Test

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3534 (follow-up from spike https://dialpad.atlassian.net/browse/DLT-3437)

## :book: Description

- Icon-family `size` props (`DtIcon`, `DtLoader`, `DtEmoji`, `DtEmojiTextWrapper`, `DtProgressCircle`, `DtToastLayoutAlternateIcon`, `DtBadge`'s `iconSize`) now accept `[String, Number]` instead of `String`-only.
- New shared `ordinalSizeValidator` util replaces duplicated size-validator logic across ~20 components.
- `DtModal`'s `size` prop (`default`/`full`) is replaced by a `fullscreen` boolean — **breaking change**, made now while `next` is prerelease.
- `dialtone-migrate-tshirt-to-numeric` codemod updated to auto-migrate `size="full"` → `fullscreen` on `DtModal`.

## :bulb: Context

Follow-up from the DLT-3437 spike into `size` prop-type inconsistencies. Closes the gap between components already on the numeric scale, the icon family (same scale, but `String`-only), and `DtModal` (a `size` prop that was never actually an ordinal scale).

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.

## :crystal_ball: Next Steps

- Consumers using `<dt-modal size="full">` should run `npx dialtone-migrate-tshirt-to-numeric` or update manually to `<dt-modal fullscreen>`.