### PR TITLE
fix(scripts): DLT-3586 fix false positives in dialtone-migrate health check

### DIFF
--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -253,9 +253,10 @@ const MIGRATIONS = [
     // prove pending work. Mirrors dialtone_migration_helper/configs/stack-gap-to-spacing.mjs's
     // isAlreadyMigrated check: new-scale-only stops indicate the file was already migrated.
     skipIfPatterns: [
-      /gap="(?:25|75|150|250)"/,
-      /d-stack--gap-(?:25|75|150|250)/,
-      /d-description-list--gap-(?:25|75|150|250)/,
+      /gap="(?:25|75|150|250|525)"/,
+      /gap="'(?:25|75|150|250|525)'"/,
+      /d-stack--gap-(?:25|75|150|250|525)/,
+      /d-description-list--gap-(?:25|75|150|250|525)/,
     ],
     fileExtensions: ['.vue', '.html', '.js', '.ts', '.jsx', '.tsx', '.md'],
   },

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -258,9 +258,11 @@ const MIGRATIONS = [
     category: 'opt-in',
     type: 'config',
     configName: 'stack-gap-to-spacing',
+    // (?<![\w-]) requires a non-word, non-hyphen boundary before "gap" (e.g. whitespace,
+    // quote, or a leading :), so unrelated attributes like data-gap aren't mistaken for it.
     // Old-only stops (never valid post-migration values) — always flagged as pending.
     detectPatterns: [
-      /gap="(?:350|450|500|550|625|650|700)"/,
+      /(?<![\w-])gap="(?:350|450|500|550|625|650|700)"/,
       /d-stack--gap-(?:350|450|500|550|625|650|700)/,
     ],
     // Old and new gap scales share some numeric stops (e.g. "100"), so a bare match on
@@ -268,15 +270,15 @@ const MIGRATIONS = [
     // marker (skipIfPatterns) — an unambiguous detectPatterns match elsewhere in the same
     // (partially migrated) file is still flagged regardless.
     ambiguousDetectPatterns: [
-      /gap="(?:50|100|200|300|400|525|600)"/,
+      /(?<![\w-])gap="(?:50|100|200|300|400|525|600)"/,
       /d-stack--gap-(?:50|100|200|300|400|525|600)/,
     ],
     // Mirrors dialtone_migration_helper/configs/stack-gap-to-spacing.mjs's isAlreadyMigrated
     // check: new-scale-only stops indicate the file was already migrated.
     skipIfPatterns: [
-      /gap="(?:25|75|150|250|525)"/,
-      /gap='(?:25|75|150|250|525)'/,
-      /gap="'(?:25|75|150|250|525)'"/,
+      /(?<![\w-])gap="(?:25|75|150|250|525)"/,
+      /(?<![\w-])gap='(?:25|75|150|250|525)'/,
+      /(?<![\w-])gap="'(?:25|75|150|250|525)'"/,
       /d-stack--gap-(?:25|75|150|250|525)/,
       /d-description-list--gap-(?:25|75|150|250|525)/,
     ],

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -73,6 +73,11 @@ const __dirname = path.dirname(__filename);
 // literal > inside one (e.g. :disabled="count > 0") doesn't truncate the match early.
 const DT_TAG_ATTRS = '(?:[^>"\']|"[^"]*"|\'[^\']*\')*';
 
+// Requires a real attribute-name boundary before "gap": blocks a word char or hyphen
+// (data-gap), an event-listener "@" (@gap), and a trailing "on:" from v-on:gap — but still
+// allows a bare gap=, a bound :gap=, or v-bind:gap= (neither ends in "on:" or starts with @).
+const GAP_ATTR_BOUNDARY = '(?<!@)(?<!on:)(?<![\\w-])';
+
 const MIGRATIONS = [
   // ── Required (breaking) ────────────────────────────────────────────
   {
@@ -258,11 +263,9 @@ const MIGRATIONS = [
     category: 'opt-in',
     type: 'config',
     configName: 'stack-gap-to-spacing',
-    // (?<![\w-]) requires a non-word, non-hyphen boundary before "gap" (e.g. whitespace,
-    // quote, or a leading :), so unrelated attributes like data-gap aren't mistaken for it.
     // Old-only stops (never valid post-migration values) — always flagged as pending.
     detectPatterns: [
-      /(?<![\w-])gap="(?:350|450|500|550|625|650|700)"/,
+      new RegExp(`${GAP_ATTR_BOUNDARY}gap="(?:350|450|500|550|625|650|700)"`),
       /d-stack--gap-(?:350|450|500|550|625|650|700)/,
     ],
     // Old and new gap scales share some numeric stops (e.g. "100"), so a bare match on
@@ -270,15 +273,15 @@ const MIGRATIONS = [
     // marker (skipIfPatterns) — an unambiguous detectPatterns match elsewhere in the same
     // (partially migrated) file is still flagged regardless.
     ambiguousDetectPatterns: [
-      /(?<![\w-])gap="(?:50|100|200|300|400|525|600)"/,
+      new RegExp(`${GAP_ATTR_BOUNDARY}gap="(?:50|100|200|300|400|525|600)"`),
       /d-stack--gap-(?:50|100|200|300|400|525|600)/,
     ],
     // Mirrors dialtone_migration_helper/configs/stack-gap-to-spacing.mjs's isAlreadyMigrated
     // check: new-scale-only stops indicate the file was already migrated.
     skipIfPatterns: [
-      /(?<![\w-])gap="(?:25|75|150|250|525)"/,
-      /(?<![\w-])gap='(?:25|75|150|250|525)'/,
-      /(?<![\w-])gap="'(?:25|75|150|250|525)'"/,
+      new RegExp(`${GAP_ATTR_BOUNDARY}gap="(?:25|75|150|250|525)"`),
+      new RegExp(`${GAP_ATTR_BOUNDARY}gap='(?:25|75|150|250|525)'`),
+      new RegExp(`${GAP_ATTR_BOUNDARY}gap="'(?:25|75|150|250|525)'"`),
       /d-stack--gap-(?:25|75|150|250|525)/,
       /d-description-list--gap-(?:25|75|150|250|525)/,
     ],

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -57,6 +57,9 @@ const __dirname = path.dirname(__filename);
  * @property {boolean} [supportsPackageArg] - Forward --package to this standalone script
  * @property {string[]} [extraArgs] - Extra CLI args to forward
  * @property {RegExp[]} detectPatterns - Patterns that indicate migration is still needed
+ * @property {RegExp[]} [skipIfPatterns] - If any of these match a file, skip detectPatterns
+ *   for that file — used when detectPatterns values are ambiguous with the post-migration
+ *   scale and a new-scale-only marker means the file has already been migrated.
  * @property {string[]} fileExtensions - File extensions to scan during health check
  */
 
@@ -162,7 +165,7 @@ const MIGRATIONS = [
     type: 'standalone',
     scriptDir: 'dialtone_migrate_props',
     detectPatterns: [
-      /(?:show|hide-close|hide-icon|label-visible|selected-values)(?:=|[\s>])/,
+      /<(?:dt-[\w-]+|Dt\w+)\b[^>]*\b(?:show|hide-close|hide-icon|label-visible|selected-values)(?:=|[\s>])/,
       /<(?:dt-(?:banner|notice|toast|modal)|Dt(?:Banner|Notice|Toast|Modal))\b[^>]*\btitle(?:=|[\s>])/,
       /<(?:dt-[\w-]+|Dt\w+)\b[^>]*@(?:input|change)(?:=|\.)/,
       /kind="(?:danger|error)"/,
@@ -245,6 +248,14 @@ const MIGRATIONS = [
     detectPatterns: [
       /gap="(?:50|100|200|300|350|400|450|500|525|550|600|625|650|700)"/,
       /d-stack--gap-(?:50|100|200|300|350|400|450|500|525|550|600|625|650|700)/,
+    ],
+    // Old and new gap scales share numeric stops (e.g. "100"), so a bare match doesn't
+    // prove pending work. Mirrors dialtone_migration_helper/configs/stack-gap-to-spacing.mjs's
+    // isAlreadyMigrated check: new-scale-only stops indicate the file was already migrated.
+    skipIfPatterns: [
+      /gap="(?:25|75|150|250)"/,
+      /d-stack--gap-(?:25|75|150|250)/,
+      /d-description-list--gap-(?:25|75|150|250)/,
     ],
     fileExtensions: ['.vue', '.html', '.js', '.ts', '.jsx', '.tsx', '.md'],
   },
@@ -546,6 +557,7 @@ async function healthCheck (cwd) {
 
     for (const [file, content] of fileContents) {
       if (!migration.fileExtensions.some(ext => file.endsWith(ext))) continue;
+      if (migration.skipIfPatterns?.some(pattern => pattern.test(content))) continue;
       for (const pattern of migration.detectPatterns) {
         // Reset lastIndex for global patterns
         const re = new RegExp(pattern.source, pattern.flags.replace('g', ''));

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -271,6 +271,7 @@ const MIGRATIONS = [
     // check: new-scale-only stops indicate the file was already migrated.
     skipIfPatterns: [
       /gap="(?:25|75|150|250|525)"/,
+      /gap='(?:25|75|150|250|525)'/,
       /gap="'(?:25|75|150|250|525)'"/,
       /d-stack--gap-(?:25|75|150|250|525)/,
       /d-description-list--gap-(?:25|75|150|250|525)/,

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -69,6 +69,10 @@ const __dirname = path.dirname(__filename);
  */
 
 /** @type {Migration[]} */
+// Consumes a Dialtone tag's attribute soup, treating quoted attribute values as opaque so a
+// literal > inside one (e.g. :disabled="count > 0") doesn't truncate the match early.
+const DT_TAG_ATTRS = '(?:[^>"\']|"[^"]*"|\'[^\']*\')*';
+
 const MIGRATIONS = [
   // ── Required (breaking) ────────────────────────────────────────────
   {
@@ -170,9 +174,9 @@ const MIGRATIONS = [
     type: 'standalone',
     scriptDir: 'dialtone_migrate_props',
     detectPatterns: [
-      /<(?:dt-[\w-]+|Dt\w+)\b[^>]*\b(?:show|hide-close|hide-icon|label-visible|selected-values)(?:=|[\s>])/,
-      /<(?:dt-(?:banner|notice|toast|modal)|Dt(?:Banner|Notice|Toast|Modal))\b[^>]*\btitle(?:=|[\s>])/,
-      /<(?:dt-[\w-]+|Dt\w+)\b[^>]*@(?:input|change)(?:=|\.)/,
+      new RegExp(`<(?:dt-[\\w-]+|Dt\\w+)\\b${DT_TAG_ATTRS}\\b(?:show|hide-close|hide-icon|label-visible|selected-values)(?:=|[\\s>])`),
+      new RegExp(`<(?:dt-(?:banner|notice|toast|modal)|Dt(?:Banner|Notice|Toast|Modal))\\b${DT_TAG_ATTRS}\\btitle(?:=|[\\s>])`),
+      new RegExp(`<(?:dt-[\\w-]+|Dt\\w+)\\b${DT_TAG_ATTRS}@(?:input|change)(?:=|\\.)`),
       /kind="(?:danger|error)"/,
       /validation-state="(?:error|success)"/,
     ],

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -177,7 +177,9 @@ const MIGRATIONS = [
       // (?<!-) blocks a hyphen immediately before the prop name — \b alone still matches
       // there (- is a non-word char), which would treat native v-show as the show prop.
       new RegExp(`<(?:dt-[\\w-]+|Dt\\w+)\\b${DT_TAG_ATTRS}\\b(?<!-)(?:show|hide-close|hide-icon|label-visible|selected-values)(?:=|[\\s>])`),
-      new RegExp(`<(?:dt-(?:banner|notice|toast|modal)|Dt(?:Banner|Notice|Toast|Modal))\\b${DT_TAG_ATTRS}\\btitle(?:=|[\\s>])`),
+      // (?<!-) blocks a hyphen immediately before "title" so data-title (and any other
+      // custom -title attribute) isn't mistaken for the title prop.
+      new RegExp(`<(?:dt-(?:banner|notice|toast|modal)|Dt(?:Banner|Notice|Toast|Modal))\\b${DT_TAG_ATTRS}\\b(?<!-)title(?:=|[\\s>])`),
       new RegExp(`<(?:dt-[\\w-]+|Dt\\w+)\\b${DT_TAG_ATTRS}@(?:input|change)(?:=|\\.)`),
       /kind="(?:danger|error)"/,
       /validation-state="(?:error|success)"/,

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -56,10 +56,15 @@ const __dirname = path.dirname(__filename);
  * @property {string} [scriptDir]  - Directory name for standalone scripts
  * @property {boolean} [supportsPackageArg] - Forward --package to this standalone script
  * @property {string[]} [extraArgs] - Extra CLI args to forward
- * @property {RegExp[]} detectPatterns - Patterns that indicate migration is still needed
- * @property {RegExp[]} [skipIfPatterns] - If any of these match a file, skip detectPatterns
- *   for that file — used when detectPatterns values are ambiguous with the post-migration
- *   scale and a new-scale-only marker means the file has already been migrated.
+ * @property {RegExp[]} detectPatterns - Patterns that unambiguously indicate migration is
+ *   still needed. Always evaluated, regardless of skipIfPatterns.
+ * @property {RegExp[]} [ambiguousDetectPatterns] - Patterns that overlap with valid
+ *   post-migration values. Only evaluated when skipIfPatterns does not match, so a file
+ *   already containing a new-scale-only marker isn't flagged on these alone — but an
+ *   unambiguous detectPatterns match elsewhere in the same (partially migrated) file
+ *   still counts.
+ * @property {RegExp[]} [skipIfPatterns] - New-scale-only markers that gate
+ *   ambiguousDetectPatterns — their presence means the file has already been migrated.
  * @property {string[]} fileExtensions - File extensions to scan during health check
  */
 
@@ -245,13 +250,21 @@ const MIGRATIONS = [
     category: 'opt-in',
     type: 'config',
     configName: 'stack-gap-to-spacing',
+    // Old-only stops (never valid post-migration values) — always flagged as pending.
     detectPatterns: [
-      /gap="(?:50|100|200|300|350|400|450|500|525|550|600|625|650|700)"/,
-      /d-stack--gap-(?:50|100|200|300|350|400|450|500|525|550|600|625|650|700)/,
+      /gap="(?:350|450|500|550|625|650|700)"/,
+      /d-stack--gap-(?:350|450|500|550|625|650|700)/,
     ],
-    // Old and new gap scales share numeric stops (e.g. "100"), so a bare match doesn't
-    // prove pending work. Mirrors dialtone_migration_helper/configs/stack-gap-to-spacing.mjs's
-    // isAlreadyMigrated check: new-scale-only stops indicate the file was already migrated.
+    // Old and new gap scales share some numeric stops (e.g. "100"), so a bare match on
+    // these doesn't prove pending work. Only counted when the file has no new-scale-only
+    // marker (skipIfPatterns) — an unambiguous detectPatterns match elsewhere in the same
+    // (partially migrated) file is still flagged regardless.
+    ambiguousDetectPatterns: [
+      /gap="(?:50|100|200|300|400|525|600)"/,
+      /d-stack--gap-(?:50|100|200|300|400|525|600)/,
+    ],
+    // Mirrors dialtone_migration_helper/configs/stack-gap-to-spacing.mjs's isAlreadyMigrated
+    // check: new-scale-only stops indicate the file was already migrated.
     skipIfPatterns: [
       /gap="(?:25|75|150|250|525)"/,
       /gap="'(?:25|75|150|250|525)'"/,
@@ -558,8 +571,14 @@ async function healthCheck (cwd) {
 
     for (const [file, content] of fileContents) {
       if (!migration.fileExtensions.some(ext => file.endsWith(ext))) continue;
-      if (migration.skipIfPatterns?.some(pattern => pattern.test(content))) continue;
-      for (const pattern of migration.detectPatterns) {
+
+      let patterns = migration.detectPatterns;
+      const alreadyMigrated = migration.skipIfPatterns?.some(pattern => pattern.test(content));
+      if (!alreadyMigrated && migration.ambiguousDetectPatterns) {
+        patterns = [...patterns, ...migration.ambiguousDetectPatterns];
+      }
+
+      for (const pattern of patterns) {
         // Reset lastIndex for global patterns
         const re = new RegExp(pattern.source, pattern.flags.replace('g', ''));
         if (re.test(content)) {

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -174,7 +174,9 @@ const MIGRATIONS = [
     type: 'standalone',
     scriptDir: 'dialtone_migrate_props',
     detectPatterns: [
-      new RegExp(`<(?:dt-[\\w-]+|Dt\\w+)\\b${DT_TAG_ATTRS}\\b(?:show|hide-close|hide-icon|label-visible|selected-values)(?:=|[\\s>])`),
+      // (?<!-) blocks a hyphen immediately before the prop name — \b alone still matches
+      // there (- is a non-word char), which would treat native v-show as the show prop.
+      new RegExp(`<(?:dt-[\\w-]+|Dt\\w+)\\b${DT_TAG_ATTRS}\\b(?<!-)(?:show|hide-close|hide-icon|label-visible|selected-values)(?:=|[\\s>])`),
       new RegExp(`<(?:dt-(?:banner|notice|toast|modal)|Dt(?:Banner|Notice|Toast|Modal))\\b${DT_TAG_ATTRS}\\btitle(?:=|[\\s>])`),
       new RegExp(`<(?:dt-[\\w-]+|Dt\\w+)\\b${DT_TAG_ATTRS}@(?:input|change)(?:=|\\.)`),
       /kind="(?:danger|error)"/,

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/index.mjs
@@ -73,10 +73,11 @@ const __dirname = path.dirname(__filename);
 // literal > inside one (e.g. :disabled="count > 0") doesn't truncate the match early.
 const DT_TAG_ATTRS = '(?:[^>"\']|"[^"]*"|\'[^\']*\')*';
 
-// Requires a real attribute-name boundary before "gap": blocks a word char or hyphen
-// (data-gap), an event-listener "@" (@gap), and a trailing "on:" from v-on:gap — but still
-// allows a bare gap=, a bound :gap=, or v-bind:gap= (neither ends in "on:" or starts with @).
-const GAP_ATTR_BOUNDARY = '(?<!@)(?<!on:)(?<![\\w-])';
+// Allowlist (not denylist) of what may immediately precede "gap": whitespace (bare gap=),
+// whitespace+":" (shorthand :gap=), or whitespace+"v-bind:" (long form). This rejects
+// data-gap, @gap, v-on:gap, v-model:gap, v-slot:gap, and any other directive namespace,
+// without having to enumerate every prefix that isn't the real gap prop/attribute.
+const GAP_ATTR_LEAD = '(?:(?<=\\s)|(?<=\\s:)|(?<=\\sv-bind:))';
 
 const MIGRATIONS = [
   // ── Required (breaking) ────────────────────────────────────────────
@@ -265,7 +266,7 @@ const MIGRATIONS = [
     configName: 'stack-gap-to-spacing',
     // Old-only stops (never valid post-migration values) — always flagged as pending.
     detectPatterns: [
-      new RegExp(`${GAP_ATTR_BOUNDARY}gap="(?:350|450|500|550|625|650|700)"`),
+      new RegExp(`${GAP_ATTR_LEAD}gap="(?:350|450|500|550|625|650|700)"`),
       /d-stack--gap-(?:350|450|500|550|625|650|700)/,
     ],
     // Old and new gap scales share some numeric stops (e.g. "100"), so a bare match on
@@ -273,15 +274,15 @@ const MIGRATIONS = [
     // marker (skipIfPatterns) — an unambiguous detectPatterns match elsewhere in the same
     // (partially migrated) file is still flagged regardless.
     ambiguousDetectPatterns: [
-      new RegExp(`${GAP_ATTR_BOUNDARY}gap="(?:50|100|200|300|400|525|600)"`),
+      new RegExp(`${GAP_ATTR_LEAD}gap="(?:50|100|200|300|400|525|600)"`),
       /d-stack--gap-(?:50|100|200|300|400|525|600)/,
     ],
     // Mirrors dialtone_migration_helper/configs/stack-gap-to-spacing.mjs's isAlreadyMigrated
     // check: new-scale-only stops indicate the file was already migrated.
     skipIfPatterns: [
-      new RegExp(`${GAP_ATTR_BOUNDARY}gap="(?:25|75|150|250|525)"`),
-      new RegExp(`${GAP_ATTR_BOUNDARY}gap='(?:25|75|150|250|525)'`),
-      new RegExp(`${GAP_ATTR_BOUNDARY}gap="'(?:25|75|150|250|525)'"`),
+      new RegExp(`${GAP_ATTR_LEAD}gap="(?:25|75|150|250|525)"`),
+      new RegExp(`${GAP_ATTR_LEAD}gap='(?:25|75|150|250|525)'`),
+      new RegExp(`${GAP_ATTR_LEAD}gap="'(?:25|75|150|250|525)'"`),
       /d-stack--gap-(?:25|75|150|250|525)/,
       /d-description-list--gap-(?:25|75|150|250|525)/,
     ],

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
@@ -86,3 +86,46 @@ describe('--package validation', () => {
     assert.equal(status, 0);
   });
 });
+
+describe('--health-check', () => {
+  function runHealthCheck (files) {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dlt-health-'));
+    try {
+      for (const [name, contents] of Object.entries(files)) {
+        fs.writeFileSync(path.join(tmp, name), contents);
+      }
+      return execFileSync(process.execPath, [cli, '--health-check', '--cwd', tmp],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+
+  it('does not flag native v-show on non-Dialtone elements as component-props', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><div v-show="isReady">Ready</div></template>',
+    });
+    assert.match(output, /\[DONE\].*Component Props & Events \(component-props\)/);
+  });
+
+  it('still flags show= on a Dialtone component as component-props', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-modal show="isOpen"></dt-modal></template>',
+    });
+    assert.match(output, /\[PENDING\].*Component Props & Events \(component-props\)/);
+  });
+
+  it('does not flag an already-migrated file for stack-gap-to-spacing', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-stack gap="100"></dt-stack><dt-stack gap="25"></dt-stack></template>',
+    });
+    assert.match(output, /\[DONE\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
+  });
+
+  it('still flags an unmigrated file for stack-gap-to-spacing', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-stack gap="625"></dt-stack></template>',
+    });
+    assert.match(output, /\[PENDING\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
+  });
+});

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
@@ -115,9 +115,30 @@ describe('--health-check', () => {
     assert.match(output, /\[DONE\].*Component Props & Events \(component-props\)/);
   });
 
+  it('does not flag v-show on dt-button as component-props', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-button v-show="visible">Go</dt-button></template>',
+    });
+    assert.match(output, /\[DONE\].*Component Props & Events \(component-props\)/);
+  });
+
+  it('does not flag data-title or v-title on a Dialtone element as component-props', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-modal data-title="tooltip" v-title="x"></dt-modal></template>',
+    });
+    assert.match(output, /\[DONE\].*Component Props & Events \(component-props\)/);
+  });
+
   it('still flags show= on a Dialtone component as component-props', () => {
     const output = runHealthCheck({
       'App.vue': '<template><dt-modal show="isOpen"></dt-modal></template>',
+    });
+    assert.match(output, /\[PENDING\].*Component Props & Events \(component-props\)/);
+  });
+
+  it('still flags title= on a Dialtone component as component-props', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-modal title="isOpen"></dt-modal></template>',
     });
     assert.match(output, /\[PENDING\].*Component Props & Events \(component-props\)/);
   });

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
@@ -199,6 +199,13 @@ describe('--health-check', () => {
     assert.match(output, /\[PENDING\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
   });
 
+  it('does not flag v-model:gap and still detects a real ambiguous gap alongside it', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-stack v-model:gap="someRef"></dt-stack><dt-stack gap="100"></dt-stack></template>',
+    });
+    assert.match(output, /\[PENDING\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
+  });
+
   it('does not flag gap="525" for stack-gap-to-spacing', () => {
     const output = runHealthCheck({
       'App.vue': '<template><dt-stack gap="525"></dt-stack></template>',

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
@@ -143,6 +143,13 @@ describe('--health-check', () => {
     assert.match(output, /\[DONE\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
   });
 
+  it('does not flag a mix of single-quoted gap=\'25\' and double-quoted gap="100" for stack-gap-to-spacing', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-stack gap=\'25\'></dt-stack><dt-stack gap="100"></dt-stack></template>',
+    });
+    assert.match(output, /\[DONE\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
+  });
+
   it('still flags an unmigrated stop in a partially migrated (mixed) file for stack-gap-to-spacing', () => {
     const output = runHealthCheck({
       'App.vue': '<template><dt-stack gap="25"></dt-stack><dt-stack gap="625"></dt-stack></template>',

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
@@ -164,6 +164,20 @@ describe('--health-check', () => {
     assert.match(output, /\[PENDING\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
   });
 
+  it('does not flag an unrelated data-gap attribute for stack-gap-to-spacing', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><div data-gap="625"></div></template>',
+    });
+    assert.match(output, /\[DONE\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
+  });
+
+  it('does not let an unrelated data-gap new-scale value suppress a real ambiguous pending gap', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><div data-gap="25"></div><dt-stack gap="100"></dt-stack></template>',
+    });
+    assert.match(output, /\[PENDING\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
+  });
+
   it('does not flag gap="525" for stack-gap-to-spacing', () => {
     const output = runHealthCheck({
       'App.vue': '<template><dt-stack gap="525"></dt-stack></template>',

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
@@ -115,6 +115,13 @@ describe('--health-check', () => {
     assert.match(output, /\[PENDING\].*Component Props & Events \(component-props\)/);
   });
 
+  it('still flags :show= on a Dialtone component when a quoted attribute earlier in the tag contains a literal >', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-modal :disabled="count > 0" :show="isOpen"></dt-modal></template>',
+    });
+    assert.match(output, /\[PENDING\].*Component Props & Events \(component-props\)/);
+  });
+
   it('does not flag an already-migrated file for stack-gap-to-spacing', () => {
     const output = runHealthCheck({
       'App.vue': '<template><dt-stack gap="100"></dt-stack><dt-stack gap="25"></dt-stack></template>',

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
@@ -128,4 +128,18 @@ describe('--health-check', () => {
     });
     assert.match(output, /\[PENDING\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
   });
+
+  it('does not flag gap="525" for stack-gap-to-spacing', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-stack gap="525"></dt-stack></template>',
+    });
+    assert.match(output, /\[DONE\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
+  });
+
+  it('does not flag an old stack class alongside a bound gap="\'25\'" for stack-gap-to-spacing', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-stack class="d-stack--gap-100" :gap="\'25\'"></dt-stack></template>',
+    });
+    assert.match(output, /\[DONE\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
+  });
 });

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
@@ -108,6 +108,13 @@ describe('--health-check', () => {
     assert.match(output, /\[DONE\].*Component Props & Events \(component-props\)/);
   });
 
+  it('does not flag native v-show on a Dialtone element as component-props', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-modal v-show="isOpen"></dt-modal></template>',
+    });
+    assert.match(output, /\[DONE\].*Component Props & Events \(component-props\)/);
+  });
+
   it('still flags show= on a Dialtone component as component-props', () => {
     const output = runHealthCheck({
       'App.vue': '<template><dt-modal show="isOpen"></dt-modal></template>',

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
@@ -178,6 +178,27 @@ describe('--health-check', () => {
     assert.match(output, /\[PENDING\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
   });
 
+  it('does not flag an @gap event-listener value as a pending gap prop', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-stack @gap="625"></dt-stack></template>',
+    });
+    assert.match(output, /\[DONE\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
+  });
+
+  it('does not let an @gap or v-on:gap event-listener value suppress a real ambiguous pending gap', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-stack @gap="25"></dt-stack><dt-stack v-on:gap="75"></dt-stack><dt-stack gap="100"></dt-stack></template>',
+    });
+    assert.match(output, /\[PENDING\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
+  });
+
+  it('still flags a bound :gap= and v-bind:gap= as pending', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-stack :gap="625"></dt-stack><dt-stack v-bind:gap="625"></dt-stack></template>',
+    });
+    assert.match(output, /\[PENDING\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
+  });
+
   it('does not flag gap="525" for stack-gap-to-spacing', () => {
     const output = runHealthCheck({
       'App.vue': '<template><dt-stack gap="525"></dt-stack></template>',

--- a/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
+++ b/packages/dialtone-css/lib/build/js/dialtone_migrate/test.mjs
@@ -136,6 +136,13 @@ describe('--health-check', () => {
     assert.match(output, /\[DONE\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
   });
 
+  it('still flags an unmigrated stop in a partially migrated (mixed) file for stack-gap-to-spacing', () => {
+    const output = runHealthCheck({
+      'App.vue': '<template><dt-stack gap="25"></dt-stack><dt-stack gap="625"></dt-stack></template>',
+    });
+    assert.match(output, /\[PENDING\].*Stack Gap to Spacing \(stack-gap-to-spacing\)/);
+  });
+
   it('does not flag an old stack class alongside a bound gap="\'25\'" for stack-gap-to-spacing', () => {
     const output = runHealthCheck({
       'App.vue': '<template><dt-stack class="d-stack--gap-100" :gap="\'25\'"></dt-stack></template>',


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3586

## :book: Description

Fixes two false positives in `npx dialtone-migrate --health-check`:

- `component-props` no longer matches Vue's native `v-show="..."` on non-Dialtone elements — the detect pattern is now scoped to `dt-*`/`Dt*` tags like its sibling patterns.
- `stack-gap-to-spacing` now skips files that already contain new-scale-only gap stops (`25`, `75`, `150`, `250`), mirroring the codemod's own `isAlreadyMigrated` check, so fully migrated files aren't flagged as pending.

Added regression tests for both cases.

## :bulb: Context

Reported by a consumer team who ran the health check after migrating and got two pending results that turned out to be detector bugs rather than real remaining work.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added / updated unit tests.
