### PR TITLE
fix(checkbox, radio, toggle): DLT-3571 improve focus style

### DIFF
--- a/apps/dialtone-documentation/docs/scratch.md
+++ b/apps/dialtone-documentation/docs/scratch.md
@@ -3,6 +3,76 @@ layout: Blank
 ---
 
 <dt-stack class="d-p-400 d-bgc-primary" gap="400">
+  <dt-stack gap="100">
+    <dt-box>
+      <dt-toggle label-class="d-pie-100" size="200">Label</dt-toggle>
+    </dt-box>
+    <dt-stack direction="row" gap="100" align="start">
+      <dt-box>
+        <dt-input
+          label="Label"
+          placeholder="Placeholder"
+        />
+      </dt-box>
+      <dt-box>
+        <dt-select-menu
+          :options="[
+                { value: ``, label: `Please select one` },
+                { value: `1`, label: `Option 1` },
+                { value: `2`, label: `Option 2` },
+                { value: `3`, label: `Option 3` },
+              ]"
+          label="Label"
+          :model-value="modelValue"
+          @update:model-value="onInput"
+        />
+      </dt-box>
+    </dt-stack>
+    <dt-box>
+      <dt-stack gap="100">
+        <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
+          <dt-button :disabled="isDisabled"> Place Call </dt-button>
+          <dt-button :disabled="isDisabled" importance="outlined"> Place Call </dt-button>
+          <dt-button :disabled="isDisabled" importance="clear"> Place Call </dt-button>
+        </dt-stack>
+        <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
+          <dt-button :disabled="isDisabled" kind="critical"> Place Call </dt-button>
+          <dt-button :disabled="isDisabled" kind="critical" importance="outlined"> Place Call </dt-button>
+          <dt-button :disabled="isDisabled" kind="critical" importance="clear"> Place Call </dt-button>
+        </dt-stack>
+        <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
+          <dt-button :disabled="isDisabled" kind="positive">Place Call</dt-button>
+          <dt-button :disabled="isDisabled" kind="positive" importance="outlined">Place Call</dt-button>
+          <dt-button :disabled="isDisabled" kind="positive" importance="clear">Place Call</dt-button>
+        </dt-stack>
+        <dt-stack gap="100" :direction="{ 'default': 'column', 'md': 'row' }">
+          <dt-button :disabled="isDisabled" kind="muted" importance="clear"> Place Call </dt-button>
+          <dt-button :disabled="isDisabled" kind="muted" importance="outlined"> Place Call </dt-button>
+        </dt-stack>
+      </dt-stack>
+    </dt-box>
+    <dt-box>
+      <dt-checkbox-group
+        name="fruits-checkbox-group"
+        legend="Fruits"
+      >
+        <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
+        <dt-checkbox value="banana" checked><span>Banana</span></dt-checkbox>
+        <dt-checkbox value="orange"><span>Orange</span></dt-checkbox>
+        <dt-checkbox value="other" indeterminate><span>Other</span></dt-checkbox>
+      </dt-checkbox-group>
+    </dt-box>
+    <dt-box>
+      <dt-radio-group
+        name="fruits-radio-group"
+        legend="Fruits"
+      >
+        <dt-radio checked value="apple"><span>Apple</span></dt-radio>
+        <dt-radio value="banana"><span>Banana</span></dt-radio>
+        <dt-radio value="other"><span>Other</span></dt-radio>
+      </dt-radio-group>
+    </dt-box>
+  </dt-stack>
   <dt-stack direction="row" gap="100">
     <dt-text as="h1" kind="headline" :size="600">
       Scratchpad

--- a/packages/dialtone-css/lib/build/less/components/radio-checkbox.less
+++ b/packages/dialtone-css/lib/build/less/components/radio-checkbox.less
@@ -197,8 +197,23 @@
         &:focus,
         &:focus-visible,
         &:checked:focus-visible {
+            --check-radio-color-border: var(--dt-color-border-focus);
+
             box-shadow: var(--dt-shadow-focus);
         }
+
+        &:checked:focus,
+        &:checked:focus-visible,
+        &:indeterminate:focus,
+        &:indeterminate:focus-visible {
+            outline: var(--dt-size-border-200) solid CanvasText;
+            outline-offset: calc(var(--dt-size-border-200) * -1);
+        }
+
+        // &:checked:focus-visible,
+        // &:indeterminate:focus-visible {
+        //   --check-radio-color-background: var(--dt-color-surface-info-strong);
+        // }
 
         &:checked {
             --check-radio-color-background: var(--check-radio-color-background-checked);
@@ -295,7 +310,11 @@
         &:focus,
         &:focus-visible,
         &:checked:focus-visible {
-          box-shadow: var(--dt-shadow-focus), inset 0 0 0 var(--dt-size-border-200) var(--dt-radio-color-foreground-checked);
+          outline: var(--dt-size-border-200) solid var(--dt-color-border-focus);
+          outline-offset: calc(var(--dt-size-border-200) * -1);
+          box-shadow:
+            inset 0 0 0 var(--dt-size-border-200) var(--dt-radio-color-foreground-checked)
+          ;
         }
 
         &--disabled:checked {

--- a/packages/dialtone-css/lib/build/less/components/radio-checkbox.less
+++ b/packages/dialtone-css/lib/build/less/components/radio-checkbox.less
@@ -210,11 +210,6 @@
             outline-offset: calc(var(--dt-size-border-200) * -1);
         }
 
-        // &:checked:focus-visible,
-        // &:indeterminate:focus-visible {
-        //   --check-radio-color-background: var(--dt-color-surface-info-strong);
-        // }
-
         &:checked {
             --check-radio-color-background: var(--check-radio-color-background-checked);
 

--- a/packages/dialtone-css/lib/build/less/components/toggle.less
+++ b/packages/dialtone-css/lib/build/less/components/toggle.less
@@ -151,8 +151,11 @@
   //  $$  FOCUSED TOGGLE
   //  ----------------------------------------------------------------------------
   &:focus-visible {
-    outline: none;
-    box-shadow: var(--dt-shadow-focus);
+    box-shadow: none;
+
+    &::after {
+      box-shadow: var(--dt-shadow-focus);
+    }
   }
 
   //  $$  DISABLED TOGGLE


### PR DESCRIPTION
<img width="320" height="320" alt="you-stay-focused-mr-miyagi-320" src="https://github.com/user-attachments/assets/58efa88e-0b14-4198-a2c5-3de87f343d80" />

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3571

## :book: Description

The global change in DLT-3551 resulted in visibility challenge of checkbox/radio/toggle focus-visible state. 

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all CSS changes:

- [x] I have used design tokens whenever possible.
- [x] I have considered how this change will behave on different screen sizes.
- [x] I have visually validated my change in light and dark mode.
- [x] I have used gap or flexbox properties for layout instead of margin whenever possible.


https://github.com/user-attachments/assets/86ee3bbf-c163-4066-8114-e3f36712c1a6