### PR TITLE
fix(popover): DLT-3601 scope modal z-index bump to the anchor's own modal

### DIFF
--- a/packages/dialtone-vue/components/Popover/Popover.test.js
+++ b/packages/dialtone-vue/components/Popover/Popover.test.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { DtPopover } from '@/components/Popover';
+import { POPOVER_MODAL_ELEMENT_Z_INDEX, POPOVER_Z_INDEX } from '@/components/Popover/PopoverConstants';
 import { DtFocustrapDirective } from '@/directives/focustrap_directive';
 import { flushPromises } from '@/common/utils';
 import SrOnlyCloseButtonComponent from '@/common/sr_only_close_button.vue';
@@ -294,6 +295,69 @@ describe('DtPopover Tests', () => {
         await wrapper.setProps({ boundary: document.body });
 
         expect(setPropsSpy).toHaveBeenCalledWith({ popperOptions: wrapper.vm.popperOptions() });
+      });
+    });
+  });
+
+  describe('Z-index Tests', () => {
+    let modal;
+
+    const createOpenModal = () => {
+      const el = document.createElement('div');
+      el.classList.add('d-modal');
+      el.setAttribute('open', '');
+      document.body.appendChild(el);
+      return el;
+    };
+
+    beforeEach(async () => {
+      await wrapper.setProps({ open: true });
+    });
+
+    afterEach(() => {
+      modal?.remove();
+      modal = null;
+    });
+
+    it('renders at the popover layer when no modal is open', () => {
+      expect(wrapper.vm.calculateAnchorZindex()).toBe(POPOVER_Z_INDEX);
+    });
+
+    describe('When the anchor is inside an open modal', () => {
+      beforeEach(() => {
+        modal = createOpenModal();
+        // Move the whole anchor container, not the anchor itself: the component's
+        // MutationObserver re-reads $refs.anchor.children[0] and would blank anchorEl.
+        modal.appendChild(wrapper.vm.$refs.anchor);
+      });
+
+      it('renders above the modal layer', () => {
+        expect(wrapper.vm.calculateAnchorZindex()).toBe(POPOVER_MODAL_ELEMENT_Z_INDEX);
+      });
+    });
+
+    describe('When an unrelated modal is open elsewhere on the page', () => {
+      beforeEach(() => {
+        modal = createOpenModal();
+      });
+
+      it('stays at the popover layer rather than painting over the unrelated overlay', () => {
+        expect(wrapper.vm.calculateAnchorZindex()).toBe(POPOVER_Z_INDEX);
+      });
+    });
+
+    describe('When the anchor is inside a drawer', () => {
+      beforeEach(() => {
+        modal = document.createElement('div');
+        modal.classList.add('d-zi-drawer');
+        document.body.appendChild(modal);
+        // Move the whole anchor container, not the anchor itself: the component's
+        // MutationObserver re-reads $refs.anchor.children[0] and would blank anchorEl.
+        modal.appendChild(wrapper.vm.$refs.anchor);
+      });
+
+      it('renders above the modal layer', () => {
+        expect(wrapper.vm.calculateAnchorZindex()).toBe(POPOVER_MODAL_ELEMENT_Z_INDEX);
       });
     });
   });

--- a/packages/dialtone-vue/components/Popover/Popover.vue
+++ b/packages/dialtone-vue/components/Popover/Popover.vue
@@ -133,14 +133,17 @@
 <script>
 /* eslint-disable max-lines */
 import {
+  OPEN_MODAL_SELECTOR,
   POPOVER_APPEND_TO_VALUES,
   POPOVER_BOUNDARY_VALUES,
   POPOVER_CONTENT_WIDTHS,
   POPOVER_HEADER_FOOTER_PADDING_CLASSES,
   POPOVER_INITIAL_FOCUS_STRINGS,
+  POPOVER_MODAL_ELEMENT_Z_INDEX,
   POPOVER_PADDING_CLASSES,
   POPOVER_ROLES,
   POPOVER_STICKY_VALUES,
+  POPOVER_Z_INDEX,
 } from './PopoverConstants';
 import { getUniqueString, hasSlotContent, isOutOfViewPort, warnIfUnmounted, disableRootScrolling, enableRootScrolling, returnFirstEl } from '@/common/utils';
 import { HTML_ELEMENT_TYPE } from '@/common/constants';
@@ -701,7 +704,7 @@ export default {
 
     modal (modal) {
       this.tip?.setProps({
-        zIndex: modal ? 650 : this.calculateAnchorZindex(),
+        zIndex: modal ? POPOVER_MODAL_ELEMENT_Z_INDEX : this.calculateAnchorZindex(),
       });
     },
 
@@ -865,16 +868,20 @@ export default {
     },
 
     calculateAnchorZindex () {
-      // if a modal is currently active render at modal-element z-index, otherwise at popover z-index
-      if (returnFirstEl(this.$el).getRootNode()
-        .querySelector('.d-modal[aria-hidden="false"], .d-modal--transparent[aria-hidden="false"], .d-modal[open], .d-modal--transparent[open]') ||
-        // Special case because we don't have any dialtone drawer component yet. Render at 650 when
-        // anchor of popover is within a drawer.
-        this.anchorEl?.closest('.d-zi-drawer')) {
-        return 650;
-      } else {
-        return 300;
-      }
+      // Only outrank the modal layer when this popover actually belongs to an open modal,
+      // i.e. its anchor lives inside one. Testing for "any open modal in the document"
+      // also promotes popovers anchored elsewhere on the page — global chrome such as a
+      // profile menu — so they paint above the overlay of a modal they have nothing to do
+      // with, which is not the intent of the modal-element layer.
+      const isAnchoredInModal = !!this.anchorEl?.closest(OPEN_MODAL_SELECTOR);
+
+      // Special case because we don't have any dialtone drawer component yet. Render at
+      // modal-element z-index when anchor of popover is within a drawer.
+      const isAnchoredInDrawer = !!this.anchorEl?.closest('.d-zi-drawer');
+
+      return isAnchoredInModal || isAnchoredInDrawer
+        ? POPOVER_MODAL_ELEMENT_Z_INDEX
+        : POPOVER_Z_INDEX;
     },
 
     defaultToggleOpen (e) {
@@ -1209,7 +1216,7 @@ export default {
         // We have to manage hideOnClick functionality manually to handle
         // popover within popover situations.
         hideOnClick: false,
-        zIndex: this.modal ? 650 : this.calculateAnchorZindex(),
+        zIndex: this.modal ? POPOVER_MODAL_ELEMENT_Z_INDEX : this.calculateAnchorZindex(),
         onClickOutside: this.onClickOutside,
         onShow: this.onShow,
       });

--- a/packages/dialtone-vue/components/Popover/PopoverConstants.js
+++ b/packages/dialtone-vue/components/Popover/PopoverConstants.js
@@ -12,6 +12,20 @@ export const POPOVER_HEADER_FOOTER_PADDING_CLASSES = {
   medium: 'd-pis-100',
   large: 'd-pis-200',
 };
+// Mirrors the --zi-popover and --zi-modal-element design tokens. Tippy takes a raw
+// number for zIndex, so the values cannot be referenced as CSS custom properties.
+export const POPOVER_Z_INDEX = 300;
+export const POPOVER_MODAL_ELEMENT_Z_INDEX = 650;
+
+// An open DtModal, in either the legacy div-based form ([aria-hidden="false"]) or the
+// native <dialog> form ([open]).
+export const OPEN_MODAL_SELECTOR = [
+  '.d-modal[aria-hidden="false"]',
+  '.d-modal--transparent[aria-hidden="false"]',
+  '.d-modal[open]',
+  '.d-modal--transparent[open]',
+].join(', ');
+
 export const POPOVER_ROLES = ['dialog', 'menu', 'listbox', 'tree', 'grid'];
 export const POPOVER_BOUNDARY_VALUES = ['clippingParents', 'viewport', 'document'];
 export const POPOVER_CONTENT_WIDTHS = ['', 'anchor'];
@@ -27,6 +41,9 @@ export const POPOVER_DIRECTIONS = [
 export default {
   POPOVER_PADDING_CLASSES,
   POPOVER_HEADER_FOOTER_PADDING_CLASSES,
+  POPOVER_Z_INDEX,
+  POPOVER_MODAL_ELEMENT_Z_INDEX,
+  OPEN_MODAL_SELECTOR,
   POPOVER_ROLES,
   POPOVER_BOUNDARY_VALUES,
   POPOVER_CONTENT_WIDTHS,


### PR DESCRIPTION
## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3601

## :book: Description

`calculateAnchorZindex()` promoted a popover from the popover layer (`--zi-popover`, 300) to the modal-element layer (`--zi-modal-element`, 650) whenever a document-wide `querySelector` found any open modal:

```js
returnFirstEl(this.$el).getRootNode()
  .querySelector('.d-modal[aria-hidden="false"], …, .d-modal[open], …')
```

It now tests the popover's own anchor with `closest()` instead, so only popovers that actually live inside an open modal are promoted. The existing drawer special case is preserved.

Also extracts the repeated `300` / `650` literals and the open-modal selector into named constants (`POPOVER_Z_INDEX`, `POPOVER_MODAL_ELEMENT_Z_INDEX`, `OPEN_MODAL_SELECTOR`) in `PopoverConstants.js`, and uses them at the two `modal ? 650 : …` call sites.

## :bulb: Context

A document-wide search cannot distinguish a popover genuinely nested inside the open modal — which should outrank it — from unrelated global chrome that merely happens to be open at the same time. The result was that a global menu rendered bright and undimmed on top of the dimming overlay of a modal it had nothing to do with.

Worth noting for reviewers: **this is a plain z-index bug, not a native `<dialog>` top-layer bug.** The modal in the reported case is opened with `show()` (DtModal's `modal: false` default), so it never enters the browser top layer and nothing is inert — confirmed by the popover remaining clickable in that state.

I verified the underlying platform behavior separately with a Playwright spike across Chromium 148, Firefox 150 and WebKit 26.4. Two results are relevant to how we approach this area going forward, though neither is addressed here:

- `showModal()` inerts everything outside the dialog's subtree, including top-layer popovers. A popover shown after `showModal()` paints bright above the backdrop but is **not** focusable or clickable — so re-promotion cannot rescue an out-of-subtree overlay.
- With the `modal: false` default there is no keyboard focus containment. `Modal.vue` has only `focusFirstTabbable` for initial placement and #1397 removed the background-inert machinery, so Tab escapes into dimmed, mouse-unreachable background content (reproduced in Chromium).

### Follow-ups, deliberately out of scope

- Product decision: an unrelated popover now renders dimmed *behind* the overlay. Closing it outright when a modal opens may be the better UX.
- The focus-containment gap above deserves its own ticket.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.

New `Z-index Tests` block covers four cases: no modal open → 300; anchor inside an open modal → 650; **unrelated modal open elsewhere → 300** (the regression guard); anchor inside a drawer → 650.

`DtDropdown` inherits the fix through `DtPopover`; no dropdown-level tests were added. No API change, so no Combinator/docs artifacts were regenerated.

Full suite: 3271 passed, 2 skipped. Lint: 0 errors.
