### PR TITLE
fix(message-input): DP-200077 disable text-align when rich-text is false

### DIFF
--- a/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.vue
+++ b/packages/dialtone-vue/recipes/conversation_view/message_input/message_input.vue
@@ -54,6 +54,7 @@
         :allow-codeblock="richText"
         :allow-italic="richText"
         :allow-strike="richText"
+        :allow-text-align="richText"
         :allow-underline="richText"
         :paste-rich-text="richText"
         :editable="editable"


### PR DESCRIPTION
# fix(message-input): DP-200077 disable text-align when rich-text is false

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DP-200077

## :book: Description

`DtRecipeMessageInput` wires every `allow-*` prop it forwards to `DtRichTextEditor` (`allow-blockquote`, `allow-bold`, `allow-bullet-list`, `allow-code`, `allow-codeblock`, `allow-italic`, `allow-strike`, `allow-underline`) to the `richText` prop, so setting `rich-text="false"` turns all of them off. `allow-text-align` was missing from that list, so it stayed at its default (`true`) even in plain-text mode. This adds `:allow-text-align="richText"` next to the other bindings.

## :bulb: Context

`@tiptap/extension-text-align` registers `Mod-Shift-l/e/r/j` for align left/center/right/justify and calls `preventDefault()` on those combos. With `rich-text="false"`, a consumer has no way to reach text alignment, but the shortcuts were still captured. In practice this meant `Cmd+Shift+R` inside a plain-text `DtRecipeMessageInput` got swallowed by "align right" instead of reloading the page.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [ ] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

None expected. Flagging in case any other `allow-*`-style prop is added in the future without being wired to `richText`.

## :link: Sources

None.