### PR TITLE
docs: NO-JIRA ensure deep-linked active side within view

### DIFF
--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/Sidebar.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/Sidebar.vue
@@ -1,5 +1,6 @@
 <template>
   <dt-stack
+    ref="sidebar"
     class="dialtone-sidebar__list d-h100p"
     @keydown="handleKeydown"
   >
@@ -25,6 +26,7 @@
           :search-active="isSearchActive"
           :persistent="props.persistent"
           @toggle="handleToggle"
+          @opened="revealActiveRouteItem"
         />
         <dt-empty-state
           v-if="visibleGroups.length === 0 && inputValue.trim()"
@@ -88,8 +90,18 @@ const highlightIndex = ref(-1);
 
 // Ref to the search input element
 const searchInput = ref(null);
+const sidebar = ref(null);
 
 const focusSearchInput = () => searchInput.value?.focus();
+const revealActiveRouteItem = async () => {
+  await nextTick();
+  const sidebarElement = sidebar.value?.$el || sidebar.value;
+  sidebarElement?.querySelector('[aria-current="page"]')?.scrollIntoView({
+    behavior: 'auto',
+    block: 'nearest',
+    inline: 'nearest',
+  });
+};
 const isModifiedKeypress = (event) => {
   return event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
 };
@@ -176,8 +188,9 @@ const handleKeydown = (event) => {
 };
 
 // Initialize open items after mount
-onMounted(() => {
+onMounted(async () => {
   openItems.value = collectOpenItemKeysForRoute(displayItems.value, route.path);
+  await revealActiveRouteItem();
   document.addEventListener('keydown', handleSearchShortcut);
 });
 
@@ -186,11 +199,12 @@ onUnmounted(() => {
 });
 
 // Update open items when route changes
-watch(() => route.path, (newPath) => {
+watch(() => route.path, async (newPath) => {
   // Clear search and keyboard highlight when navigating to a different page
   inputValue.value = '';
   highlightIndex.value = -1;
   openItems.value = collectOpenItemKeysForRoute(displayItems.value, newPath);
+  await revealActiveRouteItem();
 });
 
 // Watch search input to control expansion state

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/SidebarGroup.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/SidebarGroup.vue
@@ -17,6 +17,7 @@
       :presentation="presentation"
       :persistent="persistent"
       @toggle="forwardToggle"
+      @opened="$emit('opened')"
     />
   </dt-stack>
 </template>
@@ -57,7 +58,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['toggle']);
+const emit = defineEmits(['toggle', 'opened']);
 
 const groupGap = computed(() => props.presentation === 'promoted' ? '0' : '50');
 const peerKeys = computed(() => collectPeerKeys(props.items));

--- a/apps/dialtone-documentation/docs/.vuepress/theme/components/SidebarItem.vue
+++ b/apps/dialtone-documentation/docs/.vuepress/theme/components/SidebarItem.vue
@@ -5,6 +5,7 @@
     element-type="li"
     class="d-w100p"
     anchor-class="d-w100p"
+    @opened="handleOpened"
   >
     <template #anchor="{ attrs }">
       <sidebar-item-row
@@ -43,6 +44,7 @@
           :first-nested-child="nested && index === 0 && !subItem.children?.length"
           :persistent="persistent"
           @toggle="forwardToggle"
+          @opened="forwardOpened"
         />
       </dt-stack>
     </template>
@@ -118,7 +120,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['toggle']);
+const emit = defineEmits(['toggle', 'opened']);
 const route = useRoute();
 const router = useRouter();
 
@@ -159,5 +161,13 @@ function handleClick (event) {
 
 function forwardToggle (childKey, shouldOpen, childPeerKeys) {
   emit('toggle', childKey, shouldOpen, childPeerKeys);
+}
+
+function handleOpened (opened) {
+  if (opened) emit('opened');
+}
+
+function forwardOpened () {
+  emit('opened');
 }
 </script>


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Documentation

## :book: Jira Ticket

NO-JIRA

## :book: Description

- Keeps the route-active sidebar item within view after direct loads and client-side navigation.
- Waits for collapsible ancestors before the final reveal. Desktop sidebar and small-viewport View Menu drawer.

## :bulb: Context

Deep-linked pages can mark the correct sidebar item active while leaving it below the fold. Current location stays findable in navigation.

Only scrolls the sidebar using nearest alignment. No changes to main page scroll, routing, focus, or sidebar search/highlight behavior.

No new unit tests; verified with focused ESLint, docs tests (4/4), and desktop/mobile browser flows.

## For reviewers

Using the deploy preview:

1. Open `/components/`.
2. Click **Newest Components** → **DtSegmentedControl**.
3. Confirm **Segmented Control** is active and visible in the left sidebar without manually scrolling it.
4. Direct-load `/components/stack.html`; confirm **Stack** is active and visible.
5. At a small viewport, direct-load `/components/stack.html`, click **View Menu**, and confirm **Stack** is active and visible.

## :pencil: Checklist

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.
