### PR TITLE
feat(scroller): DLT-2624 add before/after/empty slots and scroll-end events

### DIFF
--- a/apps/dialtone-documentation/docs/components/scroller.md
+++ b/apps/dialtone-documentation/docs/components/scroller.md
@@ -200,10 +200,11 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-scroller--de
 #### Infinite Scroll
 
 Use the `after` slot for a loading indicator that scrolls with the list, and `scroll-end` to fetch
-the next page. `scroll-end` fires when the last item enters the rendered view pool — one `buffer`
-length before the viewport floor — so the fetch starts before the user runs out of content.
+the next page. `scroll-end` fires when the last item enters the rendered view pool — at least one
+`buffer` length before the viewport's end edge, earlier still if `before`/`after` slot content adds
+to the window — so the fetch starts before the user runs out of content.
 
-`scroll-start` is the mirror image, for prepending older items.
+`scroll-start` is the mirror image, for prepending older items ahead of the viewport's start edge.
 
 The scroller recomputes its rendered window on mount and on scroll. It does not watch
 `items`, so after you append a page call `updateItems()` on the component ref — otherwise

--- a/apps/dialtone-documentation/docs/components/scroller.md
+++ b/apps/dialtone-documentation/docs/components/scroller.md
@@ -205,8 +205,13 @@ length before the viewport floor — so the fetch starts before the user runs ou
 
 `scroll-start` is the mirror image, for prepending older items.
 
+The scroller recomputes its rendered window on mount and on scroll. It does not watch
+`items`, so after you append a page call `updateItems()` on the component ref — otherwise
+the new rows will not appear until the next scroll.
+
 ```html
 <dt-scroller
+ ref="scroller"
  :items="items"
  :item-size="32"
  :buffer="400"
@@ -223,6 +228,19 @@ length before the viewport floor — so the fetch starts before the user runs ou
  </template>
 </dt-scroller>
 ```
+
+```js
+async function fetchNextPage () {
+  isFetching.value = true;
+  items.value.push(...await fetchMore());
+  isFetching.value = false;
+  await nextTick();
+  scroller.value.updateItems();
+}
+```
+
+The `empty` slot renders unconditionally whenever it is provided, so guard its contents with
+your own `v-if` if it should only appear once the list is confirmed empty.
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/scroller.md
+++ b/apps/dialtone-documentation/docs/components/scroller.md
@@ -249,8 +249,7 @@ async function fetchNextPage () {
 }
 ```
 
-The `empty` slot renders unconditionally whenever it is provided, so guard its contents with
-your own `v-if` if it should only appear once the list is confirmed empty.
+The `empty` slot only renders while the list is empty.
 
 ## Vue API
 

--- a/apps/dialtone-documentation/docs/components/scroller.md
+++ b/apps/dialtone-documentation/docs/components/scroller.md
@@ -235,12 +235,16 @@ the `updateItems()` call for you, and a reference watcher never sees an in-place
 
 ```js
 async function fetchNextPage () {
+  if (isFetching.value) return;
   isFetching.value = true;
-  const page = await fetchMore();
-  items.value = [...items.value, ...page];
-  isFetching.value = false;
-  await nextTick();
-  scroller.value.updateItems();
+  try {
+    const page = await fetchMore();
+    items.value = [...items.value, ...page];
+    await nextTick();
+    scroller.value.updateItems();
+  } finally {
+    isFetching.value = false;
+  }
 }
 ```
 

--- a/apps/dialtone-documentation/docs/components/scroller.md
+++ b/apps/dialtone-documentation/docs/components/scroller.md
@@ -209,6 +209,10 @@ The scroller recomputes its rendered window on mount and on scroll. It does not 
 `items`, so after you append a page call `updateItems()` on the component ref — otherwise
 the new rows will not appear until the next scroll.
 
+Assign a new array rather than mutating the existing one in place. The scroller itself does not
+mind either way, but watching `items` by reference is the usual way a wrapper component triggers
+the `updateItems()` call for you, and a reference watcher never sees an in-place `push`.
+
 ```html
 <dt-scroller
  ref="scroller"
@@ -232,7 +236,8 @@ the new rows will not appear until the next scroll.
 ```js
 async function fetchNextPage () {
   isFetching.value = true;
-  items.value.push(...await fetchMore());
+  const page = await fetchMore();
+  items.value = [...items.value, ...page];
   isFetching.value = false;
   await nextTick();
   scroller.value.updateItems();

--- a/apps/dialtone-documentation/docs/components/scroller.md
+++ b/apps/dialtone-documentation/docs/components/scroller.md
@@ -219,7 +219,7 @@ length before the viewport floor — so the fetch starts before the user runs ou
    </div>
  </template>
  <template #after>
-   <spinner v-if="isFetching" />
+   <dt-loader v-if="isFetching" />
  </template>
 </dt-scroller>
 ```

--- a/apps/dialtone-documentation/docs/components/scroller.md
+++ b/apps/dialtone-documentation/docs/components/scroller.md
@@ -197,6 +197,33 @@ storybook: https://dialtone.dialpad.com/vue/?path=/story/components-scroller--de
 </dt-scroller>
 ```
 
+#### Infinite Scroll
+
+Use the `after` slot for a loading indicator that scrolls with the list, and `scroll-end` to fetch
+the next page. `scroll-end` fires when the last item enters the rendered view pool — one `buffer`
+length before the viewport floor — so the fetch starts before the user runs out of content.
+
+`scroll-start` is the mirror image, for prepending older items.
+
+```html
+<dt-scroller
+ :items="items"
+ :item-size="32"
+ :buffer="400"
+ :scroller-height="200"
+ @scroll-end="fetchNextPage"
+ >
+ <template #default="{ item }">
+   <div class="user">
+     {{ item.name }}
+   </div>
+ </template>
+ <template #after>
+   <spinner v-if="isFetching" />
+ </template>
+</dt-scroller>
+```
+
 ## Vue API
 
 <component-vue-api component-name="scroller" />

--- a/packages/dialtone-vue/components/scroller/modules/core_scroller.vue
+++ b/packages/dialtone-vue/components/scroller/modules/core_scroller.vue
@@ -12,6 +12,7 @@
     <div
       v-if="$slots.before"
       ref="before"
+      data-qa="dt-scroller-before"
       class="vue-recycle-scroller__slot"
     >
       <!-- @slot Content rendered before the items, inside the scroll viewport. Scrolls with the list. -->
@@ -29,6 +30,7 @@
         :is="itemTag"
         v-for="view in pool"
         :key="view.nr.id"
+        data-qa="dt-scroller-item"
         :style="ready ? {
           transform: `translate${direction === 'vertical' ? 'Y' : 'X'}(${view.position}px) translate${direction === 'vertical' ? 'X' : 'Y'}(${view.offset}px)`,
           width: undefined,
@@ -60,6 +62,7 @@
     <div
       v-if="$slots.after"
       ref="after"
+      data-qa="dt-scroller-after"
       class="vue-recycle-scroller__slot"
     >
       <!-- @slot Content rendered after the items, inside the scroll viewport. Scrolls with the list. -->

--- a/packages/dialtone-vue/components/scroller/modules/core_scroller.vue
+++ b/packages/dialtone-vue/components/scroller/modules/core_scroller.vue
@@ -11,6 +11,7 @@
   >
     <div
       v-if="$slots.before"
+      ref="before"
       class="vue-recycle-scroller__slot"
     >
       <!-- @slot Content rendered before the items, inside the scroll viewport. Scrolls with the list. -->
@@ -58,6 +59,7 @@
 
     <div
       v-if="$slots.after"
+      ref="after"
       class="vue-recycle-scroller__slot"
     >
       <!-- @slot Content rendered after the items, inside the scroll viewport. Scrolls with the list. -->
@@ -185,6 +187,8 @@ const pool = ref([]);
 const hoverKey = ref(null);
 const ready = ref(false);
 const scroller = ref(null);
+const before = ref(null);
+const after = ref(null);
 const userPosition = ref('top');
 
 let startIndex = 0;
@@ -353,6 +357,12 @@ const _updateVisibleItems = (checkItem, checkPositionDiff = false) => {
     const _buffer = props.buffer;
     scroll.start -= _buffer;
     scroll.end += _buffer;
+
+    // The leading and trailing slots sit in normal flow inside the viewport, so the item
+    // wrapper does not start at offset 0. Widen the window by their measured size.
+    const slotSize = props.direction === 'vertical' ? 'scrollHeight' : 'scrollWidth';
+    if (before.value) scroll.start -= before.value[slotSize];
+    if (after.value) scroll.end += after.value[slotSize];
 
     // Variable size mode
     if (itemSize === null) {

--- a/packages/dialtone-vue/components/scroller/modules/core_scroller.vue
+++ b/packages/dialtone-vue/components/scroller/modules/core_scroller.vue
@@ -9,6 +9,14 @@
     }"
     @scroll.passive="handleScroll"
   >
+    <div
+      v-if="$slots.before"
+      class="vue-recycle-scroller__slot"
+    >
+      <!-- @slot Content rendered before the items, inside the scroll viewport. Scrolls with the list. -->
+      <slot name="before" />
+    </div>
+
     <component
       :is="listTag"
       ref="wrapper"
@@ -43,7 +51,18 @@
           :active="view.nr.used"
         />
       </component>
+
+      <!-- @slot Content rendered inside the list wrapper, after the items. Use for an empty state. -->
+      <slot name="empty" />
     </component>
+
+    <div
+      v-if="$slots.after"
+      class="vue-recycle-scroller__slot"
+    >
+      <!-- @slot Content rendered after the items, inside the scroll viewport. Scrolls with the list. -->
+      <slot name="after" />
+    </div>
   </div>
 </template>
 

--- a/packages/dialtone-vue/components/scroller/modules/core_scroller.vue
+++ b/packages/dialtone-vue/components/scroller/modules/core_scroller.vue
@@ -55,8 +55,11 @@
         />
       </component>
 
-      <!-- @slot Content rendered inside the list wrapper, after the items. Use for an empty state. -->
-      <slot name="empty" />
+      <!-- @slot Content rendered inside the list wrapper only while the list is empty. -->
+      <slot
+        v-if="!items.length"
+        name="empty"
+      />
     </component>
 
     <div

--- a/packages/dialtone-vue/components/scroller/modules/core_scroller.vue
+++ b/packages/dialtone-vue/components/scroller/modules/core_scroller.vue
@@ -156,7 +156,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['user-position']);
+const emit = defineEmits(['user-position', 'scroll-start', 'scroll-end']);
 
 const views = reactive(new Map());
 // const reactiveItems = reactive(props.items);
@@ -461,7 +461,7 @@ const _updateVisibleItems = (checkItem, checkPositionDiff = false) => {
     type = item.type;
 
     let unusedPool = _unusedViews.get(type);
-    // let newlyUsedView = false;
+    let newlyUsedView = false;
 
     // No view assigned to item
     if (!view) {
@@ -496,12 +496,12 @@ const _updateVisibleItems = (checkItem, checkPositionDiff = false) => {
       view.nr.type = type;
       _views.set(key, view);
 
-      // newlyUsedView = true;
+      newlyUsedView = true;
     } else {
       // View already assigned to item
       if (!view.nr.used) {
         view.nr.used = true;
-        // newlyUsedView = true;
+        newlyUsedView = true;
         if (unusedPool) {
           const index = unusedPool.indexOf(view);
           if (index !== -1) unusedPool.splice(index, 1);
@@ -512,11 +512,10 @@ const _updateVisibleItems = (checkItem, checkPositionDiff = false) => {
     // Always set item in case it's a new object with the same key
     view.item = item;
 
-    // if (newlyUsedView) {
-    //   if (items.length === 0) return;
-    //   if (i === items.length - 1) emit('scroll-end');
-    //   if (i === 0) emit('scroll-start');
-    // }
+    if (newlyUsedView) {
+      if (i === items.length - 1) emit('scroll-end');
+      if (i === 0) emit('scroll-start');
+    }
 
     // Update position
     if (itemSize === null) {

--- a/packages/dialtone-vue/components/scroller/modules/core_scroller.vue
+++ b/packages/dialtone-vue/components/scroller/modules/core_scroller.vue
@@ -23,6 +23,7 @@
       :is="listTag"
       ref="wrapper"
       :style="{ [direction === 'vertical' ? 'minHeight' : 'minWidth']: `${totalSize}px` }"
+      data-qa="dt-scroller-item-wrapper"
       class="vue-recycle-scroller__item-wrapper"
       :class="listClass"
     >

--- a/packages/dialtone-vue/components/scroller/modules/dynamic_scroller.vue
+++ b/packages/dialtone-vue/components/scroller/modules/dynamic_scroller.vue
@@ -30,6 +30,27 @@
         />
       </dt-scroller-item>
     </template>
+
+    <template
+      v-if="$slots.before"
+      #before
+    >
+      <slot name="before" />
+    </template>
+
+    <template
+      v-if="$slots.empty"
+      #empty
+    >
+      <slot name="empty" />
+    </template>
+
+    <template
+      v-if="$slots.after"
+      #after
+    >
+      <slot name="after" />
+    </template>
   </core-scroller>
 </template>
 

--- a/packages/dialtone-vue/components/scroller/scroller.stories.js
+++ b/packages/dialtone-vue/components/scroller/scroller.stories.js
@@ -11,6 +11,7 @@ export const argsData = {
   itemSize: 32,
   scrollerWidth: 300,
   scrollerHeight: 200,
+  buffer: 200,
   onScrollStart: action('scroll-start'),
   onScrollEnd: action('scroll-end'),
   onUserPosition: action('user-position'),

--- a/packages/dialtone-vue/components/scroller/scroller.stories.js
+++ b/packages/dialtone-vue/components/scroller/scroller.stories.js
@@ -104,6 +104,51 @@ export const argTypesData = {
       type: { summary: 'event' },
     },
   },
+
+  'scroll-start': {
+    description: 'Emitted when the first item enters the rendered view pool, one buffer length ' +
+      'before the top of the viewport is reached.',
+    table: {
+      type: { summary: 'event' },
+    },
+  },
+
+  'scroll-end': {
+    description: 'Emitted when the last item enters the rendered view pool, one buffer length ' +
+      'before the bottom of the viewport is reached. Use it to append more items.',
+    table: {
+      type: { summary: 'event' },
+    },
+  },
+
+  before: {
+    control: { type: null },
+    description: 'Content rendered before the items, inside the scroll viewport. Scrolls with the list.',
+    table: {
+      type: { summary: 'VNode' },
+    },
+  },
+
+  after: {
+    control: { type: null },
+    description: 'Content rendered after the items, inside the scroll viewport. Scrolls with the list.',
+    table: {
+      type: { summary: 'VNode' },
+    },
+  },
+
+  empty: {
+    control: { type: null },
+    description: 'Content rendered inside the list wrapper, after the items. Use for an empty state.',
+    table: {
+      type: { summary: 'VNode' },
+    },
+  },
+
+  buffer: {
+    control: { type: 'number' },
+    defaultValue: 200,
+  },
 };
 
 export default {

--- a/packages/dialtone-vue/components/scroller/scroller.stories.js
+++ b/packages/dialtone-vue/components/scroller/scroller.stories.js
@@ -107,16 +107,17 @@ export const argTypesData = {
   },
 
   'scroll-start': {
-    description: 'Emitted when the first item enters the rendered view pool, one buffer length ' +
-      'before the top of the viewport is reached.',
+    description: 'Emitted when the first item enters the rendered view pool, at least one buffer ' +
+      'length before the viewport\'s start edge (earlier still with `before` slot content).',
     table: {
       type: { summary: 'event' },
     },
   },
 
   'scroll-end': {
-    description: 'Emitted when the last item enters the rendered view pool, one buffer length ' +
-      'before the bottom of the viewport is reached. Use it to append more items.',
+    description: 'Emitted when the last item enters the rendered view pool, at least one buffer ' +
+      'length before the viewport\'s end edge (earlier still with `after` slot content). Use it ' +
+      'to append more items.',
     table: {
       type: { summary: 'event' },
     },

--- a/packages/dialtone-vue/components/scroller/scroller.stories.js
+++ b/packages/dialtone-vue/components/scroller/scroller.stories.js
@@ -141,7 +141,7 @@ export const argTypesData = {
 
   empty: {
     control: { type: null },
-    description: 'Content rendered inside the list wrapper, after the items. Use for an empty state.',
+    description: 'Content rendered inside the list wrapper only while the list is empty.',
     table: {
       type: { summary: 'VNode' },
     },

--- a/packages/dialtone-vue/components/scroller/scroller.test.js
+++ b/packages/dialtone-vue/components/scroller/scroller.test.js
@@ -6,6 +6,32 @@ const MOCK_ITEMS = Array.from({ length: 20 }, (_, i) => ({
   name: `User ${i}`,
 }));
 
+// jsdom doesn't compute layout — mock the scroll dimensions the props imply
+// (20 items x itemSize 30 = 600 of content in a 60px viewport) so the render
+// pool can actually reach the last item.
+const originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+const originalScrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+
+function mockScrollDimensions () {
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get () { return 60; },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get () { return 600; },
+  });
+}
+
+function restoreScrollDimensions () {
+  if (originalClientHeight) {
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', originalClientHeight);
+  }
+  if (originalScrollHeight) {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight);
+  }
+}
+
 const baseProps = {
   items: MOCK_ITEMS,
   itemSize: 30,
@@ -79,6 +105,44 @@ describe('DtScroller Tests', () => {
         wrapper.trigger('scroll');
 
         expect(wrapper.emitted()['user-position'][2]).toEqual(['bottom']);
+      });
+    });
+
+    describe('Should emit scroll boundary events', () => {
+      beforeEach(() => {
+        // Must be mocked before mounting — the pool is first computed in onMounted.
+        mockScrollDimensions();
+        updateWrapper();
+      });
+
+      afterEach(() => {
+        restoreScrollDimensions();
+      });
+
+      it('`scroll-end` when the last item enters the render pool', () => {
+        expect(wrapper.emitted()['scroll-end']).toBeUndefined();
+
+        defaultContent.element.scrollTop =
+          defaultContent.element.scrollHeight - defaultContent.element.clientHeight;
+        wrapper.trigger('scroll');
+
+        expect(wrapper.emitted()['scroll-end']).toBeTruthy();
+      });
+
+      it('`scroll-start` when the first item re-enters the render pool', () => {
+        // 240 is chosen so the window starts at index 1 (240 - buffer 200 = 40, over
+        // itemSize 30) while still overlapping the mount window — the algorithm only
+        // releases off-window views on a continuous move, and a view must be released
+        // before it can count as newly used again.
+        defaultContent.element.scrollTop = 240;
+        wrapper.trigger('scroll');
+
+        const beforeReturn = wrapper.emitted()['scroll-start'].length;
+
+        defaultContent.element.scrollTop = 0;
+        wrapper.trigger('scroll');
+
+        expect(wrapper.emitted()['scroll-start'].length).toBeGreaterThan(beforeReturn);
       });
     });
 

--- a/packages/dialtone-vue/components/scroller/scroller.test.js
+++ b/packages/dialtone-vue/components/scroller/scroller.test.js
@@ -207,12 +207,31 @@ describe('DtScroller Tests', () => {
         expect(after.exists()).toBe(true);
         expect(after.element.parentElement.getAttribute('data-qa')).toBe('dt-scroller-after');
       });
+    });
 
-      it('renders the empty slot inside the item wrapper', () => {
+    describe('When the empty slot is provided and the list is empty', () => {
+      beforeEach(() => {
+        mockProps = { items: [] };
+        mockSlots = { empty: '<div class="empty-content">Empty</div>' };
+        updateWrapper();
+      });
+
+      it('renders the empty slot content inside the item wrapper', () => {
         const empty = wrapper.find('.empty-content');
 
         expect(empty.exists()).toBe(true);
         expect(empty.element.closest('.vue-recycle-scroller__item-wrapper')).not.toBeNull();
+      });
+    });
+
+    describe('When the empty slot is provided and the list is populated', () => {
+      beforeEach(() => {
+        mockSlots = { empty: '<div class="empty-content">Empty</div>' };
+        updateWrapper();
+      });
+
+      it('does not render the empty slot content', () => {
+        expect(wrapper.find('.empty-content').exists()).toBe(false);
       });
     });
 

--- a/packages/dialtone-vue/components/scroller/scroller.test.js
+++ b/packages/dialtone-vue/components/scroller/scroller.test.js
@@ -198,14 +198,14 @@ describe('DtScroller Tests', () => {
         const before = wrapper.find('.before-content');
 
         expect(before.exists()).toBe(true);
-        expect(before.element.parentElement.classList.contains('vue-recycle-scroller__slot')).toBe(true);
+        expect(before.element.parentElement.getAttribute('data-qa')).toBe('dt-scroller-before');
       });
 
       it('renders the after slot in a scroller slot wrapper', () => {
         const after = wrapper.find('.after-content');
 
         expect(after.exists()).toBe(true);
-        expect(after.element.parentElement.classList.contains('vue-recycle-scroller__slot')).toBe(true);
+        expect(after.element.parentElement.getAttribute('data-qa')).toBe('dt-scroller-after');
       });
 
       it('renders the empty slot inside the item wrapper', () => {
@@ -218,7 +218,8 @@ describe('DtScroller Tests', () => {
 
     describe('When no before or after slot is provided', () => {
       it('renders no empty slot wrapper', () => {
-        expect(wrapper.find('.vue-recycle-scroller__slot').exists()).toBe(false);
+        expect(wrapper.find('[data-qa="dt-scroller-before"]').exists()).toBe(false);
+        expect(wrapper.find('[data-qa="dt-scroller-after"]').exists()).toBe(false);
       });
     });
 
@@ -249,7 +250,7 @@ describe('DtScroller Tests', () => {
         defaultContent.element.scrollTop = 300;
         await wrapper.trigger('scroll');
 
-        const firstItem = wrapper.findAll('.vue-recycle-scroller__item-view')
+        const firstItem = wrapper.findAll('[data-qa="dt-scroller-item"]')
           .find((item) => item.text().trim() === 'User 0');
 
         expect(firstItem).toBeTruthy();
@@ -280,7 +281,8 @@ describe('DtScroller Tests', () => {
       });
 
       it('renders no empty slot wrapper', () => {
-        expect(wrapper.find('.vue-recycle-scroller__slot').exists()).toBe(false);
+        expect(wrapper.find('[data-qa="dt-scroller-before"]').exists()).toBe(false);
+        expect(wrapper.find('[data-qa="dt-scroller-after"]').exists()).toBe(false);
       });
     });
   });

--- a/packages/dialtone-vue/components/scroller/scroller.test.js
+++ b/packages/dialtone-vue/components/scroller/scroller.test.js
@@ -222,6 +222,41 @@ describe('DtScroller Tests', () => {
       });
     });
 
+    describe('When a before slot occupies space in the scroll viewport', () => {
+      beforeEach(() => {
+        // Must be mocked before mounting — the pool is first computed in onMounted.
+        mockScrollDimensions();
+        mockSlots = {
+          before: '<div class="before-content">Before</div>',
+        };
+        updateWrapper();
+      });
+
+      afterEach(() => {
+        restoreScrollDimensions();
+
+        // Confirm the mock actually came off, rather than trusting the delete/restore
+        // logic silently — a leaked mock would make every later test see clientHeight 60.
+        expect(document.createElement('div').clientHeight).toBe(0);
+      });
+
+      it('renders the first item once the before slot size is accounted for', async () => {
+        // The mocked before wrapper reports the same 600px scrollHeight as the mocked
+        // clientHeight/scrollHeight of every element, so scrolling to 300 only keeps the
+        // first item (index 0) in the render pool if its size is subtracted from the
+        // window. Otherwise the window starts further down the list and index 0 gets
+        // recycled away to represent a later item instead.
+        defaultContent.element.scrollTop = 300;
+        await wrapper.trigger('scroll');
+
+        const firstItem = wrapper.findAll('.vue-recycle-scroller__item-view')
+          .find((item) => item.text().trim() === 'User 0');
+
+        expect(firstItem).toBeTruthy();
+        expect(firstItem.element.style.transform).toContain('translateY(0px)');
+      });
+    });
+
     describe('When in dynamic mode', () => {
       beforeEach(() => {
         mockProps = { dynamic: true, minItemSize: 54, itemSize: undefined, buffer: 350 };

--- a/packages/dialtone-vue/components/scroller/scroller.test.js
+++ b/packages/dialtone-vue/components/scroller/scroller.test.js
@@ -163,4 +163,56 @@ describe('DtScroller Tests', () => {
       });
     });
   });
+
+  describe('Slot Tests', () => {
+    describe('When before, after and empty slots are provided', () => {
+      beforeEach(() => {
+        mockSlots = {
+          before: '<div class="before-content">Before</div>',
+          after: '<div class="after-content">After</div>',
+          empty: '<div class="empty-content">Empty</div>',
+        };
+        updateWrapper();
+      });
+
+      it('renders the before slot in a scroller slot wrapper', () => {
+        const before = wrapper.find('.before-content');
+
+        expect(before.exists()).toBe(true);
+        expect(before.element.parentElement.classList.contains('vue-recycle-scroller__slot')).toBe(true);
+      });
+
+      it('renders the after slot in a scroller slot wrapper', () => {
+        const after = wrapper.find('.after-content');
+
+        expect(after.exists()).toBe(true);
+        expect(after.element.parentElement.classList.contains('vue-recycle-scroller__slot')).toBe(true);
+      });
+
+      it('renders the empty slot inside the item wrapper', () => {
+        const empty = wrapper.find('.empty-content');
+
+        expect(empty.exists()).toBe(true);
+        expect(empty.element.closest('.vue-recycle-scroller__item-wrapper')).not.toBeNull();
+      });
+    });
+
+    describe('When no before or after slot is provided', () => {
+      it('renders no empty slot wrapper', () => {
+        expect(wrapper.find('.vue-recycle-scroller__slot').exists()).toBe(false);
+      });
+    });
+
+    describe('When in dynamic mode', () => {
+      beforeEach(() => {
+        mockProps = { dynamic: true, minItemSize: 54, itemSize: undefined };
+        mockSlots = { after: '<div class="after-content">After</div>' };
+        updateWrapper();
+      });
+
+      it('forwards the after slot', () => {
+        expect(wrapper.find('.after-content').exists()).toBe(true);
+      });
+    });
+  });
 });

--- a/packages/dialtone-vue/components/scroller/scroller.test.js
+++ b/packages/dialtone-vue/components/scroller/scroller.test.js
@@ -220,7 +220,7 @@ describe('DtScroller Tests', () => {
         const empty = wrapper.find('.empty-content');
 
         expect(empty.exists()).toBe(true);
-        expect(empty.element.closest('.vue-recycle-scroller__item-wrapper')).not.toBeNull();
+        expect(empty.element.closest('[data-qa="dt-scroller-item-wrapper"]')).not.toBeNull();
       });
     });
 

--- a/packages/dialtone-vue/components/scroller/scroller.test.js
+++ b/packages/dialtone-vue/components/scroller/scroller.test.js
@@ -26,9 +26,13 @@ function mockScrollDimensions () {
 function restoreScrollDimensions () {
   if (originalClientHeight) {
     Object.defineProperty(HTMLElement.prototype, 'clientHeight', originalClientHeight);
+  } else {
+    delete HTMLElement.prototype.clientHeight;
   }
   if (originalScrollHeight) {
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight);
+  } else {
+    delete HTMLElement.prototype.scrollHeight;
   }
 }
 
@@ -117,6 +121,10 @@ describe('DtScroller Tests', () => {
 
       afterEach(() => {
         restoreScrollDimensions();
+
+        // Confirm the mock actually came off, rather than trusting the delete/restore
+        // logic silently — a leaked mock would make every later test see clientHeight 60.
+        expect(document.createElement('div').clientHeight).toBe(0);
       });
 
       it('`scroll-end` when the last item enters the render pool', () => {

--- a/packages/dialtone-vue/components/scroller/scroller.test.js
+++ b/packages/dialtone-vue/components/scroller/scroller.test.js
@@ -224,13 +224,28 @@ describe('DtScroller Tests', () => {
 
     describe('When in dynamic mode', () => {
       beforeEach(() => {
-        mockProps = { dynamic: true, minItemSize: 54, itemSize: undefined };
+        mockProps = { dynamic: true, minItemSize: 54, itemSize: undefined, buffer: 350 };
         mockSlots = { after: '<div class="after-content">After</div>' };
         updateWrapper();
       });
 
       it('forwards the after slot', () => {
         expect(wrapper.find('.after-content').exists()).toBe(true);
+      });
+
+      it('forwards the buffer prop to the inner CoreScroller', () => {
+        expect(wrapper.findComponent(CoreScroller).props('buffer')).toBe(350);
+      });
+    });
+
+    describe('When in dynamic mode with no before, empty or after slots provided', () => {
+      beforeEach(() => {
+        mockProps = { dynamic: true, minItemSize: 54, itemSize: undefined };
+        updateWrapper();
+      });
+
+      it('renders no empty slot wrapper', () => {
+        expect(wrapper.find('.vue-recycle-scroller__slot').exists()).toBe(false);
       });
     });
   });

--- a/packages/dialtone-vue/components/scroller/scroller.test.js
+++ b/packages/dialtone-vue/components/scroller/scroller.test.js
@@ -92,8 +92,15 @@ describe('DtScroller Tests', () => {
         updateWrapper();
       });
 
-      it('passes the buffer down to the underlying scroller', () => {
+      it('declares buffer as its own prop and passes it to the underlying scroller', () => {
+        expect(wrapper.props('buffer')).toBe(500);
         expect(wrapper.findComponent(CoreScroller).props('buffer')).toBe(500);
+      });
+    });
+
+    describe('When no buffer is provided', () => {
+      it('defaults the buffer to 200', () => {
+        expect(wrapper.props('buffer')).toBe(200);
       });
     });
   });

--- a/packages/dialtone-vue/components/scroller/scroller.test.js
+++ b/packages/dialtone-vue/components/scroller/scroller.test.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import DtScroller from './scroller.vue';
+import CoreScroller from './modules/core_scroller.vue';
 
 const MOCK_ITEMS = Array.from({ length: 20 }, (_, i) => ({
   id: i,
@@ -82,6 +83,17 @@ describe('DtScroller Tests', () => {
 
       it('scroller content should render correctly', () => {
         expect(defaultContent.exists()).toBe(true);
+      });
+    });
+
+    describe('When a buffer is provided', () => {
+      beforeEach(() => {
+        mockProps = { buffer: 500 };
+        updateWrapper();
+      });
+
+      it('passes the buffer down to the underlying scroller', () => {
+        expect(wrapper.findComponent(CoreScroller).props('buffer')).toBe(500);
       });
     });
   });

--- a/packages/dialtone-vue/components/scroller/scroller.vue
+++ b/packages/dialtone-vue/components/scroller/scroller.vue
@@ -41,7 +41,7 @@
       v-if="$slots.empty"
       #empty
     >
-      <!-- @slot Content rendered inside the list wrapper, after the items. Use for an empty state. -->
+      <!-- @slot Content rendered inside the list wrapper only while the list is empty. -->
       <slot name="empty" />
     </template>
 

--- a/packages/dialtone-vue/components/scroller/scroller.vue
+++ b/packages/dialtone-vue/components/scroller/scroller.vue
@@ -183,14 +183,16 @@ const emits = defineEmits([
   'user-position',
 
   /**
-   * Emitted when the first item enters the rendered view pool. Fires one `buffer` length
-   * before the top of the viewport is reached, so callers can prepend items ahead of time.
+   * Emitted when the first item enters the rendered view pool. Fires at least one `buffer`
+   * length before the viewport's start edge is reached (earlier still with `before` slot
+   * content), so callers can prepend items ahead of time.
    */
   'scroll-start',
 
   /**
-   * Emitted when the last item enters the rendered view pool. Fires one `buffer` length
-   * before the bottom of the viewport is reached, so callers can append items ahead of time.
+   * Emitted when the last item enters the rendered view pool. Fires at least one `buffer`
+   * length before the viewport's end edge is reached (earlier still with `after` slot
+   * content), so callers can append items ahead of time.
    */
   'scroll-end',
 ]);

--- a/packages/dialtone-vue/components/scroller/scroller.vue
+++ b/packages/dialtone-vue/components/scroller/scroller.vue
@@ -6,6 +6,7 @@
     :items="items"
     :item-size="itemSize"
     :min-item-size="minItemSize"
+    :buffer="buffer"
     :direction="direction"
     :key-field="keyField"
     :list-tag="listTag"
@@ -64,6 +65,16 @@ defineOptions({
 });
 
 const props = defineProps({
+  /**
+      * Amount of pixels added to each edge of the scroll viewport, so items are rendered
+      * before they scroll into view. Also controls how early `scroll-start` and `scroll-end`
+      * fire relative to the viewport edges.
+     */
+  buffer: {
+    type: Number,
+    default: 200,
+  },
+
   /**
       * The direction of the scroller.
       * @values vertical, horizontal

--- a/packages/dialtone-vue/components/scroller/scroller.vue
+++ b/packages/dialtone-vue/components/scroller/scroller.vue
@@ -13,6 +13,8 @@
     :style="computedStyle"
     tabindex="0"
     @user-position="$emit('user-position', $event)"
+    @scroll-start="$emit('scroll-start')"
+    @scroll-end="$emit('scroll-end')"
   >
     <template
       #default="{ item, index, active }"
@@ -144,6 +146,18 @@ const emits = defineEmits([
    * @values start, middle, end
    */
   'user-position',
+
+  /**
+   * Emitted when the first item enters the rendered view pool. Fires one `buffer` length
+   * before the top of the viewport is reached, so callers can prepend items ahead of time.
+   */
+  'scroll-start',
+
+  /**
+   * Emitted when the last item enters the rendered view pool. Fires one `buffer` length
+   * before the bottom of the viewport is reached, so callers can append items ahead of time.
+   */
+  'scroll-end',
 ]);
 
 provide('emit', emits);

--- a/packages/dialtone-vue/components/scroller/scroller.vue
+++ b/packages/dialtone-vue/components/scroller/scroller.vue
@@ -27,6 +27,30 @@
         }"
       />
     </template>
+
+    <template
+      v-if="$slots.before"
+      #before
+    >
+      <!-- @slot Content rendered before the items, inside the scroll viewport. Scrolls with the list. -->
+      <slot name="before" />
+    </template>
+
+    <template
+      v-if="$slots.empty"
+      #empty
+    >
+      <!-- @slot Content rendered inside the list wrapper, after the items. Use for an empty state. -->
+      <slot name="empty" />
+    </template>
+
+    <template
+      v-if="$slots.after"
+      #after
+    >
+      <!-- @slot Content rendered after the items, inside the scroll viewport. Scrolls with the list. -->
+      <slot name="after" />
+    </template>
   </component>
 </template>
 

--- a/packages/dialtone-vue/components/scroller/scroller_default.story.vue
+++ b/packages/dialtone-vue/components/scroller/scroller_default.story.vue
@@ -36,6 +36,7 @@
       :list-tag="$attrs.listTag"
       :item-tag="$attrs.itemTag"
       :direction="$attrs.direction"
+      :buffer="$attrs.buffer"
       @user-position="$attrs.onUserPosition($event); userPosition = $event"
       @scroll-start="$attrs.onScrollStart()"
       @scroll-end="$attrs.onScrollEnd()"
@@ -46,7 +47,10 @@
         </div>
       </template>
       <template #after>
-        <div class="loading">
+        <div
+          v-if="isFetching"
+          class="loading"
+        >
           Loading more…
         </div>
       </template>
@@ -68,6 +72,10 @@ const scroller = ref('scroller');
 const autoScrolling = ref(false);
 
 const userPosition = ref(null);
+
+// Demonstrates the documented pattern for the `after` slot: guard it with your
+// own flag rather than relying on the scroller to show or hide it for you.
+const isFetching = ref(true);
 
 let intervalId;
 

--- a/packages/dialtone-vue/components/scroller/scroller_default.story.vue
+++ b/packages/dialtone-vue/components/scroller/scroller_default.story.vue
@@ -37,10 +37,17 @@
       :item-tag="$attrs.itemTag"
       :direction="$attrs.direction"
       @user-position="$attrs.onUserPosition($event); userPosition = $event"
+      @scroll-start="$attrs.onScrollStart()"
+      @scroll-end="$attrs.onScrollEnd()"
     >
       <template #default="{ item }">
         <div class="user">
           {{ item.name }}
+        </div>
+      </template>
+      <template #after>
+        <div class="loading">
+          Loading more…
         </div>
       </template>
     </dt-scroller>
@@ -117,6 +124,12 @@ function switchAutoScrolling () {
   display: flex;
   align-items: center;
   border-bottom: 1px solid #eee;
+}
+
+.loading {
+  padding: 8px 12px;
+  color: #666;
+  font-style: italic;
 }
 
 .autoscrolling{

--- a/packages/dialtone-vue/components/scroller/scroller_default.story.vue
+++ b/packages/dialtone-vue/components/scroller/scroller_default.story.vue
@@ -49,7 +49,7 @@
       <template #after>
         <div
           v-if="isFetching"
-          class="loading"
+          class="d-p8 d-fc-muted d-helper--md"
         >
           Loading more…
         </div>
@@ -132,12 +132,6 @@ function switchAutoScrolling () {
   display: flex;
   align-items: center;
   border-bottom: 1px solid #eee;
-}
-
-.loading {
-  padding: 8px 12px;
-  color: #666;
-  font-style: italic;
 }
 
 .autoscrolling{


### PR DESCRIPTION
## Obligatory GIF (super important!)

![Obligatory GIF](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExMmV5cmxpZ2lzNmhudXlwZGY2bHNxam9xbW9ha2p4em1mdmU5NWFrciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/OCqWD6mIrcMQl5YQUB/giphy.gif)

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [ ] Fix
- [x] Feature
- [ ] Performance Improvement
- [ ] Refactor

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-2624

## :book: Description

Adds the slots and events `DtScroller` was missing, so consumers can build infinite-scrolling lists on it.

- **`before`, `after` and `empty` slots.** Positioned exactly as upstream `vue-virtual-scroller` places them: `before` and `after` render inside a `.vue-recycle-scroller__slot` wrapper as siblings of the item wrapper, `empty` renders inside the wrapper after the items. The CSS for those wrappers already shipped in `dialtone-css`, so there is no CSS change here. Every forward is guarded by `v-if="$slots.<name>"` at all three layers, so no empty wrapper element renders when a consumer passes nothing.
- **`scroll-end` and `scroll-start` events**, restored from the vendored upstream code that had been commented out in `core_scroller.vue`. They fire when the last or first item enters the rendered view pool — one `buffer` length before the viewport edge — so a consumer can prefetch before the user runs out of content. `user-position` is unchanged.
- **`buffer` promoted to a declared prop.** It previously reached `CoreScroller` only through attribute fallthrough: functional, but untyped, undocumented, and liable to break silently if anyone added `inheritAttrs: false`.
- **Docs and Storybook.** New Infinite Scroll section on the docs page, `argTypes` entries for the new slots and events, and the `buffer` control is now actually bound in the Default story (it was previously declared but inert).

## :bulb: Context

`DtScroller` is a vendored fork of `vue-virtual-scroller` that kept only the `default` slot. Any consumer needing a loading indicator pinned to the end of a virtualised list — the standard infinite-scroll pattern — had no way to render one inside the scroll viewport, and no event telling it when to fetch. That left applications on the third-party library instead of the design system.

The docs also now cover something that was previously undocumented and easy to trip over: `DtScroller` recomputes its rendered window only on mount and on scroll, so it does not react to `items` changing on its own. Consumers have to call `updateItems()` after appending a page, and should assign a new array rather than mutating in place. This has caught more than one consumer, so it is written down now with a worked example.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

The two accessibility boxes are deliberately unticked — see Next Steps.

## :crystal_ball: Next Steps

- **Restoring the upstream `items` watcher in `core_scroller.vue`** would remove the need for consumers to call `updateItems()` at all. It was deliberately left out of scope here: it is a behaviour change to a shared component and deserves its own ticket. The commented-out original shows why it was disabled — prepending and appending need different recompute calls to avoid the scroll position jumping, and only the caller knows which happened.

## :camera: Screenshots / GIFs

The Default story in Storybook covers this: it is fixed-height with 50 items, logs `scroll-start` / `scroll-end` to the actions panel, and renders a loading indicator in the `after` slot. Scrolling to the floor there exercises the whole path — event timing, slot placement, and that the indicator scrolls with the list rather than being pinned.

## :link: Sources

- Upstream slot placement and emit conditions: https://github.com/Akryum/vue-virtual-scroller
