### PR TITLE
fix(dialtone-tokens): DLT-3538 quote "other"-type token values for iOS output

### DIFF
--- a/packages/dialtone-tokens/dialtone-transforms.js
+++ b/packages/dialtone-tokens/dialtone-transforms.js
@@ -285,7 +285,7 @@ export function registerDialtoneTransforms (styleDictionary) {
     name: 'dt/stringify',
     type: 'value',
     filter: function (token) {
-      return ['type', 'textCase'].includes(token.type);
+      return ['type', 'textCase', 'other'].includes(token.type);
     },
     transform: (token) => {
       return `"${token.value}"`;


### PR DESCRIPTION
## Summary
- Swift compilation of the `dialtone-tokens-swift` package was broken on every theme file due to `shell.base.material` tokens (e.g. `steel`, `iron`, `sandstone`, `graphite`) emitting as bare, unquoted identifiers instead of string literals.
- Root cause: the `dt/stringify` transform in `dialtone-transforms.js` only quoted values for token type `type`/`textCase`, but `shell.base.material` uses `type: "other"`.
- Added `'other'` to the `dt/stringify` filter so these values are quoted correctly (`"steel"` instead of `steel`).

## Test plan
- [x] Rebuilt `dialtone-tokens` (`pnpm nx run dialtone-tokens:build`) and iOS output (`pnpm nx run dialtone-tokens:build:ios`)
- [x] Verified `dtShellBaseMaterial` now emits as a quoted string literal in generated Swift
- [x] Ran `swiftc -parse` against all 118 generated theme `.swift` files — all pass with no errors
- [x] Audited for other latent iOS-output issues (other `"other"`-typed tokens, boxShadow/gradient leakage, unresolved refs, duplicate declarations) — none found