### PR TITLE
fix(tab-group): DLT-3564 emit target panel id on before-change

### DIFF
--- a/packages/dialtone-vue/components/Tab/TabGroup.test.js
+++ b/packages/dialtone-vue/components/Tab/TabGroup.test.js
@@ -239,6 +239,11 @@ describe('DtTabGroup Tests', () => {
       it('should emitted on click', () => {
         expect(wrapper.emitted('before-change').length).toBe(1);
       });
+
+      it('should emit the target panel id as the second argument', () => {
+        const [, payload] = wrapper.emitted('before-change')[0];
+        expect(payload).toEqual({ selected: optionTabs[1].panelId });
+      });
     });
 
     describe('Correct key navigation', () => {

--- a/packages/dialtone-vue/components/Tab/TabGroup.test.js
+++ b/packages/dialtone-vue/components/Tab/TabGroup.test.js
@@ -232,16 +232,21 @@ describe('DtTabGroup Tests', () => {
     });
 
     describe('Correct before-change event', () => {
+      let clickEvent;
+
       beforeEach(() => {
-        returnFirstEl(tabs.at(1).vm.$el).click();
+        const tabEl = returnFirstEl(tabs.at(1).vm.$el);
+        tabEl.addEventListener('click', (event) => { clickEvent = event; });
+        tabEl.click();
       });
 
       it('should emitted on click', () => {
         expect(wrapper.emitted('before-change').length).toBe(1);
       });
 
-      it('should emit the target panel id as the second argument', () => {
-        const [, payload] = wrapper.emitted('before-change')[0];
+      it('should emit the originating event and the target panel id, in order', () => {
+        const [event, payload] = wrapper.emitted('before-change')[0];
+        expect(event).toBe(clickEvent);
         expect(payload).toEqual({ selected: optionTabs[1].panelId });
       });
     });

--- a/packages/dialtone-vue/components/Tab/TabGroup.test.js
+++ b/packages/dialtone-vue/components/Tab/TabGroup.test.js
@@ -245,9 +245,7 @@ describe('DtTabGroup Tests', () => {
       });
 
       it('should emit the originating event and the target panel id, in order', () => {
-        const [event, payload] = wrapper.emitted('before-change')[0];
-        expect(event).toBe(clickEvent);
-        expect(payload).toEqual({ selected: optionTabs[1].panelId });
+        expect(wrapper.emitted('before-change')[0]).toEqual([clickEvent, { selected: optionTabs[1].panelId }]);
       });
     });
 

--- a/packages/dialtone-vue/components/Tab/TabGroup.vue
+++ b/packages/dialtone-vue/components/Tab/TabGroup.vue
@@ -228,7 +228,8 @@ export default {
     'change',
 
     /**
-     * Before change tab event with the event argument, useful to perform validations and prevent changing tabs if neccessary.
+     * Before change tab event, useful to perform validations and prevent changing tabs if neccessary.
+     * Emits the originating DOM event, followed by an object with the target tab's panel id as `selected`.
      *
      * @event before-change
      * @type {Event}
@@ -473,7 +474,8 @@ export default {
       if (this.tabItems[index]?.isDisabled) return;
       if (this.provideObj.selected === this.tabItems[index]?.panelId) return;
 
-      this.$emit('before-change', event);
+      const { panelId } = this.tabItems[index];
+      this.$emit('before-change', event, { selected: panelId });
       if (event.defaultPrevented) return;
 
       // Prevent keyboard defaults (Space scroll, Enter form submit)

--- a/packages/dialtone-vue/components/Tab/TabGroup.vue
+++ b/packages/dialtone-vue/components/Tab/TabGroup.vue
@@ -228,11 +228,11 @@ export default {
     'change',
 
     /**
-     * Before change tab event, useful to perform validations and prevent changing tabs if neccessary.
-     * Emits the originating DOM event, followed by an object with the target tab's panel id as `selected`.
+     * Before change tab event, useful to perform validations and prevent changing tabs if necessary.
      *
      * @event before-change
-     * @type {Event}
+     * @property {Event} event The originating DOM event; call `event.preventDefault()` to cancel the change.
+     * @property {Object} payload Contains the target tab's panel id as `selected`.
      */
     'before-change',
   ],


### PR DESCRIPTION
# fix(tab-group): DLT-3564 emit target panel id on before-change

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

[DLT-3564](https://dialpad.atlassian.net/browse/DLT-3564)

## :book: Description

`DtTabGroup`'s `before-change` event now emits a second argument, `{ selected: panelId }`, alongside the original DOM event. This is backward compatible — existing consumers reading only the first argument are unaffected.

## :bulb: Context

Consumers that need to know the destination tab before allowing a tab change (e.g. to intercept navigation and show a save/discard confirmation) previously had no direct way to get the target panel from `before-change` — only the raw DOM event was emitted. This forced workarounds parsing `aria-controls` off the event target to recover the panel id (see [Firespotter PR review comment](https://github.com/dialpad/firespotter/pull/79806#discussion_r3729999180)). With the target id available directly on the event payload, that workaround can be removed downstream.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

Once this lands, Firespotter's `app_settings.vue` can drop its `tabNameFromEvent`/`PANEL_ID_PREFIX`/`aria-controls`-parsing workaround in favor of reading `selected` from the second `before-change` argument.

## :link: Sources

- [Firespotter PR #79806, review comment](https://github.com/dialpad/firespotter/pull/79806#discussion_r3729999180)

[DLT-3564]: https://dialpad.atlassian.net/browse/DLT-3564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ