### PR TITLE
fix(tabs): DP-198400 fix disabled tab styling

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/tabs.less
+++ b/packages/dialtone-css/lib/build/less/components/tabs.less
@@ -163,6 +163,10 @@
 
     &:disabled::after {
         --tab-color-background: var(--dt-action-color-foreground-disabled-default);
+
+        .d-tablist--no-border & {
+            background-color: var(--tab-color-background);
+        }
     }
 }
 

--- a/packages/dialtone-css/lib/build/less/components/tabs.less
+++ b/packages/dialtone-css/lib/build/less/components/tabs.less
@@ -152,13 +152,17 @@
         --tab-color-text: var(--dt-action-color-foreground-base-active);
     }
 
-    &::after,
-    &:hover::after {
+    &:not(:disabled)::after,
+    &:not(:disabled):hover::after {
         --tab-color-background: var(--dt-action-color-foreground-base-default);
 
         .d-tablist--no-border & {
             background-color: var(--tab-color-background);
         }
+    }
+
+    &:disabled::after {
+        --tab-color-background: var(--dt-action-color-foreground-disabled-default);
     }
 }
 

--- a/packages/dialtone-css/lib/build/less/components/tabs.less
+++ b/packages/dialtone-css/lib/build/less/components/tabs.less
@@ -100,6 +100,8 @@
     &:disabled {
         --tab-color-text: var(--dt-action-color-foreground-disabled-default);
 
+        color: var(--tab-color-text);
+        background-color: var(--tab-color-background);
         cursor: not-allowed;
     }
 
@@ -190,6 +192,8 @@
         &:disabled {
             --tab-color-text: var(--dt-action-color-foreground-disabled-default);
 
+            color: var(--tab-color-text);
+            background-color: var(--tab-color-background);
             cursor: not-allowed;
         }
     }


### PR DESCRIPTION
# fix(tabs): DP-198400 fix disabled tab styling

<!--- Feel free to remove any unused sections -->

## Obligatory GIF (super important!)

<!--- go to giphy.com, pick a gif, click share, copy gif link, paste within the () brackets below. -->

![Obligatory GIF](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExYmJ6dndzajM2cWI4ZXg0dGViNHo1bHphem9mOTI1ZXRqb2Q3YzZmNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/7KwMyVvaNPXeU/giphy.gif)

## :hammer_and_wrench: Type Of Change

<!--- Tick or place an `x` for the type of change. Should match the type in the commit message / PR title
in https://github.com/dialpad/dialtone/blob/staging/.github/COMMIT_CONVENTION.md -->

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

<!--- Enter the URL of the Jira ticket associated with this PR -->
https://dialpad.atlassian.net/browse/DP-198400

## :book: Description

<!--- Describe specifically what the changes are -->

Two fixes to disabled-tab styling in `packages/dialtone-css/lib/build/less/components/tabs.less`, kept as separate commits so each can be reviewed/verified on its own:

1. **Restore muted disabled tab styling instead of faded primary color** — DLT-3269 (#1180) changed `.d-btn:disabled` to compute `color`/`background-color` directly via `color-mix()`/`oklch()`, at higher CSS specificity than `.d-tab`'s own custom-prop-based styling. Since `DtTab` renders through `DtButton` with its default `importance="primary"`, disabled tabs started rendering as a faded brand-purple pill instead of the previous muted/transparent look. Fix declares `color`/`background-color` directly on `.d-tab:disabled` (and the inverted variant) so it wins the specificity tie, restoring the exact pre-regression values.

2. **Guard the selected-tab underline indicator against the disabled state** — the `.d-tab--selected` `::after` underline rule was never scoped with `:not(:disabled)`, unlike every other interactive rule in the file. A tab that's both selected and disabled kept the brand-purple underline bar while its text correctly went gray. This was potentially a longstanding gap, not a recent regression — fixed by adding the missing guard plus a disabled variant using the same disabled-foreground token already used elsewhere in the file.

## :bulb: Context

<!--- Describe the purpose of the changes -->
<!--- Why did we make these changes? -->
<!--- What problem(s) do they solve? -->

Investigating a Jira report that disabled tabs weren't appearing as expected: https://dialpad.atlassian.net/browse/DP-198400

## :pencil: Checklist

<!--- Tick or place an `x` in all of the checkboxes that apply -->
<!--- Remove checkboxes that do not apply -->

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.

## :crystal_ball: Next Steps

<!--- Describe any future changes that need to be made after merging the PR, especially any follow up tasks after release. -->

## :camera: Screenshots / GIFs

<!--- Add these if necessary. Since we have deploy previews for every PR it may not always be. -->
<!--- Link any screenshots / GIFs below -->

<img width="569" height="588" alt="Screenshot 2026-07-17 at 11 57 49 AM" src="https://github.com/user-attachments/assets/a5d28c46-d6c1-465c-a1c2-9916759fa118" />


## :link: Sources

<!--- Add any links to external reference material -->
https://dialpad.atlassian.net/browse/DP-198400