### PR TITLE
NO-JIRA: fix links inside rich text editor message open new tab

### DIFF
--- a/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.test.js
+++ b/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.test.js
@@ -1563,8 +1563,8 @@ describe('DtRichTextEditor tests', () => {
     describe('Link click functionality', () => {
       const HREF = 'https://example.com/app/messages/123';
 
-      const _insertLink = async () => {
-        await wrapper.setProps({ link: true });
+      const _insertLink = async (props = {}) => {
+        await wrapper.setProps({ link: true, ...props });
         const editorInstance = wrapper.vm.editor;
         editorInstance.commands.setContent({
           type: 'doc',
@@ -1580,24 +1580,19 @@ describe('DtRichTextEditor tests', () => {
         await wrapper.vm.$nextTick();
       };
 
-      const _findLinkMarkPos = (state) => {
-        let pos = null;
-        state.doc.descendants((node, nodePos) => {
-          if (node.isText && node.marks.some(m => m.type.name === 'link')) {
-            pos = nodePos + 1;
-          }
-        });
-        return pos;
+      // The click handler reads the anchor from event.target.closest('a'), so
+      // build an event whose target is the rendered link element.
+      const _clickLink = (view, { cancelable = false } = {}) => {
+        const anchor = wrapper.find('a.d-link').element;
+        const event = new MouseEvent('click', { button: 0, cancelable });
+        Object.defineProperty(event, 'target', { value: anchor });
+        return view.someProp('handleClick', (fn) => fn(view, 1, event));
       };
 
       it('emits link-click with the href when a link is clicked', async () => {
-        await _insertLink();
+        await _insertLink({ emitLinkClick: true });
 
-        const { state, view } = wrapper.vm.editor;
-        const pos = _findLinkMarkPos(state);
-        // Invoke the click handler directly — dispatchEvent does not work in
-        // JSDOM because ProseMirror resolves positions via getBoundingClientRect.
-        view.someProp('handleClick', (fn) => fn(view, pos, new MouseEvent('click')));
+        _clickLink(wrapper.vm.editor.view);
         await wrapper.vm.$nextTick();
 
         expect(wrapper.emitted('link-click')).toBeTruthy();
@@ -1605,28 +1600,39 @@ describe('DtRichTextEditor tests', () => {
         expect(wrapper.emitted('link-click')[0][0].event).toBeInstanceOf(MouseEvent);
       });
 
-      it('does not emit link-click when no link mark is at the clicked position', async () => {
-        await wrapper.setProps({ link: true });
+      it('does not emit link-click when emitLinkClick is false (default)', async () => {
+        await _insertLink();
+
+        _clickLink(wrapper.vm.editor.view);
         await wrapper.vm.$nextTick();
 
+        expect(wrapper.emitted('link-click')).toBeFalsy();
+      });
+
+      it('does not emit link-click when the click is not on a link', async () => {
+        await _insertLink({ emitLinkClick: true });
+
         const { view } = wrapper.vm.editor;
-        view.someProp('handleClick', (fn) => fn(view, 1, new MouseEvent('click')));
+        const event = new MouseEvent('click', { button: 0 });
+        Object.defineProperty(event, 'target', { value: document.createElement('div') });
+        view.someProp('handleClick', (fn) => fn(view, 1, event));
         await wrapper.vm.$nextTick();
 
         expect(wrapper.emitted('link-click')).toBeFalsy();
       });
 
       it('lets the consumer suppress default navigation via preventDefault', async () => {
-        await _insertLink();
+        await _insertLink({ emitLinkClick: true });
 
-        const { state, view } = wrapper.vm.editor;
-        const pos = _findLinkMarkPos(state);
         // A consumer that intercepts the link would preventDefault on the event;
         // the click handler then reports it as handled so the browser does not
         // follow the anchor's target="_blank".
-        const event = new MouseEvent('click', { cancelable: true });
+        const view = wrapper.vm.editor.view;
+        const anchor = wrapper.find('a.d-link').element;
+        const event = new MouseEvent('click', { button: 0, cancelable: true });
+        Object.defineProperty(event, 'target', { value: anchor });
         event.preventDefault();
-        const handled = view.someProp('handleClick', (fn) => fn(view, pos, event));
+        const handled = view.someProp('handleClick', (fn) => fn(view, 1, event));
         await wrapper.vm.$nextTick();
 
         expect(handled).toBe(true);

--- a/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.test.js
+++ b/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.test.js
@@ -1640,6 +1640,25 @@ describe('DtRichTextEditor tests', () => {
 
         expect(handled).toBe(true);
       });
+
+      it('does not emit link-click when the built-in link extension is disabled', async () => {
+        // The event is scoped to the built-in `link` extension. With link
+        // disabled, anchors from other extensions (e.g. customLink) must not
+        // emit link-click, matching the documented contract.
+        await wrapper.setProps({ link: false });
+        await wrapper.vm.$nextTick();
+
+        const view = wrapper.vm.editor.view;
+        const anchor = document.createElement('a');
+        anchor.href = HREF;
+        anchor.textContent = 'a link';
+        const event = new MouseEvent('click', { button: 0, cancelable: true });
+        Object.defineProperty(event, 'target', { value: anchor });
+        view.someProp('handleDOMEvents', (handlers) => handlers.click?.(view, event));
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.emitted('link-click')).toBeFalsy();
+      });
     });
 
     describe('Mention hover functionality', () => {

--- a/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.test.js
+++ b/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.test.js
@@ -1580,17 +1580,19 @@ describe('DtRichTextEditor tests', () => {
         await wrapper.vm.$nextTick();
       };
 
-      // The click handler reads the anchor from event.target.closest('a'), so
-      // build an event whose target is the rendered link element.
-      const _clickLink = (view, { cancelable = false } = {}) => {
-        const anchor = wrapper.find('a.d-link').element;
+      // The link click is handled via a DOM `click` event (handleDOMEvents.click)
+      // rather than ProseMirror's handleClick, so that it also fires on a
+      // non-editable (read-only) editor. Build an event whose target is the
+      // rendered link element and dispatch it through the registered handler.
+      const _clickLink = (view, { cancelable = false, target } = {}) => {
+        const anchor = target ?? wrapper.find('a.d-link').element;
         const event = new MouseEvent('click', { button: 0, cancelable });
         Object.defineProperty(event, 'target', { value: anchor });
-        return view.someProp('handleClick', (fn) => fn(view, 1, event));
+        return view.someProp('handleDOMEvents', (handlers) => handlers.click?.(view, event));
       };
 
       it('emits link-click with the href when a link is clicked', async () => {
-        await _insertLink({ emitLinkClick: true });
+        await _insertLink();
 
         _clickLink(wrapper.vm.editor.view);
         await wrapper.vm.$nextTick();
@@ -1600,29 +1602,30 @@ describe('DtRichTextEditor tests', () => {
         expect(wrapper.emitted('link-click')[0][0].event).toBeInstanceOf(MouseEvent);
       });
 
-      it('does not emit link-click when emitLinkClick is false (default)', async () => {
+      it('does not emit link-click when the click is not on a link', async () => {
         await _insertLink();
 
-        _clickLink(wrapper.vm.editor.view);
+        _clickLink(wrapper.vm.editor.view, { target: document.createElement('div') });
         await wrapper.vm.$nextTick();
 
         expect(wrapper.emitted('link-click')).toBeFalsy();
       });
 
-      it('does not emit link-click when the click is not on a link', async () => {
-        await _insertLink({ emitLinkClick: true });
+      it('preserves default navigation when the consumer does not preventDefault', async () => {
+        await _insertLink();
 
-        const { view } = wrapper.vm.editor;
-        const event = new MouseEvent('click', { button: 0 });
-        Object.defineProperty(event, 'target', { value: document.createElement('div') });
-        view.someProp('handleClick', (fn) => fn(view, 1, event));
+        const handled = _clickLink(wrapper.vm.editor.view, { cancelable: true });
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.emitted('link-click')).toBeFalsy();
+        // The event still emits, but without preventDefault the handler reports
+        // not-handled (someProp returns undefined for a falsy result), so the
+        // anchor's default behavior (target="_blank") proceeds as before.
+        expect(handled).toBeFalsy();
+        expect(wrapper.emitted('link-click')).toBeTruthy();
       });
 
       it('lets the consumer suppress default navigation via preventDefault', async () => {
-        await _insertLink({ emitLinkClick: true });
+        await _insertLink();
 
         // A consumer that intercepts the link would preventDefault on the event;
         // the click handler then reports it as handled so the browser does not
@@ -1632,7 +1635,7 @@ describe('DtRichTextEditor tests', () => {
         const event = new MouseEvent('click', { button: 0, cancelable: true });
         Object.defineProperty(event, 'target', { value: anchor });
         event.preventDefault();
-        const handled = view.someProp('handleClick', (fn) => fn(view, 1, event));
+        const handled = view.someProp('handleDOMEvents', (handlers) => handlers.click?.(view, event));
         await wrapper.vm.$nextTick();
 
         expect(handled).toBe(true);

--- a/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.test.js
+++ b/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.test.js
@@ -1560,6 +1560,79 @@ describe('DtRichTextEditor tests', () => {
       });
     });
 
+    describe('Link click functionality', () => {
+      const HREF = 'https://example.com/app/messages/123';
+
+      const _insertLink = async () => {
+        await wrapper.setProps({ link: true });
+        const editorInstance = wrapper.vm.editor;
+        editorInstance.commands.setContent({
+          type: 'doc',
+          content: [{
+            type: 'paragraph',
+            content: [{
+              type: 'text',
+              text: 'a link',
+              marks: [{ type: 'link', attrs: { href: HREF } }],
+            }],
+          }],
+        });
+        await wrapper.vm.$nextTick();
+      };
+
+      const _findLinkMarkPos = (state) => {
+        let pos = null;
+        state.doc.descendants((node, nodePos) => {
+          if (node.isText && node.marks.some(m => m.type.name === 'link')) {
+            pos = nodePos + 1;
+          }
+        });
+        return pos;
+      };
+
+      it('emits link-click with the href when a link is clicked', async () => {
+        await _insertLink();
+
+        const { state, view } = wrapper.vm.editor;
+        const pos = _findLinkMarkPos(state);
+        // Invoke the click handler directly — dispatchEvent does not work in
+        // JSDOM because ProseMirror resolves positions via getBoundingClientRect.
+        view.someProp('handleClick', (fn) => fn(view, pos, new MouseEvent('click')));
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.emitted('link-click')).toBeTruthy();
+        expect(wrapper.emitted('link-click')[0][0]).toMatchObject({ href: HREF, text: 'a link' });
+        expect(wrapper.emitted('link-click')[0][0].event).toBeInstanceOf(MouseEvent);
+      });
+
+      it('does not emit link-click when no link mark is at the clicked position', async () => {
+        await wrapper.setProps({ link: true });
+        await wrapper.vm.$nextTick();
+
+        const { view } = wrapper.vm.editor;
+        view.someProp('handleClick', (fn) => fn(view, 1, new MouseEvent('click')));
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.emitted('link-click')).toBeFalsy();
+      });
+
+      it('lets the consumer suppress default navigation via preventDefault', async () => {
+        await _insertLink();
+
+        const { state, view } = wrapper.vm.editor;
+        const pos = _findLinkMarkPos(state);
+        // A consumer that intercepts the link would preventDefault on the event;
+        // the click handler then reports it as handled so the browser does not
+        // follow the anchor's target="_blank".
+        const event = new MouseEvent('click', { cancelable: true });
+        event.preventDefault();
+        const handled = view.someProp('handleClick', (fn) => fn(view, pos, event));
+        await wrapper.vm.$nextTick();
+
+        expect(handled).toBe(true);
+      });
+    });
+
     describe('Mention hover functionality', () => {
       const mentionData = {
         id: 'john.doe',

--- a/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.vue
@@ -56,7 +56,8 @@
 /* eslint-disable max-lines */
 import { Editor, EditorContent } from '@tiptap/vue-3';
 import { BubbleMenu } from '@tiptap/vue-3/menus';
-import { Extension } from '@tiptap/core';
+import { Extension, getMarkRange } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { DtButton } from '../Button';
 import { DtStack } from '../Stack';
 import Blockquote from '@tiptap/extension-blockquote';
@@ -617,6 +618,18 @@ export default {
      * @type {Object}
      */
     'phone-click',
+
+    /**
+     * Event fired when a link is clicked.
+     * Payload: { href: string, text: string, event: MouseEvent } — the link's
+     * href, its text content, and the originating click event. Call
+     * event.preventDefault() to suppress the default navigation (e.g. to route
+     * same-origin URLs in-app instead of opening a new tab).
+     * Requires the `link` prop to be set.
+     * @event link-click
+     * @type {Object}
+     */
+    'link-click',
   ],
 
   data () {
@@ -722,6 +735,30 @@ export default {
                 return true;
               },
             };
+          },
+          addProseMirrorPlugins () {
+            const markType = this.type;
+            // Emit `link-click` so consumers can intercept links (e.g. to
+            // navigate same-origin URLs in-app instead of opening a new tab).
+            // The listener may call event.preventDefault() to suppress the
+            // default navigation; otherwise the anchor behaves normally.
+            const linkClickPlugin = new Plugin({
+              key: new PluginKey('linkClick'),
+              props: {
+                handleClick (view, pos, event) {
+                  const { state } = view;
+                  const $pos = state.doc.resolve(pos);
+                  const linkMark = $pos.marks().find(m => m.type === markType);
+                  if (!linkMark) return false;
+                  const range = getMarkRange($pos, markType);
+                  const text = range ? state.doc.textBetween(range.from, range.to) : '';
+                  self.editor.emit('link-click', { href: linkMark.attrs.href, text, event });
+                  return event.defaultPrevented;
+                },
+              },
+            });
+
+            return [...(this.parent?.() ?? []), linkClickPlugin];
           },
         }).configure({
           HTMLAttributes: {
@@ -1324,6 +1361,11 @@ export default {
       // Phone number link is clicked — only emitted by the LinkPhoneNumbers extension
       this.editor.on('phone-click', (phoneData) => {
         this.$emit('phone-click', phoneData);
+      });
+
+      // A link is clicked — only emitted when the built-in `link` extension is active
+      this.editor.on('link-click', (linkData) => {
+        this.$emit('link-click', linkData);
       });
     },
 

--- a/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.vue
@@ -228,18 +228,6 @@ export default {
     },
 
     /**
-     * When true, a `link-click` event is emitted whenever a link (from the
-     * `link` extension) is clicked, letting the consumer handle navigation
-     * (e.g. route same-origin URLs in-app). The listener may call
-     * event.preventDefault() to suppress the default navigation. Defaults to
-     * false to preserve the standard anchor behavior.
-     */
-    emitLinkClick: {
-      type: Boolean,
-      default: false,
-    },
-
-    /**
      * Enables the Custom Link extension and optionally passes configurations to it
      *
      * It is not recommended to use this and the built in TipTap link extension at the same time.
@@ -1003,19 +991,25 @@ export default {
 
           // Emit `link-click` so consumers can intercept links (e.g. to
           // navigate same-origin URLs in-app instead of opening a new tab).
-          // The listener may call event.preventDefault() to suppress the
-          // default navigation; otherwise the anchor behaves normally.
-          // Opt-in: only intercept clicks when the consumer wants the event.
-          handleClick: (view, pos, event) => {
-            if (!this.emitLinkClick || event.button !== 0) return false;
-            const anchor = event.target?.closest?.('a');
-            if (!anchor) return false;
-            this.editor.emit('link-click', {
-              href: anchor.href,
-              text: anchor.textContent,
-              event,
-            });
-            return event.defaultPrevented;
+          // The default anchor behavior is preserved; a listener may call
+          // event.preventDefault() to suppress the default navigation.
+          //
+          // Uses a DOM click handler rather than ProseMirror's handleClick:
+          // handleClick is not invoked on a non-editable view (e.g. a read-only
+          // editor rendering a message), whereas handleDOMEvents fires for real
+          // DOM clicks regardless of editable state.
+          handleDOMEvents: {
+            click: (view, event) => {
+              if (event.button !== 0) return false;
+              const anchor = event.target?.closest?.('a');
+              if (!anchor) return false;
+              this.editor.emit('link-click', {
+                href: anchor.href,
+                text: anchor.textContent,
+                event,
+              });
+              return event.defaultPrevented;
+            },
           },
 
           handleKeyDown: (view, event) => {

--- a/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.vue
@@ -989,10 +989,13 @@ export default {
             class: this.inputClass,
           },
 
-          // Emit `link-click` so consumers can intercept links (e.g. to
-          // navigate same-origin URLs in-app instead of opening a new tab).
-          // The default anchor behavior is preserved; a listener may call
-          // event.preventDefault() to suppress the default navigation.
+          // Emit `link-click` for anchors from the built-in `link` extension so
+          // consumers can intercept links (e.g. to navigate same-origin URLs
+          // in-app instead of opening a new tab). The default anchor behavior is
+          // preserved; a listener may call event.preventDefault() to suppress
+          // the default navigation. Scoped to the `link` extension to match the
+          // event's documented contract (the custom link extension is out of
+          // scope and does not emit this event).
           //
           // Uses a DOM click handler rather than ProseMirror's handleClick:
           // handleClick is not invoked on a non-editable view (e.g. a read-only
@@ -1000,7 +1003,7 @@ export default {
           // DOM clicks regardless of editable state.
           handleDOMEvents: {
             click: (view, event) => {
-              if (event.button !== 0) return false;
+              if (!this.link || event.button !== 0) return false;
               const anchor = event.target?.closest?.('a');
               if (!anchor) return false;
               this.editor.emit('link-click', {

--- a/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.vue
@@ -56,7 +56,7 @@
 /* eslint-disable max-lines */
 import { Editor, EditorContent } from '@tiptap/vue-3';
 import { BubbleMenu } from '@tiptap/vue-3/menus';
-import { Extension, getMarkRange } from '@tiptap/core';
+import { Extension } from '@tiptap/core';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { DtButton } from '../Button';
 import { DtStack } from '../Stack';
@@ -225,6 +225,18 @@ export default {
      */
     link: {
       type: [Boolean, Object],
+      default: false,
+    },
+
+    /**
+     * When true, a `link-click` event is emitted whenever a link (from the
+     * `link` extension) is clicked, letting the consumer handle navigation
+     * (e.g. route same-origin URLs in-app). The listener may call
+     * event.preventDefault() to suppress the default navigation. Defaults to
+     * false to preserve the standard anchor behavior.
+     */
+    emitLinkClick: {
+      type: Boolean,
       default: false,
     },
 
@@ -737,7 +749,12 @@ export default {
             };
           },
           addProseMirrorPlugins () {
-            const markType = this.type;
+            const parentPlugins = this.parent?.() ?? [];
+            // Opt-in: only intercept clicks when the consumer wants the event.
+            if (!self.emitLinkClick) {
+              return parentPlugins;
+            }
+
             // Emit `link-click` so consumers can intercept links (e.g. to
             // navigate same-origin URLs in-app instead of opening a new tab).
             // The listener may call event.preventDefault() to suppress the
@@ -746,19 +763,20 @@ export default {
               key: new PluginKey('linkClick'),
               props: {
                 handleClick (view, pos, event) {
-                  const { state } = view;
-                  const $pos = state.doc.resolve(pos);
-                  const linkMark = $pos.marks().find(m => m.type === markType);
-                  if (!linkMark) return false;
-                  const range = getMarkRange($pos, markType);
-                  const text = range ? state.doc.textBetween(range.from, range.to) : '';
-                  self.editor.emit('link-click', { href: linkMark.attrs.href, text, event });
+                  if (event.button !== 0) return false;
+                  const anchor = event.target?.closest?.('a');
+                  if (!anchor) return false;
+                  self.editor.emit('link-click', {
+                    href: anchor.href,
+                    text: anchor.textContent,
+                    event,
+                  });
                   return event.defaultPrevented;
                 },
               },
             });
 
-            return [...(this.parent?.() ?? []), linkClickPlugin];
+            return [...parentPlugins, linkClickPlugin];
           },
         }).configure({
           HTMLAttributes: {

--- a/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.vue
+++ b/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.vue
@@ -57,7 +57,6 @@
 import { Editor, EditorContent } from '@tiptap/vue-3';
 import { BubbleMenu } from '@tiptap/vue-3/menus';
 import { Extension } from '@tiptap/core';
-import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { DtButton } from '../Button';
 import { DtStack } from '../Stack';
 import Blockquote from '@tiptap/extension-blockquote';
@@ -748,36 +747,6 @@ export default {
               },
             };
           },
-          addProseMirrorPlugins () {
-            const parentPlugins = this.parent?.() ?? [];
-            // Opt-in: only intercept clicks when the consumer wants the event.
-            if (!self.emitLinkClick) {
-              return parentPlugins;
-            }
-
-            // Emit `link-click` so consumers can intercept links (e.g. to
-            // navigate same-origin URLs in-app instead of opening a new tab).
-            // The listener may call event.preventDefault() to suppress the
-            // default navigation; otherwise the anchor behaves normally.
-            const linkClickPlugin = new Plugin({
-              key: new PluginKey('linkClick'),
-              props: {
-                handleClick (view, pos, event) {
-                  if (event.button !== 0) return false;
-                  const anchor = event.target?.closest?.('a');
-                  if (!anchor) return false;
-                  self.editor.emit('link-click', {
-                    href: anchor.href,
-                    text: anchor.textContent,
-                    event,
-                  });
-                  return event.defaultPrevented;
-                },
-              },
-            });
-
-            return [...parentPlugins, linkClickPlugin];
-          },
         }).configure({
           HTMLAttributes: {
             class: 'd-link d-wb-break-all',
@@ -1030,6 +999,23 @@ export default {
           attributes: {
             ...this.inputAttrs,
             class: this.inputClass,
+          },
+
+          // Emit `link-click` so consumers can intercept links (e.g. to
+          // navigate same-origin URLs in-app instead of opening a new tab).
+          // The listener may call event.preventDefault() to suppress the
+          // default navigation; otherwise the anchor behaves normally.
+          // Opt-in: only intercept clicks when the consumer wants the event.
+          handleClick: (view, pos, event) => {
+            if (!this.emitLinkClick || event.button !== 0) return false;
+            const anchor = event.target?.closest?.('a');
+            if (!anchor) return false;
+            this.editor.emit('link-click', {
+              href: anchor.href,
+              text: anchor.textContent,
+              event,
+            });
+            return event.defaultPrevented;
           },
 
           handleKeyDown: (view, event) => {


### PR DESCRIPTION
Alternative fix for https://github.com/dialpad/firespotter/pull/81693


## What I added to DtRichTextEditor
A new link-click event that lets consumers intercept link clicks (the root-cause fix — the target="_blank" new-tab behavior originates in this component's TipTap Link extension).

## Three changes in RichTextEditor.vue:

Imports — getMarkRange from @tiptap/core, Plugin/PluginKey from @tiptap/pm/state (verified resolvable in this repo's versions).

A ProseMirror click plugin on the built-in Link extension (addProseMirrorPlugins) — on clicking a link mark, it emits link-click with { href, text, event }. It returns event.defaultPrevented, so if the consumer calls event.preventDefault(), ProseMirror treats the click as handled and the browser does not follow the anchor's target="_blank". Crucially, it preserves any parent plugins ([...this.parent?.(), linkClickPlugin]).

Event bridge + declaration — editor.on('link-click') → this.$emit('link-click'), plus a documented entry in the emits array (mirroring the existing phone-click convention).



## Tests added (RichTextEditor.test.js):

emits link-click with the href/text/event when a link is clicked

does NOT emit when the click isn't on a link mark

reports the click as handled when the consumer prevents default


## How ubervoice will consume it (once this ships)

After a Dialtone release + version bump, the ubervoice fix simplifies to just listening to the new event on RichMediaInline:

```
<dt-rich-text-editor ... @link-click="onLinkClick" />

onLinkClick ({ href, event }) {
  const appPrefix = `${config.domain}/app/`;
  if (href?.startsWith(appPrefix)) {
    event.preventDefault();
    this.$navigate(href.substring(appPrefix.length));
  }
}
```
— replacing the delegated DOM listener (my 8d291b588d7 workaround) with the proper component API.