### PR TITLE
fix(rich-text-editor): DLT-3609 normalize emoji to unicode in markdown output

### DIFF
--- a/packages/dialtone-vue/components/RichTextEditor/MarkdownRenderer.js
+++ b/packages/dialtone-vue/components/RichTextEditor/MarkdownRenderer.js
@@ -1,4 +1,5 @@
 import { renderToMarkdown } from '@tiptap/static-renderer/pm/markdown';
+import { codeToEmojiData, stringToUnicode } from '@/common/emoji';
 
 // The pm/markdown renderer passes children as string[] (one entry per child node),
 // not as a pre-joined string. Normalize to a string before processing.
@@ -69,7 +70,12 @@ export function renderEditorToMarkdown (jsonContent, extensions) {
         },
 
         emoji ({ node }) {
-          return node.attrs?.code || '';
+          const code = node.attrs?.code;
+          if (!code) return '';
+          // Always output emoji as unicode characters rather than shortcodes, matching
+          // renderText's backwards-compatibility behavior with our backend (see Emoji.js).
+          const emojiData = codeToEmojiData(code);
+          return emojiData ? stringToUnicode(emojiData.unicode_output) : code;
         },
 
         variable ({ node }) {

--- a/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.test.js
+++ b/packages/dialtone-vue/components/RichTextEditor/RichTextEditor.test.js
@@ -480,6 +480,30 @@ describe('DtRichTextEditor tests', () => {
             const output = await getMarkdownOutput(jsonInput);
             expect(output).toBe('Check out <!-- @channel: {"id": "general", "channelKey": "channel-456", "name": "general", "locked": "false"} --> channel');
           });
+
+          it('should convert emoji stored as a shortcode to a unicode character', async () => {
+            const jsonInput = jsonInputBase([
+              { type: 'text', text: 'Hello ' },
+              {
+                type: 'emoji',
+                attrs: { code: ':cat:' },
+              },
+            ]);
+            const output = await getMarkdownOutput(jsonInput);
+            expect(output).toBe('Hello 🐱');
+          });
+
+          it('should convert emoji stored as a unicode character to a unicode character', async () => {
+            const jsonInput = jsonInputBase([
+              { type: 'text', text: 'Hello ' },
+              {
+                type: 'emoji',
+                attrs: { code: '🐱' },
+              },
+            ]);
+            const output = await getMarkdownOutput(jsonInput);
+            expect(output).toBe('Hello 🐱');
+          });
         });
       });
     });


### PR DESCRIPTION
# fix(rich-text-editor): DLT-3609 normalize emoji to unicode in markdown output

## :hammer_and_wrench: Type Of Change

- [x] Fix

## :book: Jira Ticket

https://dialpad.atlassian.net/browse/DLT-3609

## :book: Description

`MarkdownRenderer.js`'s `emoji` node mapping previously echoed the raw `node.attrs.code` verbatim, which can be either a shortcode string (e.g. `:cat:`) or a literal unicode character depending on how the emoji was entered (typed via the `:` suggestion picker vs. pasted as raw unicode). This meant markdown output for emoji was inconsistent depending on input method.

This change normalizes emoji to unicode in the markdown serializer, using the same `codeToEmojiData` / `stringToUnicode` helpers already used by the plain-text `renderText()` mapping in `Emoji.js`.

## :bulb: Context

Plain-text output (`Emoji.js` `renderText()`) already normalizes emoji to unicode for backwards compatibility with the backend. Markdown output was bypassing that normalization entirely, so the two output paths diverged for the same underlying content.

## :pencil: Checklist

For all PRs:

- [x] I have ensured no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
- [x] I have reviewed my changes.
- [x] I have added all relevant documentation.
- [x] I have considered the performance impact of my change.

For all Vue changes:

- [x] I have added / updated unit tests.
