### PR TITLE
fix(dialtone-vue): DP-203134 hide empty message paragraph in DtNoticeContent

### DIFF
--- a/packages/dialtone-vue/components/Notice/NoticeContent.test.js
+++ b/packages/dialtone-vue/components/Notice/NoticeContent.test.js
@@ -64,5 +64,21 @@ describe('DtNoticeContent tests', () => {
         expect(header.text()).toBe(slotsData.header);
       });
     });
+
+    describe('When no message content is provided', () => {
+      beforeEach(() => {
+        props = baseProps;
+        slotsData = {};
+        wrapper = mount(DtNoticeContent, {
+          props,
+          slots: slotsData,
+        });
+        _setChildWrappers();
+      });
+
+      it('does not render the message element', () => {
+        expect(content.exists()).toBe(false);
+      });
+    });
   });
 });

--- a/packages/dialtone-vue/components/Notice/NoticeContent.vue
+++ b/packages/dialtone-vue/components/Notice/NoticeContent.vue
@@ -19,6 +19,7 @@
       </slot>
     </dt-text>
     <dt-text
+      v-if="hasSlotContent($slots.default)"
       :id="contentId"
       kind="body"
       :size="200"


### PR DESCRIPTION
## Context

JIRA Link: https://dialpad.atlassian.net/browse/DP-203134

The close icon in a title-only `DtNotice`/`DtToast`/`DtBanner` (e.g. the "Copied to clipboard" toast) is misaligned relative to the title text.

## Root cause

`DtNoticeContent` always renders its message `<dt-text>` element, even when no default-slot content is provided. The header element is already guarded with `v-if="headerText || hasSlotContent(\$slots.header)"`, but the message element has no equivalent guard. A title-only notice ends up with an empty `<p class="d-notice__message">`, which still takes up line-height and throws off vertical centering against the close icon.

This is shared by every consumer of `DtNoticeContent`: `DtNotice`, both `DtToast` layouts (default and alternate), and `DtBanner`.

## Fix

Guard the message element the same way the header already is: `v-if="hasSlotContent(\$slots.default)"`.

## Tests

Added a case to `NoticeContent.test.js` covering the no-message scenario (asserts the message element does not render). Existing tests unaffected — they always pass real slot content.