### PR TITLE
refactor(documentation): NO-JIRA merge the before/after switch into the comparison mode control

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/BeforeAfter.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/BeforeAfter.vue
@@ -11,7 +11,6 @@
     >
       <before-after-body
         v-model:mode="mode"
-        v-model:shown="shown"
         v-model:blend="blend"
         v-model:split="split"
         :before="before"
@@ -52,7 +51,6 @@
     >
       <before-after-body
         v-model:mode="mode"
-        v-model:shown="shown"
         v-model:blend="blend"
         v-model:split="split"
         :before="before"
@@ -72,9 +70,10 @@ import BeforeAfterBody from './BeforeAfterBody.vue';
 // Neutral before/after image comparison for the visual migration guide.
 // Unlike DialtoneUsage this carries no do/don't semantics — both panels are
 // equally valid renders of the same scene against two Dialtone versions.
-// Offers an instant before/after toggle (default), side-by-side, split-wipe,
-// and onion-skin (blend slider) modes plus a fullscreen modal; comparison
-// state persists between the inline container and the expanded view.
+// One segmented control drives every view: instant single-image Before and
+// After modes (Before is the default), side-by-side, split-wipe, and
+// onion-skin (blend slider), plus a fullscreen modal; comparison state
+// persists between the inline container and the expanded view.
 defineProps({
   before: {
     type: String,
@@ -98,8 +97,7 @@ defineProps({
   },
 });
 
-const mode = ref('toggle');
-const shown = ref('before');
+const mode = ref('before');
 const blend = ref(50);
 const split = ref(50);
 const expanded = ref(false);

--- a/apps/dialtone-documentation/docs/.vuepress/baseComponents/BeforeAfterBody.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/baseComponents/BeforeAfterBody.vue
@@ -12,8 +12,11 @@
         aria-label="Comparison mode"
         @update:model-value="$emit('update:mode', $event)"
       >
-        <dt-segmented-control-item value="toggle">
-          Before/After
+        <dt-segmented-control-item value="before">
+          Before
+        </dt-segmented-control-item>
+        <dt-segmented-control-item value="after">
+          After
         </dt-segmented-control-item>
         <dt-segmented-control-item value="side">
           Side by side
@@ -31,7 +34,7 @@
     <!-- Both images stay mounted (stacked in the same grid cell) and only
          visibility flips, so the browser keeps both decoded and switching
          is instantaneous — no request, no reflow. -->
-    <div v-if="mode === 'toggle'">
+    <div v-if="mode === 'before' || mode === 'after'">
       <dt-box
         surface="primary"
         border-width="100"
@@ -43,35 +46,17 @@
           <img
             :src="withBase(before)"
             :alt="`${alt} — before migration`"
-            :style="{ visibility: shown === 'after' ? 'hidden' : 'visible' }"
+            :style="{ visibility: mode === 'after' ? 'hidden' : 'visible' }"
             loading="lazy"
           >
           <img
             :src="withBase(after)"
             :alt="`${alt} — after migration`"
-            :style="{ visibility: shown === 'after' ? 'visible' : 'hidden' }"
+            :style="{ visibility: mode === 'after' ? 'visible' : 'hidden' }"
             loading="lazy"
           >
         </div>
       </dt-box>
-      <dt-stack
-        direction="row"
-        justify="end"
-        class="d-mbs-200"
-      >
-        <dt-segmented-control
-          :model-value="shown"
-          aria-label="Version shown"
-          @update:model-value="$emit('update:shown', $event)"
-        >
-          <dt-segmented-control-item value="before">
-            Before
-          </dt-segmented-control-item>
-          <dt-segmented-control-item value="after">
-            After
-          </dt-segmented-control-item>
-        </dt-segmented-control>
-      </dt-stack>
     </div>
 
     <div
@@ -231,8 +216,9 @@ import { withBase } from 'vuepress/client';
 // Presentational half of <before-after>: renders the comparison as an
 // instant before/after switch (default), side-by-side, a split wipe
 // (draggable divider — before left, after right), or an onion-skin blend.
-// Mode, shown, split, and blend live in the parent so they survive
-// expanding into the fullscreen modal.
+// Mode, split, and blend live in the parent so they survive expanding
+// into the fullscreen modal. The before/after single-image views are modes
+// like any other; both images stay mounted there so switching is instant.
 // Image srcs are passed through withBase(): the site deploys under a
 // subpath (VUEPRESS_BASE_URL, e.g. /next/ and deploy previews), and VuePress
 // only auto-rewrites markdown ![]() images — not component props.
@@ -260,12 +246,7 @@ defineProps({
   mode: {
     type: String,
     required: true,
-    validator: (v) => ['toggle', 'side', 'split', 'onion'].includes(v),
-  },
-  shown: {
-    type: String,
-    required: true,
-    validator: (v) => ['before', 'after'].includes(v),
+    validator: (v) => ['before', 'after', 'side', 'split', 'onion'].includes(v),
   },
   blend: {
     type: Number,
@@ -277,7 +258,7 @@ defineProps({
   },
 });
 
-defineEmits(['update:mode', 'update:shown', 'update:blend', 'update:split']);
+defineEmits(['update:mode', 'update:blend', 'update:split']);
 </script>
 
 <style scoped>


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Refactor

## :book: Jira Ticket

NO-JIRA (follow-up to a review suggestion on #1358)

## :book: Description

Merges the Before/After switch into the comparison widget's main segmented control, as suggested in [this review comment](https://github.com/dialpad/dialtone/pull/1358). Before and After become modes alongside Side by side, Split, and Onion skin, so the widget has one control instead of a mode picker plus a sub-control. Single-image views no longer show any chrome below the image. Before is the default.

Both images stay mounted inside the shared single-image branch, so switching Before/After remains instant: no request, no reflow.

## :bulb: Context

The two-level control made the most common action (flipping between versions) the most buried one. One flat choice reads faster and drops 21 lines of state wiring (`shown` prop, its v-model, and the second radiogroup).

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :camera: Screenshots / GIFs

Verified on the built site: default state shows Before selected with the before render, After swaps instantly, layout modes and the fullscreen modal keep shared state. Deploy preview: https://dialtone.dialpad.com/deploy-previews/pr-1369/guides/migration/visual-changes/
