### PR TITLE
fix(combobox-multi-select): DP-205810 fix Japanese IME input

### DIFF
--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.test.js
@@ -428,6 +428,45 @@ describe('DtComboboxMultiSelect Tests', () => {
     });
   });
 
+  describe('IME Composition', () => {
+    beforeEach(async () => {
+      await input.trigger('focus');
+    });
+
+    it('should not emit keydown/enter during IME composition', async () => {
+      await input.trigger('compositionstart');
+      await input.trigger('keydown', { key: 'Enter', code: 'Enter', isComposing: true });
+      expect(wrapper.emitted('keydown')).toBeUndefined();
+      expect(wrapper.emitted('enter')).toBeUndefined();
+    });
+
+    it('should not emit keydown/escape during IME composition', async () => {
+      await input.trigger('compositionstart');
+      await input.trigger('keydown', { key: 'Escape', code: 'Escape', isComposing: true });
+      expect(wrapper.emitted('keydown')).toBeUndefined();
+      expect(wrapper.emitted('escape')).toBeUndefined();
+    });
+
+    it('should emit enter after composition ends', async () => {
+      await input.trigger('compositionstart');
+      await input.trigger('compositionend');
+      await input.trigger('keydown', { key: 'Enter', code: 'Enter' });
+      expect(wrapper.emitted('enter').length).toBe(1);
+    });
+
+    it('should not emit input when native InputEvent has isComposing true', async () => {
+      await input.trigger('compositionstart');
+      const inputEvent = new InputEvent('input', {
+        data: 'あ',
+        inputType: 'insertCompositionText',
+        isComposing: true,
+        bubbles: true,
+      });
+      input.element.dispatchEvent(inputEvent);
+      expect(wrapper.emitted('input')).toBeUndefined();
+    });
+  });
+
   describe('Duplicate Items Tests', () => {
     beforeEach(async () => {
       await wrapper.setProps({ selectedItems: ['item1', 'item1', 'item1'] });

--- a/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
+++ b/packages/dialtone-vue/components/combobox_multi_select/combobox_multi_select.vue
@@ -495,6 +495,7 @@ export default {
       return {
         ...extractVueListeners(this.$attrs),
         onInput: event => {
+          if (event instanceof InputEvent && event.isComposing) return;
           this.$emit('input', event);
           if (this.hasSuggestionList) {
             this.showComboboxList();
@@ -502,7 +503,7 @@ export default {
         },
 
         onKeydown: event => {
-          if (this.disabled) return;
+          if (this.disabled || event.isComposing) return;
           this.onInputKeyDown(event);
           this.$emit('keydown', event);
           // Use event.key (not event.code) so NumpadEnter normalizes to 'Enter'


### PR DESCRIPTION
## Summary

- Guard `onKeydown` in `inputListeners` with `event.isComposing` to prevent Enter/Escape from intercepting IME confirmation keys during composition (e.g. Japanese input)
- Add defense-in-depth `isComposing` guard on `onInput` for older compiled versions where the handler fell through `$attrs` as a native `InputEvent`
- Add IME composition test coverage (4 tests)

## Context

Japanese users couldn't type the first character in the disposition combobox during post-call wrap-up. The `onKeydown` handler falls through `$attrs` to the native `<input>`, so it fires during IME composition — pressing Enter to confirm an IME candidate triggers `onEnterKey` → selects a list item → clears the input, destroying the composition.

A firespotter-side workaround is already merged (PR #81582). This is the upstream Dialtone fix.

## Test plan

- [x] All 54 `combobox_multi_select` tests pass (including 4 new IME tests)
- [ ] Manual: Open a combobox multi-select, switch to Japanese IME, type a character, confirm with Enter — should insert the character, not select a list item