### PR TITLE
fix(mode-island): NO-JIRA fix tag order on Mode Island story

### DIFF
--- a/packages/dialtone-vue/components/ModeIsland/ModeIsland.stories.js
+++ b/packages/dialtone-vue/components/ModeIsland/ModeIsland.stories.js
@@ -105,8 +105,8 @@ export const NestedIslands = {
               <p class="d-body--md">Explicit Light Island (Always Light)</p>
             </dt-mode-island>
           </dt-mode-island>
-        </div>
         </dt-stack>
+      </div>
     `,
   }),
 };


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

N/A (NO-JIRA)

## :book: Description

Fixes swapped closing tags in the `NestedIslands` story's inline template in `ModeIsland.stories.js`. The `<div>` and `<dt-stack>` closing tags were in the wrong order (`</div>` before `</dt-stack>`, instead of `</dt-stack>` before `</div>`), which is an invalid/mismatched tag structure.

Original: https://dialtone.dialpad.com/vue/next/index.html?path=/story/kitchen-sink--components

PR Preview with update: https://dialtone.dialpad.com/vue/deploy-previews/pr-1389/?path=/story/kitchen-sink--components

## :bulb: Context

This one-line typo potentially is causing errors on the deployed `next` Storybook. 

From Claude...
- The malformed template makes Vue's runtime HTML parser throw `SyntaxError: https://vuejs.org/error-reference/#compiler-24` (`X_MISSING_END_TAG`) whenever the `Mode Island / Nested Islands` story renders, or whenever `Kitchen Sink` renders (it dynamically imports and renders every story in the app, including this one).
- In Storybook's **dev** build, Vue downgrades this to a `console.warn` and only that one section fails to render — so it is easy to miss.
- In the **production** build (what's actually deployed), Vue strips those dev-only guards, so the same failure becomes an uncaught, thrown exception. That crash leaves Vue's internal mount state corrupted, so navigating to *any other story* afterward in the same session throws `TypeError: Cannot destructure property 'bum' of 'e' as it is null` inside `@vue/runtime-core`'s `unmountComponent` — cascading the failure across the rest of the session.

Fixing the tag order resolves both the direct compile error and the downstream cascade. Verified locally against a full production `storybook build` (matching how the live site is built): reproduced the full failure chain pre-fix, confirmed clean after the fix.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

## :crystal_ball: Next Steps

None — this is a self-contained one-line fix.

## :camera: Screenshots / GIFs

Before (production build):
<img width="1321" height="1022" alt="Screenshot 2026-08-12 at 12 35 05 PM" src="https://github.com/user-attachments/assets/7feeb753-d39e-4e38-889f-31112297d785" />

After:
<img width="1322" height="1022" alt="Screenshot 2026-08-12 at 12 34 11 PM" src="https://github.com/user-attachments/assets/8abaed77-61ca-4298-8a7e-755eeec75d43" />

