### PR TITLE
chore(android): NO-JIRA Fix isPercentToken function

### DIFF
--- a/packages/dialtone-tokens/dialtone-transforms.js
+++ b/packages/dialtone-tokens/dialtone-transforms.js
@@ -40,8 +40,10 @@ export const isLineHeightToken = (token) => {
   return lowerPath.includes('lineheight');
 };
 
-// percent tokens (e.g. size.100-percent -> "100%")
+// percent tokens (e.g. size.100-percent -> "100%", or size.radius.circle -> "50%").
+// excludes lineHeight tokens - those are handled by the lineHeight transform.
 export const isPercentToken = (token) => {
+  if (isLineHeightToken(token)) return false;
   const originalValue = token.original?.value ?? token.value;
   if (typeof originalValue === 'string' && originalValue.trim().endsWith('%')) return true;
   const lastSegment = token.path?.[token.path.length - 1]?.toLowerCase() ?? '';


### PR DESCRIPTION
## Summary
Fix regression introduced by https://github.com/dialpad/dialtone/pull/1377. Line height tokens were being incorrectly excluded from the android library.

## Test plan
- [x] Build and publish android library locally 
```
cd packages/dialtone-tokens
rm -rf dist
node build.js
```
```
cp ./AndroidManifest.xml dist/android/
./gradlew publishToMavenLocal -Pversion=2.0.0-next.6-DEV01
```
- [x] Confirm library contents are correct