### PR TITLE
feat(dialtone-tokens): NO-JIRA add no-layers CSS build and initDialtoneTheme layers option

### DIFF
--- a/apps/dialtone-documentation/docs/guides/migration/css-cascade-layers/index.md
+++ b/apps/dialtone-documentation/docs/guides/migration/css-cascade-layers/index.md
@@ -119,6 +119,24 @@ import '@dialpad/dialtone/css/no-layers/default-theme'; // optional theme
 
 This build is identical in output — all the same classes — but no `@layer` wrappers are present.
 
+If you import token CSS directly from `@dialpad/dialtone-tokens` (rather than through `@dialpad/dialtone-css` or `@dialpad/dialtone`), use its own no-layers variant instead:
+
+```js
+import '@dialpad/dialtone-tokens/no-layers/tokens-base-light.css';
+import '@dialpad/dialtone-tokens/no-layers/tokens-dp-light.css';
+```
+
+If you theme at runtime with `initDialtoneTheme` from `@dialpad/dialtone-tokens/themes/config`, pass `{ layers: false }` to load the no-layers core tokens instead:
+
+```js
+import { initDialtoneTheme } from '@dialpad/dialtone/themes/config';
+import Dp from '@dialpad/dialtone/themes/dp';
+
+initDialtoneTheme(Dp, 'light', document.documentElement, { layers: false });
+```
+
+`setBrand`, `setContrast`, and `setMaterial` need no equivalent option — brand, contrast, and material overrides were never wrapped in `@layer` to begin with.
+
 > [!WARNING] `!important` behavior differs in the no-layers build
 > In the layered build, Dialtone's `!important` utility declarations beat your unlayered `!important` (because `!important` priority reverses across layers). In the no-layers build, both sides are unlayered, so your `!important` can beat Dialtone's through normal cascade. However, your non-`!important` rules will lose to Dialtone utility `!important` — you will need `!important` in your own overrides to beat utilities.
 

--- a/packages/dialtone-tokens/README.md
+++ b/packages/dialtone-tokens/README.md
@@ -25,6 +25,24 @@ npm install @dialpad/dialtone-tokens
 @import "@dialpad/dialtone-tokens/dist/tokens-base-dark.css";  // Dark variables
 ```
 
+Token CSS is wrapped in `@layer dialtone.base`. If your project can't use CSS Cascade Layers, import the no-layers variant instead (same variables, no `@layer` wrapper):
+
+```css
+@import "@dialpad/dialtone-tokens/no-layers/tokens-base-light.css";
+@import "@dialpad/dialtone-tokens/no-layers/tokens-base-dark.css";
+```
+
+This mirrors the [no-layers build](https://dialtone.dialpad.com/guides/migration/css-cascade-layers/#no-layers-build) available in `@dialpad/dialtone-css` and `@dialpad/dialtone` — use it if you import token CSS directly rather than through those packages. Every token CSS file that carries `@layer` has a no-layers counterpart at the same path under `no-layers/`.
+
+If you theme at runtime with `initDialtoneTheme` from `themes/config`, pass `{ layers: false }` to load the no-layers core tokens instead — `setBrand`/`setContrast`/`setMaterial` need no equivalent option since brand, contrast, and material overrides were never wrapped in `@layer`:
+
+```js
+import { initDialtoneTheme } from '@dialpad/dialtone-tokens/themes/config';
+import Dp from '@dialpad/dialtone-tokens/themes/dp';
+
+initDialtoneTheme(Dp, 'light', document.documentElement, { layers: false });
+```
+
 dialtone-tokens provides a postcss plugin that you can use to convert all tokens using rem to px. This could be useful if you are using dialtone in an embedded situation where you don't have control over the root font size.
 
 You can reference this script from:

--- a/packages/dialtone-tokens/build.js
+++ b/packages/dialtone-tokens/build.js
@@ -8,6 +8,7 @@ import { generateThemeFiles } from './generate-themes.js';
 import postcss from 'postcss';
 import fs from 'fs';
 import dialtoneTokensPlugin from './postcss/dialtone-tokens.cjs';
+import layerRemoverPlugin from './postcss/layer-remover.cjs';
 import debugMode from './postcss/debug-mode.js';
 import path from 'path';
 const TOKENS_OUTPUT_DIR = './dist/css/';
@@ -32,6 +33,17 @@ await generateThemeFiles();
 
 // Build theme files for distribution
 await buildThemeFiles();
+
+// Mirror every @layer-wrapped token CSS file under dist/css/no-layers/,
+// unwrapped from `@layer dialtone.base`, for consumers who can't use CSS
+// Cascade Layers. This is separate from dialtone-css's own no-layers build,
+// which only strips layers from its own compiled bundle (tokens it inlines
+// included) — it doesn't help consumers who import token CSS straight from
+// @dialpad/dialtone-tokens. Files never wrapped in @layer to begin with
+// (brand overrides, contrast, material) are skipped since they need no
+// unlayered counterpart.
+console.log('\n=== Generating No-Layers Token Variants ===\n');
+await generateNoLayersTokens(TOKENS_OUTPUT_DIR);
 
 /**
  * Generates the debug theme which shows all dialtone colors as bright orange so you can easily tell what is not
@@ -69,6 +81,47 @@ async function runPostCss (filesOrDirectory, plugins = [dialtoneTokensPlugin]) {
       fs.writeFileSync(file, result.map.toString());
     }
   }
+}
+
+/**
+ * Recursively find every .css file under `dir` that contains an `@layer` rule
+ * (skipping the no-layers output directory itself).
+ */
+function findLayeredCssFiles (dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'no-layers') continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findLayeredCssFiles(fullPath));
+    } else if (entry.name.endsWith('.css') && fs.readFileSync(fullPath, 'utf8').includes('@layer')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
+ * For every token CSS file wrapped in `@layer`, write an unlayered copy to
+ * dist/css/no-layers/, preserving the file's path relative to dist/css/ (so
+ * e.g. tokens-base-light.css -> no-layers/tokens-base-light.css and
+ * layered/tokens-core.css -> no-layers/layered/tokens-core.css).
+ */
+async function generateNoLayersTokens (outputDir) {
+  const postCss = postcss([layerRemoverPlugin]);
+  const layeredFiles = findLayeredCssFiles(outputDir);
+
+  for (const file of layeredFiles) {
+    const relativePath = path.relative(outputDir, file);
+    const outputPath = path.join(outputDir, 'no-layers', relativePath);
+
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    const css = fs.readFileSync(file);
+    const result = await postCss.process(css, { from: file, to: outputPath });
+    fs.writeFileSync(outputPath, result.css);
+  }
+
+  console.log(`Generated ${layeredFiles.length} no-layers token file(s)`);
 }
 
 /**

--- a/packages/dialtone-tokens/generate-themes.js
+++ b/packages/dialtone-tokens/generate-themes.js
@@ -22,6 +22,7 @@ export async function generateThemeFiles () {
 
   // Generate core theme file (shared across all brands)
   await generateCoreThemeFile();
+  await generateCoreNoLayersThemeFile();
 
   // Generate DP base theme
   await generateDpThemeFile();
@@ -61,6 +62,29 @@ export default {
 
   fs.writeFileSync(filePath, content);
   console.log('Generated core theme file');
+}
+
+/**
+ * Generate a no-layers variant of the core theme file, consumed by
+ * initDialtoneTheme's `{ layers: false }` option. tokens-core.css is the
+ * only file in the layered token system wrapped in `@layer dialtone.base` —
+ * base colors, brand overrides, contrast, and material files are already
+ * unlayered, so no equivalent no-layers entrypoint is needed for those.
+ */
+async function generateCoreNoLayersThemeFile() {
+  const filePath = path.join(THEMES_OUTPUT_DIR, 'core-no-layers.js');
+
+  const content = `import CoreTokens from '@dialpad/dialtone-tokens/no-layers/layered/tokens-core.css?inline';
+import BaseColors from '@dialpad/dialtone-tokens/layered/tokens-base-colors.css?inline';
+
+export default {
+  core: CoreTokens,
+  baseColors: BaseColors,
+};
+`;
+
+  fs.writeFileSync(filePath, content);
+  console.log('Generated core-no-layers theme file');
 }
 
 /**

--- a/packages/dialtone-tokens/package.json
+++ b/packages/dialtone-tokens/package.json
@@ -12,6 +12,7 @@
     "dist"
   ],
   "exports": {
+    "./no-layers/*.css": "./dist/css/no-layers/*.css",
     "./*.css": "./dist/css/*.css",
     "./*.less": "./dist/less/*.less",
     "./postcss/*": {

--- a/packages/dialtone-tokens/postcss/layer-remover.cjs
+++ b/packages/dialtone-tokens/postcss/layer-remover.cjs
@@ -1,0 +1,27 @@
+/**
+ * PostCSS plugin that strips CSS cascade layers from token output.
+ *
+ * Removes `@layer …;` ordering declarations and unwraps `@layer name { … }`
+ * blocks so that all rules become unlayered. Internal build-time helper only
+ * (mirrors packages/dialtone-css/postcss/postcss-layer-remover.cjs) — used to
+ * pre-generate the no-layers token files under dist/css/no-layers/. Not part
+ * of the public API; consumers just import the pre-built no-layers CSS.
+ */
+
+module.exports = () => ({
+  postcssPlugin: 'token-layer-remover',
+
+  AtRule: {
+    layer (atRule) {
+      if (atRule.nodes) {
+        // @layer name { … } — hoist children to parent, drop the @layer wrapper
+        atRule.replaceWith(atRule.nodes);
+      } else {
+        // @layer a, b, c; — ordering declaration, remove entirely
+        atRule.remove();
+      }
+    },
+  },
+});
+
+module.exports.postcss = true;

--- a/packages/dialtone-tokens/tests/config.test.js
+++ b/packages/dialtone-tokens/tests/config.test.js
@@ -39,6 +39,24 @@ describe('themes/config.js', () => {
   });
 
   describe('initDialtoneTheme', () => {
+    describe('When called with { layers: false }', () => {
+      it('Should load the no-layers core tokens', () => {
+        initDialtoneTheme(dpStub, 'light', root, { layers: false });
+
+        const coreStyleTag = root.querySelector('#dialtone-css-core');
+        expect(coreStyleTag.innerHTML).toContain('--dt-no-layers-marker');
+      });
+    });
+
+    describe('When called without options (default)', () => {
+      it('Should load the layered core tokens', () => {
+        initDialtoneTheme(dpStub, 'light', root);
+
+        const coreStyleTag = root.querySelector('#dialtone-css-core');
+        expect(coreStyleTag.innerHTML).not.toContain('--dt-no-layers-marker');
+      });
+    });
+
     describe('When the brand declares a material lock', () => {
       it.each([
         ['iron', melonStub],

--- a/packages/dialtone-tokens/tests/config.test.js
+++ b/packages/dialtone-tokens/tests/config.test.js
@@ -82,6 +82,21 @@ describe('themes/config.js', () => {
           expect(root.querySelector('#dialtone-css-core').innerHTML).toContain('--dt-no-layers-marker');
         });
       });
+
+      it('Should not let a superseded no-layers import clobber a later layers:true call', async () => {
+        // Fire the no-layers import, then immediately supersede it before it
+        // resolves — the stale resolution must not overwrite the layered core.
+        initDialtoneTheme(dpStub, 'light', root, { layers: false });
+        initDialtoneTheme(dpStub, 'light', root);
+
+        expect(root.querySelector('#dialtone-css-core').innerHTML).not.toContain('--dt-no-layers-marker');
+
+        // Give the superseded import time to settle — if it were going to
+        // (wrongly) apply, it would have by now.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        expect(root.querySelector('#dialtone-css-core').innerHTML).not.toContain('--dt-no-layers-marker');
+      });
     });
 
     describe('When the brand declares a material lock', () => {

--- a/packages/dialtone-tokens/tests/config.test.js
+++ b/packages/dialtone-tokens/tests/config.test.js
@@ -40,11 +40,14 @@ describe('themes/config.js', () => {
 
   describe('initDialtoneTheme', () => {
     describe('When called with { layers: false }', () => {
-      it('Should load the no-layers core tokens', () => {
+      it('Should load the no-layers core tokens', async () => {
         initDialtoneTheme(dpStub, 'light', root, { layers: false });
 
-        const coreStyleTag = root.querySelector('#dialtone-css-core');
-        expect(coreStyleTag.innerHTML).toContain('--dt-no-layers-marker');
+        // The no-layers core loads via a dynamic import (not bundled into the
+        // default path), so its content lands a moment after this call returns.
+        await vi.waitFor(() => {
+          expect(root.querySelector('#dialtone-css-core').innerHTML).toContain('--dt-no-layers-marker');
+        });
       });
     });
 

--- a/packages/dialtone-tokens/tests/config.test.js
+++ b/packages/dialtone-tokens/tests/config.test.js
@@ -60,6 +60,30 @@ describe('themes/config.js', () => {
       });
     });
 
+    describe('When re-initialized with the same brand/mode but a different layers value', () => {
+      it('Should swap layers:false -> layers:true by reloading the layered core', async () => {
+        initDialtoneTheme(dpStub, 'light', root, { layers: false });
+        await vi.waitFor(() => {
+          expect(root.querySelector('#dialtone-css-core').innerHTML).toContain('--dt-no-layers-marker');
+        });
+
+        initDialtoneTheme(dpStub, 'light', root);
+
+        expect(root.querySelector('#dialtone-css-core').innerHTML).not.toContain('--dt-no-layers-marker');
+      });
+
+      it('Should swap layers:true -> layers:false by reloading the no-layers core', async () => {
+        initDialtoneTheme(dpStub, 'light', root);
+        expect(root.querySelector('#dialtone-css-core').innerHTML).not.toContain('--dt-no-layers-marker');
+
+        initDialtoneTheme(dpStub, 'light', root, { layers: false });
+
+        await vi.waitFor(() => {
+          expect(root.querySelector('#dialtone-css-core').innerHTML).toContain('--dt-no-layers-marker');
+        });
+      });
+    });
+
     describe('When the brand declares a material lock', () => {
       it.each([
         ['iron', melonStub],

--- a/packages/dialtone-tokens/tests/fixtures/core-no-layers-stub.js
+++ b/packages/dialtone-tokens/tests/fixtures/core-no-layers-stub.js
@@ -4,5 +4,5 @@
 // initDialtoneTheme({ layers: false }) is wired to this file and not the layered core.
 export default {
   core: ':root { --dt-no-layers-marker: 1; }',
-  baseColors: ':root {}',
+  baseColors: ':root { --dt-no-layers-base-marker: 1; }',
 };

--- a/packages/dialtone-tokens/tests/fixtures/core-no-layers-stub.js
+++ b/packages/dialtone-tokens/tests/fixtures/core-no-layers-stub.js
@@ -1,0 +1,8 @@
+// Stubs the build-generated themes/core-no-layers.js (absent on clean checkouts) so
+// vitest can import themes/config.js without a prior token build. Aliased in
+// vitest.config.js. Deliberately distinct content from core-stub.js so tests can assert
+// initDialtoneTheme({ layers: false }) is wired to this file and not the layered core.
+export default {
+  core: ':root { --dt-no-layers-marker: 1; }',
+  baseColors: ':root {}',
+};

--- a/packages/dialtone-tokens/themes/config.js
+++ b/packages/dialtone-tokens/themes/config.js
@@ -200,10 +200,16 @@ function _setBrandLayered(theme, rootNode = document.documentElement) {
  * has already run just swaps the `#dialtone-css-core` tag's content — no DOM
  * reordering, so it's safe to use both for the initial load and later reloads
  * when a repeated initDialtoneTheme() call changes the layers option.
+ *
+ * Sets `coreTokensLoaded` only once the core CSS has actually been applied —
+ * synchronously for the layered core, or after the dynamic import resolves
+ * for the no-layers core — so a failed import doesn't falsely report core
+ * tokens as loaded.
  */
 function _loadCoreTokens (layers, styleRoot) {
   if (layers) {
     _setStyleTag('dialtone-css-core', Core.core, styleRoot);
+    coreTokensLoaded = true;
   } else {
     // Reserve the tag's DOM position synchronously so the base-colors/brand
     // tags appended below still land after it, then fill in its content once
@@ -211,6 +217,9 @@ function _loadCoreTokens (layers, styleRoot) {
     _setStyleTag('dialtone-css-core', '', styleRoot);
     import('@/themes/core-no-layers.js').then(({ default: CoreNoLayers }) => {
       _setStyleTag('dialtone-css-core', CoreNoLayers.core, styleRoot);
+      coreTokensLoaded = true;
+    }).catch((error) => {
+      console.error('[Dialtone] initDialtoneTheme: failed to load no-layers core tokens.', error);
     });
   }
 }
@@ -629,7 +638,6 @@ export function initDialtoneTheme(brandTheme, mode = 'light', rootNode = documen
 
   // Load core tokens (once per JavaScript instance)
   _loadCoreTokens(layers, styleRoot);
-  coreTokensLoaded = true;
 
   // Load base colors (once) — identical CSS whether layers is true or false
   // (tokens-base-colors.css was never wrapped in @layer), so no branching needed.

--- a/packages/dialtone-tokens/themes/config.js
+++ b/packages/dialtone-tokens/themes/config.js
@@ -1,6 +1,9 @@
 /* eslint-disable complexity */
 import Core from '@/themes/core.js';
-import CoreNoLayers from '@/themes/core-no-layers.js';
+// Not statically imported — the no-layers core is only needed when initDialtoneTheme
+// is called with { layers: false }. Dynamically importing it here lets bundlers
+// code-split it out of the default (layers: true) path, so apps that never opt into
+// no-layers don't pay for a second copy of the core token CSS string.
 
 /**
  * Names of all materials, including the default (sandstone). Material switching
@@ -467,6 +470,8 @@ export function setMaterial (name, rootNode = document.documentElement) {
  * @param {boolean} [options.layers=true] - Whether to load core tokens wrapped in `@layer dialtone.base`.
  *   Pass `false` if your app can't use CSS Cascade Layers. Brand, contrast, and material overrides are
  *   already unlayered either way — this only affects the shared core tokens initDialtoneTheme loads.
+ *   The no-layers core is loaded via a dynamic import (not bundled into the default path), so with
+ *   `layers: false` the core token styles apply asynchronously, a moment after this call returns.
  *
  * @example
  * // Standard usage (non-Shadow DOM)
@@ -505,7 +510,6 @@ export function setMaterial (name, rootNode = document.documentElement) {
  */
 export function initDialtoneTheme(brandTheme, mode = 'light', rootNode = document.documentElement, options = {}) {
   const { layers = true } = options;
-  const resolvedCore = layers ? Core : CoreNoLayers;
   // Validation: brandTheme must be an object
   if (!brandTheme || typeof brandTheme !== 'object') {
     throw new TypeError(
@@ -591,11 +595,22 @@ export function initDialtoneTheme(brandTheme, mode = 'light', rootNode = documen
   }
 
   // Load core tokens (once per JavaScript instance)
-  _setStyleTag('dialtone-css-core', resolvedCore.core, styleRoot);
+  if (layers) {
+    _setStyleTag('dialtone-css-core', Core.core, styleRoot);
+  } else {
+    // Reserve the tag's DOM position synchronously so the base-colors/brand
+    // tags appended below still land after it, then fill in its content once
+    // the dynamic import resolves.
+    _setStyleTag('dialtone-css-core', '', styleRoot);
+    import('@/themes/core-no-layers.js').then(({ default: CoreNoLayers }) => {
+      _setStyleTag('dialtone-css-core', CoreNoLayers.core, styleRoot);
+    });
+  }
   coreTokensLoaded = true;
 
-  // Load base colors (once)
-  _setStyleTag('dialtone-css-base-colors', resolvedCore.baseColors, styleRoot);
+  // Load base colors (once) — identical CSS whether layers is true or false
+  // (tokens-base-colors.css was never wrapped in @layer), so no branching needed.
+  _setStyleTag('dialtone-css-base-colors', Core.baseColors, styleRoot);
 
   // Set initial mode
   setMode(mode, rootNode);

--- a/packages/dialtone-tokens/themes/config.js
+++ b/packages/dialtone-tokens/themes/config.js
@@ -19,6 +19,12 @@ const VALID_MATERIALS_SET = new Set(VALID_MATERIALS);
 // config.js instance, so this boolean only tracks state within a single app.
 let coreTokensLoaded = false;
 
+// Bumped on every _loadCoreTokens()/resetBrand() call. The no-layers dynamic
+// import captures the generation at call time and checks it before applying
+// its result, so a superseded in-flight import (e.g. layers:false immediately
+// followed by layers:true, or a reset) can't clobber newer core CSS.
+let coreLoadGeneration = 0;
+
 // Track initialization state for idempotency protection
 // Stores: { brand: string, mode: string, contrast: string, material: string, layers: boolean } or null
 // Note: Only one rootNode per instance (per Brad's architecture)
@@ -205,8 +211,13 @@ function _setBrandLayered(theme, rootNode = document.documentElement) {
  * synchronously for the layered core, or after the dynamic import resolves
  * for the no-layers core — so a failed import doesn't falsely report core
  * tokens as loaded.
+ *
+ * Also guards against a stale in-flight no-layers import: if this function
+ * (or resetBrand) runs again before that import resolves, the earlier
+ * generation is discarded instead of clobbering newer core CSS.
  */
 function _loadCoreTokens (layers, styleRoot) {
+  const generation = ++coreLoadGeneration;
   if (layers) {
     _setStyleTag('dialtone-css-core', Core.core, styleRoot);
     coreTokensLoaded = true;
@@ -216,9 +227,11 @@ function _loadCoreTokens (layers, styleRoot) {
     // the dynamic import resolves.
     _setStyleTag('dialtone-css-core', '', styleRoot);
     import('@/themes/core-no-layers.js').then(({ default: CoreNoLayers }) => {
+      if (generation !== coreLoadGeneration) return; // superseded — discard
       _setStyleTag('dialtone-css-core', CoreNoLayers.core, styleRoot);
       coreTokensLoaded = true;
     }).catch((error) => {
+      if (generation !== coreLoadGeneration) return; // superseded — discard
       console.error('[Dialtone] initDialtoneTheme: failed to load no-layers core tokens.', error);
     });
   }
@@ -722,6 +735,9 @@ export function resetBrand(rootNode = document.documentElement) {
   // Clear initialization state (only one instance per app)
   initializationState = null;
   coreTokensLoaded = false;
+  // Invalidate any in-flight no-layers core import so its stale resolution
+  // can't recreate the #dialtone-css-core tag we're about to remove.
+  coreLoadGeneration++;
 
   // Remove all theme style tags. Material no longer injects a style tag
   // (attribute-driven), but resetBrand should still scrub any pre-existing

--- a/packages/dialtone-tokens/themes/config.js
+++ b/packages/dialtone-tokens/themes/config.js
@@ -20,7 +20,7 @@ const VALID_MATERIALS_SET = new Set(VALID_MATERIALS);
 let coreTokensLoaded = false;
 
 // Track initialization state for idempotency protection
-// Stores: { brand: string, mode: string, contrast: string } or null
+// Stores: { brand: string, mode: string, contrast: string, material: string, layers: boolean } or null
 // Note: Only one rootNode per instance (per Brad's architecture)
 let initializationState = null;
 
@@ -191,6 +191,27 @@ function _setBrandLayered(theme, rootNode = document.documentElement) {
   if (theme.contrast) {
     _setStyleTag('dialtone-css-contrast', theme.contrast.css, styleRoot);
     rootNode?.setAttribute('data-dt-contrast', theme.contrast.name);
+  }
+}
+
+/**
+ * Load (or reload) the core token stylesheet for the given layers option.
+ * `_setStyleTag` upserts in place, so calling this again after initDialtoneTheme
+ * has already run just swaps the `#dialtone-css-core` tag's content — no DOM
+ * reordering, so it's safe to use both for the initial load and later reloads
+ * when a repeated initDialtoneTheme() call changes the layers option.
+ */
+function _loadCoreTokens (layers, styleRoot) {
+  if (layers) {
+    _setStyleTag('dialtone-css-core', Core.core, styleRoot);
+  } else {
+    // Reserve the tag's DOM position synchronously so the base-colors/brand
+    // tags appended below still land after it, then fill in its content once
+    // the dynamic import resolves.
+    _setStyleTag('dialtone-css-core', '', styleRoot);
+    import('@/themes/core-no-layers.js').then(({ default: CoreNoLayers }) => {
+      _setStyleTag('dialtone-css-core', CoreNoLayers.core, styleRoot);
+    });
   }
 }
 
@@ -577,11 +598,23 @@ export function initDialtoneTheme(brandTheme, mode = 'light', rootNode = documen
   const existing = initializationState;
   if (existing) {
     if (existing.brand === brandTheme.brand.name && existing.mode === mode) {
+      if (existing.layers === layers) {
+        console.warn(
+          `[Dialtone] Theme already initialized with brand '${brandTheme.brand.name}' and mode '${mode}'. ` +
+          'Re-applying the same theme may be unnecessary. ' +
+          'If you need to switch themes dynamically, use setBaseBrand() or setMode() instead of calling initDialtoneTheme() again.',
+        );
+        return;
+      }
+
+      // Brand/mode unchanged but layers flipped — swap the core stylesheet in
+      // place instead of silently ignoring the new layers value.
       console.warn(
-        `[Dialtone] Theme already initialized with brand '${brandTheme.brand.name}' and mode '${mode}'. ` +
-        'Re-applying the same theme may be unnecessary. ' +
-        'If you need to switch themes dynamically, use setBaseBrand() or setMode() instead of calling initDialtoneTheme() again.',
+        `[Dialtone] Theme already initialized with brand '${brandTheme.brand.name}' and mode '${mode}' ` +
+        `using layers=${existing.layers}. Reloading core tokens with layers=${layers}.`,
       );
+      _loadCoreTokens(layers, styleRoot);
+      initializationState.layers = layers;
       return;
     } else {
       console.warn(
@@ -595,17 +628,7 @@ export function initDialtoneTheme(brandTheme, mode = 'light', rootNode = documen
   }
 
   // Load core tokens (once per JavaScript instance)
-  if (layers) {
-    _setStyleTag('dialtone-css-core', Core.core, styleRoot);
-  } else {
-    // Reserve the tag's DOM position synchronously so the base-colors/brand
-    // tags appended below still land after it, then fill in its content once
-    // the dynamic import resolves.
-    _setStyleTag('dialtone-css-core', '', styleRoot);
-    import('@/themes/core-no-layers.js').then(({ default: CoreNoLayers }) => {
-      _setStyleTag('dialtone-css-core', CoreNoLayers.core, styleRoot);
-    });
-  }
+  _loadCoreTokens(layers, styleRoot);
   coreTokensLoaded = true;
 
   // Load base colors (once) — identical CSS whether layers is true or false
@@ -628,6 +651,7 @@ export function initDialtoneTheme(brandTheme, mode = 'light', rootNode = documen
     mode: mode,
     contrast: 'default',
     material: getBrandMaterial(brandTheme) ?? 'sandstone',
+    layers,
   };
 }
 

--- a/packages/dialtone-tokens/themes/config.js
+++ b/packages/dialtone-tokens/themes/config.js
@@ -1,5 +1,6 @@
 /* eslint-disable complexity */
 import Core from '@/themes/core.js';
+import CoreNoLayers from '@/themes/core-no-layers.js';
 
 /**
  * Names of all materials, including the default (sandstone). Material switching
@@ -462,6 +463,10 @@ export function setMaterial (name, rootNode = document.documentElement) {
  * @param {BrandTheme} brandTheme - Initial brand theme to apply
  * @param {Mode} [mode='light'] - Initial color mode ('light' or 'dark')
  * @param {ThemeRootNode} [rootNode=document.documentElement] - Root element for style injection
+ * @param {Object} [options={}]
+ * @param {boolean} [options.layers=true] - Whether to load core tokens wrapped in `@layer dialtone.base`.
+ *   Pass `false` if your app can't use CSS Cascade Layers. Brand, contrast, and material overrides are
+ *   already unlayered either way — this only affects the shared core tokens initDialtoneTheme loads.
  *
  * @example
  * // Standard usage (non-Shadow DOM)
@@ -473,6 +478,10 @@ export function setMaterial (name, rootNode = document.documentElement) {
  * @example
  * // Explicit document.documentElement (optional but clear in config files)
  * initDialtoneTheme(Dp, 'light', document.documentElement);
+ *
+ * @example
+ * // No CSS Cascade Layers support
+ * initDialtoneTheme(Dp, 'light', document.documentElement, { layers: false });
  *
  * @example
  * // ❌ WRONG - In Web Components, forgetting rootNode causes styles to inject into document!
@@ -494,7 +503,9 @@ export function setMaterial (name, rootNode = document.documentElement) {
  *   }
  * }
  */
-export function initDialtoneTheme(brandTheme, mode = 'light', rootNode = document.documentElement) {
+export function initDialtoneTheme(brandTheme, mode = 'light', rootNode = document.documentElement, options = {}) {
+  const { layers = true } = options;
+  const resolvedCore = layers ? Core : CoreNoLayers;
   // Validation: brandTheme must be an object
   if (!brandTheme || typeof brandTheme !== 'object') {
     throw new TypeError(
@@ -580,11 +591,11 @@ export function initDialtoneTheme(brandTheme, mode = 'light', rootNode = documen
   }
 
   // Load core tokens (once per JavaScript instance)
-  _setStyleTag('dialtone-css-core', Core.core, styleRoot);
+  _setStyleTag('dialtone-css-core', resolvedCore.core, styleRoot);
   coreTokensLoaded = true;
 
   // Load base colors (once)
-  _setStyleTag('dialtone-css-base-colors', Core.baseColors, styleRoot);
+  _setStyleTag('dialtone-css-base-colors', resolvedCore.baseColors, styleRoot);
 
   // Set initial mode
   setMode(mode, rootNode);

--- a/packages/dialtone-tokens/vitest.config.js
+++ b/packages/dialtone-tokens/vitest.config.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 const packageRoot = fileURLToPath(new URL('.', import.meta.url));
 const coreStub = fileURLToPath(new URL('./tests/fixtures/core-stub.js', import.meta.url));
+const coreNoLayersStub = fileURLToPath(new URL('./tests/fixtures/core-no-layers-stub.js', import.meta.url));
 
 export default defineConfig({
   test: {
@@ -15,6 +16,7 @@ export default defineConfig({
     alias: [
       // Must precede the '@/' prefix alias below — Vite array-form aliases match in order.
       { find: '@/themes/core.js', replacement: coreStub },
+      { find: '@/themes/core-no-layers.js', replacement: coreNoLayersStub },
       // Restricted to '@/...' so it doesn't match scoped package imports like '@scope/pkg'.
       { find: /^@\/(.*)/, replacement: `${packageRoot}/$1` },
     ],


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Feature

## :book: Jira Ticket

NO-JIRA

## :book: Description

Adds a no-layers escape hatch to `dialtone-tokens`:

- Every token CSS file wrapped in `@layer dialtone.base` now has an unlayered copy pre-built at the same path under `no-layers/` (e.g. `@dialpad/dialtone-tokens/no-layers/tokens-base-light.css`).
- `initDialtoneTheme` accepts a new `{ layers: false }` option to load the unlayered core tokens at runtime instead. `setBrand`/`setContrast`/`setMaterial` need no equivalent option since brand, contrast, and material overrides were never wrapped in `@layer`.

## :bulb: Context

The dialtone-css no-layers build only strips `@layer` from its own compiled bundle. Consumers who import token CSS directly from `@dialpad/dialtone-tokens`, or theme at runtime via `setBrand`/`initDialtoneTheme`, still got `@layer dialtone.base` with no way to opt out.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
- [x] I have added / updated unit tests.
