### PR TITLE
feat(dialtone-css,dialtone): DLT-3556 add dialtone-merge-migrate CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   ],
   "bin": {
     "dialtone-migrate": "./dist/js/dialtone_migrate/index.mjs",
-    "dialtone-migrate-flex-to-stack": "./dist/js/dialtone_migrate_flex_to_stack/index.mjs"
+    "dialtone-migrate-flex-to-stack": "./dist/js/dialtone_migrate_flex_to_stack/index.mjs",
+    "dialtone-merge-migrate": "./dist/js/dialtone_merge_migrate/index.mjs"
   },
   "exports": {
     ".": {
@@ -95,16 +96,20 @@
     "@tiptap/extensions": "3.19",
     "@tiptap/pm": "3.19.0",
     "@tiptap/suggestion": "3.19.0",
+    "chalk": "^5.2.0",
     "date-fns": "4.1.0",
     "deep-equal": "2.2.3",
     "docopt": "0.6.2",
     "emoji-toolkit": "9.0.1",
     "globals": "16.3.0",
+    "globby": "^13.1.4",
+    "inquirer": "^9.1.5",
     "linkifyjs": "4.3.2",
     "overlayscrollbars": "2.10.0",
     "regex-combined-emojis": "1.6.0",
     "tippy.js": "6.3.7",
-    "vue-tsc": "3.2.6"
+    "vue-tsc": "3.2.6",
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",

--- a/packages/dialtone-css/lib/build/js/dialtone_merge_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_merge_migrate/index.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { normalize } from 'path';
+import { join, normalize } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs';
 import {
@@ -13,7 +14,7 @@ import {
 } from '../dialtone_migration_helper/helpers.mjs';
 import { runMergeMigration } from './merge-migrate.mjs';
 
-const CONFIG_FOLDER = new URL('../dialtone_migration_helper/configs', import.meta.url).pathname;
+const CONFIG_FOLDER = fileURLToPath(new URL('../dialtone_migration_helper/configs', import.meta.url));
 
 (async () => {
   const argv = yargs(hideBin(process.argv))
@@ -77,8 +78,10 @@ const CONFIG_FOLDER = new URL('../dialtone_migration_helper/configs', import.met
         `Unknown --config '${argv.config}'. Available configs: ` +
         configList.map((c) => c.value.replace(/\.mjs$/, '')).join(', '),
       );
+      return;
     }
-    [configData, configFile] = await readConfigFile(`${CONFIG_FOLDER}/${match.value}`);
+    [configData, configFile] = await readConfigFile(pathToFileURL(join(CONFIG_FOLDER, match.value)).href)
+      .catch((err) => error('readConfigFile: ' + err));
   } else {
     [configData, configFile] = await inquireForFile(CONFIG_FOLDER, configList).catch((err) =>
       error('inquireForFile: ' + err),
@@ -99,4 +102,4 @@ const CONFIG_FOLDER = new URL('../dialtone_migration_helper/configs', import.met
     getAllFileContents,
     modifyFileContents,
   });
-})();
+})().catch((err) => error(err.message || err));

--- a/packages/dialtone-css/lib/build/js/dialtone_merge_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_merge_migrate/index.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import { normalize } from 'path';
+import { hideBin } from 'yargs/helpers';
+import yargs from 'yargs';
+import {
+  error,
+  getAllFileContents,
+  getConfigFileList,
+  inquireForFile,
+  modifyFileContents,
+  readConfigFile,
+} from '../dialtone_migration_helper/helpers.mjs';
+import { runMergeMigration } from './merge-migrate.mjs';
+
+const CONFIG_FOLDER = new URL('../dialtone_migration_helper/configs', import.meta.url).pathname;
+
+(async () => {
+  const argv = yargs(hideBin(process.argv))
+    .scriptName('dialtone-merge-migrate')
+    .usage(
+      '$0 --config color-stops --merge-from staging\n\n' +
+      'Runs a dialtone_migration_helper migration config scoped only to files changed on\n' +
+      '--merge-from, relative to your currently checked out branch. Files changed only on\n' +
+      '--merge-from are safe to auto-migrate; files also touched on your current branch are\n' +
+      'flagged for manual review instead of being auto-rewritten.\n\n' +
+      'Use this when migrating a long-running branch to Dialtone 10 without clobbering\n' +
+      'manual edits your branch already made to the same files.',
+    )
+    .options({
+      config: {
+        type: 'string',
+        description: 'Migration config to run (filename in dialtone_migration_helper/configs, with or without .mjs). Prompts interactively if omitted.',
+      },
+      'merge-from': {
+        type: 'string',
+        description: 'Branch to scope the migration to.',
+        default: 'staging',
+      },
+      cwd: {
+        type: 'string',
+        description: 'Repository root to run against. Defaults to CWD.',
+        default: process.cwd(),
+      },
+      'dry-run': {
+        boolean: true,
+        description: 'Preview without modifying files.',
+        default: false,
+      },
+      force: {
+        boolean: true,
+        description: 'Skip the confirmation prompt before modifying safe files.',
+        default: false,
+      },
+      verbose: {
+        boolean: true,
+        description: 'Show line-level details for overlap files.',
+        default: false,
+      },
+    })
+    .help().argv;
+
+  const cwd = !argv.cwd ? process.cwd() : normalize(argv.cwd);
+
+  // resolve the config: from --config if provided, otherwise prompt from the list
+  const configList = await getConfigFileList(CONFIG_FOLDER).catch((err) =>
+    error('getConfigFileList: ' + err),
+  );
+
+  let configData;
+  let configFile;
+  if (argv.config) {
+    const requested = argv.config.endsWith('.mjs') ? argv.config : `${argv.config}.mjs`;
+    const match = configList.find((c) => c.value === requested);
+    if (!match) {
+      error(
+        `Unknown --config '${argv.config}'. Available configs: ` +
+        configList.map((c) => c.value.replace(/\.mjs$/, '')).join(', '),
+      );
+    }
+    [configData, configFile] = await readConfigFile(`${CONFIG_FOLDER}/${match.value}`);
+  } else {
+    [configData, configFile] = await inquireForFile(CONFIG_FOLDER, configList).catch((err) =>
+      error('inquireForFile: ' + err),
+    );
+  }
+
+  console.log(`\nConfiguration: ${configFile}`);
+
+  await runMergeMigration({
+    cwd,
+    sourceBranch: argv['merge-from'],
+    dryRun: argv['dry-run'],
+    force: argv.force,
+    verbose: argv.verbose,
+    config: configData,
+    configLabel: configFile.replace(/\.mjs$/, ''),
+    configPath: `dialtone_migration_helper/configs/${configFile}`,
+    getAllFileContents,
+    modifyFileContents,
+  });
+})();

--- a/packages/dialtone-css/lib/build/js/dialtone_merge_migrate/merge-migrate.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_merge_migrate/merge-migrate.mjs
@@ -1,0 +1,214 @@
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { createInterface } from 'readline';
+import path from 'path';
+
+const RELEVANT_EXTENSIONS = new Set([
+  '.css', '.less', '.html', '.vue', '.md',
+  '.js', '.ts', '.jsx', '.tsx',
+]);
+
+// ── git helpers ───────────────────────────────────────────────────────────────
+
+function git (cmd, cwd) {
+  try {
+    return execSync(`git ${cmd}`, { cwd, encoding: 'utf8' }).trim();
+  } catch {
+    return '';
+  }
+}
+
+// returns relative file paths changed between ref1 and ref2
+function getChangedFiles (ref1, ref2, cwd) {
+  const out = git(`diff --name-only --diff-filter=ACMR ${ref1}..${ref2}`, cwd);
+  return out ? out.split('\n').filter(Boolean) : [];
+}
+
+// returns lines added on the source side for a single file
+function getStagingAddedLines (mergeBase, sourceBranch, filePath, cwd) {
+  try {
+    // shell-quote the path to handle spaces/special characters
+    const quoted = `'${filePath.replace(/'/g, '\'\\\'\'')}'`;
+    const diff = execSync(
+      `git diff ${mergeBase}..${sourceBranch} -- ${quoted}`,
+      { cwd, encoding: 'utf8' },
+    );
+    return diff
+      .split('\n')
+      .filter(l => l.startsWith('+') && !l.startsWith('+++'))
+      .map(l => l.slice(1));
+  } catch {
+    return [];
+  }
+}
+
+// returns true if applying the migration expressions to `line` would produce a
+// different string (i.e., the line contains an old value that needs migrating)
+function lineNeedsMigration (line, expressions) {
+  return expressions.some(expr => {
+    // use a fresh regex copy to avoid lastIndex state issues with global regexes
+    const re = new RegExp(expr.from.source, expr.from.flags);
+    return line.replace(re, expr.to) !== line;
+  });
+}
+
+function confirm (question) {
+  return new Promise(resolve => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(question, answer => {
+      rl.close();
+      resolve(answer.trim().toLowerCase());
+    });
+  });
+}
+
+// splits files changed on the source branch into safe-to-auto-migrate
+// (source-only) vs. overlap (also changed on the current branch)
+function classifyFiles (stagingFiles, currentFiles, cwd) {
+  const safeFiles = [];
+  const overlapFiles = [];
+
+  for (const file of stagingFiles) {
+    if (!RELEVANT_EXTENSIONS.has(path.extname(file))) continue;
+    if (!existsSync(path.join(cwd, file))) continue; // deleted on this branch
+
+    if (currentFiles.has(file)) {
+      overlapFiles.push(file);
+    } else {
+      safeFiles.push(file);
+    }
+  }
+
+  return { safeFiles, overlapFiles };
+}
+
+async function migrateSafeFiles ({
+  safeFiles, cwd, dryRun, force, config, configLabel, getAllFileContents, modifyFileContents,
+}) {
+  if (safeFiles.length === 0) {
+    console.log('\nNo safe files to migrate.');
+    return;
+  }
+
+  console.log('\n── Safe Files ────────────────────────────────────────────────────────────────');
+  safeFiles.forEach(f => console.log(`  ${f}`));
+
+  if (dryRun) {
+    console.log(`\n[dry-run] Would run ${configLabel} migration on the above files.`);
+    return;
+  }
+
+  if (!force) {
+    const answer = await confirm(`\nProceed with ${configLabel} migration on safe files? [y/N] `);
+    if (answer !== 'y') {
+      console.log('Cancelled.');
+      process.exit(0);
+    }
+  }
+
+  console.log('\nRunning migration...');
+  const contents = await getAllFileContents(safeFiles, cwd);
+  await modifyFileContents(contents, config.expressions);
+  console.log('\nMigration complete for safe files.');
+}
+
+function reportOverlapFile ({ file, mergeBase, sourceBranch, cwd, config, configLabel, verbose }) {
+  const addedLines = getStagingAddedLines(mergeBase, sourceBranch, file, cwd);
+  const flaggedLines = addedLines.filter(line => lineNeedsMigration(line, config.expressions));
+
+  if (flaggedLines.length > 0) {
+    console.log(`\n  ${file}`);
+    console.log(`  → ${flaggedLines.length} ${sourceBranch}-added line(s) still need ${configLabel} migration`);
+    if (verbose) flaggedLines.forEach(line => console.log(`      + ${line}`));
+    return true;
+  }
+
+  if (verbose) console.log(`  ${file}: no ${configLabel} changes needed in ${sourceBranch}-added lines`);
+  return false;
+}
+
+function reportOverlapFiles ({ overlapFiles, mergeBase, sourceBranch, cwd, config, configLabel, configPath, verbose }) {
+  if (overlapFiles.length === 0) return;
+
+  console.log('\n── Overlap Files (manual review required) ────────────────────────────────────');
+  const anyNeedMigration = overlapFiles
+    .map(file => reportOverlapFile({ file, mergeBase, sourceBranch, cwd, config, configLabel, verbose }))
+    .some(Boolean);
+
+  if (!verbose) {
+    console.log('\nRe-run with --verbose to see the specific lines that need updating.');
+  }
+
+  if (anyNeedMigration) {
+    console.log(`\nAction required: manually apply the ${configLabel} migration in the flagged files above.`);
+    console.log(`Reference config: ${configPath}`);
+  } else {
+    console.log(`\nNo pending ${configLabel} changes in ${sourceBranch}-added lines — overlap files are clean.`);
+  }
+}
+
+/**
+ * Runs a dialtone_migration_helper config scoped only to files changed on a
+ * source branch, relative to the current branch checked out at `cwd`.
+ *
+ * Files changed only on the source branch are safe to auto-migrate. Files
+ * changed on both the source branch and the current branch are flagged for
+ * manual review, with line-level analysis of which source-added lines still
+ * need migrating.
+ *
+ * @param {object} params
+ * @param {string} params.cwd            Consumer repo root to run git/file operations against.
+ * @param {string} params.sourceBranch   Branch to scope the migration to (e.g. staging).
+ * @param {boolean} params.dryRun        Preview without modifying files.
+ * @param {boolean} params.force         Skip the confirmation prompt.
+ * @param {boolean} params.verbose       Show line-level details for overlap files.
+ * @param {object} params.config         Loaded migration config module (expressions, description, etc).
+ * @param {string} params.configLabel    Human label for this config, e.g. "color-stops".
+ * @param {string} params.configPath     Path to the config module, shown in the "reference MAP" message.
+ * @param {Function} params.getAllFileContents  From dialtone_migration_helper/helpers.mjs.
+ * @param {Function} params.modifyFileContents  From dialtone_migration_helper/helpers.mjs.
+ */
+export async function runMergeMigration ({
+  cwd,
+  sourceBranch,
+  dryRun,
+  force,
+  verbose,
+  config,
+  configLabel,
+  configPath,
+  getAllFileContents,
+  modifyFileContents,
+}) {
+  // 1. Compute merge base ──────────────────────────────────────────────────────
+  const mergeBase = git(`merge-base HEAD ${sourceBranch}`, cwd);
+  if (!mergeBase) {
+    console.error(`\nError: could not find merge base between HEAD and '${sourceBranch}'.`);
+    console.error(`Make sure '${sourceBranch}' is a valid branch and is fetched locally.\n`);
+    process.exit(1);
+  }
+
+  console.log(`\nMerge base : ${mergeBase.slice(0, 8)}`);
+  console.log(`Source     : ${sourceBranch}`);
+  if (dryRun) console.log('Mode       : dry-run (no files will be changed)');
+
+  // 2. Compute changed file sets ───────────────────────────────────────────────
+  const stagingFiles = new Set(getChangedFiles(mergeBase, sourceBranch, cwd));
+  const currentFiles = new Set(getChangedFiles(mergeBase, 'HEAD', cwd));
+
+  // 3. Classify files ──────────────────────────────────────────────────────────
+  const { safeFiles, overlapFiles } = classifyFiles(stagingFiles, currentFiles, cwd);
+
+  console.log(`\nSafe files   (${sourceBranch}-only, auto-migrate) : ${safeFiles.length}`);
+  console.log(`Overlap files (both branches, manual review) : ${overlapFiles.length}`);
+
+  // 4. Safe files — run migration ──────────────────────────────────────────────
+  await migrateSafeFiles({
+    safeFiles, cwd, dryRun, force, config, configLabel, getAllFileContents, modifyFileContents,
+  });
+
+  // 5. Overlap files — line-level analysis ─────────────────────────────────────
+  reportOverlapFiles({ overlapFiles, mergeBase, sourceBranch, cwd, config, configLabel, configPath, verbose });
+
+  console.log('');
+}

--- a/packages/dialtone-css/lib/build/js/dialtone_merge_migrate/merge-migrate.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_merge_migrate/merge-migrate.mjs
@@ -100,7 +100,7 @@ async function migrateSafeFiles ({
 
   if (!force) {
     const answer = await confirm(`\nProceed with ${configLabel} migration on safe files? [y/N] `);
-    if (answer !== 'y') {
+    if (answer !== 'y' && answer !== 'yes') {
       console.log('Cancelled.');
       process.exit(0);
     }

--- a/packages/dialtone-css/lib/build/js/dialtone_merge_migrate/merge-migrate.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_merge_migrate/merge-migrate.mjs
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { existsSync } from 'fs';
 import { createInterface } from 'readline';
 import path from 'path';
@@ -8,38 +8,39 @@ const RELEVANT_EXTENSIONS = new Set([
   '.js', '.ts', '.jsx', '.tsx',
 ]);
 
+// Large enough that changed-file lists / diffs from big repos or long-lived
+// branches don't overflow execFileSync's default 1MB maxBuffer, which would
+// otherwise throw and (via allowFailure) silently look like "no files".
+const GIT_MAX_BUFFER = 200 * 1024 * 1024;
+
 // ── git helpers ───────────────────────────────────────────────────────────────
 
-function git (cmd, cwd) {
+// Runs `git <args>` via execFileSync (argv array — no shell, no interpolation
+// or manual quoting needed for refs/paths). Failures propagate by default;
+// pass { allowFailure: true } to convert a failed command into an empty
+// string instead (used only for the merge-base existence check).
+function git (args, cwd, { allowFailure = false } = {}) {
   try {
-    return execSync(`git ${cmd}`, { cwd, encoding: 'utf8' }).trim();
-  } catch {
-    return '';
+    return execFileSync('git', args, { cwd, encoding: 'utf8', maxBuffer: GIT_MAX_BUFFER }).trim();
+  } catch (err) {
+    if (allowFailure) return '';
+    throw err;
   }
 }
 
 // returns relative file paths changed between ref1 and ref2
 function getChangedFiles (ref1, ref2, cwd) {
-  const out = git(`diff --name-only --diff-filter=ACMR ${ref1}..${ref2}`, cwd);
+  const out = git(['diff', '--name-only', '--diff-filter=ACMR', `${ref1}..${ref2}`], cwd);
   return out ? out.split('\n').filter(Boolean) : [];
 }
 
 // returns lines added on the source side for a single file
 function getStagingAddedLines (mergeBase, sourceBranch, filePath, cwd) {
-  try {
-    // shell-quote the path to handle spaces/special characters
-    const quoted = `'${filePath.replace(/'/g, '\'\\\'\'')}'`;
-    const diff = execSync(
-      `git diff ${mergeBase}..${sourceBranch} -- ${quoted}`,
-      { cwd, encoding: 'utf8' },
-    );
-    return diff
-      .split('\n')
-      .filter(l => l.startsWith('+') && !l.startsWith('+++'))
-      .map(l => l.slice(1));
-  } catch {
-    return [];
-  }
+  const diff = git(['diff', `${mergeBase}..${sourceBranch}`, '--', filePath], cwd);
+  return diff
+    .split('\n')
+    .filter(l => l.startsWith('+') && !l.startsWith('+++'))
+    .map(l => l.slice(1));
 }
 
 // returns true if applying the migration expressions to `line` would produce a
@@ -181,7 +182,7 @@ export async function runMergeMigration ({
   modifyFileContents,
 }) {
   // 1. Compute merge base ──────────────────────────────────────────────────────
-  const mergeBase = git(`merge-base HEAD ${sourceBranch}`, cwd);
+  const mergeBase = git(['merge-base', 'HEAD', sourceBranch], cwd, { allowFailure: true });
   if (!mergeBase) {
     console.error(`\nError: could not find merge base between HEAD and '${sourceBranch}'.`);
     console.error(`Make sure '${sourceBranch}' is a valid branch and is fetched locally.\n`);

--- a/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/color-stops.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migration_helper/configs/color-stops.mjs
@@ -10,6 +10,12 @@ const MAP = {
 };
 
 export default {
+  // Old and new stop numbers overlap (e.g. purple 250→300, but 300 is itself
+  // an old key that maps to 400, which maps to 600, then 950). The master
+  // migration script re-applies expressions to already-rewritten content
+  // until nothing changes; without singlePass that convergence loop cascades
+  // a single value through the whole chain in one run.
+  singlePass: true,
   description:
     'Migrates base color stops from old irregular numbering to the standard 12-stop scale.\n' +
     '- Renames var(--dt-color-{color}-{oldStop}) to var(--dt-color-{color}-{newStop})\n\t' +
@@ -17,7 +23,9 @@ export default {
     '- Renames d-{prefix}-{color}-{oldStop} utility classes\n\t' +
       'eg. d-bgc-purple-350 to d-bgc-purple-500\n' +
     '- Includes HSL variants (-h, -s, -l, -a, -hsl, -hsla) and OKLCH variants (-h, -c, -l, -a, -oklch, -oklcha)\n' +
-    '- Colors affected: purple, blue, magenta, gold, green, red. Other colors were already 12-stop.\n',
+    '- Colors affected: purple, blue, magenta, gold, green, red. Other colors were already 12-stop.\n' +
+    '- SAFE TO RE-RUN: singlePass prevents the master script\'s convergence loop from\n' +
+      'cascading a value through multiple stop hops in the same run.\n',
   patterns: ['**/*.{css,less,html,vue,md,js,ts,jsx,tsx}'],
   expressions: [
     // CSS custom properties: var(--dt-color-{color}-{stop}) with optional HSL/OKLCH suffix

--- a/packages/dialtone-css/package.json
+++ b/packages/dialtone-css/package.json
@@ -52,7 +52,8 @@
     "dialtone-health-check": "./lib/dist/js/dialtone_health_check/index.cjs",
     "dialtone-migrate": "./lib/dist/js/dialtone_migrate/index.mjs",
     "dialtone-migration-helper": "./lib/dist/js/dialtone_migration_helper/index.mjs",
-    "dialtone-migrate-flex-to-stack": "./lib/dist/js/dialtone_migrate_flex_to_stack/index.mjs"
+    "dialtone-migrate-flex-to-stack": "./lib/dist/js/dialtone_migrate_flex_to_stack/index.mjs",
+    "dialtone-merge-migrate": "./lib/dist/js/dialtone_merge_migrate/index.mjs"
   },
   "type": "module",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       '@tiptap/suggestion':
         specifier: 3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      chalk:
+        specifier: ^5.2.0
+        version: 5.6.2
       date-fns:
         specifier: 4.1.0
         version: 4.1.0
@@ -137,6 +140,12 @@ importers:
       globals:
         specifier: 16.3.0
         version: 16.3.0
+      globby:
+        specifier: ^13.1.4
+        version: 13.2.2
+      inquirer:
+        specifier: ^9.1.5
+        version: 9.3.8(@types/node@20.19.39)
       linkifyjs:
         specifier: 4.3.2
         version: 4.3.2
@@ -155,6 +164,9 @@ importers:
       vue-tsc:
         specifier: 3.2.6
         version: 3.2.6(typescript@5.9.3)
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
     devDependencies:
       '@commitlint/cli':
         specifier: ^18.4.3

--- a/scripts/merge-migrate-color-stops.mjs
+++ b/scripts/merge-migrate-color-stops.mjs
@@ -39,7 +39,7 @@ function stripPinnedFlags (args) {
   for (let i = 0; i < args.length; i++) {
     const [flag] = args[i].split('=');
     if (PINNED_FLAGS.has(flag)) {
-      if (!args[i].includes('=')) i++; // also skip the separate value token
+      if (!args[i].includes('=') && args[i + 1] && !args[i + 1].startsWith('-')) i++;
       continue;
     }
     result.push(args[i]);

--- a/scripts/merge-migrate-color-stops.mjs
+++ b/scripts/merge-migrate-color-stops.mjs
@@ -28,12 +28,31 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..');
 
+const PINNED_FLAGS = new Set(['--config', '--cwd']);
+
+// Strip any --config/--cwd the caller passed — this wrapper always pins them
+// to color-stops/REPO_ROOT. yargs collects duplicate string flags into an
+// array rather than "last wins", so simply appending the pinned flags after
+// caller args would corrupt parsing instead of overriding it.
+function stripPinnedFlags (args) {
+  const result = [];
+  for (let i = 0; i < args.length; i++) {
+    const [flag] = args[i].split('=');
+    if (PINNED_FLAGS.has(flag)) {
+      if (!args[i].includes('=')) i++; // also skip the separate value token
+      continue;
+    }
+    result.push(args[i]);
+  }
+  return result;
+}
+
 process.argv = [
   process.argv[0],
   process.argv[1],
+  ...stripPinnedFlags(process.argv.slice(2)),
   '--config', 'color-stops',
   '--cwd', REPO_ROOT,
-  ...process.argv.slice(2),
 ];
 
 await import(

--- a/scripts/merge-migrate-stack-gap.mjs
+++ b/scripts/merge-migrate-stack-gap.mjs
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 /**
- * merge-migrate-color-stops.mjs
+ * merge-migrate-stack-gap.mjs
  *
  * Thin repo-internal wrapper around the published `dialtone-merge-migrate`
  * CLI (packages/dialtone-css/lib/build/js/dialtone_merge_migrate), scoped to
- * the color-stops config and this monorepo's root as --cwd.
+ * the stack-gap-to-spacing config and this monorepo's root as --cwd.
  *
  * Usage:
- *   node scripts/merge-migrate-color-stops.mjs [options]
+ *   node scripts/merge-migrate-stack-gap.mjs [options]
  *
- * Options: same as `dialtone-merge-migrate --config color-stops`, e.g.
+ * Options: same as `dialtone-merge-migrate --config stack-gap-to-spacing`, e.g.
  *   --merge-from <branch>   Source branch (default: staging)
  *   --dry-run               Preview without modifying files
  *   --force                 Skip confirmation prompt
@@ -31,7 +31,7 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 process.argv = [
   process.argv[0],
   process.argv[1],
-  '--config', 'color-stops',
+  '--config', 'stack-gap-to-spacing',
   '--cwd', REPO_ROOT,
   ...process.argv.slice(2),
 ];

--- a/scripts/merge-migrate-stack-gap.mjs
+++ b/scripts/merge-migrate-stack-gap.mjs
@@ -28,12 +28,31 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..');
 
+const PINNED_FLAGS = new Set(['--config', '--cwd']);
+
+// Strip any --config/--cwd the caller passed — this wrapper always pins them
+// to stack-gap-to-spacing/REPO_ROOT. yargs collects duplicate string flags
+// into an array rather than "last wins", so simply appending the pinned
+// flags after caller args would corrupt parsing instead of overriding it.
+function stripPinnedFlags (args) {
+  const result = [];
+  for (let i = 0; i < args.length; i++) {
+    const [flag] = args[i].split('=');
+    if (PINNED_FLAGS.has(flag)) {
+      if (!args[i].includes('=')) i++; // also skip the separate value token
+      continue;
+    }
+    result.push(args[i]);
+  }
+  return result;
+}
+
 process.argv = [
   process.argv[0],
   process.argv[1],
+  ...stripPinnedFlags(process.argv.slice(2)),
   '--config', 'stack-gap-to-spacing',
   '--cwd', REPO_ROOT,
-  ...process.argv.slice(2),
 ];
 
 await import(


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Feature
- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3556

## :book: Description

- Adds `dialtone-merge-migrate --config <name> --merge-from <branch>`, a new bin exposed from both `@dialpad/dialtone-css` and `@dialpad/dialtone`. It scopes any `dialtone_migration_helper` config to files changed only on the merge source branch, and flags files changed on both branches for manual review instead of overwriting them.
- Adds `yargs`, `chalk`, `inquirer`, `globby` as root `@dialpad/dialtone` dependencies so the new bin resolves correctly for consumers who install the root package.
- Converts `scripts/merge-migrate-color-stops.mjs` and adds `scripts/merge-migrate-stack-gap.mjs` as thin wrappers around the new CLI, for this monorepo's own staging→next migration.
- Fixes a latent bug in `color-stops.mjs`: its old/new color stop numbers overlap (e.g. purple `250→300`, but `300` is itself an old key mapping further to `400→600→950`), so `dialtone-migrate`'s convergence loop could cascade a single value through the whole chain in one run instead of stopping at the correct stop. Adds `singlePass: true`, matching the guard already used by `stack-gap-to-spacing.mjs`.

## :bulb: Context

Consumers migrating long-running branches to Dialtone 10 need a way to run migrations without clobbering their own in-flight edits to files also touched by the merge source — this mirrors the existing internal `merge-migrate-color-stops.mjs` pattern and generalizes it into a public, documented tool.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

Follow-up scope tracked in DLT-3556: migration-guide docs for `dialtone-merge-migrate`, whether to promote `stack-gap-to-spacing` from opt-in, and test coverage for the new `dialtone_merge_migrate` module.