### PR TITLE
fix: NO-JIRA emoji-picker spacing issue

### DIFF
--- a/packages/dialtone-css/lib/build/less/components/emoji-picker.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji-picker.less
@@ -38,7 +38,8 @@
     // !important to default value to override popover dialog box-sizing: border-box style
     box-sizing: content-box !important;
     inline-size: auto;
-    max-inline-size: calc(var(--dt-layout-500) + var(--dt-spacing-100));
+    // 340px fits 9 emojis per row (9 × 36px + 8 × 2px gap)
+    max-inline-size: calc(var(--dt-layout-500) + var(--dt-spacing-250));
     margin: 0 var(--dt-spacing-200);
   }
 
@@ -127,7 +128,8 @@
   }
 
   &__selector {
-    min-block-size: calc(var(--dt-layout-450) + var(--dt-spacing-1));
+    // 297px keeps the list tall enough to show a full grid of emoji rows
+    min-block-size: calc(var(--dt-layout-450) + var(--dt-spacing-100) + var(--dt-spacing-1));
 
     p {
       padding-block-end: var(--dt-spacing-50);
@@ -149,7 +151,8 @@
   &__list {
     position: relative;
     block-size: 100%;
-    max-block-size: calc(var(--dt-layout-450) + var(--dt-spacing-1));
+    // 297px keeps the list tall enough to show a full grid of emoji rows
+    max-block-size: calc(var(--dt-layout-450) + var(--dt-spacing-100) + var(--dt-spacing-1));
     padding-block-end: calc(var(--dt-spacing-50) + var(--dt-spacing-1));
     overflow: hidden auto;
 
@@ -173,7 +176,8 @@
     flex-wrap: wrap;
     gap: var(--dt-spacing-25);
     inline-size: calc(100% + calc(var(--dt-layout-25) - var(--dt-spacing-1)));
-    max-inline-size: calc(var(--dt-layout-500) + var(--dt-spacing-100));
+    // 340px fits 9 emojis per row (9 × 36px + 8 × 2px gap)
+    max-inline-size: calc(var(--dt-layout-500) + var(--dt-spacing-250));
     // We use this margin left to align the emoji list with the tabset label
     margin-inline-start: var(--dt-spacing-75-negative);
     padding-block-start: var(--dt-spacing-50);

--- a/packages/dialtone-css/lib/build/less/components/emoji-picker.less
+++ b/packages/dialtone-css/lib/build/less/components/emoji-picker.less
@@ -60,6 +60,10 @@
 
   &__tabset-list {
       gap: var(--dt-spacing-0);
+      // The tabset sits flush above the emoji list, so it does not need the
+      // standalone tablist's underline gap that would otherwise add height here.
+      --tablist-padding-bottom: var(--dt-spacing-0);
+
 
       &::after {
         background-color: var(--dt-color-neutral-transparent) !important;


### PR DESCRIPTION
Firespotter PR: https://github.com/dialpad/firespotter/pull/80509

Fix wrong mapped values. Could be possible due to rerun a migration script.



Rule | Before (correct) | Regressed to | Fix
-- | -- | -- | --
__tab & __alignment max-inline-size | 340px | 328px (−12px) → 8 emojis/row | calc(--dt-layout-500 + --dt-spacing-250) = 340px
__selector & __list block-size | 297px | 289px (−8px) → shorter panel | calc(--dt-layout-450 + --dt-spacing-100 + --dt-spacing-1) = 297px


Check the comments for details!

This is related to issue: https://dialpad.atlassian.net/browse/DP-202880


With fix applied: 
<img width="1060" height="740" alt="image" src="https://github.com/user-attachments/assets/07e26bda-e197-464b-9315-72e7c30c7082" />


note: the different colors on the header are generated by a wrong OKLCH color, Im fixing it in ubervoice side.

