### PR TITLE
fix(dialtone-css): DLT-3557 remove colliding d-label size classes from components layer

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/forms.less
+++ b/packages/dialtone-css/lib/build/less/components/forms.less
@@ -9,7 +9,6 @@
 //  TABLE OF CONTENTS
 //  • FIELDSETS
 //  • LABELS
-//    - Sizes
 //  • DESCRIPTIONS
 //    - Sizes
 //  • VALIDATION MESSAGES
@@ -30,8 +29,7 @@ fieldset {
 //  ============================================================================
 //  $  LABELS
 //  ----------------------------------------------------------------------------
-.d-label,
-.d-label--md {
+.d-label {
   display: flex;
   flex: 1 0%;
   align-items: baseline;
@@ -43,24 +41,6 @@ fieldset {
   overflow-wrap: break-word;
 
   legend & { cursor: default; }
-}
-
-//  $$  SIZES
-//  ----------------------------------------------------------------------------
-.d-label--xs {
-  font-size: var(--dt-font-size-100);
-}
-
-.d-label--sm {
-  font-size: var(--dt-font-size-200);
-}
-
-.d-label--lg {
-  font-size: var(--dt-font-size-200);
-}
-
-.d-label--xl {
-  font-size: var(--dt-font-size-300);
 }
 
 //  ============================================================================


### PR DESCRIPTION
## Summary
- `forms.less` defined `.d-label--xs/--sm/--md/--lg/--xl` in `@layer dialtone.components`, colliding with the label typography utility classes of the same name in `@layer dialtone.base` (`typography.less`). The components-layer versions only overrode `font-size` instead of the full `font` shorthand, so combining both on the same element produced inconsistent styling.
- Removed the size modifiers and the `.d-label--md` alias from `forms.less`. `.d-label` remains as the base flex/layout rule; all `.d-label--*` size classes now resolve solely through the base typography utility.
- No in-repo usage combined `.d-label` with a size modifier to invoke the removed rules, so no first-party consumers are affected.

Kind of a breaking change since we are removing this class, but also not since the typography label classes of the same name will still set the styling of the label, which is likely intended for dt next anyways.

Jira: [DLT-3557](https://dialpad.atlassian.net/browse/DLT-3557) (epic DLT-3233)

[DLT-3557]: https://dialpad.atlassian.net/browse/DLT-3557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ