### PR TITLE
fix(combobox-multi-select): NO-JIRA recover input height once it actually becomes visible

### DIFF
--- a/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.test.js
+++ b/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.test.js
@@ -493,6 +493,72 @@ describe('DtComboboxMultiSelect Tests', () => {
     });
   });
 
+  describe('Input Visibility Recovery Tests', () => {
+    // jsdom never lays anything out, so getBoundingClientRect() returns 0 for every element by
+    // default — exactly the "input had a zero layout box at mount" condition this recovers from.
+    // The real ResizeObserver is mocked out globally as a no-op (tests/setupTests.js), so a local
+    // stub is installed here to capture the callback the component registers on the input itself,
+    // letting the test invoke it directly to simulate the input actually gaining layout later.
+    let inputEl;
+    let inputObserverCallback;
+    let OriginalResizeObserver;
+
+    beforeEach(() => {
+      wrapper.unmount();
+      OriginalResizeObserver = global.ResizeObserver;
+      global.ResizeObserver = class {
+        constructor (callback) {
+          this.callback = callback;
+        }
+
+        observe (target) {
+          if (target?.classList?.contains('d-input__input')) {
+            inputObserverCallback = this.callback;
+          }
+        }
+
+        disconnect () {}
+        unobserve () {}
+      };
+
+      // selectedItems is populated *before* mount, matching a real "mounted hidden with
+      // preselected items" case: initSelectedItems() runs at mount too, but only ever reads
+      // whatever height the initial (still-hidden) measurement found.
+      props = { ...baseProps, selectedItems: ['item1'] };
+      _setWrappers();
+      inputEl = wrapper.find('[data-qa="dt-input-input"]').element;
+    });
+
+    afterEach(() => {
+      global.ResizeObserver = OriginalResizeObserver;
+    });
+
+    it('should have a falsy initialInputHeight before the input has ever had real layout', () => {
+      expect(wrapper.vm.initialInputHeight).toBeFalsy();
+    });
+
+    it('should register a visibility observer on the input itself', () => {
+      expect(inputObserverCallback).toBeInstanceOf(Function);
+    });
+
+    describe('When the input later gains real layout on its own, with no other trigger', () => {
+      beforeEach(() => {
+        vi.spyOn(inputEl, 'getBoundingClientRect').mockReturnValue({
+          top: 0, left: 0, width: 300, height: 40, bottom: 40, right: 300,
+        });
+        inputObserverCallback();
+      });
+
+      it('should recover a non-zero initialInputHeight instead of staying stuck at 0', () => {
+        expect(wrapper.vm.initialInputHeight).toBe(40);
+      });
+
+      it('should set a min-height on the input so wrapped rows have room to grow into', () => {
+        expect(inputEl.style.minHeight).toBe('40px');
+      });
+    });
+  });
+
   describe('Validation Tests', () => {
     beforeEach(async () => {
       await wrapper.setProps({

--- a/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.vue
+++ b/packages/dialtone-vue/components/ComboboxMultiSelect/ComboboxMultiSelect.vue
@@ -501,6 +501,7 @@ export default {
       popoverOffset: [0, 4],
       showValidationMessages: false,
       resizeWindowObserver: null,
+      inputVisibilityObserver: null,
       initialInputHeight: null,
       CHIP_SIZES,
       hasSlotContent,
@@ -633,11 +634,34 @@ export default {
     });
     this.resizeWindowObserver.observe(document.body);
 
+    // The measurement above can land on a zero-size input — for example it's inside a collapsed
+    // panel or a not-yet-visible tab. Nothing else is guaranteed to react once the input later
+    // becomes visible: revealing it doesn't necessarily resize document.body, and with the
+    // default collapseOnFocusOut: false, focusing the input doesn't recompute anything either.
+    // Watch the input's own box directly so we can recover the instant it actually gets real
+    // layout, instead of depending on some other call site to happen to run again.
+    if (!this.initialInputHeight) {
+      const input = this.getInput();
+      if (input) {
+        this.inputVisibilityObserver = new ResizeObserver(() => {
+          if (this.initialInputHeight) return;
+          this.setInitialInputHeight();
+          if (!this.initialInputHeight) return;
+          this.setInputPadding();
+          this.setChipsTopPosition();
+          this.inputVisibilityObserver?.disconnect();
+          this.inputVisibilityObserver = null;
+        });
+        this.inputVisibilityObserver.observe(input);
+      }
+    }
+
     await this.initSelectedItems();
   },
 
   beforeUnmount () {
     this.resizeWindowObserver?.unobserve(document.body);
+    this.inputVisibilityObserver?.disconnect();
   },
 
   methods: {


### PR DESCRIPTION
# fix(combobox-multi-select): recover input height once it actually becomes visible

<!--- Feel free to remove any unused sections -->

## :hammer_and_wrench: Type Of Change

These types will increment the version number on release:

- [x] Fix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Refactor

These types will not increment the version number, but will still deploy to documentation site on release:

- [ ] Documentation
- [ ] Build system
- [ ] CI
- [ ] Style (code style changes, not css changes)
- [ ] Test
- [ ] Other (chore)

## :book: Jira Ticket

NO-JIRA

## :book: Description

`DtComboboxMultiSelect` measures its own single-line height exactly once, in `mounted()`, and stores it in `initialInputHeight`. `growInputForWrappedRows()` guards on that value being truthy before growing the input's `min-height` to make room for wrapped chip rows.

If the input has a zero layout box at the moment `mounted()` runs (for example, it is inside a collapsed panel, or a not-yet-visible tab), the measurement comes back `0`, and `growInputForWrappedRows()` silently no-ops forever afterward. The chip padding that pushes the caret down to make room for wrapped rows still applies independently, so the last row of chips renders below the input's border instead of the box growing to contain it.

An earlier version of this fix retried the measurement from `setInputPadding()`, but that isn't enough: a component that mounts hidden with items already selected runs that retry while still hidden, so it measures `0` again. Revealing the input later doesn't necessarily resize `document.body`, and with the default `collapseOnFocusOut: false`, focusing the input doesn't recompute anything either — so the height stays stuck until something else happens to change `selectedItems`.

This version instead watches the input's own layout box with a `ResizeObserver` set up at mount. Whatever later gives the input real layout — a revealed tab, an expanded panel, a resized container — the observer fires right then and the height recovers, instead of depending on some other call site happening to run again.

## :bulb: Context

Found via a real consumer report: a multi-select rendered inside an integration settings panel where the input had no layout at mount time. Selecting enough options to wrap to a second row caused that row to visually spill outside the bordered input box instead of the box growing to contain it.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [ ] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
- [ ] I have validated components with a screen reader.
- [ ] I have validated components keyboard navigation.

## :crystal_ball: Next Steps

Consumers pinned to a pre-fix Dialtone version may have their own local workarounds for this bug; once they upgrade past this fix they can remove those.

## :camera: Screenshots / GIFs

N/A — behavioral/layout fix verified via unit tests (`ComboboxMultiSelect.test.js`, "Input Visibility Recovery Tests") and manually against a real consumer app.
