### PR TITLE
fix(avatar): DP-200415 prevent presence indicators from clipping avatar content

### DIFF
--- a/apps/dialtone-documentation/docs/scratch.md
+++ b/apps/dialtone-documentation/docs/scratch.md
@@ -89,6 +89,129 @@ layout: Blank
   </dt-stack>
 <!-- ============================================================ -->
 
+<dt-stack gap="100">
+  <dt-stack direction="row" align="start" gap="100">
+    <dt-stack align="center" gap="50">
+      <dt-text variant="body-xs" size="50">200</dt-text>
+      <dt-avatar :size="200" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    </dt-stack>
+    <dt-stack align="center" gap="50">
+      <dt-text variant="body-xs" size="50">200</dt-text>
+      <dt-avatar :size="200" presence="away" seed="user-2" full-name="Marshall Mathers" />
+    </dt-stack>
+    <dt-stack align="center" gap="50">
+      <dt-text variant="body-xs" size="50">250</dt-text>
+      <dt-avatar :size="250" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    </dt-stack>
+    <dt-stack align="center" gap="50">
+      <dt-text variant="body-xs" size="50">250</dt-text>
+      <dt-avatar :size="250" presence="away" seed="user-2" full-name="Marshall Mathers" />
+    </dt-stack>
+    <dt-stack align="center" gap="50">
+      <dt-text variant="body-xs" size="50">300</dt-text>
+      <dt-avatar :size="300" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    </dt-stack>
+    <dt-stack align="center" gap="50">
+      <dt-text variant="body-xs" size="50">300</dt-text>
+      <dt-avatar :size="300" presence="busy" seed="user-3" full-name="Marshall Mathers" />
+    </dt-stack>
+    <dt-stack align="center" gap="50">
+      <dt-text variant="body-xs" size="50">400</dt-text>
+      <dt-avatar :size="400" presence="dnd" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    </dt-stack>
+    <dt-stack align="center" gap="50">
+      <dt-text variant="body-xs" size="50">400</dt-text>
+      <dt-avatar :size="400" presence="dnd" seed="user-4" full-name="Marshall Mathers" />
+    </dt-stack>
+    <dt-stack align="center" gap="50">
+      <dt-text variant="body-xs" size="50">500</dt-text>
+      <dt-avatar :size="500" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    </dt-stack>
+    <dt-stack align="center" gap="50">
+      <dt-text variant="body-xs" size="50">500</dt-text>
+      <dt-avatar :size="500" presence="offline" seed="user-5" full-name="Marshall Mathers" />
+    </dt-stack>
+  </dt-stack>
+</dt-stack>
+<dt-stack gap="200">
+  <dt-stack gap="300" direction="row" align="start">
+    <dt-stack direction="row" align="center" gap="100">
+      <dt-presence presence="active" />
+      <dt-presence presence="busy" />
+      <dt-presence presence="away" />
+      <dt-presence presence="offline" />
+    </dt-stack>
+    <dt-stack direction="row" align="center" gap="100">
+      <dt-avatar :size="200" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="200" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="200" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="200" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    </dt-stack>
+    <dt-stack direction="row" align="center" gap="100">
+      <dt-avatar :size="250" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="250" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="250" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="250" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    </dt-stack>
+    <dt-stack direction="row" align="center" gap="100">
+      <dt-avatar :size="300" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="300" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="300" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="300" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    </dt-stack>
+    <dt-stack direction="row" align="center" gap="100">
+      <dt-avatar :size="400" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="400" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="400" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="400" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    </dt-stack>
+    <dt-stack direction="row" align="center" gap="100">
+      <dt-avatar :size="500" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="500" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="500" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+      <dt-avatar :size="500" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
+    </dt-stack>
+  </dt-stack>
+  <dt-stack gap="300" direction="row" align="start">
+    <dt-stack direction="row" align="center" gap="100">
+      <dt-presence presence="active" />
+      <dt-presence presence="busy" />
+      <dt-presence presence="away" />
+      <dt-presence presence="offline" />
+    </dt-stack>
+    <dt-stack direction="row" align="center" gap="100">
+      <dt-avatar :size="200" presence="active" full-name="Layla El-Sayed" />
+      <dt-avatar :size="200" presence="busy" full-name="Luca Ferrari" />
+      <dt-avatar :size="200" presence="away" full-name="Nia Griffiths" />
+      <dt-avatar :size="200" presence="offline" full-name="Hana Horvat" />
+    </dt-stack>
+    <dt-stack direction="row" align="center" gap="100">
+      <dt-avatar :size="250" presence="active" full-name="Layla El-Sayed" />
+      <dt-avatar :size="250" presence="busy" full-name="Luca Ferrari" />
+      <dt-avatar :size="250" presence="away" full-name="Nia Griffiths" />
+      <dt-avatar :size="250" presence="offline" full-name="Hana Horvat" />
+    </dt-stack>
+    <dt-stack direction="row" align="center" gap="100">
+      <dt-avatar :size="300" presence="active" full-name="Arjun Iyer" />
+      <dt-avatar :size="300" presence="busy" full-name="Min-jun Jeong" />
+      <dt-avatar :size="300" presence="away" full-name="Zofia Kowalska" />
+      <dt-avatar :size="300" presence="offline" full-name="Mateo López" />
+    </dt-stack>
+    <dt-stack direction="row" align="center" gap="100">
+      <dt-avatar :size="400" presence="active" full-name="Zanele Mbeki" />
+      <dt-avatar :size="400" presence="busy" full-name="Chidi Nwosu" />
+      <dt-avatar :size="400" presence="away" full-name="Aoife O'Sullivan" />
+      <dt-avatar :size="400" presence="offline" full-name="Inês Pereira" />
+    </dt-stack>
+    <dt-stack direction="row" align="center" gap="100">
+      <dt-avatar :size="500" presence="active" full-name="Lian Qiao" />
+      <dt-avatar :size="500" presence="busy" full-name="Priya Raman" />
+      <dt-avatar :size="500" presence="away" full-name="Leila Saleh" />
+      <dt-avatar :size="500" presence="offline" full-name="Sione Tui" />
+    </dt-stack>
+  </dt-stack>
+</dt-stack>
+
 <p>
   A sentence goes here
   <dt-chip interactive size="200"> <template #icon> <dt-icon name="box-select" size="200" /> </template> Chip </dt-chip>
@@ -260,47 +383,6 @@ layout: Blank
     </dt-stack>
   </dt-box>
 </dt-stack>
-<!-- ============================================================ -->
-<dt-box padding="300">
-  <dt-stack gap="300" direction="row">
-    <dt-stack direction="row" align="center" gap="100">
-      <dt-presence presence="active" />
-      <dt-presence presence="busy" />
-      <dt-presence presence="away" />
-      <dt-presence presence="offline" />
-    </dt-stack>
-    <dt-stack direction="row" align="center" gap="100">
-      <dt-avatar :size="100" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="100" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="100" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="100" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-    </dt-stack>
-    <dt-stack direction="row" align="center" gap="100">
-      <dt-avatar :size="200" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="200" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="200" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="200" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-    </dt-stack>
-    <dt-stack direction="row" align="center" gap="100">
-      <dt-avatar :size="300" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="300" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="300" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="300" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-    </dt-stack>
-    <dt-stack direction="row" align="center" gap="100">
-      <dt-avatar :size="400" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="400" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="400" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="400" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-    </dt-stack>
-    <dt-stack direction="row" align="center" gap="100">
-      <dt-avatar :size="500" presence="active" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="500" presence="busy" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="500" presence="away" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-      <dt-avatar :size="500" presence="offline" image-src="/assets/images/person.png" image-alt="Person Avatar" />
-    </dt-stack>
-  </dt-stack>
-</dt-box>
 
 <!-- ============================================================ -->
 <!-- DtBox V1 Demos                                                -->

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -191,10 +191,10 @@
         position: absolute;
         background-color: var(--dt-color-neutral-white);
         border-radius: var(--avatar-border-radius);
-        opacity: 0.5;
+        opacity: var(--dt-opacity-700);
         content: '';
         pointer-events: none;
-        inset: 0;
+        inset: var(--dt-spacing-0);
       }
     }
   }
@@ -304,7 +304,7 @@
   &--clickable {
     --avatar-color-border: var(--dt-color-neutral-transparent);
 
-    padding: 0;
+    padding: var(--dt-spacing-0);
     background-color: var(--dt-color-neutral-transparent);
     border: var(--dt-size-border-0) solid var(--avatar-color-border);
     border-radius: var(--avatar-border-radius);
@@ -395,8 +395,8 @@
     --avatar-size-shape: calc(var(--dt-layout-100) * 0.75);
     --avatar-presence-shape: calc(var(--avatar-size-shape) * 0.32);
     --avatar-size-text: var(--dt-font-size-300);
-    --avatar-presence-position-right: 0;
-    --avatar-presence-position-bottom: 0;
+    --avatar-presence-position-right: var(--dt-spacing-0);
+    --avatar-presence-position-bottom: var(--dt-spacing-0);
     --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Cpath fill='white' d='M42 0C45.3137 0 48 2.68629 48 6V30.5377H34.8C32.149 30.5377 30 32.6867 30 35.3377V48H6C2.68629 48 0 45.3137 0 42V6C0 2.68629 2.68629 0 6 0H42Z'/%3E%3C/svg%3E");
   }
 

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -29,8 +29,8 @@
   --avatar-border-radius: calc(var(--avatar-size-shape) * 0.125);
   --avatar-presence-shape: calc(var(--avatar-size-shape) * 0.375);
   --avatar-presence-border-radius: calc(var(--avatar-border-radius) * 0.625);
-  --avatar-presence-position-right: var(--dt-spacing-0);
-  --avatar-presence-position-bottom: var(--dt-spacing-0);
+  --avatar-presence-position-right: var(--dt-spacing-25-negative);
+  --avatar-presence-position-bottom: var(--dt-spacing-25-negative);
   --avatar-icon-size: calc(var(--avatar-size-shape) * 0.625);
   --avatar-count-color-shadow: var(--dt-shell-color-surface-default);
 
@@ -349,51 +349,66 @@
   &--size-100 {
     --avatar-size-shape: calc(var(--dt-layout-100) * 0.25);
     --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath fill='white' d='M12.8 0c1.12 0 1.68 0 2.108.218a2 2 0 0 1 .874.874C16 1.52 16 2.08 16 3.2v5.3h-3.5c-1.4 0-2.1 0-2.635.272a2.5 2.5 0 0 0-1.093 1.093C8.5 10.4 8.5 11.1 8.5 12.5V16H3.2c-1.12 0-1.68 0-2.108-.218a2 2 0 0 1-.874-.874C0 14.48 0 13.92 0 12.8V3.2c0-1.12 0-1.68.218-2.108a2 2 0 0 1 .874-.874C1.52 0 2.08 0 3.2 0z'/%3E%3C/svg%3E");
+    --avatar-presence-position-right: var(--dt-spacing-0);
+    --avatar-presence-position-bottom: var(--dt-spacing-0);
   }
 
   &--size-150 {
     --avatar-size-shape: calc(var(--dt-layout-100) * 0.3125);
     --avatar-size-text: var(--dt-font-size-100);
-    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpath fill='white' d='M16 0c1.4 0 2.1 0 2.635.272a2.5 2.5 0 0 1 1.092 1.093C20 1.9 20 2.6 20 4v6.63h-4.37c-1.75 0-2.626 0-3.294.34-.588.3-1.066.778-1.365 1.366-.34.668-.341 1.544-.341 3.294V20H4c-1.4 0-2.1 0-2.635-.273a2.5 2.5 0 0 1-1.093-1.092C0 18.1 0 17.4 0 16V4c0-1.4 0-2.1.272-2.635A2.5 2.5 0 0 1 1.365.272C1.9 0 2.6 0 4 0z'/%3E%3C/svg%3E");
+    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpath fill='white' d='M16 0c1.4 0 2.1 0 2.635.272a2.5 2.5 0 0 1 1.092 1.093C20 1.9 20 2.6 20 4v6.63h-4.37c-1.75 0-2.626 0-3.294.34-.588.3-1.066.778-1.365 1.366-.34.668-.341 1.544-.341 3.294V20H4c-1.4 0-2.1 0-2.635-.273a2.5 2.5 0 0 1-1.093-1.092C0 18.1 0 17.4 0 16V4c0-1.4 0-2.1.272-2.635A2.5 2.5 0 0 1 1.365.272C1.9 0 2.6 0 4 0z'/%3E%3C/svg%3E");
+    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpath fill='white' d='M17.5 0C18.8807 0 20 1.11929 20 2.5V12.5908H14.5C13.3956 12.5908 12.5003 13.4855 12.5 14.5898V20H2.5C1.11929 20 0 18.8807 0 17.5V2.5C0 1.11929 1.11929 0 2.5 0H17.5Z'/%3E%3C/svg%3E");
   }
 
   &--sm,
   &--size-200 {
     --avatar-size-shape: calc(var(--dt-layout-100) * 0.375);
     --avatar-size-text: var(--dt-font-size-100);
-    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath fill='white' d='M19.2 0c1.68 0 2.52 0 3.162.327a3 3 0 0 1 1.31 1.31C24 2.28 24 3.12 24 4.8v7.95h-5.25c-2.1 0-3.15 0-3.952.41a3.74 3.74 0 0 0-1.639 1.638c-.409.802-.409 1.852-.409 3.952V24H4.8c-1.68 0-2.52 0-3.162-.327a3 3 0 0 1-1.31-1.31C0 21.72 0 20.88 0 19.2V4.8c0-1.68 0-2.52.327-3.162a3 3 0 0 1 1.31-1.31C2.28 0 3.12 0 4.8 0z'/%3E%3C/svg%3E");
+    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath fill='white' d='M19.2 0c1.68 0 2.52 0 3.162.327a3 3 0 0 1 1.31 1.31C24 2.28 24 3.12 24 4.8v7.95h-5.25c-2.1 0-3.15 0-3.952.41a3.74 3.74 0 0 0-1.639 1.638c-.409.802-.409 1.852-.409 3.952V24H4.8c-1.68 0-2.52 0-3.162-.327a3 3 0 0 1-1.31-1.31C0 21.72 0 20.88 0 19.2V4.8c0-1.68 0-2.52.327-3.162a3 3 0 0 1 1.31-1.31C2.28 0 3.12 0 4.8 0z'/%3E%3C/svg%3E");
+    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath fill='white' d='M21 0C22.65685 0 24 1.34315 24 3V15H17.4C16.07452 15 15 16.07452 15 17.4V24H3C1.34315 24 0 22.65685 0 21V3C0 1.34315 1.34315 0 3 0H21Z'/%3E%3C/svg%3E");
   }
 
   &--size-250 {
     --avatar-size-shape: calc(var(--dt-layout-100) * 0.4375);
-    --avatar-size-text: var(--dt-font-size-200);
-    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 28 28'%3E%3Cpath fill='white' d='M22.4 0c1.96 0 2.94 0 3.689.382a3.5 3.5 0 0 1 1.53 1.53C27.998 2.66 28 3.64 28 5.6v9.28h-6.12c-2.45 0-3.676 0-4.611.476a4.38 4.38 0 0 0-1.913 1.913c-.476.935-.476 2.16-.476 4.61V28H5.6c-1.96 0-2.94 0-3.689-.382a3.5 3.5 0 0 1-1.53-1.53C.002 25.34 0 24.36 0 22.4V5.6c0-1.96 0-2.94.382-3.69A3.5 3.5 0 0 1 1.912.38C2.66.002 3.64 0 5.6 0z'/%3E%3C/svg%3E");
+    --avatar-size-text: var(--dt-font-size-125);
+    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 28 28'%3E%3Cpath fill='white' d='M22.4 0c1.96 0 2.94 0 3.689.382a3.5 3.5 0 0 1 1.53 1.53C27.998 2.66 28 3.64 28 5.6v9.28h-6.12c-2.45 0-3.676 0-4.611.476a4.38 4.38 0 0 0-1.913 1.913c-.476.935-.476 2.16-.476 4.61V28H5.6c-1.96 0-2.94 0-3.689-.382a3.5 3.5 0 0 1-1.53-1.53C.002 25.34 0 24.36 0 22.4V5.6c0-1.96 0-2.94.382-3.69A3.5 3.5 0 0 1 1.912.38C2.66.002 3.64 0 5.6 0z'/%3E%3C/svg%3E");
+    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 28 28'%3E%3Cpath fill='white' d='M24.5 0C26.433 0 28 1.567 28 3.5V17.5H20.3C18.7536 17.5 17.5 18.7536 17.5 20.3V28H3.5C1.567 28 0 26.433 0 24.5V3.5C0 1.567 1.567 0 3.5 0H24.5Z'/%3E%3C/svg%3E");
   }
 
   &--md,
   &--size-300 {
     --avatar-size-text: var(--dt-font-size-200);
-    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='white' d='M25.6 0c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.749 1.748C32 3.039 32 4.16 32 6.4V17h-7c-2.8 0-4.2 0-5.27.545a5 5 0 0 0-2.185 2.185C17 20.8 17 22.2 17 25v7H6.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C0 28.961 0 27.84 0 25.6V6.4c0-2.24 0-3.36.436-4.216A4 4 0 0 1 2.184.436C3.039 0 4.16 0 6.4 0z'/%3E%3C/svg%3E");
+    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='white' d='M25.6 0c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.749 1.748C32 3.039 32 4.16 32 6.4V17h-7c-2.8 0-4.2 0-5.27.545a5 5 0 0 0-2.185 2.185C17 20.8 17 22.2 17 25v7H6.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C0 28.961 0 27.84 0 25.6V6.4c0-2.24 0-3.36.436-4.216A4 4 0 0 1 2.184.436C3.039 0 4.16 0 6.4 0z'/%3E%3C/svg%3E");
+    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='white' d='M28 0C30.20914 0 32 1.79086 32 4V20H23.2C21.43269 20 20 21.43269 20 23.2V32H4C1.79086 32 0 30.20914 0 28V4C0 1.79086 1.79086 0 4 0H28Z'/%3E%3C/svg%3E");
   }
 
   &--size-400 {
     --avatar-size-shape: calc(var(--dt-layout-100) * 0.625);
-    --avatar-size-text: var(--dt-font-size-200);
-    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3E%3Cpath fill='white' d='M32 0c2.8 0 4.2 0 5.27.545a5 5 0 0 1 2.185 2.185C40 3.8 40 5.2 40 8v13.25h-8.75c-3.5 0-5.25 0-6.588.682a6.25 6.25 0 0 0-2.73 2.73C21.25 26 21.25 27.75 21.25 31.25V40H8c-2.8 0-4.2 0-5.27-.545A5 5 0 0 1 .545 37.27C0 36.2 0 34.8 0 32V8c0-2.8 0-4.2.545-5.27A5 5 0 0 1 2.73.545C3.8 0 5.2 0 8 0z'/%3E%3C/svg%3E");
+    --avatar-presence-shape: calc(var(--avatar-size-shape) * 0.32);
+    --avatar-size-text: var(--dt-font-size-250);
+    --avatar-presence-position-right: 0;
+    --avatar-presence-position-bottom: 0;
+    // --avatar-presence-position-right: calc(var(--dt-spacing-50-negative) - var(--dt-spacing-1-negative));
+    // --avatar-presence-position-bottom: calc(var(--dt-spacing-50-negative) - var(--dt-spacing-1-negative));
+    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3E%3Cpath fill='white' d='M32 0c2.8 0 4.2 0 5.27.545a5 5 0 0 1 2.185 2.185C40 3.8 40 5.2 40 8v13.25h-8.75c-3.5 0-5.25 0-6.588.682a6.25 6.25 0 0 0-2.73 2.73C21.25 26 21.25 27.75 21.25 31.25V40H8c-2.8 0-4.2 0-5.27-.545A5 5 0 0 1 .545 37.27C0 36.2 0 34.8 0 32V8c0-2.8 0-4.2.545-5.27A5 5 0 0 1 2.73.545C3.8 0 5.2 0 8 0z'/%3E%3C/svg%3E");
+    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3E%3Cpath fill='white' d='M35 0C37.7614 0 40 2.23858 40 5V25.4986H29C26.7909 25.4986 25 27.2895 25 29.4986V40H5C2.23858 40 0 37.7614 0 35V5C0 2.23858 2.23858 0 5 0H35Z'/%3E%3C/svg%3E");
   }
 
   &--lg,
   &--size-500 {
     --avatar-size-shape: calc(var(--dt-layout-100) * 0.75);
+    --avatar-presence-shape: calc(var(--avatar-size-shape) * 0.32);
     --avatar-size-text: var(--dt-font-size-300);
-    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Cpath fill='white' d='M38.4 0c3.36 0 5.04 0 6.324.654a6 6 0 0 1 2.622 2.622C48 4.56 48 6.24 48 9.6v15.9H37.5c-4.2 0-6.3 0-7.905.817a7.5 7.5 0 0 0-3.278 3.278C25.5 31.199 25.5 33.3 25.5 37.5V48H9.6c-3.36 0-5.04 0-6.324-.654a6 6 0 0 1-2.622-2.622C0 43.44 0 41.76 0 38.4V9.6c0-3.36 0-5.04.654-6.324A6 6 0 0 1 3.276.654C4.56 0 6.24 0 9.6 0z'/%3E%3C/svg%3E");
+    --avatar-presence-position-right: 0;
+    --avatar-presence-position-bottom: 0;
+    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Cpath fill='white' d='M38.4 0c3.36 0 5.04 0 6.324.654a6 6 0 0 1 2.622 2.622C48 4.56 48 6.24 48 9.6v15.9H37.5c-4.2 0-6.3 0-7.905.817a7.5 7.5 0 0 0-3.278 3.278C25.5 31.199 25.5 33.3 25.5 37.5V48H9.6c-3.36 0-5.04 0-6.324-.654a6 6 0 0 1-2.622-2.622C0 43.44 0 41.76 0 38.4V9.6c0-3.36 0-5.04.654-6.324A6 6 0 0 1 3.276.654C4.56 0 6.24 0 9.6 0z'/%3E%3C/svg%3E");
+    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Cpath fill='white' d='M42 0C45.3137 0 48 2.68629 48 6V30.5377H34.8C32.149 30.5377 30 32.6867 30 35.3377V48H6C2.68629 48 0 45.3137 0 42V6C0 2.68629 2.68629 0 6 0H42Z'/%3E%3C/svg%3E");
   }
 
   &--xl,
   &--size-600 {
     --avatar-size-shape: var(--dt-layout-100);
     --avatar-size-text: var(--dt-font-size-350);
-    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'%3E%3Cpath fill='white' d='M51.2 0c4.48 0 6.72 0 8.432.872a8 8 0 0 1 3.496 3.496C64 6.08 64 8.32 64 12.8V34H50c-5.6 0-8.4 0-10.54 1.09a10 10 0 0 0-4.37 4.37C34 41.6 34 44.4 34 50v14H12.8c-4.48 0-6.72 0-8.432-.872a8 8 0 0 1-3.496-3.496C0 57.92 0 55.68 0 51.2V12.8c0-4.48 0-6.72.872-8.432A8 8 0 0 1 4.368.872C6.08 0 8.32 0 12.8 0z'/%3E%3C/svg%3E");
   }
 
   &--size-700 {

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -356,7 +356,6 @@
   &--size-150 {
     --avatar-size-shape: calc(var(--dt-layout-100) * 0.3125);
     --avatar-size-text: var(--dt-font-size-100);
-    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpath fill='white' d='M16 0c1.4 0 2.1 0 2.635.272a2.5 2.5 0 0 1 1.092 1.093C20 1.9 20 2.6 20 4v6.63h-4.37c-1.75 0-2.626 0-3.294.34-.588.3-1.066.778-1.365 1.366-.34.668-.341 1.544-.341 3.294V20H4c-1.4 0-2.1 0-2.635-.273a2.5 2.5 0 0 1-1.093-1.092C0 18.1 0 17.4 0 16V4c0-1.4 0-2.1.272-2.635A2.5 2.5 0 0 1 1.365.272C1.9 0 2.6 0 4 0z'/%3E%3C/svg%3E");
     --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpath fill='white' d='M17.5 0C18.8807 0 20 1.11929 20 2.5V12.5908H14.5C13.3956 12.5908 12.5003 13.4855 12.5 14.5898V20H2.5C1.11929 20 0 18.8807 0 17.5V2.5C0 1.11929 1.11929 0 2.5 0H17.5Z'/%3E%3C/svg%3E");
   }
 
@@ -364,14 +363,12 @@
   &--size-200 {
     --avatar-size-shape: calc(var(--dt-layout-100) * 0.375);
     --avatar-size-text: var(--dt-font-size-100);
-    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath fill='white' d='M19.2 0c1.68 0 2.52 0 3.162.327a3 3 0 0 1 1.31 1.31C24 2.28 24 3.12 24 4.8v7.95h-5.25c-2.1 0-3.15 0-3.952.41a3.74 3.74 0 0 0-1.639 1.638c-.409.802-.409 1.852-.409 3.952V24H4.8c-1.68 0-2.52 0-3.162-.327a3 3 0 0 1-1.31-1.31C0 21.72 0 20.88 0 19.2V4.8c0-1.68 0-2.52.327-3.162a3 3 0 0 1 1.31-1.31C2.28 0 3.12 0 4.8 0z'/%3E%3C/svg%3E");
     --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath fill='white' d='M21 0C22.65685 0 24 1.34315 24 3V15H17.4C16.07452 15 15 16.07452 15 17.4V24H3C1.34315 24 0 22.65685 0 21V3C0 1.34315 1.34315 0 3 0H21Z'/%3E%3C/svg%3E");
   }
 
   &--size-250 {
     --avatar-size-shape: calc(var(--dt-layout-100) * 0.4375);
     --avatar-size-text: var(--dt-font-size-125);
-    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 28 28'%3E%3Cpath fill='white' d='M22.4 0c1.96 0 2.94 0 3.689.382a3.5 3.5 0 0 1 1.53 1.53C27.998 2.66 28 3.64 28 5.6v9.28h-6.12c-2.45 0-3.676 0-4.611.476a4.38 4.38 0 0 0-1.913 1.913c-.476.935-.476 2.16-.476 4.61V28H5.6c-1.96 0-2.94 0-3.689-.382a3.5 3.5 0 0 1-1.53-1.53C.002 25.34 0 24.36 0 22.4V5.6c0-1.96 0-2.94.382-3.69A3.5 3.5 0 0 1 1.912.38C2.66.002 3.64 0 5.6 0z'/%3E%3C/svg%3E");
     --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 28 28'%3E%3Cpath fill='white' d='M24.5 0C26.433 0 28 1.567 28 3.5V17.5H20.3C18.7536 17.5 17.5 18.7536 17.5 20.3V28H3.5C1.567 28 0 26.433 0 24.5V3.5C0 1.567 1.567 0 3.5 0H24.5Z'/%3E%3C/svg%3E");
   }
 
@@ -381,9 +378,6 @@
     --avatar-presence-shape: calc(var(--avatar-size-shape) * 0.328);
     --avatar-presence-position-right: var(--dt-spacing-1-negative);
     --avatar-presence-position-bottom: var(--dt-spacing-1-negative);
-    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='white' d='M25.6 0c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.749 1.748C32 3.039 32 4.16 32 6.4V17h-7c-2.8 0-4.2 0-5.27.545a5 5 0 0 0-2.185 2.185C17 20.8 17 22.2 17 25v7H6.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C0 28.961 0 27.84 0 25.6V6.4c0-2.24 0-3.36.436-4.216A4 4 0 0 1 2.184.436C3.039 0 4.16 0 6.4 0z'/%3E%3C/svg%3E");
-    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='white' d='M28 0C30.20914 0 32 1.79086 32 4V20H23.2C21.43269 20 20 21.43269 20 23.2V32H4C1.79086 32 0 30.20914 0 28V4C0 1.79086 1.79086 0 4 0H28Z'/%3E%3C/svg%3E");
-    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='white' d='M28 0C30.2091 0 32 1.79086 32 4V21H24.2C22.4327 21 21 22.4327 21 24.2V32H4C1.79086 32 0 30.2091 0 28V4C0 1.79086 1.79086 0 4 0H28Z'/%3E%3C/svg%3E");
     --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='white' d='M28 0C30.2091 0 32 1.79086 32 4V20.5H23.7C21.9327 20.5 20.5 21.9327 20.5 23.7V32H4C1.79086 32 0 30.2091 0 28V4C0 1.79086 1.79086 0 4 0H28Z'/%3E%3C/svg%3E");
   }
 
@@ -393,9 +387,6 @@
     --avatar-size-text: var(--dt-font-size-250);
     --avatar-presence-position-right: 0;
     --avatar-presence-position-bottom: 0;
-    // --avatar-presence-position-right: calc(var(--dt-spacing-50-negative) - var(--dt-spacing-1-negative));
-    // --avatar-presence-position-bottom: calc(var(--dt-spacing-50-negative) - var(--dt-spacing-1-negative));
-    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3E%3Cpath fill='white' d='M32 0c2.8 0 4.2 0 5.27.545a5 5 0 0 1 2.185 2.185C40 3.8 40 5.2 40 8v13.25h-8.75c-3.5 0-5.25 0-6.588.682a6.25 6.25 0 0 0-2.73 2.73C21.25 26 21.25 27.75 21.25 31.25V40H8c-2.8 0-4.2 0-5.27-.545A5 5 0 0 1 .545 37.27C0 36.2 0 34.8 0 32V8c0-2.8 0-4.2.545-5.27A5 5 0 0 1 2.73.545C3.8 0 5.2 0 8 0z'/%3E%3C/svg%3E");
     --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3E%3Cpath fill='white' d='M35 0C37.7614 0 40 2.23858 40 5V25.4986H29C26.7909 25.4986 25 27.2895 25 29.4986V40H5C2.23858 40 0 37.7614 0 35V5C0 2.23858 2.23858 0 5 0H35Z'/%3E%3C/svg%3E");
   }
 
@@ -406,7 +397,6 @@
     --avatar-size-text: var(--dt-font-size-300);
     --avatar-presence-position-right: 0;
     --avatar-presence-position-bottom: 0;
-    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Cpath fill='white' d='M38.4 0c3.36 0 5.04 0 6.324.654a6 6 0 0 1 2.622 2.622C48 4.56 48 6.24 48 9.6v15.9H37.5c-4.2 0-6.3 0-7.905.817a7.5 7.5 0 0 0-3.278 3.278C25.5 31.199 25.5 33.3 25.5 37.5V48H9.6c-3.36 0-5.04 0-6.324-.654a6 6 0 0 1-2.622-2.622C0 43.44 0 41.76 0 38.4V9.6c0-3.36 0-5.04.654-6.324A6 6 0 0 1 3.276.654C4.56 0 6.24 0 9.6 0z'/%3E%3C/svg%3E");
     --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'%3E%3Cpath fill='white' d='M42 0C45.3137 0 48 2.68629 48 6V30.5377H34.8C32.149 30.5377 30 32.6867 30 35.3377V48H6C2.68629 48 0 45.3137 0 42V6C0 2.68629 2.68629 0 6 0H42Z'/%3E%3C/svg%3E");
   }
 

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -378,8 +378,13 @@
   &--md,
   &--size-300 {
     --avatar-size-text: var(--dt-font-size-200);
+    --avatar-presence-shape: calc(var(--avatar-size-shape) * 0.328);
+    --avatar-presence-position-right: var(--dt-spacing-1-negative);
+    --avatar-presence-position-bottom: var(--dt-spacing-1-negative);
     // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='white' d='M25.6 0c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.749 1.748C32 3.039 32 4.16 32 6.4V17h-7c-2.8 0-4.2 0-5.27.545a5 5 0 0 0-2.185 2.185C17 20.8 17 22.2 17 25v7H6.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748C0 28.961 0 27.84 0 25.6V6.4c0-2.24 0-3.36.436-4.216A4 4 0 0 1 2.184.436C3.039 0 4.16 0 6.4 0z'/%3E%3C/svg%3E");
-    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='white' d='M28 0C30.20914 0 32 1.79086 32 4V20H23.2C21.43269 20 20 21.43269 20 23.2V32H4C1.79086 32 0 30.20914 0 28V4C0 1.79086 1.79086 0 4 0H28Z'/%3E%3C/svg%3E");
+    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='white' d='M28 0C30.20914 0 32 1.79086 32 4V20H23.2C21.43269 20 20 21.43269 20 23.2V32H4C1.79086 32 0 30.20914 0 28V4C0 1.79086 1.79086 0 4 0H28Z'/%3E%3C/svg%3E");
+    // --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='white' d='M28 0C30.2091 0 32 1.79086 32 4V21H24.2C22.4327 21 21 22.4327 21 24.2V32H4C1.79086 32 0 30.2091 0 28V4C0 1.79086 1.79086 0 4 0H28Z'/%3E%3C/svg%3E");
+    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='white' d='M28 0C30.2091 0 32 1.79086 32 4V20.5H23.7C21.9327 20.5 20.5 21.9327 20.5 23.7V32H4C1.79086 32 0 30.2091 0 28V4C0 1.79086 1.79086 0 4 0H28Z'/%3E%3C/svg%3E");
   }
 
   &--size-400 {

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -385,8 +385,8 @@
     --avatar-size-shape: calc(var(--dt-layout-100) * 0.625);
     --avatar-presence-shape: calc(var(--avatar-size-shape) * 0.32);
     --avatar-size-text: var(--dt-font-size-250);
-    --avatar-presence-position-right: 0;
-    --avatar-presence-position-bottom: 0;
+    --avatar-presence-position-right: var(--dt-spacing-0);
+    --avatar-presence-position-bottom: var(--dt-spacing-0);
     --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3E%3Cpath fill='white' d='M35 0C37.7614 0 40 2.23858 40 5V25.4986H29C26.7909 25.4986 25 27.2895 25 29.4986V40H5C2.23858 40 0 37.7614 0 35V5C0 2.23858 2.23858 0 5 0H35Z'/%3E%3C/svg%3E");
   }
 

--- a/packages/dialtone-css/lib/build/less/components/avatar.less
+++ b/packages/dialtone-css/lib/build/less/components/avatar.less
@@ -348,9 +348,9 @@
   &--xs,
   &--size-100 {
     --avatar-size-shape: calc(var(--dt-layout-100) * 0.25);
-    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath fill='white' d='M12.8 0c1.12 0 1.68 0 2.108.218a2 2 0 0 1 .874.874C16 1.52 16 2.08 16 3.2v5.3h-3.5c-1.4 0-2.1 0-2.635.272a2.5 2.5 0 0 0-1.093 1.093C8.5 10.4 8.5 11.1 8.5 12.5V16H3.2c-1.12 0-1.68 0-2.108-.218a2 2 0 0 1-.874-.874C0 14.48 0 13.92 0 12.8V3.2c0-1.12 0-1.68.218-2.108a2 2 0 0 1 .874-.874C1.52 0 2.08 0 3.2 0z'/%3E%3C/svg%3E");
     --avatar-presence-position-right: var(--dt-spacing-0);
     --avatar-presence-position-bottom: var(--dt-spacing-0);
+    --avatar-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath fill='white' d='M12.8 0c1.12 0 1.68 0 2.108.218a2 2 0 0 1 .874.874C16 1.52 16 2.08 16 3.2v5.3h-3.5c-1.4 0-2.1 0-2.635.272a2.5 2.5 0 0 0-1.093 1.093C8.5 10.4 8.5 11.1 8.5 12.5V16H3.2c-1.12 0-1.68 0-2.108-.218a2 2 0 0 1-.874-.874C0 14.48 0 13.92 0 12.8V3.2c0-1.12 0-1.68.218-2.108a2 2 0 0 1 .874-.874C1.52 0 2.08 0 3.2 0z'/%3E%3C/svg%3E");
   }
 
   &--size-150 {


### PR DESCRIPTION
<img width="155" alt="image" src="https://github.com/user-attachments/assets/61e4ef4e-b000-438d-8c48-77281ca0d593" />

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

DP-200415

## :book: Description

- Adjusts presence size, position, and masks across avatar sizes. 
  - Most bump out into negative space at bottom right, at size 400 and above they are flush with the Avatar bottom-right boundary. 
- Keeps profile images and initials from clipping at the right edge.

https://github.com/user-attachments/assets/62692ae5-7756-4955-bc25-4f5f3eb6dd6d

## :bulb: Context

Presence masks cut too far into avatar content, truncating images and initials.

No Avatar API or presence-state changes. Group-avatar mask rules unchanged.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.




