### PR TITLE
refactor(dialtone-vue,dialtone-css): DLT-3536 clean up remaining legacy prop migration references

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleNotice.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleNotice.vue
@@ -2,7 +2,7 @@
   <dt-notice
     :important="important"
     :kind="kind"
-    :title="title"
+    :header-text="title"
   >
     Message body with
     <dt-link

--- a/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleToast.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/exampleComponents/ExampleToast.vue
@@ -1,7 +1,7 @@
 <template>
   <aside :class="['d-toast-wrapper', { 'd-ps-fixed': fixed }]">
     <dt-toast
-      :title="title"
+      :header-text="title"
       :open="open"
       :important="important"
       :duration="duration"

--- a/apps/dialtone-documentation/docs/components/banner.md
+++ b/apps/dialtone-documentation/docs/components/banner.md
@@ -11,7 +11,7 @@ keywords: ["alert","notification","message","d-banner","DtBanner","dt-banner"]
 ```vue demo-only
 <dt-stack gap="200" class="d-w100p" align="center">
   <dt-banner header-text="Example banner" kind="info" class="d-ps-relative d-zi-base">
-    Message body with a <dt-link kind="muted">Link</dt-link>
+    Message body with a <dt-link tone="muted">Link</dt-link>
     <template #action>
       <dt-button :size="200" kind="muted" importance="outlined">Action</dt-button>
     </template>

--- a/apps/dialtone-documentation/docs/components/button.md
+++ b/apps/dialtone-documentation/docs/components/button.md
@@ -56,7 +56,7 @@ Button labels should be clear and predictable so users have confidence in their 
 
 ## Variants
 
-Dialtone provides five options for `kind`, with three levels of `importance`. Use `kind="primary"` for the main call to action, `kind="danger"` for destructive actions, `kind="muted"` for secondary actions, `kind="clear"` for low-emphasis actions, and `kind="link"` for navigation-style buttons. The DtButton `kind` prop controls the visual hierarchy and semantic meaning of the action.
+Dialtone provides five options for `kind`, with three levels of `importance`. Use `kind="primary"` for the main call to action, `kind="critical"` for destructive actions, `kind="muted"` for secondary actions, `kind="clear"` for low-emphasis actions, and `kind="link"` for navigation-style buttons. The DtButton `kind` prop controls the visual hierarchy and semantic meaning of the action.
 
 <ButtonVariantsTable></ButtonVariantsTable>
 

--- a/apps/dialtone-documentation/docs/components/checkbox-group.md
+++ b/apps/dialtone-documentation/docs/components/checkbox-group.md
@@ -19,7 +19,7 @@ Checkbox Groups are typically paired with a legend which identifies the group. I
 <dt-checkbox-group
   name="fruits-checkbox-group"
   legend="Fruits"
-  :selectedValues="[]"
+  :model-value="[]"
 >
   <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
   <dt-checkbox value="banana"><span>Banana</span></dt-checkbox>
@@ -33,7 +33,7 @@ Checkbox Groups are typically paired with a legend which identifies the group. I
 <dt-checkbox-group
   name="my-group-name"
   legend="My Legend"
-  :selected-values="['option1']"
+  :model-value="['option1']"
 >
   <dt-checkbox
     value="option1"

--- a/apps/dialtone-documentation/docs/components/checkbox.md
+++ b/apps/dialtone-documentation/docs/components/checkbox.md
@@ -108,7 +108,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 ### Stacked Group
 
 ```vue demo
-<dt-checkbox-group legend="Call Blocking & Spam Protection" :selectedValues="[]">
+<dt-checkbox-group legend="Call Blocking & Spam Protection" :model-value="[]">
   <dt-checkbox
     name="option1"
     value="Value"
@@ -130,7 +130,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 ### With Description Text
 
 ```vue demo
-<dt-checkbox-group legend="Call Blocking & Spam Protection" :selectedValues="[]">
+<dt-checkbox-group legend="Call Blocking & Spam Protection" :model-value="[]">
   <dt-checkbox
     name="option1"
     value="Value"
@@ -155,7 +155,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 ### With Validation States
 
 ```vue demo
-<dt-checkbox-group legend="Call Blocking & Spam Protection" :selectedValues="[]">
+<dt-checkbox-group legend="Call Blocking & Spam Protection" :model-value="[]">
   <dt-checkbox
     name="option1"
     value="Value"

--- a/apps/dialtone-documentation/docs/components/modal.md
+++ b/apps/dialtone-documentation/docs/components/modal.md
@@ -276,7 +276,7 @@ When there is a need of more context information regarding the content of the Mo
 <dt-modal
   header-text="Example title"
   :open="isOpen"
-  banner-title="This banner can have different kinds."
+  banner-header-text="This banner can have different kinds."
   :bannerKind="selectedBannerKind"
   copy="Sed at orci quis nunc finibus gravida eget vitae est..."
   @update:open="updateOpen"

--- a/apps/dialtone-documentation/docs/components/notice.md
+++ b/apps/dialtone-documentation/docs/components/notice.md
@@ -31,7 +31,7 @@ Used in most scenarios when the message should be noticeable but not dominate.
 </dt-stack>
 <!-- @code -->
 <dt-notice
-  title="Base title (optional)"
+  header-text="Base title (optional)"
 >
   <span>
     Message body with
@@ -53,7 +53,7 @@ Used in most scenarios when the message should be noticeable but not dominate.
   </template>
 </dt-notice>
 <dt-notice
-  title="Info title (optional)"
+  header-text="Info title (optional)"
   kind="info"
 >
   <span>
@@ -76,7 +76,7 @@ Used in most scenarios when the message should be noticeable but not dominate.
   </template>
 </dt-notice>
 <dt-notice
-  title="Critical title (optional)"
+  header-text="Critical title (optional)"
   kind="critical"
 >
   <span>
@@ -99,7 +99,7 @@ Used in most scenarios when the message should be noticeable but not dominate.
   </template>
 </dt-notice>
 <dt-notice
-  title="Positive title (optional)"
+  header-text="Positive title (optional)"
   kind="positive"
 >
   <span>
@@ -122,7 +122,7 @@ Used in most scenarios when the message should be noticeable but not dominate.
   </template>
 </dt-notice>
 <dt-notice
-  title="Warning title (optional)"
+  header-text="Warning title (optional)"
   kind="warning"
 >
   <span>
@@ -160,7 +160,7 @@ Used occasionally in scenarios when the message needs to dominate.
 </dt-stack>
 <!-- @code -->
 <dt-notice
-  title="Base title (optional)"
+  header-text="Base title (optional)"
   important
 >
   <span>
@@ -183,7 +183,7 @@ Used occasionally in scenarios when the message needs to dominate.
   </template>
 </dt-notice>
 <dt-notice
-  title="Info title (optional)"
+  header-text="Info title (optional)"
   kind="info"
   important
 >
@@ -207,7 +207,7 @@ Used occasionally in scenarios when the message needs to dominate.
   </template>
 </dt-notice>
 <dt-notice
-  title="Critical title (optional)"
+  header-text="Critical title (optional)"
   kind="critical"
   important
 >
@@ -231,7 +231,7 @@ Used occasionally in scenarios when the message needs to dominate.
   </template>
 </dt-notice>
 <dt-notice
-  title="Positive title (optional)"
+  header-text="Positive title (optional)"
   kind="positive"
   important
 >
@@ -255,7 +255,7 @@ Used occasionally in scenarios when the message needs to dominate.
   </template>
 </dt-notice>
 <dt-notice
-  title="Warning title (optional)"
+  header-text="Warning title (optional)"
   kind="warning"
   important
 >
@@ -288,7 +288,7 @@ Truncates the text instead of wrapping it. Useful when the Notice needs to have 
 <!-- @bg d-bgc-primary -->
 <dt-notice
   :truncate-text="true"
-  title="Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+  header-text="Lorem ipsum dolor sit amet, consectetur adipiscing elit,
     sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
 >
   <span>

--- a/apps/dialtone-documentation/docs/components/toast.md
+++ b/apps/dialtone-documentation/docs/components/toast.md
@@ -22,7 +22,7 @@ keywords: ["notification", "snackbar", "alert", "message", "d-toast", "DtToast",
 </dt-stack>
 <!-- @code -->
 <dt-toast
-  title="Title"
+  header-text="Title"
   :open="showToast"
   :important="important"
   :kind="selectedKind"
@@ -70,7 +70,7 @@ If the duration is not provided the toast won't disappear automatically.
 />
 <!-- @code -->
 <dt-toast
-  title="Title"
+  header-text="Title"
   :open="showDurationToast"
   @close="closeEvent"
   :duration="7500"
@@ -98,7 +98,7 @@ If you need to self-position the toast at the top center, use the `d-toast-wrapp
 ```vue code-only
 <aside class="d-toast-wrapper">
   <dt-toast
-    :title="title"
+    :header-text="title"
     :message="message"
     :open="isShown"
   ></dt-toast>

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2022-12-9.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2022-12-9.md
@@ -27,14 +27,14 @@ The migration has been performed for all existing `DtBadge` components and `d-ba
 <dt-stack direction="row" gap="100" align="center">
   <dt-badge text="Default" />
   <dt-badge type="info" text="Info" />
-  <dt-badge type="success" text="Success" />
+  <dt-badge type="positive" text="Positive" />
   <dt-badge type="warning" text="Warning" />
   <dt-badge type="critical" text="Critical" />
   <dt-badge type="bulletin" text="Bulletin" />
   <dt-badge type="ai" text="Ai" />
   <dt-badge kind="count" text="1" />
   <dt-badge kind="count" type="info" text="1" />
-  <dt-badge kind="count" type="success" text="1" />
+  <dt-badge kind="count" type="positive" text="1" />
   <dt-badge kind="count" type="warning" text="1" />
   <dt-badge kind="count" type="critical" text="1" />
   <dt-badge kind="count" type="bulletin" text="1" />

--- a/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2022-12-9.md
+++ b/apps/dialtone-documentation/docs/dialtone/whats-new/posts/2022-12-9.md
@@ -76,7 +76,7 @@ The migration has been performed for all existing `DtBadge` components and `d-ba
   </div>
   <div>
     <dt-stack direction="row" gap="100" align="center">
-      <span class="d-badge d-badge--success"><span class="d-badge__label">Resolved</span></span>
+      <span class="d-badge d-badge--positive"><span class="d-badge__label">Resolved</span></span>
     </dt-stack>
   </div>
   <div>
@@ -134,7 +134,7 @@ The migration has been performed for all existing `DtBadge` components and `d-ba
 <code-well-header>
   <div>
     <dt-stack direction="row" gap="100" align="center">
-      <span class="d-badge d-badge--count d-badge--success">
+      <span class="d-badge d-badge--count d-badge--positive">
         <span class="d-badge__icon-left">
           <dt-icon name="arrow-up" size="200"/>
         </span>

--- a/packages/combinator/src/variants/variants_combobox_with_popover.js
+++ b/packages/combinator/src/variants/variants_combobox_with_popover.js
@@ -8,7 +8,7 @@ export default {
     },
     slots: {
       input: {
-        initialValue: '<dt-input placeholder="Select one or start typing" v-bind="inputProps" @input="onInput" />',
+        initialValue: '<dt-input placeholder="Select one or start typing" v-bind="inputProps" @update:model-value="onInput" />',
       },
       list: {
         initialValue: '<ul v-bind="listProps" class="d-p-50"><dt-list-item role="option" navigation-type="arrow-keys">+1 (555) 000-0001<template #right><span class="d-fc-secondary">Mobile</span></template></dt-list-item><dt-list-item role="option" navigation-type="arrow-keys">+1 (555) 000-0002<template #right><span class="d-fc-secondary">Work</span></template></dt-list-item><dt-list-item role="option" navigation-type="arrow-keys">+1 (555) 000-0003<template #right><span class="d-fc-secondary">Home</span></template></dt-list-item></ul>',
@@ -27,7 +27,7 @@ export default {
         initialValue: '<div class="d-px-150 d-py-100 d-fw-semibold">Select an option</div>',
       },
       input: {
-        initialValue: '<dt-input placeholder="Select one or start typing" v-bind="inputProps" @input="onInput" />',
+        initialValue: '<dt-input placeholder="Select one or start typing" v-bind="inputProps" @update:model-value="onInput" />',
       },
       list: {
         initialValue: '<ul v-bind="listProps" class="d-p-50"><dt-list-item role="option" navigation-type="arrow-keys">+1 (555) 000-0001<template #right><span class="d-fc-secondary">Mobile</span></template></dt-list-item><dt-list-item role="option" navigation-type="arrow-keys">+1 (555) 000-0002<template #right><span class="d-fc-secondary">Work</span></template></dt-list-item><dt-list-item role="option" navigation-type="arrow-keys">+1 (555) 000-0003<template #right><span class="d-fc-secondary">Home</span></template></dt-list-item></ul>',

--- a/packages/dialtone-mcp-server/scripts/acceptance-scenarios.json
+++ b/packages/dialtone-mcp-server/scripts/acceptance-scenarios.json
@@ -7,9 +7,9 @@
   },
   {
     "id": "TS-003",
-    "query": "What's the difference between DtButton kind='primary' and kind='danger'?",
+    "query": "What's the difference between DtButton kind='primary' and kind='critical'?",
     "allowlist": ["button"],
-    "rationale": "Prop value semantics — should match button Variants section describing primary/danger kinds"
+    "rationale": "Prop value semantics — should match button Variants section describing primary/critical kinds"
   },
   {
     "id": "TS-004",

--- a/packages/dialtone-query-core/tests/tools/docs.test.ts
+++ b/packages/dialtone-query-core/tests/tools/docs.test.ts
@@ -11,7 +11,7 @@ const fixture: DocumentationRecord[] = [
     docTitle: 'Button',
     category: 'components',
     headingPath: ['Usage'],
-    content: 'A button conveys an action. Use DtButton kind="primary" for the main call to action. Use kind="danger" for destructive actions.',
+    content: 'A button conveys an action. Use DtButton kind="primary" for the main call to action. Use kind="critical" for destructive actions.',
     frontmatter: {
       title: 'Button',
       description: 'Interactive button component',
@@ -27,7 +27,7 @@ const fixture: DocumentationRecord[] = [
     docTitle: 'Button',
     category: 'components',
     headingPath: ['Variants'],
-    content: 'Variants include primary, danger, muted, and clear kinds. Loading spinner shown via loading prop.',
+    content: 'Variants include primary, critical, muted, and clear kinds. Loading spinner shown via loading prop.',
     frontmatter: {
       title: 'Button',
       description: 'Interactive button component',
@@ -175,10 +175,10 @@ describe('searchDocumentation', () => {
   });
 
   test('docTitle match ranks above higher matchCount without title match', () => {
-    // 'modal danger': modal#usage has title match ('modal'==='modal'), matchCount 1.
-    // button#usage has no title match, matchCount 1 (only 'danger' matches).
+    // 'modal critical': modal#usage has title match ('modal'==='modal'), matchCount 1.
+    // button#usage has no title match, matchCount 1 (only 'critical' matches).
     // Title match is evaluated before matchCount — modal must rank first.
-    const { results } = searchDocumentation('modal danger', fixture);
+    const { results } = searchDocumentation('modal critical', fixture);
     expect(results.length).toBeGreaterThan(0);
     expect((results[0].details as any).docId).toBe('modal');
   });
@@ -243,7 +243,7 @@ describe('Acceptance scenarios — real queries against the full corpus', () => 
     },
     {
       id: 'TS-003',
-      query: "What's the difference between DtButton kind='primary' and kind='danger'?",
+      query: "What's the difference between DtButton kind='primary' and kind='critical'?",
       allowlist: ['Button'],
     },
     {

--- a/packages/dialtone-vue/components/Breadcrumbs/BreadcrumbItem.vue
+++ b/packages/dialtone-vue/components/Breadcrumbs/BreadcrumbItem.vue
@@ -9,7 +9,7 @@
     :style="$attrs.style"
   >
     <dt-link
-      :kind="linkKind"
+      :tone="linkTone"
       :inverted="linkInverted"
       :aria-current="ariaCurrent"
       :underline="false"
@@ -75,7 +75,7 @@ export default {
   },
 
   computed: {
-    linkKind () {
+    linkTone () {
       return this.inverted ? '' : MUTED;
     },
 

--- a/packages/dialtone-vue/components/CheckboxGroup/CheckboxGroupVariants.story.vue
+++ b/packages/dialtone-vue/components/CheckboxGroup/CheckboxGroupVariants.story.vue
@@ -34,7 +34,7 @@
     <dt-checkbox-group
       name="checkbox-group-with-selected-values"
       legend="With Selected Values"
-      :selected-values="['apple', 'other']"
+      :model-value="['apple', 'other']"
     >
       <dt-checkboxes-decorator />
     </dt-checkbox-group>

--- a/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.vue
+++ b/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.vue
@@ -68,7 +68,7 @@
           :messages="inputMessages"
           :size="size"
           v-bind="inputListeners"
-          @input="onInput"
+          @update:model-value="onInput"
         />
 
         <dt-validation-messages

--- a/packages/dialtone-vue/components/ComboboxWithPopover/ComboboxWithPopoverDefault.story.vue
+++ b/packages/dialtone-vue/components/ComboboxWithPopover/ComboboxWithPopoverDefault.story.vue
@@ -37,7 +37,7 @@
         v-model="value"
         placeholder="Select one or start typing"
         v-bind="inputProps"
-        @input="onInput"
+        @update:model-value="onInput"
       />
     </template>
     <template #list="{ listProps }">

--- a/packages/dialtone-vue/components/RichTextEditor/Extensions/Channels/ChannelComponent.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/Extensions/Channels/ChannelComponent.vue
@@ -4,7 +4,7 @@
     class="d-d-inline-block"
   >
     <dt-link
-      kind="mention"
+      tone="mention"
       @click.prevent="handleClick"
     >
       <dt-stack

--- a/packages/dialtone-vue/components/RichTextEditor/Extensions/Mentions/MentionComponent.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/Extensions/Mentions/MentionComponent.vue
@@ -4,7 +4,7 @@
     class="d-d-inline-block"
   >
     <dt-link
-      kind="mention"
+      tone="mention"
       @click.prevent="handleClick"
       @mouseenter="handleMouseEnter"
       @mouseleave="handleMouseLeave"


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3536

## :book: Description

Updates docs, stories, fixtures, and component code that still referenced legacy Dialtone Vue prop names/values from the component-props migration: kind/type=danger|error|success -> critical|positive, dt-link kind -> tone, title/banner-title -> header-text/banner-header-text, selectedValues -> model-value on DtCheckboxGroup, and `@input` -> `@update:model-value` on DtInput consumers.

Two of these were live bugs, not just stale docs: DtNotice/DtToast's title prop and DtInput's input event were both fully removed with no deprecated alias, so a few examples and ComboboxMultiSelect.vue's internal input handler had silently stopped working.

Three files from the ticket's original location list no longer exist (removed by DLT-3537's recipes cleanup).

## :bulb: Context

Follow-up cleanup from the component-props migration to keep current-usage examples aligned with dialtone-migrate-props output.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
- [x] I have added / updated unit tests.
